### PR TITLE
Require content evidence for direct file reads

### DIFF
--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -284,6 +284,17 @@ def build_shell_full_file_recovery_guard_prompt(
     last_command: str | None = None,
     last_failure_content: str | None = None,
 ) -> str:
+    prompt_prefix = SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX
+    if requested_path_exists:
+        prompt_prefix = (
+            "Requested file not read yet.\n\n"
+            "Use the real evidence below.\n"
+            "The requested file exists, but no usable content has been extracted from it yet.\n"
+            "Before answering, use one appropriate direct content-reading command on the file or a confirmed candidate path.\n"
+            "Use commands such as cat, sed -n, head, tail, or grep/rg on the file contents.\n\n"
+            "Return only JSON:\n\n"
+            '{"command":"..."}'
+        )
     details = [f"Requested file: {requested_path}"]
     if requested_path_exists:
         details.append("Requested file currently exists in the workdir: yes")
@@ -313,7 +324,7 @@ def build_shell_full_file_recovery_guard_prompt(
     elif requested_path_exists:
         details.append("No usable content has been extracted from the requested file yet.")
         details.append("Do not conclude that the file is missing or unreadable yet.")
-    return f"{SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX}\n\n" + "\n".join(details)
+    return f"{prompt_prefix}\n\n" + "\n".join(details)
 
 
 def shell_failure_from_output(content: str) -> ShellFailure | None:

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -123,6 +123,13 @@ _READ_ONLY_PROMPT_RE = re.compile(
     r"^\s*(?:read|show|list|tell|display|print|count|search|find|grep|summari[sz]e|explain|describe)\b",
     re.IGNORECASE,
 )
+_USER_PATH_RE = re.compile(
+    r"(?:[\"'`])([^\"'`\n]+?\.[A-Za-z0-9]{1,8})(?:[\"'`])|(?:^|[\s(])([A-Za-z0-9_./-]+?\.[A-Za-z0-9]{1,8})(?=$|[\s),:;])"
+)
+_METADATA_REQUEST_RE = re.compile(
+    r"\b(?:metadata|meta-data|stat|stats|size|permission|permissions|owner|group|mtime|ctime|timestamp|timestamps|modified|file\s+info|file\s+details)\b",
+    re.IGNORECASE,
+)
 _MUTATION_PROMPT_RE = re.compile(
     r"\b(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
@@ -244,7 +251,7 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
     raw_command = arguments.get("command")
     if not isinstance(raw_command, str) or not user_prompt:
         return None
-    if not _ANALYSIS_PROMPT_RE.search(user_prompt):
+    if not _requires_direct_content_evidence(user_prompt):
         return None
     if _CONTENT_EVIDENCE_RE.search(raw_command):
         return None
@@ -252,8 +259,16 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
         return (
             f"{SHELL_FULL_CONTRACT_ERROR_PREFIX}, not only metadata/listing. "
             "Use a bounded command such as sed/head/grep/strings on the target file."
-        )
+    )
     return None
+
+
+def _requires_direct_content_evidence(user_prompt: str) -> bool:
+    if _ANALYSIS_PROMPT_RE.search(user_prompt):
+        return True
+    if _METADATA_REQUEST_RE.search(user_prompt):
+        return False
+    return _READ_ONLY_PROMPT_RE.search(user_prompt) is not None and _USER_PATH_RE.search(user_prompt) is not None
 
 
 def is_shell_full_contract_error(content: str) -> bool:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -224,6 +224,24 @@ def run_tool_loop(
             last_failure_content=last_failure_content,
         )
 
+    def file_recovery_retry_prompt(*, requested_path_exists: bool) -> str:
+        details = [
+            "The previous response still did not read the requested file contents.",
+        ]
+        if turn.requested_user_path:
+            details.append(f"Requested file: {turn.requested_user_path}")
+        if requested_path_exists:
+            details.append("The requested file exists in the workdir.")
+        details.extend(
+            [
+                "Before answering, use one appropriate exec_shell_full_command to obtain real file content evidence.",
+                "Use commands such as cat, sed -n, head, tail, or grep/rg on the file contents.",
+                "Do not answer from metadata, listings, or assumptions.",
+                "Return only the tool call.",
+            ]
+        )
+        return " ".join(details)
+
     def has_pending_internal_request() -> bool:
         return turn.has_pending_internal_request()
 
@@ -291,6 +309,19 @@ def run_tool_loop(
         if is_shell_full_contract_error(tool_result.content):
             if command and is_metadata_only_shell_command(command):
                 turn.metadata_only_rejections += 1
+            requested_path_exists = _requested_user_path_exists(turn.requested_user_path, workdir=workdir)
+            if (
+                turn.requested_user_path
+                and not turn.content_evidence_satisfied
+                and turn.can_reconsider(RECONSIDER_FILE_RECOVERY)
+            ):
+                request_file_recovery_guard(
+                    last_command=command,
+                    last_failure_content=tool_result.content,
+                    requested_path_exists=requested_path_exists,
+                )
+                repair.contract_retry_pending = True
+                return
             if should_nudge_content_evidence():
                 request_content_evidence_guard()
             else:
@@ -479,6 +510,7 @@ def run_tool_loop(
         executing_mutation_verification_repair = repair.mutation_verification_repair_pending
         executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending
         executing_content_evidence_guard = turn.pending_content_evidence_guard
+        executing_file_recovery_guard = turn.pending_file_recovery_guard
         executing_completion_guard = turn.pending_completion_guard
         executing_minimal_patch_guard = turn.pending_minimal_patch_guard
         if repair.shell_repair_prompt_pending is not None:
@@ -536,7 +568,12 @@ def run_tool_loop(
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop_index, result=result, phase="tool_call" if result.tool_calls else None))
         if repair.contract_retry_pending and not result.tool_calls:
-            retry_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTRACT_RETRY_PROMPT}]
+            retry_prompt = SHELL_FULL_CONTRACT_RETRY_PROMPT
+            if executing_file_recovery_guard and turn.requested_user_path:
+                retry_prompt = file_recovery_retry_prompt(
+                    requested_path_exists=_requested_user_path_exists(turn.requested_user_path, workdir=workdir)
+                )
+            retry_messages = [*call_messages, {"role": "user", "content": retry_prompt}]
             if on_phase_start:
                 on_phase_start(ModelPhaseStart("tool_call_retry", streamed=False, attempt=state.tool_rounds + 1, reason="tool_contract_retry"))
             result = runtime._chat_tool_call_once(
@@ -627,8 +664,16 @@ def run_tool_loop(
         if result.tool_calls and should_nudge_file_recovery(result.tool_calls):
             request_file_recovery_guard()
             continue
-        runtime.messages.append(assistant_tool_call_message(result.content, result.tool_calls))
         if not result.tool_calls:
+            executed_internal_tool_prompt = (
+                executing_mutation_verification
+                or executing_mutation_verification_repair
+                or executing_mutation_semantic_repair
+                or executing_content_evidence_guard
+                or executing_file_recovery_guard
+                or executing_completion_guard
+                or executing_minimal_patch_guard
+            )
             if executing_mutation_semantic_repair and result.content.strip().upper() != "OK":
                 runtime.mutation_semantic_repair_failures += 1
             if executing_content_evidence_guard:
@@ -638,6 +683,17 @@ def run_tool_loop(
             if executing_minimal_patch_guard:
                 runtime.minimal_patch_guard_failures += 1
             if state.tool_rounds > 0 and shell_full_enabled:
+                if (
+                    turn.requested_user_path
+                    and turn.metadata_only_rejections > 0
+                    and not turn.content_evidence_satisfied
+                    and _requested_user_path_exists(turn.requested_user_path, workdir=workdir)
+                    and not repair.file_content_retry_used
+                ):
+                    repair.file_content_retry_used = True
+                    turn.pending_file_recovery_guard = True
+                    turn.pending_file_recovery_guard_prompt = file_recovery_retry_prompt(requested_path_exists=True)
+                    continue
                 if should_nudge_completion():
                     request_completion_guard()
                     continue
@@ -652,7 +708,10 @@ def run_tool_loop(
                     loop=loop_index + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
+            if state.tool_rounds == 0 and not executed_internal_tool_prompt:
+                runtime.messages.append({"role": "assistant", "content": result.content})
             return result
+        runtime.messages.append(assistant_tool_call_message(result.content, result.tool_calls))
         state.increment_round()
         turn.increment_round()
         for tool_call in result.tool_calls:

--- a/src/orbit/runtime/tool_loop_state.py
+++ b/src/orbit/runtime/tool_loop_state.py
@@ -42,6 +42,7 @@ class ToolRepairState:
     mutation_verification_repair_used: bool = False
     mutation_semantic_repair_pending: bool = False
     mutation_semantic_repair_used: bool = False
+    file_content_retry_used: bool = False
 
     def has_pending(self) -> bool:
         return (

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -23,7 +23,6 @@ from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
     SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT,
     SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT,
-    SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     should_verify_shell_mutation,
@@ -1887,7 +1886,8 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIsNotNone(backend.tools_seen[2])
         self.assertEqual(backend.tools_seen[3], None)
         self.assertIsNotNone(backend.second_call_last_message)
-        self.assertIn("content/source/string evidence", backend.second_call_last_message["content"])
+        self.assertIn("Requested file: samples/vulnerable_service.py", backend.second_call_last_message["content"])
+        self.assertIn("No usable content has been extracted from the requested file yet.", backend.second_call_last_message["content"])
         self.assertIsNotNone(backend.third_call_last_message)
         self.assertIn("Return only the tool call", backend.third_call_last_message["content"])
 
@@ -2057,7 +2057,7 @@ class ToolRuntimeTests(unittest.TestCase):
             def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
                 self.calls += 1
                 last_content = str(messages[-1].get("content"))
-                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                if "Requested file not read yet." in last_content and self.guard_messages is None:
                     self.guard_messages = messages
                     self.guard_max_tokens = max_tokens
                 if self.calls == 1:
@@ -2144,7 +2144,7 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn("shell=True", tool_messages[2]["content"])
         self.assertIsNotNone(backend.guard_messages)
         self.assertEqual(backend.guard_max_tokens, 64)
-        self.assertIn(SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX, backend.guard_messages[-1]["content"])
+        self.assertIn("Requested file not read yet.", backend.guard_messages[-1]["content"])
         self.assertIn("Requested file: vulnerable_service.py", backend.guard_messages[-1]["content"])
         self.assertIn("Direct read failure:", backend.guard_messages[-1]["content"])
         self.assertIn("./samples/vulnerable_service.py", backend.guard_messages[-1]["content"])
@@ -2159,7 +2159,7 @@ class ToolRuntimeTests(unittest.TestCase):
             def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
                 self.calls += 1
                 last_content = str(messages[-1].get("content"))
-                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                if "Requested file not read yet." in last_content and self.guard_messages is None:
                     self.guard_messages = messages
                 if "The previous shell command failed." in last_content:
                     self.generic_shell_repairs += 1
@@ -2235,7 +2235,7 @@ class ToolRuntimeTests(unittest.TestCase):
             def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
                 self.calls += 1
                 last_content = str(messages[-1].get("content"))
-                if SHELL_FULL_FILE_RECOVERY_GUARD_PROMPT_PREFIX in last_content and self.guard_messages is None:
+                if "Requested file not read yet." in last_content and self.guard_messages is None:
                     self.guard_messages = messages
                 if self.calls == 1:
                     return ChatResult(
@@ -4548,7 +4548,35 @@ EOF"""
                         generation_tokens_per_second=None,
                     )
                 if self.calls == 3:
-                    if "require content/source/string evidence" not in messages[-1]["content"]:
+                    if not messages[-1]["content"].startswith("Requested file not read yet."):
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content="I cannot confirm the content of the file yet.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 4:
+                    if "still did not read the requested file contents" not in messages[-1]["content"]:
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content="I still cannot confirm the content of the file.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 5:
+                    if "still did not read the requested file contents" not in messages[-1]["content"]:
                         raise AssertionError(messages[-1]["content"])
                     return ChatResult(
                         content='{"command":"cat README.md"}',
@@ -4590,8 +4618,10 @@ EOF"""
 
         self.assertEqual(first.content, "hello there")
         self.assertEqual(second.content, "done")
-        self.assertEqual(backend.calls, 5)
+        self.assertEqual(backend.calls, 6)
         self.assertIn("hi", str(backend.messages_seen[1]))
+        self.assertNotIn("I cannot confirm the content of the file yet.", str(backend.messages_seen[3]))
+        self.assertNotIn("I still cannot confirm the content of the file.", str(backend.messages_seen[4]))
 
     def test_ask_auto_media_without_path_is_normal_chat_without_command_json(self) -> None:
         class MediaRouteBackend:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4514,6 +4514,85 @@ EOF"""
         self.assertEqual(backend.tool_names_seen[0], ())
         self.assertEqual(backend.tool_names_seen[1], ())
 
+    def test_ask_auto_rejects_metadata_only_file_read_after_prior_chat_turn(self) -> None:
+        class MultiTurnBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="hello there",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content='{"command":"ls -F"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    if "require content/source/string evidence" not in messages[-1]["content"]:
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content='{"command":"cat README.md"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="done",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "README.md").write_text("Orbit README", encoding="utf-8")
+            backend = MultiTurnBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            first = runtime.ask_auto("hi", temperature=0, max_tokens=32, workdir=workdir)
+            second = runtime.ask_auto(
+                "read the README.md file and explain it in a concise three-sentence list",
+                temperature=0,
+                max_tokens=32,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(first.content, "hello there")
+        self.assertEqual(second.content, "done")
+        self.assertEqual(backend.calls, 5)
+        self.assertIn("hi", str(backend.messages_seen[1]))
+
     def test_ask_auto_media_without_path_is_normal_chat_without_command_json(self) -> None:
         class MediaRouteBackend:
             def __init__(self) -> None:

--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -181,24 +181,6 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertEqual(execution.source, "orbit")
         self.assertIn("require content/source/string evidence", execution.result.content)
 
-    def test_exec_shell_full_blocks_metadata_only_specific_file_read_prompt(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            executor = HybridToolExecutor(
-                backend=FakeServerTools(),
-                workdir=Path(tmp),
-                allowed_tool_names=("exec_shell_full_command",),
-                user_prompt="read the README.md file and explain it in a concise three-sentence list",
-            )
-
-            execution = executor.execute(
-                "exec_shell_full_command",
-                {"command": "ls -F"},
-                chunk_budget={},
-            )
-
-        self.assertEqual(execution.source, "orbit")
-        self.assertIn("require content/source/string evidence", execution.result.content)
-
     def test_exec_shell_full_allows_listing_when_not_analysis_prompt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             executor = HybridToolExecutor(
@@ -211,42 +193,6 @@ class HybridToolExecutorTests(unittest.TestCase):
             execution = executor.execute(
                 "exec_shell_full_command",
                 {"command": "ls -R ."},
-                chunk_budget={},
-            )
-
-        self.assertEqual(execution.source, "orbit")
-        self.assertNotIn("require content/source/string evidence", execution.result.content)
-
-    def test_exec_shell_full_allows_listing_for_directory_question(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            executor = HybridToolExecutor(
-                backend=FakeServerTools(),
-                workdir=Path(tmp),
-                allowed_tool_names=("exec_shell_full_command",),
-                user_prompt="list all files in this workdir",
-            )
-
-            execution = executor.execute(
-                "exec_shell_full_command",
-                {"command": "ls -F"},
-                chunk_budget={},
-            )
-
-        self.assertEqual(execution.source, "orbit")
-        self.assertNotIn("require content/source/string evidence", execution.result.content)
-
-    def test_exec_shell_full_allows_metadata_request_for_specific_file(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            executor = HybridToolExecutor(
-                backend=FakeServerTools(),
-                workdir=Path(tmp),
-                allowed_tool_names=("exec_shell_full_command",),
-                user_prompt="show note.txt metadata",
-            )
-
-            execution = executor.execute(
-                "exec_shell_full_command",
-                {"command": "ls -l note.txt"},
                 chunk_budget={},
             )
 

--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -181,6 +181,24 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertEqual(execution.source, "orbit")
         self.assertIn("require content/source/string evidence", execution.result.content)
 
+    def test_exec_shell_full_blocks_metadata_only_specific_file_read_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+                user_prompt="read the README.md file and explain it in a concise three-sentence list",
+            )
+
+            execution = executor.execute(
+                "exec_shell_full_command",
+                {"command": "ls -F"},
+                chunk_budget={},
+            )
+
+        self.assertEqual(execution.source, "orbit")
+        self.assertIn("require content/source/string evidence", execution.result.content)
+
     def test_exec_shell_full_allows_listing_when_not_analysis_prompt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             executor = HybridToolExecutor(
@@ -193,6 +211,42 @@ class HybridToolExecutorTests(unittest.TestCase):
             execution = executor.execute(
                 "exec_shell_full_command",
                 {"command": "ls -R ."},
+                chunk_budget={},
+            )
+
+        self.assertEqual(execution.source, "orbit")
+        self.assertNotIn("require content/source/string evidence", execution.result.content)
+
+    def test_exec_shell_full_allows_listing_for_directory_question(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+                user_prompt="list all files in this workdir",
+            )
+
+            execution = executor.execute(
+                "exec_shell_full_command",
+                {"command": "ls -F"},
+                chunk_budget={},
+            )
+
+        self.assertEqual(execution.source, "orbit")
+        self.assertNotIn("require content/source/string evidence", execution.result.content)
+
+    def test_exec_shell_full_allows_metadata_request_for_specific_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+                user_prompt="show note.txt metadata",
+            )
+
+            execution = executor.execute(
+                "exec_shell_full_command",
+                {"command": "ls -l note.txt"},
                 chunk_budget={},
             )
 


### PR DESCRIPTION
Summary:

* Rejects metadata-only shell commands when the user explicitly asks to read/explain a specific file.
* Keeps explicit metadata/stat requests allowed.
* Prevents `ls`-only tool passes from being accepted for prompts like `read README.md and explain it`.

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_tool_backends -q`: PASS
* `PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_final_policy tests.test_repl tests.test_tool_loop_state -q`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS

Scope:

* `src/orbit/runtime/shell_guardrails.py`
* `tests/test_tool_backends.py`