### PR TITLE
Require URL content evidence for explicit fetch

### DIFF
--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -11,6 +11,7 @@ from orbit.runtime.tool_arguments import parse_tool_arguments_or_empty
 
 SHELL_TOOL_ALIASES = {"exec_shell_full_command", "shell"}
 WEB_SEARCH_TOOL_ALIASES = {"orbit-web-search"}
+FETCH_URL_TOOL_ALIASES = {"fetch_url"}
 
 
 class ToolRoute(StrEnum):
@@ -45,6 +46,8 @@ def parse_command_decision_from_tool_calls(tool_calls: list[dict[str, Any]]) -> 
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
         if name in WEB_SEARCH_TOOL_ALIASES and _web_search_command_from_args(args):
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
+        if name in FETCH_URL_TOOL_ALIASES and _has_url(args):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
     return None
 
 
@@ -52,7 +55,8 @@ def command_tool_call_from_tool_calls(
     tool_calls: list[dict[str, Any]],
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
-    if "exec_shell_full_command" not in set(allowed_tool_names):
+    allowed = set(allowed_tool_names)
+    if not ({"exec_shell_full_command", "fetch_url"} & allowed):
         return None
     for tool_call in tool_calls:
         function = tool_call.get("function")
@@ -70,9 +74,15 @@ def command_tool_call_from_tool_calls(
             if name == "exec_shell_full_command" and isinstance(raw_arguments, str) and parsed_valid_command:
                 return tool_call
             return _tool_call("exec_shell_full_command", {"command": args["command"]})
+        if name in FETCH_URL_TOOL_ALIASES and _has_url(args):
+            if "fetch_url" not in allowed:
+                return None
+            if name == "fetch_url" and isinstance(raw_arguments, str):
+                return tool_call
+            return _tool_call("fetch_url", {"url": args["url"]})
         if name in WEB_SEARCH_TOOL_ALIASES:
             command = _web_search_command_from_args(args)
-            if command:
+            if command and "exec_shell_full_command" in allowed:
                 return _tool_call("exec_shell_full_command", {"command": command})
     return None
 
@@ -81,13 +91,23 @@ def command_tool_call_from_content(
     content: str,
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
-    if "exec_shell_full_command" not in set(allowed_tool_names):
+    allowed = set(allowed_tool_names)
+    if not ({"exec_shell_full_command", "fetch_url"} & allowed):
         return None
     raw_command = _extract_raw_tool_call_command(content)
     if raw_command:
+        if "exec_shell_full_command" not in allowed:
+            return None
         return _tool_call("exec_shell_full_command", {"command": raw_command})
+    raw_url = _extract_raw_tool_call_url(content)
+    if raw_url:
+        if "fetch_url" not in allowed:
+            return None
+        return _tool_call("fetch_url", {"url": raw_url})
     value = _parse_command_json_object(content) or _extract_last_json_object(content) or _extract_loose_command_object(content)
     if not _has_command(value):
+        if _has_url(value) and "fetch_url" in allowed:
+            return _tool_call("fetch_url", {"url": value["url"]})
         return None
     return _tool_call("exec_shell_full_command", {"command": value["command"]})
 
@@ -97,16 +117,20 @@ def parse_command_decision(content: str) -> RouteDecision | None:
     if not text:
         return None
     if _parse_raw_tool_call_decision(text) is not None:
-        return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
+        return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command", "fetch_url"))
     value = _parse_command_json_object(text)
     if _has_command(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
+    if _has_url(value):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
     if _has_command(_extract_loose_command_object(text)):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     for line in text.splitlines():
         value = _parse_command_json_object(_strip_json_fence(line.strip()))
         if _has_command(value):
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
+        if _has_url(value):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
     return None
 
 
@@ -119,13 +143,13 @@ def command_stream_state(text: str, *, max_prefix_chars: int = ROUTE_STREAM_PREF
         return "not_command"
     if not stripped:
         return "pending"
-    if _is_partial_prefix(stripped, "<|tool_call>") or _is_partial_prefix(stripped, '{"command"'):
+    if _is_partial_prefix(stripped, "<|tool_call>") or _is_partial_prefix(stripped, '{"command"') or _is_partial_prefix(stripped, '{"url"'):
         return "pending"
     if stripped.startswith("<|tool_call>"):
         if "<tool_call|>" in stripped:
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
-    if stripped.startswith('{"command"'):
+    if stripped.startswith('{"command"') or stripped.startswith('{"url"'):
         if _looks_like_complete_json_object(stripped):
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
@@ -180,14 +204,14 @@ class CommandStreamFilter:
 def tool_names_for_decision(route: ToolRoute, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if route == ToolRoute.FILESYSTEM:
-        return ("exec_shell_full_command",)
+        return ("exec_shell_full_command", "fetch_url")
     return ()
 
 
 def decision_tool_names(decision: RouteDecision, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if decision.tool_names:
-        return tuple(name for name in decision.tool_names if name == "exec_shell_full_command")
+        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url"})
     return tool_names_for_decision(decision.route)
 
 
@@ -208,6 +232,8 @@ def _parse_raw_tool_call_decision(text: str) -> ToolRoute | None:
     if "<|tool_call>" not in text:
         return None
     if _extract_raw_tool_call_command(text):
+        return ToolRoute.FILESYSTEM
+    if _extract_raw_tool_call_url(text):
         return ToolRoute.FILESYSTEM
     if "exec_shell_full_command" in text or "call:shell" in text or "command" in text:
         return ToolRoute.FILESYSTEM
@@ -230,6 +256,25 @@ def _extract_raw_tool_call_command(content: str) -> str | None:
         return value["command"]
     if name in WEB_SEARCH_TOOL_ALIASES:
         return _web_search_command_from_args(value)
+    return None
+
+
+def _extract_raw_tool_call_url(content: str) -> str | None:
+    text = content.replace('<|"|>', '"')
+    match = re.search(
+        r"<\|tool_call\>\s*call:(?P<name>[A-Za-z0-9_-]+)\s*(?P<args>\{.*?\})\s*<tool_call\|>",
+        text,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return None
+    name = match.group("name")
+    if name not in FETCH_URL_TOOL_ALIASES:
+        return None
+    raw_args = match.group("args")
+    value = _parse_command_json_object(raw_args) or _extract_last_json_object(raw_args) or _extract_loose_key_value_object(raw_args)
+    if _has_url(value):
+        return value["url"]
     return None
 
 
@@ -327,6 +372,13 @@ def _has_command(value: dict[str, Any] | None) -> bool:
         return False
     command = value.get("command")
     return isinstance(command, str) and bool(command.strip())
+
+
+def _has_url(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict):
+        return False
+    url = value.get("url")
+    return isinstance(url, str) and bool(url.strip())
 
 
 def _looks_like_complete_json_object(text: str) -> bool:

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -35,7 +35,7 @@ Return valid one-line JSON only:
 
 Environment: OS={os_name}; shell={shell_name}.
 
-Use given paths exactly. Use native commands in workdir. Generic web search: orbit-web-search "query"; explicit URLs: curl. Quote spaced paths.
+Use given paths exactly. Use native commands in workdir. Generic web search: orbit-web-search "query". For explicit URL fetch/read/explain/summarize/analyze requests, prefer the fetch_url tool; shell fetch commands such as curl are still allowed when needed. Quote spaced paths.
 
 Do not claim no access for local/system/web.
 Never use <|tool_call>, call:shell, markdown, fences, or prose for shell.
@@ -46,10 +46,11 @@ specs of this computer -> {{"command":"uname -a; lscpu; free -h; df -h"}}
 For analysis, prefer content, source, binaries, strings, logs, archives, or fetched data, not metadata."""
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())
 TOOL_CALL_SYSTEM_PROMPT = (
-    "Call exec_shell_full_command exactly once and output no prose. "
-    "Use one compact one-line shell command. "
-    'Use orbit-web-search "query" for generic web search; use curl for explicit URLs. '
-    "Quote paths containing spaces. "
+    "Call exactly one available tool and output no prose. "
+    "Prefer fetch_url for explicit URL fetch/read/explain/summarize/analyze requests. "
+    'Use orbit-web-search "query" for generic web search. '
+    "Use exec_shell_full_command for local/system tasks or when another tool is more appropriate. "
+    "Quote paths containing spaces in shell commands. "
     "For analysis, collect direct evidence from content/source/strings/logs/archives/fetched data."
 )
 TOOL_CALL_JSON_RETRY_PROMPT = (

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -136,6 +136,37 @@ _URL_CONTENT_REQUEST_RE = re.compile(
     re.IGNORECASE,
 )
 _TRIVIAL_URL_NONFETCH_RE = re.compile(r"^\s*(?:echo|printf|true|false|pwd)(?:\s|$)", re.IGNORECASE)
+_TRANSFER_PROGRESS_HEADER_RE = re.compile(
+    r"^\s*% Total\s+% Received\s+% Xferd\s+Average Speed\s+Time\s+Time\s+Time\s+Current\s*$",
+    re.IGNORECASE,
+)
+_TRANSFER_PROGRESS_COLUMNS_RE = re.compile(
+    r"^\s*Dload\s+Upload\s+Total\s+Spent\s+Left\s+Speed\s*$",
+    re.IGNORECASE,
+)
+_TRANSFER_PROGRESS_ROW_RE = re.compile(
+    r"^\s*\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+[-:\d]+\s+[-:\d]+\s+[-:\d]+\s+\d+\s*$"
+)
+_URL_FETCH_FAILURE_RE = re.compile(
+    r"\b(?:"
+    r"HTTP/\d(?:\.\d)?\s+[45]\d{2}\b|"
+    r"[45]\d{2}\s+(?:Not Found|Forbidden|Unauthorized|Internal Server Error|Bad Gateway|Service Unavailable)\b|"
+    r"Could not resolve host|"
+    r"Name or service not known|"
+    r"Temporary failure in name resolution|"
+    r"Connection refused|"
+    r"Failed to connect|"
+    r"Operation timed out|"
+    r"timed out|"
+    r"TLS|"
+    r"SSL|"
+    r"certificate|"
+    r"Proxy CONNECT aborted"
+    r")",
+    re.IGNORECASE,
+)
+_HTTP_STATUS_LINE_RE = re.compile(r"^\s*HTTP/\d(?:\.\d)?\s+\d{3}\b", re.IGNORECASE)
+_HTTP_HEADER_LINE_RE = re.compile(r"^[A-Za-z0-9-]+:\s+.+$")
 _MUTATION_PROMPT_RE = re.compile(
     r"\b(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
@@ -155,7 +186,7 @@ def exec_shell_full_definition() -> dict[str, Any]:
                 "Unrestricted local shell launched from the current workdir. May read, write, delete, execute, access network, and access paths outside workdir. "
                 "Use whatever commands are needed to complete the task. "
                 "For analysis, prefer direct evidence from content, source, binaries, strings, logs, archives, and fetched data, not only metadata. "
-                'For generic web search, use orbit-web-search "query"; for explicit URLs, use curl. '
+                'For generic web search, use orbit-web-search "query"; for explicit URL content requests, prefer fetch_url and use shell fetch commands only when needed. '
                 "Quote paths containing spaces."
             ),
             "parameters": {
@@ -315,6 +346,50 @@ def is_explicit_url_fetch_shell_command(command: str | None, *, requested_url: s
     return _TRIVIAL_URL_NONFETCH_RE.search(command) is None
 
 
+def looks_like_transfer_progress_only(text: str | None) -> bool:
+    if not text or not text.strip():
+        return False
+    cleaned = _strip_transfer_progress_noise(text)
+    return not bool(cleaned.strip())
+
+
+def looks_like_url_fetch_failure(text: str | None) -> bool:
+    if not text or not text.strip():
+        return False
+    if shell_failure_from_output(text) is not None:
+        return True
+    cleaned = _strip_transfer_progress_noise(text)
+    if not cleaned.strip():
+        return False
+    if _URL_FETCH_FAILURE_RE.search(cleaned):
+        return True
+    if _looks_like_http_headers_only(cleaned) and re.search(r"^\s*HTTP/\d(?:\.\d)?\s+[45]\d{2}\b", cleaned, re.IGNORECASE | re.MULTILINE):
+        return True
+    return False
+
+
+def looks_like_url_content_evidence(text: str | None) -> bool:
+    if not text or not text.strip():
+        return False
+    if shell_failure_from_output(text) is not None:
+        return False
+    if looks_like_transfer_progress_only(text):
+        return False
+    cleaned = _strip_transfer_progress_noise(text)
+    if not cleaned.strip():
+        return False
+    if looks_like_url_fetch_failure(cleaned):
+        return False
+    if _looks_like_http_headers_only(cleaned):
+        return False
+    if "shell_output_html_cleaned: true" in cleaned and "[no readable text extracted]" not in cleaned:
+        return True
+    if _looks_like_html_or_fragment(cleaned):
+        return True
+    compact = " ".join(line.strip() for line in cleaned.splitlines() if line.strip())
+    return len(compact) >= 40 or len(compact.split()) >= 6
+
+
 def is_shell_full_contract_error(content: str) -> bool:
     return content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX)
 
@@ -386,7 +461,7 @@ def build_shell_full_url_recovery_guard_prompt(
         details.append("A previous command still did not provide usable URL content or a real HTTP/network failure for that URL.")
     details.extend(
         [
-            "Before answering, use one appropriate exec_shell_full_command to retrieve the URL content or verify the real HTTP/network failure.",
+            "Before answering, use fetch_url or one other appropriate tool to retrieve the URL content or verify the real HTTP/network failure.",
             "Do not speculate about the page contents or existence from the URL alone.",
             "Do not replace the direct fetch with generic web search unless you already have direct fetch failure evidence.",
         ]
@@ -403,9 +478,7 @@ def build_shell_full_url_recovery_guard_prompt(
     details.extend(
         [
             "",
-            "Return only JSON:",
-            "",
-            '{"command":"..."}',
+            "Return only the tool call.",
         ]
     )
     return "\n".join(details)
@@ -592,6 +665,37 @@ def _postprocess_shell_full_output(
             return "shell_output_html_cleaned: true\ntext:\n[no readable text extracted]"
         return _bounded_text("\n".join(["shell_output_html_cleaned: true", "text:", text]), min(output_size, 4_000))
     return None
+
+
+def _strip_transfer_progress_noise(text: str) -> str:
+    kept: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _TRANSFER_PROGRESS_HEADER_RE.match(stripped):
+            continue
+        if _TRANSFER_PROGRESS_COLUMNS_RE.match(stripped):
+            continue
+        if _TRANSFER_PROGRESS_ROW_RE.match(stripped):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _looks_like_http_headers_only(text: str) -> bool:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return False
+    header_like = 0
+    for index, line in enumerate(lines):
+        if index == 0 and _HTTP_STATUS_LINE_RE.match(line):
+            header_like += 1
+            continue
+        if _HTTP_HEADER_LINE_RE.match(line):
+            header_like += 1
+            continue
+    return header_like == len(lines)
 
 
 def _read_pdf_target(raw_command: str, *, workdir: Path) -> str | None:

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -52,12 +52,13 @@ class HybridToolExecutor:
     ) -> ToolExecution:
         if name not in self.allowed_tool_names:
             return ToolExecution(ToolResult(name=name, content=f"error: tool not available for this turn: {name}"), "orbit")
-        if name != "exec_shell_full_command":
+        if name not in {"exec_shell_full_command", "fetch_url"}:
             return ToolExecution(ToolResult(name=name, content=f"error: unknown tool: {name}"), "orbit")
         parsed = parse_tool_arguments(arguments)
         if isinstance(parsed, str):
             return ToolExecution(ToolResult(name=name, content=parsed), "orbit")
-        contract_error = validate_shell_full_contract(parsed, user_prompt=self.user_prompt)
-        if contract_error:
-            return ToolExecution(ToolResult(name=name, content=contract_error), "orbit")
+        if name == "exec_shell_full_command":
+            contract_error = validate_shell_full_contract(parsed, user_prompt=self.user_prompt)
+            if contract_error:
+                return ToolExecution(ToolResult(name=name, content=contract_error), "orbit")
         return ToolExecution(execute_tool(name, parsed, workdir=self.workdir, chunk_budget=chunk_budget, user_prompt=self.user_prompt), "orbit")

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -21,6 +21,8 @@ from orbit.runtime.shell_guardrails import (
     build_shell_full_url_recovery_guard_prompt,
     extract_requested_user_url,
     is_explicit_url_fetch_shell_command,
+    looks_like_url_content_evidence,
+    looks_like_url_fetch_failure,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     is_incomplete_shell_json_or_command_error,
@@ -54,6 +56,7 @@ from orbit.runtime.tool_loop_state import (
 from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
 from orbit.runtime.tools import default_tool_names
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
+from orbit.runtime.web import fetch_url_result_error, fetch_url_result_has_text, fetch_url_result_status
 
 
 def _env_int(name: str, default: int) -> int:
@@ -285,7 +288,7 @@ def run_tool_loop(
             details.append("A direct fetch attempt is still required to answer safely.")
         details.extend(
             [
-                "Before answering, use one appropriate exec_shell_full_command to retrieve the URL content or verify the real HTTP/network failure.",
+                "Before answering, use fetch_url or another appropriate tool to retrieve the URL content or verify the real HTTP/network failure.",
                 "Do not speculate from the URL alone.",
                 "Return only the tool call.",
             ]
@@ -297,8 +300,7 @@ def run_tool_loop(
 
     def should_handoff_to_final_from_tool() -> bool:
         return (
-            shell_full_enabled
-            and has_required_direct_evidence()
+            has_required_direct_evidence()
             and turn.finalizable
             and not has_pending_internal_request()
             and not repair.shell_error_final_pending
@@ -319,7 +321,7 @@ def run_tool_loop(
         # This remains the main transition reducer for tool evidence and bounded
         # repair state. It updates turn-local state, while runtime counters stay
         # here to avoid leaking telemetry into the state objects themselves.
-        if tool_result.name != "exec_shell_full_command":
+        if tool_result.name not in {"exec_shell_full_command", "fetch_url"}:
             return
         command = _shell_command_from_tool_call(tool_call)
         raw_arguments = _shell_raw_arguments_from_tool_call(tool_call)
@@ -335,6 +337,8 @@ def run_tool_loop(
         if command:
             turn.shell_commands_seen += 1
         if command_is_url_fetch:
+            turn.url_fetch_attempted = True
+        if tool_result.name == "fetch_url":
             turn.url_fetch_attempted = True
         if command_is_mutating:
             turn.shell_mutation_attempted = True
@@ -462,12 +466,38 @@ def run_tool_loop(
             repair.shell_error_final_pending = True
             turn.mark_exhausted()
             return
+        fetch_url_status = fetch_url_result_status(tool_result.content) if tool_result.name == "fetch_url" else None
+        fetch_url_success = bool(tool_result.name == "fetch_url" and fetch_url_status == "ok" and fetch_url_result_has_text(tool_result.content))
+        fetch_url_failure = bool(
+            tool_result.name == "fetch_url"
+            and fetch_url_status in {"http_error", "network_error", "timeout", "unsupported_content", "empty_body"}
+        )
         if command_is_mutating:
             turn.shell_mutation_succeeded = True
         if tool_result.content.strip():
             if command_is_url_fetch and not command_is_mutating:
+                if looks_like_url_content_evidence(tool_result.content):
+                    turn.mark_url_content_evidence()
+                elif looks_like_url_fetch_failure(tool_result.content):
+                    turn.mark_url_failure_evidence(_summarize_shell_error(tool_result.content))
+                elif url_content_required and turn.requested_user_url and turn.can_reconsider(RECONSIDER_URL_RECOVERY):
+                    request_url_recovery_guard(
+                        last_command=command,
+                        last_failure_content=tool_result.content,
+                        fetch_attempted=True,
+                    )
+                    return
+            if fetch_url_success:
                 turn.mark_url_content_evidence()
-            if command_is_content_evidence and not command_is_mutating:
+            elif fetch_url_failure:
+                turn.mark_url_failure_evidence(fetch_url_result_error(tool_result.content))
+            elif tool_result.name == "fetch_url" and url_content_required and turn.requested_user_url and turn.can_reconsider(RECONSIDER_URL_RECOVERY):
+                request_url_recovery_guard(
+                    last_failure_content=tool_result.content,
+                    fetch_attempted=True,
+                )
+                return
+            if command_is_content_evidence and not command_is_mutating and not command_is_url_fetch:
                 turn.mark_direct_content_read()
                 if is_content_evidence_guard:
                     runtime.content_evidence_guard_successes += 1
@@ -477,8 +507,11 @@ def run_tool_loop(
                     turn.mark_candidate_paths_found(_merge_candidate_paths(turn.candidate_paths, discovered))
             if is_mutation_verification and not repair.mutation_semantic_repair_used:
                 request_mutation_semantic_repair()
-            if turn.content_evidence_satisfied or repair.shell_error_final_pending:
+            if has_required_direct_evidence() or repair.shell_error_final_pending:
                 turn.mark_finalizable()
+            return
+        if tool_result.name == "fetch_url" and url_content_required and turn.requested_user_url and turn.can_reconsider(RECONSIDER_URL_RECOVERY):
+            request_url_recovery_guard(fetch_attempted=True)
             return
         if is_content_evidence_guard:
             runtime.content_evidence_guard_failures += 1

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from orbit.runtime.shell_guardrails import exec_shell_full_definition, execute_exec_shell_full_command
 from orbit.runtime.tool_arguments import parse_tool_arguments
+from orbit.runtime.web import execute_fetch_url, fetch_url_definition
 
 
 @dataclass(frozen=True)
@@ -14,7 +15,7 @@ class ToolResult:
     content: str
 
 
-TOOL_NAMES = ("exec_shell_full_command",)
+TOOL_NAMES = ("exec_shell_full_command", "fetch_url")
 DEFAULT_TOOL_NAMES = TOOL_NAMES
 
 
@@ -27,7 +28,7 @@ def default_tool_names() -> tuple[str, ...]:
 
 
 def tool_definitions(names: tuple[str, ...] | None = None) -> list[dict[str, Any]]:
-    definitions = [exec_shell_full_definition()]
+    definitions = [exec_shell_full_definition(), fetch_url_definition()]
     if names is None:
         return definitions
     allowed = set(names)
@@ -48,4 +49,6 @@ def execute_tool(
     parsed = parse_tool_arguments(arguments)
     if isinstance(parsed, str):
         return ToolResult(name=name, content=parsed)
+    if name == "fetch_url":
+        return ToolResult(name=name, content=execute_fetch_url(parsed))
     return ToolResult(name=name, content=execute_exec_shell_full_command(parsed, workdir=workdir, user_prompt=user_prompt))

--- a/src/orbit/runtime/web.py
+++ b/src/orbit/runtime/web.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
+import socket
 from html.parser import HTMLParser
 import re
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote_plus, unquote, urlparse
 from urllib.request import Request, urlopen
 
 
 MAX_SEARCH_RESULTS = 5
 SEARCH_TIMEOUT_SECONDS = 10
+DEFAULT_FETCH_TIMEOUT_SECONDS = 10
+MAX_FETCH_TIMEOUT_SECONDS = 15
+DEFAULT_FETCH_MAX_BYTES = 128_000
+MAX_FETCH_MAX_BYTES = 256_000
+DEFAULT_FETCH_MAX_TEXT_CHARS = 4_000
+_TEXTUAL_CONTENT_TYPES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/xhtml+xml",
+    "application/javascript",
+    "application/x-javascript",
+    "image/svg+xml",
+)
 
 
 def search_web(query: str, *, max_results: int = MAX_SEARCH_RESULTS) -> str:
@@ -42,11 +58,268 @@ def search_web(query: str, *, max_results: int = MAX_SEARCH_RESULTS) -> str:
     return "\n".join(lines)
 
 
+def fetch_url_definition() -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "fetch_url",
+            "description": (
+                "Fetch a URL and return normalized textual evidence: final URL, HTTP status, content type, title, readable text, "
+                "or a real observed fetch failure. Prefer this for explicit read/fetch/explain/summarize/analyze URL requests."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                    "max_bytes": {"type": "integer"},
+                },
+                "required": ["url"],
+            },
+        },
+    }
+
+
+def execute_fetch_url(arguments: dict[str, object]) -> str:
+    url = arguments.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return "error: fetch_url requires a non-empty url"
+    timeout = _bounded_int(arguments.get("timeout"), default=DEFAULT_FETCH_TIMEOUT_SECONDS, maximum=MAX_FETCH_TIMEOUT_SECONDS)
+    max_bytes = _bounded_int(arguments.get("max_bytes"), default=DEFAULT_FETCH_MAX_BYTES, maximum=MAX_FETCH_MAX_BYTES)
+    request = Request(
+        url.strip(),
+        headers={
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.8",
+            "Accept-Encoding": "identity",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return _format_fetch_response(
+                requested_url=url.strip(),
+                final_url=response.geturl(),
+                status_code=response.getcode(),
+                content_type=response.headers.get_content_type() or "",
+                encoding=response.headers.get_content_charset() or "utf-8",
+                body=response.read(max_bytes + 1),
+                max_bytes=max_bytes,
+                reason=None,
+            )
+    except HTTPError as exc:
+        body = exc.read(max_bytes + 1)
+        return _format_fetch_response(
+            requested_url=url.strip(),
+            final_url=exc.geturl() or url.strip(),
+            status_code=exc.code,
+            content_type=exc.headers.get_content_type() if exc.headers is not None else "",
+            encoding=(exc.headers.get_content_charset() if exc.headers is not None else None) or "utf-8",
+            body=body,
+            max_bytes=max_bytes,
+            reason=exc.reason if hasattr(exc, "reason") else exc.msg,
+        )
+    except (socket.timeout, TimeoutError):
+        return _format_fetch_failure("timeout", url=url.strip(), error=f"timed out after {timeout}s")
+    except URLError as exc:
+        reason = exc.reason if getattr(exc, "reason", None) else exc
+        if isinstance(reason, socket.timeout):
+            return _format_fetch_failure("timeout", url=url.strip(), error=f"timed out after {timeout}s")
+        return _format_fetch_failure("network_error", url=url.strip(), error=str(reason))
+    except OSError as exc:
+        return _format_fetch_failure("network_error", url=url.strip(), error=str(exc))
+
+
+def fetch_url_result_status(content: str | None) -> str | None:
+    if not content:
+        return None
+    match = re.search(r"^status:\s*(\w+)\s*$", content, flags=re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def fetch_url_result_has_text(content: str | None) -> bool:
+    if not content or "text:\n" not in content:
+        return False
+    _prefix, body = content.split("text:\n", 1)
+    return bool(body.strip())
+
+
+def fetch_url_result_error(content: str | None) -> str | None:
+    if not content:
+        return None
+    match = re.search(r"^error:\s*(.+)$", content, flags=re.MULTILINE)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
 def html_to_text(html: str) -> str:
     parser = _ReadableHTMLParser()
     parser.feed(html)
     parser.close()
     return _normalize_text("\n".join(parser.blocks))
+
+
+def _format_fetch_response(
+    *,
+    requested_url: str,
+    final_url: str,
+    status_code: int,
+    content_type: str,
+    encoding: str,
+    body: bytes,
+    max_bytes: int,
+    reason: object | None,
+) -> str:
+    text_truncated = len(body) > max_bytes
+    if text_truncated:
+        body = body[:max_bytes]
+    status = "ok" if 200 <= status_code < 400 else "http_error"
+    if not _is_textual_content_type(content_type):
+        return _format_fetch_result(
+            status="unsupported_content" if status == "ok" else status,
+            url=requested_url,
+            final_url=final_url,
+            http_status=status_code,
+            content_type=content_type,
+            encoding=encoding,
+            title=None,
+            text=None,
+            text_truncated=text_truncated,
+            error=f"unsupported content type: {content_type or 'unknown'}" if status == "ok" else _http_error_text(status_code, reason),
+        )
+    decoded = body.decode(encoding or "utf-8", errors="replace")
+    title = _extract_html_title(decoded) if _looks_like_html(decoded) else None
+    readable = html_to_text(decoded) if _looks_like_html(decoded) else _normalize_text(decoded)
+    readable, text_truncated = _truncate_fetch_text(readable, already_truncated=text_truncated)
+    if status != "ok":
+        return _format_fetch_result(
+            status="http_error",
+            url=requested_url,
+            final_url=final_url,
+            http_status=status_code,
+            content_type=content_type,
+            encoding=encoding,
+            title=title,
+            text=readable or None,
+            text_truncated=text_truncated,
+            error=_http_error_text(status_code, reason),
+        )
+    if not readable.strip():
+        return _format_fetch_result(
+            status="empty_body",
+            url=requested_url,
+            final_url=final_url,
+            http_status=status_code,
+            content_type=content_type,
+            encoding=encoding,
+            title=title,
+            text=None,
+            text_truncated=text_truncated,
+            error="response body was empty after text extraction",
+        )
+    return _format_fetch_result(
+        status="ok",
+        url=requested_url,
+        final_url=final_url,
+        http_status=status_code,
+        content_type=content_type,
+        encoding=encoding,
+        title=title,
+        text=readable,
+        text_truncated=text_truncated,
+        error=None,
+    )
+
+
+def _format_fetch_failure(status: str, *, url: str, error: str) -> str:
+    return _format_fetch_result(
+        status=status,
+        url=url,
+        final_url=url,
+        http_status=None,
+        content_type=None,
+        encoding=None,
+        title=None,
+        text=None,
+        text_truncated=False,
+        error=error,
+    )
+
+
+def _format_fetch_result(
+    *,
+    status: str,
+    url: str,
+    final_url: str,
+    http_status: int | None,
+    content_type: str | None,
+    encoding: str | None,
+    title: str | None,
+    text: str | None,
+    text_truncated: bool,
+    error: str | None,
+) -> str:
+    lines = [
+        "url_fetch: true",
+        f"status: {status}",
+        f"url: {url}",
+        f"final_url: {final_url}",
+        f"http_status: {http_status if http_status is not None else 'null'}",
+        f"content_type: {content_type or 'null'}",
+        f"encoding: {encoding or 'null'}",
+        f"title: {title or 'null'}",
+        f"text_truncated: {'true' if text_truncated else 'false'}",
+    ]
+    if error:
+        lines.append(f"error: {error}")
+    if text:
+        lines.extend(["text:", text])
+    return "\n".join(lines)
+
+
+def _is_textual_content_type(content_type: str | None) -> bool:
+    if not content_type:
+        return True
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return any(normalized.startswith(prefix) or normalized == prefix for prefix in _TEXTUAL_CONTENT_TYPES)
+
+
+def _looks_like_html(text: str) -> bool:
+    lowered = text[:2048].lower()
+    return "<html" in lowered or "<body" in lowered or "<title" in lowered or "<!doctype html" in lowered
+
+
+def _extract_html_title(text: str) -> str | None:
+    match = re.search(r"<title[^>]*>(.*?)</title>", text, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return None
+    title = _normalize_inline_text(_strip_tags(match.group(1)))
+    return title or None
+
+
+def _http_error_text(status_code: int, reason: object | None) -> str:
+    suffix = f": {reason}" if reason else ""
+    return f"HTTP {status_code}{suffix}"
+
+
+def _bounded_int(value: object, *, default: int, maximum: int) -> int:
+    if not isinstance(value, int):
+        return default
+    if value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _truncate_fetch_text(text: str, *, already_truncated: bool) -> tuple[str, bool]:
+    if len(text) <= DEFAULT_FETCH_MAX_TEXT_CHARS:
+        return text, already_truncated
+    clipped = text[:DEFAULT_FETCH_MAX_TEXT_CHARS].rstrip()
+    last_break = max(clipped.rfind("\n"), clipped.rfind(". "), clipped.rfind(" "))
+    if last_break >= DEFAULT_FETCH_MAX_TEXT_CHARS // 2:
+        clipped = clipped[:last_break].rstrip()
+    return clipped, True
 
 
 def _parse_duckduckgo_html(html: str, *, max_results: int) -> list[dict[str, str]]:

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -12,6 +12,7 @@ PREVIEW_INLINE_LIMIT = 120
 COMMAND_PREVIEW_LIMIT = 96
 DISPLAY_TOOL_NAMES = {
     "exec_shell_full_command": "exec",
+    "fetch_url": "fetch_url",
 }
 
 
@@ -24,6 +25,10 @@ def format_tool_call_event(name: str, args: str) -> str:
         command = _command_from_args(args)
         if command:
             return _format_shell_command_call(command)
+    if name == "fetch_url":
+        url = _url_from_args(args)
+        if url:
+            return f"Fetch: {_truncate_inline(url, limit=COMMAND_PREVIEW_LIMIT)}"
     return f"{display_tool_name(name)} {args}"
 
 
@@ -51,6 +56,18 @@ def _command_from_args(args: str) -> str | None:
         command = parsed.get("command")
         if isinstance(command, str) and command.strip():
             return command.strip()
+    return None
+
+
+def _url_from_args(args: str) -> str | None:
+    try:
+        parsed = json.loads(args)
+    except Exception:
+        return None
+    if isinstance(parsed, dict):
+        url = parsed.get("url")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
     return None
 
 
@@ -106,6 +123,19 @@ def _tool_result_preview(content: str | None) -> str | None:
         return "rejected metadata-only output"
     if stripped.startswith("error:"):
         return stripped.splitlines()[0]
+    if "url_fetch: true" in content:
+        title = _metadata_value(content, "title")
+        if title and title != "null":
+            return title
+        preview = _body_preview(content, marker="text:")
+        if preview:
+            return preview
+        error = _metadata_value(content, "error")
+        status = _metadata_value(content, "status")
+        if error and error != "null":
+            return f"{status or 'fetch'}: {error}"
+        if status and status != "null":
+            return status
     path = _metadata_value(content, "path")
     if "shell_output_pdf_text: true" in content:
         preview = _body_preview(content, marker="content:")
@@ -160,7 +190,7 @@ def _lines_preview(content: str) -> str | None:
         line = raw.strip()
         if not line:
             continue
-        if line.startswith(("shell_output_", "path:", "extractor:", "chunk_index:", "total_chunks:", "chars:", "large_file_excerpt:")):
+        if line.startswith(("shell_output_", "path:", "extractor:", "chunk_index:", "total_chunks:", "chars:", "large_file_excerpt:", "url_fetch:", "url:", "final_url:", "http_status:", "content_type:", "encoding:", "title:", "text_truncated:", "status:", "error:")):
             continue
         if line == "[truncated]":
             continue

--- a/src/orbit/terminal/tool_mode.py
+++ b/src/orbit/terminal/tool_mode.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 ToolSpec = str
 
-SHELL_FULL_TOOL_NAMES = ("exec_shell_full_command",)
-DEFAULT_ON_TOOL_NAMES = SHELL_FULL_TOOL_NAMES
+DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url")
 
 SPECIAL_TOOL_SPECS = ("off", "on")
 USAGE = "off|on"

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -45,6 +45,9 @@ class RouteRequestTests(unittest.TestCase):
     def test_parse_tool_command_accepts_raw_orbit_web_search_key_value_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call:orbit-web-search{query="Dante Alighieri"}<tool_call|>'), ToolRoute.FILESYSTEM)
 
+    def test_parse_tool_command_accepts_raw_fetch_url_tool_call(self) -> None:
+        self.assertEqual(parse_tool_command('<|tool_call>call:fetch_url{"url":"https://example.com"}<tool_call|>'), ToolRoute.FILESYSTEM)
+
     def test_parse_tool_command_accepts_parenthesized_shell_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>'), ToolRoute.FILESYSTEM)
 
@@ -64,6 +67,22 @@ class RouteRequestTests(unittest.TestCase):
         self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
         self.assertEqual(decision_tool_names(decision), ("exec_shell_full_command",))
 
+    def test_parse_command_decision_from_tool_calls_accepts_fetch_url_arguments(self) -> None:
+        decision = parse_command_decision_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "fetch_url", "arguments": '{"url":"https://example.com"}'},
+                }
+            ]
+        )
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
+        self.assertEqual(decision_tool_names(decision), ("fetch_url",))
+
     def test_command_tool_call_from_content_uses_shell_command_json(self) -> None:
         tool_call = command_tool_call_from_content('{"command":"ls -F"}', ("exec_shell_full_command",))
 
@@ -71,6 +90,14 @@ class RouteRequestTests(unittest.TestCase):
         assert tool_call is not None
         self.assertEqual(tool_call["function"]["name"], "exec_shell_full_command")
         self.assertEqual(tool_call["function"]["arguments"], '{"command": "ls -F"}')
+
+    def test_command_tool_call_from_content_uses_fetch_url_json(self) -> None:
+        tool_call = command_tool_call_from_content('{"url":"https://example.com"}', ("exec_shell_full_command", "fetch_url"))
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "fetch_url")
+        self.assertEqual(tool_call["function"]["arguments"], '{"url": "https://example.com"}')
 
     def test_command_tool_call_from_content_converts_raw_orbit_web_search(self) -> None:
         tool_call = command_tool_call_from_content(
@@ -189,6 +216,23 @@ EOF"}"""
         self.assertEqual(tool_call["function"]["name"], "exec_shell_full_command")
         self.assertEqual(tool_call["function"]["arguments"], '{"command":"pwd"}')
 
+    def test_command_tool_call_from_tool_calls_keeps_fetch_url_tool_call(self) -> None:
+        tool_call = command_tool_call_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "fetch_url", "arguments": '{"url":"https://example.com"}'},
+                }
+            ],
+            ("exec_shell_full_command", "fetch_url"),
+        )
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "fetch_url")
+        self.assertEqual(tool_call["function"]["arguments"], '{"url":"https://example.com"}')
+
     def test_command_tool_call_from_tool_calls_accepts_shell_alias(self) -> None:
         tool_call = command_tool_call_from_tool_calls(
             [
@@ -261,7 +305,7 @@ EOF"}""",
         self.assertIsNone(tool_call)
 
     def test_tool_names_for_decision_are_bounded(self) -> None:
-        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command",))
+        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url"))
         self.assertEqual(tool_names_for_decision(ToolRoute.FILE_EDIT), ())
         self.assertEqual(tool_names_for_decision(ToolRoute.WEB), ())
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,7 +66,7 @@ class CommandTests(unittest.TestCase):
         self.assertIn("Model\n-------", status)
         self.assertIn("tools_mode: n/a", status)
         self.assertIn("thinking_mode: off", status)
-        self.assertIn("model_tools: exec_shell_full_command", status)
+        self.assertIn("model_tools: exec_shell_full_command, fetch_url", status)
         self.assertIn("memory_refresh_threshold: 6963/8192", status)
         self.assertIn("memory_refreshes: 0", status)
         self.assertIn("last_refresh_outcome: none", status)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,8 @@ class ConfigTests(unittest.TestCase):
         self.assertIn("Answer normally unless shell is needed", DEFAULT_SYSTEM_PROMPT)
         self.assertIn("Environment: OS=", DEFAULT_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", DEFAULT_SYSTEM_PROMPT)
-        self.assertIn("explicit URLs: curl", DEFAULT_SYSTEM_PROMPT)
+        self.assertIn("prefer the fetch_url tool", DEFAULT_SYSTEM_PROMPT)
+        self.assertIn("curl are still allowed", DEFAULT_SYSTEM_PROMPT)
 
     def test_command_system_prompt_sends_local_hardware_queries_to_shell(self) -> None:
         self.assertIn('{"command":"..."}', ROUTE_SYSTEM_PROMPT)
@@ -32,7 +33,7 @@ class ConfigTests(unittest.TestCase):
         self.assertIn("Use native commands", ROUTE_SYSTEM_PROMPT)
         self.assertIn("Environment: OS=", ROUTE_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", ROUTE_SYSTEM_PROMPT)
-        self.assertIn("explicit URLs: curl", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("prefer the fetch_url tool", ROUTE_SYSTEM_PROMPT)
         self.assertIn("Quote spaced paths", ROUTE_SYSTEM_PROMPT)
         self.assertIn("not metadata", ROUTE_SYSTEM_PROMPT)
 
@@ -43,10 +44,10 @@ class ConfigTests(unittest.TestCase):
         self.assertNotIn("orbit-web-search", CHAT_SYSTEM_PROMPT)
 
     def test_tool_call_prompt_mentions_quoted_shell_paths(self) -> None:
-        self.assertIn("Call exec_shell_full_command exactly once", TOOL_CALL_SYSTEM_PROMPT)
-        self.assertIn("one-line shell command", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("Call exactly one available tool", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("Prefer fetch_url", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", TOOL_CALL_SYSTEM_PROMPT)
-        self.assertIn("explicit URLs", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("exec_shell_full_command", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("Quote paths containing spaces", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("collect direct evidence", TOOL_CALL_SYSTEM_PROMPT)
 
@@ -129,10 +130,10 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "tools"):
             load_app_config(_parse("--tools", "browser"))
 
-    def test_tools_on_uses_shell_full_only(self) -> None:
+    def test_tools_on_uses_shell_and_fetch_url(self) -> None:
         names = allowed_tool_names_for_spec("on")
 
-        self.assertEqual(names, ("exec_shell_full_command",))
+        self.assertEqual(names, ("exec_shell_full_command", "fetch_url"))
 
     def test_legacy_tools_object_config_key_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -247,6 +247,10 @@ class ReplTests(unittest.TestCase):
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "curl -L https://example.com"})),
             "Web: curl -L https://example.com",
         )
+        self.assertEqual(
+            format_tool_call_event("fetch_url", json.dumps({"url": "https://example.com"})),
+            "Fetch: https://example.com",
+        )
 
     def test_tool_result_event_previews_pdf_and_list_output(self) -> None:
         pdf_content = "\n".join(
@@ -597,7 +601,7 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.ask_auto_calls, 1)
         self.assertEqual(runtime.ask_chat_calls, 0)
         self.assertIsNotNone(runtime.last_allowed_tool_names)
-        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command",))
+        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url"))
 
     def test_repl_reads_queued_prompt_before_new_input(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4754,6 +4754,76 @@ EOF"""
 
         self.assertEqual(result.content, "Grounded after reset.")
 
+    def test_ask_with_tools_retries_when_url_fetch_only_returns_transfer_progress(self) -> None:
+        class UrlProgressOnlyBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content='{"command":"python3 -c \\"import sys; sys.stderr.write(\'% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\\\\n\'); sys.stderr.write(\'                                 Dload  Upload   Total   Spent    Left  Speed\\\\n\'); sys.stderr.write(\'  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\\\\n\')\\" https://example.com/doc"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=4,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="I still cannot confirm the page contents yet.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=8,
+                        completion_tokens=4,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    if "did not obtain usable content or a real HTTP/network failure" not in str(messages[-1]["content"]):
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content='{"command":"python3 -c \\"print(\'<html><body>Central thesis: grounded evidence.</body></html>\')\\" https://example.com/doc"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=10,
+                        completion_tokens=3,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Grounded after retry.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=12,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=UrlProgressOnlyBackend(), system_prompt="route system")
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/doc and explain the central thesis in Italian.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "Grounded after retry.")
+
     def test_ask_with_tools_allows_grounded_url_failure_after_real_fetch_attempt(self) -> None:
         class UrlFailureBackend:
             def __init__(self) -> None:
@@ -4795,6 +4865,131 @@ EOF"""
             )
 
         self.assertEqual(result.content, "The URL returned an HTTP 404 error.")
+
+    def test_ask_with_tools_accepts_fetch_url_success_as_url_evidence(self) -> None:
+        class FetchUrlSuccessBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "fetch_url", "arguments": '{"url":"https://example.com/doc"}'},
+                            }
+                        ],
+                        prompt_tokens=8,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="Grounded final answer from fetch_url.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=10,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=FetchUrlSuccessBackend(), system_prompt="route system")
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/doc and summarize it.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "Grounded final answer from fetch_url.")
+
+    def test_ask_with_tools_accepts_fetch_url_http_error_as_failure_evidence(self) -> None:
+        class FetchUrlFailureBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "fetch_url", "arguments": '{"url":"https://example.com/missing"}'},
+                            }
+                        ],
+                        prompt_tokens=8,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The page returned HTTP 404.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=10,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=FetchUrlFailureBackend(), system_prompt="route system")
+            result = runtime.ask_with_tools(
+                "Fetch https://example.com/missing and summarize it.",
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "The page returned HTTP 404.")
+
+    def test_ask_with_tools_does_not_force_fetch_for_non_fetch_url_question(self) -> None:
+        class DomainOnlyBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                return ChatResult(
+                    content="The domain is example.com.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=6,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        runtime = ChatRuntime(backend=DomainOnlyBackend(), system_prompt="route system")
+        result = runtime.ask_with_tools(
+            "What is the domain in this URL: https://example.com/foo?",
+            temperature=0,
+            max_tokens=64,
+            workdir=Path("."),
+        )
+
+        self.assertEqual(result.content, "The domain is example.com.")
 
     def test_ask_auto_media_without_path_is_normal_chat_without_command_json(self) -> None:
         class MediaRouteBackend:

--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import io
 import subprocess
 import tempfile
 import time
@@ -9,6 +10,7 @@ from shutil import copyfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from urllib.error import HTTPError, URLError
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -16,7 +18,13 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from orbit.runtime.tool_backends import HybridToolExecutor
-from orbit.runtime.shell_guardrails import SHELL_FULL_CONTRACT_ERROR_PREFIX, validate_shell_full_contract
+from orbit.runtime.shell_guardrails import (
+    SHELL_FULL_CONTRACT_ERROR_PREFIX,
+    looks_like_transfer_progress_only,
+    looks_like_url_content_evidence,
+    looks_like_url_fetch_failure,
+    validate_shell_full_contract,
+)
 
 
 class FakeServerTools:
@@ -76,7 +84,8 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertIn("Unrestricted local shell launched from the current workdir", description)
         self.assertIn("access paths outside workdir", description)
         self.assertIn("orbit-web-search", description)
-        self.assertIn("explicit URLs", description)
+        self.assertIn("explicit URL content requests", description)
+        self.assertIn("fetch_url", description)
         self.assertIn("Quote paths containing spaces", description)
 
     def test_ignores_server_tools(self) -> None:
@@ -132,6 +141,168 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertEqual(execution.source, "orbit")
         self.assertIn("web_search_results: true", execution.result.content)
         self.assertEqual(backend.executed, [])
+
+    def test_fetch_url_runs_internal_url_fetch(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "text/html"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/final"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b"<html><title>Example</title><body>Hello web</body></html>"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute(
+                    "fetch_url",
+                    {"url": "https://example.com"},
+                    chunk_budget={},
+                )
+
+        self.assertEqual(execution.source, "orbit")
+        self.assertIn("status: ok", execution.result.content)
+        self.assertIn("Hello web", execution.result.content)
+
+    def test_fetch_url_plain_text_returns_text(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "text/plain"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/plain"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b"plain text body"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/plain"}, chunk_budget={})
+
+        self.assertIn("status: ok", execution.result.content)
+        self.assertIn("plain text body", execution.result.content)
+
+    def test_fetch_url_json_returns_text(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "application/json"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/data.json"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b'{\"central_thesis\":\"human dignity\"}'
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/data.json"}, chunk_budget={})
+
+        self.assertIn("status: ok", execution.result.content)
+        self.assertIn("central_thesis", execution.result.content)
+
+    def test_fetch_url_xml_returns_text(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "application/xml"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/data.xml"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b"<doc><thesis>human dignity</thesis></doc>"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/data.xml"}, chunk_budget={})
+
+        self.assertIn("status: ok", execution.result.content)
+        self.assertIn("<doc><thesis>human dignity</thesis></doc>", execution.result.content)
 
     def test_exec_shell_full_rejects_empty_internal_web_search(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -189,6 +360,190 @@ class HybridToolExecutorTests(unittest.TestCase):
 
         self.assertIsNotNone(error)
         self.assertIn("explicit URL requests require direct URL fetch", error)
+
+    def test_url_progress_meter_only_is_not_content_evidence(self) -> None:
+        progress = (
+            "% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n"
+            "                                 Dload  Upload   Total   Spent    Left  Speed\n"
+            "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"
+        )
+
+        self.assertTrue(looks_like_transfer_progress_only(progress))
+        self.assertFalse(looks_like_url_content_evidence(progress))
+        self.assertFalse(looks_like_url_fetch_failure(progress))
+
+    def test_url_html_cleaned_output_is_content_evidence(self) -> None:
+        content = "shell_output_html_cleaned: true\ntext:\nCentral thesis: human dignity and solidarity."
+
+        self.assertTrue(looks_like_url_content_evidence(content))
+        self.assertFalse(looks_like_url_fetch_failure(content))
+
+    def test_url_http_404_text_is_failure_evidence(self) -> None:
+        content = "HTTP/2 404\ncontent-type: text/html\nserver: envoy"
+
+        self.assertTrue(looks_like_url_fetch_failure(content))
+        self.assertFalse(looks_like_url_content_evidence(content))
+
+    def test_fetch_url_404_returns_structured_http_error(self) -> None:
+        error = HTTPError(
+            "https://example.com/missing",
+            404,
+            "Not Found",
+            None,
+            io.BytesIO(b"<html><title>404</title><body>Not Found</body></html>"),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", side_effect=error):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/missing"}, chunk_budget={})
+
+        self.assertIn("status: http_error", execution.result.content)
+        self.assertIn("http_status: 404", execution.result.content)
+
+    def test_fetch_url_timeout_returns_structured_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", side_effect=TimeoutError()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/slow"}, chunk_budget={})
+
+        self.assertIn("status: timeout", execution.result.content)
+
+    def test_fetch_url_dns_failure_returns_network_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", side_effect=URLError("Name or service not known")):
+                execution = executor.execute("fetch_url", {"url": "https://example.invalid"}, chunk_budget={})
+
+        self.assertIn("status: network_error", execution.result.content)
+
+    def test_fetch_url_binary_returns_unsupported_content(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "application/octet-stream"
+
+            def get_content_charset(self):
+                return None
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/file.bin"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b"\x00\x01\x02\x03"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/file.bin"}, chunk_budget={})
+
+        self.assertIn("status: unsupported_content", execution.result.content)
+
+    def test_fetch_url_empty_body_returns_empty_body_status(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "text/html"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/empty"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/empty"}, chunk_budget={})
+
+        self.assertIn("status: empty_body", execution.result.content)
+
+    def test_fetch_url_truncates_large_text_payloads(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "text/plain"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/large"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return ("paragraph " * 3000).encode("utf-8")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("fetch_url",),
+            )
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                execution = executor.execute("fetch_url", {"url": "https://example.com/large"}, chunk_budget={})
+
+        self.assertIn("status: ok", execution.result.content)
+        self.assertIn("text_truncated: true", execution.result.content)
+        self.assertLess(len(execution.result.content), 14_500)
 
     def test_exec_shell_full_allows_listing_when_not_analysis_prompt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -14,15 +15,16 @@ from orbit.runtime.tools import default_tool_names, execute_tool, tool_definitio
 
 
 class ToolTests(unittest.TestCase):
