### PR TITLE
Remove deterministic final-answer cleanup paths

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1124,40 +1124,6 @@ def _strip_reasoning_preamble(content: str) -> str:
         cleaned = "\n".join(lines[1:]).strip()
         if cleaned:
             return cleaned
-    lowered = text.lower()
-    markers = (
-        "\n**final answer:**",
-        "\n**final answer**:",
-        "\nfinal answer**:",
-        "\nfinal answer:",
-        "\nfinal answer is:",
-        "\nthe final answer is:",
-        "\nthe final answer:",
-        "\nfinal:",
-        "\nanswer:",
-    )
-    for marker in markers:
-        idx = lowered.find(marker)
-        if idx >= 0:
-            cleaned = text[idx + len(marker) :].lstrip(" \t\r\n*:")
-            if cleaned:
-                return cleaned
-    heading_markers = (
-        "### reasoning",
-        "## reasoning",
-        "# reasoning",
-        "### plan",
-        "## plan",
-        "# plan",
-        "reasoning:",
-        "plan:",
-    )
-    if lowered.startswith(heading_markers):
-        split_at = text.find("\n\n")
-        if split_at >= 0:
-            cleaned = text[split_at + 2 :].strip()
-            if cleaned:
-                return cleaned
     return text
 
 

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import re
 import threading
 import time
 
 from orbit.backend.base import StreamProgress
-from orbit.runtime.final_policy import classify_final_answer_completeness, looks_like_reasoning_leakage
 from orbit.terminal.theme import DIM, RESET, dim
 
 
@@ -245,12 +243,7 @@ class _ThinkingDisplayFilter:
         return self._drain(final=False)
 
     def finish(self) -> list[tuple[str, bool]]:
-        emitted = self._drain(final=True)
-        fallback = self._fallback_final_answer()
-        if fallback:
-            emitted.append((fallback, False))
-            self._saw_final_output = True
-        return emitted
+        return self._drain(final=True)
 
     def _drain(self, *, final: bool) -> list[tuple[str, bool]]:
         emitted: list[tuple[str, bool]] = []
@@ -328,19 +321,6 @@ class _ThinkingDisplayFilter:
             return
         self._saw_final_output = True
 
-    def _fallback_final_answer(self) -> str | None:
-        if self._saw_final_output or self._in_final:
-            return None
-        thought_text = "".join(self._thought_text_parts).strip()
-        if not thought_text or not looks_like_reasoning_leakage(thought_text):
-            return None
-        lines = [line for line in (_clean_reasoning_line(raw) for raw in thought_text.splitlines()) if line]
-        for line in reversed(lines):
-            completeness = classify_final_answer_completeness(line)
-            if completeness.is_complete and not looks_like_reasoning_leakage(line):
-                return line
-        return None
-
     def _safe_emit_length(self) -> int:
         keep = 0
         for marker in self._FINAL_MARKERS:
@@ -388,25 +368,3 @@ def _strip_channel_markup(text: str) -> str:
         .replace("<|channel>final\n", "")
         .replace("<channel|>", "")
     )
-
-
-def _clean_reasoning_line(line: str) -> str:
-    text = line.strip()
-    if not text:
-        return ""
-    text = re.sub(r"^(?:[-*]\s+)+", "", text)
-    text = text.strip()
-    text = text.strip("*")
-    text = text.strip()
-    if not text:
-        return ""
-    lowered = text.lower()
-    if re.match(r"^possibility\s+[a-z]\b", lowered):
-        return ""
-    if lowered.startswith(("the user likely meant", "the user probably meant", "the user may have meant")):
-        return ""
-    if lowered.startswith(("wait, looking at the words", "looking at the words")):
-        return ""
-    if text.startswith(("'", '"')) and text.endswith(("'", '"')) and len(text) > 8:
-        return ""
-    return text

--- a/tests/test_native_streaming.py
+++ b/tests/test_native_streaming.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import unittest
 
-from orbit.native_llama.client import _ControlChannelStreamFilter, _LeadingThoughtLabelFilter, _StopSequenceStreamFilter
+from orbit.native_llama.client import (
+    _ControlChannelStreamFilter,
+    _LeadingThoughtLabelFilter,
+    _StopSequenceStreamFilter,
+    _strip_reasoning_preamble,
+)
 
 
 class NativeStreamingTests(unittest.TestCase):
