### PR TITLE
Add live Markdown terminal rendering

### DIFF
--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -96,6 +96,7 @@ def main(argv: list[str] | None = None) -> int:
             workdir=config.workdir,
             tools=config.tools,
             thinking=config.think,
+            render_markdown_mode=config.render_markdown,
         )
     if args.image or args.audio:
         print("error: --image/--audio require a one-shot prompt", file=sys.stderr)
@@ -162,6 +163,7 @@ def _run_one_shot(
     workdir,
     tools: str,
     thinking: bool,
+    render_markdown_mode: str = "plain",
 ) -> int:
     prefill_estimator = PrefillEstimator()
     tools_enabled = tools_are_enabled(tools)
@@ -173,6 +175,7 @@ def _run_one_shot(
         prefill_estimate_seconds=_visible_prefill_seconds(prefill_seconds),
         prefill_estimate_tokens=prefill_tokens,
         thinking=thinking,
+        render_markdown_mode=render_markdown_mode,
     )
     started = time.monotonic()
     print()
@@ -219,7 +222,7 @@ def _run_one_shot(
                 ),
             )
     except KeyboardInterrupt:
-        renderer.finish()
+        renderer.finish(interrupted=True)
         print(dim("interrupted"), flush=True)
         return 130
     except ValueError as exc:

--- a/src/orbit/terminal/config.py
+++ b/src/orbit/terminal/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,7 @@ MAX_MAX_TOKENS = 4096
 MIN_CONTEXT_TOKENS = 512
 MAX_CONTEXT_TOKENS = 262_144
 DEFAULT_TOOLS = "off"
+MARKDOWN_RENDER_MODES = {"plain", "live"}
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,7 @@ class AppConfig:
     no_system: bool = False
     think: bool = DEFAULT_THINKING
     tools: ToolSpec = DEFAULT_TOOLS
+    render_markdown: str = "live"
 
 
 def add_config_arguments(parser: argparse.ArgumentParser) -> None:
@@ -47,6 +50,16 @@ def add_config_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--no-system", action="store_true", help="Do not send the default system prompt.")
     parser.add_argument("--think", help="Initial thinking mode: off or on.")
     parser.add_argument("--tools", help="Initial tool mode: off or on.")
+    parser.add_argument(
+        "--render-markdown-live",
+        action="store_true",
+        help="Render final answers with minimal live Markdown styling while streaming.",
+    )
+    parser.add_argument(
+        "--no-render-markdown",
+        action="store_true",
+        help="Disable Markdown rendering and keep plain-text streaming output.",
+    )
 
 
 def load_app_config(args: argparse.Namespace) -> AppConfig:
@@ -79,7 +92,9 @@ def load_app_config(args: argparse.Namespace) -> AppConfig:
         no_system=_bool_value(values, "no_system", AppConfig.no_system),
         think=_bool_value_or_spec(values, "think", AppConfig.think),
         tools=_tool_spec_value(values),
+        render_markdown=_markdown_mode_value(values),
     )
+    cli_markdown = _cli_markdown_mode(args)
     return AppConfig(
         base_url=args.base_url if args.base_url is not None else config.base_url,
         workdir=Path(args.workdir).expanduser().resolve() if args.workdir is not None else config.workdir,
@@ -112,6 +127,7 @@ def load_app_config(args: argparse.Namespace) -> AppConfig:
         no_system=args.no_system or config.no_system,
         think=normalize_think_spec(args.think) if args.think is not None else config.think,
         tools=normalize_tool_spec(args.tools) if args.tools is not None else config.tools,
+        render_markdown=cli_markdown if cli_markdown is not None else config.render_markdown,
     )
 
 
@@ -212,3 +228,36 @@ def _tool_spec_value(values: dict[str, Any]) -> ToolSpec:
     if isinstance(value, dict):
         value = DEFAULT_TOOLS
     return normalize_tool_spec(value, key="tool_mode")
