### PR TITLE
Format tool events with compact previews

### DIFF
--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
 import re
+import shlex
 
 
 LARGE_TOOL_RESULT_CHARS = 10_000
 SHELL_FULL_CONTRACT_ERROR_PREFIX = "error: shell-full analysis requests require content/source/string evidence"
+PREVIEW_LINE_LIMIT = 3
+PREVIEW_INLINE_LIMIT = 120
+COMMAND_PREVIEW_LIMIT = 96
 DISPLAY_TOOL_NAMES = {
     "exec_shell_full_command": "exec",
 }
@@ -15,11 +20,16 @@ def display_tool_name(name: str) -> str:
 
 
 def format_tool_call_event(name: str, args: str) -> str:
+    if name == "exec_shell_full_command":
+        command = _command_from_args(args)
+        if command:
+            return _format_shell_command_call(command)
     return f"{display_tool_name(name)} {args}"
 
 
 def format_tool_result_event(name: str, chars: int, source: str | None = None, content: str | None = None) -> str:
     del source
+    preview = _tool_result_preview(content)
     suffix_parts: list[str] = []
     if _is_rejected_contract_result(content):
         suffix_parts.append("rejected")
@@ -27,9 +37,90 @@ def format_tool_result_event(name: str, chars: int, source: str | None = None, c
         suffix_parts.append("large context")
     suffix = f" | {' | '.join(suffix_parts)}" if suffix_parts else ""
     chunk = _chunk_label(content)
-    if chunk:
-        return f" └ {chunk} {chars} chars -> model{suffix}"
-    return f" └ {chars} chars -> model{suffix}"
+    prefix = f"{chunk} " if chunk else ""
+    preview_text = f"{_truncate_inline(preview, limit=PREVIEW_INLINE_LIMIT)} | " if preview else ""
+    return f" └ {prefix}{preview_text}{chars} chars -> model{suffix}"
+
+
+def _command_from_args(args: str) -> str | None:
+    try:
+        parsed = json.loads(args)
+    except Exception:
+        return None
+    if isinstance(parsed, dict):
+        command = parsed.get("command")
+        if isinstance(command, str) and command.strip():
+            return command.strip()
+    return None
+
+
+def _format_shell_command_call(command: str) -> str:
+    category = _shell_command_category(command)
+    return f"{category}: {_truncate_inline(command, limit=COMMAND_PREVIEW_LIMIT)}"
+
+
+def _shell_command_category(command: str) -> str:
+    primary, tokens = _shell_command_tokens(command)
+    lowered = command.lower()
+    if primary in {"curl", "wget", "lynx", "links"} or "orbit-web-search" in lowered or "http://" in lowered or "https://" in lowered:
+        return "Web"
+    if primary in {"rg", "grep", "ag", "ack"}:
+        return "Search"
+    if primary == "find":
+        if any(flag in tokens for flag in ("-name", "-iname", "-path", "-ipath", "-regex", "-iregex")):
+            return "Search"
+        return "List"
+    if primary in {"ls", "tree", "du"}:
+        return "List"
+    if primary in {"cat", "head", "tail", "sed", "awk", "python", "python3", "perl", "strings", "pdftotext"}:
+        if primary in {"sed", "perl"} and "-i" in tokens:
+            return "Edit"
+        if primary in {"python", "python3", "perl"} and any(operator in command for operator in (">", ">>", ".write(", "write_text(", "write_bytes(")):
+            return "Write"
+        return "Read"
+    if primary in {"tee", "cp", "mv", "mkdir", "touch", "install", "ln", "truncate"}:
+        return "Write"
+    if primary in {"rm", "rmdir"}:
+        return "Edit"
+    if any(operator in command for operator in (">", ">>")):
+        return "Write"
+    return "Exec"
+
+
+def _shell_command_tokens(command: str) -> tuple[str, tuple[str, ...]]:
+    try:
+        tokens = tuple(shlex.split(command))
+    except ValueError:
+        tokens = tuple(command.split())
+    primary = tokens[0] if tokens else ""
+    return primary, tokens
+
+
+def _tool_result_preview(content: str | None) -> str | None:
+    if not content:
+        return None
+    stripped = content.strip()
+    if not stripped:
+        return None
+    if _is_rejected_contract_result(content):
+        return "rejected metadata-only output"
+    if stripped.startswith("error:"):
+        return stripped.splitlines()[0]
+    path = _metadata_value(content, "path")
+    if "shell_output_pdf_text: true" in content:
+        preview = _body_preview(content, marker="content:")
+        return _prefix_path_preview(path, preview or "PDF text extracted")
+    if "shell_output_read_file: true" in content:
+        preview = _body_preview(content, marker="content:")
+        return _prefix_path_preview(path, preview or "file content loaded")
+    if "shell_output_html_cleaned: true" in content:
+        preview = _body_preview(content, marker="text:")
+        return preview or "page text extracted"
+    if "content:\n" in content:
+        preview = _body_preview(content, marker="content:")
+        return _prefix_path_preview(path, preview)
+    preview = _lines_preview(content)
+    return preview
 
 
 def _chunk_label(content: str | None) -> str | None:
@@ -46,3 +137,51 @@ def _chunk_label(content: str | None) -> str | None:
 
 def _is_rejected_contract_result(content: str | None) -> bool:
     return bool(content and content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX))
