### PR TITLE
Require URL content evidence for explicit fetch

### DIFF
--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -126,10 +126,16 @@ _READ_ONLY_PROMPT_RE = re.compile(
 _USER_PATH_RE = re.compile(
     r"(?:[\"'`])([^\"'`\n]+?\.[A-Za-z0-9]{1,8})(?:[\"'`])|(?:^|[\s(])([A-Za-z0-9_./-]+?\.[A-Za-z0-9]{1,8})(?=$|[\s),:;])"
 )
+_URL_RE = re.compile(r"https?://[^\s<>'\")]+", re.IGNORECASE)
 _METADATA_REQUEST_RE = re.compile(
     r"\b(?:metadata|meta-data|stat|stats|size|permission|permissions|owner|group|mtime|ctime|timestamp|timestamps|modified|file\s+info|file\s+details)\b",
     re.IGNORECASE,
 )
+_URL_CONTENT_REQUEST_RE = re.compile(
+    r"\b(?:fetch|read|open|explain|summari[sz]e|analy[sz]e|review|inspect|translate|describe|thesis|central\s+thesis|riassum\w*|sintesi|spiega|leggi|apri|analizz\w*|descrivi|traduci)\b",
+    re.IGNORECASE,
+)
+_TRIVIAL_URL_NONFETCH_RE = re.compile(r"^\s*(?:echo|printf|true|false|pwd)(?:\s|$)", re.IGNORECASE)
 _MUTATION_PROMPT_RE = re.compile(
     r"\b(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
@@ -251,6 +257,17 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
     raw_command = arguments.get("command")
     if not isinstance(raw_command, str) or not user_prompt:
         return None
+    requested_url = extract_requested_user_url(user_prompt)
+    if requested_url and requires_url_content_evidence(user_prompt):
+        if raw_command.strip().startswith("orbit-web-search"):
+            return (
+                f"{SHELL_FULL_CONTRACT_ERROR_PREFIX}, explicit URL requests require direct URL fetch or a real HTTP/network failure, "
+                "not generic web search."
+            )
+        if not is_explicit_url_fetch_shell_command(raw_command, requested_url=requested_url):
+            return (
+                f"{SHELL_FULL_CONTRACT_ERROR_PREFIX}, explicit URL requests require direct URL content/failure evidence from the requested URL."
+            )
     if not _requires_direct_content_evidence(user_prompt):
         return None
     if _CONTENT_EVIDENCE_RE.search(raw_command):
@@ -269,6 +286,33 @@ def _requires_direct_content_evidence(user_prompt: str) -> bool:
     if _METADATA_REQUEST_RE.search(user_prompt):
         return False
     return _READ_ONLY_PROMPT_RE.search(user_prompt) is not None and _USER_PATH_RE.search(user_prompt) is not None
+
+
+def extract_requested_user_url(prompt: str | None) -> str | None:
+    if not prompt:
+        return None
+    match = _URL_RE.search(prompt)
+    if not match:
+        return None
+    return match.group(0).rstrip(".,;:!?")
+
+
+def requires_url_content_evidence(prompt: str | None) -> bool:
+    if not prompt:
+        return False
+    if not extract_requested_user_url(prompt):
+        return False
+    return _URL_CONTENT_REQUEST_RE.search(prompt) is not None
+
+
+def is_explicit_url_fetch_shell_command(command: str | None, *, requested_url: str) -> bool:
+    if not command:
+        return False
+    if requested_url not in command:
+        return False
+    if is_metadata_only_shell_command(command):
+        return False
+    return _TRIVIAL_URL_NONFETCH_RE.search(command) is None
 
 
 def is_shell_full_contract_error(content: str) -> bool:
@@ -325,6 +369,46 @@ def build_shell_full_file_recovery_guard_prompt(
         details.append("No usable content has been extracted from the requested file yet.")
         details.append("Do not conclude that the file is missing or unreadable yet.")
     return f"{prompt_prefix}\n\n" + "\n".join(details)
+
+
+def build_shell_full_url_recovery_guard_prompt(
+    *,
+    requested_url: str,
+    last_command: str | None = None,
+    last_failure_content: str | None = None,
+    fetch_attempted: bool = False,
+) -> str:
+    details = [
+        "Requested URL content not fetched yet.",
+        f"Requested URL: {requested_url}",
+    ]
+    if fetch_attempted:
+        details.append("A previous command still did not provide usable URL content or a real HTTP/network failure for that URL.")
+    details.extend(
+        [
+            "Before answering, use one appropriate exec_shell_full_command to retrieve the URL content or verify the real HTTP/network failure.",
+            "Do not speculate about the page contents or existence from the URL alone.",
+            "Do not replace the direct fetch with generic web search unless you already have direct fetch failure evidence.",
+        ]
+    )
+    failure = shell_failure_from_output(last_failure_content or "")
+    if last_command:
+        details.append(f"Last command: {last_command}")
+    if failure is not None:
+        details.append(f"Last exit code: {failure.exit_code}")
+        if failure.stderr:
+            details.append(f"Last stderr: {_bounded_stream(failure.stderr)}")
+        elif failure.stdout:
+            details.append(f"Last stdout: {_bounded_stream(failure.stdout)}")
+    details.extend(
+        [
+            "",
+            "Return only JSON:",
+            "",
+            '{"command":"..."}',
+        ]
+    )
+    return "\n".join(details)
 
 
 def shell_failure_from_output(content: str) -> ShellFailure | None:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -18,6 +18,9 @@ from orbit.runtime.shell_guardrails import (
     SHELL_FULL_CONTRACT_RETRY_PROMPT,
     SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT,
     build_shell_full_file_recovery_guard_prompt,
+    build_shell_full_url_recovery_guard_prompt,
+    extract_requested_user_url,
+    is_explicit_url_fetch_shell_command,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     is_incomplete_shell_json_or_command_error,
@@ -29,6 +32,7 @@ from orbit.runtime.shell_guardrails import (
     is_shell_full_contract_error,
     is_shell_full_execution_error,
     looks_like_broad_file_rewrite,
+    requires_url_content_evidence,
     shell_repair_prompt,
     should_verify_shell_mutation,
 )
@@ -43,6 +47,7 @@ from orbit.runtime.tool_loop_state import (
     RECONSIDER_CONTENT_EVIDENCE,
     RECONSIDER_FILE_RECOVERY,
     RECONSIDER_MINIMAL_PATCH,
+    RECONSIDER_URL_RECOVERY,
     ToolLoopState,
     ToolTurnState,
 )
@@ -91,13 +96,24 @@ def run_tool_loop(
     last_result: ChatResult | None = None
     state = ToolLoopState(allowed_tool_names)
     user_prompt = _last_user_text(runtime.messages)
-    turn = ToolTurnState(requested_user_path=_extract_requested_user_path(user_prompt))
+    turn = ToolTurnState(
+        requested_user_path=_extract_requested_user_path(user_prompt),
+        requested_user_url=extract_requested_user_url(user_prompt),
+    )
     repair = turn.repair_state
     shell_full_enabled = "exec_shell_full_command" in allowed_tool_names
+    url_content_required = requires_url_content_evidence(user_prompt)
     suppress_tool_delta = (lambda _delta: None) if on_final_delta is not None and shell_full_enabled else None
 
     # These local helpers still couple policy and runtime counters in one place.
     # The state objects only store turn-local facts; they do not decide tasks.
+
+    def has_required_direct_evidence() -> bool:
+        return (
+            turn.content_evidence_satisfied
+            or turn.url_content_evidence_satisfied
+            or turn.url_failure_evidence_satisfied
+        )
 
     def should_nudge_completion() -> bool:
         return (
@@ -224,6 +240,23 @@ def run_tool_loop(
             last_failure_content=last_failure_content,
         )
 
+    def request_url_recovery_guard(
+        *,
+        last_command: str | None = None,
+        last_failure_content: str | None = None,
+        fetch_attempted: bool = False,
+    ) -> None:
+        if not turn.requested_user_url:
+            return
+        turn.pending_url_recovery_guard = True
+        turn.mark_reconsider(RECONSIDER_URL_RECOVERY)
+        turn.pending_url_recovery_guard_prompt = build_shell_full_url_recovery_guard_prompt(
+            requested_url=turn.requested_user_url,
+            last_command=last_command,
+            last_failure_content=last_failure_content,
+            fetch_attempted=fetch_attempted or turn.url_fetch_attempted,
+        )
+
     def file_recovery_retry_prompt(*, requested_path_exists: bool) -> str:
         details = [
             "The previous response still did not read the requested file contents.",
@@ -242,13 +275,30 @@ def run_tool_loop(
         )
         return " ".join(details)
 
+    def url_recovery_retry_prompt(*, fetch_attempted: bool) -> str:
+        details = [
+            "The previous response still did not obtain usable content or a real HTTP/network failure for the requested URL.",
+        ]
+        if turn.requested_user_url:
+            details.append(f"Requested URL: {turn.requested_user_url}")
+        if fetch_attempted or turn.url_fetch_attempted:
+            details.append("A direct fetch attempt is still required to answer safely.")
+        details.extend(
+            [
+                "Before answering, use one appropriate exec_shell_full_command to retrieve the URL content or verify the real HTTP/network failure.",
+                "Do not speculate from the URL alone.",
+                "Return only the tool call.",
+            ]
+        )
+        return " ".join(details)
+
     def has_pending_internal_request() -> bool:
         return turn.has_pending_internal_request()
 
     def should_handoff_to_final_from_tool() -> bool:
         return (
             shell_full_enabled
-            and turn.content_evidence_satisfied
+            and has_required_direct_evidence()
             and turn.finalizable
             and not has_pending_internal_request()
             and not repair.shell_error_final_pending
@@ -275,10 +325,17 @@ def run_tool_loop(
         raw_arguments = _shell_raw_arguments_from_tool_call(tool_call)
         command_is_mutating = bool(command and is_mutating_shell_command(command))
         command_is_content_evidence = bool(command and is_content_evidence_shell_command(command))
+        command_is_url_fetch = bool(
+            command
+            and turn.requested_user_url
+            and is_explicit_url_fetch_shell_command(command, requested_url=turn.requested_user_url)
+        )
         tool_output_kind = _classify_shell_output_kind(command, tool_result.content, requested_path=turn.requested_user_path)
         turn.set_tool_result_kind(tool_output_kind)
         if command:
             turn.shell_commands_seen += 1
+        if command_is_url_fetch:
+            turn.url_fetch_attempted = True
         if command_is_mutating:
             turn.shell_mutation_attempted = True
         if is_content_evidence_guard:
@@ -309,6 +366,19 @@ def run_tool_loop(
         if is_shell_full_contract_error(tool_result.content):
             if command and is_metadata_only_shell_command(command):
                 turn.metadata_only_rejections += 1
+            if (
+                url_content_required
+                and turn.requested_user_url
+                and not has_required_direct_evidence()
+                and turn.can_reconsider(RECONSIDER_URL_RECOVERY)
+            ):
+                request_url_recovery_guard(
+                    last_command=command,
+                    last_failure_content=tool_result.content,
+                    fetch_attempted=command_is_url_fetch,
+                )
+                repair.contract_retry_pending = True
+                return
             requested_path_exists = _requested_user_path_exists(turn.requested_user_path, workdir=workdir)
             if (
                 turn.requested_user_path
@@ -330,6 +400,11 @@ def run_tool_loop(
                 runtime.content_evidence_guard_failures += 1
             return
         if is_shell_full_execution_error(tool_result.content):
+            if command_is_url_fetch:
+                turn.mark_url_failure_evidence(_summarize_shell_error(tool_result.content))
+                repair.shell_error_final_pending = True
+                turn.mark_exhausted()
+                return
             direct_requested_read_failed = bool(
                 turn.requested_user_path
                 and command
@@ -390,6 +465,8 @@ def run_tool_loop(
         if command_is_mutating:
             turn.shell_mutation_succeeded = True
         if tool_result.content.strip():
+            if command_is_url_fetch and not command_is_mutating:
+                turn.mark_url_content_evidence()
             if command_is_content_evidence and not command_is_mutating:
                 turn.mark_direct_content_read()
                 if is_content_evidence_guard:
@@ -511,6 +588,7 @@ def run_tool_loop(
         executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending
         executing_content_evidence_guard = turn.pending_content_evidence_guard
         executing_file_recovery_guard = turn.pending_file_recovery_guard
+        executing_url_recovery_guard = turn.pending_url_recovery_guard
         executing_completion_guard = turn.pending_completion_guard
         executing_minimal_patch_guard = turn.pending_minimal_patch_guard
         if repair.shell_repair_prompt_pending is not None:
@@ -525,6 +603,8 @@ def run_tool_loop(
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_ANALYSIS_COMPLETION_GUARD_PROMPT}]
         elif turn.pending_file_recovery_guard:
             call_messages = [*call_messages, {"role": "user", "content": turn.pending_file_recovery_guard_prompt or ""}]
+        elif turn.pending_url_recovery_guard:
+            call_messages = [*call_messages, {"role": "user", "content": turn.pending_url_recovery_guard_prompt or ""}]
         elif turn.pending_minimal_patch_guard:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT}]
         elif turn.pending_completion_guard:
@@ -538,6 +618,7 @@ def run_tool_loop(
                 or repair.mutation_semantic_repair_pending
                 or turn.pending_content_evidence_guard
                 or turn.pending_analysis_completion_guard
+                or turn.pending_url_recovery_guard
                 or turn.pending_minimal_patch_guard
                 or turn.pending_completion_guard
                 or repair.mutation_verification_pending
@@ -573,6 +654,8 @@ def run_tool_loop(
                 retry_prompt = file_recovery_retry_prompt(
                     requested_path_exists=_requested_user_path_exists(turn.requested_user_path, workdir=workdir)
                 )
+            elif executing_url_recovery_guard and turn.requested_user_url:
+                retry_prompt = url_recovery_retry_prompt(fetch_attempted=turn.url_fetch_attempted)
             retry_messages = [*call_messages, {"role": "user", "content": retry_prompt}]
             if on_phase_start:
                 on_phase_start(ModelPhaseStart("tool_call_retry", streamed=False, attempt=state.tool_rounds + 1, reason="tool_contract_retry"))
@@ -671,6 +754,7 @@ def run_tool_loop(
                 or executing_mutation_semantic_repair
                 or executing_content_evidence_guard
                 or executing_file_recovery_guard
+                or executing_url_recovery_guard
                 or executing_completion_guard
                 or executing_minimal_patch_guard
             )
@@ -683,6 +767,16 @@ def run_tool_loop(
             if executing_minimal_patch_guard:
                 runtime.minimal_patch_guard_failures += 1
             if state.tool_rounds > 0 and shell_full_enabled:
+                if (
+                    url_content_required
+                    and turn.requested_user_url
+                    and not has_required_direct_evidence()
+                    and not repair.url_content_retry_used
+                ):
+                    repair.url_content_retry_used = True
+                    turn.pending_url_recovery_guard = True
+                    turn.pending_url_recovery_guard_prompt = url_recovery_retry_prompt(fetch_attempted=turn.url_fetch_attempted)
+                    continue
                 if (
                     turn.requested_user_path
                     and turn.metadata_only_rejections > 0
@@ -708,6 +802,15 @@ def run_tool_loop(
                     loop=loop_index + 1,
                     use_tool_prompt=state.used_tool_call_prompt,
                 )
+            if (
+                shell_full_enabled
+                and url_content_required
+                and turn.requested_user_url
+                and not has_required_direct_evidence()
+                and not executed_internal_tool_prompt
+            ):
+                request_url_recovery_guard(fetch_attempted=turn.url_fetch_attempted)
+                continue
             if state.tool_rounds == 0 and not executed_internal_tool_prompt:
                 runtime.messages.append({"role": "assistant", "content": result.content})
             return result

--- a/src/orbit/runtime/tool_loop_state.py
+++ b/src/orbit/runtime/tool_loop_state.py
@@ -19,6 +19,7 @@ EVIDENCE_EXHAUSTED = "exhausted"
 RECONSIDER_CONTENT_EVIDENCE = "content_evidence"
 RECONSIDER_ANALYSIS_COMPLETION = "analysis_completion"
 RECONSIDER_FILE_RECOVERY = "file_recovery"
+RECONSIDER_URL_RECOVERY = "url_recovery"
 RECONSIDER_COMPLETION = "completion"
 RECONSIDER_MINIMAL_PATCH = "minimal_patch"
 
@@ -43,6 +44,7 @@ class ToolRepairState:
     mutation_semantic_repair_pending: bool = False
     mutation_semantic_repair_used: bool = False
     file_content_retry_used: bool = False
+    url_content_retry_used: bool = False
 
     def has_pending(self) -> bool:
         return (
@@ -67,6 +69,7 @@ class ToolTurnState:
     """
 
     requested_user_path: str | None = None
+    requested_user_url: str | None = None
     round_count: int = 0
     evidence_state: str = EVIDENCE_UNRESOLVED
     candidate_paths: list[str] = field(default_factory=list)
@@ -81,12 +84,17 @@ class ToolTurnState:
     pending_analysis_completion_guard: bool = False
     pending_file_recovery_guard: bool = False
     pending_file_recovery_guard_prompt: str | None = None
+    pending_url_recovery_guard: bool = False
+    pending_url_recovery_guard_prompt: str | None = None
     pending_completion_guard: bool = False
     pending_minimal_patch_guard: bool = False
     metadata_only_rejections: int = 0
     shell_commands_seen: int = 0
     shell_mutation_attempted: bool = False
     shell_mutation_succeeded: bool = False
+    url_fetch_attempted: bool = False
+    url_content_evidence_satisfied: bool = False
+    url_failure_evidence_satisfied: bool = False
 
     def increment_round(self) -> None:
         self.round_count += 1
@@ -103,6 +111,7 @@ class ToolTurnState:
             or self.pending_content_evidence_guard
             or self.pending_analysis_completion_guard
             or self.pending_file_recovery_guard
+            or self.pending_url_recovery_guard
             or self.pending_completion_guard
             or self.pending_minimal_patch_guard
         )
@@ -130,6 +139,16 @@ class ToolTurnState:
         self.finalizable = True
         self.evidence_state = EVIDENCE_DIRECT_CONTENT_READ
 
+    def mark_url_content_evidence(self) -> None:
+        self.url_content_evidence_satisfied = True
+        self.finalizable = True
+
+    def mark_url_failure_evidence(self, error: str | None) -> None:
+        self.url_fetch_attempted = True
+        self.url_failure_evidence_satisfied = True
+        self.last_error = error
+        self.finalizable = True
+
     def mark_finalizable(self) -> None:
         self.finalizable = True
         if self.content_evidence_satisfied:
@@ -149,6 +168,8 @@ class ToolTurnState:
         self.pending_analysis_completion_guard = False
         self.pending_file_recovery_guard = False
         self.pending_file_recovery_guard_prompt = None
+        self.pending_url_recovery_guard = False
+        self.pending_url_recovery_guard_prompt = None
         self.pending_completion_guard = False
         self.pending_minimal_patch_guard = False
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -655,6 +655,16 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(repl.tools_mode, "on")
         self.assertIn("tools: on", stdout.getvalue())
 
+    def test_reset_does_not_turn_tools_off(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+
+        repl._handle_tools_command("/tools on")
+        handled = repl._handle_command("/reset")
+
+        self.assertTrue(handled)
+        self.assertEqual(repl.tools_mode, "on")
+
     def test_sessions_clear_can_be_cancelled(self) -> None:
         runtime = CountingRuntime()
         repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4623,6 +4623,179 @@ EOF"""
         self.assertNotIn("I cannot confirm the content of the file yet.", str(backend.messages_seen[3]))
         self.assertNotIn("I still cannot confirm the content of the file.", str(backend.messages_seen[4]))
 
+    def test_ask_with_tools_requires_real_url_fetch_before_answering(self) -> None:
+        class UrlRecoveryBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="The page seems hypothetical because the date looks future-dated.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=4,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    if "Requested URL content not fetched yet." not in str(messages[-1]["content"]):
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content='{"command":"python3 -c \\"print(\'<html><body>Central thesis: human dignity and solidarity.</body></html>\')\\" https://example.com/doc"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=10,
+                        completion_tokens=3,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Grounded final answer.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=12,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=UrlRecoveryBackend(), system_prompt="route system")
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/doc and explain the central thesis in Italian.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "Grounded final answer.")
+
+    def test_ask_with_tools_requires_real_url_fetch_after_runtime_reset(self) -> None:
+        class UrlRecoveryAfterResetBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="hello back",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=4,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="I cannot confirm the page contents yet.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=4,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    if "Requested URL content not fetched yet." not in str(messages[-1]["content"]):
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content='{"command":"python3 -c \\"print(\'<html><body>Central thesis: grounded evidence.</body></html>\')\\" https://example.com/doc"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=10,
+                        completion_tokens=3,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Grounded after reset.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=12,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = UrlRecoveryAfterResetBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+            runtime.ask("hi", temperature=0, max_tokens=32)
+            runtime.reset()
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/doc and explain the central thesis in Italian.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "Grounded after reset.")
+
+    def test_ask_with_tools_allows_grounded_url_failure_after_real_fetch_attempt(self) -> None:
+        class UrlFailureBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content='{"command":"python3 -c \\"import sys; sys.stderr.write(\'HTTP 404 Not Found\\\\n\'); raise SystemExit(22)\\" https://example.com/missing"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=3,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The URL returned an HTTP 404 error.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=10,
+                    completion_tokens=4,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=UrlFailureBackend(), system_prompt="route system")
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/missing and summarize it.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "The URL returned an HTTP 404 error.")
+
     def test_ask_auto_media_without_path_is_normal_chat_without_command_json(self) -> None:
         class MediaRouteBackend:
             def __init__(self) -> None:

--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -181,6 +181,15 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertEqual(execution.source, "orbit")
         self.assertIn("require content/source/string evidence", execution.result.content)
 
+    def test_validate_shell_full_contract_rejects_explicit_url_without_fetch(self) -> None:
+        error = validate_shell_full_contract(
+            {"command": 'orbit-web-search "vatican va encyclical"'},
+            user_prompt="Fetch https://example.com/doc and explain the central thesis.",
+        )
+
+        self.assertIsNotNone(error)
+        self.assertIn("explicit URL requests require direct URL fetch", error)
+
     def test_exec_shell_full_allows_listing_when_not_analysis_prompt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             executor = HybridToolExecutor(


### PR DESCRIPTION
Summary:
- Requires real URL content evidence, or a real observed fetch failure, before finalizing explicit URL fetch/read/explain/summarize/analyze requests.
- Prevents speculative answers when the model has not fetched the URL.
- Keeps recovery model-guided and bounded.
- Does not hardcode URLs, domains, providers, or commands.
- Does not construct answers in runtime.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_tool_backends tests.test_runtime tests.test_tool_loop_state tests.test_final_policy tests.test_repl -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Smoke:
- Explicit URL fetch direct: PASS
- Explicit URL fetch after /tools on + /reset: PASS
- URL mentioned but not fetched: PASS
- Tools off explicit URL fetch: PASS
- README file-read regression: PASS
- list files regression: PASS