-    def test_only_shell_full_is_exposed(self) -> None:
-        self.assertEqual(tool_names(), ("exec_shell_full_command",))
-        self.assertEqual(default_tool_names(), ("exec_shell_full_command",))
+    def test_shell_and_fetch_url_are_exposed(self) -> None:
+        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url"))
+        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url"))
         definitions = tool_definitions()
-        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command"])
+        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url"])
 
     def test_tool_definitions_respect_allowed_names(self) -> None:
         self.assertEqual(tool_definitions(("read_file",)), [])
         self.assertEqual(len(tool_definitions(("exec_shell_full_command",))), 1)
+        self.assertEqual(len(tool_definitions(("fetch_url",))), 1)
 
     def test_unknown_tool_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -41,6 +43,41 @@ class ToolTests(unittest.TestCase):
             result = execute_tool("exec_shell_full_command", "{", workdir=Path(tmp))
 
         self.assertIn("invalid JSON", result.content)
+
+    def test_fetch_url_runs_with_structured_result(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "text/html"
+
+            def get_content_charset(self) -> str:
+                return "utf-8"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self) -> str:
+                return "https://example.com/final"
+
+            def getcode(self) -> int:
+                return 200
+
+            def read(self, amount: int = -1) -> bytes:
+                del amount
+                return b"<html><title>Example</title><body>Hello web</body></html>"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("orbit.runtime.web.urlopen", return_value=FakeResponse()):
+                result = execute_tool("fetch_url", {"url": "https://example.com"}, workdir=Path(tmp))
+
+        self.assertIn("url_fetch: true", result.content)
+        self.assertIn("status: ok", result.content)
+        self.assertIn("title: Example", result.content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Adds an explicit model-facing `fetch_url` capability for URL read/fetch/explain/summarize/analyze requests.
- Requires real URL content evidence, or a real observed fetch failure, before finalizing explicit URL content tasks.
- Prevents speculative answers when the model has not fetched the URL or only produced transfer/progress logs.
- Keeps recovery model-guided and bounded.
- Does not hardcode URLs, domains, providers, or commands.
- Does not construct answers in runtime.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_tool_backends tests.test_runtime tests.test_tool_loop_state tests.test_final_policy tests.test_repl -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Smoke:
- Explicit URL fetch direct: PASS
- Explicit URL fetch after /tools on + /reset: PASS
- URL mentioned but not fetched: PASS
- Tools off explicit URL fetch: PASS
- README file-read regression: PASS
- list files regression: PASS