### PR TITLE
End thinking display on final-answer phases

### DIFF
--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -189,6 +189,7 @@ class Repl:
 
     def _record_phase_start(self, renderer: StreamRenderer, phase: ModelPhaseStart) -> None:
         renderer.set_phase_label(_phase_progress_label(phase))
+        renderer.set_final_output_mode(_phase_starts_final_output(phase))
 
     def _show_tool_result(self, renderer: StreamRenderer, name: str, chars: int, source: str | None, content: str | None) -> None:
         if content is not None:
@@ -414,3 +415,16 @@ def _prefill_profile_for_turn(messages: list[dict[str, object]], *, tools_enable
     if any(message.get("role") == "tool" for message in messages[-4:]):
         return FINAL_FROM_TOOL_PREFILL_PROFILE
     return TOOL_PREFILL_PROFILE
+
+
+def _phase_starts_final_output(phase: ModelPhaseStart) -> bool:
+    return phase.phase in {
+        "chat_final",
+        "chat_final_retry",
+        "chat_final_completion_repair",
+        "final_from_tool",
+        "final_from_tool_retry",
+        "final_from_tool_completion_repair",
+        "final_from_tool_compact_retry",
+        "chat_continue_native",
+    }

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -151,6 +151,11 @@ class StreamRenderer:
     def set_phase_label(self, label: str | None) -> None:
         self._phase_label = label.strip() if label else None
 
+    def set_final_output_mode(self, enabled: bool) -> None:
+        if self._thinking_filter is None or not enabled:
+            return
+        self._thinking_filter.start_final_output()
+
     def _normalize_progress(self, update: StreamProgress) -> StreamProgress:
         if update.phase != "generation":
             return update
@@ -244,6 +249,10 @@ class _ThinkingDisplayFilter:
 
     def finish(self) -> list[tuple[str, bool]]:
         return self._drain(final=True)
+
+    def start_final_output(self) -> None:
+        self._in_channel_thought = False
+        self._in_final = True
 
     def _drain(self, *, final: bool) -> list[tuple[str, bool]]:
         emitted: list[tuple[str, bool]] = []

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -33,7 +33,7 @@ from orbit.terminal.repl_input import (
     visual_row_count,
 )
 from orbit.terminal.repl import Repl
-from orbit.terminal.repl import _phase_progress_label, _prefill_profile_for_turn
+from orbit.terminal.repl import _phase_progress_label, _phase_starts_final_output, _prefill_profile_for_turn
 from orbit.terminal.session_preview import format_recent_session_messages
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
@@ -285,6 +285,12 @@ class ReplTests(unittest.TestCase):
             "compact retry",
         )
 
+    def test_phase_starts_final_output_for_final_phases_only(self) -> None:
+        self.assertTrue(_phase_starts_final_output(ModelPhaseStart("chat_final", streamed=True, attempt=1)))
+        self.assertTrue(_phase_starts_final_output(ModelPhaseStart("final_from_tool_retry", streamed=False, attempt=2)))
+        self.assertFalse(_phase_starts_final_output(ModelPhaseStart("tool_plan", streamed=True, attempt=1)))
+        self.assertFalse(_phase_starts_final_output(ModelPhaseStart("tool_call", streamed=False, attempt=1)))
+
     def test_record_phase_start_updates_phase_label_without_printing_phase_event(self) -> None:
         runtime = CountingRuntime()
         repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
@@ -293,12 +299,16 @@ class ReplTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.events: list[str] = []
                 self.phase_label: str | None = None
+                self.final_output_mode: list[bool] = []
 
             def event(self, text: str, restart_timer: bool = True) -> None:
                 self.events.append(text)
 
             def set_phase_label(self, label: str | None) -> None:
                 self.phase_label = label
+
+            def set_final_output_mode(self, enabled: bool) -> None:
+                self.final_output_mode.append(enabled)
 
         renderer = Renderer()
 
@@ -308,6 +318,7 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(renderer.events, [])
         self.assertEqual(renderer.phase_label, "forced final")
+        self.assertEqual(renderer.final_output_mode, [True, True, True])
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:
         self.assertEqual(_prefill_profile_for_turn([], tools_enabled=False), CHAT_PREFILL_PROFILE)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -159,6 +159,25 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertIn("Thinking...", output)
         self.assertNotIn("\n\nThe main difference", output)
 
+    def test_final_output_mode_switches_following_text_out_of_thinking_color(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(thinking=True)
+            renderer.write("brief reasoning")
+            renderer.set_final_output_mode(True)
+            renderer.write("final answer")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Thinking...", output)
+        self.assertIn("\033[2mbrief reasoning\033[0m", output)
+        self.assertIn("\n\nfinal answer", output)
+        self.assertNotIn("\033[2mfinal answer", output)
+
     def test_event_prints_dim_message(self) -> None:
         stream = io.StringIO()
         original = sys.stdout


### PR DESCRIPTION
Summary:

* uses structured phase events to close the visual thinking channel when a final-answer pass starts
* keeps the renderer display-only: no semantic filtering, no final-answer extraction, no prompt-specific logic
* leaves runtime, final policy, backend, and MTP unchanged

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_streaming tests.test_repl -q` PASS
* `PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_final_policy tests.test_tool_loop_state -q` PASS
* `python3 -m compileall -q src tests scripts` PASS
* `git diff --check` PASS

Smoke:

* launcher reinstall via `pipx install --force /home/guelfoweb/LAB/orbit` PASS
* `orbit server` + `orbit` + `/think on` prompt PASS
* thinking stays dim, final-answer pass resets to normal style

Caveat:

* known pipx SIGINT shutdown abort remains out of scope for this PR