+
+
+def _markdown_mode_value(values: dict[str, Any]) -> str:
+    mode = values.get("render_markdown")
+    if mode is not None:
+        return _normalize_markdown_mode(mode, key="render_markdown")
+    return _markdown_mode_from_env()
+
+
+def _markdown_mode_from_env() -> str:
+    mode = os.environ.get("ORBIT_RENDER_MARKDOWN")
+    if mode is not None:
+        return _normalize_markdown_mode(mode, key="ORBIT_RENDER_MARKDOWN")
+    return "live"
+
+
+def _cli_markdown_mode(args: argparse.Namespace) -> str | None:
+    if args.render_markdown_live:
+        return "live"
+    if args.no_render_markdown:
+        return "plain"
+    return None
+
+
+def _normalize_markdown_mode(value: Any, *, key: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"invalid {key}: expected string")
+    lowered = value.strip().lower()
+    if lowered in {"off", "false", "0", "plain", ""}:
+        return "plain"
+    if lowered in MARKDOWN_RENDER_MODES:
+        return lowered
+    raise ValueError(f"invalid {key}: expected one of plain, live")

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -103,6 +103,7 @@ class Repl:
             prefill_estimate_seconds=_visible_prefill_seconds(prefill_seconds),
             prefill_estimate_tokens=prefill_tokens,
             thinking=self.config.think,
+            render_markdown_mode=self.config.render_markdown,
         )
         checkpoint = len(self.runtime.messages)
         print()
@@ -134,7 +135,7 @@ class Repl:
                     on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
                 )
         except KeyboardInterrupt:
-            renderer.finish()
+            renderer.finish(interrupted=True)
             self.runtime.restore_message_count(checkpoint)
             print(dim("interrupted"), flush=True)
             return
@@ -313,6 +314,7 @@ class Repl:
             prefill_estimate_seconds=_visible_prefill_seconds(prefill_seconds),
             prefill_estimate_tokens=prefill_tokens,
             thinking=self.config.think,
+            render_markdown_mode=self.config.render_markdown,
         )
         checkpoint = len(self.runtime.messages)
         print()
@@ -328,7 +330,7 @@ class Repl:
                 on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
             )
         except KeyboardInterrupt:
-            renderer.finish()
+            renderer.finish(interrupted=True)
             self.runtime.restore_message_count(checkpoint)
             print(dim("interrupted"), flush=True)
             return

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import re
 import threading
 import time
 
 from orbit.backend.base import StreamProgress
-from orbit.terminal.theme import DIM, RESET, dim
+from orbit.terminal.theme import CYAN, DIM, RESET, dim
 
 
 SPINNER_FRAMES = ("◐", "◓", "◑", "◒")
 PREFILL_COMPLETION_LABEL = "waiting for model..."
+MARKDOWN_HEADING = "\033[1m" + CYAN
+MARKDOWN_BOLD = "\033[1m"
+MARKDOWN_BOLD_OFF = "\033[22m"
+MARKDOWN_ITALIC = "\033[3m"
+MARKDOWN_ITALIC_OFF = "\033[23m"
 
 
 class StreamRenderer:
@@ -19,11 +25,14 @@ class StreamRenderer:
         prefill_estimate_seconds: float | None = None,
         prefill_estimate_tokens: int | None = None,
         thinking: bool = False,
+        render_markdown_mode: str = "plain",
     ) -> None:
         self.interval = interval
         self._prefill_estimate_seconds = prefill_estimate_seconds
         self._prefill_estimate_tokens = prefill_estimate_tokens
         self._thinking_filter = _ThinkingDisplayFilter() if thinking else None
+        self._markdown_mode = render_markdown_mode
+        self._markdown_live = _LiveMarkdownRenderer(enabled=render_markdown_mode == "live")
         self._started = False
         self._first_delta = False
         self._timer_active = False
@@ -54,7 +63,7 @@ class StreamRenderer:
             self._first_delta = True
             self._stop_timer(clear=True)
         if self._thinking_filter is None:
-            print(text, end="", flush=True)
+            self._write_visible_text(text)
             return
         for fragment, dimmed in self._thinking_filter.write(text):
             if not fragment:
@@ -62,6 +71,7 @@ class StreamRenderer:
             self._print_thinking_fragment(fragment, dimmed=dimmed)
 
     def event(self, text: str, *, restart_timer: bool = True, trailing_blank_line: bool = False) -> None:
+        self._flush_markdown_buffer(interrupted=False)
         self._stop_timer(clear=True)
         print(dim(text), flush=True)
         if trailing_blank_line:
@@ -87,7 +97,7 @@ class StreamRenderer:
         if self._started and not self._first_delta:
             self._render_wait_line()
 
-    def finish(self) -> None:
+    def finish(self, *, interrupted: bool = False) -> None:
         if self._thinking_filter is not None:
             for fragment, dimmed in self._thinking_filter.finish():
                 if fragment:
@@ -95,6 +105,7 @@ class StreamRenderer:
             if self._thinking_dim_open:
                 print(RESET, end="", flush=True)
                 self._thinking_dim_open = False
