### PR TITLE
Promote persistent MTP boundary split candidate default

### DIFF
--- a/docs/LLAMA_DEEP_CLIENT_EXPERIMENT.md
+++ b/docs/LLAMA_DEEP_CLIENT_EXPERIMENT.md
@@ -1,0 +1,1179 @@
+# Llama Deep Client Experiment
+
+This branch evaluates whether Orbit should move beyond the
+OpenAI-compatible `llama-server` HTTP API and become a deeper client of
+`llama.cpp`.
+
+This is an experiment, not a release path.
+
+## Goal
+
+Determine whether deeper control of `llama.cpp` provides enough value to justify
+the added complexity.
+
+Target capabilities:
+
+- real prefill progress;
+- real backend cancellation;
+- explicit KV/session ownership;
+- reliable common-prefix/cache visibility;
+- phase-level metrics that do not depend on post-hoc HTTP timings.
+
+## Non-Goals
+
+- Do not redesign Orbit as a generic agent framework.
+- Do not change routing, prompts, tool-use, or final answer behavior.
+- Do not replace model decisions with deterministic task fast paths.
+- Do not merge native or FFI code unless the measured value is clear.
+- Do not make this path the default during the experiment.
+
+## Baseline Problem
+
+Orbit currently uses:
+
+```text
+/v1/chat/completions
+```
+
+This keeps Orbit small and compatible, but it means Orbit only sees:
+
+- request sent;
+- first streamed delta;
+- final usage/timings.
+
+It does not truly own:
+
+- prefill loop progress;
+- cancellation;
+- KV/session synchronization;
+- common-prefix reuse.
+
+The `/slots` endpoint is useful for observability, but in real use it often
+updates too late or too sparsely to provide reliable prefill progress.
+
+## Candidate Designs
+
+### 1. Native library/FFI client
+
+Orbit loads `llama.cpp` as a library through a Python binding or a small native
+extension.
+
+Benefits:
+
+- full eval loop control;
+- exact prefill progress;
+- exact cancellation;
+- direct KV/session management.
+
+Costs:
+
+- high implementation complexity;
+- packaging complexity;
+- platform-specific failures;
+- tighter coupling to `llama.cpp` internals;
+- higher maintenance burden.
+
+### 2. Controlled local subprocess
+
+Orbit controls a local `llama.cpp` binary/process with a protocol richer than
+OpenAI chat completions.
+
+Benefits:
+
+- lower packaging risk than FFI;
+- process isolation;
+- easier rollback.
+
+Costs:
+
+- requires a stable protocol;
+- may still lack KV/session ownership;
+- cancellation depends on process/protocol semantics.
+
+### 3. Minimal `llama-server` patch
+
+Add server-sent prefill progress/cancel events to `llama-server`.
+
+Benefits:
+
+- keeps Orbit mostly unchanged;
+- lower scope than full deep client;
+- preserves current deployment model.
+
+Costs:
+
+- requires maintaining a fork/patch;
+- still does not give full session ownership.
+
+## Experiment Plan
+
+### Phase 1: Capability Audit
+
+Answer with code and measurements:
+
+- Can a non-HTTP client observe per-token prefill progress?
+- Can it cancel generation immediately and safely?
+- Can it report common-prefix/KV reuse?
+- Can it expose phase timings before final completion?
+- Can this be done without destabilizing packaging?
+
+### Phase 2: Prototype Adapter
+
+Create an experimental backend adapter behind an explicit flag.
+
+Requirements:
+
+- no default behavior change;
+- same `ChatBackend` contract where possible;
+- no routing/tool/prompt changes;
+- clear fallback to `llama-server`.
+
+### Phase 3: Benchmark
+
+Compare against the current `llama-server` backend:
+
+- chat short;
+- long prompt prefill;
+- tool result final inference;
+- Ctrl+C cancellation during prefill;
+- Ctrl+C cancellation during generation;
+- repeated prompt cache/common-prefix case.
+
+Report:
+
+- wall time;
+- prefill progress fidelity;
+- cancellation latency;
+- prompt/cache metrics;
+- implementation complexity.
+
+## Acceptance Criteria
+
+Do not merge unless the prototype demonstrates at least two substantial wins:
+
+- reliable live prefill progress;
+- reliable backend cancellation;
+- better KV/session reuse control;
+- measurable latency or robustness improvement.
+
+If the only improvement is a nicer progress display, close the branch without
+merge.
+
+## First Decision Point
+
+Before writing runtime code, inspect the local `llama.cpp` build and available
+interfaces:
+
+```bash
+ls /home/guelfoweb/LAB/llama.cpp-gemma4-mtp-qualcomm/build/bin
+find /home/guelfoweb/LAB/llama.cpp-gemma4-mtp-qualcomm/build -name '*llama*' -type f
+```
+
+Then decide whether the first prototype should use:
+
+- native library/FFI;
+- a controlled subprocess;
+- or a minimal server patch.
+
+## Local Capability Audit
+
+Probe:
+
+```bash
+python3 scripts/probe-llama-deep-client.py
+```
+
+Observed local build:
+
+```text
+llama-server: yes
+llama-cli: yes
+libllama.so: yes
+libllama-common.so: yes
+llama.h: yes
+llama-cpp.h: yes
+```
+
+Server capabilities:
+
+```text
+--slots: yes
+--metrics: yes
+--slot-save-path: yes
+--spec-type: yes
+--cache-ram: yes
+--ctx-checkpoints: yes
+```
+
+CLI capabilities:
+
+```text
+--perf: yes
+--show-timings: yes
+--conversation: yes
+--ctx-checkpoints: yes
+--cache-ram: yes
+--spec-type: yes
+```
+
+Initial recommendation:
+
+- `native_ffi` is possible and gives the right control surface, but has high
+  implementation and packaging complexity.
+- `subprocess_cli` is possible but likely insufficient for exact KV/session
+  ownership.
+- `server_patch` is practical for progress/cancel events, but still keeps Orbit
+  outside the eval loop.
+
+## Pure Python Native Probe
+
+This branch now tests the native path through Python `ctypes`, without C++
+helper binaries and without touching the production `llama-server` backend.
+
+Structure:
+
+```text
+src/orbit/native_llama/
+  bindings.py   ctypes ABI for the small llama.cpp API surface used here
+  paths.py      local llama.cpp/model discovery
+  client.py     model/context/sampler lifecycle and decode loop
+  events.py     progress/timing data objects
+```
+
+Probe:
+
+```bash
+PYTHONPATH=src python3 scripts/probe-llama-native-client.py \
+  --prompt "hi, who are you?" \
+  --max-tokens 12
+```
+
+Expected live progress:
+
+```text
+load: 100%
+pf: 128/933 tk (13%)
+gen: 4 tk
+```
+
+What this path can provide if it proves stable:
+
+- real prefill progress from the actual `llama_decode()` loop;
+- real abort through llama.cpp abort callbacks;
+- explicit context ownership;
+- eventual KV/session inspection and reuse experiments.
+
+What is intentionally not implemented yet:
+
+- MTP loading;
+- production backend selection;
+- packaging support.
+
+## Measured Prototype Results
+
+### Native Load
+
+The Python native client can load the local Gemma 4 12B GGUF through
+`libllama.so`.
+
+The model load callback provides real loading progress, but it is noisy and
+should be throttled in any user-facing UI.
+
+### Real Prefill Progress
+
+The native decode loop reports exact prompt-token progress because Orbit owns
+the calls to `llama_decode()`:
+
+```text
+pf: 16/28 tk (57%)
+pf: 28/28 tk (100%)
+```
+
+This is different from `/slots`: it does not depend on sparse backend polling
+or guessed prompt sizes.
+
+### Native Cancellation
+
+Ctrl+C / SIGINT sets an abort callback consumed by llama.cpp.
+
+Observed behavior:
+
+```text
+cancelled: True
+```
+
+No HTTP stream disconnect is involved. `llama_decode()` returns the native
+aborted status and the client exits cleanly.
+
+### Controlled KV Prefix Reuse
+
+The prototype keeps the previously evaluated prompt tokens and trims llama.cpp
+memory from the first divergent token before the next request.
+
+Repeated prompt benchmark:
+
+```text
+turn 1:
+prompt_tokens: 26
+reused_prompt_tokens: 0
+evaluated_prompt_tokens: 26
+prefill_ms: 1865.8
+
+turn 2:
+prompt_tokens: 26
+reused_prompt_tokens: 25
+evaluated_prompt_tokens: 1
+prefill_ms: 312.7
+```
+
+The last prompt token is intentionally re-evaluated to produce fresh logits for
+generation. This still gives controlled reuse of the stable prefix.
+
+## Architecture Direction
+
+If this branch continues, the native backend should stay layered:
+
+```text
+native_llama/bindings.py  -> ctypes ABI only
+native_llama/paths.py     -> local library/model discovery
+native_llama/client.py    -> model/context/sampler lifecycle
+native_llama/events.py    -> progress and timing events
+```
+
+Do not fold this into `backend/llama_server.py`.
+
+The production integration should be an explicit backend adapter only after the
+native path proves parity for:
+
+- chat template formatting;
+- tool-call prompting and parsing;
+- MTP/speculative decoding;
+- session memory and compaction behavior;
+- release confidence prompts.
+
+## Next Technical Steps
+
+1. Implement chat-format parity.
+   Current fallback uses the Gemma 4 control tokens directly because
+   `llama_chat_apply_template()` does not support the full model Jinja template.
+
+2. Measure long-prompt progress.
+   Use a prompt large enough to show smooth prefill progress, not only two
+   batches.
+
+3. Add MTP support.
+   Load the draft context/model only after the base native loop is stable.
+
+4. Add structured benchmark comparison.
+   Compare native vs `llama-server` for:
+   - first-turn prefill;
+   - repeated-prefix prefill;
+   - Ctrl+C during prefill;
+   - Ctrl+C during generation;
+   - tool-result final inference.
+
+5. Keep merge criteria strict.
+   Do not merge unless native mode provides substantial wins beyond display
+   polish.
+
+## Orbit Server
+
+This branch introduces an experimental `orbit-server` process implemented in
+Python.
+
+Goal:
+
+- replace `llama-server` with an Orbit-owned local model process;
+- keep the model loaded once;
+- expose Orbit-native metrics and progress;
+- preserve a compatibility bridge while the CLI is migrated.
+
+Command:
+
+```bash
+PYTHONPATH=src python3 scripts/orbit-server.py --port 18082
+```
+
+Primary protocol:
+
+```text
+POST /chat
+```
+
+Compatibility protocol:
+
+```text
+GET  /health
+GET  /v1/models
+GET  /props
+POST /v1/chat/completions
+```
+
+The OpenAI-like endpoint is a bridge only. The long-term direction is for Orbit
+to use its own protocol and avoid depending on `llama-server` response shapes.
+
+Smoke test:
+
+```bash
+PYTHONPATH=src python3 -m orbit.terminal.cli \
+  --base-url http://127.0.0.1:18082 \
+  "who developed you?"
+```
+
+Observed:
+
+```text
+I was developed by Google DeepMind.
+
+model: gemma4:12b-it-native | tks: 38->8, cached 7 | pf 14.7/s | gen 3.2/s
+```
+
+Current `orbit-server` capabilities:
+
+- loads Gemma 4 12B through Python `ctypes`;
+- keeps model/context hot;
+- supports streaming;
+- exposes real native timings;
+- exposes controlled prefix reuse as `cached_tokens`;
+- allows current Orbit CLI to run through the compatibility endpoint.
+- exposes an Orbit-native `/chat/stream` protocol with typed SSE events:
+  - `progress.prefill`
+  - `progress.generation`
+  - `delta`
+  - `metrics`
+  - `done`
+- supports explicit single-session identity through `session_id: "default"`;
+- exposes `/cancel` for native backend cancellation;
+- supports stop sequence trimming and early decode abort.
+
+Current limitations:
+
+- no native MTP yet;
+- no production packaging;
+- no dedicated Orbit protocol backend adapter yet;
+- no release-confidence run against native mode yet.
+- only one native session is supported in this experiment;
+- OpenAI-compatible streaming is a bridge and does not expose typed native
+  progress events.
+
+Decision:
+
+`orbit-server` is the correct direction for the deep-client branch. It gives the
+benefits wanted from FFI/native mode while keeping Orbit as a Python project and
+avoiding user-facing `llama-server` installation in the future.
+
+## Phase 0: Protocol Parity Notes
+
+Implemented in this branch:
+
+- stable request parser for native chat payloads;
+- native response builder with:
+  - `finish_reason`;
+  - `session_id`;
+  - prompt/completion token counts;
+  - reused/evaluated prompt token counts;
+  - prefill/generation timings;
+- OpenAI-like response bridge for current `LlamaServerBackend`;
+- typed native SSE events for future Orbit-native backend adapter;
+- `/sessions` endpoint exposing the currently supported single session;
+- `/cancel` endpoint for backend-owned cancellation.
+
+Differences from `llama-server`:
+
+- `orbit-server` owns KV reuse directly instead of relying on
+  `cache_prompt=true`.
+- Native progress is emitted from the decode loop, not inferred through `/slots`.
+- The native protocol can report `evaluated_tokens` separately from
+  `reused_tokens`.
+- The compatibility endpoint intentionally remains minimal.
+
+Known incompatibilities:
+
+- Tool schemas and llama-server built-in tools are not exposed by
+  `orbit-server`.
+- Multi-session scheduling is not implemented.
+- Native MTP is not implemented.
+
+Decision:
+
+Phase 0 is good enough for continued iteration. It proves the protocol boundary
+and backend ownership model, but it is not ready to replace `llama-server`.
+
+## Phase 1: Chat Template Parity
+
+Implemented in this branch:
+
+- explicit Gemma 4 chat renderer for native mode;
+- support for `system`, `user`, `assistant`, and `tool` messages;
+- support for assistant `tool_calls` in Gemma 4 control-token format;
+- support for tool responses in Gemma 4 control-token format;
+- fallback to the explicit renderer when `llama_chat_apply_template()` cannot
+  apply the model template;
+- generation prompt aligned with the baseline `llama-server --reasoning off`
+  profile;
+- incremental UTF-8 detokenization to avoid corrupting multibyte characters;
+- compatible finish reasons:
+  - `stop`;
+  - `length`;
+  - `cancelled`;
+  - `error`;
+- stop-sequence trimming with early native cancellation.
+
+The native template is intentionally kept in:
+
+```text
+src/orbit/native_llama/chat_template.py
+```
+
+It does not move tool execution, routing, memory, repair, verification, guards,
+or final-answer policy into the backend.
+
+### Native vs llama-server Benchmark
+
+Same payloads, OpenAI-compatible endpoint, small output budgets:
+
+```text
+case                  backend       finish  prompt  output  cached  wall
+chat breve            orbit-server  length      28      32       0  12.30s
+chat breve            llama-server  length      27      32       8   7.70s
+spiegazione tecnica   orbit-server  stop        30      33      13  11.52s
+spiegazione tecnica   llama-server  stop        29      33       8   9.99s
+prompt italiano       orbit-server  stop        34      11      13   5.48s
+prompt italiano       llama-server  stop        33      12       8   3.97s
+coding semplice       orbit-server  stop        38      18      13   8.07s
+coding semplice       llama-server  stop        37      19       8   5.44s
+prompt lungo          orbit-server  stop       588       7      13  48.54s
+prompt lungo          llama-server  stop       587       8       8  49.12s
+output con stop       orbit-server  stop        27       2      13   1.73s
+output con stop       llama-server  stop        26       2      12   2.22s
+max_tokens basso      orbit-server  length      30       3      13   2.31s
+max_tokens basso      llama-server  length      29       3       8   2.43s
+```
+
+Observed qualitative results:
+
+- no Gemma control-token leaks;
+- no empty or corrupted responses;
+- Italian UTF-8 output is preserved;
+- stop sequence output is trimmed correctly;
+- `max_tokens` low returns `finish_reason: length`;
+- native streaming returns deltas and `[DONE]`;
+- Orbit CLI can talk to `orbit-server` through the compatibility endpoint.
+
+Tool-message smoke test:
+
+```text
+assistant tool_call + tool result -> README.md
+finish: stop
+special token leak: false
+```
+
+Differences from `llama-server`:
+
+- prompt token counts differ by one token in simple cases because the native
+  renderer applies the Gemma 4 template explicitly;
+- `orbit-server` reports controlled prefix reuse from its own KV state;
+- generation is currently greedy-only and does not use MTP;
+- OpenAI-compatible streaming remains a bridge and does not expose native
+  progress events.
+
+Decision:
+
+Phase 1 is good enough to proceed to Streaming Parity. Chat formatting is now
+stable enough for comparative work, but `orbit-server` is still experimental
+until streaming, cancellation, session lifecycle, and tool parity are measured
+against the full Orbit regression suites.
+
+## Phase 3: Streaming Parity
+
+Implemented in this branch:
+
+- stop-aware streaming filter for native generation;
+- incremental UTF-8 streaming preserved from Phase 1;
+- no duplicated final content in the OpenAI-compatible stream bridge;
+- native cancellation through `/cancel`;
+- typed native stream events remain available on `/chat/stream`:
+  - `progress.prefill`;
+  - `progress.generation`;
+  - `delta`;
+  - `metrics`;
+  - `done`.
+
+The main bug found in this phase was stop-sequence leakage in streaming mode.
+The non-streamed final content was trimmed, but deltas could already have
+emitted the stop sequence. The fix keeps a small suffix buffer equal to the
+longest possible stop-sequence prefix and emits only text that can no longer be
+part of a stop sequence.
+
+The native backend now distinguishes:
+
+- user/backend cancellation -> `finish_reason: cancelled`;
+- internal stop-sequence abort -> `finish_reason: stop`.
+
+### Streaming Benchmark
+
+Same payloads, OpenAI-compatible streaming endpoint:
+
+```text
+case          backend       finish  TTFT   wall   content
+stream_short  llama-server  stop    2.20s  2.69s  hello
+stream_short  orbit-server  stop    2.29s  2.61s  hello
+stream_stop   llama-server  stop    1.76s  2.43s  alpha
+stream_stop   orbit-server  stop    2.50s  2.82s  alpha
+stream_utf8   llama-server  stop    2.22s  3.32s  città è già qui
+stream_utf8   orbit-server  stop    3.03s  4.87s  città è già qui
+```
+
+Observed:
+
+- no duplicated deltas;
+- no special-token leaks;
+- UTF-8 output is intact;
+- stop sequence is not emitted;
+- final `finish_reason` matches `llama-server`;
+- explicit backend cancellation returns `finish_reason: cancelled`.
+
+Cancellation smoke:
+
+```text
+POST /chat/stream long generation
+POST /cancel after 2s
+finish_reason: cancelled
+wall: 2.02s
+```
+
+Behavioral parity blocker:
+
+`long_command_pressure` initially failed against `orbit-server` while passing
+against `llama-server`.
+
+Root cause:
+
+- the runtime sent OpenAI-compatible `tools`;
+- `llama-server` rendered those tools through the Gemma 4 template;
+- `orbit-server` initially ignored `tools`, so the model missed part of the
+  backend/tool contract during guard-sensitive coding turns.
+
+Fix:
+
+- preserve `tools` in the native protocol request;
+- render Gemma 4 tool declarations inside the system turn using the model's
+  native wrapper:
+  - `<|tool>`;
+  - `declaration:<name>{...}`;
+  - `<tool|>`;
+- keep tool execution, tool selection, repair, memory, guards, and policy in
+  the Orbit runtime.
+
+Additional streaming parser fix:
+
+- native output can include empty Gemma channel blocks such as
+  `<|channel>thought\n<channel|>`;
+- `llama-server` strips these through its chat parser;
+- `orbit-server` now strips generated channel blocks before emitting deltas or
+  final content.
+
+Confirmed blocker result:
+
+```text
+long_command_pressure against orbit-server: PASS
+
+orbit-server:
+  cat parser.py
+  sed local return-value replacement
+  PASS
+
+llama-server:
+  ls -F
+  cat parser.py
+  sed local return-value replacement
+  PASS
+```
+
+### Promotion Run
+
+Full release confidence against `orbit-server`:
+
+```text
+summary: 13/15 passed
+json: /tmp/orbit-release-confidence-native-phase3-promotion.json
+```
+
+Baseline `llama-server` release confidence is documented as:
+
+```text
+summary: 12/15 passed
+```
+
+Residual differences:
+
+```text
+html_multiline_title:
+  orbit-server: FAIL
+  llama-server baseline: FAIL
+  classification: non-blocking known limitation
+  reason: fragile multiline HTML patch generation
+
+css_regex_sensitive:
+  orbit-server: FAIL
+  llama-server baseline: FAIL
+  classification: non-blocking known limitation
+  reason: fragile command generation with regex-sensitive CSS
+
+shell_script_hardening:
+  orbit-server: PASS
+  llama-server baseline: FAIL
+  classification: positive variance / benchmark noise
+  reason: model-driven patch strategy succeeded in this native run
+
+long_command_pressure:
+  orbit-server: PASS
+  llama-server baseline: PASS
+  classification: blocker closed
+  reason: Gemma 4 tool declaration rendering restored model-facing contract
+```
+
+No new blocker was observed.
+
+Decision:
+
+PROMOTE Phase 3.
+
+Phase 3 Streaming Parity is formally promoted. The native backend now matches
+the measured streaming semantics required for continued iteration:
+
+- no duplicated deltas;
+- no control-token leaks;
+- UTF-8 output preserved;
+- stop sequences not emitted;
+- `finish_reason` compatible with `llama-server`;
+- cancellation reports `cancelled`;
+- release confidence is at or above the `llama-server` baseline.
+
+Next phase is Backend Reliability. Do not start it until this promotion state
+is accepted.
+
+## Phase 4: Reliability & Lifecycle Validation
+
+Phase 4 validates one backend reliability risk at a time. It does not include
+performance work, MTP, broad stress testing, or architectural changes.
+
+### Iteration 1: Cancel During Prefill
+
+Risk:
+
+```text
+cancel during prefill
+```
+
+Why this risk first:
+
+- prefill is the longest silent phase on CPU-only systems;
+- cancellation must interrupt native `llama_decode()`, not only disconnect the
+  client;
+- the backend owns cancellation and decode-loop lifecycle.
+
+Minimal test:
+
+- start `orbit-server`;
+- send `/chat/stream` with a long prompt;
+- wait for `progress.prefill` where `current < total`;
+- call `/cancel`;
+- expect `done` with `finish_reason: cancelled`;
+- expect no generation progress before cancellation.
+
+Observed result:
+
+```text
+status: PASS
+first_prefill: 64/10828
+prefill_events: 2
+generation_events: 0
+finish_reason: cancelled
+wall: 3.9s
+```
+
+Decision:
+
+PASS. No fix required.
+
+Next recommended risk:
+
+```text
+client disconnect during stream
+```
+
+### Iteration 2: Client Disconnect During Stream
+
+Risk:
+
+```text
+client disconnect during stream
+```
+
+Minimal test:
+
+- start `orbit-server`;
+- send `/chat/stream` with a long generation request;
+- wait for the first SSE progress/generation event;
+- close the client connection without calling `/cancel`;
+- verify `/health`;
+- immediately send a short `/chat` request to check whether the backend lock
+  was released.
+
+Observed before fix:
+
+```text
+stream_status: 200
+events: progress.prefill, progress.generation
+client_closed: yes
+health: ok
+follow-up /chat: timeout
+```
+
+The native server remained healthy, but the abandoned generation continued to
+occupy the single backend context until it finished or reached its token limit.
+
+Options evaluated:
+
+```text
+stdlib watchdog/lifecycle:
+  complexity: low
+  reliability: good for real TCP close/EOF, still dependent on OS socket state
+  impact: backend HTTP layer only
+  regression risk: low
+  validation: raw streaming client closes TCP connection, then /chat must respond
+
+minimal ASGI streaming layer:
+  complexity: medium/high
+  reliability: stronger request disconnect signal
+  impact: new dependency/server lifecycle
+  regression risk: higher
+  validation: ASGI receive loop observes http.disconnect during SSE
+```
+
+Decision:
+
+Use the stdlib lifecycle watcher first. It is the smallest backend-only change
+and avoids migrating the experimental server before proving a real need.
+
+Implemented:
+
+- catch `BrokenPipeError` and `ConnectionResetError` while writing SSE events;
+- cancel the native client when SSE writes fail;
+- pass a backend-owned `should_cancel` predicate into the native decode loop;
+- check socket hangup using `poll()`/`POLLRDHUP` plus a `select()`/`MSG_PEEK`
+  fallback before progress and delta writes;
+- add a request-scoped disconnect watcher for streaming requests;
+- the watcher observes EOF/error on the HTTP socket in parallel with model
+  generation and calls `client.cancel()` when the peer disconnects.
+
+Observed with a high-level `HTTPConnection` close:
+
+```text
+stream_status: 200
+events: progress.prefill, progress.generation
+client_closed: yes
+health: ok
+follow-up /chat: timeout
+```
+
+That case did not produce an immediate observable TCP EOF from the server side
+and is not a reliable disconnect validation.
+
+Observed with a raw TCP streaming client that closes the connection:
+
+```text
+sent: yes
+saw_event: true
+raw_close: yes
+health: ok
+follow-up /chat: ok, 2.08s
+```
+
+Decision:
+
+PASS for real client disconnect.
+
+The fix is backend-only. It does not move runtime behavior, tool handling,
+guards, repair, memory, or final-answer policy into `orbit-server`.
+
+Remaining caveat:
+
+The stdlib server still has no framework-level `request.is_disconnected()`.
+If future clients expose cases where TCP EOF is delayed or hidden, the next
+step should be a minimal ASGI streaming layer rather than more prompt/runtime
+logic.
+
+### Iteration 3: Internal Error During Stream
+
+Risk:
+
+```text
+internal backend error during stream
+```
+
+Minimal test:
+
+- run an in-process native server with a fake backend;
+- emit `progress.prefill`;
+- emit one partial `delta`;
+- emit `progress.generation`;
+- raise `RuntimeError("injected backend failure during stream")`;
+- verify stream termination and follow-up request reuse.
+
+Observed:
+
+```text
+events: progress.prefill, delta, progress.generation, error, done
+error: injected backend failure during stream
+finish_reason: error
+follow-up /chat: ok, 0.03s
+```
+
+Decision:
+
+PASS. No fix required.
+
+The existing stream error path emits an explicit `error` event and `done` with
+`finish_reason: error`, then releases the backend lock. The next request can
+reuse the session normally.
+
+### Iteration 4: Repeated Interrupted Streams
+
+Risk:
+
+```text
+session cleanup after repeated interrupted streams
+```
+
+Minimal test:
+
+- use the real backend;
+- run 5 `/chat/stream` requests;
+- wait for first generation events;
+- call `/cancel`;
+- verify each stream ends and a final `/chat` succeeds.
+
+Observed:
+
+```text
+iterations: 5
+each stream: finish_reason=cancelled
+stream threads alive after cancel: false
+follow-up /chat: ok, 2.57s
+```
+
+Decision:
+
+PASS. No fix required.
+
+Repeated cancellations did not leave visible lock, session, or thread state
+behind.
+
+### Iteration 5: Malformed Requests
+
+Risk:
+
+```text
+malformed requests
+```
+
+Minimal test:
+
+- invalid JSON;
+- empty body;
+- missing `messages`;
+- wrong `messages` type;
+- invalid `max_tokens`;
+- then a valid `/chat`.
+
+Observed before fix:
+
+Some malformed payloads started real generation with an empty/default prompt.
+This could occupy the native context and cause client timeouts.
+
+Fix:
+
+- request parser now rejects malformed `messages`;
+- `messages` must be a non-empty list of message objects, unless legacy
+  `prompt` is a string;
+- `max_tokens`, when present, must be a positive integer;
+- request parsing errors now return HTTP 400.
+
+Observed after fix:
+
+```text
+invalid_json:        400 {"error": "invalid JSON"}
+empty_body:          400 {"error": "messages must be a list"}
+missing_messages:    400 {"error": "messages must be a list"}
+messages_wrong_type: 400 {"error": "messages must be a list"}
+max_tokens_invalid:  400 {"error": "max_tokens must be a positive integer"}
+follow-up /chat:     ok, 3.13s
+```
+
+Decision:
+
+PASS after parser fix.
+
+### Iteration 6: Malformed Requests and Cancellation Mix
+
+Risk:
+
+```text
+session reuse after malformed requests and cancellation mix
+```
+
+Minimal test:
+
+```text
+1. malformed request
+2. valid request
+3. long stream
+4. cancel
+5. malformed request
+6. valid request
+```
+
+Observed:
+
+```text
+step1 malformed: 400 invalid JSON
+step2 valid:     200 alpha., 3.55s
+step4 cancel:    200 cancel_requested
+step3 stream:    finish_reason=cancelled
+step5 malformed: 400 messages must be a list
+step6 valid:     200 omega., 3.65s
+```
+
+Decision:
+
+PASS. No fix required beyond the malformed request parser fix.
+
+Malformed requests and cancellation do not contaminate the shared native
+session or the reused context in the measured sequence.
+
+## Phase 4 Promotion Decision
+
+Final status:
+
+```text
+PROMOTE Phase 4
+```
+
+Risks investigated:
+
+```text
+cancel during prefill: PASS
+client disconnect during stream: PASS with caveat
+internal error during stream: PASS
+repeated interrupted streams: PASS
+malformed requests: PASS after fix
+malformed + cancellation mix: PASS
+```
+
+Lifecycle bugs fixed:
+
+- abandoned streaming generation after real client disconnect;
+- malformed requests starting generation with empty/default prompts;
+- malformed request errors returning non-specific conflict status.
+
+Risks validated without code changes:
+
+- cancel during prefill;
+- internal backend exception during stream;
+- repeated interrupted streams;
+- malformed/cancel mixed session reuse.
+
+Open blockers:
+
+```text
+none
+```
+
+Non-blocking caveat:
+
+- `ThreadingHTTPServer` has no framework-level `request.is_disconnected()`.
+  The current watcher handles real TCP EOF/error. If a future client hides or
+  delays EOF, evaluate a minimal ASGI streaming layer instead of adding runtime
+  behavior.
+
+Future hardening:
+
+- validate session cleanup after backend load/model errors;
+- validate malformed native `/v1/chat/completions` bridge payloads separately;
+- add a focused regression test for malformed request parsing once the native
+  server files are promoted out of experiment.
+
+Decision rationale:
+
+Phase 4 validated the main lifecycle risks for the current single-session
+native backend without moving runtime behavior into `orbit-server`. The backend
+now handles cancellation, stream errors, repeated interruptions, malformed
+requests, and mixed malformed/cancel sequences well enough to continue to the
+next roadmap phase.
+
+Next phase:
+
+```text
+Phase 5: Performance Parity
+```
+
+Do not start Phase 5 until this promotion state is accepted.
+
+## Current MTP Experimental State
+
+The persistent MTP path has an additional experimental branch controlled by:
+
+```text
+ORBIT_MTP_BOUNDARY_SPLIT=0|1
+```
+
+Status:
+
+- The boundary-split path is now the candidate default for persistent MTP.
+- Default no-flag behavior enables the split path.
+- `ORBIT_MTP_BOUNDARY_SPLIT=0` forces the rollback behavior for comparison and
+  safe disablement.
+- Runtime fallback and invariant checks remain active if the live boundary is
+  not safe.
+
+Boundary-split notes:
+
+- The split path separates the logical frontier size from the validate batch
+  starting position.
+- The goal is to match the server-side partial/live boundary more closely while
+  preserving the old path as an opt-out fallback.
+- Because long-prompt behavior can diverge from the baseline while still being
+  reference-like, correctness should be judged against the MTP invariants and
+  reference path, not only against the old default output.
+
+Draft helper policy:
+
+- The MTP draft helper currently uses an intentional `top1-greedy` policy.
+- `common_sampler_sample(...)` may return a token different from the highest
+  probability candidate.
+- That sampled token is not the committed draft token in the current helper.
+- The committed draft token is the sorted top-1 candidate and must stay aligned
+  with:
+  - sampler accept;
+  - `spec_draft` push;
+  - next draft decode input.
+- A naive switch to sampled-token draft policy regressed CPU-only latency and
+  acceptance on real prompts, so no sampled-token draft policy is enabled.
+
+Debugging aids kept intentionally gated:
+
+- `LLAMA_MTP_DRAFT_MISMATCH_TRACE=1`
+
+These traces are for boundary-level diagnosis only and should stay off during
+normal benchmarking.
+
+CPU-only benchmark discipline:
+
+- Use fixed CPU affinity for comparable runs, for example `taskset -c 0-5`.
+- Keep the same threads, batch, ubatch, prompt, model, and draft model between
+  runs.
+- Tail latency on CPU-only systems is sensitive to scheduler noise; do not
+  promote or reject an experimental MTP change from one-off median measurements
+  without controlled repeated runs.

--- a/src/orbit/native_llama/__init__.py
+++ b/src/orbit/native_llama/__init__.py
@@ -1,0 +1,7 @@
+"""Experimental native llama.cpp client.
+
+This package is intentionally isolated from the production llama-server backend.
+It exists to measure whether direct llama.cpp control is worth the maintenance
+cost.
+"""
+

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from ctypes import (
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+    c_bool,
+    c_char,
+    c_char_p,
+    c_float,
+    c_int,
+    c_int8,
+    c_int32,
+    c_size_t,
+    c_uint32,
+    c_void_p,
+    cast,
+)
+from pathlib import Path
+import ctypes
+import os
+
+
+llama_token = c_int32
+llama_pos = c_int32
+llama_seq_id = c_int32
+
+LlamaProgressCallback = CFUNCTYPE(c_bool, c_float, c_void_p)
+GgmlAbortCallback = CFUNCTYPE(c_bool, c_void_p)
+GgmlLogCallback = CFUNCTYPE(None, c_int, c_char_p, c_void_p)
+
+
+class LlamaBatch(Structure):
+    _fields_ = [
+        ("n_tokens", c_int32),
+        ("token", POINTER(llama_token)),
+        ("embd", POINTER(c_float)),
+        ("pos", POINTER(llama_pos)),
+        ("n_seq_id", POINTER(c_int32)),
+        ("seq_id", POINTER(POINTER(llama_seq_id))),
+        ("logits", POINTER(c_int8)),
+    ]
+
+
+class LlamaModelParams(Structure):
+    _fields_ = [
+        ("devices", c_void_p),
+        ("tensor_buft_overrides", c_void_p),
+        ("n_gpu_layers", c_int32),
+        ("split_mode", c_int),
+        ("main_gpu", c_int32),
+        ("tensor_split", POINTER(c_float)),
+        ("progress_callback", LlamaProgressCallback),
+        ("progress_callback_user_data", c_void_p),
+        ("kv_overrides", c_void_p),
+        ("vocab_only", c_bool),
+        ("use_mmap", c_bool),
+        ("use_direct_io", c_bool),
+        ("use_mlock", c_bool),
+        ("check_tensors", c_bool),
+        ("use_extra_bufts", c_bool),
+        ("no_host", c_bool),
+        ("no_alloc", c_bool),
+    ]
+
+
+class LlamaContextParams(Structure):
+    _fields_ = [
+        ("n_ctx", c_uint32),
+        ("n_batch", c_uint32),
+        ("n_ubatch", c_uint32),
+        ("n_seq_max", c_uint32),
+        ("n_rs_seq", c_uint32),
+        ("n_outputs_max", c_uint32),
+        ("n_threads", c_int32),
+        ("n_threads_batch", c_int32),
+        ("ctx_type", c_int),
+        ("rope_scaling_type", c_int),
+        ("pooling_type", c_int),
+        ("attention_type", c_int),
+        ("flash_attn_type", c_int),
+        ("rope_freq_base", c_float),
+        ("rope_freq_scale", c_float),
+        ("yarn_ext_factor", c_float),
+        ("yarn_attn_factor", c_float),
+        ("yarn_beta_fast", c_float),
+        ("yarn_beta_slow", c_float),
+        ("yarn_orig_ctx", c_uint32),
+        ("defrag_thold", c_float),
+        ("cb_eval", c_void_p),
+        ("cb_eval_user_data", c_void_p),
+        ("type_k", c_int),
+        ("type_v", c_int),
+        ("abort_callback", GgmlAbortCallback),
+        ("abort_callback_data", c_void_p),
+        ("embeddings", c_bool),
+        ("offload_kqv", c_bool),
+        ("no_perf", c_bool),
+        ("op_offload", c_bool),
+        ("swa_full", c_bool),
+        ("kv_unified", c_bool),
+        ("samplers", c_void_p),
+        ("n_samplers", c_size_t),
+        ("ctx_other", c_void_p),
+    ]
+
+
+class LlamaSamplerChainParams(Structure):
+    _fields_ = [("no_perf", c_bool)]
+
+
+class LlamaChatMessage(Structure):
+    _fields_ = [
+        ("role", c_char_p),
+        ("content", c_char_p),
+    ]
+
+
+class LlamaLibrary:
+    def __init__(self, build_bin: Path) -> None:
+        self.build_bin = build_bin
+        self._handles: list[CDLL] = []
+        self.lib = self._load_library("libllama.so")
+        self._configure_api()
+
+    def _load_library(self, name: str) -> CDLL:
+        flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+        # Load dependencies explicitly because LD_LIBRARY_PATH cannot be changed
+        # reliably after Python startup.
+        for dep in ("libggml-base.so", "libggml.so", "libggml-cpu.so", "libllama-common.so"):
+            path = self.build_bin / dep
+            if path.exists():
+                try:
+                    self._handles.append(ctypes.CDLL(str(path), mode=flags))
+                except OSError:
+                    pass
+        return ctypes.CDLL(str(self.build_bin / name), mode=flags)
+
+    def _configure_api(self) -> None:
+        lib = self.lib
+        lib.ggml_backend_load_all.argtypes = []
+        lib.ggml_backend_load_all.restype = None
+        lib.llama_backend_free.argtypes = []
+        lib.llama_backend_free.restype = None
+        lib.llama_log_set.argtypes = [GgmlLogCallback, c_void_p]
+        lib.llama_log_set.restype = None
+
+        lib.llama_model_default_params.argtypes = []
+        lib.llama_model_default_params.restype = LlamaModelParams
+        lib.llama_context_default_params.argtypes = []
+        lib.llama_context_default_params.restype = LlamaContextParams
+        lib.llama_sampler_chain_default_params.argtypes = []
+        lib.llama_sampler_chain_default_params.restype = LlamaSamplerChainParams
+
+        lib.llama_model_load_from_file.argtypes = [c_char_p, LlamaModelParams]
+        lib.llama_model_load_from_file.restype = c_void_p
+        lib.llama_model_free.argtypes = [c_void_p]
+        lib.llama_model_free.restype = None
+        lib.llama_init_from_model.argtypes = [c_void_p, LlamaContextParams]
+        lib.llama_init_from_model.restype = c_void_p
+        lib.llama_free.argtypes = [c_void_p]
+        lib.llama_free.restype = None
+        lib.llama_get_memory.argtypes = [c_void_p]
+        lib.llama_get_memory.restype = c_void_p
+        lib.llama_memory_clear.argtypes = [c_void_p, c_bool]
+        lib.llama_memory_clear.restype = None
+        lib.llama_memory_seq_rm.argtypes = [c_void_p, c_int32, c_int32, c_int32]
+        lib.llama_memory_seq_rm.restype = c_bool
+
+        lib.llama_model_get_vocab.argtypes = [c_void_p]
+        lib.llama_model_get_vocab.restype = c_void_p
+        lib.llama_model_chat_template.argtypes = [c_void_p, c_char_p]
+        lib.llama_model_chat_template.restype = c_char_p
+        lib.llama_chat_apply_template.argtypes = [
+            c_char_p,
+            POINTER(LlamaChatMessage),
+            c_size_t,
+            c_bool,
+            POINTER(c_char),
+            c_int32,
+        ]
+        lib.llama_chat_apply_template.restype = c_int32
+        lib.llama_tokenize.argtypes = [c_void_p, c_char_p, c_int32, POINTER(llama_token), c_int32, c_bool, c_bool]
+        lib.llama_tokenize.restype = c_int32
+        lib.llama_token_to_piece.argtypes = [c_void_p, llama_token, POINTER(c_char), c_int32, c_int32, c_bool]
+        lib.llama_token_to_piece.restype = c_int32
+        lib.llama_vocab_is_eog.argtypes = [c_void_p, llama_token]
+        lib.llama_vocab_is_eog.restype = c_bool
+
+        lib.llama_batch_get_one.argtypes = [POINTER(llama_token), c_int32]
+        lib.llama_batch_get_one.restype = LlamaBatch
+        lib.llama_decode.argtypes = [c_void_p, LlamaBatch]
+        lib.llama_decode.restype = c_int32
+        lib.llama_time_us.argtypes = []
+        lib.llama_time_us.restype = ctypes.c_int64
+
+        lib.llama_sampler_chain_init.argtypes = [LlamaSamplerChainParams]
+        lib.llama_sampler_chain_init.restype = c_void_p
+        lib.llama_sampler_chain_add.argtypes = [c_void_p, c_void_p]
+        lib.llama_sampler_chain_add.restype = None
+        lib.llama_sampler_init_greedy.argtypes = []
+        lib.llama_sampler_init_greedy.restype = c_void_p
+        lib.llama_sampler_sample.argtypes = [c_void_p, c_void_p, c_int32]
+        lib.llama_sampler_sample.restype = llama_token
+        lib.llama_sampler_accept.argtypes = [c_void_p, llama_token]
+        lib.llama_sampler_accept.restype = None
+        lib.llama_sampler_reset.argtypes = [c_void_p]
+        lib.llama_sampler_reset.restype = None
+        lib.llama_sampler_free.argtypes = [c_void_p]
+        lib.llama_sampler_free.restype = None

