### PR TITLE
Stabilize no-MTP release path and PDF recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ pip install -e .
 
 This installs the Python package and CLI. It does not yet guarantee a fully self-contained native backend on a fresh machine.
 
+### What a fresh checkout still needs today
+
+Orbit already owns the Python CLI, model download, and the native server entrypoint. What it does not yet ship by itself is the full native `llama.cpp` runtime.
+
+Today, a clean checkout still needs one of these:
+
+- packaged native libraries under `src/orbit/native_llama/vendor/lib`
+- or a local `llama.cpp` build tree passed with `--llama-root`
+- or the same path exported through `ORBIT_LLAMA_ROOT`
+
+Example:
+
+```bash
+orbit server --port 11976 --llama-root /path/to/llama.cpp
+```
+
+If you enable `--mtp`, Orbit may also rebuild a local MTP shim from the same `llama.cpp` tree when no packaged shim is available.
+
 ### 2. Download models
 
 Download only the target model:
@@ -94,6 +112,12 @@ Stable default server, with MTP disabled:
 orbit server --port 11976
 ```
 
+If native libraries are not packaged inside Orbit yet, use:
+
+```bash
+orbit server --port 11976 --llama-root /path/to/llama.cpp
+```
+
 Optional MTP mode:
 
 ```bash
@@ -122,6 +146,7 @@ What this means:
 - `orbit server` starts the stable native backend without MTP.
 - `orbit server --mtp` enables the experimental MTP path explicitly.
 - MTP can improve some workloads, but Orbit keeps it off by default because stability has priority.
+- if native libs are missing, Orbit now exits with a short error telling you to use `--llama-root` or `ORBIT_LLAMA_ROOT`
 - experimental multi-turn raw MTP chat reuse remains debug-only behind:
   - `ORBIT_MTP_CHAT_REUSE_RAW=1`
   - `ORBIT_MTP_CHAT_REUSE_DEBUG=1`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Minimal local CLI for running Gemma 4 with the native `orbit-server`.
 Orbit is designed for local execution, streaming output, optional shell tools, and a simple terminal workflow. The normal Orbit setup does not require an external `llama-server` process at runtime.
 
 Important status note:
-the native backend is the primary Orbit path, but a fresh clone is not yet a zero-build product. Today, Orbit still expects native `llama`/`ggml` components to be available locally, and some MTP paths still rebuild a local shim when needed. See [docs/NATIVE_PACKAGING_ROADMAP.md](docs/NATIVE_PACKAGING_ROADMAP.md).
+the native backend is the primary Orbit path, but a fresh clone still needs native prerequisites. Today, Orbit still expects `llama.cpp`-derived native `llama`/`ggml` components to be available locally, and some MTP paths still rebuild a local shim when needed. See [docs/NATIVE_PACKAGING_ROADMAP.md](docs/NATIVE_PACKAGING_ROADMAP.md).
 
 Linux is the main target environment. macOS may work. Windows is not a target environment.
 