+        self._flush_markdown_buffer(interrupted=interrupted)
         if not self._started:
             return
         self._stop_timer(clear=not self._first_delta)
@@ -116,7 +127,25 @@ class StreamRenderer:
                 self._thinking_dim_open = True
             print(fragment, end="", flush=True)
             return
-        print(fragment, end="", flush=True)
+        self._write_visible_text(fragment)
+
+    def _write_visible_text(self, text: str) -> None:
+        try:
+            if self._markdown_mode == "live":
+                for chunk in self._markdown_live.write(text):
+                    print(chunk, end="", flush=True)
+                return
+            print(text, end="", flush=True)
+        except Exception:
+            print(text, end="", flush=True)
+
+    def _flush_markdown_buffer(self, *, interrupted: bool) -> None:
+        if self._markdown_mode == "live":
+            try:
+                for chunk in self._markdown_live.finish():
+                    print(chunk, end="", flush=True)
+            except Exception:
+                pass
 
     def _stop_timer(self, *, clear: bool) -> None:
         self._stop.set()
@@ -225,7 +254,7 @@ def _pad_to_terminal_width(text: str) -> str:
 
 
 def _visible_len(text: str) -> int:
-    return len(__import__("re").sub(r"\x1b\[[0-9;]*m", "", text))
+    return len(re.sub(r"\x1b\[[0-9;]*m", "", text))
 
 
 def format_elapsed(seconds: float) -> str:
@@ -389,3 +418,223 @@ def _strip_channel_markup(text: str) -> str:
         .replace("<|channel>final\n", "")
         .replace("<channel|>", "")
     )