--- a/src/orbit/native_llama/chat_template.py
+++ b/src/orbit/native_llama/chat_template.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+NativeMessage = dict[str, Any]
+
+
+def render_gemma4_chat(
+    messages: list[NativeMessage],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    add_generation_prompt: bool = True,
+) -> str:
+    chunks: list[str] = ["<bos>"]
+    start = 0
+    if messages and messages[0].get("role") in {"system", "developer"}:
+        chunks.append("<|turn>system\n")
+        chunks.append(_content_text(messages[0]).strip())
+        tool_text = _render_tools(tools or [])
+        if tool_text:
+            chunks.append("\n\n")
+            chunks.append(tool_text)
+        chunks.append("<turn|>\n")
+        start = 1
+    elif tools:
+        chunks.append("<|turn>system\n")
+        chunks.append(_render_tools(tools))
+        chunks.append("<turn|>\n")
+
+    for message in messages[start:]:
+        role = message.get("role")
+        if role == "tool":
+            chunks.append(_render_tool_response(message))
+            continue
+        gemma_role = "model" if role == "assistant" else str(role or "user")
+        chunks.append(f"<|turn>{gemma_role}\n")
+        content = _strip_thinking(_content_text(message)).strip()
+        if content:
+            chunks.append(content)
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                if isinstance(tool_call, dict):
+                    chunks.append(_render_tool_call(tool_call))
+        chunks.append("<turn|>\n")
+
+    if add_generation_prompt:
+        chunks.append("<|turn>model\n")
+        chunks.append("<|channel>thought\n<channel|>")
+    return "".join(chunks)
+
+
+def _content_text(message: NativeMessage) -> str:
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return " ".join(parts)
+    return ""
+
+
+def _render_tool_call(tool_call: dict[str, Any]) -> str:
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return ""
+    name = function.get("name")
+    if not isinstance(name, str) or not name:
+        return ""
+    arguments = _arguments_mapping(function.get("arguments"))
+    return f"<|tool_call>call:{name}{{{_format_mapping(arguments)}}}<tool_call|>"
+
+
+def _render_tool_response(message: NativeMessage) -> str:
+    name = message.get("name")
+    if not isinstance(name, str) or not name:
+        name = "tool"
+    content = _content_text(message)
+    return f"<|tool_response>response:{name}{{value:{_format_argument(content)}}}<tool_response|>"
+
+
+def _render_tools(tools: list[dict[str, Any]]) -> str:
+    functions: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if isinstance(function, dict) and isinstance(function.get("name"), str):
+            functions.append(function)
+    if not functions:
+        return ""
+    return "".join(f"<|tool>{_format_function_declaration(function)}<tool|>" for function in functions)
+
+
+def _format_function_declaration(function: dict[str, Any]) -> str:
+    name = function["name"]
+    description = function.get("description", "")
+    params = function.get("parameters")
+    result = f'declaration:{name}{{description:{_format_argument(str(description))}'
+    if isinstance(params, dict):
+        result += ",parameters:{" + _format_parameters_object(params) + "}"
+    return result + "}"
+
+
+def _format_parameters_object(params: dict[str, Any]) -> str:
+    parts: list[str] = []
+    properties = params.get("properties")
+    if isinstance(properties, dict) and properties:
+        parts.append("properties:{" + _format_parameter_properties(properties) + "}")
+    required = params.get("required")
+    if isinstance(required, list) and required:
+        parts.append("required:[" + ",".join(_format_argument(item) for item in required if isinstance(item, str)) + "]")
+    param_type = params.get("type")
+    if isinstance(param_type, str) and param_type:
+        parts.append("type:" + _format_argument(param_type.upper()))
+    return ",".join(parts)
+
+
+def _format_parameter_properties(properties: dict[str, Any]) -> str:
+    rendered: list[str] = []
+    for key in sorted(properties):
+        value = properties[key]
+        if not isinstance(value, dict):
+            continue
+        fields: list[str] = []
+        description = value.get("description")
+        if isinstance(description, str) and description:
+            fields.append("description:" + _format_argument(description))
+        value_type = value.get("type")
+        if isinstance(value_type, str) and value_type:
+            fields.append("type:" + _format_argument(value_type.upper()))
+        if fields:
+            rendered.append(f"{key}:{{{','.join(fields)}}}")
+    return ",".join(rendered)
+
+
+def _arguments_mapping(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"value": value}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {}
+
+
+def _format_mapping(mapping: dict[str, Any]) -> str:
+    return ",".join(f"{key}:{_format_argument(mapping[key])}" for key in sorted(mapping))
+
+
+def _format_argument(value: object) -> str:
+    if isinstance(value, str):
+        return f'<|"|>{value}<|"|>'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, dict):
+        return "{" + _format_mapping(value) + "}"
+    if isinstance(value, list | tuple):
+        return "[" + ",".join(_format_argument(item) for item in value) + "]"
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _strip_thinking(text: str) -> str:
+    result = ""
+    for part in text.split("<channel|>"):
+        if "<|channel>" in part:
+            result += part.split("<|channel>", 1)[0]
+        else:
+            result += part
+    return result

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1,0 +1,752 @@
+from __future__ import annotations
+
+import codecs
+from ctypes import POINTER, byref, c_char, cast, c_float, create_string_buffer, c_void_p, sizeof
+from dataclasses import dataclass, replace
+from pathlib import Path
+import threading
+
+from .bindings import (
+    GgmlAbortCallback,
+    GgmlLogCallback,
+    LlamaLibrary,
+    LlamaChatMessage,
+    LlamaProgressCallback,
+    llama_token,
+)
+from .chat_template import NativeMessage, render_gemma4_chat
+from .events import NativeCompletion, NativeProgress, NativeTimings
+from .mtp_completion import MtpCompletionResult
+from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
+from .mtp_accept_probe import MtpAcceptProbeResult, run_mtp_accept_probe
+from .mtp_dry_run import MtpDryRunResult, run_mtp_dry_run
+from .mtp_probe import MtpProbeResult, run_mtp_probe
+from .paths import NativeLlamaPaths
+from .persistent_mtp import (
+    PersistentMtpSessionRuntime,
+    create_persistent_mtp_session,
+    free_persistent_mtp_session,
+    reset_persistent_mtp_session,
+    run_persistent_mtp_completion,
+)
+from .session_state import DEFAULT_NATIVE_SESSION_ID, NativeSessionSnapshot, NativeSessionState
+
+
+@dataclass(frozen=True)
+class NativeClientConfig:
+    context_tokens: int = 8192
+    threads: int = 6
+    threads_batch: int = 6
+    batch_size: int = 256
+    ubatch_size: int = 128
+    progress_step: int = 64
+    gpu_layers: int = 0
+    mtp_probe_enabled: bool = False
+    mtp_dry_run_enabled: bool = False
+    mtp_accept_probe_enabled: bool = False
+    mtp_decode_probe_enabled: bool = False
+    use_mtp_experimental: bool = False
+
+
+class NativeLlamaClient:
+    def __init__(self, paths: NativeLlamaPaths, config: NativeClientConfig | None = None) -> None:
+        self.paths = paths
+        self.config = config or NativeClientConfig()
+        self.lib = LlamaLibrary(paths.build_bin)
+        self.cancel_event = threading.Event()
+        self._callbacks: list[object] = []
+        self._model: c_void_p | None = None
+        self._vocab: c_void_p | None = None
+        self._session = NativeSessionState(session_id=DEFAULT_NATIVE_SESSION_ID)
+        self.mtp_probe = MtpProbeResult(enabled=self.config.mtp_probe_enabled, initialized=False, error=None)
+        self.mtp_dry_run = MtpDryRunResult(enabled=self.config.mtp_dry_run_enabled, success=False, error=None)
+        self.mtp_accept_probe = MtpAcceptProbeResult(enabled=self.config.mtp_accept_probe_enabled, success=False, error=None)
+        self.mtp_decode_probe = MtpDecodeProbeResult(enabled=self.config.mtp_decode_probe_enabled, success=False, error=None)
+        self.last_mtp_completion = MtpCompletionResult(enabled=self.config.use_mtp_experimental, success=False, error=None)
+        self.mtp_fallback_reason: str | None = None
+        self._persistent_mtp_runtime: PersistentMtpSessionRuntime | None = None
+
+    def session_snapshot(self, session_id: str = DEFAULT_NATIVE_SESSION_ID) -> NativeSessionSnapshot:
+        if session_id != self._session.session_id:
+            raise ValueError("only the default native session is supported in this experiment")
+        return self._session.snapshot(backend_mode="no-mtp")
+
+    def set_quiet_logging(self) -> None:
+        def log_cb(_level: int, _text: bytes, _data) -> None:
+            return None
+
+        cb = GgmlLogCallback(log_cb)
+        self._callbacks.append(cb)
+        self.lib.lib.llama_log_set(cb, None)
+
+    def close(self) -> None:
+        lib = self.lib.lib
+        self._free_persistent_mtp_session()
+        if self._session.sampler:
+            lib.llama_sampler_free(self._session.sampler)
+            self._session.sampler = None
+        if self._session.ctx_tgt:
+            lib.llama_free(self._session.ctx_tgt)
+            self._session.ctx_tgt = None
+        if self._model:
+            lib.llama_model_free(self._model)
+            self._model = None
+        lib.llama_backend_free()
+
+    def cancel(self) -> None:
+        self._session.cancel_requested = True
+        self.cancel_event.set()
+
+    def reset_cancel(self) -> None:
+        self._session.cancel_requested = False
+        self.cancel_event.clear()
+
+    def load(self, on_progress=None) -> None:
+        lib = self.lib.lib
+        lib.ggml_backend_load_all()
+
+        def load_cb(progress: float, _data) -> bool:
+            if on_progress:
+                on_progress(NativeProgress("load", int(progress * 100), 100))
+            return not self.cancel_event.is_set()
+
+        progress_cb = LlamaProgressCallback(load_cb)
+        abort_cb = GgmlAbortCallback(lambda _data: self.cancel_event.is_set())
+        self._callbacks.extend([progress_cb, abort_cb])
+
+        model_params = lib.llama_model_default_params()
+        model_params.n_gpu_layers = self.config.gpu_layers
+        model_params.progress_callback = progress_cb
+        model_params.progress_callback_user_data = None
+
+        self._model = lib.llama_model_load_from_file(str(self.paths.model).encode(), model_params)
+        if not self._model:
+            raise RuntimeError(f"failed to load model: {self.paths.model}")
+
+        ctx_params = lib.llama_context_default_params()
+        ctx_params.n_ctx = self.config.context_tokens
+        ctx_params.n_batch = self.config.batch_size
+        ctx_params.n_ubatch = self.config.ubatch_size
+        ctx_params.n_threads = self.config.threads
+        ctx_params.n_threads_batch = self.config.threads_batch
+        ctx_params.n_outputs_max = 1 + 3
+        ctx_params.abort_callback = abort_cb
+        ctx_params.abort_callback_data = None
+        ctx_params.no_perf = False
+
+        self._session.ctx_tgt = lib.llama_init_from_model(self._model, ctx_params)
+        if not self._session.ctx_tgt:
+            raise RuntimeError("failed to create llama context")
+
+        self._vocab = lib.llama_model_get_vocab(self._model)
+        sampler_params = lib.llama_sampler_chain_default_params()
+        sampler_params.no_perf = False
+        self._session.sampler = lib.llama_sampler_chain_init(sampler_params)
+        lib.llama_sampler_chain_add(self._session.sampler, lib.llama_sampler_init_greedy())
+        self._initialize_mtp_probe()
+        self._initialize_mtp_dry_run()
+        self._initialize_mtp_accept_probe()
+        self._initialize_mtp_decode_probe()
+        self._initialize_persistent_mtp_session()
+
+    def _initialize_mtp_probe(self) -> None:
+        if not self.config.mtp_probe_enabled:
+            self.mtp_probe = MtpProbeResult(enabled=False, initialized=False, error=None)
+            return
+        self.mtp_probe = run_mtp_probe(llama_root=self.paths.llama_root, paths=self.paths)
+
+    def _initialize_mtp_dry_run(self) -> None:
+        if not self.config.mtp_dry_run_enabled:
+            self.mtp_dry_run = MtpDryRunResult(enabled=False, success=False, error=None)
+            return
+        self.mtp_dry_run = run_mtp_dry_run(llama_root=self.paths.llama_root, paths=self.paths)
+
+    def _initialize_mtp_accept_probe(self) -> None:
+        if not self.config.mtp_accept_probe_enabled:
+            self.mtp_accept_probe = MtpAcceptProbeResult(enabled=False, success=False, error=None)
+            return
+        self.mtp_accept_probe = run_mtp_accept_probe(llama_root=self.paths.llama_root, paths=self.paths)
+
+    def _initialize_mtp_decode_probe(self) -> None:
+        if not self.config.mtp_decode_probe_enabled:
+            self.mtp_decode_probe = MtpDecodeProbeResult(enabled=False, success=False, error=None)
+            return
+        self.mtp_decode_probe = run_mtp_decode_probe(llama_root=self.paths.llama_root, paths=self.paths)
+
+    def _initialize_persistent_mtp_session(self) -> None:
+        self._free_persistent_mtp_session()
+        self._session.ctx_dft = None
+        self._session.spec = None
+        self._session.mtp_enabled = False
+        self._session.mtp_failed = False
+        self._session.mtp_failure_reason = None
+        if not self.paths.mtp_available or self.paths.draft_mtp_model is None:
+            self._session.mtp_failure_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
+            return
+        if not self._session.ctx_tgt:
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = "target-context-missing"
+            return
+        try:
+            runtime = create_persistent_mtp_session(
+                llama_root=self.paths.llama_root,
+                paths=self.paths,
+                ctx_tgt=self._session.ctx_tgt,
+                context_tokens=self.config.context_tokens,
+                batch_size=self.config.batch_size,
+                ubatch_size=self.config.ubatch_size,
+                threads=self.config.threads,
+                threads_batch=self.config.threads_batch,
+            )
+        except Exception as exc:
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = str(exc)
+            return
+        self._persistent_mtp_runtime = runtime
+        self._session.ctx_dft = runtime.ctx_dft
+        self._session.spec = runtime.spec
+        self._session.mtp_enabled = True
+        self._session.mtp_failed = False
+
+    def reset_session_state(self) -> None:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        lib = self.lib.lib
+        self.reset_cancel()
+        mem = lib.llama_get_memory(self._session.ctx_tgt)
+        if mem:
+            lib.llama_memory_clear(mem, True)
+        self._session.cached_prompt_tokens.clear()
+        self._session.last_metrics = None
+        if self._persistent_mtp_runtime is None:
+            return
+        try:
+            runtime = reset_persistent_mtp_session(
+                llama_root=self.paths.llama_root,
+                paths=self.paths,
+                runtime=self._persistent_mtp_runtime,
+                ctx_tgt=self._session.ctx_tgt,
+            )
+        except Exception as exc:
+            self._session.mtp_enabled = False
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = str(exc)
+            self._session.ctx_dft = None
+            self._session.spec = None
+            self._persistent_mtp_runtime = None
+            return
+        self._persistent_mtp_runtime = runtime
+        self._session.ctx_dft = runtime.ctx_dft
+        self._session.spec = runtime.spec
+        self._session.mtp_enabled = True
+        self._session.mtp_failed = False
+        self._session.mtp_failure_reason = None
+
+    def _free_persistent_mtp_session(self) -> None:
+        if self._persistent_mtp_runtime is None:
+            return
+        try:
+            free_persistent_mtp_session(
+                llama_root=self.paths.llama_root,
+                paths=self.paths,
+                runtime=self._persistent_mtp_runtime,
+            )
+        finally:
+            self._persistent_mtp_runtime = None
+            self._session.ctx_dft = None
+            self._session.spec = None
+            self._session.mtp_enabled = False
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 16,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeTimings:
+        return self.complete_prompt(
+            prompt,
+            max_tokens=max_tokens,
+            on_progress=on_progress,
+            on_token=on_token,
+            should_cancel=should_cancel,
+        )
+
+    def complete_chat(
+        self,
+        messages: list[NativeMessage],
+        *,
+        max_tokens: int = 16,
+        tools: list[dict] | None = None,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeTimings:
+        prompt = self.apply_chat_template(messages, tools=tools)
+        return self.complete_prompt(
+            prompt,
+            max_tokens=max_tokens,
+            allow_mtp_experimental=not tools and not any(message.get("role") == "tool" or message.get("tool_calls") for message in messages),
+            on_progress=on_progress,
+            on_token=on_token,
+            should_cancel=should_cancel,
+        )
+
+    def complete_chat_text(
+        self,
+        messages: list[NativeMessage],
+        *,
+        max_tokens: int = 16,
+        stop: tuple[str, ...] = (),
+        tools: list[dict] | None = None,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeCompletion:
+        parts: list[str] = []
+        channel_filter = _ControlChannelStreamFilter()
+        stop_filter = _StopSequenceStreamFilter(stop, emit=parts.append) if stop else None
+
+        def collect(text: str) -> None:
+            for visible_text in channel_filter.write(text):
+                if stop_filter:
+                    for delta in stop_filter.write(visible_text):
+                        if on_token:
+                            on_token(delta)
+                    if stop_filter.stopped:
+                        self.cancel()
+                    continue
+                parts.append(visible_text)
+                if on_token:
+                    on_token(visible_text)
+            if stop_filter and stop_filter.stopped:
+                self.cancel()
+                return
+
+        def flush_filters() -> None:
+            for visible_text in channel_filter.finish():
+                if stop_filter:
+                    for delta in stop_filter.write(visible_text):
+                        if on_token:
+                            on_token(delta)
+                    continue
+                parts.append(visible_text)
+                if on_token:
+                    on_token(visible_text)
+            if stop_filter:
+                for delta in stop_filter.finish():
+                    if on_token:
+                        on_token(delta)
+
+        timings = self.complete_chat(
+            messages,
+            max_tokens=max_tokens,
+            tools=tools,
+            on_progress=on_progress,
+            on_token=collect,
+            should_cancel=should_cancel,
+        )
+        flush_filters()
+        content = _trim_at_stop("".join(parts), stop)
+        return NativeCompletion(content=content, timings=timings, stopped_by_stop=bool(stop_filter and stop_filter.stopped))
+
+    def complete_prompt(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 16,
+        allow_mtp_experimental: bool = True,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeTimings:
+        self._session.in_flight = True
+        try:
+            if allow_mtp_experimental and should_cancel is None:
+                mtp_result = self._try_complete_with_mtp_experimental(
+                    prompt,
+                    max_tokens=max_tokens,
+                    on_token=on_token,
+                )
+                if mtp_result is not None:
+                    self._session.last_metrics = mtp_result
+                    return mtp_result
+            timings = self._complete_prompt_standard(
+                prompt,
+                max_tokens=max_tokens,
+                on_progress=on_progress,
+                on_token=on_token,
+                should_cancel=should_cancel,
+            )
+            self._session.last_metrics = timings
+            return timings
+        finally:
+            self._session.in_flight = False
+
+    def _try_complete_with_mtp_experimental(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        on_token=None,
+    ) -> NativeTimings | None:
+        if not self.config.use_mtp_experimental:
+            self.last_mtp_completion = MtpCompletionResult(enabled=False, success=False, error=None)
+            return None
+        if not self.paths.mtp_available:
+            self.mtp_fallback_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
+            self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
+            return None
+        if self.cancel_event.is_set():
+            self.mtp_fallback_reason = "cancelled"
+            self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error="cancelled")
+            return None
+        if self._persistent_mtp_runtime is None or not self._session.mtp_enabled or not self._session.ctx_tgt:
+            self.mtp_fallback_reason = self._session.mtp_failure_reason or "persistent-mtp-uninitialized"
+            self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
+            return None
+
+        mtp_prompt = _prepare_mtp_prompt(prompt)
+        result = run_persistent_mtp_completion(
+            llama_root=self.paths.llama_root,
+            paths=self.paths,
+            runtime=self._persistent_mtp_runtime,
+            ctx_tgt=self._session.ctx_tgt,
+            prompt=mtp_prompt,
+            max_tokens=min(max_tokens, 32),
+        )
+        if result.success and result.content:
+            result = replace(result, content=_strip_control_channels(result.content))
+        self.last_mtp_completion = result
+        if not result.success:
+            self.mtp_fallback_reason = result.error or "mtp-experimental-failed"
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = self.mtp_fallback_reason
+            self._session.mtp_enabled = False
+            return None
+        self.mtp_fallback_reason = None
+        self._session.mtp_failed = False
+        self._session.mtp_failure_reason = None
+        self._session.mtp_enabled = True
+        if result.content and on_token:
+            on_token(result.content)
+        prompt_token_list = self.tokenize(mtp_prompt) if self._vocab else []
+        prompt_tokens = len(prompt_token_list)
+        reused_prompt_tokens = 0
+        max_common = min(len(prompt_token_list), len(self._session.cached_prompt_tokens))
+        while reused_prompt_tokens < max_common and prompt_token_list[reused_prompt_tokens] == self._session.cached_prompt_tokens[reused_prompt_tokens]:
+            reused_prompt_tokens += 1
+        if prompt_token_list:
+            reused_prompt_tokens = min(reused_prompt_tokens, len(prompt_token_list) - 1)
+        self._session.cached_prompt_tokens = list(prompt_token_list)
+        return NativeTimings(
+            prompt_tokens=prompt_tokens,
+            output_tokens=result.output_tokens,
+            reused_prompt_tokens=reused_prompt_tokens,
+            evaluated_prompt_tokens=max(0, prompt_tokens - reused_prompt_tokens),
+            prefill_ms=0.0,
+            generation_ms=result.elapsed_ms or 0.0,
+            cancelled=False,
+        )
+
+    def _complete_prompt_standard(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 16,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeTimings:
+        if not self._session.ctx_tgt or not self._vocab or not self._session.sampler:
+            raise RuntimeError("native client not loaded")
+        self.reset_cancel()
+
+        lib = self.lib.lib
+        prompt_tokens = self.tokenize(prompt)
+        n_prompt = len(prompt_tokens)
+        if not prompt_tokens:
+            raise RuntimeError("failed to count prompt tokens")
+
+        reused = self._prepare_memory_for_prompt(prompt_tokens)
+        processed = 0
+        step = max(1, min(self.config.progress_step, self.config.batch_size))
+        pf_start = lib.llama_time_us()
+        processed = reused
+        token_array = (llama_token * n_prompt)(*prompt_tokens)
+        while processed < n_prompt and not self.cancel_event.is_set():
+            if should_cancel and should_cancel():
+                self.cancel()
+                break
+            n = min(step, n_prompt - processed)
+            token_ptr = cast(byref(token_array, processed * sizeof(llama_token)), POINTER(llama_token))
+            batch = lib.llama_batch_get_one(token_ptr, n)
+            decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            processed += n
+            if on_progress:
+                on_progress(NativeProgress("prefill", processed, n_prompt))
+            if decode_rc != 0:
+                if decode_rc == 2 and self.cancel_event.is_set():
+                    break
+                raise RuntimeError(f"llama_decode failed during prefill: {decode_rc}")
+        pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
+
+        lib.llama_sampler_reset(self._session.sampler)
+        generated = 0
+        gen_start = lib.llama_time_us()
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        while generated < max_tokens and not self.cancel_event.is_set():
+            if should_cancel and should_cancel():
+                self.cancel()
+                break
+            token = lib.llama_sampler_sample(self._session.sampler, self._session.ctx_tgt, -1)
+            lib.llama_sampler_accept(self._session.sampler, token)
+            if lib.llama_vocab_is_eog(self._vocab, token):
+                break
+            text = decoder.decode(self._token_to_bytes(token), final=False)
+            if text and on_token:
+                on_token(text)
+            one_token = (llama_token * 1)(token)
+            batch = lib.llama_batch_get_one(one_token, 1)
+            decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            generated += 1
+            if on_progress:
+                on_progress(NativeProgress("generation", generated, max_tokens))
+            if decode_rc != 0:
+                if decode_rc == 2 and self.cancel_event.is_set():
+                    break
+                raise RuntimeError(f"llama_decode failed during generation: {decode_rc}")
+            if should_cancel and should_cancel():
+                self.cancel()
+                break
+        text = decoder.decode(b"", final=True)
+        if text and on_token:
+            on_token(text)
+
+        gen_ms = (lib.llama_time_us() - gen_start) / 1000.0
+        return NativeTimings(
+            prompt_tokens=n_prompt,
+            output_tokens=generated,
+            reused_prompt_tokens=reused,
+            evaluated_prompt_tokens=n_prompt - reused,
+            prefill_ms=pf_ms,
+            generation_ms=gen_ms,
+            cancelled=self.cancel_event.is_set(),
+        )
+
+    def tokenize(self, prompt: str) -> list[int]:
+        if not self._vocab:
+            raise RuntimeError("native client not loaded")
+        lib = self.lib.lib
+        prompt_bytes = prompt.encode()
+        add_special = not prompt.startswith("<bos>")
+        n_prompt = -lib.llama_tokenize(self._vocab, prompt_bytes, len(prompt_bytes), None, 0, add_special, True)
+        if n_prompt <= 0:
+            return []
+        token_array = (llama_token * n_prompt)()
+        rc = lib.llama_tokenize(self._vocab, prompt_bytes, len(prompt_bytes), token_array, n_prompt, add_special, True)
+        if rc < 0:
+            raise RuntimeError("failed to tokenize prompt")
+        return [int(token_array[i]) for i in range(n_prompt)]
+
+    def _prepare_memory_for_prompt(self, prompt_tokens: list[int]) -> int:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        lib = self.lib.lib
+        common = 0
+        max_common = min(len(prompt_tokens), len(self._session.cached_prompt_tokens))
+        while common < max_common and prompt_tokens[common] == self._session.cached_prompt_tokens[common]:
+            common += 1
+        if prompt_tokens:
+            # The final prompt token must be evaluated to produce fresh logits
+            # for the next sampled token.
+            common = min(common, len(prompt_tokens) - 1)
+
+        mem = lib.llama_get_memory(self._session.ctx_tgt)
+        if mem:
+            if common == 0:
+                lib.llama_memory_clear(mem, True)
+            else:
+                lib.llama_memory_seq_rm(mem, 0, common, -1)
+        self._session.cached_prompt_tokens = list(prompt_tokens)
+        return common
+
+    def apply_chat_template(self, messages: list[NativeMessage], *, tools: list[dict] | None = None) -> str:
+        if not self._model:
+            raise RuntimeError("native client not loaded")
+        if tools or any(message.get("role") == "tool" or message.get("tool_calls") for message in messages):
+            return render_gemma4_chat(messages, tools=tools)
+        encoded_messages = [
+            (str(message.get("role", "user")).encode(), _message_content(message).encode())
+            for message in messages
+        ]
+        chat_array = (LlamaChatMessage * len(encoded_messages))(
+            *[
+                LlamaChatMessage(role, content)
+                for role, content in encoded_messages
+            ]
+        )
+        tmpl = self.lib.lib.llama_model_chat_template(self._model, None)
+        needed = self.lib.lib.llama_chat_apply_template(tmpl, chat_array, len(chat_array), True, None, 0)
+        if needed < 0:
+            return render_gemma4_chat(messages)
+        buf = create_string_buffer(needed + 1)
+        written = self.lib.lib.llama_chat_apply_template(tmpl, chat_array, len(chat_array), True, buf, len(buf))
+        if written < 0:
+            raise RuntimeError("failed to apply chat template")
+        return bytes(buf[:written]).decode(errors="replace")
+
+    def _token_to_bytes(self, token: int) -> bytes:
+        if not self._vocab:
+            return b""
+        buf = (c_char * 512)()
+        n = self.lib.lib.llama_token_to_piece(self._vocab, token, buf, len(buf), 0, True)
+        if n <= 0:
+            return b""
+        return bytes(buf[:n])
+
+
+def _contains_stop(content: str, stops: tuple[str, ...]) -> bool:
+    return any(stop in content for stop in stops)
+
+
+def _trim_at_stop(content: str, stops: tuple[str, ...]) -> str:
+    first: int | None = None
+    for stop in stops:
+        idx = content.find(stop)
+        if idx >= 0 and (first is None or idx < first):
+            first = idx
+    if first is None:
+        return content
+    return content[:first]
+
+
+def _prepare_mtp_prompt(prompt: str) -> str:
+    stripped = prompt.lstrip()
+    if stripped.startswith("<bos>") or "<|turn>" in prompt:
+        return prompt
+    return render_gemma4_chat([{"role": "user", "content": prompt}])
+
+
+def _strip_control_channels(content: str) -> str:
+    if not content:
+        return ""
+    channel_filter = _ControlChannelStreamFilter()
+    parts = channel_filter.write(content)
+    parts.extend(channel_filter.finish())
+    return "".join(parts)
+
+
+def _message_content(message: NativeMessage) -> str:
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+class _StopSequenceStreamFilter:
+    def __init__(self, stops: tuple[str, ...], *, emit) -> None:
+        self._stops = stops
+        self._emit = emit
+        self._buffer = ""
+        self.stopped = False
+        self._keep = max(0, max(len(stop) for stop in stops) - 1)
+
+    def write(self, text: str) -> list[str]:
+        if self.stopped or not text:
+            return []
+        self._buffer += text
+        stop_index = self._first_stop_index()
+        if stop_index is not None:
+            return self._emit_and_stop(self._buffer[:stop_index])
+        if self._keep <= 0 or len(self._buffer) <= self._keep:
+            return []
+        return self._emit_prefix(len(self._buffer) - self._keep)
+
+    def finish(self) -> list[str]:
+        if self.stopped or not self._buffer:
+            return []
+        return self._emit_prefix(len(self._buffer))
+
+    def _first_stop_index(self) -> int | None:
+        first: int | None = None
+        for stop in self._stops:
+            idx = self._buffer.find(stop)
+            if idx >= 0 and (first is None or idx < first):
+                first = idx
+        return first
+
+    def _emit_and_stop(self, text: str) -> list[str]:
+        self.stopped = True
+        self._buffer = ""
+        if not text:
+            return []
+        self._emit(text)
+        return [text]
+
+    def _emit_prefix(self, length: int) -> list[str]:
+        text = self._buffer[:length]
+        self._buffer = self._buffer[length:]
+        if not text:
+            return []
+        self._emit(text)
+        return [text]
+
+
+class _ControlChannelStreamFilter:
+    _START = "<|channel>"
+    _END = "<channel|>"
+    _MARKERS = (_START, _END)
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def write(self, text: str) -> list[str]:
+        if not text:
+            return []
+        self._buffer += text
+        return self._drain(final=False)
+
+    def finish(self) -> list[str]:
+        return self._drain(final=True)
+
+    def _drain(self, *, final: bool) -> list[str]:
+        emitted: list[str] = []
+        while self._buffer:
+            start = self._buffer.find(self._START)
+            end = self._buffer.find(self._END)
+            marker_positions = [idx for idx in (start, end) if idx >= 0]
+            if not marker_positions:
+                emit_len = len(self._buffer) if final else self._safe_emit_length()
+                if emit_len <= 0:
+                    break
+                emitted.append(self._buffer[:emit_len])
+                self._buffer = self._buffer[emit_len:]
+                continue
+            marker = min(marker_positions)
+            if marker > 0:
+                emitted.append(self._buffer[:marker])
+                self._buffer = self._buffer[marker:]
+                continue
+            if self._buffer.startswith(self._END):
+                self._buffer = self._buffer[len(self._END):]
+                continue
+            block_end = self._buffer.find(self._END, len(self._START))
+            if block_end < 0:
+                if final:
+                    self._buffer = ""
+                break
+            self._buffer = self._buffer[block_end + len(self._END):]
+        return [text for text in emitted if text]
+
+    def _safe_emit_length(self) -> int:
+        keep = 0
+        for marker in self._MARKERS:
+            max_prefix = min(len(marker) - 1, len(self._buffer))
+            for size in range(max_prefix, 0, -1):
+                if marker.startswith(self._buffer[-size:]):
+                    keep = max(keep, size)
+                    break
+        return max(0, len(self._buffer) - keep)

--- a/src/orbit/native_llama/download_cli.py
+++ b/src/orbit/native_llama/download_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from orbit.native_llama.model_download import download_model
+from orbit.native_llama.model_registry import default_models_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="orbid")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    download = subparsers.add_parser("download", help="Download a GGUF model into Orbit's local model cache.")
+    download.add_argument("spec", help="Hugging Face repo or repo/path/to/model.gguf")
+    download.add_argument("--models-dir", help="Override Orbit model cache directory.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "download":
+        return _download(args)
+    return 2
+
+
+def _download(args: argparse.Namespace) -> int:
+    models_dir = default_models_dir() if args.models_dir is None else Path(args.models_dir)
+    try:
+        result = download_model(args.spec, models_dir=models_dir)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    action = "downloaded" if result.downloaded else "already present"
+    print(f"{action}: {result.path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/native_llama/events.py
+++ b/src/orbit/native_llama/events.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+NativePhase = Literal["load", "prefill", "generation"]
+
+
+@dataclass(frozen=True)
+class NativeProgress:
+    phase: NativePhase
+    current: int
+    total: int
+
+    @property
+    def percent(self) -> int:
+        if self.total <= 0:
+            return 0
+        return min(100, max(0, int((self.current / self.total) * 100)))
+
+
+@dataclass(frozen=True)
+class NativeTimings:
+    prompt_tokens: int
+    output_tokens: int
+    reused_prompt_tokens: int
+    evaluated_prompt_tokens: int
+    prefill_ms: float
+    generation_ms: float
+    cancelled: bool = False
+
+
+@dataclass(frozen=True)
+class NativeCompletion:
+    content: str
+    timings: NativeTimings
+    stopped_by_stop: bool = False

--- a/src/orbit/native_llama/model_download.py
+++ b/src/orbit/native_llama/model_download.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import urlretrieve
+import os
+import tempfile
+
+from orbit.native_llama.model_registry import (
+    ModelFileSpec,
+    default_models_dir,
+    load_registry,
+    local_model_path,
+)
+
+
+HF_RESOLVE_BASE = "https://huggingface.co"
+
+
+@dataclass(frozen=True)
+class DownloadRequest:
+    repo: str
+    file: str
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    path: Path
+    downloaded: bool
+    url: str
+
+
+def parse_huggingface_spec(spec: str) -> DownloadRequest:
+    cleaned = spec.strip().strip("/")
+    if not cleaned:
+        raise ValueError("empty Hugging Face model spec")
+    parts = cleaned.split("/")
+    if len(parts) < 2:
+        raise ValueError("expected Hugging Face repo or repo/file")
+
+    repo = "/".join(parts[:2])
+    file_part = "/".join(parts[2:])
+    if file_part:
+        if not file_part.endswith(".gguf"):
+            raise ValueError("only explicit .gguf files are supported")
+        return DownloadRequest(repo=repo, file=file_part)
+
+    manifest_match = _find_manifest_file_for_repo(repo)
+    if manifest_match is None:
+        raise ValueError(f"repo requires an explicit .gguf file: {repo}")
+    return DownloadRequest(repo=manifest_match.repo, file=manifest_match.file)
+
+
+def download_model(
+    spec: str,
+    *,
+    models_dir: Path | None = None,
+    retrieve=urlretrieve,
+) -> DownloadResult:
+    request = parse_huggingface_spec(spec)
+    destination = local_model_path(
+        ModelFileSpec(repo=request.repo, file=request.file, cache_glob=""),
+        models_dir=models_dir or default_models_dir(),
+    )
+    url = huggingface_resolve_url(request)
+    if destination.exists():
+        return DownloadResult(path=destination, downloaded=False, url=url)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent)
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        retrieve(url, str(tmp_path))
+        tmp_path.replace(destination)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return DownloadResult(path=destination, downloaded=True, url=url)
+
+
+def huggingface_resolve_url(request: DownloadRequest) -> str:
+    return f"{HF_RESOLVE_BASE}/{request.repo}/resolve/main/{request.file}"
+
+
+def _find_manifest_file_for_repo(repo: str) -> ModelFileSpec | None:
+    for manifest in load_registry():
+        if manifest.target.repo == repo:
+            return manifest.target
+        if manifest.mtp is not None and manifest.mtp.repo == repo:
+            return manifest.mtp
+    return None

--- a/src/orbit/native_llama/model_registry.json
+++ b/src/orbit/native_llama/model_registry.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "id": "gemma4-12b-it-q4km",
+      "backend": "native-llama",
+      "architecture": "gemma4",
+      "target": {
+        "repo": "ggml-org/gemma-4-12B-it-GGUF",
+        "file": "gemma-4-12B-it-Q4_K_M.gguf",
+        "cache_glob": "models--ggml-org--gemma-4-12B-it-GGUF/snapshots/*/gemma-4-12B-it-Q4_K_M.gguf"
+      },
+      "mtp": {
+        "enabled_by_default": true,
+        "required": false,
+        "spec_type": "draft-mtp",
+        "repo": "unsloth/gemma-4-12b-it-GGUF",
+        "file": "MTP/gemma-4-12b-it-Q8_0-MTP.gguf",
+        "cache_glob": "models--unsloth--gemma-4-12b-it-GGUF/snapshots/*/MTP/gemma-4-12b-it-Q8_0-MTP.gguf"
+      }
+    }
+  ]
+}

