### PR TITLE
Show native build progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,26 +106,26 @@ orbit download --all ggml-org/gemma-4-12B-it-GGUF
 Stable default server, with MTP disabled:
 
 ```bash
-orbit server --port 11976
+orbit server --port 12120
 ```
 
 If native libraries are not packaged inside Orbit yet, use:
 
 ```bash
-orbit server --port 11976 --llama-root /path/to/llama.cpp
+orbit server --port 12120 --llama-root /path/to/llama.cpp
 ```
 
 Optional MTP mode:
 
 ```bash
-orbit server --port 11976 --mtp
+orbit server --port 12120 --mtp
 ```
 
 With a multimodal projector:
 
 ```bash
 orbit server \
-  --port 11976 \
+  --port 12120 \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
 
@@ -133,7 +133,7 @@ You can combine MTP and multimodal flags when both artifacts are available:
 
 ```bash
 orbit server \
-  --port 11976 \
+  --port 12120 \
   --mtp \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
@@ -153,7 +153,7 @@ What this means:
 After startup, you can verify that the server is healthy:
 
 ```bash
-orbit --base-url http://127.0.0.1:11976 --health
+orbit --base-url http://127.0.0.1:12120 --health
 ```
 
 Inside the interactive client, you can inspect backend state with:
@@ -174,7 +174,7 @@ Expected `/props` values:
 ### 5. Start Orbit
 
 ```bash
-orbit --base-url http://127.0.0.1:11976
+orbit --base-url http://127.0.0.1:12120
 ```
 
 Inside Orbit, tools are off by default:
@@ -186,9 +186,9 @@ Inside Orbit, tools are off by default:
 ## One-shot usage
 
 ```bash
-orbit --base-url http://127.0.0.1:11976 "Say who you are in one short sentence."
-orbit --base-url http://127.0.0.1:11976 --image workdir/media/image1.jpg "Describe this image."
-orbit --base-url http://127.0.0.1:11976 --audio workdir/media/audio1.wav "Transcribe or summarize this audio."
+orbit --base-url http://127.0.0.1:12120 "Say who you are in one short sentence."
+orbit --base-url http://127.0.0.1:12120 --image workdir/media/image1.jpg "Describe this image."
+orbit --base-url http://127.0.0.1:12120 --audio workdir/media/audio1.wav "Transcribe or summarize this audio."
 ```
 
 ## Thinking mode

--- a/docs/NATIVE_PACKAGING_ROADMAP.md
+++ b/docs/NATIVE_PACKAGING_ROADMAP.md
@@ -41,7 +41,7 @@ The intended product path is:
 pip install orbit
 python scripts/build_native.py
 orbit download --all