+
+
+class _LiveMarkdownRenderer:
+    _INLINE_BUFFER_LIMIT = 160
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+        self._inside_code_fence = False
+        self._start_of_line = True
+        self._prefix = ""
+        self._line_style: str | None = None
+        self._style_open = False
+        self._inline_buffer = ""
+        self._discard_fence_line = False
+        self._last_visible_char = ""
+
+    def write(self, text: str) -> list[str]:
+        if not text:
+            return []
+        if not self.enabled:
+            return [text]
+        emitted: list[str] = []
+        for ch in text:
+            emitted.extend(self._write_char(ch))
+        return emitted
+
+    def finish(self) -> list[str]:
+        if not self.enabled:
+            return []
+        tail: list[str] = []
+        if self._prefix:
+            tail.append(self._emit(self._prefix))
+            self._prefix = ""
+        if self._inline_buffer:
+            tail.append(self._emit(self._inline_buffer))
+            self._inline_buffer = ""
+        if self._style_open:
+            tail.append(RESET)
+            self._style_open = False
+        return tail
+
+    def _write_char(self, ch: str) -> list[str]:
+        if self._discard_fence_line:
+            if ch == "\n":
+                self._discard_fence_line = False
+                self._start_of_line = True
+            return []
+        if self._start_of_line:
+            return self._write_line_start(ch)
+        if ch == "\n":
+            chunks = self._flush_inline_buffer()
+            chunk = self._emit(ch)
+            if self._style_open:
+                chunk += RESET
+                self._style_open = False
+            self._start_of_line = True
+            self._line_style = None
+            chunks.append(chunk)
+            return chunks
+        return self._write_inline_char(ch)
+
+    def _write_line_start(self, ch: str) -> list[str]:
+        self._prefix += ch
+        if ch == "\n":
+            chunk = self._emit(self._prefix)
+            self._prefix = ""
+            self._line_style = None
+            self._start_of_line = True
+            return [chunk]
+
+        decision = self._line_start_decision()
+        if decision is None:
+            return []
+        style, keep_start, visible_prefix = decision
+        prefix = self._prefix
+        self._prefix = ""
+        self._line_style = style
+        self._start_of_line = keep_start
+        if visible_prefix is None:
+            visible_prefix = prefix
+        if visible_prefix.startswith("**"):
+            return self._write_inline_text(visible_prefix)
+        if not visible_prefix:
+            return []
+        return [self._emit(visible_prefix)]
+
+    def _line_start_decision(self) -> tuple[str | None, bool, str | None] | None:
+        prefix = self._prefix
+        if prefix.startswith("```"):
+            self._inside_code_fence = not self._inside_code_fence
+            self._discard_fence_line = True
+            return DIM if self._inside_code_fence else None, False, ""
+        if prefix in {"#", "##", "###", "-", "*", "`", "``"}:
+            return None
+        if prefix.startswith("**") and len(prefix) >= 3:
+            return None, False, prefix
+        if prefix.startswith("*") and not prefix.startswith("* "):
+            return None, False, prefix
+        if prefix.startswith("-") and not prefix.startswith("- "):
+            return None, False, prefix
+        if re.fullmatch(r"\d+", prefix) or re.fullmatch(r"\d+\.", prefix):
+            return None
+        if prefix.startswith(("### ", "## ", "# ")):
+            return MARKDOWN_HEADING, False, ""
+        if prefix.startswith(("- ", "* ")) or re.fullmatch(r"\d+\. ", prefix):
+            return CYAN, False, prefix
+        if self._inside_code_fence and not prefix.startswith("```"):
+            return DIM, False, prefix
+        if len(prefix) >= 4 or prefix[0] not in "#-*`0123456789":
+            return None, False, prefix
+        if prefix.startswith("-") or prefix.startswith("*"):
+            return None, False, prefix
+        return None, False, prefix
+
+    def _emit(self, text: str) -> str:
+        if not text:
+            return ""
+        self._remember_visible_text(text)
+        if not self._line_style:
+            return text
+        if self._style_open:
+            return text
+        self._style_open = True
+        return f"{self._line_style}{text}"
+
+    def _write_inline_char(self, ch: str) -> list[str]:
+        if self._inside_code_fence:
+            return [self._emit(ch)]
+        self._inline_buffer += ch
+        return self._drain_inline_buffer()
+
+    def _write_inline_text(self, text: str) -> list[str]:
+        emitted: list[str] = []
+        for ch in text:
+            emitted.extend(self._write_inline_char(ch))
+        return emitted
+
+    def _drain_inline_buffer(self) -> list[str]:
+        emitted: list[str] = []
+        while self._inline_buffer:
+            start, marker = self._next_inline_marker()
+            if start < 0:
+                if self._inline_buffer.endswith(("*", "_")):
+                    plain = self._inline_buffer[:-1]
+                    if plain:
+                        emitted.append(self._emit(plain))
+                    self._inline_buffer = self._inline_buffer[-1]
+                    break
+                emitted.append(self._emit(self._inline_buffer))
+                self._inline_buffer = ""
+                break
+            if start > 0:
+                emitted.append(self._emit(self._inline_buffer[:start]))
+                self._inline_buffer = self._inline_buffer[start:]
+                continue
+            end = self._inline_buffer.find(marker, len(marker))
+            if end < 0:
+                if len(self._inline_buffer) > self._INLINE_BUFFER_LIMIT:
+                    emitted.append(self._emit(self._inline_buffer))
+                    self._inline_buffer = ""
+                break
+            content = self._inline_buffer[len(marker) : end]
+            if content:
+                emitted.append(self._emit(self._inline_style(content, marker=marker)))
+            self._inline_buffer = self._inline_buffer[end + len(marker) :]
+        return emitted
+
+    def _flush_inline_buffer(self) -> list[str]:
+        if not self._inline_buffer:
+            return []
+        chunk = self._emit(self._inline_buffer)
+        self._inline_buffer = ""
+        return [chunk]
+
+    def _next_inline_marker(self) -> tuple[int, str]:
+        candidates: list[tuple[int, str]] = []
+        for marker in ("**", "*", "_"):
+            idx = self._find_inline_marker(marker)
+            if idx >= 0:
+                candidates.append((idx, marker))
+        if not candidates:
+            return -1, ""
+        return min(candidates, key=lambda item: (item[0], -len(item[1])))
+
+    def _find_inline_marker(self, marker: str) -> int:
+        start = 0
+        while True:
+            idx = self._inline_buffer.find(marker, start)
+            if idx < 0:
+                return -1
+            next_idx = idx + len(marker)
+            if marker != "**" and next_idx < len(self._inline_buffer) and self._inline_buffer[next_idx].isspace():
+                start = idx + 1
+                continue
+            if marker == "_" and self._marker_inside_word(idx=idx, marker=marker):
+                start = idx + 1
+                continue
+            return idx
+
+    def _inline_style(self, text: str, *, marker: str) -> str:
+        if marker == "**":
+            open_style = MARKDOWN_BOLD
+            close_style = MARKDOWN_BOLD_OFF
+        else:
+            open_style = MARKDOWN_ITALIC
+            close_style = MARKDOWN_ITALIC_OFF
+        if self._line_style and self._style_open:
+            close_style = RESET + self._line_style
+        return f"{open_style}{text}{close_style}"
+
+    def _marker_inside_word(self, *, idx: int, marker: str) -> bool:
+        previous = self._inline_buffer[idx - 1] if idx > 0 else self._last_visible_char
+        next_idx = idx + len(marker)
+        next_char = self._inline_buffer[next_idx] if next_idx < len(self._inline_buffer) else ""
+        return bool(previous and previous.isalnum() and next_char and next_char.isalnum())
+
+    def _remember_visible_text(self, text: str) -> None:
+        visible = re.sub(r"\x1b\[[0-9;]*m", "", text)
+        if visible:
+            self._last_visible_char = visible[-1]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 import sys
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -66,6 +68,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.max_tokens, 512)
         self.assertIsNone(config.context_tokens)
         self.assertEqual(config.tools, "off")
