### PR TITLE
Align default Orbit port to 12120

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Orbit stays model-driven. The runtime enforces safety, size, timeout, and tool-c
 
 - Primary backend path: native `orbit-server`
 - Compatibility path: `llama-server` or another OpenAI-compatible local backend
-- CLI default base URL: `http://127.0.0.1:11976`
+- CLI default base URL: `http://127.0.0.1:12120`
 
 If your native server runs on another port, pass `--base-url`.
 
@@ -106,34 +106,34 @@ orbit download --all ggml-org/gemma-4-12B-it-GGUF
 Stable default server, with MTP disabled:
 
 ```bash
-orbit server --port 11976
+orbit server
 ```
 
 If native libraries are not packaged inside Orbit yet, use:
 
 ```bash
-orbit server --port 11976 --llama-root /path/to/llama.cpp
+orbit server --llama-root /path/to/llama.cpp
 ```
 
 Optional MTP mode:
 
 ```bash
-orbit server --port 11976 --mtp
+orbit server --mtp
 ```
 
 With a multimodal projector:
 
 ```bash
-orbit server \
-  --port 11976 \
+  orbit server \
+  --port 12120 \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
 
 You can combine MTP and multimodal flags when both artifacts are available:
 
 ```bash
-orbit server \
-  --port 11976 \
+  orbit server \
+  --port 12120 \
   --mtp \
   --mmproj models/ggml-org--gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
 ```
@@ -153,7 +153,7 @@ What this means:
 After startup, you can verify that the server is healthy:
 
 ```bash
-orbit --base-url http://127.0.0.1:11976 --health
+orbit --health
 ```
 
 Inside the interactive client, you can inspect backend state with:
@@ -174,7 +174,7 @@ Expected `/props` values:
 ### 5. Start Orbit
 
 ```bash
-orbit --base-url http://127.0.0.1:11976
+orbit
 ```
 
 Inside Orbit, tools are off by default:
@@ -186,9 +186,9 @@ Inside Orbit, tools are off by default:
 ## One-shot usage
 
 ```bash
-orbit --base-url http://127.0.0.1:11976 "Say who you are in one short sentence."
-orbit --base-url http://127.0.0.1:11976 --image workdir/media/image1.jpg "Describe this image."
-orbit --base-url http://127.0.0.1:11976 --audio workdir/media/audio1.wav "Transcribe or summarize this audio."
+orbit "Say who you are in one short sentence."
+orbit --image workdir/media/image1.jpg "Describe this image."
+orbit --audio workdir/media/audio1.wav "Transcribe or summarize this audio."
 ```
 
 ## Thinking mode
@@ -246,6 +246,6 @@ Orbit can still talk to compatible local HTTP backends through `--base-url`. Kee
 ## Maintenance commands
 
 ```bash
-orbit bench-core --base-url http://127.0.0.1:11976
-orbit release-confidence --base-url http://127.0.0.1:11976 --keep-failed
+orbit bench-core --base-url http://127.0.0.1:12120
+orbit release-confidence --base-url http://127.0.0.1:12120 --keep-failed
 ```

--- a/docs/NATIVE_PACKAGING_ROADMAP.md
+++ b/docs/NATIVE_PACKAGING_ROADMAP.md
@@ -41,7 +41,7 @@ The intended product path is:
 pip install orbit
 python scripts/build_native.py
 orbit download --all
-orbit server --port 11976
+orbit server --port 12120
 orbit
 ```
 
@@ -182,8 +182,8 @@ Deliverables:
 
 Acceptance:
 - `orbit download --all`
-- `orbit server --port 11976`
-- `orbit server --port 11976 --mtp`
+- `orbit server --port 12120`
+- `orbit server --port 12120 --mtp`
 
 all work with no manual path entry on a supported packaged install.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -72,7 +72,7 @@ Implementation notes are in [TECHNIQUES.md](TECHNIQUES.md).
 Public regression benchmark:
 
 ```bash
-orbit bench-core --base-url http://127.0.0.1:11976
+orbit bench-core --base-url http://127.0.0.1:12120
 ```
 
 Rules:

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -1,12 +1,12 @@
 # PROMPTS.md
 