+
+
+def _metadata_value(content: str, key: str) -> str | None:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+)$", content, flags=re.MULTILINE)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
+def _body_preview(content: str, *, marker: str) -> str | None:
+    if f"{marker}\n" not in content:
+        return None
+    _prefix, body = content.split(f"{marker}\n", 1)
+    return _lines_preview(body)
+
+
+def _lines_preview(content: str) -> str | None:
+    lines: list[str] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith(("shell_output_", "path:", "extractor:", "chunk_index:", "total_chunks:", "chars:", "large_file_excerpt:")):
+            continue
+        if line == "[truncated]":
+            continue
+        lines.append(_truncate_inline(line, limit=48))
+        if len(lines) >= PREVIEW_LINE_LIMIT:
+            break
+    if not lines:
+        return None
+    return " | ".join(lines)
+
+
+def _prefix_path_preview(path: str | None, preview: str | None) -> str | None:
+    if path and preview:
+        return f"{path}: {preview}"
+    return path or preview
+
+
+def _truncate_inline(text: str | None, *, limit: int) -> str:
+    if not text:
+        return ""
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: max(0, limit - 1)].rstrip() + "…"

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import sys
 import tempfile
@@ -196,18 +197,22 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(format_tool_result_event("read_file", 9999), " └ 9999 chars -> model")
         self.assertEqual(format_tool_result_event("read_file", 10000), " └ 10000 chars -> model | large context")
         self.assertEqual(format_tool_result_event("read_file", 5, "orbit"), " └ 5 chars -> model")
-        self.assertEqual(format_tool_call_event("exec_shell_full_command", '{"command":"ls"}'), 'exec {"command":"ls"}')
+        self.assertEqual(format_tool_call_event("exec_shell_full_command", '{"command":"ls"}'), "List: ls")
         self.assertEqual(format_tool_result_event("exec_shell_full_command", 45), " └ 45 chars -> model")
         chunk_content = "\n".join(
             [
                 "shell_output_read_file: true",
+                "path: build_native.py",
                 "chunk_index: 0",
                 "total_chunks: 3",
                 "content:",
-                "hello",
+                "#!/usr/bin/env python3",
             ]
         )
-        self.assertEqual(format_tool_result_event("exec_shell_full_command", 200, content=chunk_content), " └ chunk 1/3 200 chars -> model")
+        self.assertEqual(
+            format_tool_result_event("exec_shell_full_command", 200, content=chunk_content),
+            " └ chunk 1/3 build_native.py: #!/usr/bin/env python3 | 200 chars -> model",
+        )
 
     def test_tool_result_event_marks_contract_rejection(self) -> None:
         content = (
@@ -217,7 +222,50 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(
             format_tool_result_event("exec_shell_full_command", len(content), content=content),
-            f" └ {len(content)} chars -> model | rejected",
+            f" └ rejected metadata-only output | {len(content)} chars -> model | rejected",
+        )
+
+    def test_tool_call_event_classifies_shell_commands(self) -> None:
+        self.assertEqual(
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": 'rg -n "build_native" src tests'})),
+            'Search: rg -n "build_native" src tests',
+        )
+        self.assertEqual(
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "cat README.md"})),
+            "Read: cat README.md",
+        )
+        self.assertEqual(
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "sed -i 's/11976/12120/' README.md"})),
+            "Edit: sed -i 's/11976/12120/' README.md",
+        )
+        self.assertEqual(
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "tee notes.txt >/dev/null"})),
+            "Write: tee notes.txt >/dev/null",
+        )
+        self.assertEqual(
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "curl -L https://example.com"})),
+            "Web: curl -L https://example.com",
+        )
+
+    def test_tool_result_event_previews_pdf_and_list_output(self) -> None:
+        pdf_content = "\n".join(
+            [
+                "shell_output_pdf_text: true",
+                "path: pdf/grande.pdf",
+                "extractor: pdftotext",
+                "content:",
+                "This document discusses eIDAS 2.0 and the EUDI Wallet.",
+            ]
+        )
+        self.assertEqual(
+            format_tool_result_event("exec_shell_full_command", len(pdf_content), content=pdf_content),
+            " └ pdf/grande.pdf: This document discusses eIDAS 2.0 and the EUDI… | 133 chars -> model",
+        )
+
+        list_content = ".\n./pdf\n./text\n./samples\n"
+        self.assertEqual(
+            format_tool_result_event("exec_shell_full_command", len(list_content), content=list_content),
+            " └ . | ./pdf | ./text | 25 chars -> model",
         )
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:


### PR DESCRIPTION
Summary:

* Improves terminal UX for tool-backed steps without changing tool execution or routing.
* Adds compact, human-readable event labels for shell-backed Search/Read/Edit/Write/List/Web steps.
* Adds short preview lines for tool results with truncation and metadata-aware summaries.
* Keeps backend/MTP/default no-MTP unchanged.

Design:

* The change is confined to `src/orbit/terminal/tool_events.py`.
* `repl.py` and `cli.py` continue to call the same formatter hooks.
* Result previews stay single-line, short, and dim-compatible.
* No deterministic task routing or runtime answer generation is introduced.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_repl -q` PASS
* `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* Search / Read / Edit / Write / List / Web formatter demo PASS
* Example outputs include:
  * `Search: rg -n "build_native|--verbose|--quiet|Popen" src tests`
  * `Read: cat text/summary.txt`
  * `Edit: sed -i 's/11976/12120/' README.md`
  * `Write: tee notes.txt >/dev/null`
  * `List: ls -R workdir`
  * `Web: curl -L https://example.com`

Residual limits:

* Tool categorization is heuristic because the runtime exposes a single shell tool.
* Result previews use metadata markers and command heuristics, so uncommon shell patterns fall back to generic `Exec` or plain content preview.
