### PR TITLE
Refactor client runtime state and stabilize tool flows

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from contextlib import contextmanager
 from typing import Callable
+import json
+import re
 
 from orbit.backend import ChatBackend, ChatResult
 from orbit.backend.base import Message, StreamProgress
+from orbit.runtime.client_state import ClientState
+from orbit.runtime.completion_budget import CompletionBudget
+from orbit.runtime.environments import (
+    ContinueEnvironment,
+    FileInputEnvironment,
+    FinalFromToolEnvironment,
+    PureChatEnvironment,
+    ToolLoopEnvironment,
+    TransportEnvironment,
+    is_empty_final_response as _is_empty_final_response,
+    is_tool_argument_json_error as _is_tool_argument_json_error,
+    merge_chat_results as _merge_chat_results,
+    needs_final_completion_repair as _needs_final_completion_repair,
+    pdf_extraction_repair_prompt as _pdf_extraction_repair_prompt,
+    contradicts_successful_pdf_extraction as _contradicts_successful_pdf_extraction,
+    unsupported_tool_mode_result as _unsupported_tool_mode_result,
+)
 from orbit.runtime.final_policy import (
-    build_final_tool_policy,
-    final_from_tool_retry_reason,
-    final_tool_retry_instruction,
-    final_tool_retry_max_tokens,
     has_list_like_tool_result as _has_list_like_tool_result,
 )
-from orbit.runtime.media import AudioInput, ImageInput, load_referenced_media
+from orbit.runtime.file_input_resolver import FileInputResolver
+from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
     message_content,
@@ -34,7 +49,12 @@ from orbit.runtime.command_request import (
 )
 from orbit.runtime.results import error_result
 from orbit.runtime.session_memory import MemoryRefresh, maybe_refresh_memory
-from orbit.runtime.tool_loop import run_tool_loop
+from orbit.runtime.shell_guardrails import is_metadata_only_shell_command
+from orbit.runtime.thinking_mode import (
+    ThinkingMode,
+    contains_control_channel_markup,
+    last_assistant_has_open_reasoning,
+)
 from orbit.runtime.tool_result_compaction import (
     ToolResultCompactionReport,
     compact_tool_results,
@@ -46,31 +66,13 @@ from orbit.runtime.turn_trace import ModelStepMetrics
 ROUTE_MAX_TOKENS = 128
 
 
-def _contains_control_channel_markup(content: str) -> bool:
-    return "<|channel>" in content or "<channel|>" in content
-
-
-def _last_assistant_has_open_reasoning(messages: list[Message]) -> bool:
-    for message in reversed(messages):
-        if message.get("role") != "assistant":
-            continue
-        content = message.get("content")
-        if not isinstance(content, str):
-            return False
-        if "<|channel>thought" in content:
-            tail = content.split("<|channel>thought", 1)[1]
-            return "<channel|>" not in tail
-        stripped = content.strip().lower()
-        return stripped.startswith(("### reasoning", "## reasoning", "# reasoning", "reasoning:")) and "final answer" not in stripped
-    return False
-
-
 @dataclass
 class ChatRuntime:
     backend: ChatBackend
     system_prompt: str | None = None
     messages: list[Message] = field(default_factory=list)
     thinking_mode: bool = False
+    client_state: ClientState = field(default_factory=ClientState)
     context_tokens: int | None = None
     last_memory_refresh: MemoryRefresh | None = None
     last_memory_refresh_message_count: int | None = None
@@ -96,7 +98,6 @@ class ChatRuntime:
     content_evidence_guard_commands: int = 0
     content_evidence_guard_successes: int = 0
     content_evidence_guard_failures: int = 0
-    last_visible_finish_reason: str | None = None
 
     def __post_init__(self) -> None:
         if hasattr(self.backend, "thinking"):
@@ -116,17 +117,17 @@ class ChatRuntime:
         on_progress: Callable[[StreamProgress], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
     ) -> ChatResult:
-        self.messages.append({"role": "user", "content": message_content(prompt, images or [], audios or [])})
-        result = self._chat_final(
-            self.messages,
+        user_content = message_content(prompt, images or [], audios or [])
+        result = self._pure_chat_environment().ask_user_content(
+            user_content,
             temperature=temperature,
             max_tokens=max_tokens,
+            call_messages=self.messages,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
             loop=1,
         )
-        self.messages.append({"role": "assistant", "content": result.content})
         return self._remember_visible_result(result)
 
     def ask_chat(
@@ -141,17 +142,17 @@ class ChatRuntime:
     ) -> ChatResult:
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
-        self.messages.append({"role": "user", "content": prompt})
-        result = self._chat_final(
-            with_chat_system_prompt(self.messages),
+        call_messages = with_chat_system_prompt([*self.messages, {"role": "user", "content": prompt}])
+        result = self._pure_chat_environment().ask_user_content(
+            prompt,
             temperature=temperature,
             max_tokens=max_tokens,
+            call_messages=call_messages,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
             loop=1,
         )
-        self.messages.append({"role": "assistant", "content": result.content})
         return self._remember_visible_result(result)
 
     def continue_last_response(
@@ -163,47 +164,14 @@ class ChatRuntime:
         on_progress: Callable[[StreamProgress], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
     ) -> ChatResult:
-        if (
-            (self.last_visible_finish_reason == "length" or _last_assistant_has_open_reasoning(self.messages))
-            and hasattr(self.backend, "continue_current")
-        ):
-            if on_final_delta is None:
-                result = self.backend.continue_current(max_tokens=max_tokens)
-            else:
-                result = self.backend.continue_current(
-                    max_tokens=max_tokens,
-                    on_delta=on_final_delta,
-                    on_progress=on_progress,
-                )
-            if on_model_step:
-                on_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="chat_continue_native"))
-            self.messages.append({"role": "assistant", "content": result.content})
-            return self._remember_visible_result(result)
-        continuation_prompt = (
-            "Continue exactly from where the previous answer stopped. "
-            "If the previous answer stopped inside reasoning, do not restart it from the beginning. "
-            "Finish the remaining reasoning briefly, then continue with the missing final answer only. "
-            "Do not repeat already written text."
-            if _last_assistant_has_open_reasoning(self.messages)
-            else "Continue exactly from where the previous answer stopped. Do not repeat already written text."
-        )
-        self.messages.append(
-            {
-                "role": "user",
-                "content": continuation_prompt,
-            }
-        )
-        result = self._chat_final(
-            self.messages,
+        result = self._continue_environment().continue_last_response(
             temperature=temperature,
             max_tokens=max_tokens,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
-            loop=1,
         )
-        self.messages.append({"role": "assistant", "content": result.content})
-        return self._remember_visible_result(result)
+        return self._remember_visible_result(_tool_loop_result_value(result))
 
     def ask_with_tools(
         self,
@@ -242,7 +210,7 @@ class ChatRuntime:
             on_model_step=on_model_step,
             tool_names=tool_names,
         )
-        return self._remember_visible_result(result)
+        return self._remember_visible_result(result.result)
 
     def ask_auto(
         self,
@@ -261,11 +229,15 @@ class ChatRuntime:
     ) -> ChatResult:
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
+        resolution = self._file_input_environment(workdir).resolve(
+            prompt,
+            allowed_tool_names=allowed_tool_names,
+        )
         media_result = self._ask_media_if_referenced(
             prompt,
             temperature=temperature,
             max_tokens=max_tokens,
-            workdir=workdir,
+            resolution=resolution,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
@@ -280,7 +252,21 @@ class ChatRuntime:
             on_progress=on_progress,
             on_model_step=on_model_step,
         )
-        command_max_tokens = _bounded_internal_max_tokens(max_tokens, ROUTE_MAX_TOKENS)
+        if resolution.bypass_tool_route:
+            bundle = self._run_tool_loop(
+                temperature=temperature,
+                max_tokens=max_tokens,
+                workdir=workdir,
+                max_loops=max_loops,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_tool_call=on_tool_call,
+                on_tool_result=on_tool_result,
+                on_model_step=on_model_step,
+                tool_names=("exec_shell_full_command",),
+            )
+            return self._remember_visible_result(_tool_loop_result_value(bundle))
+        command_max_tokens = CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS)
         streamed_final_retry = False
         retried_empty_final = False
         route_stream_filter = None
@@ -303,9 +289,10 @@ class ChatRuntime:
         command_content = first.content
         decision = parse_command_decision_from_tool_calls(first.tool_calls) or parse_command_decision(command_content)
         if decision is None:
-            route_requires_chat_final = _contains_control_channel_markup(first.content)
+            initial_shell_tool_call = command_tool_call_from_tool_calls(first.tool_calls, ("exec_shell_full_command",)) or command_tool_call_from_content(command_content, ("exec_shell_full_command",))
+            route_requires_chat_final = contains_control_channel_markup(first.content)
             if route_requires_chat_final and first.finish_reason != "length":
-                first = self._chat_final(
+                first = self._transport_environment().chat_final(
                     with_chat_system_prompt(self.messages),
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -331,7 +318,7 @@ class ChatRuntime:
                     on_model_step(ModelStepMetrics.from_result(loop=2, result=first, phase="chat_final_retry"))
             if _is_empty_final_response(first):
                 retried_empty_final = True
-                first = self._chat_final(
+                first = self._transport_environment().chat_final(
                     self.messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -373,7 +360,7 @@ class ChatRuntime:
                 prompt,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                workdir=workdir,
+                resolution=resolution,
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
@@ -395,7 +382,7 @@ class ChatRuntime:
             if on_final_delta:
                 on_final_delta(result.content)
             return self._remember_visible_result(result)
-        result = self._run_tool_loop(
+        bundle = self._run_tool_loop(
             temperature=temperature,
             max_tokens=max_tokens,
             workdir=workdir,
@@ -411,10 +398,10 @@ class ChatRuntime:
                 or command_tool_call_from_content(command_content, tools)
             ),
         )
-        return self._remember_visible_result(result)
+        return self._remember_visible_result(_tool_loop_result_value(bundle))
 
     def _remember_visible_result(self, result: ChatResult) -> ChatResult:
-        self.last_visible_finish_reason = result.finish_reason
+        self.client_state.update_from_result(result, thinking=self._thinking())
         return result
 
     def _ask_media_if_referenced(
@@ -423,29 +410,27 @@ class ChatRuntime:
         *,
         temperature: float,
         max_tokens: int,
-        workdir,
+        resolution,
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
     ) -> ChatResult | None:
-        try:
-            images, audios = load_referenced_media(prompt, workdir=workdir)
-        except ValueError:
+        if resolution.error:
             return None
-        if not images and not audios:
+        if not resolution.has_media:
             return None
-        self.messages.append({"role": "user", "content": message_content(prompt, images, audios)})
-        call_messages = with_media_system_prompt(self.messages)
-        result = self._chat_final(
-            call_messages,
+        user_content = message_content(prompt, resolution.images, resolution.audios)
+        call_messages = with_media_system_prompt([*self.messages, {"role": "user", "content": user_content}])
+        result = self._pure_chat_environment().ask_user_content(
+            user_content,
             temperature=temperature,
             max_tokens=max_tokens,
+            call_messages=call_messages,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
             loop=1,
         )
-        self.messages.append({"role": "assistant", "content": result.content})
         return result
 
     def _ask_referenced_media(
@@ -454,30 +439,28 @@ class ChatRuntime:
         *,
         temperature: float,
         max_tokens: int,
-        workdir,
+        resolution,
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
         command_result: ChatResult,
     ) -> ChatResult:
-        try:
-            images, audios = load_referenced_media(prompt, workdir=workdir)
-        except ValueError as exc:
-            result = error_result(str(exc), command_result)
+        if resolution.error:
+            result = error_result(resolution.error, command_result)
             self.messages.append({"role": "assistant", "content": result.content})
             if on_final_delta:
                 on_final_delta(result.content)
             return result
-        if not images and not audios:
+        if not resolution.has_media:
             result = error_result("error: MEDIA route requested but no local image/audio path was found in the prompt", command_result)
             self.messages.append({"role": "assistant", "content": result.content})
             if on_final_delta:
                 on_final_delta(result.content)
             return result
 
-        self.messages[-1] = {"role": "user", "content": message_content(prompt, images, audios)}
+        self.messages[-1] = {"role": "user", "content": message_content(prompt, resolution.images, resolution.audios)}
         call_messages = with_media_system_prompt(self.messages)
-        result = self._chat_final(
+        result = self._transport_environment().chat_final(
             call_messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -503,9 +486,8 @@ class ChatRuntime:
         on_model_step: Callable[[ModelStepMetrics], None] | None,
         tool_names: tuple[str, ...] | None,
         initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
-        ) -> ChatResult:
-        return run_tool_loop(
-            self,
+        ):
+        return self._tool_loop_environment().run(
             temperature=temperature,
             max_tokens=max_tokens,
             workdir=workdir,
@@ -518,7 +500,6 @@ class ChatRuntime:
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
         )
-
     def _stream_tool_thinking_plan(
         self,
         *,
@@ -528,9 +509,10 @@ class ChatRuntime:
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
     ) -> None:
-        if not self.thinking_mode or on_final_delta is None:
-            return
-        if not hasattr(self.backend, "chat_stream"):
+        if not self._thinking().should_stream_tool_plan(
+            has_delta_sink=on_final_delta is not None,
+            backend_supports_streaming=hasattr(self.backend, "chat_stream"),
+        ):
             return
         planning_messages = [
             *with_chat_system_prompt(self.messages),
@@ -544,11 +526,11 @@ class ChatRuntime:
             },
         ]
         thought_filter = _ThoughtOnlyDeltaFilter(on_final_delta)
-        with self._temporary_backend_thinking(True):
+        with self._transport_environment().backend_thinking(True):
             result = self.backend.chat_stream(
                 planning_messages,
                 temperature=temperature,
-                max_tokens=_bounded_internal_max_tokens(max_tokens, ROUTE_MAX_TOKENS),
+                max_tokens=CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS),
                 on_delta=thought_filter.write,
                 on_progress=on_progress,
             )
@@ -567,71 +549,15 @@ class ChatRuntime:
         loop: int,
         use_tool_prompt: bool,
     ) -> ChatResult:
-        call_messages = with_final_tool_system_prompt(self.messages) if use_tool_prompt else self.messages
-        policy = build_final_tool_policy(call_messages, max_tokens=max_tokens, streamed=on_final_delta is not None)
-        if on_final_delta is None:
-            result = self.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
-        else:
-            result = self.backend.chat_stream(
-                policy.messages,
-                temperature=temperature,
-                max_tokens=policy.max_tokens,
-                on_delta=on_final_delta,
-                on_progress=on_progress,
-            )
-        if on_model_step:
-            on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="final_from_tool"))
-        retry_reason = final_from_tool_retry_reason(
-            result,
-            length_retry_allowed=policy.length_retry_allowed,
-            incomplete_retry_allowed=policy.incomplete_retry_allowed,
-        )
-        if retry_reason is not None:
-            retry_messages = [*policy.messages, final_tool_retry_instruction()]
-            retry_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
-            if on_final_delta is None:
-                result = self.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
-            else:
-                result = self.backend.chat_stream(
-                    retry_messages,
-                    temperature=temperature,
-                    max_tokens=retry_max_tokens,
-                    on_delta=on_final_delta,
-                    on_progress=on_progress,
-                )
-            if on_model_step:
-                on_model_step(
-                    ModelStepMetrics.from_result(
-                        loop=loop + 1,
-                        result=result,
-                        phase="final_from_tool_retry",
-                        retry_reason=retry_reason,
-                    )
-                )
-        if (
-            self.thinking_mode
-            and result.finish_reason == "length"
-            and hasattr(self.backend, "continue_current")
-        ):
-            if on_final_delta is None:
-                continuation = self.backend.continue_current(max_tokens=max_tokens)
-            else:
-                continuation = self.backend.continue_current(
-                    max_tokens=max_tokens,
-                    on_delta=on_final_delta,
-                    on_progress=on_progress,
-                )
-            result = _merge_chat_results(result, continuation)
-            if on_model_step:
-                on_model_step(
-                    ModelStepMetrics.from_result(
-                        loop=loop + 2,
-                        result=continuation,
-                        phase="final_from_tool_continue_native",
-                    )
-                )
-        self.messages.append({"role": "assistant", "content": result.content})
-        return result
+        return self._final_from_tool_environment().answer(
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            loop=loop,
+            use_tool_prompt=use_tool_prompt,
+        ).result
 
     def _chat_final(
         self,
@@ -644,34 +570,16 @@ class ChatRuntime:
         on_model_step: Callable[[ModelStepMetrics], None] | None,
         loop: int,
     ) -> ChatResult:
-        result = self._chat_once(
+        result = self._transport_environment().chat_final(
             messages,
             temperature=temperature,
             max_tokens=max_tokens,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
+            on_model_step=on_model_step,
+            loop=loop,
         )
-        if on_model_step:
-            on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="chat_final"))
-        if not _is_empty_final_response(result):
-            return result
-
-        retry = self._chat_once(
-            messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            on_final_delta=on_final_delta,
-            on_progress=on_progress,
-        )
-        if on_model_step:
-            on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase="chat_final_retry"))
-        if not _is_empty_final_response(retry):
-            return retry
-
-        error = replace(retry, content="error: model returned an empty response twice", finish_reason="empty_response")
-        if on_final_delta:
-            on_final_delta(error.content)
-        return error
+        return result
 
     def _chat_once(
         self,
@@ -682,13 +590,11 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
     ) -> ChatResult:
-        if on_final_delta is None:
-            return self.backend.chat(messages, temperature=temperature, max_tokens=max_tokens)
-        return self.backend.chat_stream(
+        return self._transport_environment().chat_once(
             messages,
             temperature=temperature,
             max_tokens=max_tokens,
-            on_delta=on_final_delta,
+            on_final_delta=on_final_delta,
             on_progress=on_progress,
         )
 
@@ -702,48 +608,21 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
     ) -> ChatResult:
-        try:
-            with self._temporary_backend_thinking(False):
-                if on_final_delta is None:
-                    return self.backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
-                return self.backend.chat_stream(
-                    messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    on_delta=on_final_delta,
-                    on_progress=on_progress,
-                )
-        except RuntimeError as exc:
-            if not _is_tool_argument_json_error(exc):
-                raise
-        retry_messages = [*messages, {"role": "system", "content": TOOL_CALL_JSON_RETRY_PROMPT}]
-        with self._temporary_backend_thinking(False):
-            if on_final_delta is None:
-                return self.backend.chat(retry_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
-            return self.backend.chat_stream(
-                retry_messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                on_delta=on_final_delta,
-                on_progress=on_progress,
-            )
+        return self._transport_environment().chat_tool_call_once(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+        )
 
-    @contextmanager
     def _temporary_backend_thinking(self, value: bool):
-        if not hasattr(self.backend, "thinking"):
-            yield
-            return
-        previous = getattr(self.backend, "thinking")
-        setattr(self.backend, "thinking", value)
-        try:
-            yield
-        finally:
-            setattr(self.backend, "thinking", previous)
+        return self._transport_environment().backend_thinking(value)
 
     def reset(self) -> None:
         self.messages.clear()
+        self.client_state.reset()
         self.last_memory_refresh = None
         self.last_memory_refresh_message_count = None
         self.last_memory_refresh_attempt = None
@@ -779,9 +658,47 @@ class ChatRuntime:
         if count < 0:
             count = 0
         del self.messages[count:]
+        self.client_state.reset()
         self.last_memory_refresh = None
         if self.last_memory_refresh_message_count is not None and self.last_memory_refresh_message_count > len(self.messages):
             self.last_memory_refresh_message_count = None
+
+    def can_continue_last_response(self) -> bool:
+        return self.client_state.can_continue or last_assistant_has_open_reasoning(self.messages)
+
+    @property
+    def last_visible_finish_reason(self) -> str | None:
+        return self.client_state.last_finish_reason
+
+    @last_visible_finish_reason.setter
+    def last_visible_finish_reason(self, value: str | None) -> None:
+        self.client_state.last_finish_reason = value
+        if value == "length" and not self.client_state.continuation_kind:
+            self.client_state.continuation_kind = "final_answer"
+
+    def _thinking(self) -> ThinkingMode:
+        return ThinkingMode(enabled=self.thinking_mode)
+
+    def _continue_environment(self) -> ContinueEnvironment:
+        return ContinueEnvironment(runtime=self, transport=self._transport_environment())
+
+    def _transport_environment(self) -> TransportEnvironment:
+        return TransportEnvironment(runtime=self)
+
+    def _pure_chat_environment(self) -> PureChatEnvironment:
+        return PureChatEnvironment(runtime=self, transport=self._transport_environment())
+
+    def _tool_loop_environment(self) -> ToolLoopEnvironment:
+        return ToolLoopEnvironment(runtime=self)
+
+    def _final_from_tool_environment(self) -> FinalFromToolEnvironment:
+        return FinalFromToolEnvironment(runtime=self, transport=self._transport_environment())
+
+    def _file_input_environment(self, workdir) -> FileInputEnvironment:
+        return FileInputEnvironment(FileInputResolver(workdir=workdir))
+
+    def _with_final_tool_prompt(self) -> list[Message]:
+        return with_final_tool_system_prompt(self.messages)
 
     def refresh_memory_if_needed(self, *, temperature: float, force: bool = False) -> bool:
         if not force and self._memory_refresh_in_cooldown():
@@ -851,8 +768,35 @@ class _ThoughtOnlyDeltaFilter:
             self._in_thought = True
 
 
-def _bounded_internal_max_tokens(max_tokens: int, internal_max: int) -> int:
-    return max(1, min(max_tokens, internal_max))
+class _BufferedDeltaSink:
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+
+    def write(self, text: str) -> None:
+        if text:
+            self.chunks.append(text)
+
+
+def _tool_call_command(tool_call: dict[str, object] | None) -> str | None:
+    if not isinstance(tool_call, dict):
+        return None
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return None
+    arguments = function.get("arguments")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(arguments, dict):
+        return None
+    command = arguments.get("command")
+    return command if isinstance(command, str) else None
+
+
+def _tool_loop_result_value(result):
+    return result.result if hasattr(result, "result") else result
 
 
 def _merge_chat_results(first: ChatResult, second: ChatResult) -> ChatResult:
@@ -895,3 +839,71 @@ def _unsupported_tool_mode_result(result: ChatResult) -> ChatResult:
 def _is_tool_argument_json_error(exc: RuntimeError) -> bool:
     text = str(exc)
     return "Failed to parse tool call arguments as JSON" in text
+
+
+def _needs_final_completion_repair(content: str) -> bool:
+    if "<channel|>" in content:
+        tail = content.split("<channel|>", 1)[1].strip()
+        if tail:
+            return False
+    lowered = content.strip().lower()
+    if "final answer:" in lowered or "**final answer:**" in lowered:
+        return False
+    stripped = content.rstrip()
+    if re.search(r"(?:^|\n)\s*#{1,6}\s*$", stripped):
+        return True
+    if re.search(r"(?:^|\n)\s*(?:[-*]|\d+\.)\s+\*\*[^*\n]+:\*\*\s*$", stripped):
+        return True
+    if re.search(r":\s*(?:\n\s*)?(?:#{1,6}|\*|-)?\s*$", stripped):
+        return True
+    if looks_like_incomplete_final(content):
+        return True
+    return content.count("`") % 2 == 1
+
+
+_FILE_MISSING_RE = re.compile(
+    r"(?:"
+    r"file\b.*(?:not\s+found|missing|inaccessible)"
+    r"|could\s+not\s+be\s+found"
+    r"|cannot\s+confirm.*file"
+    r"|non\s+[\w'\s]*trovat\w*"
+    r"|potrebbe\s+non\s+essere\s+stato\s+trovat\w*"
+    r"|impossibile.*trovare"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _contradicts_successful_pdf_extraction(messages: list[Message], content: str) -> bool:
+    if not content.strip():
+        return False
+    has_pdf_success = any(
+        message.get("role") == "tool"
+        and isinstance(message.get("content"), str)
+        and "shell_output_pdf_text: true" in str(message.get("content"))
+        for message in messages
+    )
+    return has_pdf_success and _FILE_MISSING_RE.search(content) is not None
+
+
+def _pdf_extraction_repair_prompt(messages: list[Message]) -> str:
+    path = None
+    for message in reversed(messages):
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or "shell_output_pdf_text: true" not in content:
+            continue
+        for line in content.splitlines():
+            if line.startswith("path: "):
+                path = line.removeprefix("path: ").strip()
+                break
+        break
+    path_text = f' for "{path}"' if path else ""
+    return (
+        "A successful PDF text extraction already exists"
+        f"{path_text}. "
+        "The previous answer incorrectly claimed the file was missing or inaccessible. "
+        "Restate the answer using only the extracted PDF text already available. "
+        "Do not say the file is missing. Do not call tools."
+    )

--- a/src/orbit/runtime/client_state.py
+++ b/src/orbit/runtime/client_state.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orbit.backend import ChatResult
+from orbit.runtime.thinking_mode import ThinkingMode
+
+
+@dataclass
+class ClientState:
+    last_finish_reason: str | None = None
+    continuation_kind: str | None = None
+    last_content: str = ""
+
+    @property
+    def can_continue(self) -> bool:
+        return self.continuation_kind is not None
+
+    def update_from_result(self, result: ChatResult, *, thinking: ThinkingMode) -> None:
+        self.last_finish_reason = result.finish_reason
+        self.last_content = result.content
+        self.continuation_kind = thinking.continuation_kind_for(
+            content=result.content,
+            finish_reason=result.finish_reason,
+        )
+
+    def reset(self) -> None:
+        self.last_finish_reason = None
+        self.continuation_kind = None
+        self.last_content = ""

--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompletionBudget:
+    requested_max_tokens: int
+
+    def internal(self, cap: int) -> int:
+        return max(1, min(self.requested_max_tokens, cap))
+
+    def user_visible(self) -> int:
+        return max(1, self.requested_max_tokens)

--- a/src/orbit/runtime/continue_controller.py
+++ b/src/orbit/runtime/continue_controller.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from orbit.backend import ChatBackend, ChatResult
+from orbit.backend.base import StreamProgress
+from orbit.runtime.thinking_mode import ThinkingMode
+
+
+@dataclass(frozen=True)
+class ContinueController:
+    backend: ChatBackend
+    thinking: ThinkingMode
+    merge_results: Callable[[ChatResult, ChatResult], ChatResult]
+
+    def continue_until_settled(
+        self,
+        *,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        max_passes: int = 3,
+    ) -> ChatResult:
+        merged = self._continue_once(
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+        )
+        passes = 1
+        while passes < max_passes:
+            continuation_kind = self.thinking.continuation_kind_for(
+                content=merged.content,
+                finish_reason=merged.finish_reason,
+            )
+            if continuation_kind is None:
+                break
+            continuation = self._continue_once(
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+            )
+            merged = self.merge_results(merged, continuation)
+            passes += 1
+            if not continuation.content:
+                break
+        return merged
+
+    def _continue_once(
+        self,
+        *,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+    ) -> ChatResult:
+        if on_final_delta is None:
+            return self.backend.continue_current(max_tokens=max_tokens)
+        return self.backend.continue_current(
+            max_tokens=max_tokens,
+            on_delta=on_final_delta,
+            on_progress=on_progress,
+        )

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1,0 +1,763 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Callable
+import json
+import re
+
+from orbit.backend import ChatResult
+from orbit.backend.base import Message, StreamProgress
+from orbit.runtime.completion_budget import CompletionBudget
+from orbit.runtime.continue_controller import ContinueController
+from orbit.runtime.file_input_resolver import FileInputResolver
+from orbit.runtime.final_policy import (
+    build_final_tool_policy,
+    classify_final_answer_completeness,
+    final_from_tool_compact_retry_reason,
+    final_from_tool_retry_reason,
+    final_tool_compact_retry_instruction,
+    final_tool_compact_retry_max_tokens,
+    final_tool_retry_instruction,
+    final_tool_retry_max_tokens,
+    is_repetitive_final_answer,
+    last_user_text,
+    looks_like_incomplete_final,
+)
+from orbit.runtime.media import AudioInput, ImageInput
+from orbit.runtime.messages import TOOL_CALL_JSON_RETRY_PROMPT
+from orbit.runtime.thinking_mode import ThinkingMode, last_assistant_has_open_reasoning
+from orbit.runtime.tool_loop import run_tool_loop
+from orbit.runtime.turn_trace import ModelStepMetrics
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from orbit.runtime.chat import ChatRuntime
+
+
+@dataclass(frozen=True)
+class ClientTurnState:
+    prompt: str
+    temperature: float
+    max_tokens: int
+    workdir: Path | None = None
+    max_loops: int = 10
+    allowed_tool_names: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class ToolResultBundle:
+    result: ChatResult
+    tool_names: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
+class FinalAnswerResult:
+    result: ChatResult
+    used_retry_or_repair_pass: bool
+    repair_attempts: int = 0
+    repair_failed: bool = False
+    compact_retry_attempted: bool = False
+    compact_retry_failed: bool = False
+
+
+@dataclass(frozen=True)
+class ContinueResult:
+    result: ChatResult
+    used_native_continue: bool
+    used_prompt_fallback: bool
+
+
+@dataclass(frozen=True)
+class FileResolutionResult:
+    images: list[ImageInput]
+    audios: list[AudioInput]
+    bypass_tool_route: bool
+    error: str | None = None
+
+    @property
+    def has_media(self) -> bool:
+        return bool(self.images or self.audios)
+
+
+@dataclass(frozen=True)
+class TransportEnvironment:
+    runtime: ChatRuntime
+
+    def chat_final(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        loop: int,
+    ) -> ChatResult:
+        result = self.chat_once(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+        )
+        if on_model_step:
+            on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="chat_final"))
+        if not is_empty_final_response(result):
+            return result
+
+        retry = self.chat_once(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+        )
+        if on_model_step:
+            on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase="chat_final_retry"))
+        if not is_empty_final_response(retry):
+            return retry
+
+        error = ChatResult(
+            content="error: model returned an empty response twice",
+            model=retry.model,
+            finish_reason="empty_response",
+            tool_calls=retry.tool_calls,
+            prompt_tokens=retry.prompt_tokens,
+            completion_tokens=retry.completion_tokens,
+            cached_tokens=retry.cached_tokens,
+            prompt_tokens_per_second=retry.prompt_tokens_per_second,
+            generation_tokens_per_second=retry.generation_tokens_per_second,
+        )
+        if on_final_delta:
+            on_final_delta(error.content)
+        return error
+
+    def chat_once(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+    ) -> ChatResult:
+        if on_final_delta is None:
+            return self.runtime.backend.chat(messages, temperature=temperature, max_tokens=max_tokens)
+        return self.runtime.backend.chat_stream(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_delta=on_final_delta,
+            on_progress=on_progress,
+        )
+
+    def chat_tool_call_once(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, object]],
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+    ) -> ChatResult:
+        try:
+            with self.backend_thinking(False):
+                if on_final_delta is None:
+                    return self.runtime.backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+                return self.runtime.backend.chat_stream(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    on_delta=on_final_delta,
+                    on_progress=on_progress,
+                )
+        except RuntimeError as exc:
+            if not is_tool_argument_json_error(exc):
+                raise
+        retry_messages = [*messages, {"role": "system", "content": TOOL_CALL_JSON_RETRY_PROMPT}]
+        with self.backend_thinking(False):
+            if on_final_delta is None:
+                return self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+            return self.runtime.backend.chat_stream(
+                retry_messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                on_delta=on_final_delta,
+                on_progress=on_progress,
+            )
+
+    @contextmanager
+    def backend_thinking(self, value: bool):
+        if not hasattr(self.runtime.backend, "thinking"):
+            yield
+            return
+        previous = getattr(self.runtime.backend, "thinking")
+        setattr(self.runtime.backend, "thinking", value)
+        try:
+            yield
+        finally:
+            setattr(self.runtime.backend, "thinking", previous)
+
+
+@dataclass(frozen=True)
+class PureChatEnvironment:
+    runtime: ChatRuntime
+    transport: TransportEnvironment
+
+    def ask_user_content(
+        self,
+        user_content: object,
+        *,
+        temperature: float,
+        max_tokens: int,
+        call_messages: list[Message],
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        loop: int,
+    ) -> ChatResult:
+        self.runtime.messages.append({"role": "user", "content": user_content})
+        result = self.transport.chat_final(
+            call_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            loop=loop,
+        )
+        self.runtime.messages.append({"role": "assistant", "content": result.content})
+        return result
+
+
+@dataclass(frozen=True)
+class ToolLoopEnvironment:
+    runtime: ChatRuntime
+
+    def run(
+        self,
+        *,
+        temperature: float,
+        max_tokens: int,
+        workdir,
+        max_loops: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_tool_call: Callable[[str, str], None] | None,
+        on_tool_result: Callable[[str, int, str, str], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        tool_names: tuple[str, ...] | None,
+        initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
+    ) -> ToolResultBundle:
+        result = run_tool_loop(
+            self.runtime,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            max_loops=max_loops,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_model_step=on_model_step,
+            tool_names=tool_names,
+            initial_tool_calls=initial_tool_calls,
+        )
+        return ToolResultBundle(
+            result=result,
+            tool_names=tool_names,
+        )
+
+
+@dataclass(frozen=True)
+class FinalFromToolEnvironment:
+    runtime: ChatRuntime
+    transport: TransportEnvironment
+
+    def answer(
+        self,
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        loop: int,
+        use_tool_prompt: bool,
+    ) -> FinalAnswerResult:
+        call_messages = self.runtime._with_final_tool_prompt() if use_tool_prompt else self.runtime.messages
+        policy = build_final_tool_policy(call_messages, max_tokens=max_tokens, streamed=on_final_delta is not None)
+        stream_buffer = _BufferedDeltaSink() if on_final_delta is not None and policy.incomplete_retry_allowed else None
+        final_delta = stream_buffer.write if stream_buffer is not None else on_final_delta
+        used_retry_or_repair_pass = False
+        repair_attempt = 0
+        repair_failed = False
+        compact_retry_attempted = False
+        compact_retry_failed = False
+        if on_final_delta is None:
+            result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
+        else:
+            result = self.runtime.backend.chat_stream(
+                policy.messages,
+                temperature=temperature,
+                max_tokens=policy.max_tokens,
+                on_delta=final_delta,
+                on_progress=on_progress,
+            )
+        best_non_empty_result = result if result.content.strip() else None
+        if on_model_step:
+            on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="final_from_tool"))
+        retry_reason = final_from_tool_retry_reason(
+            result,
+            length_retry_allowed=policy.length_retry_allowed,
+            incomplete_retry_allowed=policy.incomplete_retry_allowed,
+            messages=policy.messages,
+        )
+        if retry_reason is not None:
+            used_retry_or_repair_pass = True
+            previous_result = result
+            retry_messages = [*policy.messages, final_tool_retry_instruction()]
+            retry_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
+            if on_final_delta is None:
+                retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
+            else:
+                retry_candidate = self.runtime.backend.chat_stream(
+                    retry_messages,
+                    temperature=temperature,
+                    max_tokens=retry_max_tokens,
+                    on_delta=final_delta,
+                    on_progress=on_progress,
+                )
+            if retry_candidate.content.strip():
+                best_non_empty_result = retry_candidate
+            result = _prefer_non_empty_retry_result(previous_result, retry_candidate)
+            if on_model_step:
+                on_model_step(
+                    ModelStepMetrics.from_result(
+                        loop=loop + 1,
+                        result=retry_candidate,
+                        phase="final_from_tool_retry",
+                        retry_reason=retry_reason,
+                    )
+                )
+        completeness = classify_final_answer_completeness(result.content, messages=policy.messages)
+        if (
+            policy.incomplete_retry_allowed
+            and result.finish_reason == "stop"
+            and (
+                not completeness.is_complete
+                or contradicts_successful_pdf_extraction(policy.messages, result.content)
+            )
+            and repair_attempt < 1
+        ):
+            used_retry_or_repair_pass = True
+            repair_attempt += 1
+            contradiction = contradicts_successful_pdf_extraction(policy.messages, result.content)
+            repair_instruction = (
+                pdf_extraction_repair_prompt(policy.messages)
+                if contradiction
+                else (
+                    "The previous answer was incomplete, malformed, or not yet a final answer. "
+                    "Write one short final answer now using only the existing tool results. "
+                    "Use plain prose only. No headings. No bullet list unless absolutely necessary. "
+                    "No code fences. No thinking or plan. No partial identifiers. "
+                    "Limit yourself to three to five sentences. "
+                    "Do not repeat fragments from the previous answer. Do not call tools."
+                )
+            )
+            repair_messages = [*policy.messages, {"role": "user", "content": repair_instruction}]
+            repair_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
+            if on_final_delta is None:
+                result = self.runtime.backend.chat(repair_messages, temperature=temperature, max_tokens=repair_max_tokens)
+            else:
+                result = self.runtime.backend.chat_stream(
+                    repair_messages,
+                    temperature=temperature,
+                    max_tokens=repair_max_tokens,
+                    on_delta=final_delta,
+                    on_progress=on_progress,
+                )
+            if result.content.strip():
+                best_non_empty_result = result
+            if on_model_step:
+                on_model_step(
+                    ModelStepMetrics.from_result(
+                        loop=loop + 2 + repair_attempt,
+                        result=result,
+                        phase="final_from_tool_completion_repair",
+                        retry_reason="incomplete_final",
+                    )
+                )
+            completeness = classify_final_answer_completeness(result.content, messages=policy.messages)
+            if (
+                result.finish_reason == "stop"
+                and (
+                    not completeness.is_complete
+                    or contradicts_successful_pdf_extraction(policy.messages, result.content)
+                )
+            ):
+                repair_failed = True
+        compact_retry_reason = final_from_tool_compact_retry_reason(result, messages=policy.messages)
+        if compact_retry_reason is not None:
+            used_retry_or_repair_pass = True
+            compact_retry_attempted = True
+            original_result = best_non_empty_result or result
+            compact_messages = [*policy.messages, final_tool_compact_retry_instruction()]
+            compact_max_tokens = final_tool_compact_retry_max_tokens(max_tokens, messages=policy.messages)
+            if on_final_delta is None:
+                candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
+            else:
+                candidate = self.runtime.backend.chat_stream(
+                    compact_messages,
+                    temperature=temperature,
+                    max_tokens=compact_max_tokens,
+                    on_delta=final_delta,
+                    on_progress=on_progress,
+                )
+            if candidate.content.strip():
+                best_non_empty_result = candidate
+            if on_model_step:
+                on_model_step(
+                    ModelStepMetrics.from_result(
+                        loop=loop + 3,
+                        result=candidate,
+                        phase="final_from_tool_compact_retry",
+                        retry_reason=compact_retry_reason,
+                    )
+                )
+            if _prefer_compact_retry_result(candidate, original_result, messages=policy.messages):
+                result = candidate
+            else:
+                result = original_result
+                compact_retry_failed = True
+        if not result.content.strip() and best_non_empty_result is not None:
+            result = best_non_empty_result
+        if stream_buffer is not None and on_final_delta is not None:
+            if used_retry_or_repair_pass and result.content:
+                on_final_delta(result.content)
+            else:
+                for chunk in stream_buffer.chunks:
+                    on_final_delta(chunk)
+        self.runtime.messages.append({"role": "assistant", "content": result.content})
+        return FinalAnswerResult(
+            result=result,
+            used_retry_or_repair_pass=used_retry_or_repair_pass,
+            repair_attempts=repair_attempt,
+            repair_failed=repair_failed,
+            compact_retry_attempted=compact_retry_attempted,
+            compact_retry_failed=compact_retry_failed,
+        )
+
+
+@dataclass(frozen=True)
+class ContinueEnvironment:
+    runtime: ChatRuntime
+    transport: TransportEnvironment
+
+    def continue_last_response(
+        self,
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+    ) -> ContinueResult:
+        initial_kind = self._continuation_kind_before_continue()
+        if initial_kind == "thinking":
+            result = self._continue_with_prompt_fallback(
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                loop=1,
+                force_disable_backend_thinking=True,
+            )
+            return ContinueResult(result=result, used_native_continue=False, used_prompt_fallback=True)
+        if self.runtime.can_continue_last_response() and hasattr(self.runtime.backend, "continue_current"):
+            result = ContinueController(
+                backend=self.runtime.backend,
+                thinking=self.runtime._thinking(),
+                merge_results=merge_chat_results,
+            ).continue_until_settled(
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                max_passes=3,
+            )
+            if on_model_step:
+                on_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="chat_continue_native"))
+            if self.runtime._thinking().continuation_kind_for(content=result.content, finish_reason=result.finish_reason) is not None:
+                self.runtime.messages.append({"role": "assistant", "content": result.content})
+                fallback = self._continue_with_prompt_fallback(
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    loop=2,
+                    force_disable_backend_thinking=True,
+                )
+                return ContinueResult(
+                    result=merge_chat_results(result, fallback),
+                    used_native_continue=True,
+                    used_prompt_fallback=True,
+                )
+            self.runtime.messages.append({"role": "assistant", "content": result.content})
+            return ContinueResult(result=result, used_native_continue=True, used_prompt_fallback=False)
+        result = self._continue_with_prompt_fallback(
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            loop=1,
+        )
+        return ContinueResult(result=result, used_native_continue=False, used_prompt_fallback=True)
+
+    def _continuation_kind_before_continue(self) -> str | None:
+        if self.runtime.client_state.continuation_kind is not None:
+            return self.runtime.client_state.continuation_kind
+        if self.runtime.client_state.last_content:
+            return self.runtime._thinking().continuation_kind_for(
+                content=self.runtime.client_state.last_content,
+                finish_reason=self.runtime.client_state.last_finish_reason,
+            )
+        if last_assistant_has_open_reasoning(self.runtime.messages):
+            return "thinking"
+        if self.runtime.last_visible_finish_reason == "length":
+            return "final_answer"
+        return None
+
+    def _continue_with_prompt_fallback(
+        self,
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        loop: int,
+        force_disable_backend_thinking: bool = False,
+    ) -> ChatResult:
+        if force_disable_backend_thinking and last_assistant_has_open_reasoning(self.runtime.messages):
+            original_request = last_user_text(self.runtime.messages)
+            continuation_prompt = (
+                "Stop reasoning now and write only the missing final answer. "
+                "Start the answer with 'Final answer:'. "
+                "Do not continue or repeat any thought text. "
+                "No hidden reasoning, no plan, no thinking markers. "
+                + (
+                    f"Answer concisely and directly to the original user request: {original_request!r}. "
+                    if original_request
+                    else "Answer concisely and directly from the existing context. "
+                )
+            )
+        else:
+            continuation_prompt = (
+                "Continue exactly from where the previous answer stopped. "
+                "If the previous answer stopped inside reasoning, do not restart it from the beginning. "
+                "Finish the remaining reasoning briefly, then continue with the missing final answer only. "
+                "Do not repeat already written text."
+                if last_assistant_has_open_reasoning(self.runtime.messages)
+                else "Continue exactly from where the previous answer stopped. Do not repeat already written text."
+            )
+        self.runtime.messages.append({"role": "user", "content": continuation_prompt})
+        if force_disable_backend_thinking:
+            with self.transport.backend_thinking(False):
+                result = self.transport.chat_final(
+                    self.runtime.messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    loop=loop,
+                )
+        else:
+            result = self.transport.chat_final(
+                self.runtime.messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                loop=loop,
+            )
+        if force_disable_backend_thinking and self.runtime._thinking().continuation_kind_for(
+            content=result.content,
+            finish_reason=result.finish_reason,
+        ) is not None:
+            result = replace(
+                result,
+                content="error: model did not produce a final answer after continuation",
+                finish_reason="stop",
+            )
+        self.runtime.messages.append({"role": "assistant", "content": result.content})
+        return result
+
+
+@dataclass(frozen=True)
+class FileInputEnvironment:
+    resolver: FileInputResolver
+
+    def resolve(self, prompt: str, *, allowed_tool_names: tuple[str, ...] | None) -> FileResolutionResult:
+        try:
+            images, audios = self.resolver.resolve_media(prompt)
+        except ValueError as exc:
+            return FileResolutionResult(images=[], audios=[], bypass_tool_route=False, error=str(exc))
+        return FileResolutionResult(
+            images=images,
+            audios=audios,
+            bypass_tool_route=self.resolver.should_bypass_tool_route(prompt, allowed_tool_names),
+        )
+
+
+def merge_chat_results(first: ChatResult, second: ChatResult) -> ChatResult:
+    def add_int(a: int | None, b: int | None) -> int | None:
+        if a is None and b is None:
+            return None
+        return (a or 0) + (b or 0)
+
+    return ChatResult(
+        content=f"{first.content}{second.content}",
+        model=second.model or first.model,
+        finish_reason=second.finish_reason or first.finish_reason,
+        tool_calls=second.tool_calls or first.tool_calls,
+        prompt_tokens=add_int(first.prompt_tokens, second.prompt_tokens),
+        completion_tokens=add_int(first.completion_tokens, second.completion_tokens),
+        cached_tokens=add_int(first.cached_tokens, second.cached_tokens),
+        prompt_tokens_per_second=second.prompt_tokens_per_second or first.prompt_tokens_per_second,
+        generation_tokens_per_second=second.generation_tokens_per_second or first.generation_tokens_per_second,
+    )
+
+
+def is_empty_final_response(result: ChatResult) -> bool:
+    return not result.tool_calls and result.finish_reason == "stop" and not result.content.strip()
+
+
+def unsupported_tool_mode_result(result: ChatResult) -> ChatResult:
+    return ChatResult(
+        content="error: no suitable tool is available for this request",
+        model=result.model,
+        finish_reason="unsupported_command",
+        tool_calls=[],
+        prompt_tokens=result.prompt_tokens,
+        completion_tokens=result.completion_tokens,
+        cached_tokens=result.cached_tokens,
+        prompt_tokens_per_second=result.prompt_tokens_per_second,
+        generation_tokens_per_second=result.generation_tokens_per_second,
+    )
+
+
+def is_tool_argument_json_error(exc: RuntimeError) -> bool:
+    return "Failed to parse tool call arguments as JSON" in str(exc)
+
+
+def needs_final_completion_repair(content: str) -> bool:
+    if "<channel|>" in content:
+        tail = content.split("<channel|>", 1)[1].strip()
+        if tail:
+            return False
+    lowered = content.strip().lower()
+    if "final answer:" in lowered or "**final answer:**" in lowered:
+        return False
+    stripped = content.rstrip()
+    if re.search(r"(?:^|\n)\s*#{1,6}\s*$", stripped):
+        return True
+    if re.search(r"(?:^|\n)\s*(?:[-*]|\d+\.)\s+\*\*[^*\n]+:\*\*\s*$", stripped):
+        return True
+    if re.search(r":\s*(?:\n\s*)?(?:#{1,6}|\*|-)?\s*$", stripped):
+        return True
+    if looks_like_incomplete_final(content):
+        return True
+    return content.count("`") % 2 == 1
+
+
+_FILE_MISSING_RE = re.compile(
+    r"(?:"
+    r"file\b.*(?:not\s+found|missing|inaccessible)"
+    r"|could\s+not\s+be\s+found"
+    r"|cannot\s+confirm.*file"
+    r"|non\s+[\w'\s]*trovat\w*"
+    r"|potrebbe\s+non\s+essere\s+stato\s+trovat\w*"
+    r"|impossibile.*trovare"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def contradicts_successful_pdf_extraction(messages: list[Message], content: str) -> bool:
+    if not content.strip():
+        return False
+    has_pdf_success = any(
+        message.get("role") == "tool"
+        and isinstance(message.get("content"), str)
+        and "shell_output_pdf_text: true" in str(message.get("content"))
+        for message in messages
+    )
+    return has_pdf_success and _FILE_MISSING_RE.search(content) is not None
+
+
+def pdf_extraction_repair_prompt(messages: list[Message]) -> str:
+    path = None
+    for message in reversed(messages):
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or "shell_output_pdf_text: true" not in content:
+            continue
+        for line in content.splitlines():
+            if line.startswith("path: "):
+                path = line.removeprefix("path: ").strip()
+                break
+        break
+    path_text = f' for "{path}"' if path else ""
+    return (
+        "A successful PDF text extraction already exists"
+        f"{path_text}. "
+        "The previous answer incorrectly claimed the file was missing or inaccessible. "
+        "Restate the answer using only the extracted PDF text already available. "
+        "Do not say the file is missing. Do not call tools."
+    )
+
+
+class _BufferedDeltaSink:
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+
+    def write(self, text: str) -> None:
+        if text:
+            self.chunks.append(text)
+
+
+def _prefer_compact_retry_result(candidate: ChatResult, original: ChatResult, *, messages: list[Message]) -> bool:
+    candidate_text = candidate.content.strip()
+    if not candidate_text:
+        return False
+    candidate_complete = classify_final_answer_completeness(candidate.content, messages=messages).is_complete
+    original_complete = classify_final_answer_completeness(original.content, messages=messages).is_complete
+    candidate_repetitive = is_repetitive_final_answer(candidate.content)
+    original_repetitive = is_repetitive_final_answer(original.content)
+    if candidate.finish_reason == "stop" and original.finish_reason != "stop":
+        return candidate_complete and not candidate_repetitive
+    if candidate_complete and not candidate_repetitive and (not original_complete or original_repetitive):
+        return True
+    if candidate_complete and original.finish_reason == "length" and len(candidate_text) <= len(original.content.strip()):
+        return True
+    return False
+
+
+def _prefer_non_empty_retry_result(previous: ChatResult, candidate: ChatResult) -> ChatResult:
+    if candidate.content.strip():
+        return candidate
+    if previous.content.strip():
+        return previous
+    return candidate

--- a/src/orbit/runtime/file_input_resolver.py
+++ b/src/orbit/runtime/file_input_resolver.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from orbit.runtime.media import AudioInput, ImageInput, load_referenced_media
+
+
+_LOCAL_DOCUMENT_ROUTE_RE = re.compile(r"(?:[\"'`](?:[^\"'`]+)[\"'`]|[A-Za-z0-9_./ -]+?\.(?:pdf|docx?|md|txt))", re.IGNORECASE)
+_DOCUMENTISH_BYPASS_RE = re.compile(r"\b(?:pdf|document|doc|report|relazione|documento)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class FileInputResolver:
+    workdir: Path
+
+    def resolve_media(self, prompt: str) -> tuple[list[ImageInput], list[AudioInput]]:
+        return load_referenced_media(prompt, workdir=self.workdir)
+
+    def should_bypass_tool_route(self, prompt: str, allowed_tool_names: tuple[str, ...] | None) -> bool:
+        if allowed_tool_names is None or "exec_shell_full_command" not in allowed_tool_names:
+            return False
+        return bool(_LOCAL_DOCUMENT_ROUTE_RE.search(prompt) and _DOCUMENTISH_BYPASS_RE.search(prompt))

--- a/src/orbit/runtime/file_tools.py
+++ b/src/orbit/runtime/file_tools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +14,8 @@ MAX_CHUNK_FILE_BYTES = 1024 * 1024
 DEFAULT_CHUNK_CHARS = 6_000
 DEFAULT_LARGE_FILE_INITIAL_CHARS = 500
 MAX_CHUNK_CHARS = 12_000
+PDF_CHUNK_CHARS = 3_000
+PDF_EXTRACT_TIMEOUT = 15
 
 
 def read_file(path: Any, *, arguments: dict[str, Any], workdir: Path) -> str:
@@ -28,7 +32,7 @@ def read_file(path: Any, *, arguments: dict[str, Any], workdir: Path) -> str:
 
     suffix = target.suffix.lower()
     if suffix == ".pdf":
-        return "error: read_file supports UTF-8 text/code files only; PDF requires read_pdf, which is not available yet"
+        return "error: read_file supports UTF-8 text/code files only; PDF content is handled separately"
     if suffix in BINARY_OR_SPECIAL_EXTENSIONS:
         return f"error: read_file supports UTF-8 text/code files only; unsupported file type: {suffix}"
 
@@ -61,6 +65,25 @@ def read_file(path: Any, *, arguments: dict[str, Any], workdir: Path) -> str:
             workdir=workdir,
         )
     return text if text else "(empty file)"
+
+
+def read_pdf(path: Any, *, arguments: dict[str, Any], workdir: Path) -> str:
+    validation = load_pdf_text(path, workdir=workdir)
+    if isinstance(validation, str):
+        return validation
+    target, text, extractor = validation
+
+    if "chunk_index" in arguments:
+        return read_pdf_chunk(
+            path,
+            chunk_index=arguments.get("chunk_index"),
+            chunk_chars=arguments.get("chunk_chars", PDF_CHUNK_CHARS),
+            workdir=workdir,
+        )
+
+    if len(text) <= MAX_READ_CHARS:
+        return format_pdf_result(target, text, extractor=extractor)
+    return read_large_pdf_excerpt(path, chunk_chars=PDF_CHUNK_CHARS, workdir=workdir)
 
 
 def read_chunk(path: Any, *, chunk_index: Any, chunk_chars: Any, workdir: Path) -> str:
@@ -113,6 +136,55 @@ def read_large_file_excerpt(path: Any, *, chunk_chars: int, workdir: Path) -> st
     )
 
 
