### PR TITLE
Clarify runtime phases and repair reasoning-only finals

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -60,7 +60,7 @@ from orbit.runtime.tool_result_compaction import (
     compact_tool_results,
     persistent_messages as persistent_tool_result_messages,
 )
-from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
 ROUTE_MAX_TOKENS = 128
@@ -116,6 +116,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None = None,
         on_progress: Callable[[StreamProgress], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
         user_content = message_content(prompt, images or [], audios or [])
         result = self._pure_chat_environment().ask_user_content(
@@ -126,6 +127,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=1,
         )
         return self._remember_visible_result(result)
@@ -139,6 +141,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None = None,
         on_progress: Callable[[StreamProgress], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
@@ -151,6 +154,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=1,
         )
         return self._remember_visible_result(result)
@@ -163,6 +167,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None = None,
         on_progress: Callable[[StreamProgress], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
         result = self._continue_environment().continue_last_response(
             temperature=temperature,
@@ -170,6 +175,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
         )
         return self._remember_visible_result(_tool_loop_result_value(result))
 
@@ -186,6 +192,7 @@ class ChatRuntime:
         on_tool_call: Callable[[str, str], None] | None = None,
         on_tool_result: Callable[[str, int, str, str], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
         self.last_memory_refresh = None
@@ -197,6 +204,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
         )
         result = self._run_tool_loop(
             temperature=temperature,
@@ -208,6 +216,7 @@ class ChatRuntime:
             on_tool_call=on_tool_call,
             on_tool_result=on_tool_result,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             tool_names=tool_names,
         )
         return self._remember_visible_result(result.result)
@@ -225,6 +234,7 @@ class ChatRuntime:
         on_tool_call: Callable[[str, str], None] | None = None,
         on_tool_result: Callable[[str, int, str, str], None] | None = None,
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         allowed_tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
         self.last_memory_refresh = None
@@ -241,6 +251,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
         )
         if media_result is not None:
             return self._remember_visible_result(media_result)
@@ -251,6 +262,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
         )
         if resolution.bypass_tool_route:
             bundle = self._run_tool_loop(
@@ -263,6 +275,7 @@ class ChatRuntime:
                 on_tool_call=on_tool_call,
                 on_tool_result=on_tool_result,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 tool_names=("exec_shell_full_command",),
             )
             return self._remember_visible_result(_tool_loop_result_value(bundle))
@@ -273,6 +286,8 @@ class ChatRuntime:
         route_streamed_chunks: list[str] = []
         command_messages = with_command_system_prompt(self.messages)
         with self._temporary_backend_thinking(False):
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("route", streamed=False))
             if on_progress is None:
                 first = self.backend.chat(command_messages, temperature=temperature, max_tokens=command_max_tokens)
             else:
@@ -299,6 +314,7 @@ class ChatRuntime:
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=2,
                 )
                 retried_empty_final = True
@@ -325,6 +341,7 @@ class ChatRuntime:
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=2,
                 )
             self.messages.append({"role": "assistant", "content": first.content})
@@ -345,6 +362,7 @@ class ChatRuntime:
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=2,
             )
             self.messages.append({"role": "assistant", "content": result.content})
@@ -364,6 +382,7 @@ class ChatRuntime:
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 command_result=first,
             )
         tools = decision_tool_names(decision, prompt)
@@ -392,6 +411,7 @@ class ChatRuntime:
             on_tool_call=on_tool_call,
             on_tool_result=on_tool_result,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             tool_names=tools,
             initial_tool_calls=(
                 command_tool_call_from_tool_calls(first.tool_calls, tools)
@@ -414,6 +434,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult | None:
         if resolution.error:
             return None
@@ -429,6 +450,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=1,
         )
         return result
@@ -443,6 +465,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         command_result: ChatResult,
     ) -> ChatResult:
         if resolution.error:
@@ -467,6 +490,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=2,
         )
         self.messages.append({"role": "assistant", "content": result.content})