--- a/src/orbit/native_llama/model_registry.py
+++ b/src/orbit/native_llama/model_registry.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+import glob
+import json
+from typing import Any
+
+
+REGISTRY_RESOURCE = "model_registry.json"
+
+
+@dataclass(frozen=True)
+class ModelFileSpec:
+    repo: str
+    file: str
+    cache_glob: str
+
+
+@dataclass(frozen=True)
+class MtpSpec(ModelFileSpec):
+    enabled_by_default: bool
+    required: bool
+    spec_type: str
+
+
+@dataclass(frozen=True)
+class ModelManifest:
+    id: str
+    backend: str
+    architecture: str
+    target: ModelFileSpec
+    mtp: MtpSpec | None
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    manifest: ModelManifest
+    target_path: Path
+    draft_mtp_path: Path | None
+    mtp_available: bool
+    fallback_reason: str | None
+
+
+def default_hf_cache() -> Path:
+    return Path.home() / ".cache/huggingface/hub"
+
+
+def default_orbit_model_cache() -> Path:
+    return Path.home() / ".cache/orbit/models"
+
+
+def find_project_root(start: Path | None = None) -> Path | None:
+    current = (start or Path.cwd()).expanduser().resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "src/orbit").is_dir():
+            return candidate
+    return None
+
+
+def default_models_dir(start: Path | None = None) -> Path:
+    root = find_project_root(start)
+    if root is not None:
+        return root / "models"
+    return default_orbit_model_cache()
+
+
+def local_model_path(spec: ModelFileSpec, *, models_dir: Path) -> Path:
+    return models_dir / spec.repo.replace("/", "--") / spec.file
+
+
+def newest_match(pattern: Path) -> Path | None:
+    matches = [Path(path) for path in glob.glob(str(pattern))]
+    if not matches:
+        return None
+    return max(matches, key=lambda path: path.stat().st_mtime)
+
+
+def _file_spec(data: dict[str, Any]) -> ModelFileSpec:
+    return ModelFileSpec(
+        repo=str(data["repo"]),
+        file=str(data["file"]),
+        cache_glob=str(data["cache_glob"]),
+    )
+
+
+def _mtp_spec(data: dict[str, Any]) -> MtpSpec:
+    return MtpSpec(
+        repo=str(data["repo"]),
+        file=str(data["file"]),
+        cache_glob=str(data["cache_glob"]),
+        enabled_by_default=bool(data.get("enabled_by_default", False)),
+        required=bool(data.get("required", False)),
+        spec_type=str(data["spec_type"]),
+    )
+
+
+def _manifest(data: dict[str, Any]) -> ModelManifest:
+    mtp_data = data.get("mtp")
+    return ModelManifest(
+        id=str(data["id"]),
+        backend=str(data["backend"]),
+        architecture=str(data["architecture"]),
+        target=_file_spec(data["target"]),
+        mtp=_mtp_spec(mtp_data) if isinstance(mtp_data, dict) else None,
+    )
+
+
+def load_registry(path: Path | None = None) -> list[ModelManifest]:
+    if path is None:
+        text = resources.files(__package__).joinpath(REGISTRY_RESOURCE).read_text(encoding="utf-8")
+        data = json.loads(text)
+    else:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    return [_manifest(item) for item in data.get("models", [])]
+
+
+def get_manifest(model_id: str, *, registry_path: Path | None = None) -> ModelManifest:
+    for manifest in load_registry(registry_path):
+        if manifest.id == model_id:
+            return manifest
+    raise KeyError(f"unknown native model manifest: {model_id}")
+
+
+def resolve_model(
+    manifest: ModelManifest,
+    *,
+    models_dir: Path | None = None,
+    hf_cache: Path | None = None,
+    target_override: Path | None = None,
+    draft_mtp_override: Path | None = None,
+) -> ResolvedModel:
+    local_root = models_dir or default_models_dir()
+    cache_root = hf_cache or default_hf_cache()
+    target_path = target_override or _resolve_file(manifest.target, models_dir=local_root, hf_cache=cache_root)
+    if target_path is None or not target_path.exists():
+        raise FileNotFoundError(f"target model not found: {manifest.target.repo}:{manifest.target.file}")
+
+    draft_path: Path | None = None
+    fallback_reason: str | None = None
+    mtp = manifest.mtp
+    if mtp is None:
+        fallback_reason = "mtp-not-declared"
+    elif not mtp.enabled_by_default:
+        fallback_reason = "mtp-disabled"
+    else:
+        draft_path = draft_mtp_override or _resolve_file(mtp, models_dir=local_root, hf_cache=cache_root)
+        if draft_path is None or not draft_path.exists():
+            if mtp.required:
+                raise FileNotFoundError(f"draft MTP model not found: {mtp.repo}:{mtp.file}")
+            draft_path = None
+            fallback_reason = "draft-mtp-missing"
+
+    return ResolvedModel(
+        manifest=manifest,
+        target_path=target_path,
+        draft_mtp_path=draft_path,
+        mtp_available=draft_path is not None,
+        fallback_reason=fallback_reason,
+    )
+
+
+def _resolve_file(spec: ModelFileSpec, *, models_dir: Path, hf_cache: Path) -> Path | None:
+    local_path = local_model_path(spec, models_dir=models_dir)
+    if local_path.exists():
+        return local_path
+    return newest_match(hf_cache / spec.cache_glob)

