### PR TITLE
Fix tool backend tests for current shell guardrails

### DIFF
--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import subprocess
 import tempfile
 import time
 import unittest
@@ -484,7 +485,7 @@ class HybridToolExecutorTests(unittest.TestCase):
                 workdir=workdir,
                 allowed_tool_names=("exec_shell_full_command",),
             )
-            with patch("orbit.runtime.shell_guardrails._extract_pdf_text", return_value=(sample_text, "pdftotext")):
+            with patch("orbit.runtime.shell_guardrails.extract_pdf_text", return_value=(sample_text, "pdftotext")):
                 head_execution = executor.execute(
                     "exec_shell_full_command",
                     {"command": "pdftotext sample.pdf - | head -n 3"},
@@ -524,7 +525,7 @@ class HybridToolExecutorTests(unittest.TestCase):
                 workdir=workdir,
                 allowed_tool_names=("exec_shell_full_command",),
             )
-            with patch("orbit.runtime.shell_guardrails._extract_pdf_text", return_value=(sample_text, "pdftotext")):
+            with patch("orbit.runtime.shell_guardrails.extract_pdf_text", return_value=(sample_text, "pdftotext")):
                 sed_execution = executor.execute(
                     "exec_shell_full_command",
                     {"command": "pdftotext sample.pdf - | sed -n '3,5p'"},
@@ -554,8 +555,16 @@ class HybridToolExecutorTests(unittest.TestCase):
                 allowed_tool_names=("exec_shell_full_command",),
             )
 
-            with patch("orbit.runtime.shell_guardrails.shutil.which") as which:
+            with patch("orbit.runtime.file_tools.shutil.which") as which, patch(
+                "orbit.runtime.file_tools.subprocess.run"
+            ) as run:
                 which.side_effect = lambda name: None if name == "pdftotext" else "/usr/bin/strings"
+                run.return_value = subprocess.CompletedProcess(
+                    args=["/usr/bin/strings", "-a", "-n", "8", str(target)],
+                    returncode=0,
+                    stdout="%PDF-1.4\nOrbit PDF fallback visible text\n%%EOF\n",
+                    stderr="",
+                )
                 execution = executor.execute(
                     "exec_shell_full_command",
                     {"command": "cat sample.pdf"},


### PR DESCRIPTION
This PR restores a green global unittest baseline after `tests/test_tool_backends.py` started patching internal PDF-extraction symbols that no longer live in `orbit.runtime.shell_guardrails`.

Summary:
- updates `tests/test_tool_backends.py` to patch the current PDF extraction path
- patches `orbit.runtime.shell_guardrails.extract_pdf_text` where shell guardrails use it directly
- patches `orbit.runtime.file_tools.shutil.which` and `orbit.runtime.file_tools.subprocess.run` for the strings fallback path
- keeps the change test-only
- does not include any dead-code cleanup

Root cause:
The failing tests were coupled to old internal symbol locations (`shell_guardrails._extract_pdf_text` and `shell_guardrails.shutil.which`). The runtime behavior was still correct; the tests were stale and too implementation-specific.

Validation:
- `PYTHONPATH=src python3 -m unittest tests.test_tool_backends -q` PASS
- `python3 -m unittest discover -s tests -q` PASS
- `PYTHONPATH=src python3 -m unittest tests.test_tool_loop_state tests.test_runtime tests.test_final_policy tests.test_repl -q` PASS
- `python3 -m compileall -q src tests scripts` PASS
- `git diff --check` PASS

Scope:
- test-only change in `tests/test_tool_backends.py`
- no runtime, backend, native, MTP, or tool-loop behavior changes
