### PR TITLE
Label progress ticks with current model phase

### DIFF
--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -191,6 +191,7 @@ class Repl:
 
     def _record_phase_start(self, renderer: StreamRenderer, phase: ModelPhaseStart) -> None:
         label = _phase_label(phase)
+        renderer.set_phase_label(_phase_progress_label(phase))
         if not label or label == self._last_phase_label:
             return
         self._last_phase_label = label
@@ -422,6 +423,48 @@ def _phase_label(phase: ModelPhaseStart) -> str | None:
         return f"phase: compact final answer retry{suffix}"
     if phase.phase == "chat_continue_native":
         return f"phase: continuing after length{suffix}"
+    return None
+
+
+def _phase_progress_label(phase: ModelPhaseStart) -> str | None:
+    if phase.phase == "tool_plan":
+        return "thinking"
+    if phase.phase == "route":
+        return "tool decision"
+    if phase.phase == "chat_final":
+        if phase.attempt and phase.attempt > 1:
+            return f"final answer #{phase.attempt}"
+        return "final answer"
+    if phase.phase == "chat_final_retry":
+        if phase.reason == "length":
+            return "final retry"
+        return "final retry"
+    if phase.phase == "chat_final_completion_repair":
+        if phase.reason == "reasoning_like":
+            return "forced final"
+        return "repair final"
+    if phase.phase == "tool_call":
+        if phase.attempt and phase.attempt > 1:
+            return f"tool call #{phase.attempt}"
+        return "tool call"
+    if phase.phase == "tool_call_retry":
+        return "tool retry"
+    if phase.phase == "final_from_tool":
+        if phase.attempt and phase.attempt > 1:
+            return f"tool final #{phase.attempt}"
+        return "tool final"
+    if phase.phase == "final_from_tool_retry":
+        if phase.reason == "length":
+            return "tool final continue"
+        return "tool final retry"
+    if phase.phase == "final_from_tool_completion_repair":
+        if phase.reason == "reasoning_like":
+            return "forced tool final"
+        return "tool final repair"
+    if phase.phase == "final_from_tool_compact_retry":
+        return "compact retry"
+    if phase.phase == "chat_continue_native":
+        return "continue"
     return None
 
 

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -37,6 +37,7 @@ class StreamRenderer:
         self._thinking_started = False
         self._thinking_final_started = False
         self._thinking_dim_open = False
+        self._phase_label: str | None = None
 
     def start(self) -> None:
         self._started = True
@@ -135,7 +136,7 @@ class StreamRenderer:
         elapsed = time.monotonic() - self._start_time
         frame = SPINNER_FRAMES[self._frame_index % len(SPINNER_FRAMES)]
         self._frame_index += 1
-        line = dim(f"{frame} Working ({self._working_status(elapsed)} - Ctrl+C to interrupt)")
+        line = dim(f"{frame} Working{self._working_phase_prefix()} ({self._working_status(elapsed)} - Ctrl+C to interrupt)")
         print(f"\r{_pad_to_terminal_width(line)}", end="", flush=True)
 
     @staticmethod
@@ -146,6 +147,9 @@ class StreamRenderer:
     def set_prefill_estimate(self, seconds: float | None, tokens: int | None = None) -> None:
         self._prefill_estimate_seconds = seconds
         self._prefill_estimate_tokens = tokens
+
+    def set_phase_label(self, label: str | None) -> None:
+        self._phase_label = label.strip() if label else None
 
     def _normalize_progress(self, update: StreamProgress) -> StreamProgress:
         if update.phase != "generation":
@@ -184,6 +188,11 @@ class StreamRenderer:
                 label = PREFILL_COMPLETION_LABEL if progress >= 95 else f"pf ~{progress}%"
             parts.append(label)
         return ", ".join(parts)
+
+    def _working_phase_prefix(self) -> str:
+        if not self._phase_label:
+            return ""
+        return f" [{self._phase_label}]"
 
 
 def _terminal_columns() -> int:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -33,7 +33,7 @@ from orbit.terminal.repl_input import (
     visual_row_count,
 )
 from orbit.terminal.repl import Repl
