### PR TITLE
Fix vendored mtmd include path

### DIFF
--- a/src/orbit/native_llama/vendor/source/llama.cpp/src/CMakeLists.txt
+++ b/src/orbit/native_llama/vendor/source/llama.cpp/src/CMakeLists.txt
@@ -50,6 +50,9 @@ set_target_properties(llama PROPERTIES
 
 target_include_directories(llama PRIVATE .)
 target_include_directories(llama PUBLIC ../include)
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../tools/mtmd/models/models.h")
+    target_include_directories(llama PRIVATE ../tools/mtmd)
+endif()
 target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
 
 target_link_libraries(llama PUBLIC ggml)

--- a/tests/test_native_packaging_metadata.py
+++ b/tests/test_native_packaging_metadata.py
@@ -46,6 +46,13 @@ class NativePackagingMetadataTests(unittest.TestCase):
         self.assertTrue((mtmd_models / "models.h").exists())
         self.assertGreaterEqual(len(list(mtmd_models.glob("*.cpp"))), 10)
 
+    def test_vendored_llama_cmake_includes_mtmd_models_when_present(self) -> None:
+        src_cmake = ROOT / "src/orbit/native_llama/vendor/source/llama.cpp/src/CMakeLists.txt"
+        text = src_cmake.read_text(encoding="utf-8")
+
+        self.assertIn('EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../tools/mtmd/models/models.h"', text)
+        self.assertIn("target_include_directories(llama PRIVATE ../tools/mtmd)", text)
+
     def test_native_artifact_contract_lists_expected_linux_files(self) -> None:
         self.assertIn("libllama.so", LINUX_RUNTIME_LIBS)
         self.assertIn("libggml-cpu.so", LINUX_RUNTIME_LIBS)


### PR DESCRIPTION
Summary:

* fixes fresh-clone self-build failure in vendored llama.cpp when `llama-model.cpp` includes `models/models.h`
* adds `../tools/mtmd` to the vendored `llama` target include path when the mtmd models tree is present
* adds a regression test so the vendored CMake wiring stays aligned with the vendored mtmd source tree

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_native_packaging_metadata tests.test_native_build_cli tests.test_native_paths -q`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS
* `python3 scripts/build_native.py --clean --jobs 6 --quiet`: PASS

Failure fixed:

* fresh clone + `python3 scripts/build_native.py` no longer fails on `src/llama-model.cpp:18:10: fatal error: models/models.h: No such file or directory`
