### PR TITLE
Add runtime local capability discovery

### DIFF
--- a/src/orbit/runtime/capabilities.py
+++ b/src/orbit/runtime/capabilities.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from typing import Callable
+
+
+DOCUMENT_TOOL_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("pdftotext", "document", "extract text from PDFs"),
+    ("pandoc", "document", "convert supported document formats to text"),
+    ("python3", "python", "run Python helpers for text extraction or inspection"),
+    ("python", "python", "run Python helpers for text extraction or inspection"),
+    ("file", "system", "identify file types and encodings"),
+    ("unzip", "archive", "inspect zipped document containers such as docx/odt"),
+    ("libreoffice", "document", "convert office documents in headless mode"),
+    ("soffice", "document", "convert office documents in headless mode"),
+    ("antiword", "document", "extract text from legacy .doc files"),
+)
+
+@dataclass(frozen=True)
+class LocalCapability:
+    name: str
+    available: bool
+    path: str | None
+    category: str
+    purpose: str
+
+
+@dataclass(frozen=True)
+class LocalCapabilities:
+    items: tuple[LocalCapability, ...]
+
+    def by_name(self, name: str) -> LocalCapability | None:
+        for item in self.items:
+            if item.name == name:
+                return item
+        return None
+
+    def format_prompt_summary(self) -> str:
+        available = ", ".join(item.name for item in self.items if item.available) or "none"
+        unavailable = ", ".join(item.name for item in self.items if not item.available) or "none"
+        return (
+            f"Local tools available: {available}.\n"
+            f"Unavailable: {unavailable}.\n"
+            "Use only tools that are available or verify availability before use. "
+            "Do not assume pdftotext, pandoc, libreoffice, soffice, antiword, unzip, file, python3, or python exist unless listed as available."
+        )
+
+    def format_tools_status(self) -> str:
+        lines = ["Local capabilities", "------------------"]
+        for item in self.items:
+            status = "available" if item.available else "unavailable"
+            path = item.path if item.path else "-"
+            lines.append(f"{item.name:<12} {status:<11} {item.category:<8} {path:<30} {item.purpose}")
+        return "\n".join(lines)
+
+
+def discover_local_capabilities(which: Callable[[str], str | None] = shutil.which) -> LocalCapabilities:
+    items: list[LocalCapability] = []
+    for name, category, purpose in DOCUMENT_TOOL_SPECS:
+        path = which(name)
+        items.append(
+            LocalCapability(
+                name=name,
+                available=path is not None,
+                path=path,
+                category=category,
+                purpose=purpose,
+            )
+        )
+    return LocalCapabilities(tuple(items))

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -7,6 +7,7 @@ import re
 
 from orbit.backend import ChatBackend, ChatResult
 from orbit.backend.base import Message, StreamProgress