@@ -484,6 +508,7 @@ class ChatRuntime:
         on_tool_call: Callable[[str, str], None] | None,
         on_tool_result: Callable[[str, int, str, str], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         tool_names: tuple[str, ...] | None,
         initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
         ):
@@ -497,6 +522,7 @@ class ChatRuntime:
             on_tool_call=on_tool_call,
             on_tool_result=on_tool_result,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
         )
@@ -508,6 +534,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> None:
         if not self._thinking().should_stream_tool_plan(
             has_delta_sink=on_final_delta is not None,
@@ -527,6 +554,8 @@ class ChatRuntime:
         ]
         thought_filter = _ThoughtOnlyDeltaFilter(on_final_delta)
         with self._transport_environment().backend_thinking(True):
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("tool_plan", streamed=True))
             result = self.backend.chat_stream(
                 planning_messages,
                 temperature=temperature,
@@ -546,6 +575,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         loop: int,
         use_tool_prompt: bool,
     ) -> ChatResult:
@@ -555,6 +585,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=loop,
             use_tool_prompt=use_tool_prompt,
         ).result
@@ -568,6 +599,7 @@ class ChatRuntime:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         loop: int,
     ) -> ChatResult:
         result = self._transport_environment().chat_final(
@@ -577,6 +609,7 @@ class ChatRuntime:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=loop,
         )
         return result

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable
 import json
@@ -28,7 +28,7 @@ from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import TOOL_CALL_JSON_RETRY_PROMPT
 from orbit.runtime.thinking_mode import ThinkingMode, last_assistant_has_open_reasoning
 from orbit.runtime.tool_loop import run_tool_loop
-from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,8 +94,12 @@ class TransportEnvironment:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
+        repair_incomplete_final: bool = True,
     ) -> ChatResult:
+        if on_phase_start:
+            on_phase_start(ModelPhaseStart("chat_final", streamed=on_final_delta is not None))
         result = self.chat_once(
             messages,
             temperature=temperature,
@@ -105,18 +109,42 @@ class TransportEnvironment:
         )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="chat_final"))
-        if not is_empty_final_response(result):
+        completeness = classify_final_answer_completeness(result.content, messages=messages)
+        if not repair_incomplete_final and not is_empty_final_response(result):
+            return result
+        if not is_empty_final_response(result) and completeness.is_complete:
             return result
 
-        retry = self.chat_once(
-            messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            on_final_delta=on_final_delta,
-            on_progress=on_progress,
-        )
+        retry_messages = messages
+        retry_phase = "chat_final_retry"
+        with_final_only_retry = False
+        if not completeness.is_complete:
+            retry_messages = [
+                *messages,
+                {
+                    "role": "user",
+                    "content": (
+                        "Stop reasoning and provide the final answer only. "
+                        "No thinking, no plan, no headings, no bullet list unless explicitly requested. "
+                        "Answer the user directly now."
+                    ),
+                },
+            ]
+            retry_phase = "chat_final_completion_repair"
+            with_final_only_retry = True
+        if on_phase_start:
+            on_phase_start(ModelPhaseStart(retry_phase, streamed=on_final_delta is not None))
+        retry_context = self.backend_thinking(False) if with_final_only_retry else nullcontext()
+        with retry_context:
+            retry = self.chat_once(
+                retry_messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+            )
         if on_model_step:
-            on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase="chat_final_retry"))
+            on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase=retry_phase))
         if not is_empty_final_response(retry):
             return retry
 
@@ -220,6 +248,7 @@ class PureChatEnvironment:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
     ) -> ChatResult:
         self.runtime.messages.append({"role": "user", "content": user_content})
@@ -230,6 +259,7 @@ class PureChatEnvironment:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=loop,
         )
         self.runtime.messages.append({"role": "assistant", "content": result.content})
@@ -252,6 +282,7 @@ class ToolLoopEnvironment:
         on_tool_call: Callable[[str, str], None] | None,
         on_tool_result: Callable[[str, int, str, str], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
         tool_names: tuple[str, ...] | None,
         initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
     ) -> ToolResultBundle:
@@ -266,6 +297,7 @@ class ToolLoopEnvironment:
             on_tool_call=on_tool_call,
             on_tool_result=on_tool_result,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
         )
@@ -288,6 +320,7 @@ class FinalFromToolEnvironment:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
         use_tool_prompt: bool,
     ) -> FinalAnswerResult:
@@ -300,16 +333,19 @@ class FinalFromToolEnvironment:
         repair_failed = False
         compact_retry_attempted = False
         compact_retry_failed = False
-        if on_final_delta is None:
-            result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
-        else:
-            result = self.runtime.backend.chat_stream(
-                policy.messages,
-                temperature=temperature,
-                max_tokens=policy.max_tokens,
-                on_delta=final_delta,
-                on_progress=on_progress,
-            )
+        if on_phase_start:
+            on_phase_start(ModelPhaseStart("final_from_tool", streamed=stream_buffer is None and on_final_delta is not None))
+        with self.transport.backend_thinking(False):
+            if on_final_delta is None:
+                result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
+            else:
+                result = self.runtime.backend.chat_stream(
+                    policy.messages,
+                    temperature=temperature,
+                    max_tokens=policy.max_tokens,
+                    on_delta=final_delta,
+                    on_progress=on_progress,
+                )
         best_non_empty_result = result if result.content.strip() else None
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="final_from_tool"))
@@ -324,16 +360,19 @@ class FinalFromToolEnvironment:
             previous_result = result
             retry_messages = [*policy.messages, final_tool_retry_instruction()]
             retry_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
-            if on_final_delta is None:
-                retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
-            else:
-                retry_candidate = self.runtime.backend.chat_stream(
-                    retry_messages,
-                    temperature=temperature,
-                    max_tokens=retry_max_tokens,
-                    on_delta=final_delta,
-                    on_progress=on_progress,
-                )
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("final_from_tool_retry", streamed=stream_buffer is None and on_final_delta is not None))
+            with self.transport.backend_thinking(False):
+                if on_final_delta is None:
+                    retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
+                else:
+                    retry_candidate = self.runtime.backend.chat_stream(
+                        retry_messages,
+                        temperature=temperature,
+                        max_tokens=retry_max_tokens,
+                        on_delta=final_delta,
+                        on_progress=on_progress,
+                    )
             if retry_candidate.content.strip():
                 best_non_empty_result = retry_candidate
             result = _prefer_non_empty_retry_result(previous_result, retry_candidate)
@@ -373,16 +412,21 @@ class FinalFromToolEnvironment:
             )
             repair_messages = [*policy.messages, {"role": "user", "content": repair_instruction}]
             repair_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
-            if on_final_delta is None:
-                result = self.runtime.backend.chat(repair_messages, temperature=temperature, max_tokens=repair_max_tokens)
-            else:
-                result = self.runtime.backend.chat_stream(
-                    repair_messages,
-                    temperature=temperature,
-                    max_tokens=repair_max_tokens,
-                    on_delta=final_delta,
-                    on_progress=on_progress,
+            if on_phase_start:
+                on_phase_start(
+                    ModelPhaseStart("final_from_tool_completion_repair", streamed=stream_buffer is None and on_final_delta is not None)
                 )
+            with self.transport.backend_thinking(False):
+                if on_final_delta is None:
+                    result = self.runtime.backend.chat(repair_messages, temperature=temperature, max_tokens=repair_max_tokens)
+                else:
+                    result = self.runtime.backend.chat_stream(
+                        repair_messages,
+                        temperature=temperature,
+                        max_tokens=repair_max_tokens,
+                        on_delta=final_delta,
+                        on_progress=on_progress,
+                    )
             if result.content.strip():
                 best_non_empty_result = result
             if on_model_step:
@@ -410,16 +454,19 @@ class FinalFromToolEnvironment:
             original_result = best_non_empty_result or result
             compact_messages = [*policy.messages, final_tool_compact_retry_instruction()]
             compact_max_tokens = final_tool_compact_retry_max_tokens(max_tokens, messages=policy.messages)
-            if on_final_delta is None:
-                candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
-            else:
-                candidate = self.runtime.backend.chat_stream(
-                    compact_messages,
-                    temperature=temperature,
-                    max_tokens=compact_max_tokens,
-                    on_delta=final_delta,
-                    on_progress=on_progress,
-                )
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("final_from_tool_compact_retry", streamed=stream_buffer is None and on_final_delta is not None))
+            with self.transport.backend_thinking(False):
+                if on_final_delta is None:
+                    candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
+                else:
+                    candidate = self.runtime.backend.chat_stream(
+                        compact_messages,
+                        temperature=temperature,
+                        max_tokens=compact_max_tokens,
+                        on_delta=final_delta,
+                        on_progress=on_progress,
+                    )
             if candidate.content.strip():
                 best_non_empty_result = candidate
             if on_model_step:
@@ -468,6 +515,7 @@ class ContinueEnvironment:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
     ) -> ContinueResult:
         initial_kind = self._continuation_kind_before_continue()
         if initial_kind == "thinking":
@@ -477,6 +525,7 @@ class ContinueEnvironment:
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=1,
                 force_disable_backend_thinking=True,
             )
@@ -492,6 +541,8 @@ class ContinueEnvironment:
                 on_progress=on_progress,
                 max_passes=3,
             )
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("chat_continue_native", streamed=on_final_delta is not None))
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="chat_continue_native"))
             if self.runtime._thinking().continuation_kind_for(content=result.content, finish_reason=result.finish_reason) is not None:
@@ -502,6 +553,7 @@ class ContinueEnvironment:
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=2,
                     force_disable_backend_thinking=True,
                 )
@@ -518,6 +570,7 @@ class ContinueEnvironment:
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
             loop=1,
         )
         return ContinueResult(result=result, used_native_continue=False, used_prompt_fallback=True)
@@ -546,6 +599,7 @@ class ContinueEnvironment:
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
         force_disable_backend_thinking: bool = False,
     ) -> ChatResult:
@@ -583,7 +637,9 @@ class ContinueEnvironment:
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=loop,
+                    repair_incomplete_final=False,
                 )
         else:
             result = self.transport.chat_final(
@@ -593,7 +649,9 @@ class ContinueEnvironment:
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=loop,
+                repair_incomplete_final=False,
             )
         if force_disable_backend_thinking and (
             self.runtime._thinking().continuation_kind_for(

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -442,6 +442,7 @@ def classify_final_answer_completeness(content: str, *, messages: list[Message] 
         tail = content.split("<channel|>", 1)[1].strip()
         if tail:
             return FinalAnswerCompleteness("complete")
+        return FinalAnswerCompleteness("reasoning_like")
     if re.search(r"(?:^|\n)\s*#{1,6}\s*$", content.rstrip()):
         return FinalAnswerCompleteness("malformed_markdown", "heading_stub")
     if re.search(r"(?:^|\n)\s*(?:[-*]|\d+\.)\s+\*\*[^*\n]+:\*\*\s*$", content.rstrip()):

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -48,7 +48,7 @@ from orbit.runtime.tool_loop_state import (
 )
 from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
 from orbit.runtime.tools import default_tool_names
-from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
 def _env_int(name: str, default: int) -> int:
@@ -76,6 +76,7 @@ def run_tool_loop(
     on_tool_call: Callable[[str, str], None] | None,
     on_tool_result: Callable[[str, int, str, str], None] | None,
     on_model_step: Callable[[ModelStepMetrics], None] | None,
+    on_phase_start: Callable[[ModelPhaseStart], None] | None,
     tool_names: tuple[str, ...] | None,
     initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
 ) -> ChatResult:
@@ -435,6 +436,7 @@ def run_tool_loop(
                         on_final_delta=on_final_delta,
                         on_progress=on_progress,
                         on_model_step=on_model_step,
+                        on_phase_start=on_phase_start,
                         loop=state.tool_rounds + 1,
                         use_tool_prompt=state.used_tool_call_prompt,
                     )
@@ -456,6 +458,7 @@ def run_tool_loop(
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=state.tool_rounds + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
@@ -466,6 +469,7 @@ def run_tool_loop(
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=state.tool_rounds + 1,
                 use_tool_prompt=state.used_tool_call_prompt,
             )
@@ -511,6 +515,13 @@ def run_tool_loop(
             file_recovery=turn.pending_file_recovery_guard,
         )
         tool_delta_callback = suppress_tool_delta if shell_full_enabled and (state.tool_rounds > 0 or repair.contract_retry_pending) else on_final_delta
+        if on_phase_start:
+            on_phase_start(
+                ModelPhaseStart(
+                    "tool_call",
+                    streamed=tool_delta_callback is not suppress_tool_delta and on_final_delta is not None,
+                )
+            )
         result = runtime._chat_tool_call_once(
             call_messages,
             temperature=temperature,
@@ -524,6 +535,8 @@ def run_tool_loop(
             on_model_step(ModelStepMetrics.from_result(loop=loop_index, result=result, phase="tool_call" if result.tool_calls else None))
         if repair.contract_retry_pending and not result.tool_calls:
             retry_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTRACT_RETRY_PROMPT}]
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("tool_call_retry", streamed=False))
             result = runtime._chat_tool_call_once(
                 retry_messages,
                 temperature=temperature,
@@ -565,6 +578,7 @@ def run_tool_loop(
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=loop_index + 1,
                 use_tool_prompt=state.used_tool_call_prompt,
             )
@@ -584,6 +598,7 @@ def run_tool_loop(
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=loop_index + 2,
                 )
         if result.tool_calls:
@@ -631,6 +646,7 @@ def run_tool_loop(
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=loop_index + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
@@ -646,6 +662,7 @@ def run_tool_loop(
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=loop_index + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
@@ -680,6 +697,7 @@ def run_tool_loop(
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
                     loop=loop_index + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
@@ -691,6 +709,7 @@ def run_tool_loop(
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=loop_index + 1,
                 use_tool_prompt=state.used_tool_call_prompt,
             )
@@ -705,6 +724,7 @@ def run_tool_loop(
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
                 on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
                 loop=loop_index + 1,
                 use_tool_prompt=state.used_tool_call_prompt,
             )

--- a/src/orbit/runtime/turn_trace.py
+++ b/src/orbit/runtime/turn_trace.py
@@ -6,6 +6,12 @@ from orbit.backend import ChatResult
 
 
 @dataclass(frozen=True)
+class ModelPhaseStart:
+    phase: str
+    streamed: bool = True
+
+
+@dataclass(frozen=True)
 class ModelStepMetrics:
     loop: int
     phase: str

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -23,6 +23,7 @@ from orbit.terminal.tool_events import format_tool_call_event, format_tool_resul
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
 from orbit.terminal.theme import danger, dim
 from orbit.runtime.thinking_mode import ThinkingMode
+from orbit.runtime.turn_trace import ModelPhaseStart
 
 
 @dataclass
@@ -120,6 +121,7 @@ class Repl:
                     on_tool_call=lambda name, args: renderer.event(format_tool_call_event(name, args), restart_timer=False),
                     on_tool_result=lambda name, chars, source, content: self._show_tool_result(renderer, name, chars, source, content),
                     on_model_step=self._record_model_step,
+                    on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
                 )
             else:
                 result = self.runtime.ask_chat(
@@ -129,6 +131,7 @@ class Repl:
                     on_final_delta=renderer.write,
                     on_progress=renderer.progress,
                     on_model_step=self._record_model_step,
+                    on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
                 )
         except KeyboardInterrupt:
             renderer.finish()
@@ -183,6 +186,11 @@ class Repl:
             prompt_tokens_per_second=metrics.prompt_tokens_per_second,
             profile=prefill_profile_for_phase(metrics.phase),
         )
+
+    def _record_phase_start(self, renderer: StreamRenderer, phase: ModelPhaseStart) -> None:
+        label = _phase_label(phase)
+        if label:
+            renderer.event(label, restart_timer=True)
 
     def _show_tool_result(self, renderer: StreamRenderer, name: str, chars: int, source: str | None, content: str | None) -> None:
         if content is not None:
@@ -318,6 +326,7 @@ class Repl:
                 on_final_delta=renderer.write,
                 on_progress=renderer.progress,
                 on_model_step=self._record_model_step,
+                on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
             )
         except KeyboardInterrupt:
             renderer.finish()
@@ -357,6 +366,24 @@ def _length_footer_message(thinking: bool) -> str:
     if thinking:
         return "thinking or final output stopped because max_tokens was reached"
     return "output stopped because max_tokens was reached"
+
+
+def _phase_label(phase: ModelPhaseStart) -> str | None:
+    labels = {
+        "tool_plan": "phase: thinking",
+        "route": "phase: deciding tool use (non-streaming)",
+        "chat_final": "phase: final answer",
+        "chat_final_retry": "phase: continuing after length",
+        "chat_final_completion_repair": "phase: repairing final answer",
+        "tool_call": "phase: tool call" if phase.streamed else "phase: tool call (non-streaming)",
+        "tool_call_retry": "phase: retrying tool call (non-streaming)",
+        "final_from_tool": "phase: final answer" if phase.streamed else "phase: final answer (non-streaming)",
+        "final_from_tool_retry": "phase: continuing after length" if phase.streamed else "phase: continuing after length (non-streaming)",
+        "final_from_tool_completion_repair": "phase: repairing incomplete final answer",
+        "final_from_tool_compact_retry": "phase: shortening final answer",
+        "chat_continue_native": "phase: continuing after length",
+    }
+    return labels.get(phase.phase)
 
 
 def _prefill_profile_for_turn(messages: list[dict[str, object]], *, tools_enabled: bool) -> str:

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -630,6 +630,10 @@ class FinalPolicyTests(unittest.TestCase):
         completeness = classify_final_answer_completeness("Plan:\n1. Inspect the file\n2. Summarize the findings")
         self.assertEqual(completeness.status, "reasoning_like")
 
+    def test_final_answer_completeness_detects_closed_thought_without_final_tail(self) -> None:
+        completeness = classify_final_answer_completeness("<|channel>thought\nprivate chain<channel|>")
+        self.assertEqual(completeness.status, "reasoning_like")
+
     def test_final_answer_completeness_accepts_complete_brief_answer(self) -> None:
         completeness = classify_final_answer_completeness(
             "The file is vulnerable to SQL injection and command injection due to unsanitized input handling."

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -33,10 +33,11 @@ from orbit.terminal.repl_input import (
     visual_row_count,
 )
 from orbit.terminal.repl import Repl
-from orbit.terminal.repl import _prefill_profile_for_turn
+from orbit.terminal.repl import _phase_label, _prefill_profile_for_turn
 from orbit.terminal.session_preview import format_recent_session_messages
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
+from orbit.runtime.turn_trace import ModelPhaseStart
 
 
 class InterruptingBackend:
@@ -267,6 +268,12 @@ class ReplTests(unittest.TestCase):
             format_tool_result_event("exec_shell_full_command", len(list_content), content=list_content),
             " └ . | ./pdf | ./text | 25 chars -> model",
         )
+
+    def test_phase_label_maps_buffered_and_streamed_phases(self) -> None:
+        self.assertEqual(_phase_label(ModelPhaseStart("tool_plan", streamed=True)), "phase: thinking")
+        self.assertEqual(_phase_label(ModelPhaseStart("route", streamed=False)), "phase: deciding tool use (non-streaming)")
+        self.assertEqual(_phase_label(ModelPhaseStart("final_from_tool", streamed=False)), "phase: final answer (non-streaming)")
+        self.assertEqual(_phase_label(ModelPhaseStart("final_from_tool_compact_retry", streamed=False)), "phase: shortening final answer")
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:
         self.assertEqual(_prefill_profile_for_turn([], tools_enabled=False), CHAT_PREFILL_PROFILE)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -268,6 +268,94 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(backend.chat_calls, 1)
         self.assertFalse(runtime.can_continue_last_response())
 
+    def test_ask_chat_retries_reasoning_only_stop_with_final_only_retry(self) -> None:
+        class ReasoningThenFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+                self.thinking_seen: list[bool] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                self.thinking_seen.append(self.thinking)
+                if self.chat_calls == 1:
+                    return ChatResult(
+                        content="<|channel>thought\nprivate chain<channel|>",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Final answer: Dante Alighieri was an Italian poet.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ReasoningThenFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+
+        result = runtime.ask_chat("Who is Dante Alighieri?", temperature=0, max_tokens=32)
+
+        self.assertEqual(result.content, "Final answer: Dante Alighieri was an Italian poet.")
+        self.assertEqual(backend.chat_calls, 2)
+        self.assertEqual(backend.thinking_seen, [True, False])
+
+    def test_ask_chat_retries_reasoning_only_length_with_final_only_retry(self) -> None:
+        class ReasoningThenFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+                self.thinking_seen: list[bool] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                self.thinking_seen.append(self.thinking)
+                if self.chat_calls == 1:
+                    return ChatResult(
+                        content="<|channel>thought\nprivate chain<channel|>",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Final answer: Dante Alighieri was an Italian poet.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ReasoningThenFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+
+        result = runtime.ask_chat("Who is Dante Alighieri?", temperature=0, max_tokens=32)
+
+        self.assertEqual(result.content, "Final answer: Dante Alighieri was an Italian poet.")
+        self.assertEqual(backend.chat_calls, 2)
+        self.assertEqual(backend.thinking_seen, [True, False])
+
     def test_continue_last_response_uses_prompt_fallback_for_bullet_reasoning_length(self) -> None:
         class BulletReasoningBackend(FakeBackend):
             def __init__(self) -> None:
@@ -456,7 +544,7 @@ def _last_tool_message(runtime: ChatRuntime) -> Message:
 
 
 class ToolRuntimeTests(unittest.TestCase):
-    def test_ask_with_tools_temporarily_disables_backend_thinking_for_tool_rounds_only(self) -> None:
+    def test_ask_with_tools_disables_backend_thinking_for_tool_plan_and_final_answer(self) -> None:
         class ThinkingAwareBackend:
             def __init__(self) -> None:
                 self.calls = 0
@@ -511,8 +599,7 @@ class ToolRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result.finish_reason, "stop")
         self.assertGreaterEqual(len(backend.thinking_seen), 2)
-        self.assertTrue(all(flag is False for flag in backend.thinking_seen[:-1]))
-        self.assertTrue(backend.thinking_seen[-1])
+        self.assertTrue(all(flag is False for flag in backend.thinking_seen))
         self.assertTrue(backend.thinking)
 
     def test_ask_auto_temporarily_disables_backend_thinking_for_route_phase(self) -> None:


### PR DESCRIPTION
Summary:

* Adds compact phase reporting between model passes.
* Prevents reasoning-only output from being accepted as a final answer, including length-ended passes.
* Keeps post-tool final answers out of thinking mode.
* Labels known non-streaming/buffered phases.
* Leaves backend/native streaming unchanged.

Validation:

* runtime/final_policy/repl/tool_loop tests PASS
* native_streaming/native_thinking/native_server_bootstrap PASS
* compileall PASS
* diff check PASS

Smoke:

* tools off + think off: PASS
* tools off + think on: PASS
* tools on + think off: PASS
* tools on + think on: PASS for UX blocker
* /continue after truncated think on: PASS

Residual caveats:

* Plain final-answer text may still arrive buffered on the current native backend.
* tools on + think on can still be slow if the model spends a long time planning before tool use.
* This PR improves runtime/client UX and final-answer correctness; it does not optimize backend streaming.