### PR TITLE
Add compact directory listing tool

### DIFF
--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -12,6 +12,8 @@ from orbit.runtime.tool_arguments import parse_tool_arguments_or_empty
 SHELL_TOOL_ALIASES = {"exec_shell_full_command", "shell"}
 WEB_SEARCH_TOOL_ALIASES = {"orbit-web-search"}
 FETCH_URL_TOOL_ALIASES = {"fetch_url"}
+LIST_DIRECTORY_TOOL_ALIASES = {"list_directory"}
+LIST_DIRECTORY_KEYS = ("path", "recursive", "max_depth", "max_entries", "include_hidden", "dirs_first", "files_only", "dirs_only")
 
 
 class ToolRoute(StrEnum):
@@ -48,6 +50,8 @@ def parse_command_decision_from_tool_calls(tool_calls: list[dict[str, Any]]) -> 
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
         if name in FETCH_URL_TOOL_ALIASES and _has_url(args):
             return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
+        if name in LIST_DIRECTORY_TOOL_ALIASES and _has_list_directory_args(args):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
     return None
 
 
@@ -56,7 +60,7 @@ def command_tool_call_from_tool_calls(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory"} & allowed):
         return None
     for tool_call in tool_calls:
         function = tool_call.get("function")
@@ -80,6 +84,12 @@ def command_tool_call_from_tool_calls(
             if name == "fetch_url" and isinstance(raw_arguments, str):
                 return tool_call
             return _tool_call("fetch_url", {"url": args["url"]})
+        if name in LIST_DIRECTORY_TOOL_ALIASES and _has_list_directory_args(args):
+            if "list_directory" not in allowed:
+                return None
+            if name == "list_directory" and isinstance(raw_arguments, str):
+                return tool_call
+            return _tool_call("list_directory", _list_directory_args(args))
         if name in WEB_SEARCH_TOOL_ALIASES:
             command = _web_search_command_from_args(args)
             if command and "exec_shell_full_command" in allowed:
@@ -92,7 +102,7 @@ def command_tool_call_from_content(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory"} & allowed):
         return None
     raw_command = _extract_raw_tool_call_command(content)
     if raw_command:
@@ -104,10 +114,17 @@ def command_tool_call_from_content(
         if "fetch_url" not in allowed:
             return None
         return _tool_call("fetch_url", {"url": raw_url})
+    raw_listing = _extract_raw_tool_call_list_directory(content)
+    if raw_listing:
+        if "list_directory" not in allowed:
+            return None
+        return _tool_call("list_directory", raw_listing)
     value = _parse_command_json_object(content) or _extract_last_json_object(content) or _extract_loose_command_object(content)
     if not _has_command(value):
         if _has_url(value) and "fetch_url" in allowed:
             return _tool_call("fetch_url", {"url": value["url"]})
+        if _has_list_directory_args(value) and "list_directory" in allowed:
+            return _tool_call("list_directory", _list_directory_args(value))
         return None
     return _tool_call("exec_shell_full_command", {"command": value["command"]})
 
@@ -116,6 +133,12 @@ def parse_command_decision(content: str) -> RouteDecision | None:
     text = _strip_json_fence(content.strip())
     if not text:
         return None
+    if _extract_raw_tool_call_command(text):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
+    if _extract_raw_tool_call_url(text):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
+    if _extract_raw_tool_call_list_directory(text):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
     if _parse_raw_tool_call_decision(text) is not None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command", "fetch_url"))
     value = _parse_command_json_object(text)
@@ -123,6 +146,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     if _has_url(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
+    if _has_list_directory_args(value):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
     if _has_command(_extract_loose_command_object(text)):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     for line in text.splitlines():
@@ -131,6 +156,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
         if _has_url(value):
             return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
+        if _has_list_directory_args(value):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
     return None
 
 
@@ -143,13 +170,18 @@ def command_stream_state(text: str, *, max_prefix_chars: int = ROUTE_STREAM_PREF
         return "not_command"
     if not stripped:
         return "pending"
-    if _is_partial_prefix(stripped, "<|tool_call>") or _is_partial_prefix(stripped, '{"command"') or _is_partial_prefix(stripped, '{"url"'):
+    if (
+        _is_partial_prefix(stripped, "<|tool_call>")
+        or _is_partial_prefix(stripped, '{"command"')
+        or _is_partial_prefix(stripped, '{"url"')
+        or _is_partial_prefix(stripped, '{"path"')
+    ):
         return "pending"
     if stripped.startswith("<|tool_call>"):
         if "<tool_call|>" in stripped:
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
-    if stripped.startswith('{"command"') or stripped.startswith('{"url"'):
+    if stripped.startswith('{"command"') or stripped.startswith('{"url"') or stripped.startswith('{"path"'):
         if _looks_like_complete_json_object(stripped):
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
@@ -204,14 +236,14 @@ class CommandStreamFilter:
 def tool_names_for_decision(route: ToolRoute, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if route == ToolRoute.FILESYSTEM:
-        return ("exec_shell_full_command", "fetch_url")
+        return ("exec_shell_full_command", "fetch_url", "list_directory")
     return ()
 
 
 def decision_tool_names(decision: RouteDecision, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if decision.tool_names:
-        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url"})
+        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url", "list_directory"})
     return tool_names_for_decision(decision.route)
 
 
@@ -235,7 +267,9 @@ def _parse_raw_tool_call_decision(text: str) -> ToolRoute | None:
         return ToolRoute.FILESYSTEM
     if _extract_raw_tool_call_url(text):
         return ToolRoute.FILESYSTEM
-    if "exec_shell_full_command" in text or "call:shell" in text or "command" in text:
+    if _extract_raw_tool_call_list_directory(text):
+        return ToolRoute.FILESYSTEM
+    if "exec_shell_full_command" in text or "call:shell" in text or "command" in text or "list_directory" in text:
         return ToolRoute.FILESYSTEM
     return None
 
@@ -278,6 +312,25 @@ def _extract_raw_tool_call_url(content: str) -> str | None:
     return None
 
 
+def _extract_raw_tool_call_list_directory(content: str) -> dict[str, Any] | None:
+    text = content.replace('<|"|>', '"')
+    match = re.search(
+        r"<\|tool_call\>\s*call:(?P<name>[A-Za-z0-9_-]+)\s*(?P<args>\{.*?\})\s*<tool_call\|>",
+        text,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return None
+    name = match.group("name")
+    if name not in LIST_DIRECTORY_TOOL_ALIASES:
+        return None
+    raw_args = match.group("args")
+    value = _parse_command_json_object(raw_args) or _extract_last_json_object(raw_args) or _extract_loose_key_value_object(raw_args)
+    if _has_list_directory_args(value):
+        return _list_directory_args(value)
+    return None
+
+
 def _web_search_command_from_args(value: dict[str, Any] | None) -> str | None:
     if not isinstance(value, dict):
         return None
@@ -285,6 +338,20 @@ def _web_search_command_from_args(value: dict[str, Any] | None) -> str | None:
     if not isinstance(query, str) or not query.strip():
         return None
     return f"orbit-web-search {shlex.quote(query.strip())}"
+
+
+def _has_list_directory_args(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict) or _has_command(value) or _has_url(value):
+        return False
+    if not any(key in value for key in LIST_DIRECTORY_KEYS):
+        return False
+    if "path" in value and not isinstance(value.get("path"), str):
+        return False
+    return True
+
+
+def _list_directory_args(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: value[key] for key in LIST_DIRECTORY_KEYS if key in value}
 
 
 def _extract_loose_key_value_object(content: str) -> dict[str, Any] | None:

--- a/src/orbit/runtime/directory_listing.py
+++ b/src/orbit/runtime/directory_listing.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MAX_ENTRIES = 200
+DEFAULT_RECURSIVE_MAX_DEPTH = 2
+MAX_ENTRIES_LIMIT = 1000
+MAX_DEPTH_LIMIT = 20
+
+
+def list_directory_definition() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "list_directory",
+            "description": (
+                "Return a compact, structured directory listing. Use this for directory/file listing requests "
+                "instead of noisy shell commands like ls -R, find, or tree. This tool does not read file contents."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory path to list, relative to the current workdir unless absolute.",
+                        "default": ".",
+                    },
+                    "recursive": {
+                        "type": "boolean",
+                        "description": "Whether to list nested entries.",
+                        "default": False,
+                    },
+                    "max_depth": {
+                        "type": ["integer", "null"],
+                        "description": "Maximum recursive depth. Defaults to 2 when recursive is true.",
+                        "default": None,
+                    },
+                    "max_entries": {
+                        "type": "integer",
+                        "description": "Maximum entries to return before truncating.",
+                        "default": DEFAULT_MAX_ENTRIES,
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include dotfiles and dot-directories.",
+                        "default": False,
+                    },
+                    "dirs_first": {
+                        "type": "boolean",
+                        "description": "Sort directories before files at each level.",
+                        "default": True,
+                    },
+                    "files_only": {
+                        "type": "boolean",
+                        "description": "Return only files.",
+                        "default": False,
+                    },
+                    "dirs_only": {
+                        "type": "boolean",
+                        "description": "Return only directories.",
+                        "default": False,
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def execute_list_directory(arguments: dict[str, Any], *, workdir: Path) -> str:
+    path = _string_arg(arguments.get("path"), default=".")
+    recursive = _bool_arg(arguments.get("recursive"), default=False)
+    max_depth = _max_depth_arg(arguments.get("max_depth"), recursive=recursive)
+    max_entries = _int_arg(arguments.get("max_entries"), default=DEFAULT_MAX_ENTRIES, minimum=1, maximum=MAX_ENTRIES_LIMIT)
+    include_hidden = _bool_arg(arguments.get("include_hidden"), default=False)
+    dirs_first = _bool_arg(arguments.get("dirs_first"), default=True)
+    files_only = _bool_arg(arguments.get("files_only"), default=False)
+    dirs_only = _bool_arg(arguments.get("dirs_only"), default=False)
+    if files_only and dirs_only:
+        return _error_result(path=path, status="invalid_arguments", message="files_only and dirs_only cannot both be true")
+
+    root = workdir.resolve()
+    target = _resolve_target(path, root=root)
+    if target is None:
+        return _error_result(path=path, status="path_outside_workdir", message="path is outside the current workdir")
+    if not target.exists():
+        return _error_result(path=path, status="not_found", message="path does not exist")
+    if not target.is_dir():
+        return _error_result(path=path, status="not_directory", message="path is not a directory")
+
+    entries: list[str] = []
+    total_seen = 0
+    truncated = False
+    for entry in _iter_entries(
+        target,
+        root=root,
+        recursive=recursive,
+        max_depth=max_depth,
+        include_hidden=include_hidden,
+        dirs_first=dirs_first,
+        files_only=files_only,
+        dirs_only=dirs_only,
+    ):
+        total_seen += 1
+        if len(entries) >= max_entries:
+            truncated = True
+            continue
+        entries.append(entry)
+
+    rel_path = _display_path(target, root=root)
+    lines = [
+        (
+            f"directory_listing: path={rel_path} recursive={_bool_text(recursive)} "
+            f"max_depth={max_depth if recursive else 'null'} shown={len(entries)} "
+            f"total_seen={total_seen} truncated={_bool_text(truncated)}"
+        )
+    ]
+    lines.extend(entries)
+    return "\n".join(lines)
+
+
+def _iter_entries(
+    directory: Path,
+    *,
+    root: Path,
+    recursive: bool,
+    max_depth: int,
+    include_hidden: bool,
+    dirs_first: bool,
+    files_only: bool,
+    dirs_only: bool,
+):
+    def walk(current: Path, depth: int):
+        children = _sorted_children(current, dirs_first=dirs_first)
+        for child in children:
+            if not include_hidden and child.name.startswith("."):
+                continue
+            entry_type = _entry_type(child)
+            include = not ((files_only and entry_type != "file") or (dirs_only and entry_type != "dir"))
+            if include:
+                yield _format_entry(child, root=root, entry_type=entry_type)
+            if recursive and depth < max_depth and entry_type == "dir" and not child.is_symlink():
+                yield from walk(child, depth + 1)
+
+    yield from walk(directory, 1)
+
+
+def _sorted_children(path: Path, *, dirs_first: bool) -> list[Path]:
+    try:
+        children = list(path.iterdir())
+    except OSError:
+        return []
+    return sorted(children, key=lambda item: (_type_sort(item, dirs_first=dirs_first), item.name.lower(), item.name))
+
+
+def _type_sort(path: Path, *, dirs_first: bool) -> int:
+    if not dirs_first:
+        return 0
+    return 0 if path.is_dir() and not path.is_symlink() else 1
+
+
+def _format_entry(path: Path, *, root: Path, entry_type: str) -> str:
+    rel = _display_path(path, root=root)
+    suffix = "/" if entry_type == "dir" and not rel.endswith("/") else ""
+    line = f"[{entry_type}] {rel}{suffix}"
+    if entry_type == "symlink":
+        try:
+            target = os.readlink(path)
+        except OSError:
+            target = "unreadable"
+        line += f" -> {target}"
+    elif entry_type == "file":
+        try:
+            line += f" ({path.stat().st_size} B)"
+        except OSError:
+            pass
+    return line
+
+
+def _entry_type(path: Path) -> str:
+    if path.is_symlink():
+        return "symlink"
+    if path.is_dir():
+        return "dir"
+    if path.is_file():
+        return "file"
+    return "other"
+
+
+def _resolve_target(path: str, *, root: Path) -> Path | None:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return None
+    return resolved
+
+
+def _display_path(path: Path, *, root: Path) -> str:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        try:
+            rel = path.resolve(strict=False).relative_to(root)
+        except ValueError:
+            return str(path)
+    value = rel.as_posix()
+    return "." if value == "." else value
+
+
+def _error_result(*, path: str, status: str, message: str) -> str:
+    return f"directory_listing: error=true status={status} path={path}\nerror: {message}"
+
+
+def _string_arg(value: object, *, default: str) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else default
+
+
+def _bool_arg(value: object, *, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def _int_arg(value: object, *, default: int, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _max_depth_arg(value: object, *, recursive: bool) -> int:
+    if not recursive:
+        return 1
+    return _int_arg(value, default=DEFAULT_RECURSIVE_MAX_DEPTH, minimum=1, maximum=MAX_DEPTH_LIMIT)
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -29,13 +29,17 @@ CHAT_SYSTEM_PROMPT = "Answer normally for conversation, explanation, writing, op
 MEDIA_SYSTEM_PROMPT = "Answer using the attached image/audio."
 _COMMAND_SYSTEM_TEMPLATE = """Answer normally unless shell is needed.
 Shell tasks: files/edit/create/append/delete, system, URLs/web/search/fetch, execution, analysis.
-Return valid one-line JSON only:
+Return valid one-line JSON only.
 
+For shell:
 {{"command":"..."}}
+
+For compact directory listing:
+{{"path":".","recursive":false}}
 
 Environment: OS={os_name}; shell={shell_name}.
 
-Use given paths exactly. Use native commands in workdir. Generic web search: orbit-web-search "query". For explicit URL fetch/read/explain/summarize/analyze requests, prefer the fetch_url tool; shell fetch commands such as curl are still allowed when needed. Quote spaced paths.
+Use given paths exactly. Use native commands in workdir. For compact directory listings, prefer the list_directory JSON shape over shell commands like ls -R, find, or tree. Generic web search: orbit-web-search "query". For explicit URL fetch/read/explain/summarize/analyze requests, prefer the fetch_url tool; shell fetch commands such as curl are still allowed when needed. Quote spaced paths.
 
 Do not claim no access for local/system/web.
 Never use <|tool_call>, call:shell, markdown, fences, or prose for shell.
@@ -47,6 +51,7 @@ For analysis, prefer content, source, binaries, strings, logs, archives, or fetc
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())
 TOOL_CALL_SYSTEM_PROMPT = (
     "Call exactly one available tool and output no prose. "
+    "Prefer list_directory for compact directory listings. "
     "Prefer fetch_url for explicit URL fetch/read/explain/summarize/analyze requests. "
     'Use orbit-web-search "query" for generic web search. '
     "Use exec_shell_full_command for local/system tasks or when another tool is more appropriate. "

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -52,7 +52,7 @@ class HybridToolExecutor:
     ) -> ToolExecution:
         if name not in self.allowed_tool_names:
             return ToolExecution(ToolResult(name=name, content=f"error: tool not available for this turn: {name}"), "orbit")
-        if name not in {"exec_shell_full_command", "fetch_url"}:
+        if name not in {"exec_shell_full_command", "fetch_url", "list_directory"}:
             return ToolExecution(ToolResult(name=name, content=f"error: unknown tool: {name}"), "orbit")
         parsed = parse_tool_arguments(arguments)
         if isinstance(parsed, str):

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from orbit.runtime.directory_listing import execute_list_directory, list_directory_definition
 from orbit.runtime.shell_guardrails import exec_shell_full_definition, execute_exec_shell_full_command
 from orbit.runtime.tool_arguments import parse_tool_arguments
 from orbit.runtime.web import execute_fetch_url, fetch_url_definition
@@ -15,7 +16,7 @@ class ToolResult:
     content: str
 
 
-TOOL_NAMES = ("exec_shell_full_command", "fetch_url")
+TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory")
 DEFAULT_TOOL_NAMES = TOOL_NAMES
 
 
@@ -28,7 +29,7 @@ def default_tool_names() -> tuple[str, ...]:
 
 
 def tool_definitions(names: tuple[str, ...] | None = None) -> list[dict[str, Any]]:
-    definitions = [exec_shell_full_definition(), fetch_url_definition()]
+    definitions = [exec_shell_full_definition(), fetch_url_definition(), list_directory_definition()]
     if names is None:
         return definitions
     allowed = set(names)
@@ -51,4 +52,6 @@ def execute_tool(
         return ToolResult(name=name, content=parsed)
     if name == "fetch_url":
         return ToolResult(name=name, content=execute_fetch_url(parsed))
+    if name == "list_directory":
+        return ToolResult(name=name, content=execute_list_directory(parsed, workdir=workdir))
     return ToolResult(name=name, content=execute_exec_shell_full_command(parsed, workdir=workdir, user_prompt=user_prompt))

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -13,6 +13,7 @@ COMMAND_PREVIEW_LIMIT = 96
 DISPLAY_TOOL_NAMES = {
     "exec_shell_full_command": "exec",
     "fetch_url": "fetch_url",
+    "list_directory": "list_directory",
 }
 
 
@@ -29,6 +30,11 @@ def format_tool_call_event(name: str, args: str) -> str:
         url = _url_from_args(args)
         if url:
             return f"Fetch: {_truncate_inline(url, limit=COMMAND_PREVIEW_LIMIT)}"
+    if name == "list_directory":
+        path, recursive = _list_directory_from_args(args)
+        if path:
+            suffix = " recursive" if recursive else ""
+            return f"ListDir{suffix}: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
     return f"{display_tool_name(name)} {args}"
 
 
@@ -69,6 +75,18 @@ def _url_from_args(args: str) -> str | None:
         if isinstance(url, str) and url.strip():
             return url.strip()
     return None
+
+
+def _list_directory_from_args(args: str) -> tuple[str | None, bool]:
+    try:
+        parsed = json.loads(args)
+    except Exception:
+        return None, False
+    if isinstance(parsed, dict):
+        path = parsed.get("path")
+        recursive = parsed.get("recursive")
+        return (path if isinstance(path, str) and path.strip() else ".", bool(recursive) if isinstance(recursive, bool) else False)
+    return None, False
 
 
 def _format_shell_command_call(command: str) -> str:
@@ -136,6 +154,12 @@ def _tool_result_preview(content: str | None) -> str | None:
             return f"{status or 'fetch'}: {error}"
         if status and status != "null":
             return status
+    if content.startswith("directory_listing:"):
+        if "error=true" in content:
+            status = _metadata_inline_value(content, "status")
+            return f"directory listing {status or 'error'}"
+        preview = _lines_preview(content)
+        return preview or "directory listing"
     path = _metadata_value(content, "path")
     if "shell_output_pdf_text: true" in content:
         preview = _body_preview(content, marker="content:")
@@ -177,6 +201,12 @@ def _metadata_value(content: str, key: str) -> str | None:
     return value or None
 
 
+def _metadata_inline_value(content: str, key: str) -> str | None:
+    first = content.splitlines()[0] if content else ""
+    match = re.search(rf"\b{re.escape(key)}=([^\s]+)", first)
+    return match.group(1) if match else None
+
+
 def _body_preview(content: str, *, marker: str) -> str | None:
     if f"{marker}\n" not in content:
         return None
@@ -190,7 +220,7 @@ def _lines_preview(content: str) -> str | None:
         line = raw.strip()
         if not line:
             continue
-        if line.startswith(("shell_output_", "path:", "extractor:", "chunk_index:", "total_chunks:", "chars:", "large_file_excerpt:", "url_fetch:", "url:", "final_url:", "http_status:", "content_type:", "encoding:", "title:", "text_truncated:", "status:", "error:")):
+        if line.startswith(("shell_output_", "path:", "extractor:", "chunk_index:", "total_chunks:", "chars:", "large_file_excerpt:", "url_fetch:", "url:", "final_url:", "http_status:", "content_type:", "encoding:", "title:", "text_truncated:", "status:", "directory_listing:", "error:")):
             continue
         if line == "[truncated]":
             continue

--- a/src/orbit/terminal/tool_mode.py
+++ b/src/orbit/terminal/tool_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 ToolSpec = str
 
-DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url")
+DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory")
 
 SPECIAL_TOOL_SPECS = ("off", "on")
 USAGE = "off|on"

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -48,6 +48,16 @@ class RouteRequestTests(unittest.TestCase):
     def test_parse_tool_command_accepts_raw_fetch_url_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call:fetch_url{"url":"https://example.com"}<tool_call|>'), ToolRoute.FILESYSTEM)
 
+    def test_parse_tool_command_accepts_raw_list_directory_tool_call(self) -> None:
+        self.assertEqual(parse_tool_command('<|tool_call>call:list_directory{"path":".","recursive":true}<tool_call|>'), ToolRoute.FILESYSTEM)
+
+    def test_parse_command_decision_keeps_raw_list_directory_tool_scope(self) -> None:
+        decision = parse_command_decision('<|tool_call>call:list_directory{"path":".","recursive":true}<tool_call|>')
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision_tool_names(decision), ("list_directory",))
+
     def test_parse_tool_command_accepts_parenthesized_shell_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>'), ToolRoute.FILESYSTEM)
 
@@ -83,6 +93,22 @@ class RouteRequestTests(unittest.TestCase):
         self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
         self.assertEqual(decision_tool_names(decision), ("fetch_url",))
 
+    def test_parse_command_decision_from_tool_calls_accepts_list_directory_arguments(self) -> None:
+        decision = parse_command_decision_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "list_directory", "arguments": '{"path":".","recursive":true}'},
+                }
+            ]
+        )
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
+        self.assertEqual(decision_tool_names(decision), ("list_directory",))
+
     def test_command_tool_call_from_content_uses_shell_command_json(self) -> None:
         tool_call = command_tool_call_from_content('{"command":"ls -F"}', ("exec_shell_full_command",))
 
@@ -98,6 +124,14 @@ class RouteRequestTests(unittest.TestCase):
         assert tool_call is not None
         self.assertEqual(tool_call["function"]["name"], "fetch_url")
         self.assertEqual(tool_call["function"]["arguments"], '{"url": "https://example.com"}')
+
+    def test_command_tool_call_from_content_uses_list_directory_json(self) -> None:
+        tool_call = command_tool_call_from_content('{"path": ".", "recursive": true}', ("exec_shell_full_command", "list_directory"))
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "list_directory")
+        self.assertEqual(json.loads(tool_call["function"]["arguments"]), {"path": ".", "recursive": True})
 
     def test_command_tool_call_from_content_converts_raw_orbit_web_search(self) -> None:
         tool_call = command_tool_call_from_content(
@@ -233,6 +267,23 @@ EOF"}"""
         self.assertEqual(tool_call["function"]["name"], "fetch_url")
         self.assertEqual(tool_call["function"]["arguments"], '{"url":"https://example.com"}')
 
+    def test_command_tool_call_from_tool_calls_keeps_list_directory_tool_call(self) -> None:
+        tool_call = command_tool_call_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "list_directory", "arguments": '{"path":".","recursive":true}'},
+                }
+            ],
+            ("exec_shell_full_command", "list_directory"),
+        )
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "list_directory")
+        self.assertEqual(tool_call["function"]["arguments"], '{"path":".","recursive":true}')
+
     def test_command_tool_call_from_tool_calls_accepts_shell_alias(self) -> None:
         tool_call = command_tool_call_from_tool_calls(
             [
@@ -305,7 +356,7 @@ EOF"}""",
         self.assertIsNone(tool_call)
 
     def test_tool_names_for_decision_are_bounded(self) -> None:
-        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url"))
+        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url", "list_directory"))
         self.assertEqual(tool_names_for_decision(ToolRoute.FILE_EDIT), ())
         self.assertEqual(tool_names_for_decision(ToolRoute.WEB), ())
 
@@ -316,6 +367,10 @@ EOF"}""",
         self.assertEqual(command_stream_state('{"command":"ls -F"'), "pending")
         self.assertEqual(command_stream_state("Hello"), "not_command")
         self.assertEqual(command_stream_state('{"tool":"hammer"}'), "not_command")
+
+    def test_command_stream_state_detects_complete_list_directory_json(self) -> None:
+        self.assertEqual(command_stream_state('{"path":".","recursive":true}'), "route")
+        self.assertEqual(command_stream_state('{"path"'), "pending")
 
     def test_command_stream_filter_suppresses_command_json(self) -> None:
         emitted: list[str] = []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,7 +66,7 @@ class CommandTests(unittest.TestCase):
         self.assertIn("Model\n-------", status)
         self.assertIn("tools_mode: n/a", status)
         self.assertIn("thinking_mode: off", status)
-        self.assertIn("model_tools: exec_shell_full_command, fetch_url", status)
+        self.assertIn("model_tools: exec_shell_full_command, fetch_url, list_directory", status)
         self.assertIn("memory_refresh_threshold: 6963/8192", status)
         self.assertIn("memory_refreshes: 0", status)
         self.assertIn("last_refresh_outcome: none", status)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,10 +130,10 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "tools"):
             load_app_config(_parse("--tools", "browser"))
 
-    def test_tools_on_uses_shell_and_fetch_url(self) -> None:
+    def test_tools_on_uses_shell_fetch_url_and_list_directory(self) -> None:
         names = allowed_tool_names_for_spec("on")
 
-        self.assertEqual(names, ("exec_shell_full_command", "fetch_url"))
+        self.assertEqual(names, ("exec_shell_full_command", "fetch_url", "list_directory"))
 
     def test_legacy_tools_object_config_key_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_directory_listing.py
+++ b/tests/test_directory_listing.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.directory_listing import execute_list_directory
+
+
+class DirectoryListingTests(unittest.TestCase):
+    def test_non_recursive_listing_is_compact_and_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "b.txt").write_text("b", encoding="utf-8")
+            (root / "a").mkdir()
+            (root / "a" / "nested.txt").write_text("nested", encoding="utf-8")
+
+            result = execute_list_directory({"path": "."}, workdir=root)
+
+        self.assertIn("directory_listing: path=. recursive=false", result)
+        self.assertIn("[dir] a/", result)
+        self.assertIn("[file] b.txt", result)
+        self.assertNotIn("nested.txt", result)
+        self.assertLess(result.index("[dir] a/"), result.index("[file] b.txt"))
+
+    def test_recursive_listing_honors_max_depth(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a" / "b").mkdir(parents=True)
+            (root / "a" / "one.txt").write_text("1", encoding="utf-8")
+            (root / "a" / "b" / "two.txt").write_text("2", encoding="utf-8")
+
+            result = execute_list_directory({"path": ".", "recursive": True, "max_depth": 2}, workdir=root)
+
+        self.assertIn("[dir] a/", result)
+        self.assertIn("[dir] a/b/", result)
+        self.assertIn("[file] a/one.txt", result)
+        self.assertNotIn("two.txt", result)
+
+    def test_max_entries_truncates_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for index in range(5):
+                (root / f"{index}.txt").write_text(str(index), encoding="utf-8")
+
+            result = execute_list_directory({"path": ".", "max_entries": 2}, workdir=root)
+
+        self.assertIn("shown=2", result)
+        self.assertIn("total_seen=5", result)
+        self.assertIn("truncated=true", result)
+
+    def test_hidden_entries_are_excluded_by_default_and_included_on_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".secret").write_text("hidden", encoding="utf-8")
+            (root / "shown.txt").write_text("shown", encoding="utf-8")
+
+            default = execute_list_directory({"path": "."}, workdir=root)
+            hidden = execute_list_directory({"path": ".", "include_hidden": True}, workdir=root)
+
+        self.assertIn("shown.txt", default)
+        self.assertNotIn(".secret", default)
+        self.assertIn(".secret", hidden)
+
+    def test_files_only_and_dirs_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "dir").mkdir()
+            (root / "file.txt").write_text("x", encoding="utf-8")
+
+            files = execute_list_directory({"path": ".", "files_only": True}, workdir=root)
+            dirs = execute_list_directory({"path": ".", "dirs_only": True}, workdir=root)
+
+        self.assertIn("[file] file.txt", files)
+        self.assertNotIn("[dir] dir/", files)
+        self.assertIn("[dir] dir/", dirs)
+        self.assertNotIn("[file] file.txt", dirs)
+
+    def test_symlink_is_listed_without_recursive_follow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "target").mkdir()
+            (root / "target" / "inside.txt").write_text("x", encoding="utf-8")
+            (root / "link").symlink_to(root / "target", target_is_directory=True)
+
+            result = execute_list_directory({"path": ".", "recursive": True, "max_depth": 3}, workdir=root)
+
+        self.assertIn("[symlink] link ->", result)
+        self.assertIn("[file] target/inside.txt", result)
+        self.assertNotIn("link/inside.txt", result)
+
+    def test_missing_and_non_directory_paths_are_structured_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "file.txt").write_text("x", encoding="utf-8")
+
+            missing = execute_list_directory({"path": "missing"}, workdir=root)
+            file_path = execute_list_directory({"path": "file.txt"}, workdir=root)
+
+        self.assertIn("error=true status=not_found", missing)
+        self.assertIn("error=true status=not_directory", file_path)
+
+    def test_outside_workdir_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = execute_list_directory({"path": ".."}, workdir=Path(tmp))
+
+        self.assertIn("error=true status=path_outside_workdir", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -601,7 +601,7 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.ask_auto_calls, 1)
         self.assertEqual(runtime.ask_chat_calls, 0)
         self.assertIsNotNone(runtime.last_allowed_tool_names)
-        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url"))
+        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url", "list_directory"))
 
     def test_repl_reads_queued_prompt_before_new_input(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,15 +16,16 @@ from orbit.runtime.tools import default_tool_names, execute_tool, tool_definitio
 
 class ToolTests(unittest.TestCase):
     def test_shell_and_fetch_url_are_exposed(self) -> None:
-        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url"))
-        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url"))
+        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory"))
+        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory"))
         definitions = tool_definitions()
-        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url"])
+        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url", "list_directory"])
 
     def test_tool_definitions_respect_allowed_names(self) -> None:
         self.assertEqual(tool_definitions(("read_file",)), [])
         self.assertEqual(len(tool_definitions(("exec_shell_full_command",))), 1)
         self.assertEqual(len(tool_definitions(("fetch_url",))), 1)
+        self.assertEqual(len(tool_definitions(("list_directory",))), 1)
 
     def test_unknown_tool_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -78,6 +79,16 @@ class ToolTests(unittest.TestCase):
         self.assertIn("url_fetch: true", result.content)
         self.assertIn("status: ok", result.content)
         self.assertIn("title: Example", result.content)
+
+    def test_list_directory_runs_with_compact_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "README.md").write_text("hello", encoding="utf-8")
+
+            result = execute_tool("list_directory", {"path": "."}, workdir=root)
+
+        self.assertIn("directory_listing:", result.content)
+        self.assertIn("[file] README.md", result.content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Adds an explicit model-facing list_directory tool for compact, stable directory listings.
- Keeps exec_shell_full_command available and does not auto-route or replace shell commands deterministically.
- Produces bounded structured listing evidence with stable ordering, depth, hidden-file, file/dir-only, and truncation controls.
- Updates tool routing prompts and terminal tool event previews so models can choose list_directory for listing tasks.
- Does not read file contents or construct final answers in runtime.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_tool_backends tests.test_tool_loop_state tests.test_repl tests.test_cli -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Smoke:
- tools on + list files in workdir: PASS, model used ListDir: ., compact 203-char tool result.
- tools on + list files recursively in workdir: PASS, model used ListDir recursive: ., compact 524-char tool result.
- tools on + read README.md and explain it: PASS, model used content evidence via cat README.md, not directory metadata.

Notes:
- Runtime remains model-guided; list_directory is available when tools are on, but the model chooses whether to call it.
- Ignored local PDF fixtures used for tests are not included.