-orbit server --port 11976
+orbit server --port 12120
 orbit
 ```
 
@@ -182,8 +182,8 @@ Deliverables:
 
 Acceptance:
 - `orbit download --all`
-- `orbit server --port 11976`
-- `orbit server --port 11976 --mtp`
+- `orbit server --port 12120`
+- `orbit server --port 12120 --mtp`
 
 all work with no manual path entry on a supported packaged install.
 

--- a/scripts/suggest-server-profile.sh
+++ b/scripts/suggest-server-profile.sh
@@ -166,7 +166,7 @@ cat <<EOF
 # These values are suggestions for orbit server. Review them before exporting.
 # Typical use:
 #   export THREADS=$THREADS BATCH_SIZE=$BATCH_SIZE UBATCH_SIZE=$UBATCH_SIZE CACHE_RAM=$CACHE_RAM
-#   orbit server --port 11976 --mtp
+#   orbit server --port 12120 --mtp
 
 export THREADS=$THREADS
 export BATCH_SIZE=$BATCH_SIZE

--- a/src/orbit/native_llama/build_cli.py
+++ b/src/orbit/native_llama/build_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import collections
+import queue
 import shutil
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 from .build_support import BUNDLED_SOURCE_ROOT, DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_ROOT, validate_llama_source_root
@@ -44,22 +48,39 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Build packaged MTP helper binaries and shim artifacts under vendor/shim. This is included by default for a full native build.",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Stream full configure/build command output.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Reduce output to errors and final success summary.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.verbose and args.quiet:
+        print("error: --verbose and --quiet cannot be used together", file=sys.stderr)
+        return 1
     source_root_or_error = _resolve_source_root(args.source_dir, args.llama_root)
     if isinstance(source_root_or_error, str):
         print(f"error: {source_root_or_error}", file=sys.stderr)
         return 1
     source_root = source_root_or_error
+    reporter = BuildReporter(verbose=args.verbose, quiet=args.quiet)
+    started_at = time.monotonic()
+    reporter.phase("checking toolchain")
     cmake = shutil.which("cmake")
     if not cmake:
         print("error: cmake not found in PATH", file=sys.stderr)
         return 1
 
     build_dir = DEFAULT_VENDOR_BUILD_ROOT
+    reporter.phase("preparing source/build dirs")
     if args.clean and build_dir.exists():
         shutil.rmtree(build_dir)
 
@@ -88,8 +109,11 @@ def main(argv: list[str] | None = None) -> int:
         build_cmd.extend(["-j", str(args.jobs)])
 
     try:
-        _run(configure_cmd)
-        _run(build_cmd)
+        reporter.phase("configuring CMake")
+        _run(configure_cmd, reporter=reporter, heartbeat_label="configuring CMake")
+        reporter.phase("building native libraries")
+        _run(build_cmd, reporter=reporter, heartbeat_label="building native libraries")
+        reporter.phase("copying/verifying libraries")
         _copy_runtime_libraries(DEFAULT_VENDOR_BUILD_BIN)
         _build_packaged_shims(source_root, DEFAULT_VENDOR_BUILD_BIN)
         missing = [name for name in platform_runtime_libs() if not (DEFAULT_VENDOR_LIB_DIR / name).exists()]
@@ -99,10 +123,13 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
+        duration = _format_elapsed(time.monotonic() - started_at)
         print(f"native runtime built from {source_root}", flush=True)
         print(f"packaged runtime libraries: {DEFAULT_VENDOR_LIB_DIR}", flush=True)
         print(f"packaged MTP shims: {DEFAULT_VENDOR_SHIM_DIR}", flush=True)
-        print("next: orbit server --port 11976", flush=True)
+        print(f"verified runtime libraries: {', '.join(platform_runtime_libs())}", flush=True)
+        print(f"completed in {duration}", flush=True)
+        print("next: orbit server --port 12120", flush=True)
         return 0
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -128,11 +155,101 @@ def _validate_llama_root(root: Path) -> Path | str:
     return validate_llama_source_root(root)
 
 
-def _run(command: list[str]) -> None:
-    completed = subprocess.run(command, text=True, capture_output=True, check=False)
-    if completed.returncode != 0:
-        detail = (completed.stderr or completed.stdout).strip()
-        raise RuntimeError(detail or f"command failed: {' '.join(command)}")
+class BuildReporter:
+    def __init__(self, *, verbose: bool, quiet: bool) -> None:
+        self.verbose = verbose
+        self.quiet = quiet
+
+    def phase(self, name: str) -> None:
+        if self.quiet:
+            return
+        print(f"==> {name}", flush=True)
+
+    def heartbeat(self, label: str, elapsed_seconds: float) -> None:
+        if self.quiet or self.verbose:
+            return
+        print(f"... still {label} ({int(elapsed_seconds)}s elapsed)", flush=True)
+
+    def line(self, text: str) -> None:
+        if self.quiet:
+            return
+        if self.verbose or _is_important_build_line(text):
+            print(text, flush=True)
+
+
+def _run(command: list[str], *, reporter: BuildReporter, heartbeat_label: str) -> None:
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert process.stdout is not None
+    output_queue: queue.Queue[str | None] = queue.Queue()
+    output_tail: collections.deque[str] = collections.deque(maxlen=20)
+    reader = threading.Thread(target=_enqueue_process_output, args=(process.stdout, output_queue), daemon=True)
+    reader.start()
+    start = time.monotonic()
+    last_heartbeat_at = start
+
+    while True:
+        try:
+            line = output_queue.get(timeout=1.0)
+        except queue.Empty:
+            line = None
+            now = time.monotonic()
+            if process.poll() is None and now - last_heartbeat_at >= 20:
+                reporter.heartbeat(heartbeat_label, now - start)
+                last_heartbeat_at = now
+        if isinstance(line, str):
+            text = line.rstrip()
+            output_tail.append(text)
+            reporter.line(text)
+            continue
+        if line is None and process.poll() is not None:
+            break
+
+    returncode = process.wait()
+    reader.join(timeout=1.0)
+    if returncode != 0:
+        tail = "\n".join(entry for entry in output_tail if entry)
+        detail = tail or f"command failed: {' '.join(command)}"
+        raise RuntimeError(
+            f"command failed with exit code {returncode}: {' '.join(command)}"
+            + (f"\nlast output:\n{detail}" if detail else "")
+        )
+
+
+def _enqueue_process_output(stream, output_queue: queue.Queue[str | None]) -> None:
+    try:
+        for line in iter(stream.readline, ""):
+            output_queue.put(line)
+    finally:
+        output_queue.put(None)
+
+
+def _is_important_build_line(text: str) -> bool:
+    lowered = text.lower()
+    return (
+        "built target" in lowered
+        or lowered.startswith("-- configuring done")
+        or lowered.startswith("-- generating done")
+        or lowered.startswith("-- build files have been written")
+        or "error:" in lowered
+        or "warning:" in lowered
+    )
+
+
+def _format_elapsed(seconds: float) -> str:
+    total = int(seconds)
+    minutes, secs = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
 
 
 def _copy_runtime_libraries(build_bin: Path) -> None:

--- a/tests/test_native_build_cli.py
+++ b/tests/test_native_build_cli.py
@@ -55,6 +55,15 @@ class NativeBuildCliTests(unittest.TestCase):
         self.assertTrue(args.with_mtp_shim)
         self.assertEqual(args.jobs, 4)
 
+    def test_parser_accepts_verbose_and_quiet(self) -> None:
+        args = build_cli.build_parser().parse_args(["--verbose", "--jobs", "2"])
+        self.assertTrue(args.verbose)
+        self.assertFalse(args.quiet)
+
+        args = build_cli.build_parser().parse_args(["--quiet"])
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+
     def test_resolve_source_root_uses_bundled_tree_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "bundled"
@@ -65,6 +74,141 @@ class NativeBuildCliTests(unittest.TestCase):
                 resolved = build_cli._resolve_source_root(None, None)
 
         self.assertEqual(resolved, root)
+
+    def test_main_rejects_verbose_and_quiet_together(self) -> None:
+        stream = io.StringIO()
+        with contextlib.redirect_stderr(stream):
+            code = build_cli.main(["--verbose", "--quiet"])
+
+        self.assertEqual(code, 1)
+        self.assertIn("--verbose and --quiet cannot be used together", stream.getvalue())
+
+    def test_run_verbose_streams_output(self) -> None:
+        reporter = build_cli.BuildReporter(verbose=True, quiet=False)
+        stream = io.StringIO()
+
+        class FakeStdout:
+            def readline(self) -> str:
+                return ""
+
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.stdout = FakeStdout()
+                self._poll_calls = 0
+
+            def poll(self) -> int | None:
+                self._poll_calls += 1
+                return 0 if self._poll_calls > 1 else None
+
+            def wait(self) -> int:
+                return 0
+
+        def fake_enqueue(_stream, output_queue):
+            output_queue.put("line one\n")
+            output_queue.put("line two\n")
+            output_queue.put(None)
+
+        with (
+            mock.patch("orbit.native_llama.build_cli.subprocess.Popen", return_value=FakeProcess()),
+            mock.patch("orbit.native_llama.build_cli._enqueue_process_output", side_effect=fake_enqueue),
+            contextlib.redirect_stdout(stream),
+        ):
+            build_cli._run(["cmake", "--build", "x"], reporter=reporter, heartbeat_label="building")
+
+        text = stream.getvalue()
+        self.assertIn("line one", text)
+        self.assertIn("line two", text)
+
+    def test_run_quiet_suppresses_heartbeat_and_lines(self) -> None:
+        reporter = build_cli.BuildReporter(verbose=False, quiet=True)
+        stream = io.StringIO()
+
+        class FakeStdout:
+            def readline(self) -> str:
+                return ""
+
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.stdout = FakeStdout()
+                self._poll_calls = 0
+
+            def poll(self) -> int | None:
+                self._poll_calls += 1
+                return 0 if self._poll_calls > 1 else None
+
+            def wait(self) -> int:
+                return 0
+
+        def fake_enqueue(_stream, output_queue):
+            output_queue.put("Built target llama\n")
+            output_queue.put(None)
+
+        with (
+            mock.patch("orbit.native_llama.build_cli.subprocess.Popen", return_value=FakeProcess()),
+            mock.patch("orbit.native_llama.build_cli._enqueue_process_output", side_effect=fake_enqueue),
+            contextlib.redirect_stdout(stream),
+        ):
+            build_cli._run(["cmake", "--build", "x"], reporter=reporter, heartbeat_label="building")
+
+        self.assertEqual(stream.getvalue(), "")
+
+    def test_run_failure_reports_command_exit_code_and_tail(self) -> None:
+        reporter = build_cli.BuildReporter(verbose=False, quiet=False)
+
+        class FakeStdout:
+            def readline(self) -> str:
+                return ""
+
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.stdout = FakeStdout()
+                self._poll_calls = 0
+
+            def poll(self) -> int | None:
+                self._poll_calls += 1
+                return 7 if self._poll_calls > 1 else None
+
+            def wait(self) -> int:
+                return 7
+
+        def fake_enqueue(_stream, output_queue):
+            output_queue.put("first line\n")
+            output_queue.put("last useful line\n")
+            output_queue.put(None)
+
+        with (
+            mock.patch("orbit.native_llama.build_cli.subprocess.Popen", return_value=FakeProcess()),
+            mock.patch("orbit.native_llama.build_cli._enqueue_process_output", side_effect=fake_enqueue),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                build_cli._run(["cmake", "--build", "x"], reporter=reporter, heartbeat_label="building")
+
+        message = str(ctx.exception)
+        self.assertIn("exit code 7", message)
+        self.assertIn("cmake --build x", message)
+        self.assertIn("last useful line", message)
+
+    def test_main_success_prints_updated_next_port(self) -> None:
+        stream = io.StringIO()
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            contextlib.redirect_stdout(stream),
+        ):
+            root = Path(tmp) / "bundled"
+            root.mkdir(parents=True)
+            (root / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.10)\n", encoding="utf-8")
+            with (
+                mock.patch("orbit.native_llama.build_cli.BUNDLED_SOURCE_ROOT", root),
+                mock.patch("orbit.native_llama.build_cli.shutil.which", return_value="/usr/bin/cmake"),
+                mock.patch("orbit.native_llama.build_cli._run"),
+                mock.patch("orbit.native_llama.build_cli._copy_runtime_libraries"),
+                mock.patch("orbit.native_llama.build_cli._build_packaged_shims"),
+                mock.patch("orbit.native_llama.build_cli.platform_runtime_libs", return_value=[]),
+            ):
+                code = build_cli.main(["--quiet"])
+
+        self.assertEqual(code, 0)
+        self.assertIn("next: orbit server --port 12120", stream.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

* Adds phase-based progress output and heartbeat for native self-build.
* Adds `--verbose` and `--quiet` modes.
* Preserves useful subprocess error context on failure.
* Updates the suggested server port in build output and user-facing examples to `12120`.
* Does not change runtime behavior, backend, MTP, or path resolution.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_native_build_cli -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* `python3 scripts/build_native.py --jobs 6 --clean` PASS with visible phase output and heartbeat
* `python3 scripts/build_native.py --jobs 6 --verbose` PASS with configure/build stream
* `python3 scripts/build_native.py --jobs 6 --quiet` PASS with minimal output

Notes:

* The actual runtime defaults remain unchanged.
* Remaining `11976` references are intentional where they represent the real default port or tests/config that verify it.
