### PR TITLE
Separate think-on chat reasoning from final answers

### DIFF
--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
     from orbit.runtime.chat import ChatRuntime
 
+CHAT_THINKING_MAX_TOKENS = 64
+
 
 @dataclass(frozen=True)
 class ClientTurnState:
@@ -278,6 +280,58 @@ class PureChatEnvironment:
         loop: int,
     ) -> ChatResult:
         self.runtime.messages.append({"role": "user", "content": user_content})
+        if self.runtime.thinking_mode:
+            thinking_max_tokens = CompletionBudget(max_tokens).internal(CHAT_THINKING_MAX_TOKENS)
+            thinking_messages = [
+                *call_messages,
+                {
+                    "role": "user",
+                    "content": (
+                        "Think briefly about how to answer. "
+                        "Do not answer the user yet. "
+                        "Reason only in this pass. "
+                        "Keep it to at most three very short bullets or two short sentences, then stop."
+                    ),
+                },
+            ]
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("tool_plan", streamed=on_final_delta is not None, attempt=1, reason="chat_thinking"))
+            with self.transport.backend_thinking(True):
+                thinking_result = self.transport.chat_once(
+                    thinking_messages,
+                    temperature=temperature,
+                    max_tokens=thinking_max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                )
+            if on_model_step:
+                on_model_step(ModelStepMetrics.from_result(loop=loop, result=thinking_result, phase="chat_thinking"))
+            final_messages = [
+                *call_messages,
+                {"role": "assistant", "content": thinking_result.content},
+                {
+                    "role": "user",
+                    "content": (
+                        "Now provide the final answer only. "
+                        "Start the answer with 'Final answer:'. "
+                        "Do not include reasoning, plan, or prompt analysis. "
+                        "Answer the user directly now."
+                    ),
+                },
+            ]
+            with self.transport.backend_thinking(False):
+                result = self.transport.chat_final(
+                    final_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
+                    loop=loop + 1,
+                )
+            self.runtime.messages.append({"role": "assistant", "content": result.content})
+            return result
         result = self.transport.chat_final(
             call_messages,
             temperature=temperature,

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -50,10 +50,15 @@ _REASONING_PREFIXES = (
 )
 _REASONING_LEAK_META_PHRASES = (
     "the user likely meant",
+    "the user likely means",
     "the user probably meant",
+    "the user probably means",
     "the user may have meant",
+    "the user may mean",
     "looking at the words",
     "wait, looking at the words",
+    "the sentence should",
+    "i should",
 )
 
 

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -640,6 +640,16 @@ class FinalPolicyTests(unittest.TestCase):
         )
         self.assertEqual(completeness.status, "reasoning_like")
 
+    def test_final_answer_completeness_detects_reasoning_leakage_with_means_wording(self) -> None:
+        completeness = classify_final_answer_completeness(
+            '"What is the main difference between essay and wise?"\n'
+            "The user likely means \"essay\" and \"wise\".\n"
+            "* **Possibility A:** compare essay and thesis.\n"
+            "* **Possibility B:** compare essay and wise.\n"
+            "An essay is a piece of writing, while wise describes judgment."
+        )
+        self.assertEqual(completeness.status, "reasoning_like")
+
     def test_final_answer_completeness_detects_closed_thought_without_final_tail(self) -> None:
         completeness = classify_final_answer_completeness("<|channel>thought\nprivate chain<channel|>")
         self.assertEqual(completeness.status, "reasoning_like")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -461,6 +461,89 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result.content, "error: model did not produce a clean final answer")
         self.assertEqual(result.finish_reason, "stop")
 
