### PR TITLE
Clarify suggest-server-profile MTP note

### DIFF
--- a/scripts/suggest-server-profile.sh
+++ b/scripts/suggest-server-profile.sh
@@ -166,7 +166,8 @@ cat <<EOF
 # These values are suggestions for orbit server. Review them before exporting.
 # Typical use:
 #   export THREADS=$THREADS BATCH_SIZE=$BATCH_SIZE UBATCH_SIZE=$UBATCH_SIZE CACHE_RAM=$CACHE_RAM
-#   orbit server --port 12120 --mtp
+#   orbit server --port 12120
+# MTP remains experimental and opt-in; add --mtp only when you are explicitly testing it.
 
 export THREADS=$THREADS
 export BATCH_SIZE=$BATCH_SIZE

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -92,12 +92,14 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
     shell_full_result = has_tool_result(call_messages, "exec_shell_full_command")
     operational_status_result = shell_full_result and is_operational_status_request(prompt)
     brief_request = is_brief_final_request(prompt)
+    findings_fix_request = is_findings_fix_request(prompt)
     brief_shell_result = shell_full_result and brief_request and not (
         large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result
     )
     compact_shell_analysis_result = (
         shell_full_result
         and _has_long_shell_tool_result(messages)
+        and findings_fix_request
         and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
     )
     if large_file_excerpt:
@@ -752,6 +754,10 @@ _BRIEF_FINAL_REQUEST_RE = re.compile(
     r"\b(?:one\s+sentence|single\s+sentence|one\s+concise\s+sentence|concise\s+sentence|brief(?:ly)?|short(?:ly)?|in\s+short|main\s+(?:issue|point|finding)|brief\s+answer|short\s+answer)\b",
     re.IGNORECASE,
 )
+_FINDING_FIX_REQUEST_RE = re.compile(
+    r"\b(?:audit|review|inspect|vulnerabilit(?:y|ies)|security\s+issues?|bug(?:s)?|diagnos(?:e|is)|fix(?:es|ing)?|remediat(?:e|ion)|issue(?:s)?|problem(?:s)?)\b",
+    re.IGNORECASE,
+)
 
 
 def last_user_text(messages: list[Message]) -> str | None:
@@ -767,6 +773,12 @@ def is_brief_final_request(prompt: str | None) -> bool:
     if prompt is None:
         return False
     return bool(_BRIEF_FINAL_REQUEST_RE.search(prompt))
+
+
+def is_findings_fix_request(prompt: str | None) -> bool:
+    if prompt is None:
+        return False
+    return bool(_FINDING_FIX_REQUEST_RE.search(prompt))
 
 
 def is_operational_status_request(prompt: str | None) -> bool:

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -277,6 +277,30 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("brief remediation", policy.messages[-1]["content"])
         self.assertEqual(final_tool_compact_retry_max_tokens(512, messages=policy.messages), 160)
 
+    def test_long_shell_web_info_policy_stays_natural(self) -> None:
+        messages = [
+            {"role": "user", "content": "search online for information about Mario Nobile"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "orbit-web-search 'Mario Nobile'"},
+                        }
+                    }
+                ],
+            },
+            {"role": "tool", "name": "exec_shell_full_command", "content": "x" * 1600},
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=160, streamed=False)
+
+        self.assertNotIn("'- Finding: ... Fix: ...'", policy.messages[-1]["content"])
+        self.assertNotIn("exactly 4 short bullets", policy.messages[-1]["content"])
+        self.assertIn("Answer the latest user request directly and concisely", policy.messages[-1]["content"])
+
     def test_compact_retry_max_tokens_stays_default_for_non_shell_policy(self) -> None:
         messages = [
             {"role": "user", "content": 'Leggi il PDF "pdf/small.pdf" e fammi una sintesi dettagliata.'},


### PR DESCRIPTION
Summary:

* Stops suggesting `--mtp` as the default follow-up command in `suggest-server-profile.sh`.
* Keeps the recommended launch command on the stable no-MTP path: `orbit server --port 12120`.
* Adds a short note that MTP remains experimental and opt-in.

Validation:

* `bash -n scripts/suggest-server-profile.sh`: PASS

Scope:

* `scripts/suggest-server-profile.sh`