### PR TITLE
Prevent reasoning leakage in think-on final answers

### DIFF
--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -154,13 +154,30 @@ class TransportEnvironment:
             )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase=retry_phase))
-        if not is_empty_final_response(retry):
+        retry_completeness = classify_final_answer_completeness(retry.content, messages=retry_messages)
+        if not is_empty_final_response(retry) and retry_completeness.is_complete:
             return retry
 
+        if is_empty_final_response(retry):
+            error = ChatResult(
+                content="error: model returned an empty response twice",
+                model=retry.model,
+                finish_reason="empty_response",
+                tool_calls=retry.tool_calls,
+                prompt_tokens=retry.prompt_tokens,
+                completion_tokens=retry.completion_tokens,
+                cached_tokens=retry.cached_tokens,
+                prompt_tokens_per_second=retry.prompt_tokens_per_second,
+                generation_tokens_per_second=retry.generation_tokens_per_second,
+            )
+            if on_final_delta:
+                on_final_delta(error.content)
+            return error
+
         error = ChatResult(
-            content="error: model returned an empty response twice",
+            content="error: model did not produce a clean final answer",
             model=retry.model,
-            finish_reason="empty_response",
+            finish_reason="stop",
             tool_calls=retry.tool_calls,
             prompt_tokens=retry.prompt_tokens,
             completion_tokens=retry.completion_tokens,

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -48,6 +48,13 @@ _REASONING_PREFIXES = (
     "reasoning:",
     "plan:",
 )
+_REASONING_LEAK_META_PHRASES = (
+    "the user likely meant",
+    "the user probably meant",
+    "the user may have meant",
+    "looking at the words",
+    "wait, looking at the words",
+)
 
 
 @dataclass(frozen=True)
@@ -436,7 +443,11 @@ def classify_final_answer_completeness(content: str, *, messages: list[Message] 
     lowered = stripped.lower()
     if not stripped:
         return FinalAnswerCompleteness("incomplete_stub", "empty")
-    if _has_open_thought_channel(content) or looks_like_reasoning_without_final_answer(lowered):
+    if (
+        _has_open_thought_channel(content)
+        or looks_like_reasoning_without_final_answer(lowered)
+        or looks_like_reasoning_leakage(content, lowered_content=lowered)
+    ):
         return FinalAnswerCompleteness("reasoning_like")
     if "<|channel>thought" in content and "<channel|>" in content:
         tail = content.split("<channel|>", 1)[1].strip()
@@ -486,6 +497,26 @@ def looks_like_reasoning_without_final_answer(lowered_content: str) -> bool:
     if any(marker in lowered_content for marker in _FINAL_MARKERS):
         return False
     return lowered_content.startswith(_REASONING_PREFIXES)
+
+
+def looks_like_reasoning_leakage(content: str, *, lowered_content: str | None = None) -> bool:
+    lowered = lowered_content if lowered_content is not None else content.lower()
+    if not any(phrase in lowered for phrase in _REASONING_LEAK_META_PHRASES):
+        return False
+    possibility_matches = re.findall(r"(?:^|\n)\s*(?:[-*]\s+)?(?:\*\*)?possibility\s+[a-z]\b", lowered, flags=re.MULTILINE)
+    if len(possibility_matches) >= 2:
+        return True
+    bullet_lines = [
+        line.strip().lower()
+        for line in content.splitlines()
+        if line.strip()
+    ]
+    possibility_bullets = sum(
+        1
+        for line in bullet_lines
+        if ("possibility " in line and re.search(r"possibility\s+[a-z]\b", line))
+    )
+    return possibility_bullets >= 2
 
 
 def _has_open_thought_channel(content: str) -> bool:

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import re
 import threading
 import time
 
 from orbit.backend.base import StreamProgress
+from orbit.runtime.final_policy import classify_final_answer_completeness, looks_like_reasoning_leakage
 from orbit.terminal.theme import DIM, RESET, dim
 
 
@@ -233,6 +235,8 @@ class _ThinkingDisplayFilter:
         self._buffer = ""
         self._in_final = False
         self._in_channel_thought = False
+        self._thought_text_parts: list[str] = []
+        self._saw_final_output = False
 
     def write(self, text: str) -> list[tuple[str, bool]]:
         if not text:
@@ -241,7 +245,12 @@ class _ThinkingDisplayFilter:
         return self._drain(final=False)
 
     def finish(self) -> list[tuple[str, bool]]:
-        return self._drain(final=True)
+        emitted = self._drain(final=True)
+        fallback = self._fallback_final_answer()
+        if fallback:
+            emitted.append((fallback, False))
+            self._saw_final_output = True
+        return emitted
 
     def _drain(self, *, final: bool) -> list[tuple[str, bool]]:
         emitted: list[tuple[str, bool]] = []
@@ -254,11 +263,13 @@ class _ThinkingDisplayFilter:
                         break
                     text = _strip_channel_markup(self._buffer[:emit_len])
                     if text:
+                        self._remember(text, dimmed=True)
                         emitted.append((text, True))
                     self._buffer = self._buffer[emit_len:]
                     continue
                 text = _strip_channel_markup(self._buffer[:end])
                 if text:
+                    self._remember(text, dimmed=True)
                     emitted.append((text, True))
                 self._buffer = self._buffer[end + len(self._CHANNEL_END) :]
                 self._in_channel_thought = False
@@ -279,6 +290,7 @@ class _ThinkingDisplayFilter:
                     break
                 text = _strip_channel_markup(self._buffer[:emit_len])
                 if text:
+                    self._remember(text, dimmed=False)
                     emitted.append((text, False))
                 self._buffer = self._buffer[emit_len:]
                 continue
@@ -292,6 +304,7 @@ class _ThinkingDisplayFilter:
                     break
                 text = _strip_channel_markup(self._buffer[:emit_len])
                 if text:
+                    self._remember(text, dimmed=True)
                     emitted.append((text, True))
                 self._buffer = self._buffer[emit_len:]
                 continue
@@ -299,13 +312,34 @@ class _ThinkingDisplayFilter:
             if start > 0:
                 text = _strip_channel_markup(self._buffer[:start])
                 if text:
+                    self._remember(text, dimmed=True)
                     emitted.append((text, True))
             marker = _strip_channel_markup(self._buffer[start:end])
             if marker:
+                self._remember(marker, dimmed=False)
                 emitted.append((marker, False))
             self._buffer = self._buffer[end:]
             self._in_final = True
         return emitted
+
+    def _remember(self, text: str, *, dimmed: bool) -> None:
+        if dimmed:
+            self._thought_text_parts.append(text)
+            return
+        self._saw_final_output = True
+
+    def _fallback_final_answer(self) -> str | None:
+        if self._saw_final_output or self._in_final:
+            return None
+        thought_text = "".join(self._thought_text_parts).strip()
+        if not thought_text or not looks_like_reasoning_leakage(thought_text):
+            return None
+        lines = [line for line in (_clean_reasoning_line(raw) for raw in thought_text.splitlines()) if line]
+        for line in reversed(lines):
+            completeness = classify_final_answer_completeness(line)
+            if completeness.is_complete and not looks_like_reasoning_leakage(line):
+                return line
+        return None
 
     def _safe_emit_length(self) -> int:
         keep = 0
@@ -354,3 +388,25 @@ def _strip_channel_markup(text: str) -> str:
         .replace("<|channel>final\n", "")
         .replace("<channel|>", "")
     )
+
+
+def _clean_reasoning_line(line: str) -> str:
+    text = line.strip()
+    if not text:
+        return ""
+    text = re.sub(r"^(?:[-*]\s+)+", "", text)
+    text = text.strip()
+    text = text.strip("*")
+    text = text.strip()
+    if not text:
+        return ""
+    lowered = text.lower()
+    if re.match(r"^possibility\s+[a-z]\b", lowered):
+        return ""
+    if lowered.startswith(("the user likely meant", "the user probably meant", "the user may have meant")):
+        return ""
+    if lowered.startswith(("wait, looking at the words", "looking at the words")):
+        return ""
+    if text.startswith(("'", '"')) and text.endswith(("'", '"')) and len(text) > 8:
+        return ""
+    return text

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -630,6 +630,16 @@ class FinalPolicyTests(unittest.TestCase):
         completeness = classify_final_answer_completeness("Plan:\n1. Inspect the file\n2. Summarize the findings")
         self.assertEqual(completeness.status, "reasoning_like")
 
+    def test_final_answer_completeness_detects_reasoning_leakage_with_possibilities(self) -> None:
+        completeness = classify_final_answer_completeness(
+            '"What is the main difference between essay and wise?"\n'
+            "The user likely meant \"essay\" and \"wise\".\n"
+            "* **Possibility A:** compare essay and thesis.\n"
+            "* **Possibility B:** compare essay and wise.\n"
+            "The main difference is that an essay is a piece of writing, while wise means having good judgment."
+        )
+        self.assertEqual(completeness.status, "reasoning_like")
+
     def test_final_answer_completeness_detects_closed_thought_without_final_tail(self) -> None:
         completeness = classify_final_answer_completeness("<|channel>thought\nprivate chain<channel|>")
         self.assertEqual(completeness.status, "reasoning_like")
@@ -637,6 +647,12 @@ class FinalPolicyTests(unittest.TestCase):
     def test_final_answer_completeness_accepts_complete_brief_answer(self) -> None:
         completeness = classify_final_answer_completeness(
             "The file is vulnerable to SQL injection and command injection due to unsanitized input handling."
+        )
+        self.assertEqual(completeness.status, "complete")
+
+    def test_final_answer_completeness_allows_normal_possibility_wording(self) -> None:
+        completeness = classify_final_answer_completeness(
+            "One possibility is that the user is comparing an essay with the adjective \"wise\", but the direct difference is that an essay is a written composition while wise describes judgment."
         )
         self.assertEqual(completeness.status, "complete")
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -357,6 +357,110 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(backend.chat_calls, 2)
         self.assertEqual(backend.thinking_seen, [True, False])
 
+    def test_ask_chat_rejects_reasoning_leakage_even_when_finish_reason_is_stop(self) -> None:
+        class ReasoningLeakThenFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+                self.thinking_seen: list[bool] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                self.thinking_seen.append(self.thinking)
+                if self.chat_calls == 1:
+                    return ChatResult(
+                        content=(
+                            '"What is the main difference between essay and wise?"\n'
+                            'The user likely meant "essay" and "wise".\n'
+                            "* **Possibility A:** compare essay and thesis.\n"
+                            "* **Possibility B:** compare essay and wise.\n"
+                            "An essay is a written composition, while wise means having good judgment."
+                        ),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="An essay is a written composition, while wise means having good judgment.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ReasoningLeakThenFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+
+        result = runtime.ask_chat("what is the main difference beetwen essay and wise?", temperature=0, max_tokens=64)
+
+        self.assertEqual(
+            result.content,
+            "An essay is a written composition, while wise means having good judgment.",
+        )
+        self.assertEqual(backend.chat_calls, 2)
+        self.assertEqual(backend.thinking_seen, [True, False])
+
+    def test_ask_chat_returns_controlled_error_if_final_only_retry_still_leaks_reasoning(self) -> None:
+        class ReasoningLeakTwiceBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.chat_calls += 1
+                if self.chat_calls == 1:
+                    return ChatResult(
+                        content=(
+                            "The user likely meant two different words.\n"
+                            "* **Possibility A:** first interpretation.\n"
+                            "* **Possibility B:** second interpretation.\n"
+                            "Here is a partial answer."
+                        ),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content=(
+                        "The user likely meant two different words.\n"
+                        "* **Possibility A:** first interpretation.\n"
+                        "* **Possibility B:** second interpretation.\n"
+                        "Here is another partial answer."
+                    ),
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = ReasoningLeakTwiceBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+
+        result = runtime.ask_chat("what is the main difference beetwen essay and wise?", temperature=0, max_tokens=64)
+
+        self.assertEqual(result.content, "error: model did not produce a clean final answer")
+        self.assertEqual(result.finish_reason, "stop")
+
     def test_ask_chat_emits_distinct_phase_reasons_for_reasoning_repair(self) -> None:
         class ReasoningThenFinalBackend(FakeBackend):
             def __init__(self) -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -111,6 +111,52 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertIn("Thinking...", output)
         self.assertIn("\033[2mprivate chain\033[0m", output)
 
+    def test_thinking_mode_emits_fallback_final_answer_when_reasoning_leaks_without_marker(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(thinking=True)
+            renderer.write(
+                '"What is the main difference between essay and wise?"\n'
+                "The user likely meant essay and wise.\n"
+                "* Possibility A: typo.\n"
+                "* Possibility B: meaning.\n"
+                '* The main difference is that an essay is a written composition, while "wise" means having good judgment.'
+            )
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Thinking...", output)
+        self.assertIn("The user likely meant essay and wise.", output)
+        self.assertIn(
+            '\n\nThe main difference is that an essay is a written composition, while "wise" means having good judgment.',
+            output,
+        )
+        self.assertNotIn('\n\nPossibility A: typo.', output)
+
+    def test_thinking_mode_does_not_invent_final_answer_when_only_reasoning_is_present(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(thinking=True)
+            renderer.write(
+                "The user likely meant essay and wise.\n"
+                "* Possibility A: typo.\n"
+                "* Possibility B: meaning.\n"
+            )
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Thinking...", output)
+        self.assertNotIn("\n\nPossibility", output)
+        self.assertNotIn("\n\nThe main difference", output)
+
     def test_event_prints_dim_message(self) -> None:
         stream = io.StringIO()
         original = sys.stdout


### PR DESCRIPTION
Summary:

* Tightens runtime final-answer completeness checks for reasoning leakage patterns such as meta prompt analysis and repeated Possibility A/B brainstorming.
* Rejects reasoning-like final-only retries even when they end with `finish_reason=stop`.
* Adds a conservative renderer fallback that separates a clean final sentence from `Thinking...` output when the model never emits an explicit final marker.
* Leaves backend/native streaming, MTP, and tool execution behavior unchanged.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_final_policy tests.test_repl tests.test_streaming tests.test_tool_loop_state -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* `think on` + `tools off` + `what is the main difference beetwen essay and wise?` PASS
  * reasoning stayed under `Thinking...`
  * final answer was shown separately and cleanly
* `think off` on the same prompt PASS
* `think on` + `who is Dante Alighieri? answer in one sentence` PASS

Residual caveats:

* This does not change backend/native streaming behavior.
* The renderer fallback is intentionally conservative and only triggers when no explicit final marker was seen.