+    def test_ask_chat_think_on_streams_separate_thinking_then_final_answer_pass(self) -> None:
+        class StreamingThinkingThenFinalBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+                self.thinking = True
+                self.thinking_seen: list[bool] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                raise AssertionError("streaming path expected")
+
+            def chat_stream(
+                self,
+                messages: list[Message],
+                *,
+                temperature: float,
+                max_tokens: int,
+                tools=None,
+                on_delta=None,
+                on_progress=None,
+            ) -> ChatResult:
+                self.chat_calls += 1
+                self.thinking_seen.append(self.thinking)
+                assert on_delta is not None
+                if self.chat_calls == 1:
+                    on_delta("The user likely means \"essay\" and \"wise\".\n")
+                    on_delta("* **Possibility A:** compare essay and thesis.\n")
+                    on_delta("* **Possibility B:** compare essay and wise.\n")
+                    return ChatResult(
+                        content=(
+                            "The user likely means \"essay\" and \"wise\".\n"
+                            "* **Possibility A:** compare essay and thesis.\n"
+                            "* **Possibility B:** compare essay and wise.\n"
+                        ),
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                on_delta("Final answer: An essay is a piece of writing, while wise describes good judgment.")
+                return ChatResult(
+                    content="Final answer: An essay is a piece of writing, while wise describes good judgment.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = StreamingThinkingThenFinalBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        emitted: list[str] = []
+
+        result = runtime.ask_chat(
+            "what is the main difference beetwen essay and wise?",
+            temperature=0,
+            max_tokens=64,
+            on_final_delta=emitted.append,
+        )
+
+        self.assertEqual(
+            result.content,
+            "Final answer: An essay is a piece of writing, while wise describes good judgment.",
+        )
+        self.assertEqual(
+            emitted,
+            [
+                "The user likely means \"essay\" and \"wise\".\n",
+                "* **Possibility A:** compare essay and thesis.\n",
+                "* **Possibility B:** compare essay and wise.\n",
+                "Final answer: An essay is a piece of writing, while wise describes good judgment.",
+            ],
+        )
+        self.assertEqual(backend.chat_calls, 2)
+        self.assertEqual(backend.thinking_seen, [True, False])
+
     def test_ask_chat_emits_distinct_phase_reasons_for_reasoning_repair(self) -> None:
         class ReasoningThenFinalBackend(FakeBackend):
             def __init__(self) -> None:
@@ -474,7 +557,24 @@ class RuntimeTests(unittest.TestCase):
                     return ChatResult(
                         content="<|channel>thought\nprivate chain<channel|>",
                         model="fake",
-                        finish_reason="length",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=2,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.chat_calls == 2:
+                    return ChatResult(
+                        content=(
+                            "The user likely meant two different words.\n"
+                            "* **Possibility A:** first interpretation.\n"
+                            "* **Possibility B:** second interpretation.\n"
+                            "Here is a partial answer."
+                        ),
+                        model="fake",
+                        finish_reason="stop",
                         tool_calls=[],
                         prompt_tokens=2,
                         completion_tokens=2,
@@ -508,6 +608,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(
             [(phase.phase, phase.attempt, phase.reason) for phase in phases],
             [
+                ("tool_plan", 1, "chat_thinking"),
                 ("chat_final", 1, None),
                 ("chat_final_completion_repair", 2, "reasoning_like"),
             ],


### PR DESCRIPTION
Summary:

* Pure chat `think on` now uses two explicit model-guided passes: thinking, then final answer.
* The thinking pass remains visible and streamed.
* The final answer pass runs with `thinking=False`.
* Reasoning-like final answers are rejected and retried once through the existing bounded final repair path.
* No semantic renderer filtering, no deterministic extraction, and no backend/MTP changes.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_final_policy tests.test_repl tests.test_tool_loop_state -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* `PYTHONPATH=src python3 -m orbit.terminal.cli --think on "what is the main difference beetwen essay and wise?"` PASS
* launcher path PASS after `pipx install --force /home/guelfoweb/LAB/orbit`
* target prompt PASS with streamed thinking and separate model-produced final answer
* `think off` same prompt remains on the standard path

Caveats:

* backend/native plain final streaming remains unchanged
* pipx SIGINT shutdown abort remains separate and out of scope
* `/continue think on` and `tools on + think on` were kept green by runtime tests in this iteration; they were not rerun live end-to-end here