@@ -75,6 +80,14 @@ class NativeStreamingTests(unittest.TestCase):
         self.assertEqual("".join(deltas), "hello world")
         self.assertEqual("".join(emitted), "hello world")
         self.assertFalse(stream.stopped)
+
+    def test_strip_reasoning_preamble_only_removes_plain_thought_label(self) -> None:
+        self.assertEqual(_strip_reasoning_preamble("thought\nfinal answer"), "final answer")
+
+    def test_strip_reasoning_preamble_keeps_reasoning_and_final_answer_text(self) -> None:
+        content = "Reasoning:\nstep 1\n\nFinal answer: done"
+
+        self.assertEqual(_strip_reasoning_preamble(content), content)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_thinking.py
+++ b/tests/test_native_thinking.py
@@ -259,10 +259,7 @@ class NativeThinkingTests(unittest.TestCase):
             "**Final Answer:**\n"
             "Use mv \"old report 2026.txt\" \"final report 2026.txt\""
         )
-        self.assertEqual(
-            _strip_reasoning_preamble(content),
-            'Use mv "old report 2026.txt" "final report 2026.txt"',
-        )
+        self.assertEqual(_strip_reasoning_preamble(content), content)
 
     def test_strip_reasoning_preamble_keeps_plain_answer_when_no_boundary_exists(self) -> None:
         content = "This is a direct explanation without a separate final-answer section."
@@ -276,7 +273,7 @@ class NativeThinkingTests(unittest.TestCase):
             "The final answer is:\n"
             "42"
         )
-        self.assertEqual(_strip_reasoning_preamble(content), "42")
+        self.assertEqual(_strip_reasoning_preamble(content), content)
 
     def test_detects_open_thought_channel(self) -> None:
         self.assertTrue(_has_open_thought_channel("<|channel>thought\npartial"))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -111,7 +111,7 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertIn("Thinking...", output)
         self.assertIn("\033[2mprivate chain\033[0m", output)
 
-    def test_thinking_mode_emits_fallback_final_answer_when_reasoning_leaks_without_marker(self) -> None:
+    def test_thinking_mode_does_not_extract_final_answer_from_reasoning_leakage(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
         try:
@@ -132,10 +132,13 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertIn("Thinking...", output)
         self.assertIn("The user likely meant essay and wise.", output)
         self.assertIn(
+            'The main difference is that an essay is a written composition, while "wise" means having good judgment.',
+            output,
+        )
+        self.assertNotIn(
             '\n\nThe main difference is that an essay is a written composition, while "wise" means having good judgment.',
             output,
         )
-        self.assertNotIn('\n\nPossibility A: typo.', output)
 
     def test_thinking_mode_does_not_invent_final_answer_when_only_reasoning_is_present(self) -> None:
         stream = io.StringIO()
@@ -154,7 +157,6 @@ class StreamingRendererTests(unittest.TestCase):
 
         output = stream.getvalue()
         self.assertIn("Thinking...", output)
-        self.assertNotIn("\n\nPossibility", output)
         self.assertNotIn("\n\nThe main difference", output)
 
     def test_event_prints_dim_message(self) -> None:


### PR DESCRIPTION
Summary:

* Removes deterministic semantic final-answer extraction from the renderer.
* Removes reasoning-line cleanup that suppressed/rewrote thinking content.
* Restricts native client preamble stripping to the exact non-semantic `thought` label.
* Preserves the model-guided architecture: runtime may accept/reject and retry, but the renderer/client does not construct final answers.

Validation:

* full unittest discover PASS
* targeted streaming/runtime/final_policy/native_streaming tests PASS
* compileall PASS
* diff check PASS

Smoke:

* health PASS
* think-on ambiguous prompt confirms renderer no longer reconstructs final answer

Residual WARN:

* `_read_pdf_target()` remains a documented/borderline infrastructure PDF path and should be reviewed separately if needed.
* The model may still produce verbose thinking; this PR does not alter model behavior.

Decision:

* After this PR, expected audit state: model-guided PASS with WARN, not FAIL.