-from orbit.terminal.repl import _phase_label, _prefill_profile_for_turn
+from orbit.terminal.repl import _phase_label, _phase_progress_label, _prefill_profile_for_turn
 from orbit.terminal.session_preview import format_recent_session_messages
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
@@ -285,6 +285,20 @@ class ReplTests(unittest.TestCase):
             _phase_label(ModelPhaseStart("final_from_tool_compact_retry", streamed=False, attempt=4, reason="length")),
             "phase: compact final answer retry (length) (non-streaming)",
         )
+        self.assertEqual(_phase_progress_label(ModelPhaseStart("chat_final", streamed=True, attempt=1)), "final answer")
+        self.assertEqual(_phase_progress_label(ModelPhaseStart("chat_final", streamed=True, attempt=2)), "final answer #2")
+        self.assertEqual(
+            _phase_progress_label(ModelPhaseStart("chat_final_completion_repair", streamed=True, attempt=2, reason="reasoning_like")),
+            "forced final",
+        )
+        self.assertEqual(
+            _phase_progress_label(ModelPhaseStart("final_from_tool", streamed=False, attempt=1)),
+            "tool final",
+        )
+        self.assertEqual(
+            _phase_progress_label(ModelPhaseStart("final_from_tool_compact_retry", streamed=False, attempt=4, reason="length")),
+            "compact retry",
+        )
 
     def test_record_phase_start_coalesces_duplicate_labels(self) -> None:
         runtime = CountingRuntime()
@@ -293,9 +307,13 @@ class ReplTests(unittest.TestCase):
         class Renderer:
             def __init__(self) -> None:
                 self.events: list[str] = []
+                self.phase_label: str | None = None
 
             def event(self, text: str, restart_timer: bool = True) -> None:
                 self.events.append(text)
+
+            def set_phase_label(self, label: str | None) -> None:
+                self.phase_label = label
 
         renderer = Renderer()
 
@@ -310,6 +328,7 @@ class ReplTests(unittest.TestCase):
                 "phase: forced final answer only",
             ],
         )
+        self.assertEqual(renderer.phase_label, "forced final")
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:
         self.assertEqual(_prefill_profile_for_turn([], tools_enabled=False), CHAT_PREFILL_PROFILE)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -163,11 +163,35 @@ class StreamingRendererTests(unittest.TestCase):
         output = stream.getvalue()
         self.assertIn("Working (0s, pf ~1% - Ctrl+C to interrupt)", output)
 
+    def test_wait_timer_includes_phase_label_when_present(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(interval=0.01, prefill_estimate_seconds=10)
+            renderer.set_phase_label("final answer")
+            renderer.start()
+            time.sleep(0.02)
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Working [final answer] (0s, pf ~1% - Ctrl+C to interrupt)", output)
+
     def test_wait_timer_prints_prefill_token_progress_when_estimated(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
 
         self.assertIn("pf ~500/1000 tk", renderer._working_status(5))
         self.assertIn("waiting for model...", renderer._working_status(10))
+
+    def test_wait_timer_includes_phase_label_in_real_progress_status(self) -> None:
+        renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
+        renderer.set_phase_label("forced final")
+        renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
+
+        self.assertEqual(renderer._working_phase_prefix(), " [forced final]")
+        self.assertIn("pf 243/935 tk (25%)", renderer._working_status(5))
 
     def test_wait_timer_prints_prefill_finalizing_after_estimate(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10)


### PR DESCRIPTION
Summary:

* Connects progress ticks to the current model phase.
* Replaces generic `Working (...)` with labels like:

  * `Working [final answer] (...)`
  * `Working [forced final] (...)`
  * `Working [tool final] (...)`
  * `Working [compact retry] (...)`
* Keeps labels compact and avoids unnecessary `#1`.
* Preserves duplicate phase coalescing.
* Does not modify backend/native streaming.

Validation:

* streaming/repl/runtime/final_policy/tool_loop tests PASS
* compileall PASS
* diff check PASS

Smoke:

* multipass think-on final-answer path PASS
* progress label changes from `final answer` to `forced final` when the pass changes

Residual caveats:

* Native backend plain final answers may still be buffered.
* This PR only improves progress UX; it does not change backend streaming.