### PR TITLE
Simplify working progress labels

### DIFF
--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -174,11 +174,11 @@ class StreamRenderer:
         parts = [format_elapsed(elapsed)]
         if self._progress is not None:
             if self._progress.phase == "prefill":
-                parts.append(f"prefill {self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
             elif self._progress.phase == "generation":
-                parts.append(f"generation {self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
             else:
-                parts.append(f"{self._progress.phase} {self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
             return ", ".join(parts)
         if self._prefill_estimate_seconds and self._prefill_estimate_seconds >= 1:
             progress = max(1, int((elapsed / self._prefill_estimate_seconds) * 100))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -258,7 +258,14 @@ class StreamingRendererTests(unittest.TestCase):
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
         self.assertEqual(renderer._working_phase_prefix(), " [prefill]")
-        self.assertIn("prefill 243/935 tk (25%)", renderer._working_status(1))
+        self.assertEqual(renderer._working_status(5), "5s, 243/935 tk (25%)")
+
+    def test_wait_timer_omits_repeated_generation_label_from_status(self) -> None:
+        renderer = StreamRenderer()
+        renderer.progress(StreamProgress(phase="generation", current=51, total=256, percent=19))
+
+        self.assertEqual(renderer._working_phase_prefix(), " [generation]")
+        self.assertEqual(renderer._working_status(30), "30s, 51/256 tk (19%)")
 
     def test_wait_timer_includes_generation_detail_in_phase_label(self) -> None:
         renderer = StreamRenderer()
@@ -271,7 +278,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=7, total=512, percent=1))
 
-        self.assertIn("generation 7/512 tk (1%)", renderer._working_status(1))
+        self.assertIn("7/512 tk (1%)", renderer._working_status(1))
 
     def test_wait_timer_prints_prefill_finalizing_after_estimate(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10)
@@ -282,20 +289,20 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
-        self.assertIn("prefill 243/935 tk (25%)", renderer._working_status(5))
+        self.assertIn("243/935 tk (25%)", renderer._working_status(5))
 
     def test_wait_timer_shows_real_generation_progress_when_available(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.progress(StreamProgress(phase="generation", current=7, total=32, percent=21))
 
-        self.assertIn("generation 7/32 tk (21%)", renderer._working_status(5))
+        self.assertIn("7/32 tk (21%)", renderer._working_status(5))
 
     def test_wait_timer_accumulates_generation_across_continuation_passes(self) -> None:
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=32, total=32, percent=100))
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("generation 33/160 tk (20%)", renderer._working_status(5))
+        self.assertIn("33/160 tk (20%)", renderer._working_status(5))
 
     def test_first_progress_renders_immediately_before_timer_tick(self) -> None:
         stream = io.StringIO()
@@ -310,7 +317,7 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("prefill 12/48 tk (25%)", output)
+        self.assertIn("Working [prefill] (0s, 12/48 tk (25%) - Ctrl+C to interrupt)", output)
 
     def test_wait_line_is_padded_to_clear_previous_content(self) -> None:
         padded = _pad_to_terminal_width("\033[2mshort\033[0m")
@@ -357,11 +364,11 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=6, total=32, percent=18))
 
-        self.assertIn("generation 6/32 tk (18%)", renderer._working_status(5))
+        self.assertIn("6/32 tk (18%)", renderer._working_status(5))
 
         renderer._restart_timer()
 
-        self.assertNotIn("generation 6/32 tk (18%)", renderer._working_status(0))
+        self.assertNotIn("6/32 tk (18%)", renderer._working_status(0))
 
     def test_restart_timer_clears_generation_accumulator(self) -> None:
         renderer = StreamRenderer()
@@ -371,7 +378,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer._restart_timer()
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("generation 1/128 tk (0%)", renderer._working_status(0))
+        self.assertIn("1/128 tk (0%)", renderer._working_status(0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

* simplifies `Working [...]` labels so the technical substage appears only once
* keeps `prefill estimate`, `prefill`, and `generation` in the bracket label
* removes repeated substage wording from the status detail in parentheses
* keeps the change confined to terminal progress rendering

Examples:

* `Working [prefill estimate] (30s, ~... )`
* `Working [prefill] (30s, 0/256 tk (0%))`
* `Working [generation] (30s, 0/256 tk (0%))`

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_streaming tests.test_repl -q`
* `python3 -m compileall -q src tests scripts`
* `git diff --check`

Scope:

* exactly two files:
  * `src/orbit/terminal/streaming.py`
  * `tests/test_streaming.py`