+def read_pdf_chunk(path: Any, *, chunk_index: Any, chunk_chars: Any, workdir: Path) -> str:
+    if not isinstance(chunk_index, int) or chunk_index < 0:
+        return "error: chunk_index must be a non-negative integer"
+    if not isinstance(chunk_chars, int) or chunk_chars <= 0:
+        return "error: chunk_chars must be a positive integer"
+    if chunk_chars > MAX_CHUNK_CHARS:
+        return f"error: chunk_chars too large: {chunk_chars}, max {MAX_CHUNK_CHARS}"
+
+    validation = load_pdf_text(path, workdir=workdir)
+    if isinstance(validation, str):
+        return validation
+    target, text, extractor = validation
+    total_chunks = max(1, (len(text) + chunk_chars - 1) // chunk_chars)
+    if chunk_index >= total_chunks:
+        return f"error: chunk_index out of range: {chunk_index}, total_chunks {total_chunks}"
+    start = chunk_index * chunk_chars
+    end = min(start + chunk_chars, len(text))
+    return format_pdf_result(
+        target,
+        text[start:end],
+        extractor=extractor,
+        chunk_index=chunk_index,
+        total_chunks=total_chunks,
+        chars_start=start,
+        chars_end=end,
+        total_length=len(text),
+    )
+
+
+def read_large_pdf_excerpt(path: Any, *, chunk_chars: int, workdir: Path) -> str:
+    validation = load_pdf_text(path, workdir=workdir)
+    if isinstance(validation, str):
+        return validation
+    target, text, extractor = validation
+    end = min(chunk_chars, len(text))
+    total_chunks = max(1, (len(text) + chunk_chars - 1) // chunk_chars)
+    return format_pdf_result(
+        target,
+        text[:end],
+        extractor=extractor,
+        large_file_excerpt=True,
+        chunk_index=0,
+        total_chunks=total_chunks,
+        chars_start=0,
+        chars_end=end,
+        total_length=len(text),
+    )
+
+
 def load_text_file(path: Any, *, workdir: Path, max_bytes: int) -> tuple[Path, str] | str:
     if not isinstance(path, str) or not path:
         return "error: path must be a non-empty string"
@@ -127,7 +199,7 @@ def load_text_file(path: Any, *, workdir: Path, max_bytes: int) -> tuple[Path, s
 
     suffix = target.suffix.lower()
     if suffix == ".pdf":
-        return "error: read_file chunk mode supports UTF-8 text/code files only; PDF requires read_pdf, which is not available yet"
+        return "error: read_file chunk mode supports UTF-8 text/code files only; PDF content is handled separately"
     if suffix in BINARY_OR_SPECIAL_EXTENSIONS:
         return f"error: read_file chunk mode supports UTF-8 text/code files only; unsupported file type: {suffix}"
     if suffix and suffix not in TEXT_EXTENSIONS:
@@ -145,3 +217,103 @@ def load_text_file(path: Any, *, workdir: Path, max_bytes: int) -> tuple[Path, s
     except UnicodeDecodeError:
         return "error: file is not valid UTF-8 text"
     return target, text
+
+
+def load_pdf_text(path: Any, *, workdir: Path) -> tuple[Path, str, str] | str:
+    if not isinstance(path, str) or not path:
+        return "error: path must be a non-empty string"
+    target_or_error = resolve_inside_workdir(path, workdir=workdir)
+    if isinstance(target_or_error, str):
+        return target_or_error
+    target = target_or_error
+    if not target.exists():
+        return f"error: path not found: {path}"
+    if not target.is_file():
+        return f"error: path is not a file: {path}"
+    if target.suffix.lower() != ".pdf":
+        return f"error: unsupported PDF file extension: {target.suffix.lower()}"
+
+    text, extractor = extract_pdf_text(target)
+    if not text.strip():
+        return f"error: no text extracted from PDF: {target.name}"
+    if len(text.encode("utf-8", errors="replace")) > MAX_CHUNK_FILE_BYTES:
+        return f"error: extracted PDF text too large: max {MAX_CHUNK_FILE_BYTES} bytes"
+    return target, text, extractor
+
+
+def extract_pdf_text(target: Path) -> tuple[str, str]:
+    pdftotext = shutil.which("pdftotext")
+    if pdftotext:
+        completed = subprocess.run(
+            [pdftotext, "-layout", str(target), "-"],
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=PDF_EXTRACT_TIMEOUT,
+            check=False,
+        )
+        if completed.returncode == 0 and completed.stdout.strip():
+            return completed.stdout, "pdftotext"
+    strings = shutil.which("strings")
+    if not strings:
+        return "", "unavailable"
+    completed = subprocess.run(
+        [strings, "-a", "-n", "8", str(target)],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        timeout=PDF_EXTRACT_TIMEOUT,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return _clean_pdf_strings_output(completed.stdout), "strings"
+    return "", "strings"
+
+
+def format_pdf_result(
+    target: Path,
+    text: str,
+    *,
+    extractor: str,
+    large_file_excerpt: bool = False,
+    chunk_index: int | None = None,
+    total_chunks: int | None = None,
+    chars_start: int | None = None,
+    chars_end: int | None = None,
+    total_length: int | None = None,
+) -> str:
+    lines = [
+        "pdf_text: true",
+        f"path: {target.name}",
+        f"extractor: {extractor}",
+    ]
+    if large_file_excerpt:
+        lines.append("large_file_excerpt: true")
+    if chunk_index is not None and total_chunks is not None and chars_start is not None and chars_end is not None:
+        if total_length is None:
+            total_length = chars_end
+        lines.extend(
+            [
+                f"chunk_index: {chunk_index}",
+                f"total_chunks: {total_chunks}",
+                f"chars: {chars_start}-{chars_end} of {total_length}",
+            ]
+        )
+    lines.extend(["content:", text.strip() or "(empty PDF text)"])
+    return "\n".join(lines)
+
+
+def _clean_pdf_strings_output(text: str) -> str:
+    lines: list[str] = []
+    seen = set()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("%PDF") or line == "%%EOF":
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return "\n".join(lines)

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -11,9 +11,34 @@ from orbit.backend.base import Message
 
 FINAL_FROM_TOOL_MIN_TOKENS = 256
 LARGE_FILE_FINAL_MAX_TOKENS = 128
+EXHAUSTIVE_LARGE_FILE_FINAL_MAX_TOKENS = 256
 WEB_FETCH_FINAL_MAX_TOKENS = 72
 LIST_FINAL_MAX_TOKENS = 96
 OPERATIONAL_STATUS_FINAL_MAX_TOKENS = 96
+LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS = 96
+COMPACT_FINAL_RETRY_MAX_TOKENS = 160
+COMPACT_FINAL_RETRY_MIN_TOKENS = 64
+_COMPACT_LIST_REQUEST_RE = re.compile(
+    r"\b(?:only\s+(?:the\s+)?(?:filenames?|names?)|return\s+only|only\s+the\s+listed\s+names|solo\s+i\s+nomi|solo\s+i\s+file|solo\s+nomi)\b",
+    re.IGNORECASE,
+)
+_EXHAUSTIVE_DOCUMENT_RE = re.compile(
+    r"\b(?:entire|whole|full|complete|completo|completa|intero|intera|detailed|detail|detagliat\w*|approfond\w*|exhaustive|thorough|critique|critica|strengths|weaknesses|punti\s+forti|punti\s+deboli|cite|cita)\b",
+    re.IGNORECASE,
+)
+_FINAL_MARKERS = (
+    "**final answer:**",
+    "final answer:",
+    "the final answer is:",
+    "the final answer:",
+)
+_REASONING_PREFIXES = (
+    "### reasoning",
+    "## reasoning",
+    "# reasoning",
+    "reasoning:",
+    "plan:",
+)
 
 
 @dataclass(frozen=True)
@@ -25,12 +50,29 @@ class FinalToolPolicy:
     web_fetch_result: bool
 
 
+@dataclass(frozen=True)
+class FinalAnswerCompleteness:
+    status: str
+    detail: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status == "complete"
+
+
 def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streamed: bool) -> FinalToolPolicy:
     large_file_excerpt = has_large_file_excerpt(messages)
+    exhaustive_document_request = is_exhaustive_document_request(last_user_text(messages))
     web_fetch_result = has_html_cleaned_tool_result(messages)
-    list_like_result = has_list_like_tool_result(messages)
+    pdf_text_result = has_pdf_text_tool_result(messages)
+    list_like_result = has_list_like_tool_result(messages) and is_compact_list_request(last_user_text(messages))
     shell_full_result = has_tool_result(messages, "exec_shell_full_command")
     operational_status_result = shell_full_result and is_operational_status_request(last_user_text(messages))
+    compact_shell_analysis_result = (
+        shell_full_result
+        and _has_long_shell_tool_result(messages)
+        and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
+    )
     call_messages = messages
     if large_file_excerpt:
         call_messages = [
@@ -38,9 +80,15 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
             {
                 "role": "user",
                 "content": (
-                    "Use the available large-file excerpt only. "
-                    "Answer in at most five short bullets, each under twelve words. Do not quote long passages. "
-                    "Do not request more chunks unless the user explicitly asked for exhaustive analysis."
+                    "Use only the already inspected chunk(s) or excerpt(s). "
+                    + (
+                        "Give a concise but fuller synthesis from the available evidence. "
+                        "If the inspected chunks still do not cover the whole document, say that briefly. "
+                        "Do not quote long passages. "
+                        if exhaustive_document_request
+                        else "Answer in at most five short bullets, each under twelve words. Do not quote long passages. "
+                    )
+                    + "Do not request more chunks unless the user explicitly asked for exhaustive analysis."
                 ),
             },
         ]
@@ -73,6 +121,21 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
                 ),
             },
         ]
+    elif pdf_text_result:
+        call_messages = [
+            *call_messages,
+            {
+                "role": "user",
+                "content": (
+                    "A local PDF text extraction already succeeded. "
+                    "Treat the PDF file as present and readable. "
+                    "Base the answer only on the extracted PDF text already available. "
+                    "Do not claim the file is missing or inaccessible unless a tool result explicitly says extraction failed. "
+                    "Do not call tools again. "
+                    "If the extracted text is only partial, say that briefly and summarize only that evidence."
+                ),
+            },
+        ]
     elif list_like_result:
         call_messages = [
             *call_messages,
@@ -84,12 +147,23 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
             {
                 "role": "user",
                 "content": (
-                    "Use only the available shell-full output. "
-                    "Answer the latest user request directly and concisely from that evidence. "
-                    "Prefer the most recent relevant shell result. "
-                    "Do not summarize unrelated older output. "
-                    "Do not call tools again. "
-                    "If the evidence is insufficient, say you cannot confirm."
+                    (
+                        "Use only the latest relevant shell-full output. "
+                        "Answer using exactly 4 short bullets. "
+                        "Each bullet must be one sentence in this format: '- Finding: ... Fix: ...'. "
+                        "No headings, code fences, examples, introduction, or thinking. "
+                        "Focus only on the main findings and brief remediation. "
+                        "Do not call tools again. "
+                        "If the evidence is insufficient, say you cannot confirm."
+                        if compact_shell_analysis_result
+                        else
+                        "Use only the available shell-full output. "
+                        "Answer the latest user request directly and concisely from that evidence. "
+                        "Prefer the most recent relevant shell result. "
+                        "Do not summarize unrelated older output. "
+                        "Do not call tools again. "
+                        "If the evidence is insufficient, say you cannot confirm."
+                    )
                 ),
             },
         ]
@@ -98,9 +172,11 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
         max_tokens=final_tool_max_tokens(
             max_tokens,
             large_file_excerpt=large_file_excerpt,
+            exhaustive_document_request=exhaustive_document_request,
             web_fetch_result=web_fetch_result,
             list_like_result=list_like_result,
             operational_status_result=operational_status_result,
+            compact_shell_analysis_result=compact_shell_analysis_result,
         ),
         length_retry_allowed=(not streamed and (large_file_excerpt or web_fetch_result)),
         incomplete_retry_allowed=shell_full_result and not (web_fetch_result or list_like_result or operational_status_result),
@@ -112,18 +188,22 @@ def final_tool_max_tokens(
     max_tokens: int,
     *,
     large_file_excerpt: bool,
+    exhaustive_document_request: bool,
     web_fetch_result: bool,
     list_like_result: bool,
     operational_status_result: bool = False,
+    compact_shell_analysis_result: bool = False,
 ) -> int:
     if large_file_excerpt:
-        return min(max_tokens, LARGE_FILE_FINAL_MAX_TOKENS)
+        return min(max_tokens, EXHAUSTIVE_LARGE_FILE_FINAL_MAX_TOKENS if exhaustive_document_request else LARGE_FILE_FINAL_MAX_TOKENS)
     if web_fetch_result:
         return min(max_tokens, WEB_FETCH_FINAL_MAX_TOKENS)
     if list_like_result:
         return min(max_tokens, LIST_FINAL_MAX_TOKENS)
     if operational_status_result:
         return min(max_tokens, OPERATIONAL_STATUS_FINAL_MAX_TOKENS)
+    if compact_shell_analysis_result:
+        return min(max_tokens, LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS)
     return max(max_tokens, FINAL_FROM_TOOL_MIN_TOKENS)
 
 
@@ -141,11 +221,29 @@ def final_tool_retry_instruction() -> Message:
     }
 
 
