### PR TITLE
Make MTP opt-in and stabilize native default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ orbit download --all ggml-org/gemma-4-12B-it-GGUF
 
 ### 3. Start the native backend
 
-Basic native server:
+Basic native server, with MTP disabled by default:
 
 ```bash
 orbit server --port 11976
 ```
 
-With MTP enabled:
+With MTP enabled explicitly:
 
 ```bash
 orbit server --port 11976 --mtp
@@ -116,6 +116,13 @@ orbit server \
   --mtp \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
+
+Notes:
+
+- `orbit server` does not enable MTP unless `--mtp` is passed.
+- experimental multi-turn raw MTP chat reuse remains debug-only behind:
+  - `ORBIT_MTP_CHAT_REUSE_RAW=1`
+  - `ORBIT_MTP_CHAT_REUSE_DEBUG=1`
 
 ### 4. Start Orbit
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # orbit
 
-Minimal local agentic CLI centered on native `orbit-server`, with optional compatibility for other OpenAI-compatible local backends.
+Minimal local CLI for running Gemma 4 with the native `orbit-server`.
 
-Orbit is designed around Gemma 4, local execution, streaming output, shell-tool opt-in, and CPU-only usability. The native path supports chat, tools, session reuse, MTP, and multimodal input without requiring `llama-server` as the primary backend.
+Orbit is designed for local execution, streaming output, optional shell tools, and a simple terminal workflow. The normal Orbit setup does not require an external `llama-server` process at runtime.
 
 Important status note:
-the native backend is the primary Orbit path, but a fresh clone is not yet a zero-build product. Today, native Orbit still expects prepared native `llama`/`ggml` libraries, and some MTP paths still rely on local shim compilation. See [docs/NATIVE_PACKAGING_ROADMAP.md](docs/NATIVE_PACKAGING_ROADMAP.md).
+the native backend is the primary Orbit path, but a fresh clone is not yet a zero-build product. Today, Orbit still expects native `llama`/`ggml` components to be available locally, and some MTP paths still rebuild a local shim when needed. See [docs/NATIVE_PACKAGING_ROADMAP.md](docs/NATIVE_PACKAGING_ROADMAP.md).
 
 Linux is the main target environment. macOS may work. Windows is not a target environment.
 
@@ -88,13 +88,13 @@ orbit download --all ggml-org/gemma-4-12B-it-GGUF
 
 ### 3. Start the native backend
 
-Basic native server, with MTP disabled by default:
+Stable default server, with MTP disabled:
 
 ```bash
 orbit server --port 11976
 ```
 
-With MTP enabled explicitly:
+Optional MTP mode:
 
 ```bash
 orbit server --port 11976 --mtp
@@ -117,14 +117,40 @@ orbit server \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
 
-Notes:
+What this means:
 
-- `orbit server` does not enable MTP unless `--mtp` is passed.
+- `orbit server` starts the stable native backend without MTP.
+- `orbit server --mtp` enables the experimental MTP path explicitly.
+- MTP can improve some workloads, but Orbit keeps it off by default because stability has priority.
 - experimental multi-turn raw MTP chat reuse remains debug-only behind:
   - `ORBIT_MTP_CHAT_REUSE_RAW=1`
   - `ORBIT_MTP_CHAT_REUSE_DEBUG=1`
 
-### 4. Start Orbit
+### 4. Check the server
+
+After startup, you can verify that the server is healthy:
+
+```bash
+orbit --base-url http://127.0.0.1:11976 --health
+```
+
+Inside the interactive client, you can inspect backend state with:
+
+```text
+/health
+/props
+```
+
+Expected `/props` values:
+
+- default server:
+  - `backend_mode=no-mtp`
+  - `mtp_enabled=false`
+- with `--mtp`:
+  - `backend_mode=mtp-ready`
+  - `mtp_enabled=true`
+
+### 5. Start Orbit
 
 ```bash
 orbit --base-url http://127.0.0.1:11976

--- a/docs/NATIVE_PACKAGING_ROADMAP.md
+++ b/docs/NATIVE_PACKAGING_ROADMAP.md
@@ -28,6 +28,12 @@ orbit server --port 11976 --mtp
 orbit
 ```
 
