### PR TITLE
Integrate pending UX and tool-routing fixes

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -36,6 +36,7 @@ from orbit.runtime.messages import (
     with_final_tool_system_prompt,
     with_media_system_prompt,
     with_command_system_prompt,
+    with_tool_call_system_prompt,
 )
 
 from orbit.runtime.command_request import (
@@ -64,6 +65,14 @@ from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
 ROUTE_MAX_TOKENS = 128
+_ROUTE_TOOL_RETRY_PROMPT_RE = re.compile(
+    r"\b(?:search|online|web|url|http|https|read|show|print|inspect|analy[sz]e|review|list|find|grep|curl|fetch|directory|folder|file|path|pdf|html|source|current\s+directory|computer|system|specs?)\b|[/\\]|[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,8}\b",
+    re.IGNORECASE,
+)
+_EXPLICIT_WEB_SEARCH_RE = re.compile(
+    r"\b(?:search\s+(?:online|the\s+web|web)|web\s+search|look\s+up\s+online|find\s+online|cerca\s+(?:online|sul\s+web|nel\s+web))\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -304,55 +313,108 @@ class ChatRuntime:
         command_content = first.content
         decision = parse_command_decision_from_tool_calls(first.tool_calls) or parse_command_decision(command_content)
         if decision is None:
-            initial_shell_tool_call = command_tool_call_from_tool_calls(first.tool_calls, ("exec_shell_full_command",)) or command_tool_call_from_content(command_content, ("exec_shell_full_command",))
-            route_requires_chat_final = contains_control_channel_markup(first.content)
-            if route_requires_chat_final and first.finish_reason != "length":
-                first = self._transport_environment().chat_final(
-                    with_chat_system_prompt(self.messages),
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    on_final_delta=on_final_delta,
-                    on_progress=on_progress,
-                    on_model_step=on_model_step,
-                    on_phase_start=on_phase_start,
-                    loop=2,
-                )
-                retried_empty_final = True
-            if first.finish_reason == "length":
-                if on_final_delta is None:
-                    first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
-                else:
-                    streamed_final_retry = True
-                    first = self.backend.chat_stream(
+            explicit_web_search = _requires_explicit_web_search_tool(prompt, allowed_tool_names)
+            if _should_force_tool_route_retry(prompt, allowed_tool_names, first.finish_reason):
+                with self._temporary_backend_thinking(False):
+                    route_retry_messages = _route_retry_messages(
+                        self.messages,
+                        explicit_web_search=explicit_web_search,
+                    )
+                    if on_phase_start:
+                        on_phase_start(
+                            ModelPhaseStart(
+                                "route_retry",
+                                streamed=False,
+                                attempt=2,
+                                reason="explicit_web_search" if explicit_web_search else "length_without_decision",
+                            )
+                        )
+                    if on_progress is None:
+                        route_retry = self.backend.chat(
+                            route_retry_messages,
+                            temperature=temperature,
+                            max_tokens=command_max_tokens,
+                        )
+                    else:
+                        route_retry = self.backend.chat_stream(
+                            route_retry_messages,
+                            temperature=temperature,
+                            max_tokens=command_max_tokens,
+                            on_delta=lambda _text: None,
+                            on_progress=on_progress,
+                        )
+                if on_model_step:
+                    on_model_step(ModelStepMetrics.from_result(loop=2, result=route_retry, phase="route_retry"))
+                retry_decision = parse_command_decision_from_tool_calls(route_retry.tool_calls) or parse_command_decision(route_retry.content)
+                if retry_decision is not None:
+                    first = route_retry
+                    command_content = route_retry.content
+                    decision = retry_decision
+            if decision is None:
+                if explicit_web_search:
+                    bundle = self._run_tool_loop(
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        workdir=workdir,
+                        max_loops=max_loops,
+                        on_final_delta=on_final_delta,
+                        on_progress=on_progress,
+                        on_tool_call=on_tool_call,
+                        on_tool_result=on_tool_result,
+                        on_model_step=on_model_step,
+                        on_phase_start=on_phase_start,
+                        tool_names=("exec_shell_full_command",),
+                    )
+                    return self._remember_visible_result(_tool_loop_result_value(bundle))
+                initial_shell_tool_call = command_tool_call_from_tool_calls(first.tool_calls, ("exec_shell_full_command",)) or command_tool_call_from_content(command_content, ("exec_shell_full_command",))
+                route_requires_chat_final = contains_control_channel_markup(first.content)
+                if route_requires_chat_final and first.finish_reason != "length":
+                    first = self._transport_environment().chat_final(
+                        with_chat_system_prompt(self.messages),
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        on_final_delta=on_final_delta,
+                        on_progress=on_progress,
+                        on_model_step=on_model_step,
+                        on_phase_start=on_phase_start,
+                        loop=2,
+                    )
+                    retried_empty_final = True
+                if first.finish_reason == "length":
+                    if on_final_delta is None:
+                        first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
+                    else:
+                        streamed_final_retry = True
+                        first = self.backend.chat_stream(
+                            self.messages,
+                            temperature=temperature,
+                            max_tokens=max_tokens,
+                            on_delta=on_final_delta,
+                            on_progress=on_progress,
+                        )
+                    if on_model_step:
+                        on_model_step(ModelStepMetrics.from_result(loop=2, result=first, phase="chat_final_retry"))
+                if _is_empty_final_response(first):
+                    retried_empty_final = True
+                    first = self._transport_environment().chat_final(
                         self.messages,
                         temperature=temperature,
                         max_tokens=max_tokens,
-                        on_delta=on_final_delta,
+                        on_final_delta=on_final_delta,
                         on_progress=on_progress,
+                        on_model_step=on_model_step,
+                        on_phase_start=on_phase_start,
+                        loop=2,
                     )
-                if on_model_step:
-                    on_model_step(ModelStepMetrics.from_result(loop=2, result=first, phase="chat_final_retry"))
-            if _is_empty_final_response(first):
-                retried_empty_final = True
-                first = self._transport_environment().chat_final(
-                    self.messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    on_final_delta=on_final_delta,
-                    on_progress=on_progress,
-                    on_model_step=on_model_step,
-                    on_phase_start=on_phase_start,
-                    loop=2,
-                )
-            self.messages.append({"role": "assistant", "content": first.content})
-            if on_final_delta and not streamed_final_retry and not retried_empty_final:
-                if route_stream_filter is not None:
-                    route_stream_filter.finish()
-                    for chunk in route_streamed_chunks:
-                        on_final_delta(chunk)
-                else:
-                    on_final_delta(first.content)
-            return self._remember_visible_result(first)
+                self.messages.append({"role": "assistant", "content": first.content})
+                if on_final_delta and not streamed_final_retry and not retried_empty_final:
+                    if route_stream_filter is not None:
+                        route_stream_filter.finish()
+                        for chunk in route_streamed_chunks:
+                            on_final_delta(chunk)
+                    else:
+                        on_final_delta(first.content)
+                return self._remember_visible_result(first)
         if decision.route == ToolRoute.CHAT:
             chat_messages = with_chat_system_prompt(self.messages)
             result = self._chat_final(
@@ -826,6 +888,40 @@ def _tool_call_command(tool_call: dict[str, object] | None) -> str | None:
         return None
     command = arguments.get("command")
     return command if isinstance(command, str) else None
+
+
+def _should_retry_route_as_tool_call(prompt: str, allowed_tool_names: tuple[str, ...] | None) -> bool:
+    if "exec_shell_full_command" not in set(allowed_tool_names or ()):
+        return False
+    return bool(_ROUTE_TOOL_RETRY_PROMPT_RE.search(prompt))
+
+
+def _requires_explicit_web_search_tool(prompt: str, allowed_tool_names: tuple[str, ...] | None) -> bool:
+    if "exec_shell_full_command" not in set(allowed_tool_names or ()):
+        return False
+    return bool(_EXPLICIT_WEB_SEARCH_RE.search(prompt))
+
+
+def _should_force_tool_route_retry(prompt: str, allowed_tool_names: tuple[str, ...] | None, finish_reason: str | None) -> bool:
+    if _requires_explicit_web_search_tool(prompt, allowed_tool_names):
+        return True
+    return finish_reason == "length" and _should_retry_route_as_tool_call(prompt, allowed_tool_names)
+
+
+def _route_retry_messages(messages: list[Message], *, explicit_web_search: bool) -> list[Message]:
+    reminder = (
+        "The user explicitly asked for an online/web search. "
+        "Do not answer from memory. "
+        "Return exactly one shell tool call now that performs the search. Output no prose."
+        if explicit_web_search
+        else
+        "The previous routing pass did not return a valid decision. "
+        "Return exactly one shell tool call now if shell/web/file access is needed. Output no prose."
+    )
+    return [
+        *with_tool_call_system_prompt(messages),
+        {"role": "user", "content": reminder},
+    ]
 
 
 def _tool_loop_result_value(result):

--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -289,6 +289,17 @@ def _extract_loose_command_object(content: str) -> dict[str, Any] | None:
 
 
 def _extract_loose_raw_shell_command(text: str) -> str | None:
+    call_match = re.search(
+        r'<\|tool_call\>\s*call\s*\(\s*(?P<name>[A-Za-z0-9_-]+)\s*,\s*"(?P<command>(?:[^"\\]|\\.)*)"\s*\)\s*(?=<\|tool_call\>|<tool_call\|>|$)',
+        text,
+        flags=re.DOTALL,
+    )
+    if call_match:
+        name = call_match.group("name")
+        if name not in SHELL_TOOL_ALIASES:
+            return None
+        command = _decode_loose_json_string(call_match.group("command")).strip()
+        return command or None
     match = re.search(
         r"<\|tool_call\>\s*call\s+shell\s+(?P<command>.*?)(?=<\|tool_call\>|<tool_call\|>|$)",
         text,

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -593,6 +593,8 @@ class FinalFromToolEnvironment:
         if stream_buffer is not None and on_final_delta is not None:
             if used_retry_or_repair_pass and result.content:
                 on_final_delta(result.content)
+            elif not stream_buffer.chunks and result.content:
+                on_final_delta(result.content)
             else:
                 for chunk in stream_buffer.chunks:
                     on_final_delta(chunk)

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -98,6 +98,7 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
     compact_shell_analysis_result = (
         shell_full_result
         and _has_long_shell_tool_result(messages)
+        and is_shell_review_request(prompt)
         and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
     )
     if large_file_excerpt:
@@ -752,6 +753,10 @@ _BRIEF_FINAL_REQUEST_RE = re.compile(
     r"\b(?:one\s+sentence|single\s+sentence|one\s+concise\s+sentence|concise\s+sentence|brief(?:ly)?|short(?:ly)?|in\s+short|main\s+(?:issue|point|finding)|brief\s+answer|short\s+answer)\b",
     re.IGNORECASE,
 )
+_SHELL_REVIEW_REQUEST_RE = re.compile(
+    r"\b(?:review|inspect|audit|diagnos(?:e|is)|debug|bug|issue|issues|problem|problems|fix|remediat\w*|vulnerab\w*|security|secure|weakness|weaknesses|risk|risks|exploit|injection|misconfig\w*|failure|failures)\b",
+    re.IGNORECASE,
+)
 
 
 def last_user_text(messages: list[Message]) -> str | None:
@@ -767,6 +772,12 @@ def is_brief_final_request(prompt: str | None) -> bool:
     if prompt is None:
         return False
     return bool(_BRIEF_FINAL_REQUEST_RE.search(prompt))
+
+
+def is_shell_review_request(prompt: str | None) -> bool:
+    if not prompt:
+        return False
+    return bool(_SHELL_REVIEW_REQUEST_RE.search(prompt))
 
 
 def is_operational_status_request(prompt: str | None) -> bool:

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -174,9 +174,9 @@ class StreamRenderer:
         parts = [format_elapsed(elapsed)]
         if self._progress is not None:
             if self._progress.phase == "prefill":
-                parts.append(f"prefill {self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
             elif self._progress.phase == "generation":
-                parts.append(f"generation {self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
             else:
                 parts.append(f"{self._progress.phase} {self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
             return ", ".join(parts)

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -45,6 +45,9 @@ class RouteRequestTests(unittest.TestCase):
     def test_parse_tool_command_accepts_raw_orbit_web_search_key_value_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call:orbit-web-search{query="Dante Alighieri"}<tool_call|>'), ToolRoute.FILESYSTEM)
 
+    def test_parse_tool_command_accepts_parenthesized_shell_tool_call(self) -> None:
+        self.assertEqual(parse_tool_command('<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>'), ToolRoute.FILESYSTEM)
+
     def test_parse_command_decision_from_tool_calls_accepts_command_arguments(self) -> None:
         decision = parse_command_decision_from_tool_calls(
             [
@@ -138,6 +141,16 @@ EOF"}"""
         assert tool_call is not None
         args = json.loads(tool_call["function"]["arguments"])
         self.assertEqual(args["command"], "cat backup.sh")
+
+    def test_command_tool_call_from_content_accepts_parenthesized_shell_tool_call(self) -> None:
+        content = '<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>'
+
+        tool_call = command_tool_call_from_content(content, ("exec_shell_full_command",))
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        args = json.loads(tool_call["function"]["arguments"])
+        self.assertEqual(args["command"], 'orbit-web-search "Mario Nobile"')
 
     def test_command_tool_call_from_content_respects_allowed_tools(self) -> None:
         self.assertIsNone(command_tool_call_from_content('{"command":"ls -F"}', ("read_file",)))

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -277,6 +277,31 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("brief remediation", policy.messages[-1]["content"])
         self.assertEqual(final_tool_compact_retry_max_tokens(512, messages=policy.messages), 160)
 
+    def test_long_shell_informational_policy_does_not_use_finding_fix_format(self) -> None:
+        messages = [
+            {"role": "user", "content": "tell me the specs about this computer"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "uname -a; lscpu; free -h; df -h"},
+                        }
+                    }
+                ],
+            },
+            {"role": "tool", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=160, streamed=False)
+
+        self.assertNotIn("'- Finding: ... Fix: ...'", policy.messages[-1]["content"])
+        self.assertIn("Answer the latest user request directly and concisely", policy.messages[-1]["content"])
+        self.assertIn("Prefer the most recent relevant shell result", policy.messages[-1]["content"])
+        self.assertEqual(policy.max_tokens, 256)
+
     def test_compact_retry_max_tokens_stays_default_for_non_shell_policy(self) -> None:
         messages = [
             {"role": "user", "content": 'Leggi il PDF "pdf/small.pdf" e fammi una sintesi dettagliata.'},

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1583,6 +1583,217 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(backend.tool_names_seen[0], ())
         self.assertEqual(backend.tool_names_seen[1], ())
 
+    def test_ask_auto_routes_parenthesized_raw_shell_tool_call_to_tool_loop(self) -> None:
+        class RoutedBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content='<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=22,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": "{\"command\":\"orbit-web-search 'Mario Nobile'\"}",
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Mario Nobile is an Italian public official.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=9,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = RoutedBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "search online for information about Mario Nobile",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "Mario Nobile is an Italian public official.")
+        self.assertEqual(backend.calls, 3)
+
+    def test_ask_auto_retries_route_as_tool_call_after_length_without_decision(self) -> None:
+        class RoutedBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.retry_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="This answer wanders and never reaches a valid routing decision",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=96,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    self.retry_messages = messages
+                    return ChatResult(
+                        content='{"command":"cat note.txt"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="hello from note",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("hello from note", encoding="utf-8")
+            backend = RoutedBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "read note.txt",
+                temperature=0,
+                max_tokens=96,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "hello from note")
+        self.assertEqual(backend.calls, 3)
+        self.assertIsNotNone(backend.retry_messages)
+        self.assertEqual(backend.retry_messages[0]["content"], TOOL_CALL_SYSTEM_PROMPT)
+
+    def test_ask_auto_retries_explicit_web_search_prompt_when_route_answers_in_prose(self) -> None:
+        class RoutedBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.retry_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="I could not find anything useful from memory.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=12,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    self.retry_messages = messages
+                    return ChatResult(
+                        content="I still cannot route this correctly.",
+                        model="fake",
+                        finish_reason="length",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=96,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"printf 'Mario Nobile is a public official.'\"}"},
+                            }
+                        ],
+                        prompt_tokens=7,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Mario Nobile is a public official.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=6,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = RoutedBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_auto(
+                "search online for information about Mario Nobile",
+                temperature=0,
+                max_tokens=96,
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "Mario Nobile is a public official.")
+        self.assertEqual(backend.calls, 5)
+        self.assertIsNotNone(backend.retry_messages)
+        self.assertEqual(backend.retry_messages[0]["content"], TOOL_CALL_SYSTEM_PROMPT)
+
     def test_shell_full_analysis_metadata_only_command_gets_one_model_retry(self) -> None:
         class ShellFullAnalysisBackend:
             def __init__(self) -> None:
@@ -5426,6 +5637,63 @@ EOF"""
         self.assertEqual(backend.chat_stream_calls, 3)
         phases = [step.phase for step in steps]
         self.assertEqual(phases, ["tool_call", "final_from_tool", "final_from_tool_retry"])
+
+    def test_final_from_tool_emits_result_content_when_buffered_stream_has_no_deltas(self) -> None:
+        class BufferedNoDeltaBackend:
+            def __init__(self) -> None:
+                self.chat_stream_calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                raise AssertionError("streaming path expected")
+
+            def chat_stream(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None, on_delta=None, on_progress=None) -> ChatResult:
+                self.chat_stream_calls += 1
+                if self.chat_stream_calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"orbit-web-search 'Mario Nobile'\"}"},
+                            }
+                        ],
+                        prompt_tokens=None,
+                        completion_tokens=None,
+                        cached_tokens=None,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Mario Nobile is an Italian public official.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=9,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        emitted: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = BufferedNoDeltaBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+            result = runtime.ask_with_tools(
+                "search online for information about Mario Nobile",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+                on_final_delta=emitted.append,
+            )
+
+        self.assertEqual(result.content, "Mario Nobile is an Italian public official.")
+        self.assertEqual(emitted, ["Mario Nobile is an Italian public official."])
+        self.assertEqual(backend.chat_stream_calls, 2)
 
     def test_ask_with_tools_emits_tool_call_event(self) -> None:
         events: list[tuple[str, str]] = []

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -258,7 +258,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
         self.assertEqual(renderer._working_phase_prefix(), " [prefill]")
-        self.assertIn("prefill 243/935 tk (25%)", renderer._working_status(1))
+        self.assertIn("243/935 tk (25%)", renderer._working_status(1))
 
     def test_wait_timer_includes_generation_detail_in_phase_label(self) -> None:
         renderer = StreamRenderer()
@@ -271,7 +271,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=7, total=512, percent=1))
 
-        self.assertIn("generation 7/512 tk (1%)", renderer._working_status(1))
+        self.assertIn("7/512 tk (1%)", renderer._working_status(1))
 
     def test_wait_timer_prints_prefill_finalizing_after_estimate(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10)
@@ -282,20 +282,20 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
-        self.assertIn("prefill 243/935 tk (25%)", renderer._working_status(5))
+        self.assertIn("243/935 tk (25%)", renderer._working_status(5))
 
     def test_wait_timer_shows_real_generation_progress_when_available(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.progress(StreamProgress(phase="generation", current=7, total=32, percent=21))
 
-        self.assertIn("generation 7/32 tk (21%)", renderer._working_status(5))
+        self.assertIn("7/32 tk (21%)", renderer._working_status(5))
 
     def test_wait_timer_accumulates_generation_across_continuation_passes(self) -> None:
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=32, total=32, percent=100))
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("generation 33/160 tk (20%)", renderer._working_status(5))
+        self.assertIn("33/160 tk (20%)", renderer._working_status(5))
 
     def test_first_progress_renders_immediately_before_timer_tick(self) -> None:
         stream = io.StringIO()
@@ -310,7 +310,7 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("prefill 12/48 tk (25%)", output)
+        self.assertIn("Working [prefill] (0s, 12/48 tk (25%) - Ctrl+C to interrupt)", output)
 
     def test_wait_line_is_padded_to_clear_previous_content(self) -> None:
         padded = _pad_to_terminal_width("\033[2mshort\033[0m")
@@ -357,11 +357,11 @@ class StreamingRendererTests(unittest.TestCase):
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=6, total=32, percent=18))
 
-        self.assertIn("generation 6/32 tk (18%)", renderer._working_status(5))
+        self.assertIn("6/32 tk (18%)", renderer._working_status(5))
 
         renderer._restart_timer()
 
-        self.assertNotIn("generation 6/32 tk (18%)", renderer._working_status(0))
+        self.assertNotIn("6/32 tk (18%)", renderer._working_status(0))
 
     def test_restart_timer_clears_generation_accumulator(self) -> None:
         renderer = StreamRenderer()
@@ -371,7 +371,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer._restart_timer()
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("generation 1/128 tk (0%)", renderer._working_status(0))
+        self.assertIn("1/128 tk (0%)", renderer._working_status(0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

* integrates the remaining clean fixes that were still outside `origin/main`
* switches long informational shell final answers away from `Finding/Fix` audit formatting
* removes duplicate `prefill` / `generation` wording from `Working [...]` progress lines
* restores bounded model-guided retry for explicit web-search prompts when the route pass fails to return a tool decision

Included commits:

* `540c8c6` Use natural final style for informational shell results
* `9302975` Remove duplicate progress stage wording
* `32bfbe7` Repair explicit web-search tool routing

Validation:

* `python3 -m unittest discover -s tests -q`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS

Notes:

* based directly on `origin/main`
* no backend/native/MTP changes
* no deterministic renderer filtering or final-answer rewriting