-Manual regression prompts for Orbit against the current local backend, preferably native `orbit-server` on `http://127.0.0.1:11976`.
+Manual regression prompts for Orbit against the current local backend, preferably native `orbit-server` on `http://127.0.0.1:12120`.
 
 Run from the repository root with a clean temporary home when possible:
 
 ```bash
 HOME_DIR="$(mktemp -d)" HOME="$HOME_DIR" .venv/bin/orbit \
-  --base-url http://127.0.0.1:11976 \
+  --base-url http://127.0.0.1:12120 \
   --workdir workdir
 ```
 

--- a/docs/RELEASE_CONFIDENCE.md
+++ b/docs/RELEASE_CONFIDENCE.md
@@ -8,7 +8,7 @@ Run it with a healthy local Orbit backend:
 orbit release-confidence --keep-failed
 ```
 
-If you are using the native backend default path, this means `orbit-server` running on `http://127.0.0.1:11976`.
+If you are using the native backend default path, this means `orbit-server` running on `http://127.0.0.1:12120`.
 
 The suite writes a machine-readable report to `/tmp/orbit-release-confidence.json`.
 

--- a/scripts/bench_final_from_tool.py
+++ b/scripts/bench_final_from_tool.py
@@ -115,7 +115,7 @@ def _run_case(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Benchmark final_from_tool-heavy paths against a local Orbit server.")
-    parser.add_argument("--base-url", default="http://127.0.0.1:11976")
+    parser.add_argument("--base-url", default="http://127.0.0.1:12120")
     parser.add_argument("--workdir", default=str(WORKDIR))
     parser.add_argument("--json-out")
     args = parser.parse_args()

--- a/scripts/suggest-server-profile.sh
+++ b/scripts/suggest-server-profile.sh
@@ -166,7 +166,7 @@ cat <<EOF
 # These values are suggestions for orbit server. Review them before exporting.
 # Typical use:
 #   export THREADS=$THREADS BATCH_SIZE=$BATCH_SIZE UBATCH_SIZE=$UBATCH_SIZE CACHE_RAM=$CACHE_RAM
-#   orbit server --port 11976 --mtp
+#   orbit server --port 12120 --mtp
 
 export THREADS=$THREADS
 export BATCH_SIZE=$BATCH_SIZE

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -223,11 +223,11 @@ class LlamaServerBackend:
                 return _parse_chat_stream(response, on_delta=on_delta)
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
-            raise LlamaServerError(f"llama-server HTTP {exc.code}: {detail}") from exc
+            raise LlamaServerError(f"backend server HTTP {exc.code}: {detail}") from exc
         except URLError as exc:
-            raise LlamaServerError(f"cannot connect to llama-server at {self.base_url}: {exc.reason}") from exc
+            raise LlamaServerError(f"cannot connect to backend server at {self.base_url}: {exc.reason}") from exc
         except TimeoutError as exc:
-            raise LlamaServerError(f"llama-server request timed out after {self.timeout:.0f}s") from exc
+            raise LlamaServerError(f"backend server request timed out after {self.timeout:.0f}s") from exc
 
     def _post_native_stream(
         self,
@@ -249,11 +249,11 @@ class LlamaServerBackend:
                 return _parse_native_stream(response, on_delta=on_delta, on_progress=on_progress)
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
-            raise LlamaServerError(f"llama-server HTTP {exc.code}: {detail}") from exc
+            raise LlamaServerError(f"backend server HTTP {exc.code}: {detail}") from exc
         except URLError as exc:
-            raise LlamaServerError(f"cannot connect to llama-server at {self.base_url}: {exc.reason}") from exc
+            raise LlamaServerError(f"cannot connect to backend server at {self.base_url}: {exc.reason}") from exc
         except TimeoutError as exc:
-            raise LlamaServerError(f"llama-server request timed out after {self.timeout:.0f}s") from exc
+            raise LlamaServerError(f"backend server request timed out after {self.timeout:.0f}s") from exc
 
     def _send(self, request: Request) -> Any:
         try:
@@ -261,28 +261,28 @@ class LlamaServerBackend:
                 raw = response.read().decode("utf-8")
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
-            raise LlamaServerError(f"llama-server HTTP {exc.code}: {detail}") from exc
+            raise LlamaServerError(f"backend server HTTP {exc.code}: {detail}") from exc
         except URLError as exc:
-            raise LlamaServerError(f"cannot connect to llama-server at {self.base_url}: {exc.reason}") from exc
+            raise LlamaServerError(f"cannot connect to backend server at {self.base_url}: {exc.reason}") from exc
         except TimeoutError as exc:
-            raise LlamaServerError(f"llama-server request timed out after {self.timeout:.0f}s") from exc
+            raise LlamaServerError(f"backend server request timed out after {self.timeout:.0f}s") from exc
 
         try:
             data = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise LlamaServerError(f"llama-server returned invalid JSON: {raw[:200]}") from exc
+            raise LlamaServerError(f"backend server returned invalid JSON: {raw[:200]}") from exc
         return data
 
 def _parse_chat_result(data: dict[str, Any]) -> ChatResult:
     choices = data.get("choices")
     if not isinstance(choices, list) or not choices:
-        raise LlamaServerError("llama-server response has no choices")
+        raise LlamaServerError("backend server response has no choices")
     first = choices[0]
     if not isinstance(first, dict):
-        raise LlamaServerError("llama-server choice is invalid")
+        raise LlamaServerError("backend server choice is invalid")
     message = first.get("message")
     if not isinstance(message, dict):
-        raise LlamaServerError("llama-server choice has no message")
+        raise LlamaServerError("backend server choice has no message")
     content = message.get("content")
     if not isinstance(content, str):
         content = ""

--- a/src/orbit/dev/bench_core.py
+++ b/src/orbit/dev/bench_core.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 
 
-DEFAULT_BASE_URL = "http://127.0.0.1:11976"
+DEFAULT_BASE_URL = "http://127.0.0.1:12120"
 DEFAULT_WORKDIR = "workdir"
 DEFAULT_TIMEOUT = 600
 DEFAULT_MAX_TOKENS = 512

--- a/src/orbit/dev/release_confidence.py
+++ b/src/orbit/dev/release_confidence.py
@@ -603,7 +603,7 @@ def health_check(base_url: str, timeout: int) -> None:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Orbit release confidence tests against a local backend.")
-    parser.add_argument("--base-url", default=os.environ.get("ORBIT_BASE_URL", "http://127.0.0.1:11976"))
+    parser.add_argument("--base-url", default=os.environ.get("ORBIT_BASE_URL", "http://127.0.0.1:12120"))
     parser.add_argument("--timeout", type=int, default=int(os.environ.get("ORBIT_TEST_TIMEOUT", "300")))
     parser.add_argument("--max-tokens", type=int, default=int(os.environ.get("ORBIT_TEST_MAX_TOKENS", "320")))
     parser.add_argument("--only", action="append", default=[], help="Run only a case id. Can be repeated.")

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -29,7 +29,7 @@ from orbit.native_server.protocol import (
 
 
 DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 11976
+DEFAULT_PORT = 12120
 DEFAULT_ALIAS = "gemma4:12b-it-native"
 
 

--- a/src/orbit/terminal/config.py
+++ b/src/orbit/terminal/config.py
@@ -23,7 +23,7 @@ DEFAULT_TOOLS = "off"
 
 @dataclass(frozen=True)
 class AppConfig:
-    base_url: str = "http://127.0.0.1:11976"
+    base_url: str = "http://127.0.0.1:12120"
     workdir: Path = Path(".")
     timeout: float = 300.0
     temperature: float = 0.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("", "/status")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("base_url: http://127.0.0.1:11976", completed.stdout)
+        self.assertIn("base_url: http://127.0.0.1:12120", completed.stdout)
         self.assertIn("server:", completed.stdout)
         self.assertIn("messages: 1", completed.stdout)
         self.assertNotIn("model: fake", completed.stdout)
@@ -52,7 +52,7 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0)
         self.assertIn("Health\n------", completed.stdout)
-        self.assertIn("base_url: http://127.0.0.1:11976", completed.stdout)
+        self.assertIn("base_url: http://127.0.0.1:12120", completed.stdout)
         self.assertIn("server:", completed.stdout)
         self.assertNotIn("orbit interactive mode", completed.stdout)
 
@@ -96,7 +96,7 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0)
         self.assertIn("orbit interactive mode", completed.stdout)
-        self.assertIn("base_url: http://127.0.0.1:11976", completed.stdout)
+        self.assertIn("base_url: http://127.0.0.1:12120", completed.stdout)
         self.assertIn("server:", completed.stdout)
         self.assertIn("messages: 1", completed.stdout)
         self.assertIn("workdir:", completed.stdout)

--- a/tests/test_cli_download_dispatch.py
+++ b/tests/test_cli_download_dispatch.py
@@ -37,18 +37,18 @@ class CliDownloadDispatchTests(unittest.TestCase):
 
     def test_main_dispatches_server_subcommand(self) -> None:
         with mock.patch("orbit.terminal.cli.run_server", return_value=11) as mocked:
-            code = cli.main(["server", "--port", "11976"])
+            code = cli.main(["server", "--port", "12120"])
 
         self.assertEqual(code, 11)
-        mocked.assert_called_once_with(["--port", "11976"])
+        mocked.assert_called_once_with(["--port", "12120"])
 
     def test_main_dispatches_bench_core_subcommand(self) -> None:
         with mock.patch("orbit.terminal.cli.bench_core_main", return_value=12) as mocked:
-            code = cli.main(["bench-core", "--base-url", "http://127.0.0.1:11976"])
+            code = cli.main(["bench-core", "--base-url", "http://127.0.0.1:12120"])
 
         self.assertEqual(code, 12)
         mocked.assert_called_once()
-        self.assertEqual(mocked.call_args.args[0], ["--base-url", "http://127.0.0.1:11976"])
+        self.assertEqual(mocked.call_args.args[0], ["--base-url", "http://127.0.0.1:12120"])
 
     def test_main_dispatches_release_confidence_subcommand(self) -> None:
         with mock.patch("orbit.terminal.cli.release_confidence_main", return_value=13) as mocked:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,7 @@ class ConfigTests(unittest.TestCase):
 
         config = load_app_config(args)
 
-        self.assertEqual(config.base_url, "http://127.0.0.1:11976")
+        self.assertEqual(config.base_url, "http://127.0.0.1:12120")
         self.assertEqual(config.workdir, Path(".").resolve())
         self.assertEqual(config.max_tokens, 512)
         self.assertIsNone(config.context_tokens)

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -21,6 +21,7 @@ from orbit.backend.llama_server import (
 )
 from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
 from orbit.backend import model_names
+from urllib.error import URLError
 
 
 class FakeStream:
@@ -47,6 +48,13 @@ class FakeNativeStreamWithTrailingNoise:
 
 
 class LlamaServerBackendTests(unittest.TestCase):
+    def test_backend_connection_error_mentions_backend_server(self) -> None:
+        backend = LlamaServerBackend(base_url="http://127.0.0.1:12120", model="fake", timeout=1)
+
+        with self.assertRaisesRegex(Exception, "cannot connect to backend server at http://127.0.0.1:12120"):
+            with unittest.mock.patch("orbit.backend.llama_server.urlopen", side_effect=URLError("[Errno 111] Connection refused")):
+                backend._get_json("/health")
+
     def test_continue_current_uses_native_continue_stream_endpoint_for_non_stream_call(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -83,6 +83,11 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
         self.assertEqual(args.think, "on")
 
+    def test_parser_defaults_to_new_user_port(self) -> None:
+        args = build_parser().parse_args([])
+
+        self.assertEqual(args.port, 12120)
+
     def test_bootstrap_supports_legacy_direct_model_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
Summary:

* Changes the default Orbit client base URL from `http://127.0.0.1:11976` to `http://127.0.0.1:12120`.
* Changes the default `orbit server` port to `12120`.
* Updates user-facing connection errors to say `backend server` instead of `llama-server`.
* Aligns README and primary docs/examples with the new default user path.
* Aligns benchmark and release-confidence defaults with the new default base URL.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_config tests.test_cli tests.test_native_build_cli tests.test_repl tests.test_cli_download_dispatch tests.test_native_server_bootstrap tests.test_llama_server_backend -q` PASS
* `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* `orbit server` binds to `http://127.0.0.1:12120`
* `orbit --health` uses `http://127.0.0.1:12120`
* `orbit "hi, how are you?"` connects without `--base-url` and returns a normal answer
* connection errors now say `cannot connect to backend server at ...`

Residual notes:

* `11976` remains only in `AGENTS.md` internal instructions and in one REPL formatter test string example.
* Stopping the native server after the smoke reproduced an existing native shutdown abort outside the scope of this port-alignment patch.