+Current product default:
+
+- `orbit server` starts the native backend with MTP off.
+- `orbit server --mtp` enables the native MTP path explicitly.
+- persistent multi-turn raw MTP chat reuse is not default and remains debug-only.
+
 No external `llama.cpp` checkout.
 No manual CMake build.
 No `llama-server` install.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -213,6 +213,8 @@ class NativeLlamaClient:
         self._session.mtp_enabled = False
         self._session.mtp_failed = False
         self._session.mtp_failure_reason = None
+        if not self.config.use_mtp_experimental:
+            return
         if not self.paths.mtp_available or self.paths.draft_mtp_model is None:
             self._session.mtp_failure_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
             return

--- a/src/orbit/native_llama/paths.py
+++ b/src/orbit/native_llama/paths.py
@@ -10,6 +10,7 @@ from .model_registry import ResolvedModel, get_manifest, resolve_model
 PACKAGE_NATIVE_ROOT = Path(__file__).resolve().parent / "vendor"
 DEFAULT_VENDOR_LIB_DIR = PACKAGE_NATIVE_ROOT / "lib"
 DEFAULT_VENDOR_SHIM_DIR = PACKAGE_NATIVE_ROOT / "shim"
+BUNDLED_SOURCE_ROOT = PACKAGE_NATIVE_ROOT / "source" / "llama.cpp"
 DEFAULT_LLAMA_ROOT = Path(os.environ["ORBIT_LLAMA_ROOT"]).expanduser().resolve() if os.environ.get("ORBIT_LLAMA_ROOT") else None
 DEFAULT_MODEL_ID = "gemma4-12b-it-q4km"
 LEGACY_MODEL_ID = "legacy-path"
@@ -39,7 +40,8 @@ def resolve_paths(
     models_dir: Path | None = None,
     hf_cache: Path | None = None,
 ) -> NativeLlamaPaths:
-    resolved_llama_root, build_bin, library = _resolve_native_runtime(llama_root)
+    source_root = _resolve_build_source_root(llama_root)
+    _runtime_llama_root, build_bin, library = _resolve_native_runtime(llama_root)
     manifest = get_manifest(model_id)
     resolved = _resolve_model(
         manifest_id=model_id,
@@ -50,7 +52,7 @@ def resolve_paths(
     )
 
     return NativeLlamaPaths(
-        llama_root=resolved_llama_root,
+        llama_root=source_root,
         build_bin=build_bin,
         library=library,
         model=resolved.target_path,
@@ -70,7 +72,8 @@ def resolve_legacy_paths(
     model: Path,
     mmproj: Path | None = None,
 ) -> NativeLlamaPaths:
-    resolved_llama_root, build_bin, library = _resolve_native_runtime(llama_root)
+    source_root = _resolve_build_source_root(llama_root)
+    _runtime_llama_root, build_bin, library = _resolve_native_runtime(llama_root)
     resolved_model = model.expanduser().resolve()
 
     if not resolved_model.exists():
@@ -80,7 +83,7 @@ def resolve_legacy_paths(
         raise FileNotFoundError(f"mmproj not found: {resolved_mmproj}")
 
     return NativeLlamaPaths(
-        llama_root=resolved_llama_root,
+        llama_root=source_root,
         build_bin=build_bin,
         library=library,
         model=resolved_model,
@@ -130,3 +133,13 @@ def _resolve_native_runtime(llama_root: Path | None) -> tuple[Path | None, Path,
         f"Searched: {searched_text}. "
         "Provide --llama-root or ORBIT_LLAMA_ROOT, or package native libraries under orbit/native_llama/vendor/lib."
     )
+
+
+def _resolve_build_source_root(llama_root: Path | None) -> Path | None:
+    if llama_root is not None:
+        resolved_root = llama_root.expanduser().resolve()
+        if (resolved_root / "CMakeLists.txt").exists():
+            return resolved_root
+    if (BUNDLED_SOURCE_ROOT / "CMakeLists.txt").exists():
+        return BUNDLED_SOURCE_ROOT
+    return None

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -11,6 +11,11 @@ from .mtp_completion import MtpCompletionResult
 from .native_artifacts import packaged_shim_path, require_legacy_llama_root
 from .paths import NativeLlamaPaths
 
+_REQUIRED_SHIM_SYMBOLS = (
+    "orbit_mtp_session_complete",
+    "orbit_mtp_session_set_followup_suffix_tokens",
+)
+
 MtpTokenCallback = CFUNCTYPE(None, c_char_p, c_void_p)
 MtpProgressCallback = CFUNCTYPE(None, c_int32, c_int32, c_int32, c_void_p)
 
@@ -136,14 +141,14 @@ def build_persistent_mtp_shim(
     runner=subprocess.run,
 ) -> Path:
     packaged = packaged_shim_path("liborbit-persistent-mtp.so")
-    if packaged is not None:
+    if packaged is not None and _shim_exports_required_symbols(packaged):
         return packaged
     llama_root = require_legacy_llama_root(llama_root, artifact_name="liborbit-persistent-mtp.so")
     build_root = build_dir or (Path.home() / ".orbit" / "native-build")
     build_root.mkdir(parents=True, exist_ok=True)
     source = Path(__file__).parent / "vendor" / "shim" / "orbit_persistent_mtp.cpp"
     output = build_root / "liborbit-persistent-mtp.so"
-    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime:
+    if output.exists() and output.stat().st_mtime >= source.stat().st_mtime and _shim_exports_required_symbols(output):
         return output
 
     bin_dir = llama_root / "build/bin"
@@ -172,6 +177,17 @@ def build_persistent_mtp_shim(
         detail = (completed.stderr or completed.stdout).strip()
         raise RuntimeError(f"failed to build persistent mtp shim: {detail or completed.returncode}")
     return output
+
+
+def _shim_exports_required_symbols(path: Path) -> bool:
+    if not path.exists() or not path.is_file():
+        return False
+    flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+    try:
+        lib = ctypes.CDLL(str(path), mode=flags)
+    except OSError:
+        return False
+    return all(hasattr(lib, symbol) for symbol in _REQUIRED_SHIM_SYMBOLS)
 
 
 def create_persistent_mtp_session(

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -523,13 +523,15 @@ class ContinueEnvironment:
         return ContinueResult(result=result, used_native_continue=False, used_prompt_fallback=True)
 
     def _continuation_kind_before_continue(self) -> str | None:
-        if self.runtime.client_state.continuation_kind is not None:
-            return self.runtime.client_state.continuation_kind
         if self.runtime.client_state.last_content:
-            return self.runtime._thinking().continuation_kind_for(
+            current_kind = self.runtime._thinking().continuation_kind_for(
                 content=self.runtime.client_state.last_content,
                 finish_reason=self.runtime.client_state.last_finish_reason,
             )
+            if current_kind is not None:
+                return current_kind
+        if self.runtime.client_state.continuation_kind is not None:
+            return self.runtime.client_state.continuation_kind
         if last_assistant_has_open_reasoning(self.runtime.messages):
             return "thinking"
         if self.runtime.last_visible_finish_reason == "length":
@@ -547,12 +549,14 @@ class ContinueEnvironment:
         loop: int,
         force_disable_backend_thinking: bool = False,
     ) -> ChatResult:
-        if force_disable_backend_thinking and last_assistant_has_open_reasoning(self.runtime.messages):
+        if force_disable_backend_thinking:
             original_request = last_user_text(self.runtime.messages)
             continuation_prompt = (
                 "Stop reasoning now and write only the missing final answer. "
                 "Start the answer with 'Final answer:'. "
+                "Write exactly one short final-answer sentence. "
                 "Do not continue or repeat any thought text. "
+                "Do not explain the plan again. "
                 "No hidden reasoning, no plan, no thinking markers. "
                 + (
                     f"Answer concisely and directly to the original user request: {original_request!r}. "
@@ -591,10 +595,13 @@ class ContinueEnvironment:
                 on_model_step=on_model_step,
                 loop=loop,
             )
-        if force_disable_backend_thinking and self.runtime._thinking().continuation_kind_for(
-            content=result.content,
-            finish_reason=result.finish_reason,
-        ) is not None:
+        if force_disable_backend_thinking and (
+            self.runtime._thinking().continuation_kind_for(
+                content=result.content,
+                finish_reason=result.finish_reason,
+            ) is not None
+            or looks_like_incomplete_final(result.content)
+        ):
             result = replace(
                 result,
                 content="error: model did not produce a final answer after continuation",

--- a/src/orbit/runtime/thinking_mode.py
+++ b/src/orbit/runtime/thinking_mode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 
 
 FINAL_MARKERS = (
@@ -15,6 +16,17 @@ REASONING_PREFIXES = (
     "# reasoning",
     "reasoning:",
     "plan:",
+)
+
+_REASONING_META_KEYWORDS = (
+    "constraint",
+    "constraints",
+    "scenario",
+    "user's request",
+    "user request",
+    "looking at the prompt",
+    "drafting the response",
+    "let's assume",
 )
 
 
@@ -53,6 +65,22 @@ def looks_like_reasoning_without_final(content: str, *, thinking_enabled: bool) 
     return stripped.startswith(REASONING_PREFIXES)
 
 
+def looks_like_truncated_reasoning_prelude(content: str) -> bool:
+    stripped = content.strip().lower()
+    if not stripped:
+        return False
+    if any(marker in stripped for marker in FINAL_MARKERS):
+        return False
+    if stripped.startswith(REASONING_PREFIXES):
+        return True
+    preview = stripped[:600]
+    if any(keyword in preview for keyword in _REASONING_META_KEYWORDS):
+        return True
+    lines = [line.strip() for line in preview.splitlines() if line.strip()]
+    bullet_lines = sum(1 for line in lines[:8] if re.match(r"(?:[-*•]\s|\d+[.)]\s)", line))
+    return bullet_lines >= 2
+
+
 def looks_like_incomplete_tool_answer(content: str) -> bool:
     text = content.strip()
     if len(text) < 24:
@@ -71,6 +99,8 @@ class ThinkingMode:
 
     def continuation_kind_for(self, *, content: str, finish_reason: str | None) -> str | None:
         if looks_like_reasoning_without_final(content, thinking_enabled=self.enabled):
+            return "thinking"
+        if self.enabled and finish_reason == "length" and looks_like_truncated_reasoning_prelude(content):
             return "thinking"
         if finish_reason == "length":
             return "final_answer"

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -28,6 +28,10 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         args = build_parser().parse_args(["--mtp"])
         self.assertTrue(args.enable_mtp_experimental)
 
+    def test_parser_defaults_mtp_flag_to_off(self) -> None:
+        args = build_parser().parse_args([])
+        self.assertFalse(args.enable_mtp_experimental)
+
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_try_complete_with_mtp_experimental_falls_back_when_draft_missing(self, _mocked_lib) -> None:
         client = NativeLlamaClient(self._paths(mtp_available=False, fallback_reason="draft-mtp-missing"), NativeClientConfig(use_mtp_experimental=True))

--- a/tests/test_native_paths.py
+++ b/tests/test_native_paths.py
@@ -22,13 +22,39 @@ class NativePathsTests(unittest.TestCase):
             target.write_text("target", encoding="utf-8")
             mmproj.write_text("mmproj", encoding="utf-8")
 
-            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib):
+            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.BUNDLED_SOURCE_ROOT", root / "missing-bundled-source"
+            ):
                 paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
 
         self.assertIsNone(paths.llama_root)
         self.assertEqual(paths.build_bin, vendor_lib)
         self.assertEqual(paths.library, vendor_lib / "libllama.so")
         self.assertEqual(paths.model, target)
+
+    def test_resolves_vendored_runtime_and_preserves_bundled_source_root_for_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            vendor_lib = root / "vendor/lib"
+            bundled = root / "vendor/source/llama.cpp"
+            models_dir = root / "models"
+            target = models_dir / "ggml-org--gemma-4-12B-it-GGUF" / "gemma-4-12B-it-Q4_K_M.gguf"
+            mmproj = models_dir / "ggml-org--gemma-4-12B-it-GGUF" / "mmproj-gemma-4-12B-it-Q8_0.gguf"
+            vendor_lib.mkdir(parents=True)
+            (vendor_lib / "libllama.so").write_text("", encoding="utf-8")
+            (bundled / "CMakeLists.txt").parent.mkdir(parents=True, exist_ok=True)
+            (bundled / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.20)\n", encoding="utf-8")
+            target.parent.mkdir(parents=True)
+            target.write_text("target", encoding="utf-8")
+            mmproj.write_text("mmproj", encoding="utf-8")
+
+            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.BUNDLED_SOURCE_ROOT", bundled
+            ):
+                paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
+
+        self.assertEqual(paths.llama_root, bundled)
+        self.assertEqual(paths.build_bin, vendor_lib)
 
     def test_resolves_target_from_models_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_persistent_mtp.py
+++ b/tests/test_native_persistent_mtp.py
@@ -16,10 +16,30 @@ class NativePersistentMtpTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             packaged = Path(tmp) / "liborbit-persistent-mtp.so"
             packaged.write_text("", encoding="utf-8")
-            with mock.patch("orbit.native_llama.persistent_mtp.packaged_shim_path", return_value=packaged):
+            with mock.patch("orbit.native_llama.persistent_mtp.packaged_shim_path", return_value=packaged), mock.patch(
+                "orbit.native_llama.persistent_mtp._shim_exports_required_symbols", return_value=True
+            ):
                 shim = build_persistent_mtp_shim(llama_root=None)
 
         self.assertEqual(shim, packaged)
+
+    def test_build_persistent_shim_rebuilds_when_packaged_artifact_is_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            packaged = tmp_path / "liborbit-persistent-mtp.so"
+            packaged.write_text("stale", encoding="utf-8")
+            llama_root = tmp_path / "llama"
+            (llama_root / "build/bin").mkdir(parents=True)
+            for name in ("libllama-common.so", "libllama.so", "libggml.so", "libggml-base.so", "libggml-cpu.so"):
+                (llama_root / "build/bin" / name).write_text("", encoding="utf-8")
+            runner = mock.Mock(return_value=mock.Mock(returncode=0, stderr="", stdout=""))
+            with mock.patch("orbit.native_llama.persistent_mtp.packaged_shim_path", return_value=packaged), mock.patch(
+                "orbit.native_llama.persistent_mtp._shim_exports_required_symbols", side_effect=[False, False, True]
+            ):
+                shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=tmp_path, runner=runner)
+
+        self.assertEqual(shim, packaged)
+        runner.assert_called_once()
 
     def _paths(self, *, mtp_available: bool = True, fallback_reason: str | None = None) -> NativeLlamaPaths:
         return NativeLlamaPaths(
@@ -34,8 +54,25 @@ class NativePersistentMtpTests(unittest.TestCase):
         )
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_persistent_mtp_stays_disabled_by_default_when_experimental_flag_is_off(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client._session.ctx_tgt = object()
+
+        with mock.patch("orbit.native_llama.client.create_persistent_mtp_session") as mocked_create:
+            client._initialize_persistent_mtp_session()
+
+        snapshot = client.session_snapshot()
+        self.assertFalse(snapshot.mtp_enabled)
+        self.assertFalse(snapshot.mtp_initialized)
+        self.assertIsNone(snapshot.mtp_failure_reason)
+        mocked_create.assert_not_called()
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_persistent_mtp_stays_disabled_when_draft_is_missing(self, _mocked_lib) -> None:
-        client = NativeLlamaClient(self._paths(mtp_available=False, fallback_reason="draft-mtp-missing"), NativeClientConfig())
+        client = NativeLlamaClient(
+            self._paths(mtp_available=False, fallback_reason="draft-mtp-missing"),
+            NativeClientConfig(use_mtp_experimental=True),
+        )
         client._session.ctx_tgt = object()
 
         client._initialize_persistent_mtp_session()
@@ -48,7 +85,7 @@ class NativePersistentMtpTests(unittest.TestCase):
     @mock.patch("orbit.native_llama.client.create_persistent_mtp_session")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_persistent_mtp_initializes_and_exposes_runtime_handles(self, _mocked_lib, mocked_create) -> None:
-        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         client._session.ctx_tgt = object()
         mocked_create.return_value = PersistentMtpSessionRuntime(
             handle=object(),
@@ -71,7 +108,7 @@ class NativePersistentMtpTests(unittest.TestCase):
     @mock.patch("orbit.native_llama.client.create_persistent_mtp_session")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_persistent_mtp_records_init_failure(self, _mocked_lib, mocked_create) -> None:
-        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         client._session.ctx_tgt = object()
         mocked_create.side_effect = RuntimeError("init failed")
 
@@ -85,7 +122,7 @@ class NativePersistentMtpTests(unittest.TestCase):
     @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_reset_session_state_clears_target_cache_and_reinitializes_persistent_mtp(self, mocked_lib_cls, mocked_reset) -> None:
-        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         fake_lib = mock.Mock()
         fake_lib.llama_get_memory.return_value = object()
         mocked_lib_cls.return_value.lib = fake_lib

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -267,6 +267,83 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(backend.chat_calls, 1)
         self.assertFalse(runtime.can_continue_last_response())
 
+    def test_continue_last_response_uses_prompt_fallback_for_bullet_reasoning_length(self) -> None:
+        class BulletReasoningBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.continue_calls = 0
+                self.chat_calls = 0
+                self.thinking = True
+                self.last_messages: list[Message] = []
+
+            def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
+                self.continue_calls += 1
+                raise AssertionError("native continue should not be used for truncated reasoning prelude")
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                self.last_thinking = self.thinking
+                self.last_messages = messages
+                return ChatResult(
+                    content="Final answer: I understand and will answer concisely.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = BulletReasoningBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        runtime.messages.append(
+            {
+                "role": "assistant",
+                "content": "* Constraint 1: explain the plan.\n* Constraint 2: give the final answer.\n* Drafting the response:",
+            }
+        )
+        runtime.client_state.last_content = runtime.messages[-1]["content"]
+        runtime.last_visible_finish_reason = "length"
+
+        result = runtime.continue_last_response(temperature=0, max_tokens=32)
+
+        self.assertEqual(result.content, "Final answer: I understand and will answer concisely.")
+        self.assertEqual(backend.continue_calls, 0)
+        self.assertEqual(backend.chat_calls, 1)
+        self.assertFalse(backend.last_thinking)
+        self.assertIn("Stop reasoning now and write only the missing final answer.", backend.last_messages[-2]["content"])
+        self.assertIn("Write exactly one short final-answer sentence.", backend.last_messages[-2]["content"])
+
+    def test_continue_last_response_returns_controlled_error_if_forced_final_is_incomplete(self) -> None:
+        class IncompleteForcedFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.thinking = True
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                return ChatResult(
+                    content="Final answer: I will now provide a concise final",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = IncompleteForcedFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        runtime.messages.append({"role": "assistant", "content": "### Reasoning\npartial"})
+
+        result = runtime.continue_last_response(temperature=0, max_tokens=32)
+
+        self.assertEqual(result.content, "error: model did not produce a final answer after continuation")
+        self.assertFalse(runtime.can_continue_last_response())
+
     def test_continue_last_response_uses_native_backend_continuation_after_length_even_without_open_reasoning(self) -> None:
         class NativeContinueBackend(FakeBackend):
             def __init__(self) -> None:


### PR DESCRIPTION
Summary

This PR makes the native Orbit server default to no-MTP while keeping `--mtp` available as an explicit opt-in.

Default behavior

- `orbit server` starts in the stable no-MTP path by default.
- `/props` reports:
  - `backend_mode=no-mtp`
  - `mtp_enabled=false`
  - `mtp_initialized=false`
  - `mtp_failure_reason=null`
- Orbit default runtime remains independent from `llama-server`.

`--mtp` opt-in behavior

- `orbit server --mtp` enables native MTP explicitly.
- Stale vendored persistent-MTP shim artifacts are detected and rebuilt when required symbols are missing.
- `/props` reports:
  - `backend_mode=mtp-ready`
  - `mtp_enabled=true`
  - `mtp_initialized=true`
  - `mtp_failure_reason=null`
- One-shot MTP and first-turn chat MTP remain available.
- Follow-up chat safety fallback remains active by default.
- Raw frontier multi-turn reuse remains debug-only and is not promoted.

Validation

- `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
- `PYTHONPATH=src python3 -m unittest tests.test_native_paths tests.test_native_streaming tests.test_native_thinking tests.test_native_mtp_experimental tests.test_native_session_state tests.test_native_persistent_mtp -q` PASS
- `python3 -m compileall -q src tests scripts` PASS
- `git diff --check` PASS

Smoke matrix

Default no-MTP:

- `/health` PASS
- `/props` PASS
- chat think off PASS
- chat think on PASS
- `/continue think on` PASS
- runtime independence from `llama-server` confirmed

MTP opt-in:

- `orbit server --mtp` PASS
- `/props` PASS
- one-shot MTP PASS
- first-turn chat MTP PASS
- follow-up safety path PASS
- no `s,t,e,p...`
- no `empty-visible-content`

Residual risks

- `think on` may still be slower for reasoning-heavy prompts.
- Raw frontier multi-turn reuse remains debug-only.

Final decision

Release candidate.