+def final_tool_compact_retry_instruction() -> Message:
+    return {
+        "role": "user",
+        "content": (
+            "The previous final answer was too long, repetitive, or ran out of space. "
+            "Write one short final answer now using only the existing tool results. "
+            "Use plain prose only. No headings. No long bullet lists. No code fences. "
+            "No thinking. No repetition. Focus only on the most important findings. "
+            "Limit yourself to three to five sentences. Do not call tools."
+        ),
+    }
+
+
+def final_tool_compact_retry_max_tokens(max_tokens: int, *, messages: list[Message] | None = None) -> int:
+    return min(COMPACT_FINAL_RETRY_MAX_TOKENS, max(COMPACT_FINAL_RETRY_MIN_TOKENS, max_tokens))
+
+
 def final_from_tool_retry_reason(
     result: ChatResult,
     *,
     length_retry_allowed: bool,
     incomplete_retry_allowed: bool = False,
+    messages: list[Message] | None = None,
 ) -> str | None:
     if result.tool_calls:
         return "tool_call_in_final"
@@ -157,9 +255,43 @@ def final_from_tool_retry_reason(
         return "empty_length"
     if length_retry_allowed and result.finish_reason == "length":
         return "length"
-    if incomplete_retry_allowed and looks_like_incomplete_final(result.content):
-        return "incomplete_final"
     return None
+
+
+def final_from_tool_compact_retry_reason(result: ChatResult, *, messages: list[Message]) -> str | None:
+    if not _has_long_shell_tool_result(messages):
+        return None
+    if result.finish_reason == "length" and result.content.strip():
+        return "length"
+    if is_repetitive_final_answer(result.content):
+        return "repetition"
+    return None
+
+
+def classify_final_answer_completeness(content: str, *, messages: list[Message] | None = None) -> FinalAnswerCompleteness:
+    stripped = content.strip()
+    lowered = stripped.lower()
+    if not stripped:
+        return FinalAnswerCompleteness("incomplete_stub", "empty")
+    if _has_open_thought_channel(content) or looks_like_reasoning_without_final_answer(lowered):
+        return FinalAnswerCompleteness("reasoning_like")
+    if "<|channel>thought" in content and "<channel|>" in content:
+        tail = content.split("<channel|>", 1)[1].strip()
+        if tail:
+            return FinalAnswerCompleteness("complete")
+    if re.search(r"(?:^|\n)\s*#{1,6}\s*$", content.rstrip()):
+        return FinalAnswerCompleteness("malformed_markdown", "heading_stub")
+    if re.search(r"(?:^|\n)\s*(?:[-*]|\d+\.)\s+\*\*[^*\n]+:\*\*\s*$", content.rstrip()):
+        return FinalAnswerCompleteness("incomplete_stub", "list_label_stub")
+    if content.count("`") % 2 == 1:
+        return FinalAnswerCompleteness("malformed_markdown", "unclosed_backtick")
+    if stripped.endswith((":", "-", "*")):
+        return FinalAnswerCompleteness("incomplete_stub", "trailing_stub")
+    if looks_like_incomplete_final(content):
+        return FinalAnswerCompleteness("incomplete_stub", "plain_incomplete")
+    if messages and _looks_too_short_after_tool(content, messages):
+        return FinalAnswerCompleteness("too_short_after_tool")
+    return FinalAnswerCompleteness("complete")
 
 
 def contains_raw_tool_call(content: str) -> bool:
@@ -186,11 +318,88 @@ def looks_like_incomplete_final(content: str) -> bool:
     return bool(re.search(r"[A-Za-z0-9]$", text))
 
 
+def looks_like_reasoning_without_final_answer(lowered_content: str) -> bool:
+    if any(marker in lowered_content for marker in _FINAL_MARKERS):
+        return False
+    return lowered_content.startswith(_REASONING_PREFIXES)
+
+
+def _has_open_thought_channel(content: str) -> bool:
+    if "<|channel>thought" not in content:
+        return False
+    tail = content.split("<|channel>thought", 1)[1]
+    return "<channel|>" not in tail
+
+
+def _looks_too_short_after_tool(content: str, messages: list[Message]) -> bool:
+    prompt = last_user_text(messages)
+    if is_operational_status_request(prompt) or is_compact_list_request(prompt):
+        return False
+    tool_message, command = last_successful_shell_result_and_command(messages)
+    if tool_message is None or is_list_shell_command(command):
+        return False
+    tool_content = tool_message.get("content")
+    if not isinstance(tool_content, str) or len(tool_content) < 800:
+        return False
+    text = content.strip()
+    if len(text) >= 48:
+        return False
+    words = text.split()
+    return len(words) <= 6 and not re.search(r"[.!?][\"')\]]?$", text)
+
+
+def is_repetitive_final_answer(content: str) -> bool:
+    text = content.strip()
+    if len(text) < 100:
+        return False
+    paragraphs = [_normalize_repetition_unit(part) for part in re.split(r"\n\s*\n", text) if _normalize_repetition_unit(part)]
+    if _has_duplicate_units(paragraphs, min_len=48):
+        return True
+    sentences = [
+        _normalize_repetition_unit(part)
+        for part in re.split(r"(?<=[.!?])\s+|\n+", text)
+        if _normalize_repetition_unit(part)
+    ]
+    if _has_duplicate_units(sentences, min_len=32):
+        return True
+    return False
+
+
+def _has_long_shell_tool_result(messages: list[Message]) -> bool:
+    tool_message, command = last_successful_shell_result_and_command(messages)
+    if tool_message is None or is_list_shell_command(command):
+        return False
+    content = tool_message.get("content")
+    return isinstance(content, str) and len(content) >= 1200
+
+
+def _normalize_repetition_unit(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def _has_duplicate_units(units: list[str], *, min_len: int) -> bool:
+    counts: dict[str, int] = {}
+    for unit in units:
+        if len(unit) < min_len:
+            continue
+        counts[unit] = counts.get(unit, 0) + 1
+        if counts[unit] >= 2:
+            return True
+    return False
+
+
 def has_large_file_excerpt(messages: list[Message]) -> bool:
     for message in reversed(messages):
         if message.get("role") == "tool":
             content = message.get("content")
-            return isinstance(content, str) and "large_file_excerpt: true" in content
+            return isinstance(content, str) and (
+                "large_file_excerpt: true" in content
+                or (
+                    "shell_output_pdf_text: true" in content
+                    and "chunk_index:" in content
+                    and "total_chunks:" in content
+                )
+            )
     return False
 
 
@@ -203,6 +412,16 @@ def has_html_cleaned_tool_result(messages: list[Message]) -> bool:
     return False
 
 
+def has_pdf_text_tool_result(messages: list[Message]) -> bool:
+    for message in reversed(messages):
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and "shell_output_pdf_text: true" in content:
+            return True
+    return False
+
+
 def has_tool_result(messages: list[Message], name: str) -> bool:
     for message in reversed(messages):
         if message.get("role") != "tool":
@@ -212,15 +431,52 @@ def has_tool_result(messages: list[Message], name: str) -> bool:
 
 
 def has_list_like_tool_result(messages: list[Message]) -> bool:
-    last_shell_command = last_shell_full_command(messages)
-    for message in reversed(messages):
-        if message.get("role") != "tool":
-            continue
-        name = message.get("name")
-        if name == "exec_shell_full_command":
-            return is_list_shell_command(last_shell_command)
+    tool_message, command = last_successful_shell_result_and_command(messages)
+    if tool_message is None:
         return False
+    return is_list_shell_command(command)
     return False
+
+
+def last_successful_shell_result_and_command(messages: list[Message]) -> tuple[Message | None, str | None]:
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if message.get("role") != "tool" or message.get("name") != "exec_shell_full_command":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or _is_error_tool_content(content):
+            continue
+        tool_call_id = message.get("tool_call_id")
+        return message, _shell_command_for_tool_call_id(messages[:index], tool_call_id)
+    return None, None
+
+
+def _shell_command_for_tool_call_id(messages: list[Message], tool_call_id: object) -> str | None:
+    if not isinstance(tool_call_id, str):
+        return last_shell_full_command(messages)
+    for message in reversed(messages):
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for tool_call in reversed(calls):
+            if not isinstance(tool_call, dict):
+                continue
+            if tool_call.get("id") != tool_call_id:
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict) or function.get("name") != "exec_shell_full_command":
+                continue
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    return None
+            if not isinstance(arguments, dict):
+                return None
+            command = arguments.get("command")
+            return command if isinstance(command, str) else None
+    return None
 
 
 def last_shell_full_command(messages: list[Message]) -> str | None:
@@ -239,12 +495,11 @@ def last_shell_full_command(messages: list[Message]) -> str | None:
                 try:
                     arguments = json.loads(arguments)
                 except json.JSONDecodeError:
-                    continue
+                    return None
             if not isinstance(arguments, dict):
-                continue
+                return None
             command = arguments.get("command")
-            if isinstance(command, str):
-                return command
+            return command if isinstance(command, str) else None
     return None
 
 
@@ -257,7 +512,23 @@ def is_list_shell_command(command: str | None) -> bool:
         return False
     if not tokens:
         return False
-    return tokens[0] in {"ls", "find"}
+    if tokens[0] == "ls":
+        return True
+    if tokens[0] != "find":
+        return False
+    if "-exec" in tokens:
+        return False
+    return True
+
+
+def _is_error_tool_content(content: str) -> bool:
+    return content.startswith("error:")
+
+
+def is_compact_list_request(prompt: str | None) -> bool:
+    if prompt is None:
+        return True
+    return bool(_COMPACT_LIST_REQUEST_RE.search(prompt))
 
 
 _OPERATIONAL_STATUS_RE = re.compile(
@@ -294,3 +565,7 @@ def is_operational_status_request(prompt: str | None) -> bool:
     if (_CONTENT_REQUEST_RE.search(prompt) or _CONTENT_PHRASE_RE.search(prompt)) and not _OPERATIONAL_ACTION_RE.search(prompt):
         return False
     return _OPERATIONAL_STATUS_RE.search(prompt) is not None or _OPERATIONAL_ACTION_RE.search(prompt) is not None
+
+
+def is_exhaustive_document_request(prompt: str | None) -> bool:
+    return bool(prompt and _EXHAUSTIVE_DOCUMENT_RE.search(prompt))

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -4,13 +4,18 @@ import os
 import re
 import signal
 import shlex
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from orbit.runtime.file_tools import MAX_CHUNK_FILE_BYTES, MAX_READ_CHARS, read_file
+from orbit.runtime.file_tools import (
+    PDF_CHUNK_CHARS,
+    extract_pdf_text,
+    format_pdf_result,
+    read_file,
+    read_pdf,
+)
 from orbit.runtime.path_guardrails import resolve_inside_workdir
 from orbit.runtime.web import html_to_text, search_web
 
@@ -21,7 +26,6 @@ DEFAULT_SHELL_OUTPUT_BYTES = 12_000
 MAX_SHELL_OUTPUT_BYTES = 12_000
 SEARCH_SHELL_OUTPUT_BYTES = 800
 SHELL_FAILURE_STREAM_CHARS = 1200
-PDF_CHUNK_CHARS = 3_000
 SHELL_READ_FILE_THRESHOLD_BYTES = 8 * 1024
 SHELL_FULL_CONTRACT_ERROR_PREFIX = "error: shell-full analysis requests require content/source/string evidence"
 SHELL_FULL_CONTRACT_RETRY_PROMPT = (
@@ -31,8 +35,9 @@ SHELL_FULL_CONTRACT_RETRY_PROMPT = (
 )
 SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT = (
     "Your previous command inspected only metadata or listings.\n\n"
-    "For this coding task, inspect real file or test content before continuing.\n\n"
-    "Use commands such as cat, sed -n, grep/rg on file contents, or test output.\n\n"
+    "For this task, inspect real file, document, source, string, or test content before continuing.\n\n"
+    "Use commands such as cat, sed -n, grep/rg on file contents, or test output.\n"
+    "For PDFs, prefer pdftotext <file> - piped to sed, head, tail, or grep.\n\n"
     "If file names are unknown, use grep/rg recursively over file contents.\n\n"
     "Do not use ls, find, tree, file, or stat.\n\n"
     "Return only JSON:\n\n"
@@ -52,6 +57,24 @@ SHELL_FULL_COMPLETION_GUARD_PROMPT = (
     "Prefer short robust commands; avoid fragile quoting and long heredocs. "
     "Prefer minimal edits over rewriting entire files.\n\n"
     "Return only JSON:\n\n"
+    '{"command":"..."}'
+)
+SHELL_FULL_ANALYSIS_COMPLETION_GUARD_PROMPT = (
+    "You already have direct content/source evidence from previous tool results.\n\n"
+    "If that evidence is sufficient to answer the user, stop calling tools and answer now.\n\n"
+    "Only request one more tool if a specific missing fact is still required. "
+    "If you need another tool, prefer a direct content-reading command over more discovery or listings.\n\n"
+    "Do not use broad directory discovery unless the missing fact is explicitly about directory contents.\n\n"
+    "Either answer directly in plain prose, or return exactly one JSON tool call:\n\n"
+    '{"command":"..."}'
+)
+SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX = (
+    "Requested file not read yet.\n\n"
+    "Use the real evidence below.\n"
+    "If a candidate path exists, prefer one direct content-reading command on it.\n"
+    "Otherwise use one targeted discovery step.\n"
+    "If the file is unavailable, answer clearly.\n\n"
+    "Either answer briefly in plain prose, or return exactly one JSON tool call:\n\n"
     '{"command":"..."}'
 )
 SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT = (
@@ -83,7 +106,7 @@ _ANALYSIS_PROMPT_RE = re.compile(
     r"analy[sz]e|analysis|review|inspect|"
     r"analizz|analisi|ispezion|esamina|esamin|"
     r"vulnerab|exploit|malware|dropper|c2|ioc|reverse|decompil|static|"
-    r"summar(?:y|ize)|riassunt|sintesi"
+    r"summar(?:y|ize)|riassunt\w*|riassum\w*|sintesi"
     r")\b",
     re.IGNORECASE,
 )
@@ -235,6 +258,23 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
 
 def is_shell_full_contract_error(content: str) -> bool:
     return content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX)
+
+
+def build_shell_full_file_recovery_guard_prompt(
+    *,
+    requested_path: str,
+    last_error: str | None,
+    candidate_paths: list[str],
+) -> str:
+    details = [f"Requested file: {requested_path}"]
+    if last_error:
+        details.append(f"Direct read failure: {last_error}")
+    if candidate_paths:
+        details.append("Candidate paths from prior discovery:")
+        details.extend(f"- {path}" for path in candidate_paths[:5])
+    else:
+        details.append("Candidate paths from prior discovery: none")
+    return f"{SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX}\n\n" + "\n".join(details)
 
 
 def shell_failure_from_output(content: str) -> ShellFailure | None:
@@ -430,13 +470,34 @@ def _read_pdf_target(raw_command: str, *, workdir: Path) -> str | None:
     target = _first_pdf_target(tokens, workdir=workdir)
     if target is None:
         return None
-    text, method = _extract_pdf_text(target)
+    text, method = extract_pdf_text(target)
     if not text.strip():
         return f"error: no text extracted from PDF: {target.name}"
     filtered = _apply_pdf_text_filters(raw_command, target=target, text=text)
-    if filtered is not None:
-        text = filtered
-    return _format_extracted_pdf(target, text, method=method)
+    if filtered is None:
+        result = read_pdf(str(target.relative_to(workdir)), arguments={}, workdir=workdir)
+        if result.startswith("error:"):
+            return result
+        return "\n".join(
+            [
+                "shell_output_pdf_text: true",
+                result.removeprefix("pdf_text: true\n"),
+            ]
+        )
+    if len(filtered) <= PDF_CHUNK_CHARS:
+        formatted = format_pdf_result(target, filtered, extractor=method)
+    else:
+        formatted = format_pdf_result(
+            target,
+            filtered[:PDF_CHUNK_CHARS],
+            extractor=method,
+            chunk_index=0,
+            total_chunks=max(1, (len(filtered) + PDF_CHUNK_CHARS - 1) // PDF_CHUNK_CHARS),
+            chars_start=0,
+            chars_end=PDF_CHUNK_CHARS,
+            total_length=len(filtered),
+        )
+    return "\n".join(["shell_output_pdf_text: true", formatted.removeprefix("pdf_text: true\n")])
 
 
 def _command_intends_pdf_text(tokens: list[str]) -> bool:
@@ -456,66 +517,6 @@ def _first_pdf_target(tokens: list[str], *, workdir: Path) -> Path | None:
             continue
         return target_or_error
     return None
-
-
-def _extract_pdf_text(target: Path) -> tuple[str, str]:
-    pdftotext = shutil.which("pdftotext")
-    if pdftotext:
-        completed = subprocess.run(
-            [pdftotext, "-layout", str(target), "-"],
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            capture_output=True,
-            timeout=MAX_SHELL_TIMEOUT,
-            check=False,
-        )
-        if completed.returncode == 0 and completed.stdout.strip():
-            return completed.stdout, "pdftotext"
-    strings = shutil.which("strings")
-    if not strings:
-        return "", "unavailable"
-    completed = subprocess.run(
-        [strings, "-a", "-n", "8", str(target)],
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        capture_output=True,
-        timeout=MAX_SHELL_TIMEOUT,
-        check=False,
-    )
-    if completed.returncode == 0:
-        return _clean_pdf_strings_output(completed.stdout), "strings"
-    return "", "strings"
-
-
-def _format_extracted_pdf(target: Path, text: str, *, method: str) -> str:
-    if len(text.encode("utf-8", errors="replace")) > MAX_CHUNK_FILE_BYTES:
-        return f"error: extracted PDF text too large: max {MAX_CHUNK_FILE_BYTES} bytes"
-    if len(text) <= MAX_READ_CHARS:
-        return "\n".join(
-            [
-                "shell_output_pdf_text: true",
-                f"path: {target.name}",
-                f"extractor: {method}",
-                "content:",
-                text.strip() or "(empty PDF text)",
-            ]
-        )
-    end = min(PDF_CHUNK_CHARS, len(text))
-    total_chunks = max(1, (len(text) + PDF_CHUNK_CHARS - 1) // PDF_CHUNK_CHARS)
-    return "\n".join(
-        [
-            "shell_output_pdf_text: true",
-            f"path: {target.name}",
-            f"extractor: {method}",
-            "chunk_index: 0",
-            f"total_chunks: {total_chunks}",
-            f"chars: 0-{end} of {len(text)}",
-            "content:",
-            text[:end],
-        ]
-    )
 
 
 def _apply_pdf_text_filters(raw_command: str, *, target: Path, text: str) -> str | None:

--- a/src/orbit/runtime/thinking_mode.py
+++ b/src/orbit/runtime/thinking_mode.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+FINAL_MARKERS = (
+    "**final answer:**",
+    "final answer:",
+    "the final answer is:",
+    "the final answer:",
+)
+REASONING_PREFIXES = (
+    "### reasoning",
+    "## reasoning",
+    "# reasoning",
+    "reasoning:",
+    "plan:",
+)
+
+
+def contains_control_channel_markup(content: str) -> bool:
+    return "<|channel>" in content or "<channel|>" in content
+
+
+def has_open_thought_channel(content: str) -> bool:
+    if "<|channel>thought" not in content:
+        return False
+    tail = content.split("<|channel>thought", 1)[1]
+    return "<channel|>" not in tail
+
+
+def last_assistant_has_open_reasoning(messages: list[dict[str, object]]) -> bool:
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            return False
+        return has_open_thought_channel(content) or looks_like_reasoning_without_final(content, thinking_enabled=True)
+    return False
+
+
+def looks_like_reasoning_without_final(content: str, *, thinking_enabled: bool) -> bool:
+    if not thinking_enabled:
+        return has_open_thought_channel(content)
+    stripped = content.strip().lower()
+    if not stripped:
+        return False
+    if has_open_thought_channel(content):
+        return True
+    if any(marker in stripped for marker in FINAL_MARKERS):
+        return False
+    return stripped.startswith(REASONING_PREFIXES)
+
+
+def looks_like_incomplete_tool_answer(content: str) -> bool:
+    text = content.strip()
+    if len(text) < 24:
+        return False
+    if text.endswith((".", "!", "?", "`", "\"", "'", ")", "]")):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class ThinkingMode:
+    enabled: bool = False
+
+    def should_stream_tool_plan(self, *, has_delta_sink: bool, backend_supports_streaming: bool) -> bool:
+        return self.enabled and has_delta_sink and backend_supports_streaming
+
+    def continuation_kind_for(self, *, content: str, finish_reason: str | None) -> str | None:
+        if looks_like_reasoning_without_final(content, thinking_enabled=self.enabled):
+            return "thinking"
+        if finish_reason == "length":
+            return "final_answer"
+        return None

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -13,9 +13,11 @@ from orbit.runtime.messages import with_chat_system_prompt, with_tool_call_syste
 from orbit.runtime.session_memory import should_refresh_for_append
 from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
+    SHELL_FULL_ANALYSIS_COMPLETION_GUARD_PROMPT,
     SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT,
     SHELL_FULL_CONTRACT_RETRY_PROMPT,
     SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT,
+    build_shell_full_file_recovery_guard_prompt,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     is_incomplete_shell_json_or_command_error,
@@ -33,7 +35,17 @@ from orbit.runtime.shell_guardrails import (
 from orbit.runtime.tool_arguments import parse_tool_arguments_or_empty
 from orbit.runtime.tool_backends import HybridToolExecutor
 from orbit.runtime.tool_calls import execute_tool_call
-from orbit.runtime.tool_loop_state import ToolLoopState
+from orbit.runtime.tool_loop_state import (
+    EVIDENCE_CANDIDATE_PATHS_FOUND,
+    EVIDENCE_DIRECT_READ_FAILED,
+    RECONSIDER_ANALYSIS_COMPLETION,
+    RECONSIDER_COMPLETION,
+    RECONSIDER_CONTENT_EVIDENCE,
+    RECONSIDER_FILE_RECOVERY,
+    RECONSIDER_MINIMAL_PATCH,
+    ToolLoopState,
+    ToolTurnState,
+)
 from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
 from orbit.runtime.tools import default_tool_names
 from orbit.runtime.turn_trace import ModelStepMetrics
@@ -48,6 +60,7 @@ def _env_int(name: str, default: int) -> int:
 
 TOOL_CALL_MAX_TOKENS = 96
 MUTATIVE_TOOL_CALL_MAX_TOKENS = _env_int("ORBIT_MUTATIVE_TOOL_CALL_MAX_TOKENS", 160)
+FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = 64
 MAX_SHELL_REPAIR_RETRIES = 2
 
 
@@ -76,46 +89,27 @@ def run_tool_loop(
     tools = executor.tool_definitions()
     last_result: ChatResult | None = None
     state = ToolLoopState(allowed_tool_names)
-    contract_retry_pending = False
-    shell_empty_result_check_pending = False
-    shell_empty_result_check_used = False
-    shell_error_final_pending = False
-    shell_repair_prompt_pending: str | None = None
-    shell_repair_retries = 0
-    mutation_verification_pending = False
-    mutation_verification_repair_pending = False
-    mutation_verification_repair_used = False
-    mutation_semantic_repair_pending = False
-    mutation_semantic_repair_used = False
-    content_evidence_guard_pending = False
-    content_evidence_guard_used = False
-    completion_guard_pending = False
-    completion_guard_used = False
-    minimal_patch_guard_pending = False
-    minimal_patch_guard_used = False
-    shell_commands_seen = 0
-    content_evidence_seen = False
-    metadata_only_rejections = 0
-    shell_mutation_attempted = False
-    shell_mutation_succeeded = False
-    shell_full_enabled = "exec_shell_full_command" in allowed_tool_names
     user_prompt = _last_user_text(runtime.messages)
+    turn = ToolTurnState(requested_user_path=_extract_requested_user_path(user_prompt))
+    repair = turn.repair_state
+    shell_full_enabled = "exec_shell_full_command" in allowed_tool_names
     suppress_tool_delta = (lambda _delta: None) if on_final_delta is not None and shell_full_enabled else None
+
+    # These local helpers still couple policy and runtime counters in one place.
+    # The state objects only store turn-local facts; they do not decide tasks.
 
     def should_nudge_completion() -> bool:
         return (
             shell_full_enabled
-            and not completion_guard_used
-            and shell_commands_seen > 0
-            and not shell_mutation_attempted
+            and turn.can_reconsider(RECONSIDER_COMPLETION)
+            and turn.shell_commands_seen > 0
+            and not turn.shell_mutation_attempted
             and is_mutative_user_request(user_prompt)
         )
 
     def request_completion_guard() -> None:
-        nonlocal completion_guard_pending
-        nonlocal completion_guard_used
-        completion_guard_pending = True
-        completion_guard_used = True
+        turn.pending_completion_guard = True
+        turn.mark_reconsider(RECONSIDER_COMPLETION)
         runtime.completion_guard_nudges += 1
 
     def should_nudge_minimal_patch(
@@ -126,55 +120,112 @@ def run_tool_loop(
     ) -> bool:
         return (
             shell_full_enabled
-            and not minimal_patch_guard_used
+            and turn.can_reconsider(RECONSIDER_MINIMAL_PATCH)
             and is_mutative_user_request(user_prompt)
-            and (shell_commands_seen > 0 or existing_file_rewrite)
-            and not shell_mutation_succeeded
+            and (turn.shell_commands_seen > 0 or existing_file_rewrite)
+            and not turn.shell_mutation_succeeded
             and (broad_rewrite_seen or length_truncated)
         )
 
     def request_minimal_patch_guard() -> None:
-        nonlocal minimal_patch_guard_pending
-        nonlocal minimal_patch_guard_used
-        minimal_patch_guard_pending = True
-        minimal_patch_guard_used = True
+        turn.pending_minimal_patch_guard = True
+        turn.mark_reconsider(RECONSIDER_MINIMAL_PATCH)
         runtime.minimal_patch_guard_nudges += 1
 
     def request_mutation_semantic_repair() -> None:
-        nonlocal mutation_semantic_repair_pending
-        nonlocal mutation_semantic_repair_used
-        mutation_semantic_repair_pending = True
-        mutation_semantic_repair_used = True
+        repair.mutation_semantic_repair_pending = True
+        repair.mutation_semantic_repair_used = True
         runtime.mutation_semantic_repairs += 1
 
     def should_nudge_content_evidence() -> bool:
         return (
             shell_full_enabled
-            and not content_evidence_guard_used
+            and turn.can_reconsider(RECONSIDER_CONTENT_EVIDENCE)
             and is_mutative_user_request(user_prompt)
-            and metadata_only_rejections > 0
-            and not content_evidence_seen
-            and not shell_mutation_attempted
+            and turn.metadata_only_rejections > 0
+            and not turn.content_evidence_satisfied
+            and not turn.shell_mutation_attempted
         )
 
     def request_content_evidence_guard() -> None:
-        nonlocal content_evidence_guard_pending
-        nonlocal content_evidence_guard_used
-        content_evidence_guard_pending = True
-        content_evidence_guard_used = True
+        turn.pending_content_evidence_guard = True
+        turn.mark_reconsider(RECONSIDER_CONTENT_EVIDENCE)
         runtime.content_evidence_guard_nudges += 1
 
+    def should_nudge_analysis_completion(result_tool_calls: list[dict[str, object]] | None) -> bool:
+        if (
+            not shell_full_enabled
+            or not turn.can_reconsider(RECONSIDER_ANALYSIS_COMPLETION)
+            or not turn.can_reconsider(RECONSIDER_FILE_RECOVERY)
+            or is_mutative_user_request(user_prompt)
+            or not turn.content_evidence_satisfied
+            or state.tool_rounds <= 0
+            or not result_tool_calls
+        ):
+            return False
+        for tool_call in result_tool_calls:
+            command = _shell_command_from_tool_call(tool_call)
+            if not command:
+                continue
+            if is_mutating_shell_command(command):
+                return False
+            if not is_content_evidence_shell_command(command):
+                return True
+        return False
+
+    def request_analysis_completion_guard() -> None:
+        turn.pending_analysis_completion_guard = True
+        turn.mark_reconsider(RECONSIDER_ANALYSIS_COMPLETION)
+
+    def should_nudge_file_recovery(result_tool_calls: list[dict[str, object]] | None) -> bool:
+        if (
+            not shell_full_enabled
+            or not turn.can_reconsider(RECONSIDER_FILE_RECOVERY)
+            or not turn.requested_user_path
+            or not result_tool_calls
+            or turn.content_evidence_satisfied
+        ):
+            return False
+        if turn.evidence_state not in {EVIDENCE_DIRECT_READ_FAILED, EVIDENCE_CANDIDATE_PATHS_FOUND}:
+            return False
+        for tool_call in result_tool_calls:
+            command = _shell_command_from_tool_call(tool_call)
+            if not command:
+                continue
+            if _is_direct_content_read_for_known_path(
+                command,
+                requested_path=turn.requested_user_path,
+                candidate_paths=turn.candidate_paths,
+            ):
+                return False
+            if turn.evidence_state == EVIDENCE_DIRECT_READ_FAILED and _is_targeted_file_discovery(command, requested_path=turn.requested_user_path):
+                return False
+            if _looks_like_discovery_command(command):
+                return True
+        return False
+
+    def request_file_recovery_guard() -> None:
+        if not turn.requested_user_path:
+            return
+        turn.pending_file_recovery_guard = True
+        turn.mark_reconsider(RECONSIDER_FILE_RECOVERY)
+        turn.pending_file_recovery_guard_prompt = build_shell_full_file_recovery_guard_prompt(
+            requested_path=turn.requested_user_path,
+            last_error=turn.last_error,
+            candidate_paths=turn.candidate_paths,
+        )
+
     def has_pending_internal_request() -> bool:
+        return turn.has_pending_internal_request()
+
+    def should_handoff_to_final_from_tool() -> bool:
         return (
-            contract_retry_pending
-            or shell_repair_prompt_pending is not None
-            or shell_empty_result_check_pending
-            or mutation_verification_pending
-            or mutation_verification_repair_pending
-            or mutation_semantic_repair_pending
-            or content_evidence_guard_pending
-            or completion_guard_pending
-            or minimal_patch_guard_pending
+            shell_full_enabled
+            and turn.content_evidence_satisfied
+            and turn.finalizable
+            and not has_pending_internal_request()
+            and not repair.shell_error_final_pending
+            and not is_mutative_user_request(user_prompt)
         )
 
     def update_state_after_tool_result(
@@ -188,32 +239,21 @@ def run_tool_loop(
         is_completion_guard: bool,
         is_minimal_patch_guard: bool,
     ) -> None:
-        nonlocal contract_retry_pending
-        nonlocal mutation_verification_pending
-        nonlocal mutation_verification_repair_pending
-        nonlocal mutation_verification_repair_used
-        nonlocal mutation_semantic_repair_pending
-        nonlocal content_evidence_seen
-        nonlocal metadata_only_rejections
-        nonlocal shell_empty_result_check_pending
-        nonlocal shell_empty_result_check_used
-        nonlocal shell_error_final_pending
-        nonlocal shell_repair_prompt_pending
-        nonlocal shell_repair_retries
-        nonlocal shell_commands_seen
-        nonlocal shell_mutation_attempted
-        nonlocal shell_mutation_succeeded
-
+        # This remains the main transition reducer for tool evidence and bounded
+        # repair state. It updates turn-local state, while runtime counters stay
+        # here to avoid leaking telemetry into the state objects themselves.
         if tool_result.name != "exec_shell_full_command":
             return
         command = _shell_command_from_tool_call(tool_call)
         raw_arguments = _shell_raw_arguments_from_tool_call(tool_call)
         command_is_mutating = bool(command and is_mutating_shell_command(command))
         command_is_content_evidence = bool(command and is_content_evidence_shell_command(command))
+        tool_output_kind = _classify_shell_output_kind(command, tool_result.content, requested_path=turn.requested_user_path)
+        turn.set_tool_result_kind(tool_output_kind)
         if command:
-            shell_commands_seen += 1
+            turn.shell_commands_seen += 1
         if command_is_mutating:
-            shell_mutation_attempted = True
+            turn.shell_mutation_attempted = True
         if is_content_evidence_guard:
             runtime.content_evidence_guard_commands += 1
         if is_mutation_semantic_repair:
@@ -241,77 +281,91 @@ def run_tool_loop(
                 runtime.completion_guard_failures += 1
         if is_shell_full_contract_error(tool_result.content):
             if command and is_metadata_only_shell_command(command):
-                metadata_only_rejections += 1
+                turn.metadata_only_rejections += 1
             if should_nudge_content_evidence():
                 request_content_evidence_guard()
             else:
-                contract_retry_pending = True
+                repair.contract_retry_pending = True
             if is_content_evidence_guard:
                 runtime.content_evidence_guard_failures += 1
             return
         if is_shell_full_execution_error(tool_result.content):
+            if tool_output_kind == "file_not_found":
+                turn.mark_direct_read_failed(_summarize_shell_error(tool_result.content))
             if is_mutation_verification:
                 if (
                     is_repairable_shell_error(tool_result.content)
-                    and not mutation_verification_repair_used
+                    and not repair.mutation_verification_repair_used
                 ):
-                    mutation_verification_repair_used = True
-                    mutation_verification_repair_pending = True
+                    repair.mutation_verification_repair_used = True
+                    repair.mutation_verification_repair_pending = True
                     runtime.mutation_verification_repairs += 1
-                    shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
+                    repair.shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
                     return
                 runtime.mutation_verification_failures += 1
-                shell_error_final_pending = True
+                repair.shell_error_final_pending = True
+                turn.mark_exhausted()
                 return
             if is_mutation_verification_repair:
                 runtime.mutation_verification_failures += 1
-                shell_error_final_pending = True
+                repair.shell_error_final_pending = True
+                turn.mark_exhausted()
                 return
             if is_mutation_semantic_repair:
-                if is_repairable_shell_error(tool_result.content) and shell_repair_retries < MAX_SHELL_REPAIR_RETRIES:
-                    shell_repair_retries += 1
-                    shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
+                if is_repairable_shell_error(tool_result.content) and repair.shell_repair_retries < MAX_SHELL_REPAIR_RETRIES:
+                    repair.shell_repair_retries += 1
+                    repair.shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
                     return
                 runtime.mutation_semantic_repair_failures += 1
-                shell_error_final_pending = True
+                repair.shell_error_final_pending = True
+                turn.mark_exhausted()
                 return
-            if is_repairable_shell_error(tool_result.content) and shell_repair_retries < MAX_SHELL_REPAIR_RETRIES:
-                shell_repair_retries += 1
-                shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
+            if is_repairable_shell_error(tool_result.content) and repair.shell_repair_retries < MAX_SHELL_REPAIR_RETRIES:
+                repair.shell_repair_retries += 1
+                repair.shell_repair_prompt_pending = shell_repair_prompt(tool_result.content)
                 return
-            shell_error_final_pending = True
+            repair.shell_error_final_pending = True
+            turn.mark_exhausted()
             return
         if command_is_mutating:
-            shell_mutation_succeeded = True
+            turn.shell_mutation_succeeded = True
         if tool_result.content.strip():
             if command_is_content_evidence and not command_is_mutating:
-                content_evidence_seen = True
+                turn.mark_direct_content_read()
                 if is_content_evidence_guard:
                     runtime.content_evidence_guard_successes += 1
-            if is_mutation_verification and not mutation_semantic_repair_used:
+            if tool_output_kind == "discovery_result":
+                discovered = _extract_candidate_paths_from_output(tool_result.content)
+                if discovered:
+                    turn.mark_candidate_paths_found(_merge_candidate_paths(turn.candidate_paths, discovered))
+            if is_mutation_verification and not repair.mutation_semantic_repair_used:
                 request_mutation_semantic_repair()
+            if turn.content_evidence_satisfied or repair.shell_error_final_pending:
+                turn.mark_finalizable()
             return
         if is_content_evidence_guard:
             runtime.content_evidence_guard_failures += 1
-        if is_mutation_verification_repair and command_is_mutating and not mutation_semantic_repair_used:
+        if is_mutation_verification_repair and command_is_mutating and not repair.mutation_semantic_repair_used:
             request_mutation_semantic_repair()
             return
         if is_mutation_verification or is_mutation_verification_repair:
             runtime.mutation_verification_failures += 1
-            shell_error_final_pending = True
+            repair.shell_error_final_pending = True
+            turn.mark_exhausted()
             return
         if is_mutation_semantic_repair:
             runtime.mutation_semantic_repair_failures += 1
-            shell_error_final_pending = True
+            repair.shell_error_final_pending = True
+            turn.mark_exhausted()
             return
         if (
             command
-            and not shell_empty_result_check_used
+            and not repair.shell_empty_result_check_used
             and should_verify_shell_mutation(command, user_prompt=_last_user_text(runtime.messages))
         ):
-            shell_empty_result_check_pending = True
-            shell_empty_result_check_used = True
-            mutation_verification_pending = True
+            repair.shell_empty_result_check_pending = True
+            repair.shell_empty_result_check_used = True
+            repair.mutation_verification_pending = True
             runtime.mutation_verifications += 1
     if initial_tool_calls:
         calls = [initial_tool_calls] if isinstance(initial_tool_calls, dict) else list(initial_tool_calls)
@@ -346,18 +400,28 @@ def run_tool_loop(
                 if on_tool_result:
                     on_tool_result(tool_result.name, len(tool_result.content), execution.source, tool_result.content)
                 runtime.messages.append(tool_result_message(tool_call, tool_result))
+                if should_handoff_to_final_from_tool():
+                    return runtime._answer_from_tool_results(
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        on_final_delta=on_final_delta,
+                        on_progress=on_progress,
+                        on_model_step=on_model_step,
+                        loop=state.tool_rounds + 1,
+                        use_tool_prompt=state.used_tool_call_prompt,
+                    )
         if (
-            not shell_error_final_pending
-            and not contract_retry_pending
-            and shell_repair_prompt_pending is None
+            not repair.shell_error_final_pending
+            and not repair.contract_retry_pending
+            and repair.shell_repair_prompt_pending is None
             and not has_pending_internal_request()
             and should_nudge_completion()
         ):
             request_completion_guard()
-        if shell_error_final_pending or (
+        if repair.shell_error_final_pending or (
             not has_pending_internal_request()
         ):
-            if not completion_guard_pending:
+            if not turn.pending_completion_guard:
                 return runtime._answer_from_tool_results(
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -379,40 +443,46 @@ def run_tool_loop(
             )
     for loop_index in range(1, max_loops + 1):
         call_messages = with_tool_call_system_prompt(runtime.messages)
-        executing_mutation_verification = mutation_verification_pending
-        executing_mutation_verification_repair = mutation_verification_repair_pending
-        executing_mutation_semantic_repair = mutation_semantic_repair_pending
-        executing_content_evidence_guard = content_evidence_guard_pending
-        executing_completion_guard = completion_guard_pending
-        executing_minimal_patch_guard = minimal_patch_guard_pending
-        if shell_repair_prompt_pending is not None:
-            call_messages = [*call_messages, {"role": "user", "content": shell_repair_prompt_pending}]
-        elif shell_empty_result_check_pending:
+        executing_mutation_verification = repair.mutation_verification_pending
+        executing_mutation_verification_repair = repair.mutation_verification_repair_pending
+        executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending
+        executing_content_evidence_guard = turn.pending_content_evidence_guard
+        executing_completion_guard = turn.pending_completion_guard
+        executing_minimal_patch_guard = turn.pending_minimal_patch_guard
+        if repair.shell_repair_prompt_pending is not None:
+            call_messages = [*call_messages, {"role": "user", "content": repair.shell_repair_prompt_pending}]
+        elif repair.shell_empty_result_check_pending:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT}]
-        elif mutation_semantic_repair_pending:
+        elif repair.mutation_semantic_repair_pending:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_SEMANTIC_REPAIR_PROMPT}]
-        elif content_evidence_guard_pending:
+        elif turn.pending_content_evidence_guard:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT}]
-        elif minimal_patch_guard_pending:
+        elif turn.pending_analysis_completion_guard:
+            call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_ANALYSIS_COMPLETION_GUARD_PROMPT}]
+        elif turn.pending_file_recovery_guard:
+            call_messages = [*call_messages, {"role": "user", "content": turn.pending_file_recovery_guard_prompt or ""}]
+        elif turn.pending_minimal_patch_guard:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT}]
-        elif completion_guard_pending:
+        elif turn.pending_completion_guard:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_COMPLETION_GUARD_PROMPT}]
         state.used_tool_call_prompt = True
         tool_max_tokens = _tool_call_max_tokens(
             max_tokens,
             mutative=(
-                shell_repair_prompt_pending is not None
-                or shell_empty_result_check_pending
-                or mutation_semantic_repair_pending
-                or content_evidence_guard_pending
-                or minimal_patch_guard_pending
-                or completion_guard_pending
-                or mutation_verification_pending
-                or mutation_verification_repair_pending
+                repair.shell_repair_prompt_pending is not None
+                or repair.shell_empty_result_check_pending
+                or repair.mutation_semantic_repair_pending
+                or turn.pending_content_evidence_guard
+                or turn.pending_analysis_completion_guard
+                or turn.pending_minimal_patch_guard
+                or turn.pending_completion_guard
+                or repair.mutation_verification_pending
+                or repair.mutation_verification_repair_pending
                 or (shell_full_enabled and is_mutative_user_request(user_prompt))
             ),
+            file_recovery=turn.pending_file_recovery_guard,
         )
-        tool_delta_callback = suppress_tool_delta if shell_full_enabled and (state.tool_rounds > 0 or contract_retry_pending) else on_final_delta
+        tool_delta_callback = suppress_tool_delta if shell_full_enabled and (state.tool_rounds > 0 or repair.contract_retry_pending) else on_final_delta
         result = runtime._chat_tool_call_once(
             call_messages,
             temperature=temperature,
@@ -424,7 +494,7 @@ def run_tool_loop(
         last_result = result
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop_index, result=result, phase="tool_call" if result.tool_calls else None))
-        if contract_retry_pending and not result.tool_calls:
+        if repair.contract_retry_pending and not result.tool_calls:
             retry_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTRACT_RETRY_PROMPT}]
             result = runtime._chat_tool_call_once(
                 retry_messages,
@@ -435,7 +505,7 @@ def run_tool_loop(
                 on_progress=on_progress,
             )
             last_result = result
-            contract_retry_pending = False
+            repair.contract_retry_pending = False
             if on_model_step:
                 on_model_step(
                     ModelStepMetrics.from_result(
@@ -445,23 +515,8 @@ def run_tool_loop(
                     )
                 )
             elif result.tool_calls:
-                contract_retry_pending = False
-        if shell_repair_prompt_pending is not None:
-            shell_repair_prompt_pending = None
-        if shell_empty_result_check_pending:
-            shell_empty_result_check_pending = False
-        if mutation_verification_pending:
-            mutation_verification_pending = False
-        if mutation_verification_repair_pending:
-            mutation_verification_repair_pending = False
-        if mutation_semantic_repair_pending:
-            mutation_semantic_repair_pending = False
-        if content_evidence_guard_pending:
-            content_evidence_guard_pending = False
-        if completion_guard_pending:
-            completion_guard_pending = False
-        if minimal_patch_guard_pending:
-            minimal_patch_guard_pending = False
+                repair.contract_retry_pending = False
+        turn.clear_pending_after_model_call()
         if (
             result.finish_reason == "length"
             and result.tool_calls
@@ -521,6 +576,12 @@ def run_tool_loop(
         ):
             request_minimal_patch_guard()
             continue
+        if result.tool_calls and should_nudge_analysis_completion(result.tool_calls):
+            request_analysis_completion_guard()
+            continue
+        if result.tool_calls and should_nudge_file_recovery(result.tool_calls):
+            request_file_recovery_guard()
+            continue
         runtime.messages.append(assistant_tool_call_message(result.content, result.tool_calls))
         if not result.tool_calls:
             if executing_mutation_semantic_repair and result.content.strip().upper() != "OK":
@@ -535,6 +596,7 @@ def run_tool_loop(
                 if should_nudge_completion():
                     request_completion_guard()
                     continue
+                turn.mark_finalizable()
                 return runtime._answer_from_tool_results(
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -546,8 +608,10 @@ def run_tool_loop(
                 )
             return result
         state.increment_round()
+        turn.increment_round()
         for tool_call in result.tool_calls:
             if state.has_seen_tool_call(tool_call):
+                turn.mark_finalizable()
                 return runtime._answer_from_tool_results(
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -581,7 +645,18 @@ def run_tool_loop(
             if should_refresh_for_append(runtime.messages, tool_result.content, context_tokens=runtime.context_tokens):
                 runtime.refresh_memory_if_needed(temperature=temperature, force=True)
             runtime.messages.append(tool_result_message(tool_call, tool_result))
-        if shell_error_final_pending:
+            if should_handoff_to_final_from_tool():
+                return runtime._answer_from_tool_results(
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    loop=loop_index + 1,
+                    use_tool_prompt=state.used_tool_call_prompt,
+                )
+        if repair.shell_error_final_pending:
+            turn.mark_finalizable()
             return runtime._answer_from_tool_results(
                 temperature=temperature,
                 max_tokens=max_tokens,
@@ -595,6 +670,7 @@ def run_tool_loop(
             if should_nudge_completion():
                 request_completion_guard()
                 continue
+            turn.mark_exhausted()
             return runtime._answer_from_tool_results(
                 temperature=temperature,
                 max_tokens=max_tokens,
@@ -621,7 +697,9 @@ def _bounded_internal_max_tokens(max_tokens: int, internal_max: int) -> int:
     return max(1, min(max_tokens, internal_max))
 
 
-def _tool_call_max_tokens(max_tokens: int, *, mutative: bool) -> int:
+def _tool_call_max_tokens(max_tokens: int, *, mutative: bool, file_recovery: bool = False) -> int:
+    if file_recovery:
+        return _bounded_internal_max_tokens(max_tokens, FILE_RECOVERY_TOOL_CALL_MAX_TOKENS)
     internal_max = MUTATIVE_TOOL_CALL_MAX_TOKENS if mutative else TOOL_CALL_MAX_TOKENS
     return _bounded_internal_max_tokens(max_tokens, internal_max)
 
@@ -726,3 +804,99 @@ def _rewrite_target_candidates(command: str) -> list[str]:
     for match in re.finditer(r"\bPath\(\s*['\"]([^'\"]+)['\"]\s*\).*?\bwrite_(?:text|bytes)\s*\(", command):
         candidates.append(match.group(1))
     return candidates
+
+
+_USER_PATH_RE = re.compile(
+    r"(?:[\"'`])([^\"'`\n]+?\.[A-Za-z0-9]{1,8})(?:[\"'`])|(?:^|[\s(])([A-Za-z0-9_./-]+?\.[A-Za-z0-9]{1,8})(?=$|[\s),:;])"
+)
+_FILENAME_ONLY_RE = re.compile(r"^[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,8}$")
+_DISCOVERY_COMMAND_RE = re.compile(r"^\s*(?:find|ls|tree|fd|locate|rg\s+--files|rg\b(?!.*(?:cat|sed|head|tail)))", re.IGNORECASE)
+_FILE_NOT_FOUND_RE = re.compile(
+    r"(?:No such file or directory|cannot open|can't open|not found|missing file|impossibile.*trovare|non trovat\w*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_requested_user_path(prompt: str | None) -> str | None:
+    if not prompt:
+        return None
+    for match in _USER_PATH_RE.finditer(prompt):
+        candidate = match.group(1) or match.group(2)
+        if candidate:
+            return candidate.strip()
+    return None
+
+
+def _looks_like_discovery_command(command: str) -> bool:
+    return bool(_DISCOVERY_COMMAND_RE.search(command))
+
+
+def _is_targeted_file_discovery(command: str, *, requested_path: str) -> bool:
+    if not _looks_like_discovery_command(command):
+        return False
+    basename = Path(requested_path).name
+    return requested_path in command or basename in command
+
+
+def _classify_shell_output_kind(command: str | None, content: str, *, requested_path: str | None) -> str:
+    stripped = content.strip()
+    if not stripped:
+        return "empty"
+    if is_shell_full_contract_error(stripped):
+        return "metadata_listing"
+    if stripped.startswith("shell_command_failed: true"):
+        if requested_path and command and _looks_like_direct_requested_read(command, requested_path) and _FILE_NOT_FOUND_RE.search(stripped):
+            return "file_not_found"
+        return "error"
+    if command and _looks_like_discovery_command(command):
+        return "discovery_result"
+    if requested_path and command and _looks_like_direct_requested_read(command, requested_path):
+        return "direct_content"
+    if command and is_content_evidence_shell_command(command):
+        return "direct_content"
+    return "other"
+
+
+def _looks_like_direct_requested_read(command: str, requested_path: str) -> bool:
+    basename = Path(requested_path).name
+    return requested_path in command or basename in command
+
+
+def _extract_candidate_paths_from_output(content: str) -> list[str]:
+    candidates: list[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("shell_"):
+            continue
+        if "/" not in stripped and not _FILENAME_ONLY_RE.match(stripped):
+            continue
+        if "." not in stripped:
+            continue
+        candidates.append(stripped)
+    return candidates
+
+
+def _merge_candidate_paths(existing: list[str], discovered: list[str]) -> list[str]:
+    merged = list(existing)
+    for path in discovered:
+        if path not in merged:
+            merged.append(path)
+    return merged
+
+
+def _is_direct_content_read_for_known_path(command: str, *, requested_path: str, candidate_paths: list[str]) -> bool:
+    if not is_content_evidence_shell_command(command):
+        return False
+    if _looks_like_direct_requested_read(command, requested_path):
+        return True
+    return any(path in command or Path(path).name in command for path in candidate_paths)
+
+
+def _summarize_shell_error(content: str) -> str:
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    if not lines:
+        return "unknown shell error"
+    for line in lines:
+        if line.startswith("stderr:"):
+            return line.removeprefix("stderr:").strip() or lines[-1]
+    return lines[-1]

--- a/src/orbit/runtime/tool_loop_state.py
+++ b/src/orbit/runtime/tool_loop_state.py
@@ -8,9 +8,158 @@ from orbit.runtime.tool_calls import tool_call_signature
 SHELL_FULL_ROUND_LIMIT = 8
 DEFAULT_TOOL_ROUND_LIMIT = 1
 
+EVIDENCE_UNRESOLVED = "unresolved"
+EVIDENCE_METADATA_ONLY = "metadata_only"
+EVIDENCE_DIRECT_READ_FAILED = "direct_read_failed"
+EVIDENCE_CANDIDATE_PATHS_FOUND = "candidate_paths_found"
+EVIDENCE_DIRECT_CONTENT_READ = "direct_content_read"
+EVIDENCE_FINALIZABLE = "finalizable"
+EVIDENCE_EXHAUSTED = "exhausted"
+
+RECONSIDER_CONTENT_EVIDENCE = "content_evidence"
+RECONSIDER_ANALYSIS_COMPLETION = "analysis_completion"
+RECONSIDER_FILE_RECOVERY = "file_recovery"
+RECONSIDER_COMPLETION = "completion"
+RECONSIDER_MINIMAL_PATCH = "minimal_patch"
+
+
+@dataclass
+class ToolRepairState:
+    """Bounded internal retries for a single tool turn.
+
+    This state is local to one tool-driven user turn. It tracks only runtime
+    repair/verification requests and must not carry semantic task decisions.
+    """
+
+    contract_retry_pending: bool = False
+    shell_empty_result_check_pending: bool = False
+    shell_empty_result_check_used: bool = False
+    shell_error_final_pending: bool = False
+    shell_repair_prompt_pending: str | None = None
+    shell_repair_retries: int = 0
+    mutation_verification_pending: bool = False
+    mutation_verification_repair_pending: bool = False
+    mutation_verification_repair_used: bool = False
+    mutation_semantic_repair_pending: bool = False
+    mutation_semantic_repair_used: bool = False
+
+    def has_pending(self) -> bool:
+        return (
+            self.contract_retry_pending
+            or self.shell_empty_result_check_pending
+            or self.shell_repair_prompt_pending is not None
+            or self.mutation_verification_pending
+            or self.mutation_verification_repair_pending
+            or self.mutation_semantic_repair_pending
+        )
+
+
+@dataclass
+class ToolTurnState:
+    """Semantic state for one tool turn, not for the whole session.
+
+    Invariants:
+    - no UI/REPL state
+    - no global/session memory
+    - no semantic override of the model's next step
+    - at most one reconsider per reconsider kind
+    """
+
+    requested_user_path: str | None = None
+    round_count: int = 0
+    evidence_state: str = EVIDENCE_UNRESOLVED
+    candidate_paths: list[str] = field(default_factory=list)
+    direct_read_failed: bool = False
+    last_error: str | None = None
+    tool_result_kind: str | None = None
+    reconsider_counts: dict[str, int] = field(default_factory=dict)
+    repair_state: ToolRepairState = field(default_factory=ToolRepairState)
+    content_evidence_satisfied: bool = False
+    finalizable: bool = False
+    pending_content_evidence_guard: bool = False
+    pending_analysis_completion_guard: bool = False
+    pending_file_recovery_guard: bool = False
+    pending_file_recovery_guard_prompt: str | None = None
+    pending_completion_guard: bool = False
+    pending_minimal_patch_guard: bool = False
+    metadata_only_rejections: int = 0
+    shell_commands_seen: int = 0
+    shell_mutation_attempted: bool = False
+    shell_mutation_succeeded: bool = False
+
+    def increment_round(self) -> None:
+        self.round_count += 1
+
+    def can_reconsider(self, kind: str) -> bool:
+        return self.reconsider_counts.get(kind, 0) < 1
+
+    def mark_reconsider(self, kind: str) -> None:
+        self.reconsider_counts[kind] = self.reconsider_counts.get(kind, 0) + 1
+
+    def has_pending_internal_request(self) -> bool:
+        return (
+            self.repair_state.has_pending()
+            or self.pending_content_evidence_guard
+            or self.pending_analysis_completion_guard
+            or self.pending_file_recovery_guard
+            or self.pending_completion_guard
+            or self.pending_minimal_patch_guard
+        )
+
+    def set_tool_result_kind(self, kind: str) -> None:
+        self.tool_result_kind = kind
+        if kind == "metadata_listing" and self.evidence_state == EVIDENCE_UNRESOLVED:
+            self.evidence_state = EVIDENCE_METADATA_ONLY
+
+    def mark_direct_read_failed(self, error: str | None) -> None:
+        self.direct_read_failed = True
+        self.last_error = error
+        self.evidence_state = EVIDENCE_DIRECT_READ_FAILED
+        self.finalizable = False
+
+    def mark_candidate_paths_found(self, paths: list[str]) -> None:
+        for path in paths:
+            if path not in self.candidate_paths:
+                self.candidate_paths.append(path)
+        if self.direct_read_failed and not self.content_evidence_satisfied and self.candidate_paths:
+            self.evidence_state = EVIDENCE_CANDIDATE_PATHS_FOUND
+
+    def mark_direct_content_read(self) -> None:
+        self.content_evidence_satisfied = True
+        self.finalizable = True
+        self.evidence_state = EVIDENCE_DIRECT_CONTENT_READ
+
+    def mark_finalizable(self) -> None:
+        self.finalizable = True
+        if self.content_evidence_satisfied:
+            self.evidence_state = EVIDENCE_FINALIZABLE
+
+    def mark_exhausted(self) -> None:
+        self.finalizable = True
+        self.evidence_state = EVIDENCE_EXHAUSTED
+
+    def clear_pending_after_model_call(self) -> None:
+        self.repair_state.shell_repair_prompt_pending = None
+        self.repair_state.shell_empty_result_check_pending = False
+        self.repair_state.mutation_verification_pending = False
+        self.repair_state.mutation_verification_repair_pending = False
+        self.repair_state.mutation_semantic_repair_pending = False
+        self.pending_content_evidence_guard = False
+        self.pending_analysis_completion_guard = False
+        self.pending_file_recovery_guard = False
+        self.pending_file_recovery_guard_prompt = None
+        self.pending_completion_guard = False
+        self.pending_minimal_patch_guard = False
+
 
 @dataclass
 class ToolLoopState:
+    """Loop-global mechanics for the current request only.
+
+    This object owns round limits, seen tool-call signatures, and chunk budgets.
+    It intentionally does not track file evidence or semantic recovery state.
+    """
+
     allowed_tool_names: tuple[str, ...]
     chunk_budget: dict[str, int] = field(default_factory=dict)
     seen_tool_calls: set[tuple[str, str]] = field(default_factory=set)

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -22,6 +22,7 @@ from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
 from orbit.terminal.theme import danger, dim
+from orbit.runtime.thinking_mode import ThinkingMode
 
 
 @dataclass
@@ -146,7 +147,13 @@ class Repl:
         self._print_turn_footer(result, elapsed_seconds=elapsed)
 
     def _print_turn_footer(self, result, *, elapsed_seconds: float) -> None:
-        self.can_continue = result.finish_reason == "length"
+        self.can_continue = self.runtime.can_continue_last_response() or (
+            ThinkingMode(enabled=self.config.think).continuation_kind_for(
+                content=result.content,
+                finish_reason=result.finish_reason,
+            )
+            is not None
+        )
         if self.runtime.last_memory_refresh:
             refresh = self.runtime.last_memory_refresh
             print(dim(format_memory_refresh(refresh)), flush=True)
@@ -161,8 +168,12 @@ class Repl:
             ),
             flush=True,
         )
-        if result.finish_reason == "length":
-            print(dim(_length_footer_message(self.config.think)), flush=True)
+        if self.can_continue:
+            if result.finish_reason == "length":
+                message = _length_footer_message(self.config.think)
+            else:
+                message = "reasoning finished without a complete final answer"
+            print(dim(message), flush=True)
             print(dim("/continue       continue the answer"), flush=True)
             print(dim("/max-tokens N   increase output budget"), flush=True)
 
@@ -268,6 +279,7 @@ class Repl:
         return f"think: {value}"
 
     def _continue_last_answer(self) -> None:
+        self.can_continue = self.can_continue or self.runtime.can_continue_last_response()
         if not self.can_continue:
             print("error: no truncated answer to continue", file=sys.stderr)
             return
@@ -304,6 +316,7 @@ class Repl:
                 temperature=self.config.temperature,
                 max_tokens=self.config.max_tokens,
                 on_final_delta=renderer.write,
+                on_progress=renderer.progress,
                 on_model_step=self._record_model_step,
             )
         except KeyboardInterrupt:

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -11,10 +11,19 @@ if str(SRC) not in sys.path:
 
 from orbit.backend.base import ChatResult
 from orbit.runtime.final_policy import (
+    LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS,
+    classify_final_answer_completeness,
     build_final_tool_policy,
+    final_from_tool_compact_retry_reason,
+    final_tool_compact_retry_max_tokens,
     final_from_tool_retry_reason,
+    final_tool_compact_retry_instruction,
     final_tool_retry_instruction,
     has_list_like_tool_result,
+    has_pdf_text_tool_result,
+    is_repetitive_final_answer,
+    is_compact_list_request,
+    is_list_shell_command,
     is_operational_status_request,
 )
 
@@ -54,6 +63,60 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertFalse(policy.length_retry_allowed)
         self.assertFalse(policy.incomplete_retry_allowed)
 
+    def test_pdf_chunk_result_uses_large_excerpt_policy(self) -> None:
+        messages = [
+            {
+                "role": "user",
+                "content": 'Leggi il PDF "report.pdf" e fammi una sintesi.',
+            },
+            {
+                "role": "tool",
+                "name": "exec_shell_full_command",
+                "content": (
+                    "shell_output_pdf_text: true\n"
+                    "path: report.pdf\n"
+                    "extractor: pdftotext\n"
+                    "chunk_index: 1\n"
+                    "total_chunks: 4\n"
+                    "chars: 3000-6000 of 9000\n"
+                    "content:\nchunk one"
+                ),
+            }
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=512, streamed=False)
+
+        self.assertEqual(policy.max_tokens, 128)
+        self.assertTrue(policy.length_retry_allowed)
+        self.assertIn("Use only the already inspected chunk(s) or excerpt(s)", policy.messages[-1]["content"])
+
+    def test_exhaustive_pdf_chunk_policy_allows_larger_final_budget(self) -> None:
+        messages = [
+            {
+                "role": "user",
+                "content": 'Analizza intero documento PDF "report.pdf" e fammi una sintesi dettagliata.',
+            },
+            {
+                "role": "tool",
+                "name": "exec_shell_full_command",
+                "content": (
+                    "shell_output_pdf_text: true\n"
+                    "path: report.pdf\n"
+                    "extractor: pdftotext\n"
+                    "chunk_index: 2\n"
+                    "total_chunks: 4\n"
+                    "chars: 6000-9000 of 9000\n"
+                    "content:\nchunk two"
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=512, streamed=False)
+
+        self.assertEqual(policy.max_tokens, 256)
+        self.assertTrue(policy.length_retry_allowed)
+        self.assertIn("fuller synthesis", policy.messages[-1]["content"])
+
     def test_shell_list_command_is_detected_as_list_like(self) -> None:
         messages = [
             {
@@ -92,6 +155,84 @@ class FinalPolicyTests(unittest.TestCase):
 
         self.assertTrue(has_list_like_tool_result(messages))
 
+    def test_find_exec_cat_is_not_treated_as_listing(self) -> None:
+        self.assertFalse(is_list_shell_command('find . -name "vulnerable_service.py" -exec cat {} +'))
+
+    def test_rejected_ls_after_pdf_excerpt_is_not_treated_as_list_like(self) -> None:
+        messages = [
+            {"role": "user", "content": 'Read pdf/small.pdf and summarize the document topic in one concise sentence.'},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-pdf",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "pdftotext pdf/small.pdf - | sed -n '1,10p'"},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-pdf",
+                "name": "exec_shell_full_command",
+                "content": "shell_output_pdf_text: true\npath: pdf/small.pdf\nextractor: pdftotext\nA short PDF about safety.",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-ls",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "ls -R pdf/"},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-ls",
+                "name": "exec_shell_full_command",
+                "content": "error: shell-full analysis requests require content/source/string evidence",
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=128, streamed=False)
+
+        self.assertFalse(has_list_like_tool_result(messages))
+        self.assertFalse(is_compact_list_request(messages[0]["content"]))
+        self.assertNotIn("Return only the listed names", policy.messages[-1]["content"])
+        self.assertIn("PDF text extraction already succeeded", policy.messages[-1]["content"])
+
+    def test_generic_recursive_listing_request_does_not_force_compact_names_mode(self) -> None:
+        messages = [
+            {"role": "user", "content": "List all files and directories in this workdir, including subdirectories."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-find",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "find . -maxdepth 10 -not -path '*/.*'"},
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-find", "name": "exec_shell_full_command", "content": ".\n./pdf\n./text"},
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=128, streamed=False)
+
+        self.assertTrue(has_list_like_tool_result(messages))
+        self.assertFalse(is_compact_list_request(messages[0]["content"]))
+        self.assertNotIn("Return only the listed names", policy.messages[-1]["content"])
+
     def test_shell_full_policy_answers_latest_request_directly(self) -> None:
         messages = [
             {"role": "user", "content": "Use the shell output and answer with the exact first line only."},
@@ -106,6 +247,76 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("Do not call tools again", policy.messages[-1]["content"])
         self.assertIn("If the evidence is insufficient", policy.messages[-1]["content"])
         self.assertTrue(policy.incomplete_retry_allowed)
+
+    def test_long_shell_analysis_policy_is_compact_and_bounded(self) -> None:
+        messages = [
+            {"role": "user", "content": "inspect vulnerable_service.py and explain the vulnerabilities"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "find . -name \"vulnerable_service.py\" -exec cat {} +"},
+                        }
+                    }
+                ],
+            },
+            {"role": "tool", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=160, streamed=False)
+
+        self.assertEqual(policy.max_tokens, LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS)
+        self.assertIn("latest relevant shell-full output", policy.messages[-1]["content"])
+        self.assertIn("exactly 4 short bullets", policy.messages[-1]["content"])
+        self.assertIn("'- Finding: ... Fix: ...'", policy.messages[-1]["content"])
+        self.assertIn("brief remediation", policy.messages[-1]["content"])
+        self.assertEqual(final_tool_compact_retry_max_tokens(512, messages=policy.messages), 160)
+
+    def test_compact_retry_max_tokens_stays_default_for_non_shell_policy(self) -> None:
+        messages = [
+            {"role": "user", "content": 'Leggi il PDF "pdf/small.pdf" e fammi una sintesi dettagliata.'},
+            {
+                "role": "tool",
+                "name": "exec_shell_full_command",
+                "content": (
+                    "shell_output_pdf_text: true\n"
+                    "path: pdf/small.pdf\n"
+                    "extractor: pdftotext\n"
+                    "content:\n"
+                    "Questo documento descrive una rete sicura con firewall e monitoraggio."
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        self.assertEqual(final_tool_compact_retry_max_tokens(512, messages=policy.messages), 160)
+
+    def test_pdf_text_policy_treats_file_as_present_and_readable(self) -> None:
+        messages = [
+            {"role": "user", "content": 'Leggi il PDF "pdf/small.pdf" e fammi una sintesi dettagliata.'},
+            {
+                "role": "tool",
+                "name": "exec_shell_full_command",
+                "content": (
+                    "shell_output_pdf_text: true\n"
+                    "path: pdf/small.pdf\n"
+                    "extractor: pdftotext\n"
+                    "content:\n"
+                    "Questo documento descrive una rete sicura con firewall e monitoraggio."
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        self.assertTrue(has_pdf_text_tool_result(messages))
+        self.assertIn("PDF text extraction already succeeded", policy.messages[-1]["content"])
+        self.assertIn("Treat the PDF file as present and readable", policy.messages[-1]["content"])
+        self.assertIn("Do not claim the file is missing", policy.messages[-1]["content"])
 
     def test_operational_status_policy_prefers_recent_shell_evidence(self) -> None:
         messages = [
@@ -210,7 +421,7 @@ class FinalPolicyTests(unittest.TestCase):
 
         self.assertEqual(reason, "empty_length")
 
-    def test_final_retry_reason_detects_incomplete_plain_final(self) -> None:
+    def test_final_retry_reason_does_not_handle_semantic_incomplete_final(self) -> None:
         result = ChatResult(
             content="Il documento e una relazione tecnica per il servizio di gestione della rete QX",
             model="m",
@@ -229,7 +440,7 @@ class FinalPolicyTests(unittest.TestCase):
             incomplete_retry_allowed=True,
         )
 
-        self.assertEqual(reason, "incomplete_final")
+        self.assertIsNone(reason)
 
     def test_final_retry_reason_ignores_short_operational_or_path_like_outputs(self) -> None:
         path_result = ChatResult(
@@ -263,6 +474,131 @@ class FinalPolicyTests(unittest.TestCase):
             final_tool_retry_instruction()["content"],
             "Do not call tools. Provide a shorter final answer from the available tool result now.",
         )
+
+    def test_final_tool_compact_retry_instruction_is_constrained(self) -> None:
+        content = final_tool_compact_retry_instruction()["content"]
+        self.assertIn("three to five sentences", content)
+        self.assertIn("No repetition", content)
+        self.assertIn("Do not call tools", content)
+
+    def test_final_answer_completeness_detects_heading_stub(self) -> None:
+        completeness = classify_final_answer_completeness("The file contains several vulnerabilities.\n\n### ")
+        self.assertEqual(completeness.status, "malformed_markdown")
+
+    def test_final_answer_completeness_detects_list_label_stub(self) -> None:
+        completeness = classify_final_answer_completeness("1. **SQL Injection:**")
+        self.assertEqual(completeness.status, "incomplete_stub")
+
+    def test_final_answer_completeness_detects_unclosed_backtick(self) -> None:
+        completeness = classify_final_answer_completeness("Use the variable `user_input to build the query.")
+        self.assertEqual(completeness.status, "malformed_markdown")
+
+    def test_final_answer_completeness_detects_reasoning_like_answer(self) -> None:
+        completeness = classify_final_answer_completeness("Plan:\n1. Inspect the file\n2. Summarize the findings")
+        self.assertEqual(completeness.status, "reasoning_like")
+
+    def test_final_answer_completeness_accepts_complete_brief_answer(self) -> None:
+        completeness = classify_final_answer_completeness(
+            "The file is vulnerable to SQL injection and command injection due to unsanitized input handling."
+        )
+        self.assertEqual(completeness.status, "complete")
+
+    def test_repetitive_final_answer_is_detected(self) -> None:
+        content = (
+            "The file contains several issues that need review. "
+            "The file contains several issues that need review. "
+            "The file contains several issues that need review."
+        )
+        self.assertTrue(is_repetitive_final_answer(content))
+
+    def test_final_answer_completeness_detects_too_short_after_large_tool_result(self) -> None:
+        messages = [
+            {
+                "role": "user",
+                "content": "inspect vulnerable_service.py and explain the vulnerabilities",
+            },
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": "{\"command\":\"cat samples/vulnerable_service.py\"}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "exec_shell_full_command",
+                "tool_call_id": "call-1",
+                "content": "x" * 1200,
+            },
+        ]
+        completeness = classify_final_answer_completeness("Several flaws exist", messages=messages)
+        self.assertEqual(completeness.status, "too_short_after_tool")
+
+    def test_compact_retry_reason_detects_long_length_final(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "exec_shell_full_command", "arguments": {"command": "cat vulnerable_service.py"}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+        result = ChatResult(
+            content="Long answer that ran out of space before finishing the explanation.",
+            model="m",
+            finish_reason="length",
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+        self.assertEqual(final_from_tool_compact_retry_reason(result, messages=messages), "length")
+
+    def test_compact_retry_reason_detects_repetitive_final(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "exec_shell_full_command", "arguments": {"command": "cat vulnerable_service.py"}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+        result = ChatResult(
+            content=(
+                "The application is vulnerable to injection and weak validation. "
+                "The application is vulnerable to injection and weak validation. "
+                "The application is vulnerable to injection and weak validation."
+            ),
+            model="m",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+        self.assertEqual(final_from_tool_compact_retry_reason(result, messages=messages), "repetition")
 
 
 if __name__ == "__main__":

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -72,6 +72,7 @@ class CountingRuntime(ChatRuntime):
         self.ask_auto_calls = 0
         self.ask_chat_calls = 0
         self.last_allowed_tool_names = None
+        self.last_continue_on_progress = None
 
     def ask_auto(self, *args, **kwargs) -> ChatResult:
         self.ask_calls += 1
@@ -107,6 +108,7 @@ class CountingRuntime(ChatRuntime):
     def continue_last_response(self, *args, **kwargs) -> ChatResult:
         self.ask_calls += 1
         on_final_delta = kwargs.get("on_final_delta")
+        self.last_continue_on_progress = kwargs.get("on_progress")
         if on_final_delta:
             on_final_delta("continued")
         return ChatResult(
@@ -449,6 +451,29 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.ask_calls, 1)
         self.assertIn("continued", stdout.getvalue())
         self.assertFalse(repl.can_continue)
+        self.assertIsNotNone(runtime.last_continue_on_progress)
+
+    def test_footer_offers_continue_for_reasoning_only_stop(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path("."), think=True))
+        result = ChatResult(
+            content="### Reasoning\nstill thinking",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=10,
+            completion_tokens=16,
+            cached_tokens=0,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            repl._print_turn_footer(result, elapsed_seconds=1)
+
+        self.assertTrue(repl.can_continue)
+        self.assertIn("/continue", stdout.getvalue())
 
     def test_tools_are_off_by_default_and_chat_path_is_used(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -21,6 +21,7 @@ from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
     SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT,
     SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT,
+    SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     should_verify_shell_mutation,
@@ -173,20 +174,21 @@ class RuntimeTests(unittest.TestCase):
         runtime.continue_last_response(temperature=0, max_tokens=32)
 
         self.assertEqual(runtime.messages[-2]["role"], "user")
-        self.assertIn("do not restart it from the beginning", runtime.messages[-2]["content"].lower())
+        self.assertIn("stop reasoning now", runtime.messages[-2]["content"].lower())
 
-    def test_continue_last_response_uses_native_backend_continuation_for_open_reasoning(self) -> None:
-        class NativeContinueBackend(FakeBackend):
+    def test_continue_last_response_uses_prompt_fallback_for_open_reasoning(self) -> None:
+        class FallbackBackend(FakeBackend):
             def __init__(self) -> None:
                 super().__init__()
                 self.continue_calls = 0
+                self.chat_calls = 0
+                self.thinking = True
+                self.last_messages: list[Message] = []
 
             def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
                 self.continue_calls += 1
-                if on_delta:
-                    on_delta("continued")
                 return ChatResult(
-                    content="continued",
+                    content="should not be used",
                     model="fake",
                     finish_reason="stop",
                     tool_calls=[],
@@ -197,15 +199,73 @@ class RuntimeTests(unittest.TestCase):
                     generation_tokens_per_second=None,
                 )
 
-        backend = NativeContinueBackend()
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                self.last_thinking = self.thinking
+                self.last_messages = messages
+                return ChatResult(
+                    content="Final answer from fallback.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = FallbackBackend()
         runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
         runtime.messages.append({"role": "assistant", "content": "<|channel>thought\npartial reasoning"})
 
         result = runtime.continue_last_response(temperature=0, max_tokens=32)
 
-        self.assertEqual(result.content, "continued")
-        self.assertEqual(backend.continue_calls, 1)
-        self.assertEqual(runtime.messages[-1]["content"], "continued")
+        self.assertEqual(result.content, "Final answer from fallback.")
+        self.assertEqual(backend.continue_calls, 0)
+        self.assertEqual(backend.chat_calls, 1)
+        self.assertEqual(runtime.messages[-1]["content"], "Final answer from fallback.")
+        self.assertFalse(backend.last_thinking)
+        self.assertIn("Stop reasoning now and write only the missing final answer.", backend.last_messages[-2]["content"])
+        self.assertIn("Start the answer with 'Final answer:'", backend.last_messages[-2]["content"])
+
+    def test_continue_last_response_returns_controlled_error_if_fallback_stays_thinking_like(self) -> None:
+        class ThinkingFallbackBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.continue_calls = 0
+                self.chat_calls = 0
+                self.thinking = True
+
+            def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
+                self.continue_calls += 1
+                raise AssertionError("native continue should not be used for thinking continuation")
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                return ChatResult(
+                    content="<|channel>thought\nstill thinking",
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ThinkingFallbackBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        runtime.messages.append({"role": "assistant", "content": "<|channel>thought\npartial reasoning"})
+
+        result = runtime.continue_last_response(temperature=0, max_tokens=32)
+
+        self.assertEqual(result.content, "error: model did not produce a final answer after continuation")
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertEqual(backend.continue_calls, 0)
+        self.assertEqual(backend.chat_calls, 1)
+        self.assertFalse(runtime.can_continue_last_response())
 
     def test_continue_last_response_uses_native_backend_continuation_after_length_even_without_open_reasoning(self) -> None:
         class NativeContinueBackend(FakeBackend):
@@ -1187,16 +1247,650 @@ class ToolRuntimeTests(unittest.TestCase):
             )
 
         self.assertEqual(result.content, "vulnerability found from source evidence")
-        self.assertEqual(backend.calls, 5)
+        self.assertEqual(backend.calls, 4)
         self.assertEqual(backend.tools_seen[0], None)
         self.assertIsNotNone(backend.tools_seen[1])
         self.assertIsNotNone(backend.tools_seen[2])
-        self.assertIsNotNone(backend.tools_seen[3])
-        self.assertEqual(backend.tools_seen[4], None)
+        self.assertEqual(backend.tools_seen[3], None)
         self.assertIsNotNone(backend.second_call_last_message)
         self.assertIn("content/source/string evidence", backend.second_call_last_message["content"])
         self.assertIsNotNone(backend.third_call_last_message)
         self.assertIn("Return only the tool call", backend.third_call_last_message["content"])
+
+    def test_analysis_completion_guard_reconsiders_non_content_followup_after_evidence(self) -> None:
+        class AnalysisCompletionBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.guard_messages: list[Message] | None = None
+                self.final_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "sed -n '1,80p' vulnerable_service.py"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "ls -R"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    self.guard_messages = messages
+                    return ChatResult(
+                        content="I already have enough evidence.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=4,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                self.final_messages = messages
+                return ChatResult(
+                    content="The file is vulnerable because it executes shell commands with shell=True.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            backend = AnalysisCompletionBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "inspect vulnerable_service.py and explain the vulnerabilities",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertTrue(result.content.strip())
+        self.assertIn(backend.calls, {3, 4})
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertIn("shell=True", tool_messages[0]["content"])
+
+    def test_analysis_completion_guard_does_not_block_followup_content_read(self) -> None:
+        class FollowupContentBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "sed -n '1,40p' report.txt"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "sed -n '41,80p' report.txt"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Final summary from both chunks.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=4,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "report.txt").write_text("A\n" * 120, encoding="utf-8")
+            backend = FollowupContentBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "inspect report.txt and summarize it",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "Final summary from both chunks.")
+
+    def test_file_recovery_guard_guides_model_to_candidate_read(self) -> None:
+        class FileRecoveryBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.guard_messages: list[Message] | None = None
+                self.guard_max_tokens: int | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                last_content = str(messages[-1].get("content"))
+                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                    self.guard_messages = messages
+                    self.guard_max_tokens = max_tokens
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "cat vulnerable_service.py"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content=json.dumps({"command": "find . -name \"vulnerable_service.py\""}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    return ChatResult(
+                        content=json.dumps({"command": "ls -R"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 4:
+                    return ChatResult(
+                        content=json.dumps({"command": "sed -n '1,80p' ./samples/vulnerable_service.py"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The file is vulnerable because it uses shell=True in subprocess.run.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=9,
+                    completion_tokens=6,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            samples = workdir / "samples"
+            samples.mkdir()
+            (samples / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            backend = FileRecoveryBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "inspect vulnerable_service.py and explain the vulnerabilities",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertIn("shell=True", result.content)
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 3)
+        self.assertIn("No such file or directory", tool_messages[0]["content"])
+        self.assertIn("./samples/vulnerable_service.py", tool_messages[1]["content"])
+        self.assertIn("shell=True", tool_messages[2]["content"])
+        self.assertIsNotNone(backend.guard_messages)
+        self.assertEqual(backend.guard_max_tokens, 64)
+        self.assertIn(SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX, backend.guard_messages[-1]["content"])
+        self.assertIn("Requested file: vulnerable_service.py", backend.guard_messages[-1]["content"])
+        self.assertIn("Direct read failure:", backend.guard_messages[-1]["content"])
+        self.assertIn("./samples/vulnerable_service.py", backend.guard_messages[-1]["content"])
+
+    def test_file_recovery_guard_allows_final_not_found_answer(self) -> None:
+        class MissingFileBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.guard_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                last_content = str(messages[-1].get("content"))
+                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                    self.guard_messages = messages
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "cat missing.py"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content=json.dumps({"command": "find . -name \"missing.py\""}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    return ChatResult(
+                        content=json.dumps({"command": "ls -R"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="I could not find `missing.py` after a direct read and a targeted search.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            backend = MissingFileBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "inspect missing.py and explain the vulnerabilities",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertIn("could not find", result.content.lower())
+        self.assertIsNotNone(backend.guard_messages)
+        self.assertIn("Requested file: missing.py", backend.guard_messages[-1]["content"])
+
+    def test_file_recovery_guard_does_not_block_recursive_listing_requests(self) -> None:
+        class RecursiveListingBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "ls -R"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Directory listing complete.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=6,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            backend = RecursiveListingBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "list files recursively",
+                temperature=0,
+                max_tokens=32,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "Directory listing complete.")
+        self.assertEqual(backend.calls, 2)
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+
+    def test_direct_content_read_handoffs_immediately_to_final_from_tool(self) -> None:
+        class DirectContentHandoffBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.final_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "sed -n '1,80p' vulnerable_service.py"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                self.final_messages = messages
+                assert tools is None
+                assert "shell-full output" in str(messages[-1].get("content"))
+                return ChatResult(
+                    content="The file is vulnerable because it uses shell=True in subprocess.run.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=6,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            backend = DirectContentHandoffBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                "inspect vulnerable_service.py and explain the vulnerabilities",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertIn("shell=True", result.content)
+        self.assertEqual(backend.calls, 2)
+        self.assertIsNotNone(backend.final_messages)
+
+    def test_candidate_paths_without_direct_content_do_not_handoff_to_final_from_tool(self) -> None:
+        class CandidatePathBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.third_call_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat vulnerable_service.py"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "find . -name \"vulnerable_service.py\""}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    self.third_call_messages = messages
+                    assert tools is not None
+                    assert "shell-full output" not in str(messages[-1].get("content"))
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-3",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "sed -n '1,80p' ./samples/vulnerable_service.py"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=7,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                assert tools is None
+                assert "shell-full output" in str(messages[-1].get("content"))
+                return ChatResult(
+                    content="The file is vulnerable because it uses shell=True in subprocess.run.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            samples = workdir / "samples"
+            samples.mkdir()
+            (samples / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            backend = CandidatePathBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                "inspect vulnerable_service.py and explain the vulnerabilities",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertIn("shell=True", result.content)
+        self.assertEqual(backend.calls, 4)
+        self.assertIsNotNone(backend.third_call_messages)
+
+    def test_mutative_request_does_not_handoff_directly_to_final_from_tool(self) -> None:
+        class MutativeNoHandoffBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.second_call_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "printf 'updated\\n' > note.txt && cat note.txt"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    self.second_call_messages = messages
+                    assert tools is not None
+                    assert "shell-full output" not in str(messages[-1].get("content"))
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat note.txt"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="done",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            backend = MutativeNoHandoffBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                "update note.txt with the word updated",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "done")
+        self.assertEqual(backend.calls, 4)
+        self.assertIsNotNone(backend.second_call_messages)
 
     def test_shell_full_failed_initial_command_gets_one_model_retry(self) -> None:
         class FailedShellCommandBackend:
@@ -2706,13 +3400,12 @@ EOF"""
             )
 
         self.assertEqual(result.content, "final answer from multiple shell results")
-        self.assertEqual(backend.calls, 4)
+        self.assertEqual(backend.calls, 3)
         self.assertIsNotNone(backend.tools_seen[0])
-        self.assertIsNotNone(backend.tools_seen[1])
-        self.assertIsNotNone(backend.tools_seen[2])
-        self.assertIsNone(backend.tools_seen[3])
+        self.assertIsNone(backend.tools_seen[1])
+        self.assertIsNone(backend.tools_seen[2])
         tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
-        self.assertEqual(len(tool_messages), 2)
+        self.assertEqual(len(tool_messages), 1)
 
     def test_ask_auto_streams_route_phase_when_progress_is_requested(self) -> None:
         class StreamingRouteBackend:
@@ -3346,8 +4039,8 @@ EOF"""
         self.assertEqual(result.content, "Sintesi: relazione tecnica sulla gestione, manutenzione ed evoluzione della rete QX.")
         self.assertEqual(backend.calls, 4)
         self.assertIsNotNone(backend.tools_seen[0])
-        self.assertIsNotNone(backend.tools_seen[1])
-        self.assertIsNotNone(backend.tools_seen[2])
+        self.assertIsNone(backend.tools_seen[1])
+        self.assertIsNone(backend.tools_seen[2])
         self.assertIsNone(backend.tools_seen[3])
 
     def test_ask_with_tools_can_read_text_file(self) -> None:
@@ -3505,7 +4198,7 @@ EOF"""
             )
 
         self.assertEqual(result.content, "CPU information from tool result")
-        self.assertEqual(backend.calls, 4)
+        self.assertEqual(backend.calls, 3)
         self.assertEqual(steps[-1].phase, "final_from_tool")
 
     def test_ask_with_tools_traces_tool_call_retry_in_final_answer(self) -> None:
@@ -3662,7 +4355,7 @@ EOF"""
         self.assertEqual(result.content, "<|channel>thought\nfrom tool result<channel|>final answer")
         self.assertEqual(emitted, ["<|channel>thought\nfrom tool result", "<channel|>final answer"])
 
-    def test_final_from_tool_uses_native_continuation_once_when_thinking_hits_length(self) -> None:
+    def test_final_from_tool_uses_compact_retry_once_when_thinking_hits_length(self) -> None:
         class StreamingFinalThoughtLengthBackend:
             def __init__(self) -> None:
                 self.calls = 0
@@ -3708,13 +4401,26 @@ EOF"""
                     )
                 assert on_delta is not None
                 on_delta("<|channel>thought\npartial")
+                if self.calls == 3:
+                    return ChatResult(
+                        content="<|channel>thought\npartial",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=22,
+                        completion_tokens=5,
+                        cached_tokens=10,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                on_delta("short final answer")
                 return ChatResult(
-                    content="<|channel>thought\npartial",
+                    content="short final answer",
                     model="fake",
-                    finish_reason="length",
+                    finish_reason="stop",
                     tool_calls=[],
-                    prompt_tokens=22,
-                    completion_tokens=5,
+                    prompt_tokens=24,
+                    completion_tokens=6,
                     cached_tokens=10,
                     prompt_tokens_per_second=None,
                     generation_tokens_per_second=None,
@@ -3722,19 +4428,7 @@ EOF"""
 
             def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
                 self.continue_calls += 1
-                assert on_delta is not None
-                on_delta("<channel|>final answer")
-                return ChatResult(
-                    content="<channel|>final answer",
-                    model="fake",
-                    finish_reason="stop",
-                    tool_calls=[],
-                    prompt_tokens=0,
-                    completion_tokens=4,
-                    cached_tokens=0,
-                    prompt_tokens_per_second=None,
-                    generation_tokens_per_second=None,
-                )
+                raise AssertionError("final-from-tool should not use native continuation")
 
         with tempfile.TemporaryDirectory() as tmp:
             emitted: list[str] = []
@@ -3751,13 +4445,13 @@ EOF"""
                 on_model_step=steps.append,
             )
 
-        self.assertEqual(backend.continue_calls, 1)
-        self.assertEqual(result.content, "<|channel>thought\npartial<channel|>final answer")
+        self.assertEqual(backend.continue_calls, 0)
+        self.assertEqual(result.content, "short final answer")
         self.assertEqual(result.finish_reason, "stop")
-        self.assertEqual(emitted, ["plan before tools", "<|channel>thought\npartial", "<channel|>final answer"])
-        self.assertEqual(steps[-1].phase, "final_from_tool_continue_native")
+        self.assertEqual(emitted, ["plan before tools", "<|channel>thought\npartial", "short final answer"])
+        self.assertIn(steps[-1].phase, {"final_from_tool", "final_from_tool_compact_retry"})
 
-    def test_final_from_tool_non_stream_uses_native_continuation_once_when_thinking_hits_length(self) -> None:
+    def test_final_from_tool_non_stream_uses_compact_retry_once_when_thinking_hits_length(self) -> None:
         class FinalThoughtLengthBackend:
             def __init__(self) -> None:
                 self.calls = 0
@@ -3784,13 +4478,25 @@ EOF"""
                         prompt_tokens_per_second=None,
                         generation_tokens_per_second=None,
                     )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="<|channel>thought\npartial",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=22,
+                        completion_tokens=5,
+                        cached_tokens=10,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
                 return ChatResult(
-                    content="<|channel>thought\npartial",
+                    content="short final answer",
                     model="fake",
-                    finish_reason="length",
+                    finish_reason="stop",
                     tool_calls=[],
-                    prompt_tokens=22,
-                    completion_tokens=5,
+                    prompt_tokens=24,
+                    completion_tokens=6,
                     cached_tokens=10,
                     prompt_tokens_per_second=None,
                     generation_tokens_per_second=None,
@@ -3798,17 +4504,7 @@ EOF"""
 
             def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
                 self.continue_calls += 1
-                return ChatResult(
-                    content="<channel|>final answer",
-                    model="fake",
-                    finish_reason="stop",
-                    tool_calls=[],
-                    prompt_tokens=0,
-                    completion_tokens=4,
-                    cached_tokens=0,
-                    prompt_tokens_per_second=None,
-                    generation_tokens_per_second=None,
-                )
+                raise AssertionError("final-from-tool should not use native continuation")
 
         with tempfile.TemporaryDirectory() as tmp:
             backend = FinalThoughtLengthBackend()
@@ -3821,8 +4517,8 @@ EOF"""
                 tool_names=("exec_shell_full_command",),
             )
 
-        self.assertEqual(backend.continue_calls, 1)
-        self.assertEqual(result.content, "<|channel>thought\npartial<channel|>final answer")
+        self.assertEqual(backend.continue_calls, 0)
+        self.assertEqual(result.content, "short final answer")
         self.assertEqual(result.finish_reason, "stop")
 
     def test_ask_with_tools_streams_planning_thought_when_thinking_mode_is_on(self) -> None:
@@ -4132,7 +4828,7 @@ EOF"""
 
         self.assertEqual(result.content, "done")
         self.assertEqual(emitted, ["done"])
-        self.assertEqual(backend.calls, 3)
+        self.assertEqual(backend.calls, 2)
 
     def test_ask_with_tools_streaming_retries_empty_final_then_streams_thought_and_answer(self) -> None:
         class EmptyThenThoughtFinalBackend:
@@ -4225,11 +4921,11 @@ EOF"""
             )
 
         self.assertEqual(result.content, "<|channel>thought\nfrom tool result<channel|>final answer")
-        self.assertEqual(emitted, ["<|channel>thought\nfrom tool result", "<channel|>final answer"])
-        self.assertEqual(backend.chat_calls, 1)
+        self.assertEqual(emitted, ["<|channel>thought\nfrom tool result<channel|>final answer"])
+        self.assertEqual(backend.chat_calls, 0)
         self.assertEqual(backend.chat_stream_calls, 3)
         phases = [step.phase for step in steps]
-        self.assertEqual(phases, ["tool_call", "final", "tool_call_retry", "final_from_tool"])
+        self.assertEqual(phases, ["tool_call", "final_from_tool", "final_from_tool_retry"])
 
     def test_ask_with_tools_emits_tool_call_event(self) -> None:
         events: list[tuple[str, str]] = []
@@ -4268,7 +4964,7 @@ EOF"""
                 on_model_step=steps.append,
             )
 
-        self.assertEqual(len(steps), 3)
+        self.assertEqual(len(steps), 2)
         self.assertEqual(steps[0].loop, 1)
         self.assertEqual(steps[0].phase, "tool_call")
         self.assertEqual(steps[0].cached_tokens, 8)

--- a/tests/test_tool_loop_state.py
+++ b/tests/test_tool_loop_state.py
@@ -9,7 +9,14 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from orbit.runtime.tool_loop_state import ToolLoopState
+from orbit.runtime.tool_loop_state import (
+    EVIDENCE_CANDIDATE_PATHS_FOUND,
+    EVIDENCE_DIRECT_CONTENT_READ,
+    EVIDENCE_DIRECT_READ_FAILED,
+    RECONSIDER_FILE_RECOVERY,
+    ToolLoopState,
+    ToolTurnState,
+)
 from orbit.runtime import tool_loop
 
 
@@ -50,15 +57,44 @@ class ToolLoopStateTests(unittest.TestCase):
         self.assertTrue(state.has_seen_tool_call(tool_call))
 
     def test_mutative_tool_call_budget_is_separate_and_bounded(self) -> None:
-        original = tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS
+        original_mutative = tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS
+        original_file_recovery = tool_loop.FILE_RECOVERY_TOOL_CALL_MAX_TOKENS
         try:
             tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS = 192
+            tool_loop.FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = 64
 
             self.assertEqual(tool_loop._tool_call_max_tokens(512, mutative=False), 96)
             self.assertEqual(tool_loop._tool_call_max_tokens(512, mutative=True), 192)
             self.assertEqual(tool_loop._tool_call_max_tokens(160, mutative=True), 160)
+            self.assertEqual(tool_loop._tool_call_max_tokens(512, mutative=False, file_recovery=True), 64)
+            self.assertEqual(tool_loop._tool_call_max_tokens(48, mutative=False, file_recovery=True), 48)
         finally:
-            tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS = original
+            tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS = original_mutative
+            tool_loop.FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = original_file_recovery
+
+    def test_tool_turn_state_tracks_file_recovery_transitions(self) -> None:
+        state = ToolTurnState(requested_user_path="vulnerable_service.py")
+
+        state.mark_direct_read_failed("No such file")
+        self.assertEqual(state.evidence_state, EVIDENCE_DIRECT_READ_FAILED)
+        self.assertTrue(state.direct_read_failed)
+        self.assertFalse(state.finalizable)
+
+        state.mark_candidate_paths_found(["./samples/vulnerable_service.py"])
+        self.assertEqual(state.evidence_state, EVIDENCE_CANDIDATE_PATHS_FOUND)
+        self.assertEqual(state.candidate_paths, ["./samples/vulnerable_service.py"])
+
+        state.mark_direct_content_read()
+        self.assertEqual(state.evidence_state, EVIDENCE_DIRECT_CONTENT_READ)
+        self.assertTrue(state.content_evidence_satisfied)
+        self.assertTrue(state.finalizable)
+
+    def test_tool_turn_state_limits_reconsider_once_per_kind(self) -> None:
+        state = ToolTurnState()
+
+        self.assertTrue(state.can_reconsider(RECONSIDER_FILE_RECOVERY))
+        state.mark_reconsider(RECONSIDER_FILE_RECOVERY)
+        self.assertFalse(state.can_reconsider(RECONSIDER_FILE_RECOVERY))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors Orbit client/runtime state handling to reduce coupling between pure chat, tool loop, file recovery, final-from-tool, and `/continue`.

Key changes:

* Introduces explicit runtime state helpers:

  * `ClientState`
  * `CompletionBudget`
  * `ContinueController`
  * `ThinkingMode`
  * `FileInputResolver`
  * `ToolTurnState`
  * `ToolRepairState`
  * `ToolLoopState`
* Separates tool-loop semantic state from loop mechanics.
* Makes file recovery model-guided with explicit turn-local state.
* Fixes `/continue` think-on live behavior by routing thinking continuations through a final-answer fallback.
* Adds final-answer completeness classification for post-tool responses.
* Adds bounded compact retry for long or repetitive post-tool final answers.
* Adds handoff from tool loop to final-from-tool once direct content evidence is finalizable.

Scope:

* Client/runtime/terminal/tests only.
* No backend/native/MTP changes.
* No deterministic routing hardcoding.
* No command blocking for `ls`, `find`, or `ls -R`.
* Tool decisions remain model-guided.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* chat think off: PASS
* chat think on: PASS
* `/continue think on`: PASS
* tools off: PASS
* shell pwd: PASS
* text/summary.txt: PASS
* pdf/piccolo.pdf: PASS
* inspect vulnerable_service.py breve: PASS
* inspect vulnerable_service.py lungo: PASS
* list files recursively: slow smoke, output correct, not a quick gate

Risk:
Recursive listing is intentionally treated as a slow smoke, not a rapid PR gate. It completes correctly with a higher timeout and does not show a tool-loop spiral.

Final decision:
Merge candidate.
