### PR TITLE
Remove remaining 11976 references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ The tool name remains `orbit`. The repository directory may be temporary.
 
 - Primary backend: native `orbit-server`.
 - Compatibility backend: local OpenAI-compatible chat completions, including `llama-server`.
-- Default base URL: `http://127.0.0.1:11976`.
+- Default base URL: `http://127.0.0.1:12120`.
 - Primary target model: `gemma4:12b-it`.
 - Reasoning should remain disabled by default at backend startup unless explicitly testing visible thinking.
 - Context profiles are provided by helper scripts, not hidden runtime magic.

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -235,8 +235,8 @@ class ReplTests(unittest.TestCase):
             "Read: cat README.md",
         )
         self.assertEqual(
-            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "sed -i 's/11976/12120/' README.md"})),
-            "Edit: sed -i 's/11976/12120/' README.md",
+            format_tool_call_event("exec_shell_full_command", json.dumps({"command": "sed -i 's/12120/12121/' README.md"})),
+            "Edit: sed -i 's/12120/12121/' README.md",
         )
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "tee notes.txt >/dev/null"})),


### PR DESCRIPTION
Summary:

* Removes the last remaining `11976` references from the repo.
* Updates the internal AGENTS default base URL note to `12120`.
* Updates the REPL formatter demo string to avoid keeping `11976` in snapshots.
* Does not change runtime behavior.

Shutdown classification:

* The native shutdown abort is reproducible on `SIGINT` when launching `orbit server` through the installed `orbit` console script.
* The same server launched as `python3 -m orbit.terminal.cli server` shuts down cleanly under `SIGINT`.
* `SIGTERM` shuts down cleanly in both no-request and after-request scenarios.
* This does not point to the `12120` port change itself.
* No shutdown patch is included because the root cause is not yet isolated to a safe repo-local fix.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_config tests.test_cli tests.test_repl -q` PASS
* `PYTHONPATH=src python3 -m unittest tests.test_native_server_bootstrap tests.test_native_streaming tests.test_native_thinking -q` PASS
* `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS
* `rg "11976"` returns no results

Scope:

* `AGENTS.md`
* `tests/test_repl.py`
