### PR TITLE
Label model phase retries with attempt and reason

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -287,7 +287,7 @@ class ChatRuntime:
         command_messages = with_command_system_prompt(self.messages)
         with self._temporary_backend_thinking(False):
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("route", streamed=False))
+                on_phase_start(ModelPhaseStart("route", streamed=False, attempt=1, reason="tool_decision"))
             if on_progress is None:
                 first = self.backend.chat(command_messages, temperature=temperature, max_tokens=command_max_tokens)
             else:
@@ -555,7 +555,7 @@ class ChatRuntime:
         thought_filter = _ThoughtOnlyDeltaFilter(on_final_delta)
         with self._transport_environment().backend_thinking(True):
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("tool_plan", streamed=True))
+                on_phase_start(ModelPhaseStart("tool_plan", streamed=True, attempt=1, reason="pre_tool_thinking"))
             result = self.backend.chat_stream(
                 planning_messages,
                 temperature=temperature,

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -99,7 +99,7 @@ class TransportEnvironment:
         repair_incomplete_final: bool = True,
     ) -> ChatResult:
         if on_phase_start:
-            on_phase_start(ModelPhaseStart("chat_final", streamed=on_final_delta is not None))
+            on_phase_start(ModelPhaseStart("chat_final", streamed=on_final_delta is not None, attempt=1))
         result = self.chat_once(
             messages,
             temperature=temperature,
@@ -117,6 +117,7 @@ class TransportEnvironment:
 
         retry_messages = messages
         retry_phase = "chat_final_retry"
+        retry_reason = "empty_or_invalid"
         with_final_only_retry = False
         if not completeness.is_complete:
             retry_messages = [
@@ -131,9 +132,17 @@ class TransportEnvironment:
                 },
             ]
             retry_phase = "chat_final_completion_repair"
+            retry_reason = completeness.status
             with_final_only_retry = True
         if on_phase_start:
-            on_phase_start(ModelPhaseStart(retry_phase, streamed=on_final_delta is not None))
+            on_phase_start(
+                ModelPhaseStart(
+                    retry_phase,
+                    streamed=on_final_delta is not None,
+                    attempt=2,
+                    reason=retry_reason,
+                )
+            )
         retry_context = self.backend_thinking(False) if with_final_only_retry else nullcontext()
         with retry_context:
             retry = self.chat_once(
@@ -334,7 +343,13 @@ class FinalFromToolEnvironment:
         compact_retry_attempted = False
         compact_retry_failed = False
         if on_phase_start:
-            on_phase_start(ModelPhaseStart("final_from_tool", streamed=stream_buffer is None and on_final_delta is not None))
+            on_phase_start(
+                ModelPhaseStart(
+                    "final_from_tool",
+                    streamed=stream_buffer is None and on_final_delta is not None,
+                    attempt=1,
+                )
+            )
         with self.transport.backend_thinking(False):
             if on_final_delta is None:
                 result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
@@ -361,7 +376,14 @@ class FinalFromToolEnvironment:
             retry_messages = [*policy.messages, final_tool_retry_instruction()]
             retry_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("final_from_tool_retry", streamed=stream_buffer is None and on_final_delta is not None))
+                on_phase_start(
+                    ModelPhaseStart(
+                        "final_from_tool_retry",
+                        streamed=stream_buffer is None and on_final_delta is not None,
+                        attempt=2,
+                        reason=retry_reason,
+                    )
+                )
             with self.transport.backend_thinking(False):
                 if on_final_delta is None:
                     retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
@@ -414,7 +436,12 @@ class FinalFromToolEnvironment:
             repair_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
             if on_phase_start:
                 on_phase_start(
-                    ModelPhaseStart("final_from_tool_completion_repair", streamed=stream_buffer is None and on_final_delta is not None)
+                    ModelPhaseStart(
+                        "final_from_tool_completion_repair",
+                        streamed=stream_buffer is None and on_final_delta is not None,
+                        attempt=3,
+                        reason="pdf_contradiction" if contradiction else completeness.status,
+                    )
                 )
             with self.transport.backend_thinking(False):
                 if on_final_delta is None:
@@ -455,7 +482,14 @@ class FinalFromToolEnvironment:
             compact_messages = [*policy.messages, final_tool_compact_retry_instruction()]
             compact_max_tokens = final_tool_compact_retry_max_tokens(max_tokens, messages=policy.messages)
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("final_from_tool_compact_retry", streamed=stream_buffer is None and on_final_delta is not None))
+                on_phase_start(
+                    ModelPhaseStart(
+                        "final_from_tool_compact_retry",
+                        streamed=stream_buffer is None and on_final_delta is not None,
+                        attempt=4,
+                        reason=compact_retry_reason,
+                    )
+                )
             with self.transport.backend_thinking(False):
                 if on_final_delta is None:
                     candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
@@ -542,7 +576,14 @@ class ContinueEnvironment:
                 max_passes=3,
             )
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("chat_continue_native", streamed=on_final_delta is not None))
+                on_phase_start(
+                    ModelPhaseStart(
+                        "chat_continue_native",
+                        streamed=on_final_delta is not None,
+                        attempt=1,
+                        reason="length",
+                    )
+                )
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="chat_continue_native"))
             if self.runtime._thinking().continuation_kind_for(content=result.content, finish_reason=result.finish_reason) is not None:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -520,6 +520,8 @@ def run_tool_loop(
                 ModelPhaseStart(
                     "tool_call",
                     streamed=tool_delta_callback is not suppress_tool_delta and on_final_delta is not None,
+                    attempt=state.tool_rounds + 1,
+                    reason="model_tool_call",
                 )
             )
         result = runtime._chat_tool_call_once(
@@ -536,7 +538,7 @@ def run_tool_loop(
         if repair.contract_retry_pending and not result.tool_calls:
             retry_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTRACT_RETRY_PROMPT}]
             if on_phase_start:
-                on_phase_start(ModelPhaseStart("tool_call_retry", streamed=False))
+                on_phase_start(ModelPhaseStart("tool_call_retry", streamed=False, attempt=state.tool_rounds + 1, reason="tool_contract_retry"))
             result = runtime._chat_tool_call_once(
                 retry_messages,
                 temperature=temperature,

--- a/src/orbit/runtime/turn_trace.py
+++ b/src/orbit/runtime/turn_trace.py
@@ -9,6 +9,8 @@ from orbit.backend import ChatResult
 class ModelPhaseStart:
     phase: str
     streamed: bool = True
+    attempt: int | None = None
+    reason: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -37,6 +37,7 @@ class Repl:
     can_continue: bool = False
     tools_mode: ToolSpec | None = None
     queued_prompts: list[str] = field(default_factory=list)
+    _last_phase_label: str | None = None
 
     def __post_init__(self) -> None:
         if self.tools_mode is None:
@@ -94,6 +95,7 @@ class Repl:
         return read_prompt_input()
 
     def _ask(self, prompt: str) -> None:
+        self._last_phase_label = None
         tools_enabled = tools_are_enabled(self.tools_mode or "off")
         system_prompt = ROUTE_SYSTEM_PROMPT if tools_enabled else CHAT_SYSTEM_PROMPT
         prefill_tokens = estimate_prefill_tokens(self.runtime.messages, prompt, system_prompt=system_prompt)
@@ -189,8 +191,10 @@ class Repl:
 
     def _record_phase_start(self, renderer: StreamRenderer, phase: ModelPhaseStart) -> None:
         label = _phase_label(phase)
-        if label:
-            renderer.event(label, restart_timer=True)
+        if not label or label == self._last_phase_label:
+            return
+        self._last_phase_label = label
+        renderer.event(label, restart_timer=True)
 
     def _show_tool_result(self, renderer: StreamRenderer, name: str, chars: int, source: str | None, content: str | None) -> None:
         if content is not None:
@@ -308,6 +312,7 @@ class Repl:
             self.history.save()
 
     def _ask_continue(self) -> None:
+        self._last_phase_label = None
         prefill_tokens = estimate_prefill_tokens(self.runtime.messages, "")
         prefill_seconds = self.prefill_estimator.estimate_seconds(prefill_tokens)
         renderer = StreamRenderer(
@@ -369,21 +374,55 @@ def _length_footer_message(thinking: bool) -> str:
 
 
 def _phase_label(phase: ModelPhaseStart) -> str | None:
-    labels = {
-        "tool_plan": "phase: thinking",
-        "route": "phase: deciding tool use (non-streaming)",
-        "chat_final": "phase: final answer",
-        "chat_final_retry": "phase: continuing after length",
-        "chat_final_completion_repair": "phase: repairing final answer",
-        "tool_call": "phase: tool call" if phase.streamed else "phase: tool call (non-streaming)",
-        "tool_call_retry": "phase: retrying tool call (non-streaming)",
-        "final_from_tool": "phase: final answer" if phase.streamed else "phase: final answer (non-streaming)",
-        "final_from_tool_retry": "phase: continuing after length" if phase.streamed else "phase: continuing after length (non-streaming)",
-        "final_from_tool_completion_repair": "phase: repairing incomplete final answer",
-        "final_from_tool_compact_retry": "phase: shortening final answer",
-        "chat_continue_native": "phase: continuing after length",
-    }
-    return labels.get(phase.phase)
+    suffix = ""
+    if not phase.streamed:
+        suffix = " (non-streaming)"
+
+    if phase.phase == "tool_plan":
+        return "phase: thinking"
+    if phase.phase == "route":
+        return f"phase: deciding tool use{suffix}"
+    if phase.phase == "chat_final":
+        pass_label = f" pass {phase.attempt}" if phase.attempt else ""
+        return f"phase: final answer{pass_label}{suffix}"
+    if phase.phase == "chat_final_retry":
+        reason = " after length" if phase.reason == "length" else ""
+        return f"phase: retrying final answer{reason}{suffix}"
+    if phase.phase == "chat_final_completion_repair":
+        if phase.reason == "reasoning_like":
+            return f"phase: forced final answer only{suffix}"
+        if phase.reason:
+            return f"phase: repairing final answer ({phase.reason}){suffix}"
+        return f"phase: repairing final answer{suffix}"
+    if phase.phase == "tool_call":
+        pass_label = f" pass {phase.attempt}" if phase.attempt else ""
+        return f"phase: tool call{pass_label}{suffix}"
+    if phase.phase == "tool_call_retry":
+        if phase.reason == "tool_contract_retry":
+            return "phase: retrying tool call after contract mismatch (non-streaming)"
+        return f"phase: retrying tool call{suffix}"
+    if phase.phase == "final_from_tool":
+        pass_label = f" pass {phase.attempt}" if phase.attempt else ""
+        return f"phase: final answer from tool result{pass_label}{suffix}"
+    if phase.phase == "final_from_tool_retry":
+        if phase.reason == "length":
+            return f"phase: continuing final answer from tool result after length{suffix}"
+        if phase.reason:
+            return f"phase: final answer from tool result retry ({phase.reason}){suffix}"
+        return f"phase: final answer from tool result retry{suffix}"
+    if phase.phase == "final_from_tool_completion_repair":
+        if phase.reason == "reasoning_like":
+            return f"phase: forced final answer from tool result only{suffix}"
+        if phase.reason:
+            return f"phase: repairing final answer from tool result ({phase.reason}){suffix}"
+        return f"phase: repairing final answer from tool result{suffix}"
+    if phase.phase == "final_from_tool_compact_retry":
+        if phase.reason:
+            return f"phase: compact final answer retry ({phase.reason}){suffix}"
+        return f"phase: compact final answer retry{suffix}"
+    if phase.phase == "chat_continue_native":
+        return f"phase: continuing after length{suffix}"
+    return None
 
 
 def _prefill_profile_for_turn(messages: list[dict[str, object]], *, tools_enabled: bool) -> str:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -272,8 +272,44 @@ class ReplTests(unittest.TestCase):
     def test_phase_label_maps_buffered_and_streamed_phases(self) -> None:
         self.assertEqual(_phase_label(ModelPhaseStart("tool_plan", streamed=True)), "phase: thinking")
         self.assertEqual(_phase_label(ModelPhaseStart("route", streamed=False)), "phase: deciding tool use (non-streaming)")
-        self.assertEqual(_phase_label(ModelPhaseStart("final_from_tool", streamed=False)), "phase: final answer (non-streaming)")
-        self.assertEqual(_phase_label(ModelPhaseStart("final_from_tool_compact_retry", streamed=False)), "phase: shortening final answer")
+        self.assertEqual(_phase_label(ModelPhaseStart("chat_final", streamed=True, attempt=1)), "phase: final answer pass 1")
+        self.assertEqual(
+            _phase_label(ModelPhaseStart("chat_final_completion_repair", streamed=True, attempt=2, reason="reasoning_like")),
+            "phase: forced final answer only",
+        )
+        self.assertEqual(
+            _phase_label(ModelPhaseStart("final_from_tool", streamed=False, attempt=1)),
+            "phase: final answer from tool result pass 1 (non-streaming)",
+        )
+        self.assertEqual(
+            _phase_label(ModelPhaseStart("final_from_tool_compact_retry", streamed=False, attempt=4, reason="length")),
+            "phase: compact final answer retry (length) (non-streaming)",
+        )
+
+    def test_record_phase_start_coalesces_duplicate_labels(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+
+        class Renderer:
+            def __init__(self) -> None:
+                self.events: list[str] = []
+
+            def event(self, text: str, restart_timer: bool = True) -> None:
+                self.events.append(text)
+
+        renderer = Renderer()
+
+        repl._record_phase_start(renderer, ModelPhaseStart("chat_final", streamed=True, attempt=1))
+        repl._record_phase_start(renderer, ModelPhaseStart("chat_final", streamed=True, attempt=1))
+        repl._record_phase_start(renderer, ModelPhaseStart("chat_final_completion_repair", streamed=True, attempt=2, reason="reasoning_like"))
+
+        self.assertEqual(
+            renderer.events,
+            [
+                "phase: final answer pass 1",
+                "phase: forced final answer only",
+            ],
+        )
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:
         self.assertEqual(_prefill_profile_for_turn([], tools_enabled=False), CHAT_PREFILL_PROFILE)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -18,6 +18,7 @@ from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, MEDIA_SYSTEM_P
 from orbit.runtime.chat import _has_list_like_tool_result
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.tool_loop import _should_guard_existing_file_rewrite
+from orbit.runtime.turn_trace import ModelPhaseStart
 from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
     SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT,
@@ -355,6 +356,58 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result.content, "Final answer: Dante Alighieri was an Italian poet.")
         self.assertEqual(backend.chat_calls, 2)
         self.assertEqual(backend.thinking_seen, [True, False])
+
+    def test_ask_chat_emits_distinct_phase_reasons_for_reasoning_repair(self) -> None:
+        class ReasoningThenFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                if self.chat_calls == 1:
+                    return ChatResult(
+                        content="<|channel>thought\nprivate chain<channel|>",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Final answer: Dante Alighieri was an Italian poet.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ReasoningThenFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        phases: list[ModelPhaseStart] = []
+
+        runtime.ask_chat(
+            "Who is Dante Alighieri?",
+            temperature=0,
+            max_tokens=32,
+            on_phase_start=phases.append,
+        )
+
+        self.assertEqual(
+            [(phase.phase, phase.attempt, phase.reason) for phase in phases],
+            [
+                ("chat_final", 1, None),
+                ("chat_final_completion_repair", 2, "reasoning_like"),
+            ],
+        )
 
     def test_continue_last_response_uses_prompt_fallback_for_bullet_reasoning_length(self) -> None:
         class BulletReasoningBackend(FakeBackend):


### PR DESCRIPTION
Summary:

* Makes repeated model passes understandable in the terminal.
* Adds attempt/reason metadata to model phase events.
* Replaces repeated generic `phase: final answer` lines with specific labels.
* Coalesces identical duplicate phase events.
* Keeps backend/native streaming unchanged.

Examples:
Before:

```text
phase: final answer
[prefill/gen]
phase: final answer
[prefill/gen]
```

After:

```text
phase: final answer pass 1
[prefill/gen]

phase: forced final answer only
[prefill/gen final-only repair]
```

Post-tool:

```text
phase: final answer from tool result pass 1 (non-streaming)
```

Validation:

* runtime/repl/final_policy/tool_loop tests PASS
* native_streaming/native_thinking/native_server_bootstrap PASS
* compileall PASS
* diff check PASS

Smoke:

* simple chat PASS
* think on reasoning-only first pass PASS
* tools on shell query PASS
* tools on final_from_tool PASS
* retry without length PASS
* /continue covered by tests, not rerun live in this iteration

Residual caveats:

* Plain final answers on the native backend can still arrive buffered.
* This PR does not change backend/native streaming.
* Very slow tools-on + think-on paths can still be slow; the restart reason is now visible.