### PR TITLE
Fix markdown question final answer stub detection

### DIFF
--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -466,7 +466,8 @@ def classify_final_answer_completeness(content: str, *, messages: list[Message] 
         return FinalAnswerCompleteness("incomplete_stub", "list_label_stub")
     if content.count("`") % 2 == 1:
         return FinalAnswerCompleteness("malformed_markdown", "unclosed_backtick")
-    if stripped.endswith((":", "-", "*")):
+    stub_text = re.sub(r"[*_~`]+$", "", stripped).rstrip()
+    if stub_text.endswith((":", "-", "*")):
         return FinalAnswerCompleteness("incomplete_stub", "trailing_stub")
     if looks_like_incomplete_final(content):
         return FinalAnswerCompleteness("incomplete_stub", "plain_incomplete")

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -685,6 +685,12 @@ class FinalPolicyTests(unittest.TestCase):
         )
         self.assertEqual(completeness.status, "complete")
 
+    def test_final_answer_completeness_accepts_markdown_emphasis_closer_after_complete_sentence(self) -> None:
+        completeness = classify_final_answer_completeness(
+            "I can help with many tasks.\n\n**What's on your mind today? Is there anything specific I can help you with?**"
+        )
+        self.assertEqual(completeness.status, "complete")
+
     def test_final_answer_completeness_allows_normal_possibility_wording(self) -> None:
         completeness = classify_final_answer_completeness(
             "One possibility is that the user is comparing an essay with the adjective \"wise\", but the direct difference is that an essay is a written composition while wise describes judgment."

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -613,6 +613,64 @@ class RuntimeTests(unittest.TestCase):
             ],
         )
 
+    def test_ask_chat_does_not_retry_complete_markdown_answer_with_trailing_bold_closer(self) -> None:
+        class MarkdownCompleteBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.chat_calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                raise AssertionError("streaming path expected")
+
+            def chat_stream(
+                self,
+                messages: list[Message],
+                *,
+                temperature: float,
+                max_tokens: int,
+                tools=None,
+                on_delta=None,
+                on_progress=None,
+            ) -> ChatResult:
+                self.chat_calls += 1
+                assert on_delta is not None
+                content = (
+                    "I am a large language model, trained by Google. I can help answer questions and explain topics.\n\n"
+                    "**What's on your mind today? Is there anything specific I can help you with?**"
+                )
+                on_delta(content)
+                return ChatResult(
+                    content=content,
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=2,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = MarkdownCompleteBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=False)
+        emitted: list[str] = []
+        phases: list[ModelPhaseStart] = []
+
+        result = runtime.ask_chat(
+            "hi, tell me something about yourself",
+            temperature=0,
+            max_tokens=512,
+            on_final_delta=emitted.append,
+            on_phase_start=phases.append,
+        )
+
+        self.assertEqual(backend.chat_calls, 1)
+        self.assertEqual("".join(emitted), result.content)
+        self.assertEqual(
+            [(phase.phase, phase.attempt, phase.reason) for phase in phases],
+            [("chat_final", 1, None)],
+        )
+
     def test_continue_last_response_uses_prompt_fallback_for_bullet_reasoning_length(self) -> None:
         class BulletReasoningBackend(FakeBackend):
             def __init__(self) -> None:


### PR DESCRIPTION
Summary:
- Fixes a false incomplete_stub classification for complete final answers ending with markdown/question punctuation.
- Prevents unnecessary second final pass that appended an extra sentence to an already complete answer.
- Confirms tools are off by default and this was not hidden tool exposure.
- Keeps final_policy limited to accept/retry decisions; it does not rewrite answers.

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_final_policy tests.test_runtime tests.test_repl -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Smoke:
- tools off chat prompt: PASS
- no appended final sentence: PASS
- file-read guard regression: PASS
- fetch_url regression: PASS