--- a/src/orbit/native_llama/mtp_accept_probe.py
+++ b/src/orbit/native_llama/mtp_accept_probe.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class MtpAcceptProbeResult:
+    enabled: bool
+    success: bool
+    error: str | None
+    draft_tokens: int = 0
+    accepted_tokens: int = 0
+    rejected_tokens: int = 0
+    acceptance_ratio: float | None = None
+    target_decode_calls: int = 0
+    draft_decode_calls: int = 0
+    elapsed_ms: float | None = None
+    rss_before_kb: int | None = None
+    rss_after_kb: int | None = None
+    rss_peak_kb: int | None = None
+
+
+def run_mtp_accept_probe(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> MtpAcceptProbeResult:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        return MtpAcceptProbeResult(enabled=True, success=False, error=paths.fallback_reason or "draft-mtp-unavailable")
+
+    helper = build_mtp_accept_probe_helper(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    completed = runner(
+        [str(helper), str(paths.model), str(paths.draft_mtp_model)],
+        capture_output=True,
+        text=True,
+        env={"LD_LIBRARY_PATH": str(paths.build_bin)},
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return MtpAcceptProbeResult(enabled=True, success=False, error=f"mtp accept probe failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        return MtpAcceptProbeResult(enabled=True, success=False, error=f"invalid mtp accept probe output: {exc}")
+    if completed.returncode != 0 or not payload.get("ok"):
+        return MtpAcceptProbeResult(
+            enabled=True,
+            success=False,
+            error=str(payload.get("error") or f"mtp accept probe failed with exit code {completed.returncode}"),
+            draft_tokens=_int_or_default(payload.get("draft_tokens")),
+            accepted_tokens=_int_or_default(payload.get("accepted_tokens")),
+            rejected_tokens=_int_or_default(payload.get("rejected_tokens")),
+            acceptance_ratio=_float_or_none(payload.get("acceptance_ratio")),
+            target_decode_calls=_int_or_default(payload.get("target_decode_calls")),
+            draft_decode_calls=_int_or_default(payload.get("draft_decode_calls")),
+            elapsed_ms=_float_or_none(payload.get("elapsed_ms")),
+            rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+            rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+            rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+        )
+    return MtpAcceptProbeResult(
+        enabled=True,
+        success=True,
+        error=None,
+        draft_tokens=_int_or_default(payload.get("draft_tokens")),
+        accepted_tokens=_int_or_default(payload.get("accepted_tokens")),
+        rejected_tokens=_int_or_default(payload.get("rejected_tokens")),
+        acceptance_ratio=_float_or_none(payload.get("acceptance_ratio")),
+        target_decode_calls=_int_or_default(payload.get("target_decode_calls")),
+        draft_decode_calls=_int_or_default(payload.get("draft_decode_calls")),
+        elapsed_ms=_float_or_none(payload.get("elapsed_ms")),
+        rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+        rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+        rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+    )
+
+
+def build_mtp_accept_probe_helper(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_mtp_accept_probe.cpp"
+    output = build_root / "orbit-mtp-accept-probe"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build mtp accept probe helper: {detail or completed.returncode}")
+    return output
+
+
+def _int_or_none(value) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _int_or_default(value) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _float_or_none(value) -> float | None:
+    if isinstance(value, (float, int)):
+        return float(value)
+    return None

--- a/src/orbit/native_llama/mtp_completion.py
+++ b/src/orbit/native_llama/mtp_completion.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class MtpCompletionResult:
+    enabled: bool
+    success: bool
+    error: str | None
+    content: str = ""
+    output_tokens: int = 0
+    draft_tokens_total: int = 0
+    accepted_tokens_total: int = 0
+    rejected_tokens_total: int = 0
+    acceptance_ratio: float | None = None
+    fresh_acceptance_ratio: float | None = None
+    consumed_acceptance_ratio: float | None = None
+    reused_draft_tokens_total: int = 0
+    reused_accepted_tokens_total: int = 0
+    reused_rejected_tokens_total: int = 0
+    target_decode_calls: int = 0
+    draft_decode_calls: int = 0
+    elapsed_ms: float | None = None
+    tokens_per_second: float | None = None
+    full_accept_steps: int = 0
+    replay_steps: int = 0
+    partial_accept_steps: int = 0
+    partial_no_replay_steps: int = 0
+    replay_fallback_steps: int = 0
+    seq_rm_supported: bool = False
+    rollback_tokens_total: int = 0
+    checkpoint_count: int = 0
+    restore_count: int = 0
+
+
+def run_mtp_completion(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    prompt: str,
+    max_tokens: int,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> MtpCompletionResult:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        return MtpCompletionResult(enabled=True, success=False, error=paths.fallback_reason or "draft-mtp-unavailable")
+
+    helper = build_mtp_completion_helper(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    completed = runner(
+        [str(helper), str(paths.model), str(paths.draft_mtp_model), prompt, str(max_tokens)],
+        capture_output=True,
+        text=True,
+        env={"LD_LIBRARY_PATH": str(paths.build_bin)},
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return MtpCompletionResult(enabled=True, success=False, error=f"mtp completion failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        return MtpCompletionResult(enabled=True, success=False, error=f"invalid mtp completion output: {exc}")
+    if completed.returncode != 0 or not payload.get("ok"):
+        return MtpCompletionResult(
+            enabled=True,
+            success=False,
+            error=str(payload.get("error") or f"mtp completion failed with exit code {completed.returncode}"),
+            content=str(payload.get("content") or ""),
+            output_tokens=_int_or_default(payload.get("output_tokens")),
+            draft_tokens_total=_int_or_default(payload.get("draft_tokens_total")),
+            accepted_tokens_total=_int_or_default(payload.get("accepted_tokens_total")),
+            rejected_tokens_total=_int_or_default(payload.get("rejected_tokens_total")),
+            acceptance_ratio=_float_or_none(payload.get("acceptance_ratio")),
+            target_decode_calls=_int_or_default(payload.get("target_decode_calls")),
+            draft_decode_calls=_int_or_default(payload.get("draft_decode_calls")),
+            elapsed_ms=_float_or_none(payload.get("elapsed_ms")),
+            tokens_per_second=_float_or_none(payload.get("tokens_per_second")),
+        )
+    return MtpCompletionResult(
+        enabled=True,
+        success=True,
+        error=None,
+        content=str(payload.get("content") or ""),
+        output_tokens=_int_or_default(payload.get("output_tokens")),
+        draft_tokens_total=_int_or_default(payload.get("draft_tokens_total")),
+        accepted_tokens_total=_int_or_default(payload.get("accepted_tokens_total")),
+        rejected_tokens_total=_int_or_default(payload.get("rejected_tokens_total")),
+        acceptance_ratio=_float_or_none(payload.get("acceptance_ratio")),
+        target_decode_calls=_int_or_default(payload.get("target_decode_calls")),
+        draft_decode_calls=_int_or_default(payload.get("draft_decode_calls")),
+        elapsed_ms=_float_or_none(payload.get("elapsed_ms")),
+        tokens_per_second=_float_or_none(payload.get("tokens_per_second")),
+    )
+
+
+def build_mtp_completion_helper(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_mtp_completion.cpp"
+    output = build_root / "orbit-mtp-completion"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build mtp completion helper: {detail or completed.returncode}")
+    return output
+
+
+def _int_or_default(value) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _float_or_none(value) -> float | None:
+    if isinstance(value, (float, int)):
+        return float(value)
+    return None

--- a/src/orbit/native_llama/mtp_decode_probe.py
+++ b/src/orbit/native_llama/mtp_decode_probe.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class MtpDecodePromptResult:
+    name: str
+    output_tokens: int
+    draft_tokens_total: int
+    accepted_tokens_total: int
+    rejected_tokens_total: int
+    acceptance_ratio: float | None
+    target_decode_calls: int
+    draft_decode_calls: int
+    elapsed_ms: float | None
+    tokens_per_second: float | None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class MtpDecodeProbeResult:
+    enabled: bool
+    success: bool
+    error: str | None
+    prompts: tuple[MtpDecodePromptResult, ...] = ()
+    rss_before_kb: int | None = None
+    rss_after_kb: int | None = None
+    rss_peak_kb: int | None = None
+
+
+def run_mtp_decode_probe(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> MtpDecodeProbeResult:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        return MtpDecodeProbeResult(enabled=True, success=False, error=paths.fallback_reason or "draft-mtp-unavailable")
+
+    helper = build_mtp_decode_probe_helper(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    completed = runner(
+        [str(helper), str(paths.model), str(paths.draft_mtp_model)],
+        capture_output=True,
+        text=True,
+        env={"LD_LIBRARY_PATH": str(paths.build_bin)},
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return MtpDecodeProbeResult(enabled=True, success=False, error=f"mtp decode probe failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        return MtpDecodeProbeResult(enabled=True, success=False, error=f"invalid mtp decode probe output: {exc}")
+    prompts = tuple(_prompt_result(item) for item in payload.get("prompts", []) if isinstance(item, dict))
+    if completed.returncode != 0 or not payload.get("ok"):
+        return MtpDecodeProbeResult(
+            enabled=True,
+            success=False,
+            error=str(payload.get("error") or f"mtp decode probe failed with exit code {completed.returncode}"),
+            prompts=prompts,
+            rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+            rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+            rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+        )
+    return MtpDecodeProbeResult(
+        enabled=True,
+        success=True,
+        error=None,
+        prompts=prompts,
+        rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+        rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+        rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+    )
+
+
+def build_mtp_decode_probe_helper(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_mtp_decode_probe.cpp"
+    output = build_root / "orbit-mtp-decode-probe"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build mtp decode probe helper: {detail or completed.returncode}")
+    return output
+
+
+def _prompt_result(item: dict) -> MtpDecodePromptResult:
+    return MtpDecodePromptResult(
+        name=str(item.get("name") or "prompt"),
+        output_tokens=_int_or_default(item.get("output_tokens")),
+        draft_tokens_total=_int_or_default(item.get("draft_tokens_total")),
+        accepted_tokens_total=_int_or_default(item.get("accepted_tokens_total")),
+        rejected_tokens_total=_int_or_default(item.get("rejected_tokens_total")),
+        acceptance_ratio=_float_or_none(item.get("acceptance_ratio")),
+        target_decode_calls=_int_or_default(item.get("target_decode_calls")),
+        draft_decode_calls=_int_or_default(item.get("draft_decode_calls")),
+        elapsed_ms=_float_or_none(item.get("elapsed_ms")),
+        tokens_per_second=_float_or_none(item.get("tokens_per_second")),
+        error=str(item.get("error")) if item.get("error") is not None else None,
+    )
+
+
+def _int_or_none(value) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _int_or_default(value) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _float_or_none(value) -> float | None:
+    if isinstance(value, (float, int)):
+        return float(value)
+    return None

--- a/src/orbit/native_llama/mtp_dry_run.py
+++ b/src/orbit/native_llama/mtp_dry_run.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class MtpDryRunResult:
+    enabled: bool
+    success: bool
+    error: str | None
+    draft_tokens: int = 0
+    rss_before_kb: int | None = None
+    rss_after_kb: int | None = None
+    rss_peak_kb: int | None = None
+    target_load_s: float | None = None
+    draft_load_s: float | None = None
+    target_ctx_s: float | None = None
+    draft_ctx_s: float | None = None
+    speculative_init_s: float | None = None
+    prompt_decode_s: float | None = None
+    draft_s: float | None = None
+
+
+def run_mtp_dry_run(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> MtpDryRunResult:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        return MtpDryRunResult(enabled=True, success=False, error=paths.fallback_reason or "draft-mtp-unavailable")
+
+    helper = build_mtp_dry_run_helper(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    completed = runner(
+        [str(helper), str(paths.model), str(paths.draft_mtp_model)],
+        capture_output=True,
+        text=True,
+        env={"LD_LIBRARY_PATH": str(paths.build_bin)},
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return MtpDryRunResult(enabled=True, success=False, error=f"mtp dry run failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        return MtpDryRunResult(enabled=True, success=False, error=f"invalid mtp dry run output: {exc}")
+    if completed.returncode != 0 or not payload.get("ok"):
+        return MtpDryRunResult(
+            enabled=True,
+            success=False,
+            error=str(payload.get("error") or f"mtp dry run failed with exit code {completed.returncode}"),
+            draft_tokens=_int_or_default(payload.get("draft_tokens")),
+            rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+            rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+            rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+            target_load_s=_float_or_none(payload.get("target_load_s")),
+            draft_load_s=_float_or_none(payload.get("draft_load_s")),
+            target_ctx_s=_float_or_none(payload.get("target_ctx_s")),
+            draft_ctx_s=_float_or_none(payload.get("draft_ctx_s")),
+            speculative_init_s=_float_or_none(payload.get("speculative_init_s")),
+            prompt_decode_s=_float_or_none(payload.get("prompt_decode_s")),
+            draft_s=_float_or_none(payload.get("draft_s")),
+        )
+    return MtpDryRunResult(
+        enabled=True,
+        success=True,
+        error=None,
+        draft_tokens=_int_or_default(payload.get("draft_tokens")),
+        rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+        rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+        rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+        target_load_s=_float_or_none(payload.get("target_load_s")),
+        draft_load_s=_float_or_none(payload.get("draft_load_s")),
+        target_ctx_s=_float_or_none(payload.get("target_ctx_s")),
+        draft_ctx_s=_float_or_none(payload.get("draft_ctx_s")),
+        speculative_init_s=_float_or_none(payload.get("speculative_init_s")),
+        prompt_decode_s=_float_or_none(payload.get("prompt_decode_s")),
+        draft_s=_float_or_none(payload.get("draft_s")),
+    )
+
+
+def build_mtp_dry_run_helper(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_mtp_dry_run.cpp"
+    output = build_root / "orbit-mtp-dry-run"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build mtp dry run helper: {detail or completed.returncode}")
+    return output
+
+
+def _int_or_none(value) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _int_or_default(value) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _float_or_none(value) -> float | None:
+    if isinstance(value, (float, int)):
+        return float(value)
+    return None

--- a/src/orbit/native_llama/mtp_probe.py
+++ b/src/orbit/native_llama/mtp_probe.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class MtpProbeResult:
+    enabled: bool
+    initialized: bool
+    error: str | None
+    rss_before_kb: int | None = None
+    rss_after_kb: int | None = None
+    rss_peak_kb: int | None = None
+
+
+def run_mtp_probe(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> MtpProbeResult:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        return MtpProbeResult(enabled=True, initialized=False, error=paths.fallback_reason or "draft-mtp-unavailable")
+
+    helper = build_mtp_probe_helper(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    completed = runner(
+        [str(helper), str(paths.model), str(paths.draft_mtp_model)],
+        capture_output=True,
+        text=True,
+        env={"LD_LIBRARY_PATH": str(paths.build_bin)},
+        check=False,
+    )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return MtpProbeResult(enabled=True, initialized=False, error=f"mtp probe failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        return MtpProbeResult(enabled=True, initialized=False, error=f"invalid mtp probe output: {exc}")
+    if completed.returncode != 0 or not payload.get("ok"):
+        return MtpProbeResult(
+            enabled=True,
+            initialized=False,
+            error=str(payload.get("error") or f"mtp probe failed with exit code {completed.returncode}"),
+            rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+            rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+            rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+        )
+    return MtpProbeResult(
+        enabled=True,
+        initialized=True,
+        error=None,
+        rss_before_kb=_int_or_none(payload.get("rss_before_kb")),
+        rss_after_kb=_int_or_none(payload.get("rss_after_kb")),
+        rss_peak_kb=_int_or_none(payload.get("rss_peak_kb")),
+    )
+
+
+def build_mtp_probe_helper(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_mtp_probe.cpp"
+    output = build_root / "orbit-mtp-probe"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build mtp probe helper: {detail or completed.returncode}")
+    return output
+
+
+def _int_or_none(value) -> int | None:
+    return value if isinstance(value, int) else None

--- a/src/orbit/native_llama/paths.py
+++ b/src/orbit/native_llama/paths.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .model_registry import ResolvedModel, get_manifest, resolve_model
+
+
+DEFAULT_LLAMA_ROOT = Path("/home/guelfoweb/LAB/llama.cpp-gemma4-mtp-qualcomm")
+DEFAULT_MODEL_ID = "gemma4-12b-it-q4km"
+LEGACY_MODEL_ID = "legacy-path"
+
+
+@dataclass(frozen=True)
+class NativeLlamaPaths:
+    llama_root: Path
+    build_bin: Path
+    library: Path
+    model: Path
+    draft_mtp_model: Path | None
+    mtp_available: bool
+    fallback_reason: str | None
+    model_id: str
+
+
+def resolve_paths(
+    *,
+    llama_root: Path = DEFAULT_LLAMA_ROOT,
+    model_id: str = DEFAULT_MODEL_ID,
+    model: Path | None = None,
+    models_dir: Path | None = None,
+    hf_cache: Path | None = None,
+) -> NativeLlamaPaths:
+    build_bin = llama_root / "build/bin"
+    library = build_bin / "libllama.so"
+    manifest = get_manifest(model_id)
+    resolved = _resolve_model(
+        manifest_id=model_id,
+        model_override=model,
+        models_dir=models_dir,
+        hf_cache=hf_cache,
+    )
+
+    if not library.exists():
+        raise FileNotFoundError(f"libllama.so not found: {library}")
+
+    return NativeLlamaPaths(
+        llama_root=llama_root,
+        build_bin=build_bin,
+        library=library,
+        model=resolved.target_path,
+        draft_mtp_model=resolved.draft_mtp_path,
+        mtp_available=resolved.mtp_available,
+        fallback_reason=resolved.fallback_reason,
+        model_id=manifest.id,
+    )
+
+
+def resolve_legacy_paths(
+    *,
+    llama_root: Path = DEFAULT_LLAMA_ROOT,
+    model: Path,
+) -> NativeLlamaPaths:
+    build_bin = llama_root / "build/bin"
+    library = build_bin / "libllama.so"
+    resolved_model = model.expanduser().resolve()
+
+    if not library.exists():
+        raise FileNotFoundError(f"libllama.so not found: {library}")
+    if not resolved_model.exists():
+        raise FileNotFoundError(f"model not found: {resolved_model}")
+
+    return NativeLlamaPaths(
+        llama_root=llama_root,
+        build_bin=build_bin,
+        library=library,
+        model=resolved_model,
+        draft_mtp_model=None,
+        mtp_available=False,
+        fallback_reason="legacy-model-path",
+        model_id=LEGACY_MODEL_ID,
+    )
+
+
+def _resolve_model(
+    *,
+    manifest_id: str,
+    model_override: Path | None,
+    models_dir: Path | None,
+    hf_cache: Path | None,
+) -> ResolvedModel:
+    manifest = get_manifest(manifest_id)
+    return resolve_model(
+        manifest,
+        models_dir=models_dir,
+        hf_cache=hf_cache,
+        target_override=model_override,
+    )

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from ctypes import CDLL, c_bool, c_char_p, c_int32, c_long, c_uint32, c_void_p
+from dataclasses import dataclass
+from pathlib import Path
+import ctypes
+import os
+import subprocess
+
+from .mtp_completion import MtpCompletionResult
+from .paths import NativeLlamaPaths
+
+
+@dataclass(frozen=True)
+class PersistentMtpSessionRuntime:
+    handle: c_void_p
+    ctx_dft: c_void_p
+    spec: c_void_p
+    rss_before_kb: int | None = None
+    rss_after_init_kb: int | None = None
+    rss_peak_kb: int | None = None
+
+
+class PersistentMtpLibrary:
+    def __init__(self, build_bin: Path, shim_path: Path) -> None:
+        self.build_bin = build_bin
+        self.shim_path = shim_path
+        self._handles: list[CDLL] = []
+        self.lib = self._load_library()
+        self._configure_api()
+
+    def _load_library(self) -> CDLL:
+        flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+        for dep in ("libggml-base.so", "libggml.so", "libggml-cpu.so", "libllama-common.so", "libllama.so"):
+            path = self.build_bin / dep
+            if path.exists():
+                self._handles.append(ctypes.CDLL(str(path), mode=flags))
+        return ctypes.CDLL(str(self.shim_path), mode=flags)
+
+    def _configure_api(self) -> None:
+        lib = self.lib
+        lib.orbit_mtp_last_error.argtypes = []
+        lib.orbit_mtp_last_error.restype = c_char_p
+        lib.orbit_mtp_session_create.argtypes = [c_char_p, c_void_p, c_uint32, c_uint32, c_uint32, c_int32, c_int32]
+        lib.orbit_mtp_session_create.restype = c_void_p
+        lib.orbit_mtp_session_reset.argtypes = [c_void_p, c_void_p]
+        lib.orbit_mtp_session_reset.restype = c_bool
+        lib.orbit_mtp_session_free.argtypes = [c_void_p]
+        lib.orbit_mtp_session_free.restype = None
+        lib.orbit_mtp_session_ctx_dft.argtypes = [c_void_p]
+        lib.orbit_mtp_session_ctx_dft.restype = c_void_p
+        lib.orbit_mtp_session_spec.argtypes = [c_void_p]
+        lib.orbit_mtp_session_spec.restype = c_void_p
+        lib.orbit_mtp_session_rss_before_kb.argtypes = [c_void_p]
+        lib.orbit_mtp_session_rss_before_kb.restype = c_long
+        lib.orbit_mtp_session_rss_after_init_kb.argtypes = [c_void_p]
+        lib.orbit_mtp_session_rss_after_init_kb.restype = c_long
+        lib.orbit_mtp_session_rss_peak_kb.argtypes = [c_void_p]
+        lib.orbit_mtp_session_rss_peak_kb.restype = c_long
+        lib.orbit_mtp_session_complete.argtypes = [c_void_p, c_void_p, c_char_p, c_int32]
+        lib.orbit_mtp_session_complete.restype = c_bool
+        lib.orbit_mtp_session_last_content.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_content.restype = c_char_p
+        lib.orbit_mtp_session_last_output_tokens.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_output_tokens.restype = c_int32
+        lib.orbit_mtp_session_last_draft_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_draft_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_accepted_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_accepted_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_rejected_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_rejected_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_reused_draft_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_reused_draft_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_reused_accepted_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_reused_accepted_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_reused_rejected_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_reused_rejected_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_acceptance_ratio.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_acceptance_ratio.restype = ctypes.c_double
+        lib.orbit_mtp_session_last_fresh_acceptance_ratio.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_fresh_acceptance_ratio.restype = ctypes.c_double
+        lib.orbit_mtp_session_last_consumed_acceptance_ratio.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_consumed_acceptance_ratio.restype = ctypes.c_double
+        lib.orbit_mtp_session_last_target_decode_calls.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_target_decode_calls.restype = c_int32
+        lib.orbit_mtp_session_last_draft_decode_calls.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_draft_decode_calls.restype = c_int32
+        lib.orbit_mtp_session_last_elapsed_ms.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_elapsed_ms.restype = ctypes.c_double
+        lib.orbit_mtp_session_last_tokens_per_second.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_tokens_per_second.restype = ctypes.c_double
+        lib.orbit_mtp_session_last_full_accept_steps.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_full_accept_steps.restype = c_int32
+        lib.orbit_mtp_session_last_replay_steps.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_replay_steps.restype = c_int32
+        lib.orbit_mtp_session_last_partial_accept_steps.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_partial_accept_steps.restype = c_int32
+        lib.orbit_mtp_session_last_partial_no_replay_steps.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_partial_no_replay_steps.restype = c_int32
+        lib.orbit_mtp_session_last_replay_fallback_steps.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_replay_fallback_steps.restype = c_int32
+        lib.orbit_mtp_session_last_seq_rm_supported.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_seq_rm_supported.restype = c_bool
+        lib.orbit_mtp_session_last_rollback_tokens_total.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_rollback_tokens_total.restype = c_int32
+        lib.orbit_mtp_session_last_checkpoint_count.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_checkpoint_count.restype = c_int32
+        lib.orbit_mtp_session_last_restore_count.argtypes = [c_void_p]
+        lib.orbit_mtp_session_last_restore_count.restype = c_int32
+
+
+def build_persistent_mtp_shim(
+    *,
+    llama_root: Path,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+) -> Path:
+    build_root = build_dir or (Path.home() / ".orbit" / "native-build")
+    build_root.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_persistent_mtp.cpp"
+    output = build_root / "liborbit-persistent-mtp.so"
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+        return output
+
+    bin_dir = llama_root / "build/bin"
+    command = [
+        "g++",
+        "-std=c++17",
+        "-shared",
+        "-fPIC",
+        str(source),
+        f"-I{llama_root / 'include'}",
+        f"-I{llama_root / 'common'}",
+        f"-I{llama_root}",
+        f"-I{llama_root / 'ggml/include'}",
+        f"-I{llama_root / 'src'}",
+        f"-Wl,-rpath,{bin_dir}",
+        str(bin_dir / "libllama-common.so"),
+        str(bin_dir / "libllama.so"),
+        str(bin_dir / "libggml.so"),
+        str(bin_dir / "libggml-base.so"),
+        str(bin_dir / "libggml-cpu.so"),
+        "-o",
+        str(output),
+    ]
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"failed to build persistent mtp shim: {detail or completed.returncode}")
+    return output
+
+
+def create_persistent_mtp_session(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    ctx_tgt: c_void_p,
+    context_tokens: int,
+    batch_size: int,
+    ubatch_size: int,
+    threads: int,
+    threads_batch: int,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+    library_factory=PersistentMtpLibrary,
+) -> PersistentMtpSessionRuntime:
+    if not paths.mtp_available or paths.draft_mtp_model is None:
+        raise RuntimeError(paths.fallback_reason or "draft-mtp-unavailable")
+    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    library = library_factory(paths.build_bin, shim)
+    handle = library.lib.orbit_mtp_session_create(
+        str(paths.draft_mtp_model).encode(),
+        ctx_tgt,
+        context_tokens,
+        batch_size,
+        ubatch_size,
+        threads,
+        threads_batch,
+    )
+    if not handle:
+        raise RuntimeError(_decode_error(library.lib.orbit_mtp_last_error()))
+    return PersistentMtpSessionRuntime(
+        handle=c_void_p(handle),
+        ctx_dft=library.lib.orbit_mtp_session_ctx_dft(handle),
+        spec=library.lib.orbit_mtp_session_spec(handle),
+        rss_before_kb=_long_or_none(library.lib.orbit_mtp_session_rss_before_kb(handle)),
+        rss_after_init_kb=_long_or_none(library.lib.orbit_mtp_session_rss_after_init_kb(handle)),
+        rss_peak_kb=_long_or_none(library.lib.orbit_mtp_session_rss_peak_kb(handle)),
+    )
+
+
+def reset_persistent_mtp_session(
+    *,
+    paths: NativeLlamaPaths,
+    runtime: PersistentMtpSessionRuntime,
+    ctx_tgt: c_void_p,
+    build_dir: Path | None = None,
+    library_factory=PersistentMtpLibrary,
+    llama_root: Path,
+) -> PersistentMtpSessionRuntime:
+    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
+    library = library_factory(paths.build_bin, shim)
+    ok = library.lib.orbit_mtp_session_reset(runtime.handle, ctx_tgt)
+    if not ok:
+        raise RuntimeError(_decode_error(library.lib.orbit_mtp_last_error()))
+    return PersistentMtpSessionRuntime(
+        handle=runtime.handle,
+        ctx_dft=library.lib.orbit_mtp_session_ctx_dft(runtime.handle),
+        spec=library.lib.orbit_mtp_session_spec(runtime.handle),
+        rss_before_kb=runtime.rss_before_kb,
+        rss_after_init_kb=runtime.rss_after_init_kb,
+        rss_peak_kb=runtime.rss_peak_kb,
+    )
+
+
+def free_persistent_mtp_session(
+    *,
+    paths: NativeLlamaPaths,
+    runtime: PersistentMtpSessionRuntime,
+    build_dir: Path | None = None,
+    library_factory=PersistentMtpLibrary,
+    llama_root: Path,
+) -> None:
+    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
+    library = library_factory(paths.build_bin, shim)
+    library.lib.orbit_mtp_session_free(runtime.handle)
+
+
+def run_persistent_mtp_completion(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    runtime: PersistentMtpSessionRuntime | None,
+    ctx_tgt: c_void_p,
+    prompt: str,
+    max_tokens: int,
+    build_dir: Path | None = None,
+    library_factory=PersistentMtpLibrary,
+) -> MtpCompletionResult:
+    if runtime is None:
+        return MtpCompletionResult(enabled=True, success=False, error="persistent-mtp-uninitialized")
+    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
+    library = library_factory(paths.build_bin, shim)
+    ok = library.lib.orbit_mtp_session_complete(runtime.handle, ctx_tgt, prompt.encode(), max(1, min(max_tokens, 32)))
+    if not ok:
+        return MtpCompletionResult(
+            enabled=True,
+            success=False,
+            error=_decode_error(library.lib.orbit_mtp_last_error()),
+        )
+    return MtpCompletionResult(
+        enabled=True,
+        success=True,
+        error=None,
+        content=_decode_text(library.lib.orbit_mtp_session_last_content(runtime.handle)),
+        output_tokens=int(library.lib.orbit_mtp_session_last_output_tokens(runtime.handle)),
+        draft_tokens_total=int(library.lib.orbit_mtp_session_last_draft_tokens_total(runtime.handle)),
+        accepted_tokens_total=int(library.lib.orbit_mtp_session_last_accepted_tokens_total(runtime.handle)),
+        rejected_tokens_total=int(library.lib.orbit_mtp_session_last_rejected_tokens_total(runtime.handle)),
+        reused_draft_tokens_total=int(library.lib.orbit_mtp_session_last_reused_draft_tokens_total(runtime.handle)),
+        reused_accepted_tokens_total=int(library.lib.orbit_mtp_session_last_reused_accepted_tokens_total(runtime.handle)),
+        reused_rejected_tokens_total=int(library.lib.orbit_mtp_session_last_reused_rejected_tokens_total(runtime.handle)),
+        acceptance_ratio=float(library.lib.orbit_mtp_session_last_acceptance_ratio(runtime.handle)),
+        fresh_acceptance_ratio=float(library.lib.orbit_mtp_session_last_fresh_acceptance_ratio(runtime.handle)),
+        consumed_acceptance_ratio=float(library.lib.orbit_mtp_session_last_consumed_acceptance_ratio(runtime.handle)),
+        target_decode_calls=int(library.lib.orbit_mtp_session_last_target_decode_calls(runtime.handle)),
+        draft_decode_calls=int(library.lib.orbit_mtp_session_last_draft_decode_calls(runtime.handle)),
+        elapsed_ms=float(library.lib.orbit_mtp_session_last_elapsed_ms(runtime.handle)),
+        tokens_per_second=float(library.lib.orbit_mtp_session_last_tokens_per_second(runtime.handle)),
+        full_accept_steps=int(library.lib.orbit_mtp_session_last_full_accept_steps(runtime.handle)),
+        replay_steps=int(library.lib.orbit_mtp_session_last_replay_steps(runtime.handle)),
+        partial_accept_steps=int(library.lib.orbit_mtp_session_last_partial_accept_steps(runtime.handle)),
+        partial_no_replay_steps=int(library.lib.orbit_mtp_session_last_partial_no_replay_steps(runtime.handle)),
+        replay_fallback_steps=int(library.lib.orbit_mtp_session_last_replay_fallback_steps(runtime.handle)),
+        seq_rm_supported=bool(library.lib.orbit_mtp_session_last_seq_rm_supported(runtime.handle)),
+        rollback_tokens_total=int(library.lib.orbit_mtp_session_last_rollback_tokens_total(runtime.handle)),
+        checkpoint_count=int(library.lib.orbit_mtp_session_last_checkpoint_count(runtime.handle)),
+        restore_count=int(library.lib.orbit_mtp_session_last_restore_count(runtime.handle)),
+    )
+
+
+def _decode_error(value: bytes | None) -> str:
+    if not value:
+        return "persistent mtp operation failed"
+    return value.decode(errors="replace")
+
+
+def _decode_text(value: bytes | None) -> str:
+    if not value:
+        return ""
+    return value.decode(errors="replace")
+
+
+def _long_or_none(value: int | None) -> int | None:
+    if not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value

--- a/src/orbit/native_llama/session_state.py
+++ b/src/orbit/native_llama/session_state.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from ctypes import c_void_p
+from dataclasses import dataclass, field
+
+from .events import NativeTimings
+
+
+DEFAULT_NATIVE_SESSION_ID = "default"
+
+
+@dataclass(frozen=True)
+class NativeSessionSnapshot:
+    session_id: str
+    cached_tokens: int
+    in_flight: bool
+    cancel_requested: bool
+    backend_mode: str
+    last_metrics: NativeTimings | None
+    mtp_enabled: bool
+    mtp_initialized: bool
+    mtp_failure_reason: str | None
+
+
+@dataclass
+class NativeSessionState:
+    session_id: str = DEFAULT_NATIVE_SESSION_ID
+    ctx_tgt: c_void_p | None = None
+    sampler: c_void_p | None = None
+    cached_prompt_tokens: list[int] = field(default_factory=list)
+    in_flight: bool = False
+    cancel_requested: bool = False
+    last_metrics: NativeTimings | None = None
+    # Reserved for future persistent MTP session state.
+    ctx_dft: c_void_p | None = None
+    spec: c_void_p | None = None
+    mtp_enabled: bool = False
+    mtp_failed: bool = False
+    mtp_failure_reason: str | None = None
+
+    def snapshot(self, *, backend_mode: str = "no-mtp") -> NativeSessionSnapshot:
+        return NativeSessionSnapshot(
+            session_id=self.session_id,
+            cached_tokens=len(self.cached_prompt_tokens),
+            in_flight=self.in_flight,
+            cancel_requested=self.cancel_requested,
+            backend_mode=backend_mode,
+            last_metrics=self.last_metrics,
+            mtp_enabled=self.mtp_enabled,
+            mtp_initialized=self.ctx_dft is not None and self.spec is not None and self.mtp_enabled,
+            mtp_failure_reason=self.mtp_failure_reason,
+        )

--- a/src/orbit/native_llama/vendor/README.md
+++ b/src/orbit/native_llama/vendor/README.md
@@ -1,0 +1,12 @@
+# Native backend vendor area
+
+This directory is the packaging boundary for native Orbit backend artifacts.
+
+Expected future contents:
+
+- `lib/`: packaged `libllama`, `libllama-common`, and `ggml` runtime libraries.
+- `include/`: pinned public headers needed by the Orbit shim.
+- `shim/`: Orbit-owned C/C++ shim source or built extension.
+
+It is intentionally empty in this phase: no native libraries are committed and
+no runtime code loads from this directory yet.

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_accept_probe.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_accept_probe.cpp
@@ -1,0 +1,300 @@
+#include "llama.h"
+#include "common/speculative.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static long rss_kb() {
+    FILE * f = std::fopen("/proc/self/status", "r");
+    if (!f) {
+        return -1;
+    }
+    char line[256];
+    long kb = -1;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::sscanf(line, "VmRSS: %ld kB", &kb) == 1) {
+            break;
+        }
+    }
+    std::fclose(f);
+    return kb;
+}
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static void print_json(
+    bool ok,
+    const char * error,
+    int draft_tokens,
+    int accepted_tokens,
+    int rejected_tokens,
+    double acceptance_ratio,
+    int target_decode_calls,
+    int draft_decode_calls,
+    double elapsed_ms,
+    long rss_before,
+    long rss_after,
+    long rss_peak
+) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    if (error) {
+        std::printf("\"error\":\"");
+        for (const char * p = error; *p; ++p) {
+            if (*p == '"' || *p == '\\') {
+                std::printf("\\");
+            }
+            std::printf("%c", *p);
+        }
+        std::printf("\",");
+    } else {
+        std::printf("\"error\":null,");
+    }
+    std::printf(
+        "\"draft_tokens\":%d,\"accepted_tokens\":%d,\"rejected_tokens\":%d,"
+        "\"acceptance_ratio\":%.6f,\"target_decode_calls\":%d,\"draft_decode_calls\":%d,"
+        "\"elapsed_ms\":%.6f,\"rss_before_kb\":%ld,\"rss_after_kb\":%ld,\"rss_peak_kb\":%ld}\n",
+        draft_tokens,
+        accepted_tokens,
+        rejected_tokens,
+        acceptance_ratio,
+        target_decode_calls,
+        draft_decode_calls,
+        elapsed_ms,
+        rss_before,
+        rss_after,
+        rss_peak
+    );
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s TARGET.gguf DRAFT.gguf\n", argv[0]);
+        return 2;
+    }
+
+    llama_model * model_tgt = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_tgt = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    llama_sampler * smpl = nullptr;
+    llama_batch prompt_batch = {};
+    llama_batch validate_batch = {};
+    const char * error = nullptr;
+    llama_context_params mtp_params;
+    common_params_speculative spec_params;
+    std::vector<llama_token> prompt;
+    std::vector<llama_token> draft;
+    llama_token sampled = 0;
+
+    int draft_tokens = 0;
+    int accepted_tokens = 0;
+    int rejected_tokens = 0;
+    int target_decode_calls = 0;
+    int draft_decode_calls = 0;
+    double acceptance_ratio = 0.0;
+
+    const auto total_start = std::chrono::steady_clock::now();
+    long rss_before = rss_kb();
+    long rss_peak = rss_before;
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 16;
+
+    model_tgt = llama_model_load_from_file(argv[1], model_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_tgt) {
+        error = "failed to load target model";
+        goto cleanup;
+    }
+
+    model_dft = llama_model_load_from_file(argv[2], model_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_dft) {
+        error = "failed to load draft model";
+        goto cleanup;
+    }
+
+    ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_tgt) {
+        error = "failed to create target context";
+        goto cleanup;
+    }
+
+    mtp_params = ctx_params;
+    mtp_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    mtp_params.n_rs_seq = 0;
+    mtp_params.ctx_other = ctx_tgt;
+
+    ctx_dft = llama_init_from_model(model_dft, mtp_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_dft) {
+        error = "failed to create MTP draft context";
+        goto cleanup;
+    }
+
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+    spec = common_speculative_init(spec_params, 1);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!spec) {
+        error = "failed to initialize speculative MTP state";
+        goto cleanup;
+    }
+
+    {
+        const char * text = "Hello";
+        auto * vocab = llama_model_get_vocab(model_tgt);
+        const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, true, true);
+        if (n_tok <= 0) {
+            error = "failed to size prompt tokenization";
+            goto cleanup;
+        }
+        prompt.resize((size_t) n_tok);
+        const int32_t rc = llama_tokenize(vocab, text, (int32_t) std::strlen(text), prompt.data(), n_tok, true, true);
+        if (rc < 0) {
+            error = "failed to tokenize prompt";
+            goto cleanup;
+        }
+    }
+
+    prompt_batch = llama_batch_init((int32_t) prompt.size(), 0, 1);
+    prompt_batch.n_tokens = (int32_t) prompt.size();
+    for (int32_t i = 0; i < prompt_batch.n_tokens; ++i) {
+        prompt_batch.token[i] = prompt[(size_t) i];
+        prompt_batch.pos[i] = i;
+        prompt_batch.n_seq_id[i] = 1;
+        prompt_batch.seq_id[i][0] = 0;
+        prompt_batch.logits[i] = 1;
+    }
+
+    if (llama_decode(ctx_tgt, prompt_batch) != 0) {
+        error = "failed to decode target prompt";
+        goto cleanup;
+    }
+    target_decode_calls++;
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!common_speculative_process(spec, prompt_batch)) {
+        error = "failed to process speculative prompt batch";
+        goto cleanup;
+    }
+
+    common_speculative_begin(spec, 0, prompt);
+
+    smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+    sampled = llama_sampler_sample(smpl, ctx_tgt, -1);
+    llama_sampler_accept(smpl, sampled);
+
+    common_speculative_get_draft_params(spec, 0) = {
+        /* .drafting = */ true,
+        /* .n_max    = */ 3,
+        /* .n_past   = */ (llama_pos) prompt.size(),
+        /* .id_last  = */ sampled,
+        /* .prompt   = */ &prompt,
+        /* .result   = */ &draft,
+    };
+
+    common_speculative_draft(spec);
+    draft_tokens = (int) draft.size();
+    draft_decode_calls = draft_tokens > 0 ? 1 : 0;
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (draft.empty()) {
+        error = "draft probe produced no tokens";
+        goto cleanup;
+    }
+
+    validate_batch = llama_batch_init((int32_t) draft.size(), 0, 1);
+    validate_batch.n_tokens = (int32_t) draft.size();
+    for (int32_t i = 0; i < validate_batch.n_tokens; ++i) {
+        validate_batch.token[i] = draft[(size_t) i];
+        validate_batch.pos[i] = (llama_pos) prompt.size() + i;
+        validate_batch.n_seq_id[i] = 1;
+        validate_batch.seq_id[i][0] = 0;
+        validate_batch.logits[i] = 1;
+    }
+
+    if (llama_decode(ctx_tgt, validate_batch) != 0) {
+        error = "failed to validate drafted tokens on target";
+        goto cleanup;
+    }
+    target_decode_calls++;
+    rss_peak = std::max(rss_peak, rss_kb());
+
+    {
+        llama_sampler * validate_sampler = llama_sampler_chain_init(llama_sampler_chain_default_params());
+        llama_sampler_chain_add(validate_sampler, llama_sampler_init_greedy());
+        for (int i = 0; i < draft_tokens; ++i) {
+            const llama_token predicted = llama_sampler_sample(validate_sampler, ctx_tgt, i);
+            llama_sampler_accept(validate_sampler, predicted);
+            if (predicted != draft[(size_t) i]) {
+                break;
+            }
+            accepted_tokens++;
+        }
+        llama_sampler_free(validate_sampler);
+    }
+
+    rejected_tokens = draft_tokens - accepted_tokens;
+    acceptance_ratio = draft_tokens > 0 ? (double) accepted_tokens / (double) draft_tokens : 0.0;
+    common_speculative_accept(spec, 0, (uint16_t) accepted_tokens);
+
+cleanup:
+    if (validate_batch.token || validate_batch.embd || validate_batch.pos || validate_batch.n_seq_id || validate_batch.seq_id || validate_batch.logits) {
+        llama_batch_free(validate_batch);
+    }
+    if (prompt_batch.token || prompt_batch.embd || prompt_batch.pos || prompt_batch.n_seq_id || prompt_batch.seq_id || prompt_batch.logits) {
+        llama_batch_free(prompt_batch);
+    }
+    if (smpl) {
+        llama_sampler_free(smpl);
+    }
+    if (spec) {
+        common_speculative_free(spec);
+    }
+    if (ctx_dft) {
+        llama_free(ctx_dft);
+    }
+    if (ctx_tgt) {
+        llama_free(ctx_tgt);
+    }
+    if (model_dft) {
+        llama_model_free(model_dft);
+    }
+    if (model_tgt) {
+        llama_model_free(model_tgt);
+    }
+    llama_backend_free();
+
+    print_json(
+        error == nullptr,
+        error,
+        draft_tokens,
+        accepted_tokens,
+        rejected_tokens,
+        acceptance_ratio,
+        target_decode_calls,
+        draft_decode_calls,
+        elapsed_s(total_start) * 1000.0,
+        rss_before,
+        rss_kb(),
+        rss_peak
+    );
+    return error == nullptr ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_completion.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_completion.cpp
@@ -1,0 +1,329 @@
+#include "llama.h"
+#include "common/speculative.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static std::string token_piece(const llama_vocab * vocab, llama_token token) {
+    char buf[512];
+    const int n = llama_token_to_piece(vocab, token, buf, sizeof(buf), 0, true);
+    if (n <= 0) {
+        return {};
+    }
+    return std::string(buf, buf + n);
+}
+
+static void print_json(
+    bool ok,
+    const char * error,
+    const std::string & content,
+    int output_tokens,
+    int draft_tokens_total,
+    int accepted_tokens_total,
+    int rejected_tokens_total,
+    double acceptance_ratio,
+    int target_decode_calls,
+    int draft_decode_calls,
+    double elapsed_ms,
+    double tokens_per_second
+) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    if (error) {
+        std::printf("\"error\":\"");
+        for (const char * p = error; *p; ++p) {
+            if (*p == '"' || *p == '\\') {
+                std::printf("\\");
+            }
+            std::printf("%c", *p);
+        }
+        std::printf("\",");
+    } else {
+        std::printf("\"error\":null,");
+    }
+    std::printf("\"content\":\"");
+    for (const char * p = content.c_str(); *p; ++p) {
+        if (*p == '"' || *p == '\\') {
+            std::printf("\\");
+        }
+        if (*p == '\n') {
+            std::printf("\\n");
+            continue;
+        }
+        std::printf("%c", *p);
+    }
+    std::printf("\",");
+    std::printf(
+        "\"output_tokens\":%d,\"draft_tokens_total\":%d,\"accepted_tokens_total\":%d,"
+        "\"rejected_tokens_total\":%d,\"acceptance_ratio\":%.6f,"
+        "\"target_decode_calls\":%d,\"draft_decode_calls\":%d,"
+        "\"elapsed_ms\":%.6f,\"tokens_per_second\":%.6f}\n",
+        output_tokens,
+        draft_tokens_total,
+        accepted_tokens_total,
+        rejected_tokens_total,
+        acceptance_ratio,
+        target_decode_calls,
+        draft_decode_calls,
+        elapsed_ms,
+        tokens_per_second
+    );
+}
+
+static bool tokenize_prompt(llama_model * model, const char * text, std::vector<llama_token> & out) {
+    auto * vocab = llama_model_get_vocab(model);
+    const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, true, true);
+    if (n_tok <= 0) {
+        return false;
+    }
+    out.resize((size_t) n_tok);
+    return llama_tokenize(vocab, text, (int32_t) std::strlen(text), out.data(), n_tok, true, true) >= 0;
+}
+
+static void fill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0) {
+    batch.n_tokens = (int32_t) tokens.size();
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        batch.token[i] = tokens[(size_t) i];
+        batch.pos[i] = pos0 + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = 1;
+    }
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 5) {
+        std::fprintf(stderr, "usage: %s TARGET.gguf DRAFT.gguf PROMPT MAXTOKENS\n", argv[0]);
+        return 2;
+    }
+
+    llama_model * model_tgt = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_tgt = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    llama_sampler * smpl = nullptr;
+    const char * error = nullptr;
+    std::string content;
+    common_params_speculative spec_params;
+
+    int output_tokens = 0;
+    int draft_tokens_total = 0;
+    int accepted_tokens_total = 0;
+    int rejected_tokens_total = 0;
+    int target_decode_calls = 0;
+    int draft_decode_calls = 0;
+    double acceptance_ratio = 0.0;
+
+    std::vector<llama_token> prompt;
+    std::vector<llama_token> prompt_tgt;
+    std::vector<llama_token> generated;
+    llama_token id_last = 0;
+
+    const int max_tokens = std::max(1, std::min(32, std::atoi(argv[4])));
+    const auto t0 = std::chrono::steady_clock::now();
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 256;
+
+    model_tgt = llama_model_load_from_file(argv[1], model_params);
+    if (!model_tgt) {
+        error = "failed to load target model";
+        goto cleanup;
+    }
+    model_dft = llama_model_load_from_file(argv[2], model_params);
+    if (!model_dft) {
+        error = "failed to load draft model";
+        goto cleanup;
+    }
+    ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    if (!ctx_tgt) {
+        error = "failed to create target context";
+        goto cleanup;
+    }
+
+    {
+        auto mtp_params = ctx_params;
+        mtp_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+        mtp_params.n_rs_seq = 0;
+        mtp_params.ctx_other = ctx_tgt;
+        ctx_dft = llama_init_from_model(model_dft, mtp_params);
+    }
+    if (!ctx_dft) {
+        error = "failed to create MTP draft context";
+        goto cleanup;
+    }
+
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+    spec = common_speculative_init(spec_params, 1);
+    if (!spec) {
+        error = "failed to initialize speculative MTP state";
+        goto cleanup;
+    }
+
+    smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+
+    if (!tokenize_prompt(model_tgt, argv[3], prompt)) {
+        error = "failed to tokenize prompt";
+        goto cleanup;
+    }
+    if (prompt.size() < 2) {
+        error = "prompt too short for mtp completion";
+        goto cleanup;
+    }
+    id_last = prompt.back();
+    prompt_tgt.assign(prompt.begin(), prompt.end() - 1);
+    generated.reserve((size_t) max_tokens);
+
+    while ((int) generated.size() < max_tokens) {
+        llama_memory_clear(llama_get_memory(ctx_tgt), true);
+        llama_memory_clear(llama_get_memory(ctx_dft), true);
+
+        if (!prompt_tgt.empty()) {
+            llama_batch prefill = llama_batch_init((int32_t) prompt_tgt.size(), 0, 1);
+            fill_batch(prefill, prompt_tgt, 0);
+            if (llama_decode(ctx_tgt, prefill) != 0) {
+                error = "failed to decode target prefill";
+                llama_batch_free(prefill);
+                goto cleanup;
+            }
+            target_decode_calls++;
+            if (!common_speculative_process(spec, prefill)) {
+                error = "failed to process speculative prefill";
+                llama_batch_free(prefill);
+                goto cleanup;
+            }
+            common_speculative_begin(spec, 0, prompt_tgt);
+            llama_batch_free(prefill);
+        } else {
+            common_speculative_begin(spec, 0, prompt_tgt);
+        }
+
+        std::vector<llama_token> draft;
+        common_speculative_get_draft_params(spec, 0) = {
+            /* .drafting = */ true,
+            /* .n_max    = */ std::min(3, max_tokens - (int) generated.size()),
+            /* .n_past   = */ (llama_pos) prompt_tgt.size(),
+            /* .id_last  = */ id_last,
+            /* .prompt   = */ &prompt_tgt,
+            /* .result   = */ &draft,
+        };
+        common_speculative_draft(spec);
+        draft_decode_calls++;
+        draft_tokens_total += (int) draft.size();
+
+        std::vector<llama_token> validate_tokens;
+        validate_tokens.reserve(draft.size() + 1);
+        validate_tokens.push_back(id_last);
+        validate_tokens.insert(validate_tokens.end(), draft.begin(), draft.end());
+
+        llama_batch validate = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+        fill_batch(validate, validate_tokens, (int32_t) prompt_tgt.size());
+        if (llama_decode(ctx_tgt, validate) != 0) {
+            error = "failed to validate speculative batch on target";
+            llama_batch_free(validate);
+            goto cleanup;
+        }
+        target_decode_calls++;
+
+        std::vector<llama_token> ids;
+        ids.reserve(draft.size() + 1);
+        for (int i = 0; i < (int) draft.size(); ++i) {
+            const llama_token predicted = llama_sampler_sample(smpl, ctx_tgt, i);
+            llama_sampler_accept(smpl, predicted);
+            ids.push_back(predicted);
+            if (predicted != draft[(size_t) i]) {
+                break;
+            }
+        }
+        if (ids.size() == draft.size()) {
+            const llama_token predicted = llama_sampler_sample(smpl, ctx_tgt, (int) draft.size());
+            llama_sampler_accept(smpl, predicted);
+            ids.push_back(predicted);
+        }
+        llama_batch_free(validate);
+
+        if (ids.empty()) {
+            error = "speculative acceptance produced no ids";
+            goto cleanup;
+        }
+
+        const int accepted = std::max(0, (int) ids.size() - 1);
+        common_speculative_accept(spec, 0, (uint16_t) accepted);
+        accepted_tokens_total += accepted;
+        rejected_tokens_total += (int) draft.size() - accepted;
+
+        for (size_t i = 0; i < ids.size() && (int) generated.size() < max_tokens; ++i) {
+            prompt_tgt.push_back(id_last);
+            id_last = ids[i];
+
+            if (llama_vocab_is_eog(llama_model_get_vocab(model_tgt), id_last)) {
+                goto done;
+            }
+
+            generated.push_back(id_last);
+            content += token_piece(llama_model_get_vocab(model_tgt), id_last);
+            output_tokens++;
+        }
+    }
+
+done:
+    acceptance_ratio = draft_tokens_total > 0 ? (double) accepted_tokens_total / (double) draft_tokens_total : 0.0;
+
+cleanup:
+    if (smpl) {
+        llama_sampler_free(smpl);
+    }
+    if (spec) {
+        common_speculative_free(spec);
+    }
+    if (ctx_dft) {
+        llama_free(ctx_dft);
+    }
+    if (ctx_tgt) {
+        llama_free(ctx_tgt);
+    }
+    if (model_dft) {
+        llama_model_free(model_dft);
+    }
+    if (model_tgt) {
+        llama_model_free(model_tgt);
+    }
+    llama_backend_free();
+
+    const double elapsed_ms = elapsed_s(t0) * 1000.0;
+    const double tps = elapsed_ms > 0.0 ? ((double) output_tokens / elapsed_ms) * 1000.0 : 0.0;
+    print_json(
+        error == nullptr,
+        error,
+        content,
+        output_tokens,
+        draft_tokens_total,
+        accepted_tokens_total,
+        rejected_tokens_total,
+        acceptance_ratio,
+        target_decode_calls,
+        draft_decode_calls,
+        elapsed_ms,
+        tps
+    );
+    return error == nullptr ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_decode_probe.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_decode_probe.cpp
@@ -1,0 +1,355 @@
+#include "llama.h"
+#include "common/speculative.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+struct prompt_result {
+    std::string name;
+    int output_tokens = 0;
+    int draft_tokens_total = 0;
+    int accepted_tokens_total = 0;
+    int rejected_tokens_total = 0;
+    double acceptance_ratio = 0.0;
+    int target_decode_calls = 0;
+    int draft_decode_calls = 0;
+    double elapsed_ms = 0.0;
+    double tokens_per_second = 0.0;
+    std::string error;
+};
+
+static long rss_kb() {
+    FILE * f = std::fopen("/proc/self/status", "r");
+    if (!f) {
+        return -1;
+    }
+    char line[256];
+    long kb = -1;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::sscanf(line, "VmRSS: %ld kB", &kb) == 1) {
+            break;
+        }
+    }
+    std::fclose(f);
+    return kb;
+}
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static void print_json(bool ok, const char * error, const std::vector<prompt_result> & prompts, long rss_before, long rss_after, long rss_peak) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    if (error) {
+        std::printf("\"error\":\"");
+        for (const char * p = error; *p; ++p) {
+            if (*p == '"' || *p == '\\') {
+                std::printf("\\");
+            }
+            std::printf("%c", *p);
+        }
+        std::printf("\",");
+    } else {
+        std::printf("\"error\":null,");
+    }
+    std::printf("\"prompts\":[");
+    for (size_t i = 0; i < prompts.size(); ++i) {
+        const auto & pr = prompts[i];
+        if (i > 0) {
+            std::printf(",");
+        }
+        std::printf(
+            "{\"name\":\"%s\",\"output_tokens\":%d,\"draft_tokens_total\":%d,"
+            "\"accepted_tokens_total\":%d,\"rejected_tokens_total\":%d,"
+            "\"acceptance_ratio\":%.6f,\"target_decode_calls\":%d,\"draft_decode_calls\":%d,"
+            "\"elapsed_ms\":%.6f,\"tokens_per_second\":%.6f,",
+            pr.name.c_str(),
+            pr.output_tokens,
+            pr.draft_tokens_total,
+            pr.accepted_tokens_total,
+            pr.rejected_tokens_total,
+            pr.acceptance_ratio,
+            pr.target_decode_calls,
+            pr.draft_decode_calls,
+            pr.elapsed_ms,
+            pr.tokens_per_second
+        );
+        if (pr.error.empty()) {
+            std::printf("\"error\":null}");
+        } else {
+            std::printf("\"error\":\"");
+            for (const char * p = pr.error.c_str(); *p; ++p) {
+                if (*p == '"' || *p == '\\') {
+                    std::printf("\\");
+                }
+                std::printf("%c", *p);
+            }
+            std::printf("\"}");
+        }
+    }
+    std::printf("],\"rss_before_kb\":%ld,\"rss_after_kb\":%ld,\"rss_peak_kb\":%ld}\n", rss_before, rss_after, rss_peak);
+}
+
+static bool tokenize_prompt(llama_model * model, const char * text, std::vector<llama_token> & out) {
+    auto * vocab = llama_model_get_vocab(model);
+    const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, true, true);
+    if (n_tok <= 0) {
+        return false;
+    }
+    out.resize((size_t) n_tok);
+    return llama_tokenize(vocab, text, (int32_t) std::strlen(text), out.data(), n_tok, true, true) >= 0;
+}
+
+static void fill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0) {
+    batch.n_tokens = (int32_t) tokens.size();
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        batch.token[i] = tokens[(size_t) i];
+        batch.pos[i] = pos0 + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = 1;
+    }
+}
+
+static bool run_prompt(
+    llama_model * model_tgt,
+    llama_context * ctx_tgt,
+    llama_context * ctx_dft,
+    common_speculative * spec,
+    const char * prompt_text,
+    const char * prompt_name,
+    prompt_result & out,
+    long & rss_peak
+) {
+    out.name = prompt_name;
+    const auto t0 = std::chrono::steady_clock::now();
+    auto * mem_tgt = llama_get_memory(ctx_tgt);
+    auto * mem_dft = llama_get_memory(ctx_dft);
+    auto * vocab = llama_model_get_vocab(model_tgt);
+
+    std::vector<llama_token> prompt;
+    if (!tokenize_prompt(model_tgt, prompt_text, prompt)) {
+        out.error = "failed to tokenize prompt";
+        return false;
+    }
+    if (prompt.size() < 2) {
+        out.error = "prompt too short for mtp probe";
+        return false;
+    }
+
+    llama_token id_last = prompt.back();
+    std::vector<llama_token> prompt_tgt(prompt.begin(), prompt.end() - 1);
+    std::vector<llama_token> generated;
+    generated.reserve(16);
+    llama_sampler * smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+
+    while ((int) generated.size() < 16) {
+        llama_memory_clear(mem_tgt, true);
+        llama_memory_clear(mem_dft, true);
+
+        if (!prompt_tgt.empty()) {
+            llama_batch prefill = llama_batch_init((int32_t) prompt_tgt.size(), 0, 1);
+            fill_batch(prefill, prompt_tgt, 0);
+            if (llama_decode(ctx_tgt, prefill) != 0) {
+                out.error = "failed to decode target prefill";
+                llama_batch_free(prefill);
+                llama_sampler_free(smpl);
+                return false;
+            }
+            out.target_decode_calls++;
+            rss_peak = std::max(rss_peak, rss_kb());
+
+            if (!common_speculative_process(spec, prefill)) {
+                out.error = "failed to process speculative prefill";
+                llama_batch_free(prefill);
+                llama_sampler_free(smpl);
+                return false;
+            }
+            common_speculative_begin(spec, 0, prompt_tgt);
+            llama_batch_free(prefill);
+        } else {
+            common_speculative_begin(spec, 0, prompt_tgt);
+        }
+
+        std::vector<llama_token> draft;
+        common_speculative_get_draft_params(spec, 0) = {
+            /* .drafting = */ true,
+            /* .n_max    = */ std::min(3, 16 - (int) generated.size()),
+            /* .n_past   = */ (llama_pos) prompt_tgt.size(),
+            /* .id_last  = */ id_last,
+            /* .prompt   = */ &prompt_tgt,
+            /* .result   = */ &draft,
+        };
+        common_speculative_draft(spec);
+        out.draft_decode_calls++;
+        rss_peak = std::max(rss_peak, rss_kb());
+        out.draft_tokens_total += (int) draft.size();
+
+        std::vector<llama_token> validate_tokens;
+        validate_tokens.reserve(draft.size() + 1);
+        validate_tokens.push_back(id_last);
+        validate_tokens.insert(validate_tokens.end(), draft.begin(), draft.end());
+
+        llama_batch validate = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+        fill_batch(validate, validate_tokens, (int32_t) prompt_tgt.size());
+        if (llama_decode(ctx_tgt, validate) != 0) {
+            out.error = "failed to validate speculative batch on target";
+            llama_batch_free(validate);
+            llama_sampler_free(smpl);
+            return false;
+        }
+        out.target_decode_calls++;
+        rss_peak = std::max(rss_peak, rss_kb());
+
+        std::vector<llama_token> ids;
+        ids.reserve(draft.size() + 1);
+        for (int i = 0; i < (int) draft.size(); ++i) {
+            const llama_token predicted = llama_sampler_sample(smpl, ctx_tgt, i);
+            llama_sampler_accept(smpl, predicted);
+            ids.push_back(predicted);
+            if (predicted != draft[(size_t) i]) {
+                break;
+            }
+        }
+        if (ids.size() == draft.size()) {
+            const llama_token predicted = llama_sampler_sample(smpl, ctx_tgt, (int) draft.size());
+            llama_sampler_accept(smpl, predicted);
+            ids.push_back(predicted);
+        }
+        if (ids.empty()) {
+            out.error = "speculative acceptance produced no ids";
+            llama_batch_free(validate);
+            llama_sampler_free(smpl);
+            return false;
+        }
+
+        const int accepted = std::max(0, (int) ids.size() - 1);
+
+        common_speculative_accept(spec, 0, (uint16_t) accepted);
+        out.accepted_tokens_total += accepted;
+        out.rejected_tokens_total += (int) draft.size() - accepted;
+
+        for (size_t i = 0; i < ids.size() && (int) generated.size() < 16; ++i) {
+            prompt_tgt.push_back(id_last);
+            id_last = ids[i];
+
+            if (llama_vocab_is_eog(vocab, id_last)) {
+                break;
+            }
+            generated.push_back(id_last);
+            out.output_tokens++;
+        }
+
+        llama_batch_free(validate);
+    }
+
+    llama_sampler_free(smpl);
+    out.acceptance_ratio = out.draft_tokens_total > 0 ? (double) out.accepted_tokens_total / (double) out.draft_tokens_total : 0.0;
+    out.elapsed_ms = elapsed_s(t0) * 1000.0;
+    out.tokens_per_second = out.elapsed_ms > 0.0 ? ((double) out.output_tokens / out.elapsed_ms) * 1000.0 : 0.0;
+    return true;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s TARGET.gguf DRAFT.gguf\n", argv[0]);
+        return 2;
+    }
+
+    llama_model * model_tgt = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_tgt = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    const char * error = nullptr;
+    std::vector<prompt_result> prompts;
+    llama_context_params mtp_params;
+    common_params_speculative spec_params;
+
+    long rss_before = rss_kb();
+    long rss_peak = rss_before;
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 256;
+
+    model_tgt = llama_model_load_from_file(argv[1], model_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_tgt) {
+        error = "failed to load target model";
+        goto cleanup;
+    }
+    model_dft = llama_model_load_from_file(argv[2], model_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_dft) {
+        error = "failed to load draft model";
+        goto cleanup;
+    }
+    ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_tgt) {
+        error = "failed to create target context";
+        goto cleanup;
+    }
+
+    mtp_params = ctx_params;
+    mtp_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    mtp_params.n_rs_seq = 0;
+    mtp_params.ctx_other = ctx_tgt;
+    ctx_dft = llama_init_from_model(model_dft, mtp_params);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_dft) {
+        error = "failed to create MTP draft context";
+        goto cleanup;
+    }
+
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+    spec = common_speculative_init(spec_params, 1);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!spec) {
+        error = "failed to initialize speculative MTP state";
+        goto cleanup;
+    }
+
+    prompts.resize(2);
+    if (!run_prompt(model_tgt, ctx_tgt, ctx_dft, spec, "Say only: ok.", "prompt_short", prompts[0], rss_peak) && error == nullptr) {
+        error = prompts[0].error.c_str();
+    }
+    if (error == nullptr && !run_prompt(model_tgt, ctx_tgt, ctx_dft, spec, "In one short sentence, explain what a CPU does.", "prompt_medium", prompts[1], rss_peak)) {
+        error = prompts[1].error.c_str();
+    }
+
+cleanup:
+    if (spec) {
+        common_speculative_free(spec);
+    }
+    if (ctx_dft) {
+        llama_free(ctx_dft);
+    }
+    if (ctx_tgt) {
+        llama_free(ctx_tgt);
+    }
+    if (model_dft) {
+        llama_model_free(model_dft);
+    }
+    if (model_tgt) {
+        llama_model_free(model_tgt);
+    }
+    llama_backend_free();
+    print_json(error == nullptr, error, prompts, rss_before, rss_kb(), rss_peak);
+    return error == nullptr ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_dry_run.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_dry_run.cpp
@@ -1,0 +1,277 @@
+#include "llama.h"
+#include "common/speculative.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static long rss_kb() {
+    FILE * f = std::fopen("/proc/self/status", "r");
+    if (!f) {
+        return -1;
+    }
+    char line[256];
+    long kb = -1;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::sscanf(line, "VmRSS: %ld kB", &kb) == 1) {
+            break;
+        }
+    }
+    std::fclose(f);
+    return kb;
+}
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static void print_json(
+    bool ok,
+    const char * error,
+    int draft_tokens,
+    long rss_before,
+    long rss_after,
+    long rss_peak,
+    double target_load_s,
+    double draft_load_s,
+    double target_ctx_s,
+    double draft_ctx_s,
+    double speculative_init_s,
+    double prompt_decode_s,
+    double draft_s
+) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    if (error) {
+        std::printf("\"error\":\"");
+        for (const char * p = error; *p; ++p) {
+            if (*p == '"' || *p == '\\') {
+                std::printf("\\");
+            }
+            std::printf("%c", *p);
+        }
+        std::printf("\",");
+    } else {
+        std::printf("\"error\":null,");
+    }
+    std::printf(
+        "\"draft_tokens\":%d,"
+        "\"rss_before_kb\":%ld,\"rss_after_kb\":%ld,\"rss_peak_kb\":%ld,"
+        "\"target_load_s\":%.6f,\"draft_load_s\":%.6f,"
+        "\"target_ctx_s\":%.6f,\"draft_ctx_s\":%.6f,"
+        "\"speculative_init_s\":%.6f,\"prompt_decode_s\":%.6f,\"draft_s\":%.6f}\n",
+        draft_tokens,
+        rss_before,
+        rss_after,
+        rss_peak,
+        target_load_s,
+        draft_load_s,
+        target_ctx_s,
+        draft_ctx_s,
+        speculative_init_s,
+        prompt_decode_s,
+        draft_s
+    );
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s TARGET.gguf DRAFT.gguf\n", argv[0]);
+        return 2;
+    }
+
+    llama_model * model_tgt = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_tgt = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    llama_sampler * smpl = nullptr;
+    llama_batch prompt_batch = {};
+    const char * error = nullptr;
+    llama_context_params mtp_params;
+    common_params_speculative spec_params;
+    std::vector<llama_token> prompt;
+    std::vector<llama_token> draft;
+    int draft_tokens = 0;
+    llama_token sampled = 0;
+
+    long rss_before = rss_kb();
+    long rss_peak = rss_before;
+    double target_load_s = 0.0;
+    double draft_load_s = 0.0;
+    double target_ctx_s = 0.0;
+    double draft_ctx_s = 0.0;
+    double speculative_init_s = 0.0;
+    double prompt_decode_s = 0.0;
+    double draft_s = 0.0;
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 16;
+
+    auto t0 = std::chrono::steady_clock::now();
+    model_tgt = llama_model_load_from_file(argv[1], model_params);
+    target_load_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_tgt) {
+        error = "failed to load target model";
+        goto cleanup;
+    }
+
+    t0 = std::chrono::steady_clock::now();
+    model_dft = llama_model_load_from_file(argv[2], model_params);
+    draft_load_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_dft) {
+        error = "failed to load draft model";
+        goto cleanup;
+    }
+
+    t0 = std::chrono::steady_clock::now();
+    ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    target_ctx_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_tgt) {
+        error = "failed to create target context";
+        goto cleanup;
+    }
+
+    mtp_params = ctx_params;
+    mtp_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    mtp_params.n_rs_seq = 0;
+    mtp_params.ctx_other = ctx_tgt;
+
+    t0 = std::chrono::steady_clock::now();
+    ctx_dft = llama_init_from_model(model_dft, mtp_params);
+    draft_ctx_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_dft) {
+        error = "failed to create MTP draft context";
+        goto cleanup;
+    }
+
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+
+    t0 = std::chrono::steady_clock::now();
+    spec = common_speculative_init(spec_params, 1);
+    speculative_init_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!spec) {
+        error = "failed to initialize speculative MTP state";
+        goto cleanup;
+    }
+
+    {
+        const char * text = "Hello";
+        auto * vocab = llama_model_get_vocab(model_tgt);
+        const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, true, true);
+        if (n_tok <= 0) {
+            error = "failed to size prompt tokenization";
+            goto cleanup;
+        }
+        prompt.resize((size_t) n_tok);
+        const int32_t rc = llama_tokenize(vocab, text, (int32_t) std::strlen(text), prompt.data(), n_tok, true, true);
+        if (rc < 0) {
+            error = "failed to tokenize prompt";
+            goto cleanup;
+        }
+    }
+
+    {
+        prompt_batch = llama_batch_init((int32_t) prompt.size(), 0, 1);
+        prompt_batch.n_tokens = (int32_t) prompt.size();
+        for (int32_t i = 0; i < prompt_batch.n_tokens; ++i) {
+            prompt_batch.token[i] = prompt[(size_t) i];
+            prompt_batch.pos[i] = i;
+            prompt_batch.n_seq_id[i] = 1;
+            prompt_batch.seq_id[i][0] = 0;
+            prompt_batch.logits[i] = 1;
+        }
+        t0 = std::chrono::steady_clock::now();
+        const int rc = llama_decode(ctx_tgt, prompt_batch);
+        prompt_decode_s = elapsed_s(t0);
+        rss_peak = std::max(rss_peak, rss_kb());
+        if (rc != 0) {
+            error = "failed to decode target prompt";
+            goto cleanup;
+        }
+        if (!common_speculative_process(spec, prompt_batch)) {
+            error = "failed to process speculative prompt batch";
+            goto cleanup;
+        }
+    }
+
+    common_speculative_begin(spec, 0, prompt);
+
+    smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+    sampled = llama_sampler_sample(smpl, ctx_tgt, -1);
+    llama_sampler_accept(smpl, sampled);
+
+    common_speculative_get_draft_params(spec, 0) = {
+        /* .drafting = */ true,
+        /* .n_max    = */ 3,
+        /* .n_past   = */ (llama_pos) prompt.size(),
+        /* .id_last  = */ sampled,
+        /* .prompt   = */ &prompt,
+        /* .result   = */ &draft,
+    };
+
+    t0 = std::chrono::steady_clock::now();
+    common_speculative_draft(spec);
+    draft_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    draft_tokens = (int) draft.size();
+
+cleanup:
+    if (smpl) {
+        llama_sampler_free(smpl);
+    }
+    if (prompt_batch.token || prompt_batch.embd || prompt_batch.pos || prompt_batch.n_seq_id || prompt_batch.seq_id || prompt_batch.logits) {
+        llama_batch_free(prompt_batch);
+    }
+    if (spec) {
+        common_speculative_free(spec);
+    }
+    if (ctx_dft) {
+        llama_free(ctx_dft);
+    }
+    if (ctx_tgt) {
+        llama_free(ctx_tgt);
+    }
+    if (model_dft) {
+        llama_model_free(model_dft);
+    }
+    if (model_tgt) {
+        llama_model_free(model_tgt);
+    }
+    llama_backend_free();
+
+    print_json(
+        error == nullptr,
+        error,
+        draft_tokens,
+        rss_before,
+        rss_kb(),
+        rss_peak,
+        target_load_s,
+        draft_load_s,
+        target_ctx_s,
+        draft_ctx_s,
+        speculative_init_s,
+        prompt_decode_s,
+        draft_s
+    );
+    return error == nullptr ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_probe.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_probe.cpp
@@ -1,0 +1,187 @@
+#include "llama.h"
+#include "common/speculative.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+
+static long rss_kb() {
+    FILE * f = std::fopen("/proc/self/status", "r");
+    if (!f) {
+        return -1;
+    }
+    char line[256];
+    long kb = -1;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::sscanf(line, "VmRSS: %ld kB", &kb) == 1) {
+            break;
+        }
+    }
+    std::fclose(f);
+    return kb;
+}
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static void print_json(
+    bool ok,
+    const char * error,
+    long rss_before,
+    long rss_after,
+    long rss_peak,
+    double target_load_s,
+    double draft_load_s,
+    double target_ctx_s,
+    double draft_ctx_s,
+    double speculative_init_s
+) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    if (error) {
+        std::printf("\"error\":\"");
+        for (const char * p = error; *p; ++p) {
+            if (*p == '"' || *p == '\\') {
+                std::printf("\\");
+            }
+            std::printf("%c", *p);
+        }
+        std::printf("\",");
+    } else {
+        std::printf("\"error\":null,");
+    }
+    std::printf(
+        "\"rss_before_kb\":%ld,\"rss_after_kb\":%ld,\"rss_peak_kb\":%ld,"
+        "\"target_load_s\":%.6f,\"draft_load_s\":%.6f,"
+        "\"target_ctx_s\":%.6f,\"draft_ctx_s\":%.6f,\"speculative_init_s\":%.6f}\n",
+        rss_before,
+        rss_after,
+        rss_peak,
+        target_load_s,
+        draft_load_s,
+        target_ctx_s,
+        draft_ctx_s,
+        speculative_init_s
+    );
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s TARGET.gguf DRAFT.gguf\n", argv[0]);
+        return 2;
+    }
+
+    llama_model * model_tgt = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_tgt = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    const char * error = nullptr;
+    llama_context_params mtp_params;
+    common_params_speculative spec_params;
+
+    long rss_before = rss_kb();
+    long rss_peak = rss_before;
+    double target_load_s = 0.0;
+    double draft_load_s = 0.0;
+    double target_ctx_s = 0.0;
+    double draft_ctx_s = 0.0;
+    double speculative_init_s = 0.0;
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 1;
+
+    auto t0 = std::chrono::steady_clock::now();
+    model_tgt = llama_model_load_from_file(argv[1], model_params);
+    target_load_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_tgt) {
+        error = "failed to load target model";
+        goto cleanup;
+    }
+
+    t0 = std::chrono::steady_clock::now();
+    model_dft = llama_model_load_from_file(argv[2], model_params);
+    draft_load_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!model_dft) {
+        error = "failed to load draft model";
+        goto cleanup;
+    }
+
+    t0 = std::chrono::steady_clock::now();
+    ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    target_ctx_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_tgt) {
+        error = "failed to create target context";
+        goto cleanup;
+    }
+
+    mtp_params = ctx_params;
+    mtp_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    mtp_params.n_rs_seq = 0;
+    mtp_params.ctx_other = ctx_tgt;
+
+    t0 = std::chrono::steady_clock::now();
+    ctx_dft = llama_init_from_model(model_dft, mtp_params);
+    draft_ctx_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!ctx_dft) {
+        error = "failed to create MTP draft context";
+        goto cleanup;
+    }
+
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+
+    t0 = std::chrono::steady_clock::now();
+    spec = common_speculative_init(spec_params, 1);
+    speculative_init_s = elapsed_s(t0);
+    rss_peak = std::max(rss_peak, rss_kb());
+    if (!spec) {
+        error = "failed to initialize speculative MTP state";
+        goto cleanup;
+    }
+
+cleanup:
+    if (spec) {
+        common_speculative_free(spec);
+    }
+    if (ctx_dft) {
+        llama_free(ctx_dft);
+    }
+    if (ctx_tgt) {
+        llama_free(ctx_tgt);
+    }
+    if (model_dft) {
+        llama_model_free(model_dft);
+    }
+    if (model_tgt) {
+        llama_model_free(model_tgt);
+    }
+    llama_backend_free();
+
+    print_json(
+        error == nullptr,
+        error,
+        rss_before,
+        rss_kb(),
+        rss_peak,
+        target_load_s,
+        draft_load_s,
+        target_ctx_s,
+        draft_ctx_s,
+        speculative_init_s
+    );
+    return error == nullptr ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_mtp_step_trace.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_mtp_step_trace.cpp
@@ -1,0 +1,736 @@
+#include "llama.h"
+#include "common/common.h"
+#include "common/speculative.h"
+#include "common/sampling.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+static constexpr int32_t ORBIT_MTP_DRAFT_N_MAX = 3;
+
+struct trace_step {
+    int index = 0;
+    std::string mode;
+    std::vector<llama_token> draft;
+    std::vector<llama_token> accepted_ids;
+    int accepted_draft = 0;
+    int validated_count = 0;
+    int checkpoint_total = 0;
+    int restore_total = 0;
+    bool checkpoint_created = false;
+    bool restore_executed = false;
+    bool validate_processed_by_spec = false;
+    std::string resolution;
+    std::string sampler_before;
+    std::string sampler_after;
+    int32_t kv_tgt_before_min = -1;
+    int32_t kv_tgt_before_max = -1;
+    int32_t kv_dft_before_min = -1;
+    int32_t kv_dft_before_max = -1;
+    int32_t kv_tgt_after_min = -1;
+    int32_t kv_tgt_after_max = -1;
+    int32_t kv_dft_after_min = -1;
+    int32_t kv_dft_after_max = -1;
+};
+
+struct trace_summary {
+    std::string mode;
+    int draft_tokens_total = 0;
+    int accepted_tokens_total = 0;
+    int rejected_tokens_total = 0;
+    double acceptance_ratio = 0.0;
+    int target_decode_calls = 0;
+    int draft_decode_calls = 0;
+    int checkpoint_count = 0;
+    int restore_count = 0;
+    int output_tokens = 0;
+    std::string error;
+};
+
+static void fill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0) {
+    batch.n_tokens = (int32_t) tokens.size();
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        batch.token[i] = tokens[(size_t) i];
+        batch.pos[i] = pos0 + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = 1;
+    }
+}
+
+static bool tokenize_prompt(llama_model * model, const char * text, std::vector<llama_token> & out) {
+    auto * vocab = llama_model_get_vocab(model);
+    const bool add_special = std::strncmp(text, "<bos>", 5) != 0;
+    const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, add_special, true);
+    if (n_tok <= 0) {
+        return false;
+    }
+    out.resize((size_t) n_tok);
+    return llama_tokenize(vocab, text, (int32_t) std::strlen(text), out.data(), n_tok, add_special, true) >= 0;
+}
+
+static common_params_sampling make_sampling_params() {
+    common_params_sampling params;
+    params.top_k = 1;
+    params.top_p = 1.0f;
+    params.min_p = 0.0f;
+    params.typ_p = 1.0f;
+    params.temp = 0.0f;
+    params.penalty_last_n = 0;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.dry_multiplier = 0.0f;
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+    };
+    return params;
+}
+
+static std::string json_escape(const std::string & value) {
+    std::string out;
+    out.reserve(value.size() + 16);
+    for (unsigned char c : value) {
+        switch (c) {
+            case '\\': out += "\\\\"; break;
+            case '"': out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out.push_back((char) c);
+                }
+        }
+    }
+    return out;
+}
+
+static std::string token_piece(const llama_context * ctx, llama_token tok) {
+    return common_token_to_piece(ctx, tok, true);
+}
+
+static void print_token_vector_json(const llama_context * ctx, const std::vector<llama_token> & tokens) {
+    std::printf("[");
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        if (i > 0) {
+            std::printf(",");
+        }
+        std::printf(
+            "{\"id\":%d,\"piece\":\"%s\"}",
+            (int) tokens[i],
+            json_escape(token_piece(ctx, tokens[i])).c_str());
+    }
+    std::printf("]");
+}
+
+static void print_optional_token_json(const llama_context * ctx, const std::vector<llama_token> & draft, int accepted_draft) {
+    if (accepted_draft < 0 || accepted_draft >= (int) draft.size()) {
+        std::printf("null");
+        return;
+    }
+    const auto tok = draft[(size_t) accepted_draft];
+    std::printf(
+        "{\"id\":%d,\"piece\":\"%s\"}",
+        (int) tok,
+        json_escape(token_piece(ctx, tok)).c_str());
+}
+
+static void print_trace_json(
+    bool ok,
+    const trace_summary & summary,
+    const std::vector<trace_step> & steps,
+    const llama_context * ctx_tgt
+) {
+    std::printf("{\"ok\":%s,", ok ? "true" : "false");
+    std::printf("\"mode\":\"%s\",", summary.mode.c_str());
+    if (summary.error.empty()) {
+        std::printf("\"error\":null,");
+    } else {
+        std::printf("\"error\":\"%s\",", json_escape(summary.error).c_str());
+    }
+    std::printf(
+        "\"summary\":{\"draft_tokens_total\":%d,\"accepted_tokens_total\":%d,"
+        "\"rejected_tokens_total\":%d,\"acceptance_ratio\":%.6f,"
+        "\"target_decode_calls\":%d,\"draft_decode_calls\":%d,"
+        "\"checkpoint_count\":%d,\"restore_count\":%d,\"output_tokens\":%d},",
+        summary.draft_tokens_total,
+        summary.accepted_tokens_total,
+        summary.rejected_tokens_total,
+        summary.acceptance_ratio,
+        summary.target_decode_calls,
+        summary.draft_decode_calls,
+        summary.checkpoint_count,
+        summary.restore_count,
+        summary.output_tokens
+    );
+    std::printf("\"steps\":[");
+    for (size_t i = 0; i < steps.size(); ++i) {
+        const auto & step = steps[i];
+        if (i > 0) {
+            std::printf(",");
+        }
+        std::printf(
+            "{\"index\":%d,\"mode\":\"%s\",\"accepted_draft\":%d,"
+            "\"validated_count\":%d,\"checkpoint_created\":%s,"
+            "\"restore_executed\":%s,\"checkpoint_total\":%d,"
+            "\"restore_total\":%d,\"validate_processed_by_spec\":%s,"
+            "\"resolution\":\"%s\",\"sampler_before\":\"%s\","
+            "\"sampler_after\":\"%s\",\"kv_tgt_before\":{\"min\":%d,\"max\":%d},"
+            "\"kv_dft_before\":{\"min\":%d,\"max\":%d},\"kv_tgt_after\":{\"min\":%d,\"max\":%d},"
+            "\"kv_dft_after\":{\"min\":%d,\"max\":%d},\"draft\":",
+            step.index,
+            step.mode.c_str(),
+            step.accepted_draft,
+            step.validated_count,
+            step.checkpoint_created ? "true" : "false",
+            step.restore_executed ? "true" : "false",
+            step.checkpoint_total,
+            step.restore_total,
+            step.validate_processed_by_spec ? "true" : "false",
+            step.resolution.c_str(),
+            json_escape(step.sampler_before).c_str(),
+            json_escape(step.sampler_after).c_str(),
+            step.kv_tgt_before_min,
+            step.kv_tgt_before_max,
+            step.kv_dft_before_min,
+            step.kv_dft_before_max,
+            step.kv_tgt_after_min,
+            step.kv_tgt_after_max,
+            step.kv_dft_after_min,
+            step.kv_dft_after_max
+        );
+        print_token_vector_json(ctx_tgt, step.draft);
+        std::printf(",\"accepted_ids\":");
+        print_token_vector_json(ctx_tgt, step.accepted_ids);
+        std::printf(",\"first_rejected\":");
+        print_optional_token_json(ctx_tgt, step.draft, step.accepted_draft);
+        std::printf("}");
+    }
+    std::printf("]}\n");
+}
+
+static bool run_orbit_current(
+    llama_model * model_tgt,
+    llama_context * ctx_tgt,
+    llama_context * ctx_dft,
+    common_speculative * spec,
+    const char * prompt_text,
+    int max_tokens,
+    trace_summary & summary,
+    std::vector<trace_step> & steps
+) {
+    summary.mode = "orbit-current";
+    auto * mem_tgt = llama_get_memory(ctx_tgt);
+    auto * mem_dft = llama_get_memory(ctx_dft);
+    if (!mem_tgt || !mem_dft) {
+        summary.error = "missing llama memory";
+        return false;
+    }
+
+    std::vector<llama_token> prompt;
+    if (!tokenize_prompt(model_tgt, prompt_text, prompt) || prompt.size() < 2) {
+        summary.error = "failed to tokenize prompt";
+        return false;
+    }
+
+    std::vector<llama_token> prompt_tgt(prompt);
+    llama_token id_last = LLAMA_TOKEN_NULL;
+    int32_t n_past = (int32_t) prompt_tgt.size();
+    const auto sampling_params = make_sampling_params();
+    common_sampler * smpl = common_sampler_init(model_tgt, const_cast<common_params_sampling &>(sampling_params));
+    if (!smpl) {
+        summary.error = "failed to create sampler";
+        return false;
+    }
+
+    bool need_replay = true;
+    std::vector<llama_token> draft;
+    common_prompt_checkpoint ckpt;
+    bool have_ckpt = false;
+    bool stop = false;
+    int step_index = 0;
+
+    while (summary.output_tokens < max_tokens && !stop) {
+        if (need_replay) {
+            llama_memory_clear(mem_tgt, true);
+            llama_memory_clear(mem_dft, true);
+            if (!prompt_tgt.empty()) {
+                llama_batch prefill_tgt = llama_batch_init((int32_t) prompt_tgt.size(), 0, 1);
+                fill_batch(prefill_tgt, prompt_tgt, 0);
+                if (llama_decode(ctx_tgt, prefill_tgt) != 0) {
+                    llama_batch_free(prefill_tgt);
+                    summary.error = "target prefill failed";
+                    common_sampler_free(smpl);
+                    return false;
+                }
+                summary.target_decode_calls++;
+                llama_batch_free(prefill_tgt);
+
+                llama_batch prefill_spec = llama_batch_init((int32_t) prompt_tgt.size(), 0, 1);
+                fill_batch(prefill_spec, prompt_tgt, 0);
+                if (!common_speculative_process(spec, prefill_spec)) {
+                    llama_batch_free(prefill_spec);
+                    summary.error = "speculative prefill failed";
+                    common_sampler_free(smpl);
+                    return false;
+                }
+                llama_batch_free(prefill_spec);
+            }
+            common_speculative_begin(spec, 0, prompt_tgt);
+            draft.clear();
+            ckpt.clear();
+            have_ckpt = false;
+            n_past = (int32_t) prompt_tgt.size();
+            if (summary.output_tokens == 0) {
+                id_last = common_sampler_sample(smpl, ctx_tgt, -1);
+                common_sampler_accept(smpl, id_last, true);
+            }
+            need_replay = false;
+        }
+
+        bool checkpoint_created = false;
+        if (draft.empty()) {
+            ckpt.update_pos(
+                (int64_t) prompt_tgt.size(),
+                llama_memory_seq_pos_min(mem_tgt, 0),
+                llama_memory_seq_pos_max(mem_tgt, 0));
+            ckpt.update_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+
+            common_speculative_get_draft_params(spec, 0) = {
+                true,
+                std::min(ORBIT_MTP_DRAFT_N_MAX, max_tokens - summary.output_tokens),
+                (llama_pos) n_past,
+                id_last,
+                &prompt_tgt,
+                &draft,
+            };
+            common_speculative_draft(spec);
+            summary.draft_decode_calls++;
+            summary.draft_tokens_total += (int) draft.size();
+
+            if (!draft.empty()) {
+                ckpt.update_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                ckpt.load_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                have_ckpt = true;
+                checkpoint_created = true;
+                summary.checkpoint_count++;
+            } else {
+                have_ckpt = false;
+            }
+        }
+
+        std::vector<llama_token> validate_tokens;
+        validate_tokens.push_back(id_last);
+        validate_tokens.insert(validate_tokens.end(), draft.begin(), draft.end());
+
+        trace_step step;
+        step.index = ++step_index;
+        step.mode = summary.mode;
+        step.draft = draft;
+        step.validated_count = (int) validate_tokens.size();
+        step.checkpoint_created = checkpoint_created;
+        step.checkpoint_total = summary.checkpoint_count;
+        step.restore_total = summary.restore_count;
+        step.validate_processed_by_spec = true;
+        step.sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
+        step.kv_tgt_before_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        step.kv_tgt_before_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        step.kv_dft_before_min = llama_memory_seq_pos_min(mem_dft, 0);
+        step.kv_dft_before_max = llama_memory_seq_pos_max(mem_dft, 0);
+
+        llama_batch validate = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+        fill_batch(validate, validate_tokens, n_past);
+        if (llama_decode(ctx_tgt, validate) != 0) {
+            llama_batch_free(validate);
+            summary.error = "target validate failed";
+            common_sampler_free(smpl);
+            return false;
+        }
+        summary.target_decode_calls++;
+        if (!common_speculative_process(spec, validate)) {
+            llama_batch_free(validate);
+            summary.error = "speculative validate process failed";
+            common_sampler_free(smpl);
+            return false;
+        }
+        std::vector<int> rows(validate_tokens.size());
+        for (size_t i = 0; i < rows.size(); ++i) {
+            rows[i] = (int) i;
+        }
+        auto * smpl_save = have_ckpt ? common_sampler_clone(smpl) : nullptr;
+        auto ids = common_sampler_sample_and_accept_n(smpl, ctx_tgt, rows, draft);
+        llama_batch_free(validate);
+        if (ids.empty()) {
+            if (smpl_save) {
+                common_sampler_free(smpl_save);
+            }
+            summary.error = "acceptance produced no ids";
+            common_sampler_free(smpl);
+            return false;
+        }
+
+        const int accepted = std::max(0, (int) ids.size() - 1);
+        summary.accepted_tokens_total += accepted;
+        summary.rejected_tokens_total += (int) draft.size() - accepted;
+        step.accepted_draft = accepted;
+        step.accepted_ids = ids;
+        step.sampler_after = common_sampler_prev_str(smpl, ctx_tgt, 8);
+
+        if (accepted == (int) draft.size()) {
+            if (smpl_save) {
+                common_sampler_free(smpl_save);
+            }
+            step.resolution = "full_accept";
+            common_speculative_accept(spec, 0, (uint16_t) accepted);
+            for (llama_token tok : ids) {
+                prompt_tgt.push_back(id_last);
+                id_last = tok;
+                if (llama_vocab_is_eog(llama_model_get_vocab(model_tgt), id_last)) {
+                    stop = true;
+                    break;
+                }
+                summary.output_tokens++;
+                if (summary.output_tokens >= max_tokens) {
+                    break;
+                }
+            }
+            n_past = (int32_t) prompt_tgt.size();
+            llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+            llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+            draft.clear();
+            have_ckpt = false;
+            need_replay = false;
+        } else if (have_ckpt) {
+            step.resolution = "partial_restore";
+            draft = ids;
+            ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            llama_memory_seq_rm(mem_tgt, 0, ckpt.pos_max + 1, -1);
+            ckpt.load_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+            prompt_tgt.resize((size_t) ckpt.n_tokens);
+            n_past = (int32_t) prompt_tgt.size();
+            if (smpl_save) {
+                common_sampler_free(smpl);
+                smpl = smpl_save;
+                smpl_save = nullptr;
+            }
+            summary.restore_count++;
+            step.restore_executed = true;
+            step.restore_total = summary.restore_count;
+        } else {
+            if (smpl_save) {
+                common_sampler_free(smpl_save);
+            }
+            step.resolution = "replay_fallback";
+            need_replay = true;
+            draft.clear();
+        }
+
+        step.kv_tgt_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        step.kv_tgt_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
+        step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
+        steps.push_back(step);
+    }
+
+    common_sampler_free(smpl);
+    summary.acceptance_ratio = summary.draft_tokens_total > 0
+        ? (double) summary.accepted_tokens_total / (double) summary.draft_tokens_total
+        : 0.0;
+    return true;
+}
+
+static bool run_server_context_like(
+    llama_model * model_tgt,
+    llama_context * ctx_tgt,
+    llama_context * ctx_dft,
+    common_speculative * spec,
+    const char * prompt_text,
+    int max_tokens,
+    trace_summary & summary,
+    std::vector<trace_step> & steps
+) {
+    summary.mode = "server-context-like";
+    auto * mem_tgt = llama_get_memory(ctx_tgt);
+    auto * mem_dft = llama_get_memory(ctx_dft);
+    if (!mem_tgt || !mem_dft) {
+        summary.error = "missing llama memory";
+        return false;
+    }
+
+    std::vector<llama_token> prompt;
+    if (!tokenize_prompt(model_tgt, prompt_text, prompt) || prompt.empty()) {
+        summary.error = "failed to tokenize prompt";
+        return false;
+    }
+
+    const auto sampling_params = make_sampling_params();
+    common_sampler * smpl = common_sampler_init(model_tgt, const_cast<common_params_sampling &>(sampling_params));
+    if (!smpl) {
+        summary.error = "failed to create sampler";
+        return false;
+    }
+
+    llama_memory_clear(mem_tgt, true);
+    llama_memory_clear(mem_dft, true);
+    llama_batch prompt_batch = llama_batch_init((int32_t) prompt.size(), 0, 1);
+    fill_batch(prompt_batch, prompt, 0);
+    if (llama_decode(ctx_tgt, prompt_batch) != 0) {
+        llama_batch_free(prompt_batch);
+        summary.error = "target prompt prefill failed";
+        common_sampler_free(smpl);
+        return false;
+    }
+    summary.target_decode_calls++;
+    if (!common_speculative_process(spec, prompt_batch)) {
+        llama_batch_free(prompt_batch);
+        summary.error = "speculative prompt process failed";
+        common_sampler_free(smpl);
+        return false;
+    }
+    llama_batch_free(prompt_batch);
+
+    std::vector<llama_token> prompt_tgt = prompt;
+    common_speculative_begin(spec, 0, prompt_tgt);
+    llama_token id_last = common_sampler_sample(smpl, ctx_tgt, -1);
+    common_sampler_accept(smpl, id_last, true);
+    int32_t n_past = (int32_t) prompt_tgt.size();
+
+    std::vector<llama_token> draft;
+    common_prompt_checkpoint ckpt;
+    bool stop = false;
+    int step_index = 0;
+
+    while (summary.output_tokens < max_tokens && !stop) {
+        bool checkpoint_created = false;
+        if (draft.empty()) {
+            ckpt.update_pos(
+                (int64_t) prompt_tgt.size(),
+                llama_memory_seq_pos_min(mem_tgt, 0),
+                llama_memory_seq_pos_max(mem_tgt, 0));
+            ckpt.update_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            common_speculative_get_draft_params(spec, 0) = {
+                true,
+                std::min(ORBIT_MTP_DRAFT_N_MAX, max_tokens - summary.output_tokens),
+                (llama_pos) n_past,
+                id_last,
+                &prompt_tgt,
+                &draft,
+            };
+            common_speculative_draft(spec);
+            summary.draft_decode_calls++;
+            summary.draft_tokens_total += (int) draft.size();
+
+            if (!draft.empty()) {
+                ckpt.update_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                ckpt.load_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                summary.checkpoint_count++;
+                checkpoint_created = true;
+            }
+        }
+
+        std::vector<llama_token> validate_tokens;
+        validate_tokens.push_back(id_last);
+        validate_tokens.insert(validate_tokens.end(), draft.begin(), draft.end());
+
+        trace_step step;
+        step.index = ++step_index;
+        step.mode = summary.mode;
+        step.draft = draft;
+        step.validated_count = (int) validate_tokens.size();
+        step.checkpoint_created = checkpoint_created;
+        step.checkpoint_total = summary.checkpoint_count;
+        step.restore_total = summary.restore_count;
+        step.validate_processed_by_spec = true;
+        step.sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
+        step.kv_tgt_before_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        step.kv_tgt_before_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        step.kv_dft_before_min = llama_memory_seq_pos_min(mem_dft, 0);
+        step.kv_dft_before_max = llama_memory_seq_pos_max(mem_dft, 0);
+
+        llama_batch validate = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+        fill_batch(validate, validate_tokens, n_past);
+        if (llama_decode(ctx_tgt, validate) != 0) {
+            llama_batch_free(validate);
+            summary.error = "target validate failed";
+            common_sampler_free(smpl);
+            return false;
+        }
+        summary.target_decode_calls++;
+        if (!common_speculative_process(spec, validate)) {
+            llama_batch_free(validate);
+            summary.error = "speculative validate process failed";
+            common_sampler_free(smpl);
+            return false;
+        }
+        std::vector<int> rows(validate_tokens.size());
+        for (size_t i = 0; i < rows.size(); ++i) {
+            rows[i] = (int) i;
+        }
+        auto * smpl_save = common_sampler_clone(smpl);
+        auto ids = common_sampler_sample_and_accept_n(smpl, ctx_tgt, rows, draft);
+        llama_batch_free(validate);
+        if (ids.empty()) {
+            if (smpl_save) {
+                common_sampler_free(smpl_save);
+            }
+            summary.error = "acceptance produced no ids";
+            common_sampler_free(smpl);
+            return false;
+        }
+
+        const int accepted = std::max(0, (int) ids.size() - 1);
+        summary.accepted_tokens_total += accepted;
+        summary.rejected_tokens_total += (int) draft.size() - accepted;
+        step.accepted_draft = accepted;
+        step.accepted_ids = ids;
+        step.sampler_after = common_sampler_prev_str(smpl, ctx_tgt, 8);
+
+        if (accepted < (int) draft.size()) {
+            step.resolution = "partial_restore";
+            draft = ids;
+            ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            llama_memory_seq_rm(mem_tgt, 0, ckpt.pos_max + 1, -1);
+            ckpt.load_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+            prompt_tgt.resize((size_t) ckpt.n_tokens);
+            n_past = (int32_t) prompt_tgt.size();
+            common_sampler_free(smpl);
+            smpl = smpl_save;
+            smpl_save = nullptr;
+            summary.restore_count++;
+            step.restore_executed = true;
+            step.restore_total = summary.restore_count;
+            step.kv_tgt_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+            step.kv_tgt_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+            step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
+            step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
+            steps.push_back(step);
+            continue;
+        }
+
+        if (smpl_save) {
+            common_sampler_free(smpl_save);
+        }
+        step.resolution = "full_accept";
+        common_speculative_accept(spec, 0, (uint16_t) accepted);
+        for (llama_token tok : ids) {
+            prompt_tgt.push_back(id_last);
+            id_last = tok;
+            if (llama_vocab_is_eog(llama_model_get_vocab(model_tgt), id_last)) {
+                stop = true;
+                break;
+            }
+            summary.output_tokens++;
+            if (summary.output_tokens >= max_tokens) {
+                break;
+            }
+        }
+        n_past = (int32_t) prompt_tgt.size();
+        llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+        llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+        draft.clear();
+
+        step.kv_tgt_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        step.kv_tgt_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
+        step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
+        steps.push_back(step);
+    }
+
+    common_sampler_free(smpl);
+    summary.acceptance_ratio = summary.draft_tokens_total > 0
+        ? (double) summary.accepted_tokens_total / (double) summary.draft_tokens_total
+        : 0.0;
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    if (argc < 6) {
+        std::fprintf(stderr, "usage: %s MODE TARGET.gguf DRAFT.gguf PROMPT MAX_TOKENS\n", argv[0]);
+        return 2;
+    }
+
+    const std::string mode = argv[1];
+    const char * target = argv[2];
+    const char * draft = argv[3];
+    const char * prompt = argv[4];
+    const int max_tokens = std::max(1, std::atoi(argv[5]));
+
+    llama_backend_init();
+
+    auto model_params = llama_model_default_params();
+    auto * model_tgt = llama_model_load_from_file(target, model_params);
+    auto * model_dft = llama_model_load_from_file(draft, model_params);
+    if (!model_tgt || !model_dft) {
+        std::fprintf(stderr, "failed to load models\n");
+        return 1;
+    }
+
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = 8192;
+    ctx_params.n_batch = 256;
+    ctx_params.n_ubatch = 128;
+    ctx_params.n_threads = 6;
+    ctx_params.n_threads_batch = 6;
+    ctx_params.n_outputs_max = 256;
+    auto * ctx_tgt = llama_init_from_model(model_tgt, ctx_params);
+    ctx_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    ctx_params.ctx_other = ctx_tgt;
+    ctx_params.n_rs_seq = 0;
+    auto * ctx_dft = llama_init_from_model(model_dft, ctx_params);
+    if (!ctx_tgt || !ctx_dft) {
+        std::fprintf(stderr, "failed to create contexts\n");
+        return 1;
+    }
+
+    common_params_speculative spec_params;
+    spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    spec_params.draft.n_max = ORBIT_MTP_DRAFT_N_MAX;
+    spec_params.draft.ctx_tgt = ctx_tgt;
+    spec_params.draft.ctx_dft = ctx_dft;
+    auto * spec = common_speculative_init(spec_params, 1);
+    if (!spec) {
+        std::fprintf(stderr, "failed to init speculative state\n");
+        return 1;
+    }
+
+    trace_summary summary;
+    std::vector<trace_step> steps;
+    bool ok = false;
+    if (mode == "orbit-current") {
+        ok = run_orbit_current(model_tgt, ctx_tgt, ctx_dft, spec, prompt, max_tokens, summary, steps);
+    } else if (mode == "server-context-like") {
+        ok = run_server_context_like(model_tgt, ctx_tgt, ctx_dft, spec, prompt, max_tokens, summary, steps);
+    } else {
+        summary.mode = mode;
+        summary.error = "unknown mode";
+    }
+
+    print_trace_json(ok, summary, steps, ctx_tgt);
+
+    common_speculative_free(spec);
+    llama_free(ctx_dft);
+    llama_free(ctx_tgt);
+    llama_model_free(model_dft);
+    llama_model_free(model_tgt);
+    llama_backend_free();
+    return ok ? 0 : 1;
+}

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -1,0 +1,2428 @@
+#include "llama.h"
+#include "common/speculative.h"
+#include "common/sampling.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+static void fill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0);
+static void fill_target_prefill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0);
+static std::string token_piece(const llama_vocab * vocab, llama_token token);
+static bool can_partial_rollback(llama_context * ctx, uint32_t n_rollback);
+
+namespace {
+
+thread_local std::string g_last_error;
+
+static constexpr int32_t ORBIT_MTP_DRAFT_N_MAX = 3;
+
+struct phase_stat {
+    double total_ms = 0.0;
+    int calls = 0;
+};
+
+static double elapsed_ms(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+}
+
+static void phase_add(phase_stat & stat, std::chrono::steady_clock::time_point start) {
+    stat.total_ms += elapsed_ms(start);
+    stat.calls += 1;
+}
+
+static void set_error(const char * message) {
+    g_last_error = message ? message : "persistent mtp operation failed";
+}
+
+static bool partial_debug_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_PARTIAL_DEBUG");
+    return value && value[0] && std::strcmp(value, "0") != 0;
+}
+
+static bool validate_debug_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_VALIDATE_DEBUG");
+    return value && value[0] && std::strcmp(value, "0") != 0;
+}
+
+static bool boundary_split_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_BOUNDARY_SPLIT");
+    if (!value || !value[0]) {
+        return true;
+    }
+    return std::strcmp(value, "0") != 0;
+}
+
+static bool draft_trace_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_DRAFT_TRACE");
+    return value && value[0] && std::strcmp(value, "0") != 0;
+}
+
+static void emit_orbit_frontier_trace(const char * label, const std::string & payload) {
+    if (!partial_debug_enabled()) {
+        return;
+    }
+    std::fprintf(stderr, "ORBIT_MTP_FRONTIER %s %s\n", label ? label : "event", payload.c_str());
+}
+
+static void emit_orbit_draft_trace(const std::string & payload) {
+    if (!draft_trace_enabled()) {
+        return;
+    }
+    std::fprintf(stderr, "ORBIT_MTP_DRAFT %s\n", payload.c_str());
+}
+
+static void emit_orbit_dft_trace(const std::string & payload) {
+    if (!draft_trace_enabled()) {
+        return;
+    }
+    std::fprintf(stderr, "ORBIT_MTP_DFT %s\n", payload.c_str());
+}
+
+static void emit_orbit_validate_trace(const char * label, const std::string & payload) {
+    if (!validate_debug_enabled()) {
+        return;
+    }
+    std::fprintf(stderr, "ORBIT_MTP_VALIDATE %s %s\n", label ? label : "event", payload.c_str());
+}
+
+static uint64_t stable_hash_string(const std::string & value) {
+    uint64_t hash = 1469598103934665603ull;
+    for (unsigned char c : value) {
+        hash ^= (uint64_t) c;
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+static long rss_kb() {
+    FILE * f = std::fopen("/proc/self/status", "r");
+    if (!f) {
+        return -1;
+    }
+    char line[256];
+    long kb = -1;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::sscanf(line, "VmRSS: %ld kB", &kb) == 1) {
+            break;
+        }
+    }
+    std::fclose(f);
+    return kb;
+}
+
+struct orbit_mtp_session {
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_dft = nullptr;
+    common_speculative * spec = nullptr;
+    common_params_speculative spec_params;
+    common_prompt_checkpoint request_boundary_ckpt;
+    std::vector<llama_token> request_boundary_prompt_tgt;
+    long rss_before_kb = -1;
+    long rss_after_init_kb = -1;
+    long rss_peak_kb = -1;
+    std::vector<llama_token> cached_prompt_tokens;
+    std::string last_content;
+    int last_output_tokens = 0;
+    int last_draft_tokens_total = 0;
+    int last_accepted_tokens_total = 0;
+    int last_rejected_tokens_total = 0;
+    int last_reused_draft_tokens_total = 0;
+    int last_reused_accepted_tokens_total = 0;
+    int last_reused_rejected_tokens_total = 0;
+    double last_acceptance_ratio = 0.0;
+    double last_fresh_acceptance_ratio = 0.0;
+    double last_consumed_acceptance_ratio = 0.0;
+    int last_target_decode_calls = 0;
+    int last_draft_decode_calls = 0;
+    double last_elapsed_ms = 0.0;
+    double last_tokens_per_second = 0.0;
+    int last_full_accept_steps = 0;
+    int last_replay_steps = 0;
+    int last_partial_accept_steps = 0;
+    int last_partial_no_replay_steps = 0;
+    int last_replay_fallback_steps = 0;
+    bool last_seq_rm_supported = false;
+    int last_rollback_tokens_total = 0;
+    int last_checkpoint_count = 0;
+    int last_restore_count = 0;
+    std::string last_trace_json;
+    std::string last_timing_json;
+    std::string last_validate_trace_json;
+    std::string last_target_decode_trace_json;
+    phase_stat phase_prefix_restore;
+    phase_stat phase_suffix_decode_target;
+    phase_stat phase_draft_generation;
+    phase_stat phase_target_validate;
+    phase_stat phase_speculative_process;
+    phase_stat phase_sampler_clone;
+    phase_stat phase_sampler_restore;
+    phase_stat phase_sampler_ops;
+    phase_stat phase_seq_rm;
+    phase_stat phase_batch_build;
+    phase_stat phase_ctx_tgt_checkpoint;
+    phase_stat phase_ctx_tgt_restore;
+    phase_stat phase_ctx_dft_checkpoint;
+    phase_stat phase_ctx_dft_restore;
+    phase_stat phase_rollback_replay;
+    phase_stat phase_detokenize_bridge;
+    phase_stat phase_loop_total;
+    int debug_memory_clear_count = 0;
+    int debug_seq_rm_count = 0;
+    int debug_replay_count = 0;
+    int debug_prefill_target_count = 0;
+    int debug_prefill_target_suffix_count = 0;
+    int debug_validate_decode_count = 0;
+    int debug_draft_decode_count = 0;
+};
+
+enum class orbit_step_resolution {
+    full_accept,
+    live_partial,
+    restored_partial,
+    replay_fallback,
+    error,
+};
+
+struct orbit_step_outcome {
+    orbit_step_resolution resolution = orbit_step_resolution::error;
+    std::vector<llama_token> ids;
+};
+
+struct orbit_trace_step {
+    int index = 0;
+    std::string sampler_before;
+    std::string sampler_after;
+    uint64_t sampler_before_hash = 0;
+    uint64_t sampler_after_hash = 0;
+    std::vector<llama_token> draft;
+    std::vector<llama_token> accepted_ids;
+    int accepted_draft = 0;
+    int sampled_id = -1;
+    int rejected_id = -1;
+    std::string resolution;
+    int validated_count = 0;
+    int checkpoint_total = 0;
+    int restore_total = 0;
+    int32_t kv_tgt_before_min = -1;
+    int32_t kv_tgt_before_max = -1;
+    int32_t kv_tgt_after_min = -1;
+    int32_t kv_tgt_after_max = -1;
+    int32_t kv_dft_before_min = -1;
+    int32_t kv_dft_before_max = -1;
+    int32_t kv_dft_after_min = -1;
+    int32_t kv_dft_after_max = -1;
+    bool validate_processed_by_spec = false;
+    double validate_batch_prepare_ms = 0.0;
+    double validate_logits_rows_setup_ms = 0.0;
+    double validate_llama_decode_ms = 0.0;
+    double validate_post_decode_sample_ms = 0.0;
+    int validate_batch_n_tokens = 0;
+    int validate_batch_logits_count = 0;
+    int validate_n_outputs_requested = 0;
+    int id_last_before = -1;
+    int id_last_after = -1;
+    int32_t n_past_before = -1;
+    int32_t n_past_after = -1;
+    int32_t prompt_tgt_size_before = -1;
+    int32_t prompt_tgt_size_after = -1;
+    int32_t prompt_tgt_pos_next_before = -1;
+    int32_t prompt_tgt_pos_next_after = -1;
+    int32_t residual_draft_size_after = 0;
+    std::string residual_draft_after_json = "[]";
+    bool debug_enabled = false;
+    std::string partial_state_before_json = "{}";
+    std::string partial_state_after_restore_json = "{}";
+    std::string partial_state_after_logical_commit_json = "{}";
+    std::string sampler_checkpoint_used = "none";
+    std::string next_draft_origin = "unknown";
+    bool next_draft_is_fresh = false;
+    int next_draft_size = 0;
+    std::string next_draft_tokens_json = "[]";
+    int next_validate_n_tok = 0;
+    int fresh_draft_tokens_contrib = 0;
+    int fresh_accepted_tokens_contrib = 0;
+    int fresh_rejected_tokens_contrib = 0;
+    double fresh_acceptance_ratio_contrib = 0.0;
+    int consumed_draft_tokens_contrib = 0;
+    int consumed_accepted_tokens_contrib = 0;
+    int consumed_rejected_tokens_contrib = 0;
+    double consumed_acceptance_ratio_contrib = 0.0;
+    bool post_step_draft_is_fresh = false;
+    bool post_step_need_replay = false;
+    std::string extra_target_decode_reason = "none";
+    std::string extra_draft_decode_reason = "none";
+    int memory_clear_count = 0;
+    int seq_rm_count = 0;
+    int replay_count = 0;
+    int prefill_count = 0;
+    std::string pre_sample_state_json = "{}";
+};
+
+struct orbit_validate_trace {
+    int step = 0;
+    double batch_prepare_ms = 0.0;
+    double logits_rows_setup_ms = 0.0;
+    double llama_decode_validate_ms = 0.0;
+    double post_decode_sample_ms = 0.0;
+    int token_count_validated = 0;
+    int n_seq_tokens = 0;
+    int batch_n_tokens = 0;
+    int batch_logits_count = 0;
+    int n_outputs_requested = 0;
+    int32_t kv_before_min = -1;
+    int32_t kv_before_max = -1;
+    int32_t kv_after_min = -1;
+    int32_t kv_after_max = -1;
+};
+
+struct orbit_target_decode_trace {
+    std::string phase;
+    int step = 0;
+    int draft_size = 0;
+    int accepted_draft_expected = 0;
+    long long started_us = 0;
+    double decode_ms = 0.0;
+    int batch_n_tokens = 0;
+    int batch_logits_count = 0;
+    int output_reserve_n_outputs = 0;
+    std::vector<int> logits_flags;
+    std::vector<llama_token> token_ids;
+    std::vector<int32_t> positions;
+    std::vector<int32_t> seq_ids;
+};
+
+static std::string json_escape(const std::string & value) {
+    std::string out;
+    out.reserve(value.size() + 16);
+    for (unsigned char c : value) {
+        switch (c) {
+            case '\\': out += "\\\\"; break;
+            case '"': out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out.push_back((char) c);
+                }
+        }
+    }
+    return out;
+}
+
+static std::string token_piece_json(const llama_vocab * vocab, llama_token token) {
+    return json_escape(token_piece(vocab, token));
+}
+
+static std::vector<llama_token> tail_tokens(const std::vector<llama_token> & tokens, size_t limit) {
+    if (tokens.size() <= limit) {
+        return tokens;
+    }
+    return std::vector<llama_token>(tokens.end() - (ptrdiff_t) limit, tokens.end());
+}
+
+static std::string token_vec_json(const llama_vocab * vocab, const std::vector<llama_token> & tokens) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << "{\"id\":" << (int) tokens[i] << ",\"piece\":\"" << token_piece_json(vocab, tokens[i]) << "\"}";
+    }
+    out << "]";
+    return out.str();
+}
+
+static std::string optional_rejected_json(const llama_vocab * vocab, const std::vector<llama_token> & draft, int accepted_draft) {
+    if (accepted_draft < 0 || accepted_draft >= (int) draft.size()) {
+        return "null";
+    }
+    std::ostringstream out;
+    const auto tok = draft[(size_t) accepted_draft];
+    out << "{\"id\":" << (int) tok << ",\"piece\":\"" << token_piece_json(vocab, tok) << "\"}";
+    return out.str();
+}
+
+static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_step & step) {
+    std::ostringstream out;
+    out
+        << "{\"index\":" << step.index
+        << ",\"sampler_before\":\"" << json_escape(step.sampler_before) << "\""
+        << ",\"sampler_after\":\"" << json_escape(step.sampler_after) << "\""
+        << ",\"sampler_before_hash\":" << step.sampler_before_hash
+        << ",\"sampler_after_hash\":" << step.sampler_after_hash
+        << ",\"draft\":" << token_vec_json(vocab, step.draft)
+        << ",\"accepted_ids\":" << token_vec_json(vocab, step.accepted_ids)
+        << ",\"accepted_draft\":" << step.accepted_draft
+        << ",\"sampled_id\":" << step.sampled_id
+        << ",\"rejected_id\":" << step.rejected_id
+        << ",\"first_rejected\":" << optional_rejected_json(vocab, step.draft, step.accepted_draft)
+        << ",\"resolution\":\"" << step.resolution << "\""
+        << ",\"id_last_before\":" << step.id_last_before
+        << ",\"id_last_after\":" << step.id_last_after
+        << ",\"n_past_before\":" << step.n_past_before
+        << ",\"n_past_after\":" << step.n_past_after
+        << ",\"prompt_tgt_size_before\":" << step.prompt_tgt_size_before
+        << ",\"prompt_tgt_size_after\":" << step.prompt_tgt_size_after
+        << ",\"prompt_tgt_pos_next_before\":" << step.prompt_tgt_pos_next_before
+        << ",\"prompt_tgt_pos_next_after\":" << step.prompt_tgt_pos_next_after
+        << ",\"residual_draft_size_after\":" << step.residual_draft_size_after
+        << ",\"residual_draft_after\":" << step.residual_draft_after_json
+        << ",\"validated_count\":" << step.validated_count
+        << ",\"checkpoint_total\":" << step.checkpoint_total
+        << ",\"restore_total\":" << step.restore_total
+        << ",\"kv_tgt_before\":{\"min\":" << step.kv_tgt_before_min << ",\"max\":" << step.kv_tgt_before_max << "}"
+        << ",\"kv_tgt_after\":{\"min\":" << step.kv_tgt_after_min << ",\"max\":" << step.kv_tgt_after_max << "}"
+        << ",\"kv_dft_before\":{\"min\":" << step.kv_dft_before_min << ",\"max\":" << step.kv_dft_before_max << "}"
+        << ",\"kv_dft_after\":{\"min\":" << step.kv_dft_after_min << ",\"max\":" << step.kv_dft_after_max << "}"
+        << ",\"validate_processed_by_spec\":" << (step.validate_processed_by_spec ? "true" : "false")
+        << ",\"validate_batch_prepare_ms\":" << step.validate_batch_prepare_ms
+        << ",\"validate_logits_rows_setup_ms\":" << step.validate_logits_rows_setup_ms
+        << ",\"validate_llama_decode_ms\":" << step.validate_llama_decode_ms
+        << ",\"validate_post_decode_sample_ms\":" << step.validate_post_decode_sample_ms
+        << ",\"validate_batch_n_tokens\":" << step.validate_batch_n_tokens
+        << ",\"validate_batch_logits_count\":" << step.validate_batch_logits_count
+        << ",\"validate_n_outputs_requested\":" << step.validate_n_outputs_requested
+        ;
+    if (step.debug_enabled) {
+        out
+            << ",\"partial_state_before\":" << step.partial_state_before_json
+            << ",\"partial_state_after_restore\":" << step.partial_state_after_restore_json
+            << ",\"partial_state_after_logical_commit\":" << step.partial_state_after_logical_commit_json
+            << ",\"sampler_checkpoint_used\":\"" << json_escape(step.sampler_checkpoint_used) << "\""
+            << ",\"next_draft_origin\":\"" << json_escape(step.next_draft_origin) << "\""
+            << ",\"next_draft_is_fresh\":" << (step.next_draft_is_fresh ? "true" : "false")
+            << ",\"next_draft_size\":" << step.next_draft_size
+            << ",\"next_draft_tokens\":" << step.next_draft_tokens_json
+            << ",\"next_validate_n_tok\":" << step.next_validate_n_tok
+            << ",\"fresh_draft_tokens_contrib\":" << step.fresh_draft_tokens_contrib
+            << ",\"fresh_accepted_tokens_contrib\":" << step.fresh_accepted_tokens_contrib
+            << ",\"fresh_rejected_tokens_contrib\":" << step.fresh_rejected_tokens_contrib
+            << ",\"fresh_acceptance_ratio_contrib\":" << step.fresh_acceptance_ratio_contrib
+            << ",\"consumed_draft_tokens_contrib\":" << step.consumed_draft_tokens_contrib
+            << ",\"consumed_accepted_tokens_contrib\":" << step.consumed_accepted_tokens_contrib
+            << ",\"consumed_rejected_tokens_contrib\":" << step.consumed_rejected_tokens_contrib
+            << ",\"consumed_acceptance_ratio_contrib\":" << step.consumed_acceptance_ratio_contrib
+            << ",\"post_step_draft_is_fresh\":" << (step.post_step_draft_is_fresh ? "true" : "false")
+            << ",\"post_step_need_replay\":" << (step.post_step_need_replay ? "true" : "false")
+            << ",\"extra_target_decode_reason\":\"" << json_escape(step.extra_target_decode_reason) << "\""
+            << ",\"extra_draft_decode_reason\":\"" << json_escape(step.extra_draft_decode_reason) << "\""
+            << ",\"memory_clear_count\":" << step.memory_clear_count
+            << ",\"seq_rm_count\":" << step.seq_rm_count
+            << ",\"replay_count\":" << step.replay_count
+            << ",\"prefill_count\":" << step.prefill_count
+            << ",\"pre_sample_state\":" << step.pre_sample_state_json;
+    }
+    out << "}";
+    return out.str();
+}
+
+static std::string validate_trace_json(const std::vector<orbit_validate_trace> & items) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < items.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        const auto & item = items[i];
+        out
+            << "{\"step\":" << item.step
+            << ",\"batch_prepare_ms\":" << item.batch_prepare_ms
+            << ",\"logits_rows_setup_ms\":" << item.logits_rows_setup_ms
+            << ",\"llama_decode_validate_ms\":" << item.llama_decode_validate_ms
+            << ",\"post_decode_sample_ms\":" << item.post_decode_sample_ms
+            << ",\"token_count_validated\":" << item.token_count_validated
+            << ",\"n_seq_tokens\":" << item.n_seq_tokens
+            << ",\"batch_n_tokens\":" << item.batch_n_tokens
+            << ",\"batch_logits_count\":" << item.batch_logits_count
+            << ",\"n_outputs_requested\":" << item.n_outputs_requested
+            << ",\"kv_before\":{\"min\":" << item.kv_before_min << ",\"max\":" << item.kv_before_max << "}"
+            << ",\"kv_after\":{\"min\":" << item.kv_after_min << ",\"max\":" << item.kv_after_max << "}"
+            << "}";
+    }
+    out << "]";
+    return out.str();
+}
+
+static std::string int_vec_json(const std::vector<int> & values) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << values[i];
+    }
+    out << "]";
+    return out.str();
+}
+
+static std::string int32_vec_json(const std::vector<int32_t> & values) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << values[i];
+    }
+    out << "]";
+    return out.str();
+}
+
+static std::string target_decode_trace_json(const llama_vocab * vocab, const std::vector<orbit_target_decode_trace> & items) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < items.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        const auto & item = items[i];
+        out
+            << "{\"phase\":\"" << item.phase << "\""
+            << ",\"step\":" << item.step
+            << ",\"draft_size\":" << item.draft_size
+            << ",\"accepted_draft_expected\":" << item.accepted_draft_expected
+            << ",\"started_us\":" << item.started_us
+            << ",\"decode_ms\":" << item.decode_ms
+            << ",\"batch_n_tokens\":" << item.batch_n_tokens
+            << ",\"batch_n_outputs_requested\":" << item.batch_logits_count
+            << ",\"logits_count\":" << item.batch_logits_count
+            << ",\"output_reserve_n_outputs\":" << item.output_reserve_n_outputs
+            << ",\"logits_flags\":" << int_vec_json(item.logits_flags)
+            << ",\"token_ids\":" << token_vec_json(vocab, item.token_ids)
+            << ",\"positions\":" << int32_vec_json(item.positions)
+            << ",\"seq_ids\":" << int32_vec_json(item.seq_ids)
+            << "}";
+    }
+    out << "]";
+    return out.str();
+}
+
+static orbit_target_decode_trace make_target_decode_trace(
+    const char * phase,
+    int step,
+    int draft_size,
+    int accepted_draft_expected,
+    const llama_batch & batch,
+    long long started_us = 0,
+    double decode_ms = 0.0
+) {
+    orbit_target_decode_trace item;
+    item.phase = phase ? phase : "";
+    item.step = step;
+    item.draft_size = draft_size;
+    item.accepted_draft_expected = accepted_draft_expected;
+    item.started_us = started_us;
+    item.decode_ms = decode_ms;
+    item.batch_n_tokens = batch.n_tokens;
+    item.logits_flags.reserve((size_t) batch.n_tokens);
+    item.token_ids.reserve((size_t) batch.n_tokens);
+    item.positions.reserve((size_t) batch.n_tokens);
+    item.seq_ids.reserve((size_t) batch.n_tokens);
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        const int flag = batch.logits ? (batch.logits[i] ? 1 : 0) : 0;
+        item.batch_logits_count += flag;
+        item.logits_flags.push_back(flag);
+        item.token_ids.push_back(batch.token ? batch.token[i] : LLAMA_TOKEN_NULL);
+        item.positions.push_back(batch.pos ? batch.pos[i] : -1);
+        int32_t seq0 = 0;
+        if (batch.n_seq_id && batch.n_seq_id[i] > 0 && batch.seq_id && batch.seq_id[i]) {
+            seq0 = batch.seq_id[i][0];
+        }
+        item.seq_ids.push_back(seq0);
+    }
+    // For this single-sequence non-embedding path, balloc->get_n_outputs() is
+    // equal to the number of rows marked via batch.logits.
+    item.output_reserve_n_outputs = item.batch_logits_count;
+    return item;
+}
+
+static std::string phase_json(const phase_stat & stat) {
+    std::ostringstream out;
+    const double avg_ms = stat.calls > 0 ? stat.total_ms / (double) stat.calls : 0.0;
+    out << "{\"total_ms\":" << stat.total_ms << ",\"calls\":" << stat.calls << ",\"avg_ms\":" << avg_ms << "}";
+    return out.str();
+}
+
+static std::string partial_state_json(
+    const llama_vocab * vocab,
+    const char * stage,
+    size_t prompt_tgt_size,
+    int32_t prompt_tgt_pos_next,
+    llama_token id_last,
+    int32_t n_past,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft,
+    bool sampler_checkpoint_used,
+    const std::vector<llama_token> & draft,
+    bool draft_is_fresh,
+    const std::vector<llama_token> * ids
+) {
+    std::ostringstream out;
+    out
+        << "{"
+        << "\"stage\":\"" << json_escape(stage ? stage : "") << "\""
+        << ",\"prompt_tgt_size\":" << prompt_tgt_size
+        << ",\"prompt_tgt_pos_next\":" << prompt_tgt_pos_next
+        << ",\"id_last\":" << (int) id_last
+        << ",\"n_past\":" << n_past
+        << ",\"ctx_tgt_expected\":{\"min\":" << llama_memory_seq_pos_min(mem_tgt, 0) << ",\"max\":" << llama_memory_seq_pos_max(mem_tgt, 0) << "}"
+        << ",\"ctx_dft_expected\":{\"min\":" << llama_memory_seq_pos_min(mem_dft, 0) << ",\"max\":" << llama_memory_seq_pos_max(mem_dft, 0) << "}"
+        << ",\"sampler_checkpoint_used\":" << (sampler_checkpoint_used ? "true" : "false")
+        << ",\"draft_origin\":\"" << (draft_is_fresh ? "fresh" : "reused") << "\""
+        << ",\"draft_size\":" << draft.size()
+        << ",\"draft\":" << token_vec_json(vocab, draft);
+    if (ids) {
+        out << ",\"ids\":" << token_vec_json(vocab, *ids);
+    }
+    out << "}";
+    return out.str();
+}
+
+static std::string pre_sample_state_json(
+    const llama_vocab * vocab,
+    const std::vector<llama_token> & prompt_tgt,
+    int32_t n_past,
+    llama_token id_last,
+    const std::vector<llama_token> & draft,
+    const std::vector<llama_token> & validate_tokens,
+    const std::vector<int> & validate_rows,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft,
+    const std::string & sampler_before,
+    bool have_ckpt,
+    int32_t seq_rm_start_candidate
+) {
+    std::ostringstream out;
+    out
+        << "{"
+        << "\"frontier_tail\":" << token_vec_json(vocab, tail_tokens(prompt_tgt, 16))
+        << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+        << ",\"prompt_tgt_pos_next\":" << n_past
+        << ",\"n_past\":" << n_past
+        << ",\"id_last\":" << (int) id_last
+        << ",\"spec_draft\":" << token_vec_json(vocab, draft)
+        << ",\"spec_i_batch\":" << int_vec_json(validate_rows)
+        << ",\"validate_tokens\":" << token_vec_json(vocab, validate_tokens)
+        << ",\"ctx_tgt_max_pos\":" << llama_memory_seq_pos_max(mem_tgt, 0)
+        << ",\"ctx_dft_max_pos\":" << llama_memory_seq_pos_max(mem_dft, 0)
+        << ",\"sampler_summary\":\"" << json_escape(sampler_before) << "\""
+        << ",\"sampler_hash\":" << stable_hash_string(sampler_before)
+        << ",\"next_sample_logits_row\":" << (validate_rows.empty() ? -1 : validate_rows.back())
+        << ",\"draft_tokens_committed_before_sample\":0"
+        << ",\"seq_rm_start_candidate\":" << seq_rm_start_candidate
+        << ",\"path_candidate\":\"" << (have_ckpt ? "checkpoint-capable" : "live-only") << "\""
+        << ",\"frontier_kv_gap\":" << ((int64_t) n_past - 1 - (int64_t) llama_memory_seq_pos_max(mem_tgt, 0))
+        << "}";
+    return out.str();
+}
+
+static std::string frontier_event_json(
+    const llama_vocab * vocab,
+    const char * event,
+    const char * origin,
+    const std::vector<llama_token> & prompt_tgt,
+    int32_t n_past,
+    llama_token id_last,
+    const std::vector<llama_token> & draft,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft,
+    const std::string & sampler_summary,
+    const std::vector<llama_token> * emitted_tokens
+) {
+    std::ostringstream out;
+    out
+        << "{"
+        << "\"event\":\"" << json_escape(event ? event : "") << "\""
+        << ",\"origin\":\"" << json_escape(origin ? origin : "") << "\""
+        << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+        << ",\"prompt_tgt_pos_next\":" << n_past
+        << ",\"n_past\":" << n_past
+        << ",\"id_last\":" << (int) id_last
+        << ",\"ctx_tgt_max\":" << llama_memory_seq_pos_max(mem_tgt, 0)
+        << ",\"ctx_dft_max\":" << llama_memory_seq_pos_max(mem_dft, 0)
+        << ",\"frontier_tail\":" << token_vec_json(vocab, tail_tokens(prompt_tgt, 16))
+        << ",\"spec_draft\":" << token_vec_json(vocab, draft)
+        << ",\"sampler_hash\":" << stable_hash_string(sampler_summary)
+        << ",\"sampler_summary\":\"" << json_escape(sampler_summary) << "\"";
+    if (emitted_tokens) {
+        out << ",\"tokens\":" << token_vec_json(vocab, *emitted_tokens);
+    }
+    out << "}";
+    return out.str();
+}
+
+static bool suffix_matches(
+    const std::vector<llama_token> & haystack,
+    const std::vector<llama_token> & needle
+) {
+    if (needle.size() > haystack.size()) {
+        return false;
+    }
+    return std::equal(needle.begin(), needle.end(), haystack.end() - (ptrdiff_t) needle.size());
+}
+
+static std::string validate_pre_decode_json(
+    const llama_vocab * vocab,
+    const char * mode,
+    const std::vector<llama_token> & prompt_tgt,
+    int32_t n_past,
+    llama_token id_last,
+    const std::vector<llama_token> & draft,
+    const std::vector<llama_token> & validate_tokens,
+    const llama_batch & validate,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft
+) {
+    std::vector<int32_t> positions;
+    positions.reserve((size_t) validate.n_tokens);
+    for (int32_t i = 0; i < validate.n_tokens; ++i) {
+        positions.push_back(validate.pos ? validate.pos[i] : -1);
+    }
+    const int32_t ctx_tgt_max = llama_memory_seq_pos_max(mem_tgt, 0);
+    const int32_t ctx_dft_max = llama_memory_seq_pos_max(mem_dft, 0);
+    const int32_t validate_start = positions.empty() ? -1 : positions.front();
+    const int32_t validate_end = positions.empty() ? -1 : positions.back();
+    const bool all_positions_already_in_kv = validate_start >= 0 && validate_end <= ctx_tgt_max;
+    const int32_t kv_gap = validate_start >= 0 ? (validate_start - (ctx_tgt_max + 1)) : -1;
+    std::ostringstream out;
+    out
+        << "{"
+        << "\"mode\":\"" << json_escape(mode ? mode : "") << "\""
+        << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+        << ",\"n_past\":" << n_past
+        << ",\"ctx_tgt_max_pos\":" << ctx_tgt_max
+        << ",\"ctx_dft_max_pos\":" << ctx_dft_max
+        << ",\"id_last\":" << (int) id_last
+        << ",\"draft\":" << token_vec_json(vocab, draft)
+        << ",\"validate_tokens\":" << token_vec_json(vocab, validate_tokens)
+        << ",\"validate_positions\":" << int32_vec_json(positions)
+        << ",\"frontier_tail\":" << token_vec_json(vocab, tail_tokens(prompt_tgt, 16))
+        << ",\"validate_tokens_in_frontier_suffix\":" << (suffix_matches(prompt_tgt, validate_tokens) ? "true" : "false")
+        << ",\"positions_already_in_kv\":" << (all_positions_already_in_kv ? "true" : "false")
+        << ",\"kv_gap_before_validate\":" << kv_gap
+        << ",\"seq_id\":0"
+        << "}";
+    return out.str();
+}
+
+static orbit_step_outcome resolve_validate_accept_restore(
+    orbit_mtp_session * session,
+    common_speculative * spec,
+    llama_context * ctx_tgt,
+    llama_context * ctx_dft,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft,
+    common_sampler *& smpl,
+    const common_prompt_checkpoint & ckpt,
+    bool have_ckpt,
+    std::vector<llama_token> & prompt_tgt,
+    std::vector<llama_token> & draft,
+    bool & draft_is_fresh,
+    int32_t & n_past,
+    const std::vector<llama_token> & validate_tokens,
+    int32_t validate_pos0,
+    bool boundary_committed_live,
+    size_t frontier_logical_base,
+    const llama_vocab * vocab_tgt,
+    orbit_trace_step * debug_trace_step,
+    bool debug_partial,
+    orbit_validate_trace * validate_trace,
+    std::vector<orbit_target_decode_trace> * decode_traces,
+    int trace_step_index,
+    std::string * replay_reason
+) {
+    orbit_step_outcome outcome;
+
+    if (validate_debug_enabled()) {
+        emit_orbit_validate_trace("pre", validate_pre_decode_json(
+            vocab_tgt,
+            boundary_committed_live ? "committed_live_pre" : "baseline",
+            prompt_tgt,
+            n_past,
+            validate_tokens.empty() ? LLAMA_TOKEN_NULL : validate_tokens.front(),
+            draft,
+            validate_tokens,
+            llama_batch{},
+            mem_tgt,
+            mem_dft));
+
+        std::vector<llama_token> prompt_shadow = prompt_tgt;
+        prompt_shadow.insert(prompt_shadow.end(), validate_tokens.begin(), validate_tokens.end());
+        llama_batch shadow = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+        fill_batch(shadow, validate_tokens, (int32_t) prompt_shadow.size());
+        emit_orbit_validate_trace("pre", validate_pre_decode_json(
+            vocab_tgt,
+            "boundary_split_shadow",
+            prompt_shadow,
+            (int32_t) prompt_shadow.size(),
+            validate_tokens.empty() ? LLAMA_TOKEN_NULL : validate_tokens.front(),
+            draft,
+            validate_tokens,
+            shadow,
+            mem_tgt,
+            mem_dft));
+        llama_batch_free(shadow);
+    }
+
+    const auto batch_prepare_start = std::chrono::steady_clock::now();
+    llama_batch validate = llama_batch_init((int32_t) validate_tokens.size(), 0, 1);
+    fill_batch(validate, validate_tokens, validate_pos0);
+    phase_add(session->phase_batch_build, batch_prepare_start);
+    if (validate_debug_enabled()) {
+        emit_orbit_validate_trace("pre", validate_pre_decode_json(
+            vocab_tgt,
+            boundary_committed_live ? "committed_live_with_batch" : "baseline_with_batch",
+            prompt_tgt,
+            n_past,
+            validate_tokens.empty() ? LLAMA_TOKEN_NULL : validate_tokens.front(),
+            draft,
+            validate_tokens,
+            validate,
+            mem_tgt,
+            mem_dft));
+    }
+    if (decode_traces) {
+        decode_traces->push_back(make_target_decode_trace(
+            "validate",
+            trace_step_index,
+            (int) draft.size(),
+            (int) draft.size(),
+            validate));
+    }
+    if (validate_trace) {
+        validate_trace->batch_prepare_ms = elapsed_ms(batch_prepare_start);
+        validate_trace->token_count_validated = (int) validate_tokens.size();
+        validate_trace->n_seq_tokens = (int) validate_tokens.size();
+        validate_trace->batch_n_tokens = validate.n_tokens;
+        int logits_count = 0;
+        for (int32_t i = 0; i < validate.n_tokens; ++i) {
+            logits_count += validate.logits[i] ? 1 : 0;
+        }
+        validate_trace->batch_logits_count = logits_count;
+        validate_trace->n_outputs_requested = logits_count;
+        validate_trace->kv_before_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        validate_trace->kv_before_max = llama_memory_seq_pos_max(mem_tgt, 0);
+    }
+    {
+        const auto phase_start = std::chrono::steady_clock::now();
+        if (llama_decode(ctx_tgt, validate) != 0) {
+            if (validate_debug_enabled()) {
+                std::ostringstream out;
+                out << "{\"mode\":\"" << (boundary_committed_live ? "committed_live_with_batch" : "baseline_with_batch") << "\",\"llama_decode_rc\":-1}";
+                emit_orbit_validate_trace("decode_error", out.str());
+            }
+            phase_add(session->phase_target_validate, phase_start);
+            if (validate_trace) {
+                validate_trace->llama_decode_validate_ms = elapsed_ms(phase_start);
+            }
+            llama_batch_free(validate);
+            set_error("failed to validate speculative batch on target");
+            return outcome;
+        }
+        phase_add(session->phase_target_validate, phase_start);
+        if (validate_trace) {
+            validate_trace->llama_decode_validate_ms = elapsed_ms(phase_start);
+            validate_trace->kv_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+            validate_trace->kv_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        }
+        if (boundary_committed_live) {
+            n_past = (int32_t) prompt_tgt.size();
+        }
+        if (validate_debug_enabled()) {
+            std::ostringstream out;
+            out
+                << "{\"mode\":\"" << (boundary_committed_live ? "committed_live_with_batch" : "baseline_with_batch") << "\",\"llama_decode_rc\":0"
+                << ",\"ctx_tgt_max_after\":" << llama_memory_seq_pos_max(mem_tgt, 0)
+                << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                << ",\"n_past_after\":" << n_past
+                << "}";
+            emit_orbit_validate_trace("decode_result", out.str());
+        }
+    }
+    session->last_target_decode_calls++;
+    if (spec) {
+        const auto phase_start = std::chrono::steady_clock::now();
+        const bool ok = common_speculative_process(spec, validate);
+        phase_add(session->phase_speculative_process, phase_start);
+        if (!ok) {
+            llama_batch_free(validate);
+            set_error("failed to process speculative validate batch");
+            return outcome;
+        }
+    }
+
+    common_sampler * smpl_save = nullptr;
+    if (have_ckpt) {
+        const auto phase_start = std::chrono::steady_clock::now();
+        smpl_save = common_sampler_clone(smpl);
+        phase_add(session->phase_sampler_clone, phase_start);
+    }
+
+    std::vector<int> validate_rows(validate_tokens.size());
+    const auto logits_rows_start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < validate_rows.size(); ++i) {
+        validate_rows[i] = (int) i;
+    }
+    if (validate_trace) {
+        validate_trace->logits_rows_setup_ms = elapsed_ms(logits_rows_start);
+    }
+    const auto sample_start = std::chrono::steady_clock::now();
+    outcome.ids = common_sampler_sample_and_accept_n(smpl, ctx_tgt, validate_rows, draft);
+    phase_add(session->phase_sampler_ops, sample_start);
+    if (validate_trace) {
+        validate_trace->post_decode_sample_ms = elapsed_ms(sample_start);
+    }
+    llama_batch_free(validate);
+
+    if (outcome.ids.empty()) {
+        if (smpl_save) {
+            common_sampler_free(smpl_save);
+        }
+        set_error("speculative acceptance produced no ids");
+        return outcome;
+    }
+
+    const int accepted = std::max(0, (int) outcome.ids.size() - 1);
+    const uint32_t n_rollback = (uint32_t) ((int) draft.size() + 1 - (int) outcome.ids.size());
+    if (draft_is_fresh) {
+        session->last_rollback_tokens_total += (int) n_rollback;
+        session->last_accepted_tokens_total += accepted;
+        session->last_rejected_tokens_total += (int) draft.size() - accepted;
+    } else {
+        session->last_reused_draft_tokens_total += (int) draft.size();
+        session->last_reused_accepted_tokens_total += accepted;
+        session->last_reused_rejected_tokens_total += (int) draft.size() - accepted;
+    }
+
+    if (accepted == (int) draft.size()) {
+        if (smpl_save) {
+            common_sampler_free(smpl_save);
+        }
+        outcome.resolution = orbit_step_resolution::full_accept;
+        if (debug_partial && debug_trace_step) {
+            debug_trace_step->partial_state_after_logical_commit_json = partial_state_json(
+                vocab_tgt,
+                "full_accept_commit",
+                prompt_tgt.size(),
+                n_past,
+                outcome.ids.empty() ? validate_tokens.front() : outcome.ids.back(),
+                n_past,
+                mem_tgt,
+                mem_dft,
+                false,
+                draft,
+                draft_is_fresh,
+                &outcome.ids);
+        }
+        return outcome;
+    }
+
+    session->last_partial_accept_steps++;
+    session->last_seq_rm_supported = false;
+    if (boundary_committed_live && have_ckpt) {
+        common_speculative_accept(spec, 0, (uint16_t) accepted);
+        const size_t committed_prompt_size = frontier_logical_base + 1 + (size_t) accepted;
+        if (committed_prompt_size <= prompt_tgt.size()) {
+            prompt_tgt.resize(committed_prompt_size);
+            n_past = (int32_t) prompt_tgt.size();
+            {
+                const auto phase_start = std::chrono::steady_clock::now();
+                llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+                llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+                phase_add(session->phase_seq_rm, phase_start);
+            }
+            session->debug_seq_rm_count += 2;
+            const bool live_ok =
+                prompt_tgt.size() == (size_t) n_past &&
+                llama_memory_seq_pos_max(mem_tgt, 0) == n_past - 1 &&
+                llama_memory_seq_pos_max(mem_dft, 0) == n_past - 1;
+            if (live_ok) {
+                if (smpl_save) {
+                    common_sampler_free(smpl_save);
+                    smpl_save = nullptr;
+                }
+                draft.clear();
+                draft_is_fresh = true;
+                session->last_partial_no_replay_steps++;
+                session->last_seq_rm_supported = true;
+                outcome.resolution = orbit_step_resolution::live_partial;
+                if (debug_partial && debug_trace_step) {
+                    debug_trace_step->partial_state_after_logical_commit_json = partial_state_json(
+                        vocab_tgt,
+                        "after_live_partial_consume",
+                        prompt_tgt.size(),
+                        n_past,
+                        outcome.ids.back(),
+                        n_past,
+                        mem_tgt,
+                        mem_dft,
+                        false,
+                        draft,
+                        draft_is_fresh,
+                        &outcome.ids);
+                }
+                return outcome;
+            }
+            prompt_tgt.resize(frontier_logical_base);
+            n_past = (int32_t) prompt_tgt.size();
+        }
+    }
+    if (have_ckpt && smpl_save) {
+        {
+            const auto phase_start = std::chrono::steady_clock::now();
+            ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            {
+                const auto phase_start = std::chrono::steady_clock::now();
+                llama_memory_seq_rm(mem_tgt, 0, ckpt.pos_max + 1, -1);
+                phase_add(session->phase_seq_rm, phase_start);
+            }
+            session->debug_seq_rm_count++;
+            phase_add(session->phase_ctx_tgt_restore, phase_start);
+        }
+
+        {
+            const auto phase_start = std::chrono::steady_clock::now();
+            ckpt.load_dft(ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            if (draft_trace_enabled()) {
+                std::ostringstream out;
+                out
+                    << "{"
+                    << "\"op\":\"load_dft_ckpt\""
+                    << ",\"step_index\":" << (validate_trace ? validate_trace->step : -1)
+                    << ",\"reason\":\"partial_restore\""
+                    << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                    << ",\"n_past\":" << n_past
+                    << ",\"id_last\":" << (int) validate_tokens.front()
+                    << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                    << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                    << "}";
+                emit_orbit_dft_trace(out.str());
+            }
+            {
+                const auto phase_start_seq_rm = std::chrono::steady_clock::now();
+                const int32_t before_max = llama_memory_seq_pos_max(mem_dft, 0);
+                llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                phase_add(session->phase_seq_rm, phase_start_seq_rm);
+                if (draft_trace_enabled()) {
+                    std::ostringstream out;
+                    out
+                        << "{"
+                        << "\"op\":\"seq_rm_dft\""
+                        << ",\"step_index\":" << (validate_trace ? validate_trace->step : -1)
+                        << ",\"reason\":\"partial_restore\""
+                        << ",\"start_pos\":" << (ckpt.pos_max + 1)
+                        << ",\"end_pos\":-1"
+                        << ",\"ctx_dft_max_before\":" << before_max
+                        << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                        << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                        << ",\"n_past\":" << n_past
+                        << ",\"id_last\":" << (int) validate_tokens.front()
+                        << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                        << "}";
+                    emit_orbit_dft_trace(out.str());
+                }
+            }
+            session->debug_seq_rm_count++;
+            phase_add(session->phase_ctx_dft_restore, phase_start);
+        }
+
+        if (debug_partial && debug_trace_step) {
+            debug_trace_step->partial_state_after_restore_json = partial_state_json(
+                vocab_tgt,
+                "after_restore_before_logical_commit",
+                prompt_tgt.size(),
+                n_past,
+                validate_tokens.front(),
+                n_past,
+                mem_tgt,
+                mem_dft,
+                true,
+                draft,
+                draft_is_fresh,
+                &outcome.ids);
+        }
+        prompt_tgt.resize((size_t) ckpt.n_tokens);
+        n_past = (int32_t) prompt_tgt.size();
+
+        draft = outcome.ids;
+        draft_is_fresh = false;
+
+        {
+            const auto phase_start = std::chrono::steady_clock::now();
+            common_sampler_free(smpl);
+            smpl = smpl_save;
+            phase_add(session->phase_sampler_restore, phase_start);
+        }
+        smpl_save = nullptr;
+
+        session->last_restore_count++;
+        outcome.resolution = orbit_step_resolution::restored_partial;
+        if (debug_partial && debug_trace_step) {
+            debug_trace_step->partial_state_after_logical_commit_json = partial_state_json(
+                vocab_tgt,
+                "after_partial_restore_logical_frontier",
+                prompt_tgt.size(),
+                n_past,
+                outcome.ids.back(),
+                n_past,
+                mem_tgt,
+                mem_dft,
+                true,
+                draft,
+                draft_is_fresh,
+                &outcome.ids);
+        }
+        return outcome;
+    }
+
+    const bool smpl_clone_available = smpl_save != nullptr;
+    if (smpl_save) {
+        common_sampler_free(smpl_save);
+        smpl_save = nullptr;
+    }
+    if (debug_partial && debug_trace_step) {
+        debug_trace_step->partial_state_after_logical_commit_json = partial_state_json(
+            vocab_tgt,
+            "replay_fallback_decision",
+            prompt_tgt.size(),
+            n_past,
+            validate_tokens.empty() ? LLAMA_TOKEN_NULL : validate_tokens.front(),
+            n_past,
+            mem_tgt,
+            mem_dft,
+            true,
+            draft,
+            draft_is_fresh,
+            &outcome.ids);
+        std::ostringstream replay_out;
+        replay_out
+            << "{"
+            << "\"boundary_split_live\":" << (boundary_committed_live ? "true" : "false")
+            << ",\"boundary_logical_base\":" << frontier_logical_base
+            << ",\"have_ckpt\":" << (have_ckpt ? "true" : "false")
+            << ",\"sampler_clone_available\":"
+            << (smpl_clone_available ? "true" : "false")
+            << ",\"n_past\":" << n_past
+            << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+            << ",\"id_last\":" << (validate_tokens.empty() ? (int) LLAMA_TOKEN_NULL : (int) validate_tokens.front())
+            << ",\"draft_size\":" << draft.size()
+            << ",\"draft\":" << token_vec_json(vocab_tgt, draft)
+            << ",\"draft_is_fresh\":" << (draft_is_fresh ? "true" : "false")
+            << ",\"ctx_tgt_max_before\":" << llama_memory_seq_pos_max(mem_tgt, 0)
+            << ",\"ctx_dft_max_before\":" << llama_memory_seq_pos_max(mem_dft, 0)
+            << ",\"reason\":\"replay_fallback\""
+            << "}";
+        emit_orbit_validate_trace("need_replay", replay_out.str());
+        emit_orbit_frontier_trace("need_replay", replay_out.str());
+    }
+    session->last_replay_fallback_steps++;
+    if (replay_reason) {
+        if (!have_ckpt) {
+            *replay_reason = "replay_fallback: no checkpoint";
+        } else if (boundary_committed_live) {
+            *replay_reason = "replay_fallback: boundary split fallback";
+        } else {
+            *replay_reason = "replay_fallback: unsupported partial path";
+        }
+    }
+    outcome.resolution = orbit_step_resolution::replay_fallback;
+    return outcome;
+}
+
+static void cleanup_session(orbit_mtp_session * session) {
+    if (!session) {
+        return;
+    }
+    if (session->spec) {
+        common_speculative_free(session->spec);
+        session->spec = nullptr;
+    }
+    if (session->ctx_dft) {
+        llama_free(session->ctx_dft);
+        session->ctx_dft = nullptr;
+    }
+    if (session->model_dft) {
+        llama_model_free(session->model_dft);
+        session->model_dft = nullptr;
+    }
+}
+
+static bool reset_speculative_request_state(
+    orbit_mtp_session * session,
+    llama_context * ctx_tgt
+) {
+    if (!session || !ctx_tgt) {
+        set_error("missing speculative request state handles");
+        return false;
+    }
+
+    if (session->spec) {
+        common_speculative_free(session->spec);
+        session->spec = nullptr;
+    }
+
+    session->spec_params.draft.ctx_tgt = ctx_tgt;
+    session->spec_params.draft.ctx_dft = session->ctx_dft;
+    session->spec = common_speculative_init(session->spec_params, 1);
+    if (!session->spec) {
+        set_error("failed to reinitialize speculative request state");
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+static double elapsed_s(std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+static std::string token_piece(const llama_vocab * vocab, llama_token token) {
+    char buf[512];
+    const int n = llama_token_to_piece(vocab, token, buf, sizeof(buf), 0, true);
+    if (n <= 0) {
+        return {};
+    }
+    return std::string(buf, buf + n);
+}
+
+static bool tokenize_prompt(const llama_model * model, const char * text, std::vector<llama_token> & out) {
+    auto * vocab = llama_model_get_vocab(model);
+    const bool add_special = std::strncmp(text, "<bos>", 5) != 0;
+    const int32_t n_tok = -llama_tokenize(vocab, text, (int32_t) std::strlen(text), nullptr, 0, add_special, true);
+    if (n_tok <= 0) {
+        return false;
+    }
+    out.resize((size_t) n_tok);
+    return llama_tokenize(vocab, text, (int32_t) std::strlen(text), out.data(), n_tok, add_special, true) >= 0;
+}
+
+static bool can_partial_rollback(
+    llama_context * ctx,
+    uint32_t n_rollback
+) {
+    const auto mode = common_context_can_seq_rm(ctx);
+    if (mode == COMMON_CONTEXT_SEQ_RM_TYPE_PART) {
+        return true;
+    }
+    if (mode == COMMON_CONTEXT_SEQ_RM_TYPE_RS) {
+        return n_rollback <= (uint32_t) llama_n_rs_seq(ctx);
+    }
+    return false;
+}
+
+static common_params_sampling make_reference_sampling_params() {
+    common_params_sampling params;
+    params.top_k = 1;
+    params.top_p = 1.0f;
+    params.min_p = 0.0f;
+    params.typ_p = 1.0f;
+    params.temp = 0.0f;
+    params.penalty_last_n = 0;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.dry_multiplier = 0.0f;
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+    };
+    return params;
+}
+
+static size_t shared_prefix_tokens(
+    const std::vector<llama_token> & a,
+    const std::vector<llama_token> & b
+) {
+    const size_t max_common = std::min(a.size(), b.size());
+    size_t common = 0;
+    while (common < max_common && a[common] == b[common]) {
+        common++;
+    }
+    return common;
+}
+
+static bool is_token_prefix(
+    const std::vector<llama_token> & prefix,
+    const std::vector<llama_token> & tokens
+) {
+    return prefix.size() <= tokens.size() &&
+        shared_prefix_tokens(prefix, tokens) == prefix.size();
+}
+
+static void fill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0) {
+    batch.n_tokens = (int32_t) tokens.size();
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        batch.token[i] = tokens[(size_t) i];
+        batch.pos[i] = pos0 + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = 1;
+    }
+}
+
+static void fill_target_prefill_batch(llama_batch & batch, const std::vector<llama_token> & tokens, int32_t pos0) {
+    batch.n_tokens = (int32_t) tokens.size();
+    for (int32_t i = 0; i < batch.n_tokens; ++i) {
+        batch.token[i] = tokens[(size_t) i];
+        batch.pos[i] = pos0 + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = 0;
+    }
+    if (batch.n_tokens > 0) {
+        batch.logits[batch.n_tokens - 1] = 1;
+    }
+}
+
+extern "C" const char * orbit_mtp_last_error() {
+    return g_last_error.c_str();
+}
+
+extern "C" void * orbit_mtp_session_create(
+    const char * draft_model_path,
+    void * ctx_tgt_ptr,
+    uint32_t n_ctx,
+    uint32_t n_batch,
+    uint32_t n_ubatch,
+    int32_t n_threads,
+    int32_t n_threads_batch
+) {
+    g_last_error.clear();
+    if (!draft_model_path || !draft_model_path[0]) {
+        set_error("draft model path is required");
+        return nullptr;
+    }
+    if (!ctx_tgt_ptr) {
+        set_error("target context is required");
+        return nullptr;
+    }
+
+    std::unique_ptr<orbit_mtp_session> session(new orbit_mtp_session());
+    session->rss_before_kb = rss_kb();
+    session->rss_peak_kb = session->rss_before_kb;
+
+    auto model_params = llama_model_default_params();
+    session->model_dft = llama_model_load_from_file(draft_model_path, model_params);
+    session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
+    if (!session->model_dft) {
+        set_error("failed to load draft model");
+        return nullptr;
+    }
+
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = n_ctx;
+    ctx_params.n_batch = n_batch;
+    ctx_params.n_ubatch = n_ubatch;
+    ctx_params.n_threads = n_threads;
+    ctx_params.n_threads_batch = n_threads_batch;
+    ctx_params.n_outputs_max = 1 + ORBIT_MTP_DRAFT_N_MAX;
+    ctx_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    ctx_params.n_rs_seq = 0;
+    ctx_params.ctx_other = static_cast<llama_context *>(ctx_tgt_ptr);
+
+    session->ctx_dft = llama_init_from_model(session->model_dft, ctx_params);
+    session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
+    if (!session->ctx_dft) {
+        set_error("failed to create MTP draft context");
+        cleanup_session(session.get());
+        return nullptr;
+    }
+
+    session->spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    session->spec_params.draft.n_max = ORBIT_MTP_DRAFT_N_MAX;
+    session->spec_params.draft.ctx_tgt = static_cast<llama_context *>(ctx_tgt_ptr);
+    session->spec_params.draft.ctx_dft = session->ctx_dft;
+
+    session->spec = common_speculative_init(session->spec_params, 1);
+    session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
+    if (!session->spec) {
+        set_error("failed to initialize speculative MTP state");
+        cleanup_session(session.get());
+        return nullptr;
+    }
+
+    session->rss_after_init_kb = rss_kb();
+    return session.release();
+}
+
+extern "C" bool orbit_mtp_session_reset(void * handle, void * ctx_tgt_ptr) {
+    g_last_error.clear();
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    auto * ctx_tgt = static_cast<llama_context *>(ctx_tgt_ptr);
+    if (!session || !ctx_tgt) {
+        set_error("persistent MTP session reset requires valid handles");
+        return false;
+    }
+
+    if (session->spec) {
+        common_speculative_free(session->spec);
+        session->spec = nullptr;
+    }
+
+    auto * mem = llama_get_memory(session->ctx_dft);
+    if (mem) {
+        llama_memory_clear(mem, true);
+    }
+
+    session->spec_params.draft.ctx_tgt = ctx_tgt;
+    session->spec_params.draft.ctx_dft = session->ctx_dft;
+    session->spec = common_speculative_init(session->spec_params, 1);
+    if (!session->spec) {
+        set_error("failed to reinitialize speculative MTP state");
+        return false;
+    }
+    session->request_boundary_ckpt.clear();
+    session->request_boundary_prompt_tgt.clear();
+
+    return true;
+}
+
+extern "C" void orbit_mtp_session_free(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    cleanup_session(session);
+    delete session;
+}
+
+extern "C" void * orbit_mtp_session_ctx_dft(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? static_cast<void *>(session->ctx_dft) : nullptr;
+}
+
+extern "C" void * orbit_mtp_session_spec(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? static_cast<void *>(session->spec) : nullptr;
+}
+
+extern "C" long orbit_mtp_session_rss_before_kb(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->rss_before_kb : -1;
+}
+
+extern "C" long orbit_mtp_session_rss_after_init_kb(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->rss_after_init_kb : -1;
+}
+
+extern "C" long orbit_mtp_session_rss_peak_kb(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->rss_peak_kb : -1;
+}
+
+extern "C" bool orbit_mtp_session_complete(void * handle, void * ctx_tgt_ptr, const char * prompt_text, int32_t max_tokens) {
+    g_last_error.clear();
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    auto * ctx_tgt = static_cast<llama_context *>(ctx_tgt_ptr);
+    if (!session || !ctx_tgt || !prompt_text) {
+        set_error("persistent MTP completion requires valid handles and prompt");
+        return false;
+    }
+    if (!session->ctx_dft || !session->spec) {
+        set_error("persistent MTP session is not initialized");
+        return false;
+    }
+    if (!reset_speculative_request_state(session, ctx_tgt)) {
+        return false;
+    }
+
+    session->last_content.clear();
+    session->last_output_tokens = 0;
+    session->last_draft_tokens_total = 0;
+    session->last_accepted_tokens_total = 0;
+    session->last_rejected_tokens_total = 0;
+    session->last_reused_draft_tokens_total = 0;
+    session->last_reused_accepted_tokens_total = 0;
+    session->last_reused_rejected_tokens_total = 0;
+    session->last_acceptance_ratio = 0.0;
+    session->last_fresh_acceptance_ratio = 0.0;
+    session->last_consumed_acceptance_ratio = 0.0;
+    session->last_target_decode_calls = 0;
+    session->last_draft_decode_calls = 0;
+    session->last_elapsed_ms = 0.0;
+    session->last_tokens_per_second = 0.0;
+    session->last_full_accept_steps = 0;
+    session->last_replay_steps = 0;
+    session->last_partial_accept_steps = 0;
+    session->last_partial_no_replay_steps = 0;
+    session->last_replay_fallback_steps = 0;
+    session->last_seq_rm_supported = false;
+    session->last_rollback_tokens_total = 0;
+    session->last_checkpoint_count = 0;
+    session->last_restore_count = 0;
+    session->last_trace_json = "[]";
+    session->last_timing_json = "{}";
+    session->last_validate_trace_json = "[]";
+    session->last_target_decode_trace_json = "[]";
+    session->phase_prefix_restore = {};
+    session->phase_suffix_decode_target = {};
+    session->phase_draft_generation = {};
+    session->phase_target_validate = {};
+    session->phase_speculative_process = {};
+    session->phase_sampler_clone = {};
+    session->phase_sampler_restore = {};
+    session->phase_sampler_ops = {};
+    session->phase_seq_rm = {};
+    session->phase_batch_build = {};
+    session->phase_ctx_tgt_checkpoint = {};
+    session->phase_ctx_tgt_restore = {};
+    session->phase_ctx_dft_checkpoint = {};
+    session->phase_ctx_dft_restore = {};
+    session->phase_rollback_replay = {};
+    session->phase_detokenize_bridge = {};
+    session->phase_loop_total = {};
+    session->debug_memory_clear_count = 0;
+    session->debug_seq_rm_count = 0;
+    session->debug_replay_count = 0;
+    session->debug_prefill_target_count = 0;
+    session->debug_prefill_target_suffix_count = 0;
+    session->debug_validate_decode_count = 0;
+    session->debug_draft_decode_count = 0;
+
+    auto * model_tgt = llama_get_model(ctx_tgt);
+    auto * vocab_tgt = llama_model_get_vocab(model_tgt);
+    std::vector<llama_token> prompt;
+    if (!tokenize_prompt(model_tgt, prompt_text, prompt)) {
+        set_error("failed to tokenize prompt");
+        return false;
+    }
+    if (prompt.size() < 2) {
+        set_error("prompt too short for persistent mtp completion");
+        return false;
+    }
+
+    auto * mem_tgt = llama_get_memory(ctx_tgt);
+    auto * mem_dft = llama_get_memory(session->ctx_dft);
+    if (!mem_tgt || !mem_dft) {
+        set_error("failed to access llama memory");
+        return false;
+    }
+
+    std::vector<llama_token> prompt_tgt(prompt);
+    llama_token id_last = LLAMA_TOKEN_NULL;
+    int32_t n_past = (int32_t) prompt_tgt.size();
+
+    auto sampling_params = make_reference_sampling_params();
+    common_sampler * smpl = common_sampler_init(model_tgt, sampling_params);
+    if (!smpl) {
+        set_error("failed to initialize common sampler");
+        return false;
+    }
+    std::vector<llama_token> generated;
+    generated.reserve((size_t) std::max(1, std::min(32, (int) max_tokens)));
+    const auto t0 = std::chrono::steady_clock::now();
+    bool need_replay = true;
+    bool is_recovery_replay = false;
+    std::vector<llama_token> draft;
+    common_prompt_checkpoint ckpt;
+    bool have_ckpt = false;
+    bool draft_is_fresh = false;
+    std::vector<orbit_trace_step> trace_steps;
+    std::vector<orbit_validate_trace> validate_traces;
+    std::vector<orbit_target_decode_trace> target_decode_traces;
+    int trace_step_index = 0;
+    int pending_partial_trace_index = -1;
+    const bool debug_partial = partial_debug_enabled();
+    bool frontier_trace_before_first_partial = true;
+    const size_t reusable_request_prefix =
+        session->request_boundary_ckpt.empty() ? 0 : session->request_boundary_prompt_tgt.size();
+    const bool can_restore_request_boundary =
+        !session->request_boundary_ckpt.empty() &&
+        is_token_prefix(session->request_boundary_prompt_tgt, prompt_tgt);
+    bool used_request_boundary = false;
+
+    while ((int) generated.size() < std::max(1, std::min(32, (int) max_tokens))) {
+        const auto loop_phase_start = std::chrono::steady_clock::now();
+        if (need_replay) {
+            const bool replay_is_recovery = is_recovery_replay;
+            const auto replay_phase_start = std::chrono::steady_clock::now();
+            const bool use_request_boundary = generated.empty() && can_restore_request_boundary && !used_request_boundary;
+            if (debug_partial) {
+                const auto replay_origin =
+                    use_request_boundary ? "request_boundary" :
+                    (prompt_tgt.empty() ? "initial_replay" : "target_replay_suffix_or_validate");
+                emit_orbit_frontier_trace("replay", frontier_event_json(
+                    vocab_tgt,
+                    replay_origin,
+                    "replay_entry",
+                    prompt_tgt,
+                    n_past,
+                    id_last,
+                    draft,
+                    mem_tgt,
+                    mem_dft,
+                    common_sampler_prev_str(smpl, ctx_tgt, 8),
+                    nullptr));
+            }
+            if (replay_is_recovery) {
+                session->last_replay_steps++;
+                session->debug_replay_count++;
+            }
+            llama_memory_clear(mem_tgt, true);
+            llama_memory_clear(mem_dft, true);
+            session->debug_memory_clear_count += 2;
+
+            if (!prompt_tgt.empty()) {
+                if (use_request_boundary) {
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        session->request_boundary_ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        session->request_boundary_ckpt.load_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        phase_add(session->phase_prefix_restore, phase_start);
+                    }
+                    used_request_boundary = true;
+                } else {
+                    const auto batch_build_start = std::chrono::steady_clock::now();
+                    llama_batch prefill_tgt = llama_batch_init((int32_t) prompt_tgt.size(), 0, 1);
+                    fill_target_prefill_batch(prefill_tgt, prompt_tgt, 0);
+                    phase_add(session->phase_batch_build, batch_build_start);
+                    const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::steady_clock::now().time_since_epoch()).count();
+                    double decode_ms = 0.0;
+                    session->debug_prefill_target_count++;
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        if (llama_decode(ctx_tgt, prefill_tgt) != 0) {
+                            decode_ms = elapsed_ms(phase_start);
+                            target_decode_traces.push_back(make_target_decode_trace(
+                                "prefill_target",
+                                trace_step_index,
+                                0,
+                                0,
+                                prefill_tgt,
+                                decode_started_us,
+                                decode_ms));
+                            phase_add(session->phase_suffix_decode_target, phase_start);
+                            llama_batch_free(prefill_tgt);
+                            common_sampler_free(smpl);
+                            set_error("failed to decode target prefill");
+                            return false;
+                        }
+                        decode_ms = elapsed_ms(phase_start);
+                        phase_add(session->phase_suffix_decode_target, phase_start);
+                    }
+                    target_decode_traces.push_back(make_target_decode_trace(
+                        "prefill_target",
+                        trace_step_index,
+                        0,
+                        0,
+                        prefill_tgt,
+                        decode_started_us,
+                        decode_ms));
+                    session->last_target_decode_calls++;
+                    llama_batch_free(prefill_tgt);
+                }
+                std::vector<llama_token> process_tokens;
+                int32_t process_pos0 = 0;
+                if (use_request_boundary) {
+                    process_tokens.assign(
+                        prompt_tgt.begin() + (ptrdiff_t) reusable_request_prefix,
+                        prompt_tgt.end());
+                    process_pos0 = (int32_t) reusable_request_prefix;
+                } else {
+                    process_tokens = prompt_tgt;
+                    process_pos0 = 0;
+                }
+                if (!process_tokens.empty()) {
+                    if (use_request_boundary) {
+                        const auto batch_build_start = std::chrono::steady_clock::now();
+                        llama_batch prefill_tgt = llama_batch_init((int32_t) process_tokens.size(), 0, 1);
+                        fill_target_prefill_batch(prefill_tgt, process_tokens, process_pos0);
+                        phase_add(session->phase_batch_build, batch_build_start);
+                        const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch()).count();
+                        double decode_ms = 0.0;
+                        session->debug_prefill_target_suffix_count++;
+                        {
+                            const auto phase_start = std::chrono::steady_clock::now();
+                            if (llama_decode(ctx_tgt, prefill_tgt) != 0) {
+                                decode_ms = elapsed_ms(phase_start);
+                                target_decode_traces.push_back(make_target_decode_trace(
+                                    "prefill_target_suffix",
+                                    trace_step_index,
+                                    0,
+                                    0,
+                                    prefill_tgt,
+                                    decode_started_us,
+                                    decode_ms));
+                                phase_add(session->phase_suffix_decode_target, phase_start);
+                                llama_batch_free(prefill_tgt);
+                                common_sampler_free(smpl);
+                                set_error("failed to decode target prefill suffix");
+                                return false;
+                            }
+                            decode_ms = elapsed_ms(phase_start);
+                            phase_add(session->phase_suffix_decode_target, phase_start);
+                        }
+                        target_decode_traces.push_back(make_target_decode_trace(
+                            "prefill_target_suffix",
+                            trace_step_index,
+                            0,
+                            0,
+                            prefill_tgt,
+                            decode_started_us,
+                            decode_ms));
+                        session->last_target_decode_calls++;
+                        llama_batch_free(prefill_tgt);
+                    }
+                    const auto batch_build_start = std::chrono::steady_clock::now();
+                    llama_batch prefill = llama_batch_init((int32_t) process_tokens.size(), 0, 1);
+                    fill_batch(prefill, process_tokens, process_pos0);
+                    phase_add(session->phase_batch_build, batch_build_start);
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        const bool ok = common_speculative_process(session->spec, prefill);
+                        phase_add(session->phase_speculative_process, phase_start);
+                        if (!ok) {
+                            llama_batch_free(prefill);
+                            common_sampler_free(smpl);
+                            set_error("failed to process speculative prefill");
+                            return false;
+                        }
+                    }
+                    llama_batch_free(prefill);
+                }
+                common_speculative_begin(session->spec, 0, prompt_tgt);
+                if (generated.empty()) {
+                    session->request_boundary_ckpt.clear();
+                    session->request_boundary_ckpt.update_pos(
+                        (int64_t) prompt_tgt.size(),
+                        llama_memory_seq_pos_min(mem_tgt, 0),
+                        llama_memory_seq_pos_max(mem_tgt, 0));
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        session->request_boundary_ckpt.update_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        phase_add(session->phase_ctx_tgt_checkpoint, phase_start);
+                    }
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        session->request_boundary_ckpt.update_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        phase_add(session->phase_ctx_dft_checkpoint, phase_start);
+                    }
+                    session->last_checkpoint_count++;
+                    session->request_boundary_prompt_tgt = prompt_tgt;
+                }
+            } else {
+                common_speculative_begin(session->spec, 0, prompt_tgt);
+                if (generated.empty()) {
+                    session->request_boundary_ckpt.clear();
+                    session->request_boundary_prompt_tgt.clear();
+                }
+            }
+            draft.clear();
+            ckpt.clear();
+            have_ckpt = false;
+            draft_is_fresh = false;
+            n_past = (int32_t) prompt_tgt.size();
+            if (generated.empty()) {
+                {
+                    const auto phase_start = std::chrono::steady_clock::now();
+                    id_last = common_sampler_sample(smpl, ctx_tgt, -1);
+                    common_sampler_accept(smpl, id_last, true);
+                    phase_add(session->phase_sampler_ops, phase_start);
+                }
+                if (llama_vocab_is_eog(vocab_tgt, id_last)) {
+                    goto done;
+                }
+                generated.push_back(id_last);
+                {
+                    const auto phase_start = std::chrono::steady_clock::now();
+                    session->last_content += token_piece(vocab_tgt, id_last);
+                    phase_add(session->phase_detokenize_bridge, phase_start);
+                }
+                session->last_output_tokens++;
+                if (frontier_trace_before_first_partial) {
+                    const std::vector<llama_token> tok = {id_last};
+                    emit_orbit_frontier_trace("advance", frontier_event_json(
+                        vocab_tgt,
+                        "initial_sample",
+                        "target_sample",
+                        prompt_tgt,
+                        n_past,
+                        id_last,
+                        draft,
+                        mem_tgt,
+                        mem_dft,
+                        common_sampler_prev_str(smpl, ctx_tgt, 8),
+                        &tok));
+                }
+                if ((int) generated.size() >= std::max(1, std::min(32, (int) max_tokens))) {
+                    goto done;
+                }
+            }
+            need_replay = false;
+            if (replay_is_recovery) {
+                phase_add(session->phase_rollback_replay, replay_phase_start);
+            }
+            is_recovery_replay = false;
+        }
+
+        size_t n_draft = draft.size();
+        if (draft.empty()) {
+            const int32_t draft_ctx_tgt_max_before = llama_memory_seq_pos_max(mem_tgt, 0);
+            const int32_t draft_ctx_dft_max_before = llama_memory_seq_pos_max(mem_dft, 0);
+            const std::string draft_sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
+            ckpt.update_pos(
+                (int64_t) prompt_tgt.size(),
+                llama_memory_seq_pos_min(mem_tgt, 0),
+                llama_memory_seq_pos_max(mem_tgt, 0));
+            ckpt.update_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+            if (draft_trace_enabled()) {
+                std::ostringstream out;
+                out
+                    << "{"
+                    << "\"op\":\"update_dft_ckpt\""
+                    << ",\"step_index\":" << (trace_step_index + 1)
+                    << ",\"reason\":\"before_fresh_draft\""
+                    << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                    << ",\"n_past\":" << n_past
+                    << ",\"id_last\":" << (int) id_last
+                    << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                    << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                    << "}";
+                emit_orbit_dft_trace(out.str());
+            }
+
+            common_speculative_get_draft_params(session->spec, 0) = {
+                true,
+                std::min(ORBIT_MTP_DRAFT_N_MAX, std::max(1, std::min(32, (int) max_tokens)) - (int) generated.size()),
+                (llama_pos) n_past,
+                id_last,
+                &prompt_tgt,
+                &draft,
+            };
+            {
+                const auto phase_start = std::chrono::steady_clock::now();
+                common_speculative_draft(session->spec);
+                phase_add(session->phase_draft_generation, phase_start);
+            }
+            if (draft_trace_enabled()) {
+                std::ostringstream out;
+                out
+                    << "{"
+                    << "\"op\":\"draft_decode\""
+                    << ",\"step_index\":" << (trace_step_index + 1)
+                    << ",\"reason\":\"fresh_draft_generation\""
+                    << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                    << ",\"n_past\":" << n_past
+                    << ",\"id_last\":" << (int) id_last
+                    << ",\"draft_tokens\":" << token_vec_json(vocab_tgt, draft)
+                    << ",\"draft_positions_start\":" << n_past
+                    << ",\"draft_positions_end\":" << (draft.empty() ? n_past - 1 : n_past + (int32_t) draft.size() - 1)
+                    << ",\"n_outputs\":" << (int) draft.size()
+                    << ",\"ctx_dft_max_before\":" << draft_ctx_dft_max_before
+                    << ",\"ctx_dft_max_after_expected\":" << (draft.empty() ? draft_ctx_dft_max_before : draft_ctx_dft_max_before + (int32_t) draft.size())
+                    << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                    << "}";
+                emit_orbit_dft_trace(out.str());
+            }
+            session->last_draft_decode_calls++;
+            session->debug_draft_decode_count++;
+            session->last_draft_tokens_total += (int) draft.size();
+            draft_is_fresh = true;
+            n_draft = draft.size();
+            if (draft_trace_enabled()) {
+                const uint64_t sampler_hash_before = stable_hash_string(draft_sampler_before);
+                const uint64_t sampler_hash_after = stable_hash_string(common_sampler_prev_str(smpl, ctx_tgt, 8));
+                for (size_t i = 0; i < draft.size(); ++i) {
+                    const llama_token input_token = i == 0 ? id_last : draft[i - 1];
+                    const llama_token sampled_token = draft[i];
+                    std::ostringstream out;
+                    out
+                        << "{"
+                        << "\"step_index\":" << (trace_step_index + 1)
+                        << ",\"draft_index\":" << (int) i
+                        << ",\"input_token\":{\"id\":" << (int) input_token << ",\"piece\":\"" << token_piece_json(vocab_tgt, input_token) << "\"}"
+                        << ",\"sampled_draft_token\":{\"id\":" << (int) sampled_token << ",\"piece\":\"" << token_piece_json(vocab_tgt, sampled_token) << "\"}"
+                        << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                        << ",\"n_past\":" << n_past
+                        << ",\"ctx_tgt_max_before\":" << draft_ctx_tgt_max_before
+                        << ",\"ctx_dft_max_before\":" << draft_ctx_dft_max_before
+                        << ",\"ctx_dft_max_after_expected\":" << (draft_ctx_dft_max_before + (int32_t) i + 1)
+                        << ",\"batch_position\":" << (n_past + (int32_t) i)
+                        << ",\"logits_row\":" << (int) i
+                        << ",\"sampler_hash_before\":" << sampler_hash_before
+                        << ",\"sampler_hash_after\":" << sampler_hash_after
+                        << ",\"memory_clear_count\":" << session->debug_memory_clear_count
+                        << ",\"seq_rm_count\":" << session->debug_seq_rm_count
+                        << ",\"batch_n_tokens\":" << (int) draft.size()
+                        << ",\"batch_n_outputs\":" << (int) draft.size()
+                        << ",\"boundary_split\":" << (boundary_split_enabled() ? "true" : "false")
+                        << "}";
+                    emit_orbit_draft_trace(out.str());
+                }
+            }
+            if (frontier_trace_before_first_partial) {
+                emit_orbit_frontier_trace("advance", frontier_event_json(
+                    vocab_tgt,
+                    "draft_generated",
+                    "draft_generation",
+                    prompt_tgt,
+                    n_past,
+                    id_last,
+                    draft,
+                    mem_tgt,
+                    mem_dft,
+                    common_sampler_prev_str(smpl, ctx_tgt, 8),
+                    nullptr));
+            }
+
+            if (!draft.empty()) {
+                {
+                    const auto phase_start = std::chrono::steady_clock::now();
+                    ckpt.update_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                    phase_add(session->phase_ctx_tgt_checkpoint, phase_start);
+                }
+                {
+                    const auto phase_start = std::chrono::steady_clock::now();
+                    ckpt.load_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                    if (draft_trace_enabled()) {
+                        std::ostringstream out;
+                        out
+                            << "{"
+                            << "\"op\":\"load_dft_ckpt\""
+                            << ",\"step_index\":" << (trace_step_index + 1)
+                            << ",\"reason\":\"post_fresh_draft_restore\""
+                            << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                            << ",\"n_past\":" << n_past
+                            << ",\"id_last\":" << (int) id_last
+                            << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                            << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                            << "}";
+                        emit_orbit_dft_trace(out.str());
+                    }
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        const int32_t before_max = llama_memory_seq_pos_max(mem_dft, 0);
+                        llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                        phase_add(session->phase_seq_rm, phase_start);
+                        if (draft_trace_enabled()) {
+                            std::ostringstream out;
+                            out
+                                << "{"
+                                << "\"op\":\"seq_rm_dft\""
+                                << ",\"step_index\":" << (trace_step_index + 1)
+                                << ",\"reason\":\"post_fresh_draft_trim\""
+                                << ",\"start_pos\":" << (ckpt.pos_max + 1)
+                                << ",\"end_pos\":-1"
+                                << ",\"ctx_dft_max_before\":" << before_max
+                                << ",\"ctx_dft_max_after\":" << llama_memory_seq_pos_max(mem_dft, 0)
+                                << ",\"prompt_tgt_size\":" << prompt_tgt.size()
+                                << ",\"n_past\":" << n_past
+                                << ",\"id_last\":" << (int) id_last
+                                << ",\"frontier_tail\":" << token_vec_json(vocab_tgt, tail_tokens(prompt_tgt, 24))
+                                << "}";
+                            emit_orbit_dft_trace(out.str());
+                        }
+                    }
+                    session->debug_seq_rm_count++;
+                    phase_add(session->phase_ctx_dft_restore, phase_start);
+                }
+                session->last_checkpoint_count++;
+                have_ckpt = true;
+            } else {
+                have_ckpt = false;
+            }
+        }
+
+        std::vector<llama_token> validate_tokens;
+        validate_tokens.reserve(draft.size() + 1);
+        validate_tokens.push_back(id_last);
+        validate_tokens.insert(validate_tokens.end(), draft.begin(), draft.end());
+        const int32_t validate_pos0 = n_past;
+        const size_t frontier_logical_base = prompt_tgt.size();
+        bool boundary_committed_live = false;
+        if (boundary_split_enabled() &&
+            have_ckpt &&
+            !draft.empty() &&
+            n_past == (int32_t) prompt_tgt.size() &&
+            llama_memory_seq_pos_max(mem_tgt, 0) == n_past - 1 &&
+            llama_memory_seq_pos_max(mem_dft, 0) == n_past - 1) {
+            prompt_tgt.push_back(id_last);
+            prompt_tgt.insert(prompt_tgt.end(), draft.begin(), draft.end());
+            boundary_committed_live = true;
+        }
+
+        if (debug_partial && pending_partial_trace_index > 0) {
+            for (auto & prev : trace_steps) {
+                if (prev.index == pending_partial_trace_index) {
+                    prev.next_draft_origin = draft.empty() ? "fresh" : (draft_is_fresh ? "fresh" : "reused");
+                    prev.next_draft_is_fresh = draft_is_fresh;
+                    prev.next_draft_size = (int) draft.size();
+                    prev.next_draft_tokens_json = token_vec_json(vocab_tgt, draft);
+                    prev.extra_target_decode_reason = need_replay
+                        ? (generated.empty() ? "target_replay_prefill_plus_validate" : "target_replay_suffix_or_validate")
+                        : "validate_only";
+                    prev.extra_draft_decode_reason = draft.empty() ? "fresh_draft_generation" : "reuse_residual_draft";
+                    prev.next_validate_n_tok = (int) validate_tokens.size();
+                    prev.prefill_count = session->debug_prefill_target_count + session->debug_prefill_target_suffix_count;
+                    prev.validated_count = (int) validate_tokens.size();
+                    break;
+                }
+            }
+            pending_partial_trace_index = -1;
+        }
+
+        orbit_trace_step trace_step;
+        trace_step.index = ++trace_step_index;
+        trace_step.debug_enabled = debug_partial;
+        trace_step.sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
+        trace_step.sampler_before_hash = stable_hash_string(trace_step.sampler_before);
+        trace_step.draft = draft;
+        trace_step.sampled_id = -1;
+        trace_step.rejected_id = -1;
+        trace_step.validated_count = (int) validate_tokens.size();
+        trace_step.checkpoint_total = session->last_checkpoint_count;
+        trace_step.restore_total = session->last_restore_count;
+        trace_step.id_last_before = (int) id_last;
+        trace_step.n_past_before = n_past;
+        trace_step.prompt_tgt_size_before = (int32_t) prompt_tgt.size();
+        trace_step.prompt_tgt_pos_next_before = n_past;
+        trace_step.kv_tgt_before_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        trace_step.kv_tgt_before_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        trace_step.kv_dft_before_min = llama_memory_seq_pos_min(mem_dft, 0);
+        trace_step.kv_dft_before_max = llama_memory_seq_pos_max(mem_dft, 0);
+        if (debug_partial) {
+            trace_step.partial_state_before_json = partial_state_json(
+                vocab_tgt,
+                "before_partial_or_validate",
+                prompt_tgt.size(),
+                n_past,
+                id_last,
+                n_past,
+                mem_tgt,
+                mem_dft,
+                have_ckpt,
+                draft,
+                draft_is_fresh,
+                nullptr);
+            trace_step.sampler_checkpoint_used = have_ckpt ? "checkpoint" : "none";
+            trace_step.extra_target_decode_reason = need_replay
+                ? (generated.empty() ? "target_replay_prefill_plus_validate" : "target_replay_suffix_or_validate")
+                : "validate_only";
+            trace_step.extra_draft_decode_reason = draft.empty() ? "fresh_draft_generation" : "reuse_residual_draft";
+            trace_step.memory_clear_count = session->debug_memory_clear_count;
+            trace_step.seq_rm_count = session->debug_seq_rm_count;
+            trace_step.replay_count = session->debug_replay_count;
+            trace_step.prefill_count = session->debug_prefill_target_count + session->debug_prefill_target_suffix_count;
+            std::vector<int> validate_rows_preview(validate_tokens.size());
+            for (size_t i = 0; i < validate_rows_preview.size(); ++i) {
+                validate_rows_preview[i] = (int) i;
+            }
+            trace_step.pre_sample_state_json = pre_sample_state_json(
+                vocab_tgt,
+                prompt_tgt,
+                n_past,
+                id_last,
+                draft,
+                validate_tokens,
+                validate_rows_preview,
+                mem_tgt,
+                mem_dft,
+                trace_step.sampler_before,
+                have_ckpt,
+                have_ckpt ? ckpt.pos_max + 1 : n_past);
+        }
+        orbit_validate_trace validate_trace;
+        validate_trace.step = trace_step.index;
+
+        std::string replay_reason = "none";
+        orbit_step_outcome step = resolve_validate_accept_restore(
+            session,
+            session->spec,
+            ctx_tgt,
+            session->ctx_dft,
+            mem_tgt,
+            mem_dft,
+            smpl,
+            ckpt,
+            have_ckpt,
+            prompt_tgt,
+            draft,
+            draft_is_fresh,
+            n_past,
+            validate_tokens,
+            validate_pos0,
+            boundary_committed_live,
+            frontier_logical_base,
+            vocab_tgt,
+            &trace_step,
+            debug_partial,
+            &validate_trace,
+            &target_decode_traces,
+            trace_step.index,
+            &replay_reason);
+        session->debug_validate_decode_count++;
+        if (step.resolution == orbit_step_resolution::error) {
+            common_sampler_free(smpl);
+            return false;
+        }
+        const std::vector<llama_token> & ids = step.ids;
+        const int accepted = std::max(0, (int) ids.size() - 1);
+        const bool full_accept = step.resolution == orbit_step_resolution::full_accept;
+        const int rejected = std::max(0, (int) trace_step.draft.size() - accepted);
+        trace_step.accepted_ids = ids;
+        trace_step.accepted_draft = accepted;
+        trace_step.fresh_draft_tokens_contrib = draft_is_fresh ? (int) trace_step.draft.size() : 0;
+        trace_step.fresh_accepted_tokens_contrib = draft_is_fresh ? accepted : 0;
+        trace_step.fresh_rejected_tokens_contrib = draft_is_fresh ? rejected : 0;
+        trace_step.fresh_acceptance_ratio_contrib = trace_step.fresh_draft_tokens_contrib > 0
+            ? (double) trace_step.fresh_accepted_tokens_contrib / (double) trace_step.fresh_draft_tokens_contrib
+            : 0.0;
+        trace_step.consumed_draft_tokens_contrib = (int) trace_step.draft.size();
+        trace_step.consumed_accepted_tokens_contrib = accepted;
+        trace_step.consumed_rejected_tokens_contrib = rejected;
+        trace_step.consumed_acceptance_ratio_contrib = trace_step.consumed_draft_tokens_contrib > 0
+            ? (double) trace_step.consumed_accepted_tokens_contrib / (double) trace_step.consumed_draft_tokens_contrib
+            : 0.0;
+        trace_step.sampler_after = common_sampler_prev_str(smpl, ctx_tgt, 8);
+        trace_step.sampler_after_hash = stable_hash_string(trace_step.sampler_after);
+        trace_step.sampled_id = ids.empty() ? -1 : (int) ids.back();
+        trace_step.rejected_id = (accepted >= 0 && accepted < (int) trace_step.draft.size()) ? (int) trace_step.draft[(size_t) accepted] : -1;
+        trace_step.id_last_after = ids.empty() ? (int) id_last : (int) ids.back();
+        trace_step.validate_processed_by_spec = true;
+        trace_step.validate_batch_prepare_ms = validate_trace.batch_prepare_ms;
+        trace_step.validate_logits_rows_setup_ms = validate_trace.logits_rows_setup_ms;
+        trace_step.validate_llama_decode_ms = validate_trace.llama_decode_validate_ms;
+        trace_step.validate_post_decode_sample_ms = validate_trace.post_decode_sample_ms;
+        trace_step.validate_batch_n_tokens = validate_trace.batch_n_tokens;
+        trace_step.validate_batch_logits_count = validate_trace.batch_logits_count;
+        trace_step.validate_n_outputs_requested = validate_trace.n_outputs_requested;
+        if (full_accept) {
+            session->last_full_accept_steps++;
+            common_speculative_accept(session->spec, 0, (uint16_t) accepted);
+            trace_step.resolution = "full_accept";
+        } else if (step.resolution == orbit_step_resolution::live_partial) {
+            frontier_trace_before_first_partial = false;
+            trace_step.resolution = "live_partial";
+            if (debug_partial) {
+                pending_partial_trace_index = trace_step.index;
+            }
+        } else if (step.resolution == orbit_step_resolution::restored_partial) {
+            frontier_trace_before_first_partial = false;
+            trace_step.resolution = "partial_restore";
+            trace_step.restore_total = session->last_restore_count;
+            trace_step.kv_tgt_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+            trace_step.kv_tgt_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+            trace_step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
+            trace_step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
+            trace_step.n_past_after = n_past;
+            trace_step.prompt_tgt_size_after = (int32_t) prompt_tgt.size();
+            trace_step.prompt_tgt_pos_next_after = n_past;
+            trace_step.residual_draft_size_after = (int32_t) draft.size();
+            trace_step.residual_draft_after_json = token_vec_json(vocab_tgt, draft);
+            if (debug_partial) {
+                pending_partial_trace_index = trace_step.index;
+            }
+            validate_traces.push_back(validate_trace);
+            trace_steps.push_back(trace_step);
+            need_replay = false;
+            phase_add(session->phase_loop_total, loop_phase_start);
+            continue;
+        } else {
+            if (boundary_committed_live) {
+                prompt_tgt.resize(frontier_logical_base);
+                n_past = (int32_t) prompt_tgt.size();
+            }
+            trace_step.resolution = "replay_fallback";
+            if (debug_partial) {
+                trace_step.extra_target_decode_reason = replay_reason;
+            }
+        }
+
+        for (size_t i = 0; i < ids.size() && (int) generated.size() < std::max(1, std::min(32, (int) max_tokens)); ++i) {
+            if (!boundary_committed_live) {
+                prompt_tgt.push_back(id_last);
+            }
+            id_last = ids[i];
+
+            if (llama_vocab_is_eog(vocab_tgt, id_last)) {
+                goto done;
+            }
+
+            generated.push_back(id_last);
+            {
+                const auto phase_start = std::chrono::steady_clock::now();
+                session->last_content += token_piece(vocab_tgt, id_last);
+                phase_add(session->phase_detokenize_bridge, phase_start);
+            }
+            session->last_output_tokens++;
+            if (frontier_trace_before_first_partial) {
+                const std::vector<llama_token> tok = {id_last};
+                emit_orbit_frontier_trace("advance", frontier_event_json(
+                    vocab_tgt,
+                    "accept_commit",
+                    "validate_accept",
+                    prompt_tgt,
+                    n_past,
+                    id_last,
+                    draft,
+                    mem_tgt,
+                    mem_dft,
+                    common_sampler_prev_str(smpl, ctx_tgt, 8),
+                    &tok));
+            }
+        }
+
+        if (full_accept) {
+            n_past = (int32_t) prompt_tgt.size();
+            {
+                const auto phase_start = std::chrono::steady_clock::now();
+                llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+                llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+                phase_add(session->phase_seq_rm, phase_start);
+            }
+            session->debug_seq_rm_count += 2;
+            draft.clear();
+            have_ckpt = false;
+            draft_is_fresh = false;
+            need_replay = false;
+        } else if (step.resolution == orbit_step_resolution::live_partial) {
+            n_past = (int32_t) prompt_tgt.size();
+            draft.clear();
+            have_ckpt = false;
+            draft_is_fresh = true;
+            need_replay = false;
+        } else {
+            need_replay = true;
+        }
+        trace_step.post_step_draft_is_fresh = draft_is_fresh;
+        trace_step.post_step_need_replay = need_replay;
+        trace_step.kv_tgt_after_min = llama_memory_seq_pos_min(mem_tgt, 0);
+        trace_step.kv_tgt_after_max = llama_memory_seq_pos_max(mem_tgt, 0);
+        trace_step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
+        trace_step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
+        trace_step.n_past_after = n_past;
+        trace_step.prompt_tgt_size_after = (int32_t) prompt_tgt.size();
+        trace_step.prompt_tgt_pos_next_after = n_past;
+        trace_step.residual_draft_size_after = (int32_t) draft.size();
+        trace_step.residual_draft_after_json = token_vec_json(vocab_tgt, draft);
+        validate_traces.push_back(validate_trace);
+        trace_steps.push_back(trace_step);
+        phase_add(session->phase_loop_total, loop_phase_start);
+    }
+
+done:
+    common_sampler_free(smpl);
+    session->cached_prompt_tokens = prompt;
+    session->last_fresh_acceptance_ratio = session->last_draft_tokens_total > 0
+        ? (double) session->last_accepted_tokens_total / (double) session->last_draft_tokens_total
+        : 0.0;
+    const int consumed_draft_tokens_total = session->last_draft_tokens_total + session->last_reused_draft_tokens_total;
+    const int consumed_accepted_tokens_total = session->last_accepted_tokens_total + session->last_reused_accepted_tokens_total;
+    session->last_consumed_acceptance_ratio = consumed_draft_tokens_total > 0
+        ? (double) consumed_accepted_tokens_total / (double) consumed_draft_tokens_total
+        : 0.0;
+    session->last_acceptance_ratio = session->last_fresh_acceptance_ratio;
+    session->last_elapsed_ms = elapsed_s(t0) * 1000.0;
+    session->last_tokens_per_second = session->last_elapsed_ms > 0.0
+        ? ((double) session->last_output_tokens / session->last_elapsed_ms) * 1000.0
+        : 0.0;
+    {
+        std::ostringstream out;
+        out << "[";
+        for (size_t i = 0; i < trace_steps.size(); ++i) {
+            if (i > 0) {
+                out << ",";
+            }
+            out << trace_step_json(vocab_tgt, trace_steps[i]);
+        }
+        out << "]";
+        session->last_trace_json = out.str();
+    }
+    session->last_validate_trace_json = validate_trace_json(validate_traces);
+    session->last_target_decode_trace_json = target_decode_trace_json(vocab_tgt, target_decode_traces);
+    {
+        std::ostringstream out;
+        out
+            << "{"
+            << "\"prompt_prefix_restore\":" << phase_json(session->phase_prefix_restore) << ","
+            << "\"suffix_decode_target\":" << phase_json(session->phase_suffix_decode_target) << ","
+            << "\"draft_generation\":" << phase_json(session->phase_draft_generation) << ","
+            << "\"target_validate\":" << phase_json(session->phase_target_validate) << ","
+            << "\"speculative_process\":" << phase_json(session->phase_speculative_process) << ","
+            << "\"sampler_clone\":" << phase_json(session->phase_sampler_clone) << ","
+            << "\"sampler_restore\":" << phase_json(session->phase_sampler_restore) << ","
+            << "\"sampler_ops\":" << phase_json(session->phase_sampler_ops) << ","
+            << "\"seq_rm\":" << phase_json(session->phase_seq_rm) << ","
+            << "\"batch_build\":" << phase_json(session->phase_batch_build) << ","
+            << "\"ctx_tgt_checkpoint\":" << phase_json(session->phase_ctx_tgt_checkpoint) << ","
+            << "\"ctx_tgt_restore\":" << phase_json(session->phase_ctx_tgt_restore) << ","
+            << "\"ctx_dft_checkpoint\":" << phase_json(session->phase_ctx_dft_checkpoint) << ","
+            << "\"ctx_dft_restore\":" << phase_json(session->phase_ctx_dft_restore) << ","
+            << "\"rollback_replay\":" << phase_json(session->phase_rollback_replay) << ","
+            << "\"detokenize_output_bridge\":" << phase_json(session->phase_detokenize_bridge) << ","
+            << "\"speculative_loop_total\":" << phase_json(session->phase_loop_total);
+        if (debug_partial) {
+            out
+                << ",\"partial_debug\":{"
+                << "\"memory_clear_count\":" << session->debug_memory_clear_count << ","
+                << "\"seq_rm_count\":" << session->debug_seq_rm_count << ","
+                << "\"replay_count\":" << session->debug_replay_count << ","
+                << "\"prefill_target_count\":" << session->debug_prefill_target_count << ","
+                << "\"prefill_target_suffix_count\":" << session->debug_prefill_target_suffix_count << ","
+                << "\"validate_decode_count\":" << session->debug_validate_decode_count << ","
+                << "\"draft_decode_count\":" << session->debug_draft_decode_count
+                << "}";
+        }
+        out
+            << "}";
+        session->last_timing_json = out.str();
+    }
+    return true;
+}
+
+extern "C" const char * orbit_mtp_session_last_content(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_content.c_str() : "";
+}
+
+extern "C" int32_t orbit_mtp_session_last_output_tokens(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_output_tokens : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_draft_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_draft_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_accepted_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_accepted_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_rejected_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_rejected_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_reused_draft_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_reused_draft_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_reused_accepted_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_reused_accepted_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_reused_rejected_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_reused_rejected_tokens_total : 0;
+}
+
+extern "C" double orbit_mtp_session_last_acceptance_ratio(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_acceptance_ratio : 0.0;
+}
+
+extern "C" double orbit_mtp_session_last_fresh_acceptance_ratio(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_fresh_acceptance_ratio : 0.0;
+}
+
+extern "C" double orbit_mtp_session_last_consumed_acceptance_ratio(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_consumed_acceptance_ratio : 0.0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_target_decode_calls(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_target_decode_calls : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_draft_decode_calls(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_draft_decode_calls : 0;
+}
+
+extern "C" double orbit_mtp_session_last_elapsed_ms(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_elapsed_ms : 0.0;
+}
+
+extern "C" double orbit_mtp_session_last_tokens_per_second(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_tokens_per_second : 0.0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_full_accept_steps(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_full_accept_steps : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_replay_steps(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_replay_steps : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_partial_accept_steps(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_partial_accept_steps : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_partial_no_replay_steps(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_partial_no_replay_steps : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_replay_fallback_steps(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_replay_fallback_steps : 0;
+}
+
+extern "C" bool orbit_mtp_session_last_seq_rm_supported(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_seq_rm_supported : false;
+}
+
+extern "C" int32_t orbit_mtp_session_last_rollback_tokens_total(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_rollback_tokens_total : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_checkpoint_count(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_checkpoint_count : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_restore_count(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_restore_count : 0;
+}
+
+extern "C" const char * orbit_mtp_session_last_trace_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_trace_json.c_str() : "[]";
+}
+
+extern "C" const char * orbit_mtp_session_last_timing_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_timing_json.c_str() : "{}";
+}
+
+extern "C" const char * orbit_mtp_session_last_validate_trace_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_validate_trace_json.c_str() : "[]";
+}
+
+extern "C" const char * orbit_mtp_session_last_target_decode_trace_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_target_decode_trace_json.c_str() : "[]";
+}

--- a/src/orbit/native_server/__init__.py
+++ b/src/orbit/native_server/__init__.py
@@ -1,0 +1,2 @@
+"""Experimental Orbit native model server."""
+

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import argparse
+import json
+import select
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import socket
+import threading
+import time
+from typing import Any
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
+from orbit.native_server.protocol import (
+    DEFAULT_SESSION_ID,
+    ChatRequest,
+    native_chat_response,
+    openai_chat_response,
+    parse_chat_request,
+    sse_data,
+    sse_event,
+    trim_at_stop,
+    validate_session_id,
+)
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 18081
+DEFAULT_ALIAS = "gemma4:12b-it-native"
+
+
+class OrbitNativeServer:
+    def __init__(self, *, client: NativeLlamaClient, model_alias: str) -> None:
+        self.client = client
+        self.model_alias = model_alias
+        self.lock = threading.Lock()
+
+    def chat(self, payload: dict[str, Any], *, on_token=None, on_progress=None, should_cancel=None) -> dict[str, Any]:
+        request = parse_chat_request(payload)
+        validate_session_id(request.session_id)
+        return self.complete(request, on_token=on_token, on_progress=on_progress, should_cancel=should_cancel)
+
+    def complete(self, request: ChatRequest, *, on_token=None, on_progress=None, should_cancel=None) -> dict[str, Any]:
+        parts: list[str] = []
+
+        def collect(text: str) -> None:
+            parts.append(text)
+            if on_token:
+                on_token(text)
+
+        with self.lock:
+            completion = self.client.complete_chat_text(
+                request.messages,
+                max_tokens=request.max_tokens,
+                stop=request.stop,
+                tools=request.tools,
+                on_progress=on_progress,
+                on_token=collect,
+                should_cancel=should_cancel,
+            )
+        timings = completion.timings
+        content, stopped = trim_at_stop("".join(parts) or completion.content, request.stop)
+        stopped = stopped or completion.stopped_by_stop
+        finish_reason = "cancelled" if timings.cancelled else "stop"
+        if stopped:
+            finish_reason = "stop"
+        if timings.output_tokens >= request.max_tokens and not timings.cancelled and not stopped:
+            finish_reason = "length"
+        return native_chat_response(
+            content=content,
+            model=self.model_alias,
+            finish_reason=finish_reason,
+            session_id=request.session_id,
+            prompt_tokens=timings.prompt_tokens,
+            completion_tokens=timings.output_tokens,
+            reused_prompt_tokens=timings.reused_prompt_tokens,
+            evaluated_prompt_tokens=timings.evaluated_prompt_tokens,
+            prefill_ms=timings.prefill_ms,
+            generation_ms=timings.generation_ms,
+            cancelled=timings.cancelled and not stopped,
+        )
+
+    def cancel(self, session_id: str = DEFAULT_SESSION_ID) -> dict[str, Any]:
+        validate_session_id(session_id)
+        self.client.cancel()
+        return {"status": "cancel_requested", "session_id": session_id}
+
+    def session_info(self, session_id: str = DEFAULT_SESSION_ID) -> dict[str, Any]:
+        validate_session_id(session_id)
+        snapshot = self.client.session_snapshot(session_id)
+        return {
+            "id": snapshot.session_id,
+            "active": True,
+            "backend_mode": snapshot.backend_mode,
+            "cached_tokens": snapshot.cached_tokens,
+            "in_flight": snapshot.in_flight,
+            "cancel_requested": snapshot.cancel_requested,
+            "mtp_enabled": snapshot.mtp_enabled,
+            "mtp_initialized": snapshot.mtp_initialized,
+            "mtp_failure_reason": snapshot.mtp_failure_reason,
+        }
+
+    def runtime_info(self) -> dict[str, Any]:
+        return {
+            "threads": self.client.config.threads,
+            "threads_batch": self.client.config.threads_batch,
+            "ctx_size": self.client.config.context_tokens,
+            "batch_size": self.client.config.batch_size,
+            "ubatch_size": self.client.config.ubatch_size,
+            "parallel_slots": 1,
+        }
+
+    def error_result(self, message: str, payload: dict[str, Any]) -> dict[str, Any]:
+        request = parse_chat_request(payload)
+        return native_chat_response(
+            content=f"error: {message}",
+            model=self.model_alias,
+            finish_reason="error",
+            session_id=request.session_id,
+            prompt_tokens=0,
+            completion_tokens=0,
+            reused_prompt_tokens=0,
+            evaluated_prompt_tokens=0,
+            prefill_ms=0.0,
+            generation_ms=0.0,
+            cancelled=False,
+        )
+
+
+class OrbitNativeHandler(BaseHTTPRequestHandler):
+    server_version = "orbit-server/experimental"
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._json({"status": "ok"})
+            return
+        if self.path == "/v1/models":
+            state = self._state()
+            self._json({"object": "list", "data": [{"id": state.model_alias, "object": "model"}]})
+            return
+        if self.path == "/props":
+            state = self._state()
+            session = state.session_info()
+            runtime = state.runtime_info()
+            self._json(
+                {
+                    "model_path": str(state.client.paths.model),
+                    "draft_model_path": str(state.client.paths.draft_mtp_model) if state.client.paths.draft_mtp_model else None,
+                    "mtp_available": state.client.paths.mtp_available,
+                    "fallback_reason": state.client.paths.fallback_reason,
+                    "mtp_probe_enabled": state.client.mtp_probe.enabled,
+                    "mtp_probe_initialized": state.client.mtp_probe.initialized,
+                    "mtp_probe_error": state.client.mtp_probe.error,
+                    "mtp_dry_run_enabled": state.client.mtp_dry_run.enabled,
+                    "mtp_dry_run_success": state.client.mtp_dry_run.success,
+                    "mtp_draft_tokens": state.client.mtp_dry_run.draft_tokens,
+                    "mtp_dry_run_error": state.client.mtp_dry_run.error,
+                    "mtp_accept_probe_enabled": state.client.mtp_accept_probe.enabled,
+                    "mtp_accept_probe_success": state.client.mtp_accept_probe.success,
+                    "mtp_accept_probe_draft_tokens": state.client.mtp_accept_probe.draft_tokens,
+                    "mtp_accept_probe_accepted_tokens": state.client.mtp_accept_probe.accepted_tokens,
+                    "mtp_accept_probe_error": state.client.mtp_accept_probe.error,
+                    "mtp_decode_probe_enabled": state.client.mtp_decode_probe.enabled,
+                    "mtp_decode_probe_success": state.client.mtp_decode_probe.success,
+                    "mtp_decode_probe_error": state.client.mtp_decode_probe.error,
+                    "mtp_experimental_enabled": state.client.config.use_mtp_experimental,
+                    "mtp_last_completion_success": state.client.last_mtp_completion.success,
+                    "mtp_fallback_reason": state.client.mtp_fallback_reason,
+                    "mtp_enabled": session["mtp_enabled"],
+                    "mtp_initialized": session["mtp_initialized"],
+                    "mtp_failure_reason": session["mtp_failure_reason"],
+                    "model_id": state.client.paths.model_id,
+                    "backend": "orbit-native",
+                    "backend_mode": session["backend_mode"],
+                    "session_id": session["id"],
+                    "cached_tokens": session["cached_tokens"],
+                    "in_flight": session["in_flight"],
+                    "threads": runtime["threads"],
+                    "threads_batch": runtime["threads_batch"],
+                    "ctx_size": runtime["ctx_size"],
+                    "batch_size": runtime["batch_size"],
+                    "ubatch_size": runtime["ubatch_size"],
+                    "parallel_slots": runtime["parallel_slots"],
+                }
+            )
+            return
+        if self.path == "/tools":
+            self._json([])
+            return
+        if self.path == "/sessions":
+            self._json({"sessions": [self._state().session_info()]})
+            return
+        self._json({"error": "not found"}, status=404)
+
+    def do_POST(self) -> None:
+        try:
+            payload = self._read_json()
+        except ValueError as exc:
+            self._json({"error": str(exc)}, status=400)
+            return
+
+        try:
+            if self.path == "/chat":
+                try:
+                    self._json(self._state().chat(payload))
+                except RuntimeError as exc:
+                    self._json(self._state().error_result(str(exc), payload), status=500)
+                return
+            if self.path == "/chat/stream":
+                self._native_stream(payload)
+                return
+            if self.path == "/cancel":
+                self._json(self._state().cancel(_session_id_from_payload(payload)))
+                return
+        except ValueError as exc:
+            self._json({"error": str(exc)}, status=400)
+            return
+        if self.path == "/v1/chat/completions":
+            if payload.get("stream") is True:
+                self._openai_stream(payload)
+            else:
+                try:
+                    self._json(openai_chat_response(self._state().chat(payload)))
+                except RuntimeError as exc:
+                    self._json(openai_chat_response(self._state().error_result(str(exc), payload)), status=500)
+                except ValueError as exc:
+                    self._json({"error": str(exc)}, status=400)
+            return
+        self._json({"error": "not found"}, status=404)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _state(self) -> OrbitNativeServer:
+        return self.server.orbit_state  # type: ignore[attr-defined]
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length)
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid JSON") from exc
+        if not isinstance(data, dict):
+            raise ValueError("JSON body must be an object")
+        return data
+
+    def _json(self, data: dict[str, Any] | list[Any], *, status: int = 200) -> None:
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _openai_stream(self, payload: dict[str, Any]) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        disconnect = self._start_disconnect_watcher()
+
+        def emit(data: dict[str, Any]) -> None:
+            try:
+                if disconnect.is_set():
+                    self._state().client.cancel()
+                    raise BrokenPipeError("client disconnected")
+                if self._client_disconnected():
+                    self._state().client.cancel()
+                    raise BrokenPipeError("client disconnected")
+                self.wfile.write(sse_data(data))
+                self.wfile.flush()
+            except CLIENT_DISCONNECT_ERRORS:
+                self._state().client.cancel()
+                raise
+
+        def on_token(text: str) -> None:
+            emit({"model": self._state().model_alias, "choices": [{"delta": {"content": text}}]})
+
+        try:
+            result = self._state().chat(
+                payload,
+                on_token=on_token,
+                should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
+            )
+            emit(openai_chat_response(result, content=""))
+            self.wfile.write(sse_data("[DONE]"))
+            self.wfile.flush()
+        except ValueError as exc:
+            emit({"error": str(exc)})
+        except RuntimeError as exc:
+            emit(openai_chat_response(self._state().error_result(str(exc), payload), content=""))
+            self.wfile.write(sse_data("[DONE]"))
+            self.wfile.flush()
+        except CLIENT_DISCONNECT_ERRORS:
+            self._state().client.cancel()
+        finally:
+            disconnect.stop()
+
+    def _native_stream(self, payload: dict[str, Any]) -> None:
+        try:
+            request = parse_chat_request(payload)
+            validate_session_id(request.session_id)
+        except ValueError as exc:
+            self._json({"error": str(exc)}, status=400)
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        disconnect = self._start_disconnect_watcher()
+
+        def emit(event: str, data: dict[str, Any]) -> None:
+            try:
+                if disconnect.is_set():
+                    self._state().client.cancel()
+                    raise BrokenPipeError("client disconnected")
+                if self._client_disconnected():
+                    self._state().client.cancel()
+                    raise BrokenPipeError("client disconnected")
+                self.wfile.write(sse_event(event, data))
+                self.wfile.flush()
+            except CLIENT_DISCONNECT_ERRORS:
+                self._state().client.cancel()
+                raise
+
+        def on_token(text: str) -> None:
+            emit("delta", {"text": text, "session_id": request.session_id})
+
+        def on_progress(progress) -> None:
+            emit(
+                f"progress.{progress.phase}",
+                {
+                    "current": progress.current,
+                    "total": progress.total,
+                    "percent": progress.percent,
+                    "session_id": request.session_id,
+                },
+            )
+
+        try:
+            result = self._state().complete(
+                request,
+                on_progress=on_progress,
+                on_token=on_token,
+                should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
+            )
+            emit("metrics", {"usage": result["usage"], "timings": result["timings"], "native": result["native"]})
+            emit("done", {"finish_reason": result["finish_reason"], "session_id": request.session_id})
+        except RuntimeError as exc:
+            emit("error", {"message": str(exc), "session_id": request.session_id})
+            emit("done", {"finish_reason": "error", "session_id": request.session_id})
+        except CLIENT_DISCONNECT_ERRORS:
+            self._state().client.cancel()
+        finally:
+            disconnect.stop()
+
+    def _start_disconnect_watcher(self) -> "_DisconnectWatcher":
+        watcher = _DisconnectWatcher(self.connection, self._state().client.cancel)
+        watcher.start()
+        return watcher
+
+    def _client_disconnected(self) -> bool:
+        try:
+            poll = select.poll()
+            events = select.POLLHUP | select.POLLERR
+            if hasattr(select, "POLLRDHUP"):
+                events |= select.POLLRDHUP
+            poll.register(self.connection, events)
+            if poll.poll(0):
+                return True
+        except (AttributeError, OSError, ValueError):
+            pass
+        try:
+            readable, _, _ = select.select([self.connection], [], [], 0)
+            if not readable:
+                return False
+            return self.connection.recv(1, socket.MSG_PEEK) == b""
+        except BlockingIOError:
+            return False
+        except CLIENT_DISCONNECT_ERRORS:
+            return True
+
+
+def run_server(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    paths = resolve_bootstrap_paths(args)
+    client = NativeLlamaClient(
+        paths,
+        NativeClientConfig(
+            context_tokens=args.ctx,
+            threads=args.threads,
+            threads_batch=args.threads_batch,
+            batch_size=args.batch,
+            ubatch_size=args.ubatch,
+            mtp_probe_enabled=args.enable_mtp_probe,
+            mtp_dry_run_enabled=args.enable_mtp_dry_run,
+            mtp_accept_probe_enabled=args.enable_mtp_accept_probe,
+            mtp_decode_probe_enabled=args.enable_mtp_decode_probe,
+            use_mtp_experimental=args.enable_mtp_experimental,
+        ),
+    )
+    if not args.verbose_llama_log:
+        client.set_quiet_logging()
+    client.load()
+
+    httpd = ThreadingHTTPServer((args.host, args.port), OrbitNativeHandler)
+    httpd.orbit_state = OrbitNativeServer(client=client, model_alias=args.alias)  # type: ignore[attr-defined]
+    print(f"orbit-server listening on http://{args.host}:{args.port}", flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\norbit-server stopped", flush=True)
+    finally:
+        client.close()
+        httpd.server_close()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="orbit-server")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--llama-root", type=Path, default=DEFAULT_LLAMA_ROOT)
+    parser.add_argument("--model-id", default=None, help=f"Orbit model id. Defaults to {DEFAULT_MODEL_ID} when --model is not used.")
+    parser.add_argument("--model", type=Path, help="Legacy direct target model path override.")
+    parser.add_argument("--models-dir", type=Path, help="Orbit local models directory.")
+    parser.add_argument("--hf-cache", type=Path, help="Hugging Face cache root fallback.")
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--ctx", type=int, default=8192)
+    parser.add_argument("--threads", type=int, default=6)
+    parser.add_argument("--threads-batch", type=int, default=6)
+    parser.add_argument("--batch", type=int, default=256)
+    parser.add_argument("--ubatch", type=int, default=128)
+    parser.add_argument("--enable-mtp-probe", action="store_true", help="Backend-only MTP load/init probe. No generation.")
+    parser.add_argument("--enable-mtp-dry-run", action="store_true", help="Backend-only MTP draft generation dry run. No accept loop or user output.")
+    parser.add_argument("--enable-mtp-accept-probe", action="store_true", help="Backend-only MTP single accept-loop probe. No user output or runtime integration.")
+    parser.add_argument("--enable-mtp-decode-probe", action="store_true", help="Backend-only experimental MTP decode-loop probe. No user output or runtime integration.")
+    parser.add_argument("--enable-mtp-experimental", action="store_true", help="Backend-only experimental MTP completion path with automatic no-MTP fallback.")
+    parser.add_argument("--verbose-llama-log", action="store_true")
+    return parser
+
+
+def resolve_bootstrap_paths(args: argparse.Namespace) -> NativeLlamaPaths:
+    if args.model_id:
+        return resolve_paths(
+            llama_root=args.llama_root,
+            model_id=args.model_id,
+            model=args.model,
+            models_dir=args.models_dir,
+            hf_cache=args.hf_cache,
+        )
+    if args.model is not None:
+        return resolve_legacy_paths(llama_root=args.llama_root, model=args.model)
+    return resolve_paths(
+        llama_root=args.llama_root,
+        model_id=DEFAULT_MODEL_ID,
+        models_dir=args.models_dir,
+        hf_cache=args.hf_cache,
+    )
+
+
+def _session_id_from_payload(payload: dict[str, Any]) -> str:
+    value = payload.get("session_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return DEFAULT_SESSION_ID
+
+
+CLIENT_DISCONNECT_ERRORS = (BrokenPipeError, ConnectionResetError)
+
+
+class _DisconnectWatcher:
+    def __init__(self, sock: socket.socket, on_disconnect) -> None:
+        self._sock = sock
+        self._on_disconnect = on_disconnect
+        self._disconnected = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="orbit-stream-disconnect", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def is_set(self) -> bool:
+        return self._disconnected.is_set()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=0.5)
+
+    def _run(self) -> None:
+        while not self._stop.is_set() and not self._disconnected.is_set():
+            try:
+                readable, _, exceptional = select.select([self._sock], [], [self._sock], 0.1)
+                if exceptional:
+                    self._mark_disconnected()
+                    return
+                if not readable:
+                    continue
+                data = self._sock.recv(1, socket.MSG_PEEK)
+                if data == b"":
+                    self._mark_disconnected()
+                    return
+            except BlockingIOError:
+                continue
+            except CLIENT_DISCONNECT_ERRORS:
+                self._mark_disconnected()
+                return
+            except OSError:
+                if not self._stop.is_set():
+                    self._mark_disconnected()
+                return
+            time.sleep(0)
+
+    def _mark_disconnected(self) -> None:
+        self._disconnected.set()
+        self._on_disconnect()

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Iterable
+
+
+DEFAULT_SESSION_ID = "default"
+
+
+@dataclass(frozen=True)
+class ChatRequest:
+    messages: list[dict[str, Any]]
+    max_tokens: int
+    temperature: float
+    session_id: str
+    stop: tuple[str, ...]
+    stream: bool
+    tools: list[dict[str, Any]]
+
+
+def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
+    return ChatRequest(
+        messages=_messages_from_payload(payload),
+        max_tokens=_int_value(payload.get("max_tokens"), 256),
+        temperature=_float_value(payload.get("temperature"), 0.0),
+        session_id=_session_id(payload.get("session_id")),
+        stop=_stop_sequences(payload.get("stop")),
+        stream=payload.get("stream") is True,
+        tools=_tools_from_payload(payload.get("tools")),
+    )
+
+
+def native_chat_response(
+    *,
+    content: str,
+    model: str,
+    finish_reason: str,
+    session_id: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    reused_prompt_tokens: int,
+    evaluated_prompt_tokens: int,
+    prefill_ms: float,
+    generation_ms: float,
+    cancelled: bool,
+) -> dict[str, Any]:
+    return {
+        "content": content,
+        "model": model,
+        "session_id": session_id,
+        "finish_reason": finish_reason,
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "prompt_tokens_details": {
+                "cached_tokens": reused_prompt_tokens,
+                "reused_tokens": reused_prompt_tokens,
+                "evaluated_tokens": evaluated_prompt_tokens,
+            },
+        },
+        "timings": {
+            "prompt_ms": prefill_ms,
+            "predicted_ms": generation_ms,
+            "prompt_per_second": _rate(evaluated_prompt_tokens, prefill_ms),
+            "predicted_per_second": _rate(completion_tokens, generation_ms),
+        },
+        "native": {
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": completion_tokens,
+            "reused_prompt_tokens": reused_prompt_tokens,
+            "evaluated_prompt_tokens": evaluated_prompt_tokens,
+            "prefill_ms": prefill_ms,
+            "generation_ms": generation_ms,
+            "cancelled": cancelled,
+        },
+    }
+
+
+def openai_chat_response(result: dict[str, Any], *, content: str | None = None) -> dict[str, Any]:
+    return {
+        "model": result["model"],
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": result["content"] if content is None else content},
+                "finish_reason": result["finish_reason"],
+            }
+        ],
+        "usage": result["usage"],
+        "timings": result["timings"],
+    }
+
+
+def sse_event(event: str, data: dict[str, Any]) -> bytes:
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n".encode("utf-8")
+
+
+def sse_data(data: dict[str, Any] | str) -> bytes:
+    if isinstance(data, str):
+        return f"data: {data}\n\n".encode("utf-8")
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n".encode("utf-8")
+
+
+def validate_session_id(session_id: str) -> None:
+    if session_id != DEFAULT_SESSION_ID:
+        raise ValueError("only the default native session is supported in this experiment")
+
+
+def _messages_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = payload.get("messages")
+    if not isinstance(raw, list):
+        prompt = payload.get("prompt")
+        if isinstance(prompt, str):
+            return [{"role": "user", "content": prompt}]
+        raise ValueError("messages must be a list")
+    messages: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("messages must contain objects")
+        role = item.get("role")
+        if not isinstance(role, str):
+            raise ValueError("message role must be a string")
+        message = dict(item)
+        message["role"] = role
+        if "content" not in message:
+            message["content"] = ""
+        messages.append(message)
+    if not messages:
+        raise ValueError("messages must not be empty")
+    return messages
+
+
+def _tools_from_payload(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _stop_sequences(value: object) -> tuple[str, ...]:
+    if isinstance(value, str) and value:
+        return (value,)
+    if isinstance(value, list):
+        return tuple(item for item in value if isinstance(item, str) and item)
+    return ()
+
+
+def _session_id(value: object) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return DEFAULT_SESSION_ID
+
+
+def _int_value(value: object, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, int) and value > 0:
+        return value
+    raise ValueError("max_tokens must be a positive integer")
+
+
+def _float_value(value: object, default: float) -> float:
+    if isinstance(value, int | float):
+        return float(value)
+    return default
+
+
+def _rate(tokens: int, ms: float) -> float | None:
+    if tokens <= 0 or ms <= 0:
+        return None
+    return tokens / (ms / 1000.0)
+
+
+def trim_at_stop(content: str, stops: Iterable[str]) -> tuple[str, bool]:
+    first: int | None = None
+    for stop in stops:
+        idx = content.find(stop)
+        if idx >= 0 and (first is None or idx < first):
+            first = idx
+    if first is None:
+        return content, False
+    return content[:first], True

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.mtp_completion import MtpCompletionResult
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_server.app import build_parser
+
+
+class NativeMtpExperimentalTests(unittest.TestCase):
+    def _paths(self, *, mtp_available: bool = True, fallback_reason: str | None = None) -> NativeLlamaPaths:
+        return NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/target.gguf"),
+            draft_mtp_model=Path("/models/draft.gguf") if mtp_available else None,
+            mtp_available=mtp_available,
+            fallback_reason=fallback_reason,
+            model_id="gemma4-12b-it-q4km",
+        )
+
+    def test_parser_accepts_enable_mtp_experimental_flag(self) -> None:
+        args = build_parser().parse_args(["--enable-mtp-experimental"])
+        self.assertTrue(args.enable_mtp_experimental)
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_falls_back_when_draft_missing(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(mtp_available=False, fallback_reason="draft-mtp-missing"), NativeClientConfig(use_mtp_experimental=True))
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "draft-mtp-missing")
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_returns_timings_on_success(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        client.tokenize = lambda prompt: [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="ok",
+            output_tokens=1,
+            draft_tokens_total=3,
+            accepted_tokens_total=2,
+            rejected_tokens_total=1,
+            acceptance_ratio=2 / 3,
+            target_decode_calls=2,
+            draft_decode_calls=1,
+            elapsed_ms=12.5,
+            tokens_per_second=80.0,
+            full_accept_steps=1,
+            replay_steps=0,
+            partial_accept_steps=0,
+            partial_no_replay_steps=0,
+            replay_fallback_steps=0,
+            seq_rm_supported=False,
+            rollback_tokens_total=0,
+        )
+        emitted: list[str] = []
+
+        timings = client._try_complete_with_mtp_experimental("hello", max_tokens=8, on_token=emitted.append)
+
+        self.assertIsNotNone(timings)
+        assert timings is not None
+        self.assertEqual(timings.output_tokens, 1)
+        self.assertEqual(timings.reused_prompt_tokens, 0)
+        self.assertEqual("".join(emitted), "ok")
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertEqual(client._session.cached_prompt_tokens, [1, 2, 3])
+        self.assertEqual(client.last_mtp_completion.full_accept_steps, 1)
+        self.assertEqual(client.last_mtp_completion.replay_steps, 0)
+        self.assertEqual(client.last_mtp_completion.partial_accept_steps, 0)
+        self.assertEqual(client.last_mtp_completion.partial_no_replay_steps, 0)
+        self.assertEqual(client.last_mtp_completion.replay_fallback_steps, 0)
+        self.assertFalse(client.last_mtp_completion.seq_rm_supported)
+        self.assertEqual(client.last_mtp_completion.rollback_tokens_total, 0)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_strips_control_channel_tokens(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        client.tokenize = lambda prompt: [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="<|channel>thought\n<channel|>ok.",
+            output_tokens=2,
+            draft_tokens_total=3,
+            accepted_tokens_total=2,
+            rejected_tokens_total=1,
+            acceptance_ratio=2 / 3,
+            target_decode_calls=2,
+            draft_decode_calls=1,
+            elapsed_ms=12.5,
+            tokens_per_second=80.0,
+        )
+        emitted: list[str] = []
+
+        timings = client._try_complete_with_mtp_experimental("hello", max_tokens=8, on_token=emitted.append)
+
+        self.assertIsNotNone(timings)
+        self.assertEqual("".join(emitted), "ok.")
+        self.assertEqual(client.last_mtp_completion.content, "ok.")
+        self.assertEqual(client.last_mtp_completion.acceptance_ratio, 2 / 3)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_wraps_raw_prompt_in_gemma_chat_template(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        client.tokenize = lambda prompt: [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="ok.",
+            output_tokens=1,
+        )
+
+        client._try_complete_with_mtp_experimental("Say only: ok.", max_tokens=8)
+
+        called_prompt = mocked_run.call_args.kwargs["prompt"]
+        self.assertIn("<bos>", called_prompt)
+        self.assertIn("<|turn>user", called_prompt)
+        self.assertIn("Say only: ok.", called_prompt)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_reuses_cached_prompt_tokens_from_previous_turn(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        client.tokenize = lambda prompt: [1, 2, 3]
+        client._session.cached_prompt_tokens = [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="ok",
+            output_tokens=1,
+            draft_tokens_total=3,
+            accepted_tokens_total=2,
+            rejected_tokens_total=1,
+            acceptance_ratio=2 / 3,
+            target_decode_calls=2,
+            draft_decode_calls=1,
+            elapsed_ms=12.5,
+            tokens_per_second=80.0,
+        )
+
+        timings = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNotNone(timings)
+        assert timings is not None
+        self.assertEqual(timings.reused_prompt_tokens, 2)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_falls_back_on_helper_error(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        mocked_run.return_value = MtpCompletionResult(enabled=True, success=False, error="mtp helper failed")
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "mtp helper failed")
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_falls_back_when_persistent_session_is_uninitialized(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._session.mtp_failure_reason = "persistent-mtp-uninitialized"
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "persistent-mtp-uninitialized")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_persistent_mtp.py
+++ b/tests/test_native_persistent_mtp.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.events import NativeTimings
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime
+
+
+class NativePersistentMtpTests(unittest.TestCase):
+    def _paths(self, *, mtp_available: bool = True, fallback_reason: str | None = None) -> NativeLlamaPaths:
+        return NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/target.gguf"),
+            draft_mtp_model=Path("/models/draft.gguf") if mtp_available else None,
+            mtp_available=mtp_available,
+            fallback_reason=fallback_reason,
+            model_id="gemma4-12b-it-q4km",
+        )
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_persistent_mtp_stays_disabled_when_draft_is_missing(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(mtp_available=False, fallback_reason="draft-mtp-missing"), NativeClientConfig())
+        client._session.ctx_tgt = object()
+
+        client._initialize_persistent_mtp_session()
+
+        snapshot = client.session_snapshot()
+        self.assertFalse(snapshot.mtp_enabled)
+        self.assertFalse(snapshot.mtp_initialized)
+        self.assertEqual(snapshot.mtp_failure_reason, "draft-mtp-missing")
+
+    @mock.patch("orbit.native_llama.client.create_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_persistent_mtp_initializes_and_exposes_runtime_handles(self, _mocked_lib, mocked_create) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client._session.ctx_tgt = object()
+        mocked_create.return_value = PersistentMtpSessionRuntime(
+            handle=object(),
+            ctx_dft=object(),
+            spec=object(),
+            rss_before_kb=100,
+            rss_after_init_kb=200,
+            rss_peak_kb=300,
+        )
+
+        client._initialize_persistent_mtp_session()
+
+        snapshot = client.session_snapshot()
+        self.assertTrue(snapshot.mtp_enabled)
+        self.assertTrue(snapshot.mtp_initialized)
+        self.assertIsNone(snapshot.mtp_failure_reason)
+        self.assertIsNotNone(client._session.ctx_dft)
+        self.assertIsNotNone(client._session.spec)
+
+    @mock.patch("orbit.native_llama.client.create_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_persistent_mtp_records_init_failure(self, _mocked_lib, mocked_create) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client._session.ctx_tgt = object()
+        mocked_create.side_effect = RuntimeError("init failed")
+
+        client._initialize_persistent_mtp_session()
+
+        snapshot = client.session_snapshot()
+        self.assertFalse(snapshot.mtp_enabled)
+        self.assertFalse(snapshot.mtp_initialized)
+        self.assertEqual(snapshot.mtp_failure_reason, "init failed")
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_reset_session_state_clears_target_cache_and_reinitializes_persistent_mtp(self, mocked_lib_cls, mocked_reset) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        fake_lib = mock.Mock()
+        fake_lib.llama_get_memory.return_value = object()
+        mocked_lib_cls.return_value.lib = fake_lib
+        client._session.ctx_tgt = object()
+        client._session.cached_prompt_tokens = [1, 2, 3]
+        client._session.last_metrics = NativeTimings(5, 1, 2, 3, 1.0, 2.0)
+        client._persistent_mtp_runtime = PersistentMtpSessionRuntime(handle=object(), ctx_dft=object(), spec=object())
+        mocked_reset.return_value = PersistentMtpSessionRuntime(handle=object(), ctx_dft=object(), spec=object())
+
+        client.reset_session_state()
+
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+        self.assertIsNone(client._session.last_metrics)
+        self.assertTrue(client._session.mtp_enabled)
+        fake_lib.llama_memory_clear.assert_called()
+        mocked_reset.assert_called_once()
+
+    @mock.patch("orbit.native_llama.client.free_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_close_frees_persistent_mtp_before_releasing_target_context(self, mocked_lib_cls, mocked_free) -> None:
+        fake_lib = mock.Mock()
+        mocked_lib_cls.return_value.lib = fake_lib
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client._persistent_mtp_runtime = PersistentMtpSessionRuntime(handle=object(), ctx_dft=object(), spec=object())
+        client._session.ctx_tgt = object()
+        client._session.sampler = object()
+        client._model = object()
+
+        client.close()
+
+        mocked_free.assert_called_once()
+        fake_lib.llama_sampler_free.assert_called_once()
+        fake_lib.llama_free.assert_called_once()
+        fake_lib.llama_model_free.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Promotes persistent MTP boundary split to default while keeping `ORBIT_MTP_BOUNDARY_SPLIT=0` as rollback.

Review note:
This branch was built from a clean integration baseline that did not yet include the native backend/MTP package, so the PR may include `native_llama`, `native_server`, and MTP tests as part of the isolated merge candidate. The review-critical behavioral delta is limited to the persistent MTP boundary split default, rollback flag, and documentation.

Reviewer focus:

* `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`

  * boundary split is now default
  * `ORBIT_MTP_BOUNDARY_SPLIT=0` restores previous behavior
  * fallback/guardrails remain in place
* `docs/LLAMA_DEEP_CLIENT_EXPERIMENT.md`

  * documents the new default, rollback flag, top1-greedy draft policy, and CPU-affinity benchmark requirement
* native MTP tests

  * validate persistent MTP and experimental MTP paths

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_native_persistent_mtp tests.test_native_mtp_experimental -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS
* smoke PASS on:

  * `response_short`
  * `response_medium`
  * `long_prompt`
  * `session_reuse_repeat`
* opt-out rollback verified with `ORBIT_MTP_BOUNDARY_SPLIT=0`

Benchmark:
Controlled with `taskset -c 0-5`, 10 runs per mode per scenario.

* `response_medium`: median -14.3%, p75 -14.5%
* `long_prompt`: median -16.3%, p75 -16.5%
* `session_reuse_repeat`: median -24.0%, p75 -24.9%
* `response_short`: median +0.5%, p75 +0.3%

Safety:

* zero assert
* zero unexpected fallback
* replay does not increase
* rollback flag works

Risk:
CPU-only latency remains sensitive to scheduler noise. Keep `ORBIT_MTP_BOUNDARY_SPLIT=0` available during stabilization and run follow-up benchmarks on another host before removing the rollback flag.

Final decision:
Merge candidate.
