### PR TITLE
Use natural final style for informational shell results

### DIFF
--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -98,6 +98,7 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
     compact_shell_analysis_result = (
         shell_full_result
         and _has_long_shell_tool_result(messages)
+        and is_shell_review_request(prompt)
         and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
     )
     if large_file_excerpt:
@@ -752,6 +753,10 @@ _BRIEF_FINAL_REQUEST_RE = re.compile(
     r"\b(?:one\s+sentence|single\s+sentence|one\s+concise\s+sentence|concise\s+sentence|brief(?:ly)?|short(?:ly)?|in\s+short|main\s+(?:issue|point|finding)|brief\s+answer|short\s+answer)\b",
     re.IGNORECASE,
 )
+_SHELL_REVIEW_REQUEST_RE = re.compile(
+    r"\b(?:review|inspect|audit|diagnos(?:e|is)|debug|bug|issue|issues|problem|problems|fix|remediat\w*|vulnerab\w*|security|secure|weakness|weaknesses|risk|risks|exploit|injection|misconfig\w*|failure|failures)\b",
+    re.IGNORECASE,
+)
 
 
 def last_user_text(messages: list[Message]) -> str | None:
@@ -767,6 +772,12 @@ def is_brief_final_request(prompt: str | None) -> bool:
     if prompt is None:
         return False
     return bool(_BRIEF_FINAL_REQUEST_RE.search(prompt))
+
+
+def is_shell_review_request(prompt: str | None) -> bool:
+    if not prompt:
+        return False
+    return bool(_SHELL_REVIEW_REQUEST_RE.search(prompt))
 
 
 def is_operational_status_request(prompt: str | None) -> bool:

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -277,6 +277,31 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("brief remediation", policy.messages[-1]["content"])
         self.assertEqual(final_tool_compact_retry_max_tokens(512, messages=policy.messages), 160)
 
+    def test_long_shell_informational_policy_does_not_use_finding_fix_format(self) -> None:
+        messages = [
+            {"role": "user", "content": "tell me the specs about this computer"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "uname -a; lscpu; free -h; df -h"},
+                        }
+                    }
+                ],
+            },
+            {"role": "tool", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=160, streamed=False)
+
+        self.assertNotIn("'- Finding: ... Fix: ...'", policy.messages[-1]["content"])
+        self.assertIn("Answer the latest user request directly and concisely", policy.messages[-1]["content"])
+        self.assertIn("Prefer the most recent relevant shell result", policy.messages[-1]["content"])
+        self.assertEqual(policy.max_tokens, 256)
+
     def test_compact_retry_max_tokens_stays_default_for_non_shell_policy(self) -> None:
         messages = [
             {"role": "user", "content": 'Leggi il PDF "pdf/small.pdf" e fammi una sintesi dettagliata.'},


### PR DESCRIPTION
Summary:

* restricts the `Finding: ... Fix: ...` final-from-tool format to review, audit, and security-style shell requests
* keeps informational shell questions in natural prose, even when the shell output is long
* avoids using audit/remediation wording for requests like system specs or general explanations

Examples:

* `tell me the specs about this computer` -> natural summary
* `inspect vulnerable_service.py and explain the vulnerabilities` -> `Finding/Fix` format still allowed

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_final_policy tests.test_runtime tests.test_repl tests.test_tool_loop_state -q`
* `python3 -m compileall -q src tests scripts`
* `git diff --check`

Scope:

* exactly two files:
  * `src/orbit/runtime/final_policy.py`
  * `tests/test_final_policy.py`