+from orbit.runtime.capabilities import LocalCapabilities, discover_local_capabilities
 from orbit.runtime.client_state import ClientState
 from orbit.runtime.completion_budget import CompletionBudget
 from orbit.runtime.environments import (
@@ -107,12 +108,17 @@ class ChatRuntime:
     content_evidence_guard_commands: int = 0
     content_evidence_guard_successes: int = 0
     content_evidence_guard_failures: int = 0
+    local_capabilities: LocalCapabilities = field(default_factory=discover_local_capabilities)
 
     def __post_init__(self) -> None:
         if hasattr(self.backend, "thinking"):
             self.thinking_mode = bool(getattr(self.backend, "thinking"))
         if not self.messages and self.system_prompt:
             self.messages.append({"role": "system", "content": self.system_prompt})
+
+    def refresh_local_capabilities(self) -> LocalCapabilities:
+        self.local_capabilities = discover_local_capabilities()
+        return self.local_capabilities
 
     def ask(
         self,
@@ -587,6 +593,7 @@ class ChatRuntime:
             on_phase_start=on_phase_start,
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
+            local_capabilities=self.local_capabilities,
         )
     def _stream_tool_thinking_plan(
         self,

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -365,6 +365,7 @@ class ToolLoopEnvironment:
         on_phase_start: Callable[[ModelPhaseStart], None] | None,
         tool_names: tuple[str, ...] | None,
         initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
+        local_capabilities=None,
     ) -> ToolResultBundle:
         result = run_tool_loop(
             self.runtime,
@@ -380,6 +381,7 @@ class ToolLoopEnvironment:
             on_phase_start=on_phase_start,
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
+            local_capabilities=local_capabilities,
         )
         return ToolResultBundle(
             result=result,

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
+from orbit.runtime.capabilities import LocalCapabilities
 from orbit.runtime.command_request import command_like_tool_call, command_tool_call_from_tool_calls
 from orbit.runtime.messages import with_chat_system_prompt, with_tool_call_system_prompt
 from orbit.runtime.session_memory import should_refresh_for_append
@@ -87,6 +88,7 @@ def run_tool_loop(
     on_phase_start: Callable[[ModelPhaseStart], None] | None,
     tool_names: tuple[str, ...] | None,
     initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
+    local_capabilities: LocalCapabilities | None = None,
 ) -> ChatResult:
     allowed_tool_names = tool_names or default_tool_names()
     executor = HybridToolExecutor(
@@ -106,6 +108,7 @@ def run_tool_loop(
     repair = turn.repair_state
     shell_full_enabled = "exec_shell_full_command" in allowed_tool_names
     url_content_required = requires_url_content_evidence(user_prompt)
+    capability_context = local_capabilities.format_prompt_summary() if local_capabilities is not None else None
     suppress_tool_delta = (lambda _delta: None) if on_final_delta is not None and shell_full_enabled else None
 
     # These local helpers still couple policy and runtime counters in one place.
@@ -616,6 +619,8 @@ def run_tool_loop(
             )
     for loop_index in range(1, max_loops + 1):
         call_messages = with_tool_call_system_prompt(runtime.messages)
+        if capability_context:
+            call_messages = [*call_messages, {"role": "system", "content": capability_context}]
         executing_mutation_verification = repair.mutation_verification_pending
         executing_mutation_verification_repair = repair.mutation_verification_repair_pending
         executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending

--- a/src/orbit/terminal/commands.py
+++ b/src/orbit/terminal/commands.py
@@ -27,7 +27,7 @@ def help_text() -> str:
         ("/reset", "Clear current conversation and saved session."),
         ("/sessions clear", "Delete all saved sessions for this workdir."),
         ("/status [ctx]", "Show runtime status or estimated context usage."),
-        ("/tools [off|on]", "Show or set shell tool access."),
+        ("/tools [off|on|status|refresh]", "Show tool access or local capabilities."),
         ("/exit", "Exit interactive mode."),
     ]
     width = max(len(command) for command, _ in commands) + 2
@@ -67,6 +67,8 @@ def tools_text(current: ToolSpec | None = None) -> str:
             "Use:",
             "  /tools off = chat only",
             "  /tools on  = unrestricted local shell for files, web, edits, system, and automation",
+            "  /tools status = show detected local document capabilities",
+            "  /tools refresh = refresh detected local document capabilities",
         ]
     )
     return "\n".join(lines)

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -258,6 +258,11 @@ class Repl:
         value = command.removeprefix("/tools").strip().lower()
         if not value:
             return tools_text(self.tools_mode)
+        if value == "status":
+            return self.runtime.local_capabilities.format_tools_status()
+        if value == "refresh":
+            capabilities = self.runtime.refresh_local_capabilities()
+            return "tools capabilities refreshed\n" + capabilities.format_tools_status()
         try:
             self.tools_mode = normalize_tool_spec(value)
         except ValueError:

--- a/src/orbit/terminal/tool_mode.py
+++ b/src/orbit/terminal/tool_mode.py
@@ -6,7 +6,7 @@ ToolSpec = str
 DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url")
 
 SPECIAL_TOOL_SPECS = ("off", "on")
-USAGE = "off|on"
+USAGE = "off|on|status|refresh"
 
 
 def normalize_tool_spec(value: object, *, key: str = "tools") -> ToolSpec:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.capabilities import (
+    discover_local_capabilities,
+)
+
+
+class CapabilityTests(unittest.TestCase):
+    def test_discovery_normalizes_available_and_missing_tools(self) -> None:
+        paths = {
+            "pdftotext": "/usr/bin/pdftotext",
+            "python3": "/usr/bin/python3",
+            "unzip": "/usr/bin/unzip",
+        }
+
+        capabilities = discover_local_capabilities(paths.get)
+
+        self.assertTrue(capabilities.by_name("pdftotext").available)
+        self.assertEqual(capabilities.by_name("pdftotext").path, "/usr/bin/pdftotext")
+        self.assertTrue(capabilities.by_name("python3").available)
+        self.assertFalse(capabilities.by_name("pandoc").available)
+        self.assertIsNone(capabilities.by_name("pandoc").path)
+
+    def test_prompt_summary_reports_available_and_unavailable_tools(self) -> None:
+        capabilities = discover_local_capabilities({"pdftotext": "/usr/bin/pdftotext"}.get)
+
+        summary = capabilities.format_prompt_summary()
+
+        self.assertIn("Local tools available: pdftotext", summary)
+        self.assertIn("Unavailable:", summary)
+        self.assertIn("pandoc", summary)
+
+    def test_prompt_summary_warns_against_assuming_external_tools(self) -> None:
+        capabilities = discover_local_capabilities({"python3": "/usr/bin/python3"}.get)
+
+        prompt = capabilities.format_prompt_summary()
+
+        self.assertIn("Do not assume pdftotext", prompt)
+        self.assertIn("Local tools available: python3", prompt)
+        self.assertIn("verify availability before use", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -25,7 +25,7 @@ class CommandTests(unittest.TestCase):
         self.assertIn("/sessions clear", help_text())
         self.assertIn("/think [off|on]", help_text())
         self.assertIn("/status [ctx]", help_text())
-        self.assertIn("/tools [off|on]", help_text())
+        self.assertIn("/tools [off|on|status|refresh]", help_text())
         self.assertNotIn("Show or set tools: off or on.", help_text())
 
     def test_set_max_tokens_without_value_reports_current_value(self) -> None:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -632,16 +632,32 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(repl.tools_mode, "off")
         self.assertEqual(
             repl._handle_tools_command("/tools bad"),
-            "error: usage: /tools [off|on]",
+            "error: usage: /tools [off|on|status|refresh]",
         )
         self.assertEqual(
             repl._handle_tools_command("/tools read_file"),
-            "error: usage: /tools [off|on]",
+            "error: usage: /tools [off|on|status|refresh]",
         )
         self.assertEqual(
             repl._handle_tools_command("/tools time"),
-            "error: usage: /tools [off|on]",
+            "error: usage: /tools [off|on|status|refresh]",
         )
+
+    def test_tools_status_and_refresh_show_local_capabilities(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+
+        status = repl._handle_tools_command("/tools status")
+
+        self.assertIn("Local capabilities", status)
+        self.assertIn("pdftotext", status)
+        self.assertEqual(runtime.ask_calls, 0)
+
+        refreshed = repl._handle_tools_command("/tools refresh")
+
+        self.assertIn("tools capabilities refreshed", refreshed)
+        self.assertIn("Local capabilities", refreshed)
+        self.assertEqual(runtime.ask_calls, 0)
 
     def test_tools_slash_command_is_handled_locally_in_repl_loop(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -16,6 +16,7 @@ from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
 from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, MEDIA_SYSTEM_PROMPT, TOOL_CALL_JSON_RETRY_PROMPT, TOOL_CALL_SYSTEM_PROMPT
 from orbit.runtime.chat import _has_list_like_tool_result
+from orbit.runtime.capabilities import LocalCapabilities, LocalCapability
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.tool_loop import _should_guard_existing_file_rewrite
 from orbit.runtime.turn_trace import ModelPhaseStart
@@ -154,6 +155,13 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(steps[0].prompt_tokens, 1)
         self.assertEqual(steps[0].cached_tokens, 0)
 
+    def test_capability_discovery_does_not_invoke_model_at_startup(self) -> None:
+        backend = FakeBackend()
+
+        ChatRuntime(backend=backend, system_prompt=None)
+
+        self.assertEqual(backend.calls, 0)
+
     def test_continue_last_response_uses_chat_without_tools(self) -> None:
         backend = FakeBackend()
         runtime = ChatRuntime(backend=backend, system_prompt=None)
@@ -176,6 +184,73 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertEqual(runtime.messages[-2]["role"], "user")
         self.assertIn("stop reasoning now", runtime.messages[-2]["content"].lower())
+
+    def test_local_capabilities_are_added_to_tool_prompts(self) -> None:
+        backend = CaptureToolPromptBackend()
+        runtime = ChatRuntime(
+            backend=backend,
+            system_prompt=None,
+            local_capabilities=LocalCapabilities(
+                (
+                    LocalCapability("pdftotext", True, "/usr/bin/pdftotext", "document", "extract text from PDFs"),
+                    LocalCapability("pandoc", False, None, "document", "convert supported document formats to text"),
+                    LocalCapability("python3", True, "/usr/bin/python3", "python", "run Python helpers"),
+                )
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime.ask_with_tools(
+                "read pdf/piccolo.pdf and summarize it",
+                temperature=0,
+                max_tokens=32,
+                workdir=Path(tmp),
+                max_loops=1,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.calls[0])
+        self.assertIn("Local tools available:", rendered)
+        self.assertIn("pdftotext", rendered)
+        self.assertIn("Unavailable: pandoc", rendered)
+
+    def test_local_capabilities_are_added_to_normal_tool_prompts(self) -> None:
+        backend = CaptureToolPromptBackend()
+        runtime = ChatRuntime(
+            backend=backend,
+            system_prompt=None,
+            local_capabilities=LocalCapabilities(
+                (LocalCapability("pdftotext", True, "/usr/bin/pdftotext", "document", "extract text from PDFs"),)
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime.ask_with_tools(
+                "list files",
+                temperature=0,
+                max_tokens=32,
+                workdir=Path(tmp),
+                max_loops=1,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.calls[0])
+        self.assertIn("Local tools available:", rendered)
+
+    def test_local_capabilities_are_not_added_to_tools_off_chat(self) -> None:
+        backend = FakeBackend()
+        runtime = ChatRuntime(
+            backend=backend,
+            system_prompt=None,
+            local_capabilities=LocalCapabilities(
+                (LocalCapability("pdftotext", True, "/usr/bin/pdftotext", "document", "extract text from PDFs"),)
+            ),
+        )
+
+        runtime.ask("hello", temperature=0, max_tokens=32)
+
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.messages)
+        self.assertNotIn("Local tools available:", rendered)
 
     def test_continue_last_response_uses_prompt_fallback_for_open_reasoning(self) -> None:
         class FallbackBackend(FakeBackend):
@@ -849,6 +924,25 @@ class ToolCallingBackend:
             cached_tokens=10,
             prompt_tokens_per_second=80.0,
             generation_tokens_per_second=9.0,
+        )
+
+
+class CaptureToolPromptBackend:
+    def __init__(self) -> None:
+        self.calls: list[list[Message]] = []
+
+    def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+        self.calls.append(messages)
+        return ChatResult(
+            content="ok",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=1,
+            completion_tokens=1,
+            cached_tokens=0,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
         )
 
 


### PR DESCRIPTION
Summary:
- Discovers local document/system helper capabilities at ChatRuntime startup with shutil.which.
- Adds compact capability context to tools-on tool prompts without adding inference steps or deterministic command selection.
- Adds /tools status and /tools refresh as local diagnostics only.
- Keeps tools off chat unchanged and does not modify backend/native/MTP/rendering behavior.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_capabilities tests.test_runtime tests.test_repl tests.test_commands tests.test_tool_backends tests.test_tool_loop_state -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Notes:
- Validation was run in a clean worktree with ignored PDF fixtures copied into workdir/pdf for existing tests.
- No workdir files are included.