+        self.assertEqual(config.render_markdown, "live")
 
     def test_config_file_sets_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -82,6 +85,7 @@ class ConfigTests(unittest.TestCase):
                         "no_system": True,
                         "think": True,
                         "tools": "on",
+                        "render_markdown": "live",
                     }
                 ),
                 encoding="utf-8",
@@ -97,6 +101,7 @@ class ConfigTests(unittest.TestCase):
         self.assertTrue(config.no_system)
         self.assertTrue(config.think)
         self.assertEqual(config.tools, "on")
+        self.assertEqual(config.render_markdown, "live")
 
     def test_cli_flags_override_config_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -117,6 +122,7 @@ class ConfigTests(unittest.TestCase):
                     "on",
                     "--tools",
                     "on",
+                    "--render-markdown-live",
                 )
             )
 
@@ -125,6 +131,46 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.context_tokens, 2048)
         self.assertTrue(config.think)
         self.assertEqual(config.tools, "on")
+        self.assertEqual(config.render_markdown, "live")
+
+    def test_env_can_enable_live_markdown_rendering(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_RENDER_MARKDOWN": "live"}):
+            config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json"))
+
+        self.assertEqual(config.render_markdown, "live")
+
+    def test_no_render_markdown_disables_default_live_rendering(self) -> None:
+        config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json", "--no-render-markdown"))
+
+        self.assertEqual(config.render_markdown, "plain")
+
+    def test_cli_has_precedence_over_markdown_render_env(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_RENDER_MARKDOWN": "off"}):
+            enabled = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json", "--render-markdown-live"))
+        self.assertEqual(enabled.render_markdown, "live")
+
+        with mock.patch.dict(os.environ, {"ORBIT_RENDER_MARKDOWN": "live"}):
+            disabled = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json", "--no-render-markdown"))
+        self.assertEqual(disabled.render_markdown, "plain")
+
+    def test_env_can_disable_markdown_rendering(self) -> None:
+        for value in ("0", "false", "off", "plain"):
+            with self.subTest(value=value):
+                with mock.patch.dict(os.environ, {"ORBIT_RENDER_MARKDOWN": value}):
+                    config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json"))
+
+                self.assertEqual(config.render_markdown, "plain")
+
+    def test_cli_can_enable_live_markdown_rendering(self) -> None:
+        config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json", "--render-markdown-live"))
+
+        self.assertEqual(config.render_markdown, "live")
+
+    def test_no_render_markdown_forces_plain(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_RENDER_MARKDOWN": "live"}):
+            config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json", "--no-render-markdown"))
+
+        self.assertEqual(config.render_markdown, "plain")
 
     def test_config_rejects_unknown_tool_spec(self) -> None:
         with self.assertRaisesRegex(ValueError, "tools"):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4,6 +4,7 @@ import io
 import sys
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -27,6 +28,326 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         self.assertIn("hello", stream.getvalue())
+
+    def test_plain_markdown_rendering_keeps_literal_text(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="plain")
+            renderer.write("Hello **world**\n\n")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "Hello **world**\n\n")
+
+    def test_live_markdown_rendering_does_not_apply_to_thinking_fragments(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(thinking=True, render_markdown_mode="live")
+            renderer.write("### Reasoning\nstep 1\n")
+            renderer.set_final_output_mode(True)
+            renderer.write("**Final** answer.\n")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Thinking...", output)
+        self.assertIn("### Reasoning\nstep 1\n", output)
+        self.assertIn("\033[1mFinal\033[22m answer.\n", output)
+
+    def test_live_markdown_rendering_does_not_apply_to_tool_events(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.event("Read: **cat** README.md", restart_timer=False)
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Read: **cat** README.md", output)
+        self.assertNotIn("\033[1mcat", output)
+
+    def test_live_markdown_rendering_styles_heading_immediately(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("# Title")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Title", output)
+        self.assertNotIn("# Title", output)
+        self.assertIn("\033[1m\033[36m", output)
+
+    def test_live_markdown_rendering_handles_split_heading_marker(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("#")
+            renderer.write(" Title")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("Title", output)
+        self.assertNotIn("# Title", output)
+        self.assertIn("\033[1m\033[36m", output)
+
+    def test_live_markdown_rendering_emits_partial_paragraph_before_blank_line(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("This paragraph is still growing")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "This paragraph is still growing")
+
+    def test_live_markdown_rendering_styles_list_immediately(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("- item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("- item", output)
+        self.assertIn("\033[36m", output)
+
+    def test_live_markdown_rendering_emits_list_item_before_list_end(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("- first item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("- first item", output)
+        self.assertNotEqual(output, "")
+
+    def test_live_markdown_rendering_handles_split_list_marker(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("1")
+            renderer.write(". item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("1. item", output)
+        self.assertIn("\033[36m", output)
+
+    def test_live_markdown_rendering_styles_complete_inline_bold(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("The **first** item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("The ", output)
+        self.assertIn("\033[1mfirst\033[22m", output)
+        self.assertIn(" item", output)
+        self.assertNotIn("**first**", output)
+
+    def test_live_markdown_rendering_styles_line_start_inline_bold(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("**First** item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[1mFirst\033[22m", output)
+        self.assertIn(" item", output)
+        self.assertNotIn("**First**", output)
+
+    def test_live_markdown_rendering_handles_split_inline_bold(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("The **bo")
+            renderer.write("ld** word")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("The ", output)
+        self.assertIn("\033[1mbold\033[22m", output)
+        self.assertIn(" word", output)
+        self.assertNotIn("**bold**", output)
+
+    def test_live_markdown_rendering_preserves_incomplete_inline_bold(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("The **first item")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "The **first item")
+
+    def test_live_markdown_rendering_styles_complete_inline_italic(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("The *first* and _second_ item")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[3mfirst\033[23m", output)
+        self.assertIn("\033[3msecond\033[23m", output)
+        self.assertNotIn("*first*", output)
+        self.assertNotIn("_second_", output)
+
+    def test_live_markdown_rendering_handles_split_inline_italic(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("The *ita")
+            renderer.write("lic* word")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[3mitalic\033[23m", output)
+        self.assertIn(" word", output)
+
+    def test_live_markdown_rendering_does_not_style_snake_case_as_italic(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("use snake_case_name here")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "use snake_case_name here")
+
+    def test_live_markdown_rendering_does_not_hold_plain_asterisk_math(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("2 * 3 = 6")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "2 * 3 = 6")
+
+    def test_live_markdown_rendering_restores_heading_style_after_inline_bold(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("# A **bold** title")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[1mbold\033[0m\033[1m\033[36m", output)
+        self.assertIn(" title", output)
+
+    def test_live_markdown_rendering_shows_code_fence_before_close(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("```python\nprint('x')")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("print('x')", output)
+        self.assertNotIn("```python", output)
+        self.assertNotIn("python\n", output)
+        self.assertIn("\033[2m", output)
+
+    def test_live_markdown_rendering_handles_split_code_fence(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("`")
+            renderer.write("``python\nprint('x')")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("print('x')", output)
+        self.assertNotIn("```python", output)
+        self.assertNotIn("python\n", output)
+        self.assertIn("\033[2m", output)
+
+    def test_live_markdown_tables_fall_back_to_plain_text(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("| a | b |\n| - | - |\n")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "| a | b |\n| - | - |\n")
+
+    def test_live_markdown_falls_back_to_plain_text_on_renderer_error(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            with mock.patch.object(renderer._markdown_live, "write", side_effect=RuntimeError("boom")):
+                renderer.write("hello **world**")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "hello **world**")
 
     def test_thinking_mode_dims_reasoning_and_keeps_final_answer_normal(self) -> None:
         stream = io.StringIO()


### PR DESCRIPTION
Summary:
- Adds minimal live Markdown rendering for final answers while preserving immediate streaming.
- Makes live Markdown the default terminal mode with --no-render-markdown as opt-out.
- Keeps rendering out of thinking, tool events, progress, raw stdout/stderr, and debug/status output.
- Removes the block-rendering path and does not add rich or other dependencies.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_streaming tests.test_config tests.test_repl tests.test_cli -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Scope:
- terminal UX only
- no runtime/tool-loop/backend/native/MTP changes
- no workdir files included