### PR TITLE
Remove unused private helpers

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -311,23 +311,6 @@ def _parse_chat_result(data: dict[str, Any]) -> ChatResult:
     )
 
 
-def _parse_native_chat_result(data: dict[str, Any]) -> ChatResult:
-    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
-    timings = data.get("timings") if isinstance(data.get("timings"), dict) else {}
-    details = usage.get("prompt_tokens_details") if isinstance(usage.get("prompt_tokens_details"), dict) else {}
-    return ChatResult(
-        content=_str_or_none(data.get("content")) or "",
-        model=_str_or_none(data.get("model")),
-        finish_reason=_str_or_none(data.get("finish_reason")),
-        tool_calls=[],
-        prompt_tokens=_int_or_none(usage.get("prompt_tokens")),
-        completion_tokens=_int_or_none(usage.get("completion_tokens")),
-        cached_tokens=_int_or_none(details.get("cached_tokens")),
-        prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
-        generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
-    )
-
-
 def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> ChatResult:
     content_parts: list[str] = []
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
@@ -568,19 +551,6 @@ class _ContentStreamFilter:
                 self._on_delta(self._buffer[:emit_len])
                 self._buffer = self._buffer[emit_len:]
             return
-
-
-def _raw_tool_call_stream_state(text: str) -> str:
-    stripped = text.lstrip()
-    if not stripped:
-        return "pending"
-    if _is_partial_prefix(stripped, "<|tool_call>"):
-        return "pending"
-    if not stripped.startswith("<|tool_call>"):
-        return "text"
-    if "<tool_call|>" not in stripped:
-        return "pending"
-    return "tool_call" if _parse_raw_tool_call_content(stripped) else "text"
 
 
 def _is_partial_prefix(text: str, prefix: str) -> bool:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1079,10 +1079,6 @@ class NativeLlamaClient:
         return bytes(buf[:n])
 
 
-def _contains_stop(content: str, stops: tuple[str, ...]) -> bool:
-    return any(stop in content for stop in stops)
-
-
 def _trim_at_stop(content: str, stops: tuple[str, ...]) -> str:
     first: int | None = None
     for stop in stops:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -758,18 +758,6 @@ def _is_empty_final_response(result: ChatResult) -> bool:
     return not result.tool_calls and result.finish_reason == "stop" and not result.content.strip()
 
 
-def _all_tool_calls_allowed(tool_calls: list[dict[str, object]], allowed_tool_names: tuple[str, ...]) -> bool:
-    allowed = set(allowed_tool_names)
-    for tool_call in tool_calls:
-        function = tool_call.get("function")
-        if not isinstance(function, dict):
-            return False
-        name = function.get("name")
-        if not isinstance(name, str) or name not in allowed:
-            return False
-    return True
-
-
 def _last_user_text(messages: list[Message]) -> str | None:
     for message in reversed(messages):
         if message.get("role") != "user":

--- a/src/orbit/runtime/turn_trace.py
+++ b/src/orbit/runtime/turn_trace.py
@@ -48,9 +48,3 @@ class ModelStepMetrics:
             tool_calls=tool_calls,
             retry_reason=retry_reason,
         )
-
-
-def cache_ratio(metrics: ModelStepMetrics) -> float | None:
-    if metrics.cached_tokens is None or not metrics.prompt_tokens:
-        return None
-    return metrics.cached_tokens / metrics.prompt_tokens


### PR DESCRIPTION
This PR removes five private helpers with zero references.

Removed:
- `src/orbit/backend/llama_server.py:_parse_native_chat_result`
- `src/orbit/backend/llama_server.py:_raw_tool_call_stream_state`
- `src/orbit/native_llama/client.py:_contains_stop`
- `src/orbit/runtime/tool_loop.py:_all_tool_calls_allowed`
- `src/orbit/runtime/turn_trace.py:cache_ratio`

Notes:
- no behavior changes
- no MTP, backend/native, tool-loop, renderer, or docs changes
- global `unittest discover` remains green

Validation:
- `python3 -m unittest discover -s tests -q` PASS
- `PYTHONPATH=src python3 -m unittest tests.test_llama_server_backend tests.test_native_streaming tests.test_runtime tests.test_tool_loop_state tests.test_repl -q` PASS
- `python3 -m compileall -q src tests scripts` PASS
- `git diff --check` PASS
