### PR TITLE
Simplify working progress status

### DIFF
--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -178,7 +178,7 @@ class StreamRenderer:
             elif self._progress.phase == "generation":
                 parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
             else:
-                parts.append(f"{self._progress.phase} {self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
+                parts.append(f"{self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
             return ", ".join(parts)
         if self._prefill_estimate_seconds and self._prefill_estimate_seconds >= 1:
             progress = max(1, int((elapsed / self._prefill_estimate_seconds) * 100))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -258,7 +258,14 @@ class StreamingRendererTests(unittest.TestCase):
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
         self.assertEqual(renderer._working_phase_prefix(), " [prefill]")
-        self.assertIn("243/935 tk (25%)", renderer._working_status(1))
+        self.assertEqual(renderer._working_status(5), "5s, 243/935 tk (25%)")
+
+    def test_wait_timer_omits_repeated_generation_label_from_status(self) -> None:
+        renderer = StreamRenderer()
+        renderer.progress(StreamProgress(phase="generation", current=51, total=256, percent=19))
+
+        self.assertEqual(renderer._working_phase_prefix(), " [generation]")
+        self.assertEqual(renderer._working_status(30), "30s, 51/256 tk (19%)")
 
     def test_wait_timer_includes_generation_detail_in_phase_label(self) -> None:
         renderer = StreamRenderer()


### PR DESCRIPTION
Summary:

* Removes repeated technical stage wording from the wait-line status payload.
* Keeps the stage label in `Working [...]` and the numeric/token detail in the parenthesized status.
* Confines the change to terminal progress rendering.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_streaming tests.test_repl -q`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS

Scope:

* `src/orbit/terminal/streaming.py`
* `tests/test_streaming.py`