@@ -52,7 +52,7 @@ python3 -m venv .venv
 pip install -e .
 ```
 
-This installs the Python package and CLI. It does not yet guarantee a fully self-contained native backend on a fresh machine.
+This installs the Python package and CLI. It does not yet guarantee that a fresh machine already has the native libraries Orbit needs.
 
 ### What a fresh checkout still needs today
 

--- a/docs/NATIVE_PACKAGING_ROADMAP.md
+++ b/docs/NATIVE_PACKAGING_ROADMAP.md
@@ -15,7 +15,7 @@ Today, a fresh clone still depends on:
 - a prepared `llama.cpp` build tree with `libllama.so`, `libllama-common.so`, and `ggml` libraries
 - local native helper or shim compilation for some MTP paths
 
-That means Orbit is already independent from `llama-server` as a backend choice, but it is not yet a zero-build product for a new user.
+That means Orbit does not require an external `llama-server` runtime process, but it is not yet a packaged no-prerequisite product for a new user.
 
 ## Current bootstrap contract
 
@@ -129,7 +129,7 @@ Acceptance:
 ### Milestone 3. Packaged native libs
 
 Goal:
-- make the native backend self-contained from Orbit’s point of view
+- make the native backend start from Orbit-owned packaged artifacts instead of requiring a separate local native build tree
 
 Deliverables:
 - packaged `libllama`, `libllama-common`, `ggml`, and `mtmd` runtime libraries
@@ -197,7 +197,7 @@ all work with no manual path entry on a supported packaged install.
 - Native ABI drift is the main packaging risk.
 - Shipping mismatched `llama` and shim binaries is worse than keeping the current explicit dependency.
 - Linux should remain the first supported packaging target.
-- macOS should be treated as follow-up, not as part of the first self-contained product milestone.
+- macOS should be treated as follow-up, not as part of the first fully packaged native product milestone.
 
 ## Release criterion for “Orbit is autonomous”
 

--- a/docs/NATIVE_PACKAGING_ROADMAP.md
+++ b/docs/NATIVE_PACKAGING_ROADMAP.md
@@ -17,6 +17,21 @@ Today, a fresh clone still depends on:
 
 That means Orbit is already independent from `llama-server` as a backend choice, but it is not yet a zero-build product for a new user.
 
+## Current bootstrap contract
+
+Today, `orbit server` can start in three ways:
+
+1. packaged native runtime libraries already exist under `src/orbit/native_llama/vendor/lib`
+2. `ORBIT_LLAMA_ROOT` points to a prepared local `llama.cpp` tree
+3. the user passes `--llama-root /path/to/llama.cpp`
+
+For MTP paths, Orbit also needs either:
+
+- a packaged shim under `src/orbit/native_llama/vendor/shim`
+- or a buildable local `llama.cpp` tree so the shim can be rebuilt explicitly
+
+If these prerequisites are missing, the release path should fail with a short actionable error, not a Python stacktrace.
+
 ## Target UX
 
 The intended product path is:

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -92,8 +92,8 @@ Use only in a safe workdir or isolated lab:
 28. `Check whether strings, file, readelf, objdump, jadx, and apktool are available on this system, then say which ones are present.`
 29. `Extract printable strings from samples/suspicious_dropper_demo.js and report suspicious network or execution-related strings.`
 30. `Create a temporary lab directory named shell-lab-test, write a marker file containing "orbit-ok" inside it, show the marker contents, and then remove the directory.`
-31. `Read pdf/small.pdf and summarize the document topic in one concise sentence.`
-32. `Read pdf/big.pdf and summarize the document topic in one concise sentence.`
+31. `Read pdf/piccolo.pdf and summarize the document topic in one concise sentence.`
+32. `Read pdf/grande.pdf and summarize the document topic in one concise sentence.`
 
 Expected: command chosen by the model, bounded evidence, concise final answer.
 

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -6,6 +6,7 @@ import select
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import socket
+import sys
 import threading
 import time
 from typing import Any
@@ -530,26 +531,30 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
 def run_server(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
-    paths = resolve_bootstrap_paths(args)
-    client = NativeLlamaClient(
-        paths,
-        NativeClientConfig(
-            context_tokens=args.ctx,
-            threads=args.threads,
-            threads_batch=args.threads_batch,
-            batch_size=args.batch,
-            ubatch_size=args.ubatch,
-            thinking=args.think == "on",
-            mtp_probe_enabled=args.enable_mtp_probe,
-            mtp_dry_run_enabled=args.enable_mtp_dry_run,
-            mtp_accept_probe_enabled=args.enable_mtp_accept_probe,
-            mtp_decode_probe_enabled=args.enable_mtp_decode_probe,
-            use_mtp_experimental=args.enable_mtp_experimental,
-        ),
-    )
-    if not args.verbose_llama_log:
-        client.set_quiet_logging()
-    client.load()
+    try:
+        paths = resolve_bootstrap_paths(args)
+        client = NativeLlamaClient(
+            paths,
+            NativeClientConfig(
+                context_tokens=args.ctx,
+                threads=args.threads,
+                threads_batch=args.threads_batch,
+                batch_size=args.batch,
+                ubatch_size=args.ubatch,
+                thinking=args.think == "on",
+                mtp_probe_enabled=args.enable_mtp_probe,
+                mtp_dry_run_enabled=args.enable_mtp_dry_run,
+                mtp_accept_probe_enabled=args.enable_mtp_accept_probe,
+                mtp_decode_probe_enabled=args.enable_mtp_decode_probe,
+                use_mtp_experimental=args.enable_mtp_experimental,
+            ),
+        )
+        if not args.verbose_llama_log:
+            client.set_quiet_logging()
+        client.load()
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(_format_native_bootstrap_error(exc), file=sys.stderr)
+        return 1
 
     httpd = ThreadingHTTPServer((args.host, args.port), OrbitNativeHandler)
     httpd.orbit_state = OrbitNativeServer(client=client, model_alias=args.alias)  # type: ignore[attr-defined]
@@ -620,6 +625,25 @@ def resolve_bootstrap_paths(args: argparse.Namespace) -> NativeLlamaPaths:
         models_dir=args.models_dir,
         hf_cache=args.hf_cache,
     )
+
+
+def _format_native_bootstrap_error(exc: Exception) -> str:
+    detail = str(exc).strip() or exc.__class__.__name__
+    if "libllama.so not found" in detail:
+        return (
+            "error: native backend libraries are missing.\n"
+            f"detail: {detail}\n"
+            "hint: provide --llama-root /path/to/llama.cpp, or set ORBIT_LLAMA_ROOT, "
+            "or package native libraries under src/orbit/native_llama/vendor/lib."
+        )
+    if "missing native build inputs for" in detail:
+        return (
+            "error: native MTP shim inputs are missing.\n"
+            f"detail: {detail}\n"
+            "hint: use --llama-root /path/to/llama.cpp (or ORBIT_LLAMA_ROOT) so Orbit can rebuild "
+            "the required shim, or package the shim under src/orbit/native_llama/vendor/shim."
+        )
+    return f"error: failed to start native backend: {detail}"
 
 
 def _session_id_from_payload(payload: dict[str, Any]) -> str:

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -265,15 +265,39 @@ def build_shell_full_file_recovery_guard_prompt(
     requested_path: str,
     last_error: str | None,
     candidate_paths: list[str],
+    requested_path_exists: bool = False,
+    last_command: str | None = None,
+    last_failure_content: str | None = None,
 ) -> str:
     details = [f"Requested file: {requested_path}"]
+    if requested_path_exists:
+        details.append("Requested file currently exists in the workdir: yes")
     if last_error:
         details.append(f"Direct read failure: {last_error}")
+    failure = shell_failure_from_output(last_failure_content or "")
+    if last_command:
+        details.append(f"Last failed command: {last_command}")
+    if failure is not None:
+        details.append(f"Last exit code: {failure.exit_code}")
+        if failure.stderr:
+            details.append(f"Last stderr: {_bounded_stream(failure.stderr)}")
+        elif failure.stdout:
+            details.append(f"Last stdout: {_bounded_stream(failure.stdout)}")
     if candidate_paths:
         details.append("Candidate paths from prior discovery:")
         details.extend(f"- {path}" for path in candidate_paths[:5])
     else:
         details.append("Candidate paths from prior discovery: none")
+    if requested_path_exists and requested_path.lower().endswith(".pdf"):
+        details.append("No usable content has been extracted from the requested PDF yet.")
+        details.append("Do not conclude that the file is missing or unreadable yet.")
+        details.append("Verify the file path in the workdir, then use a simple PDF text extractor if available, preferably pdftotext.")
+        details.append("If pdftotext is unavailable or still fails, try a minimal text fallback such as strings.")
+        details.append("Avoid specialist PDF utilities when the goal is only to read text and summarize the document.")
+        details.append("Use only text actually extracted from the file in the final answer.")
+    elif requested_path_exists:
+        details.append("No usable content has been extracted from the requested file yet.")
+        details.append("Do not conclude that the file is missing or unreadable yet.")
     return f"{SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX}\n\n" + "\n".join(details)
 
 

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -204,7 +204,12 @@ def run_tool_loop(
                 return True
         return False
 
-    def request_file_recovery_guard() -> None:
+    def request_file_recovery_guard(
+        *,
+        last_command: str | None = None,
+        last_failure_content: str | None = None,
+        requested_path_exists: bool = False,
+    ) -> None:
         if not turn.requested_user_path:
             return
         turn.pending_file_recovery_guard = True
@@ -213,6 +218,9 @@ def run_tool_loop(
             requested_path=turn.requested_user_path,
             last_error=turn.last_error,
             candidate_paths=turn.candidate_paths,
+            requested_path_exists=requested_path_exists,
+            last_command=last_command,
+            last_failure_content=last_failure_content,
         )
 
     def has_pending_internal_request() -> bool:
@@ -290,7 +298,12 @@ def run_tool_loop(
                 runtime.content_evidence_guard_failures += 1
             return
         if is_shell_full_execution_error(tool_result.content):
-            if tool_output_kind == "file_not_found":
+            direct_requested_read_failed = bool(
+                turn.requested_user_path
+                and command
+                and _looks_like_direct_requested_read(command, turn.requested_user_path)
+            )
+            if tool_output_kind == "file_not_found" or direct_requested_read_failed:
                 turn.mark_direct_read_failed(_summarize_shell_error(tool_result.content))
             if is_mutation_verification:
                 if (
@@ -319,6 +332,21 @@ def run_tool_loop(
                 runtime.mutation_semantic_repair_failures += 1
                 repair.shell_error_final_pending = True
                 turn.mark_exhausted()
+                return
+            requested_path_exists = _requested_user_path_exists(turn.requested_user_path, workdir=workdir)
+            requested_pdf_path = bool(turn.requested_user_path and turn.requested_user_path.lower().endswith(".pdf"))
+            if (
+                is_repairable_shell_error(tool_result.content)
+                and direct_requested_read_failed
+                and requested_pdf_path
+                and requested_path_exists
+                and turn.can_reconsider(RECONSIDER_FILE_RECOVERY)
+            ):
+                request_file_recovery_guard(
+                    last_command=command,
+                    last_failure_content=tool_result.content,
+                    requested_path_exists=True,
+                )
                 return
             if is_repairable_shell_error(tool_result.content) and repair.shell_repair_retries < MAX_SHELL_REPAIR_RETRIES:
                 repair.shell_repair_retries += 1
@@ -825,6 +853,18 @@ def _extract_requested_user_path(prompt: str | None) -> str | None:
         if candidate:
             return candidate.strip()
     return None
+
+
+def _requested_user_path_exists(requested_path: str | None, *, workdir) -> bool:
+    if not requested_path:
+        return False
+    root = Path(workdir).expanduser().resolve()
+    target = (root / requested_path).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return False
+    return target.is_file()
 
 
 def _looks_like_discovery_command(command: str) -> bool:

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest import mock
 
-from orbit.native_server.app import build_parser, resolve_bootstrap_paths
+from orbit.native_server.app import build_parser, resolve_bootstrap_paths, run_server
 
 
 class NativeServerBootstrapTests(unittest.TestCase):
@@ -113,6 +115,38 @@ class NativeServerBootstrapTests(unittest.TestCase):
             args = build_parser().parse_args(["--llama-root", str(llama_root), "--model-id", "gemma4-12b-it-q4km", "--models-dir", str(root / "models"), "--hf-cache", str(root / "hf")])
             with self.assertRaises(FileNotFoundError):
                 resolve_bootstrap_paths(args)
+
+    def test_run_server_reports_clear_error_when_native_runtime_is_missing(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch(
+            "orbit.native_server.app.resolve_bootstrap_paths",
+            side_effect=FileNotFoundError("libllama.so not found. Searched: /missing/libllama.so."),
+        ):
+            with redirect_stderr(stderr):
+                code = run_server([])
+
+        self.assertEqual(code, 1)
+        output = stderr.getvalue()
+        self.assertIn("error: native backend libraries are missing.", output)
+        self.assertIn("--llama-root", output)
+        self.assertIn("ORBIT_LLAMA_ROOT", output)
+
+    def test_run_server_reports_clear_error_when_mtp_shim_inputs_are_missing(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as mocked_paths, mock.patch(
+            "orbit.native_server.app.NativeLlamaClient"
+        ) as mocked_client:
+            mocked_paths.return_value = mock.Mock()
+            mocked_client.return_value.load.side_effect = RuntimeError(
+                "missing native build inputs for liborbit-persistent-mtp.so"
+            )
+            with redirect_stderr(stderr):
+                code = run_server(["--mtp"])
+
+        self.assertEqual(code, 1)
+        output = stderr.getvalue()
+        self.assertIn("error: native MTP shim inputs are missing.", output)
+        self.assertIn("--llama-root", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ import json
 import unittest
 import tempfile
 from pathlib import Path
+from shutil import copyfile
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -1591,6 +1592,83 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn("Requested file: vulnerable_service.py", backend.guard_messages[-1]["content"])
         self.assertIn("Direct read failure:", backend.guard_messages[-1]["content"])
         self.assertIn("./samples/vulnerable_service.py", backend.guard_messages[-1]["content"])
+
+    def test_pdf_recovery_guard_prefers_robust_text_extraction_without_auto_running_it(self) -> None:
+        class PdfRecoveryBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.guard_messages: list[Message] | None = None
+                self.generic_shell_repairs = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                last_content = str(messages[-1].get("content"))
+                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                    self.guard_messages = messages
+                if "The previous shell command failed." in last_content:
+                    self.generic_shell_repairs += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content=json.dumps({"command": "pdffind pdf/grande.pdf"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content=json.dumps({"command": "pdftotext pdf/grande.pdf - | head -n 20"}),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The document is a presentation about eIDAS regulation and identity proofing.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=10,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "pdf").mkdir()
+            copyfile(ROOT / "workdir" / "pdf" / "grande.pdf", workdir / "pdf" / "grande.pdf")
+            backend = PdfRecoveryBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "Read pdf/grande.pdf and summarize the document topic in one concise sentence.",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertIn("identity proofing", result.content.lower())
+        self.assertIsNotNone(backend.guard_messages)
+        self.assertEqual(backend.generic_shell_repairs, 0)
+        guard = str(backend.guard_messages[-1]["content"])
+        self.assertIn("Requested file: pdf/grande.pdf", guard)
+        self.assertIn("Requested file currently exists in the workdir: yes", guard)
+        self.assertIn("Last failed command: pdffind pdf/grande.pdf", guard)
+        self.assertIn("Last exit code:", guard)
+        self.assertIn("preferably pdftotext", guard)
+        self.assertIn("fallback such as strings", guard)
+        self.assertIn("Do not conclude that the file is missing or unreadable yet.", guard)
 
     def test_file_recovery_guard_allows_final_not_found_answer(self) -> None:
         class MissingFileBackend:


### PR DESCRIPTION
Summary:

* Keeps Orbit default server path no-MTP.
* Clarifies that Orbit does not require an external `llama-server` runtime process.
* Clarifies that native llama.cpp/ggml-derived libraries are still required until vendored self-build packaging is implemented.
* Aligns PROMPTS.md with real PDF fixtures: `pdf/piccolo.pdf` and `pdf/grande.pdf`.
* Adds bounded model-guided PDF recovery for local PDF reads.
* Suggests robust extraction strategies such as `pdftotext` and `strings` without executing them deterministically.
* Prevents premature negative answers when a local PDF exists but no content evidence has been extracted.
* Keeps MTP opt-in and raw multi-turn reuse debug-only.

Validation:

* `tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl`: PASS
* `tests.test_native_paths tests.test_native_streaming tests.test_native_thinking tests.test_native_mtp_experimental tests.test_native_session_state tests.test_native_persistent_mtp tests.test_native_server_bootstrap`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS

Smoke:

* `/props` default no-MTP: PASS
* `pdf/piccolo.pdf`: PASS
* `pdf/grande.pdf`: PASS semantic
* shell `pwd`: PASS
* `text/summary.txt`: PASS
* no external `llama-server` process used

Residual caveats:

* Large PDF summaries can still be slow in `final_from_tool`.
* Large PDF final answers may be more verbose than “one concise sentence”.
* Native llama.cpp/ggml-derived libraries remain a documented prerequisite until vendored self-build packaging is implemented.

Decision:

* RC PASS
