### PR TITLE
Add compact system info tool

### DIFF
--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -14,6 +14,8 @@ WEB_SEARCH_TOOL_ALIASES = {"orbit-web-search"}
 FETCH_URL_TOOL_ALIASES = {"fetch_url"}
 LIST_DIRECTORY_TOOL_ALIASES = {"list_directory"}
 LIST_DIRECTORY_KEYS = ("path", "recursive", "max_depth", "max_entries", "include_hidden", "dirs_first", "files_only", "dirs_only")
+SYSTEM_INFO_TOOL_ALIASES = {"system_info"}
+SYSTEM_INFO_KEYS = ("include_disks", "include_cpu", "include_memory", "include_os", "include_runtime", "include_gpu", "human_readable")
 
 
 class ToolRoute(StrEnum):
@@ -52,6 +54,8 @@ def parse_command_decision_from_tool_calls(tool_calls: list[dict[str, Any]]) -> 
             return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
         if name in LIST_DIRECTORY_TOOL_ALIASES and _has_list_directory_args(args):
             return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
+        if name in SYSTEM_INFO_TOOL_ALIASES and _valid_system_info_args(args):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
     return None
 
 
@@ -60,7 +64,7 @@ def command_tool_call_from_tool_calls(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url", "list_directory"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info"} & allowed):
         return None
     for tool_call in tool_calls:
         function = tool_call.get("function")
@@ -90,6 +94,12 @@ def command_tool_call_from_tool_calls(
             if name == "list_directory" and isinstance(raw_arguments, str):
                 return tool_call
             return _tool_call("list_directory", _list_directory_args(args))
+        if name in SYSTEM_INFO_TOOL_ALIASES and _valid_system_info_args(args):
+            if "system_info" not in allowed:
+                return None
+            if name == "system_info" and isinstance(raw_arguments, str):
+                return tool_call
+            return _tool_call("system_info", _system_info_args(args))
         if name in WEB_SEARCH_TOOL_ALIASES:
             command = _web_search_command_from_args(args)
             if command and "exec_shell_full_command" in allowed:
@@ -102,7 +112,7 @@ def command_tool_call_from_content(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url", "list_directory"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info"} & allowed):
         return None
     raw_command = _extract_raw_tool_call_command(content)
     if raw_command:
@@ -119,12 +129,19 @@ def command_tool_call_from_content(
         if "list_directory" not in allowed:
             return None
         return _tool_call("list_directory", raw_listing)
+    raw_system_info = _extract_raw_tool_call_system_info(content)
+    if raw_system_info is not None:
+        if "system_info" not in allowed:
+            return None
+        return _tool_call("system_info", raw_system_info)
     value = _parse_command_json_object(content) or _extract_last_json_object(content) or _extract_loose_command_object(content)
     if not _has_command(value):
         if _has_url(value) and "fetch_url" in allowed:
             return _tool_call("fetch_url", {"url": value["url"]})
         if _has_list_directory_args(value) and "list_directory" in allowed:
             return _tool_call("list_directory", _list_directory_args(value))
+        if _has_system_info_args(value) and "system_info" in allowed:
+            return _tool_call("system_info", _system_info_args(value))
         return None
     return _tool_call("exec_shell_full_command", {"command": value["command"]})
 
@@ -139,8 +156,10 @@ def parse_command_decision(content: str) -> RouteDecision | None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
     if _extract_raw_tool_call_list_directory(text):
         return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
+    if _extract_raw_tool_call_system_info(text) is not None:
+        return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
     if _parse_raw_tool_call_decision(text) is not None:
-        return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command", "fetch_url"))
+        return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
     value = _parse_command_json_object(text)
     if _has_command(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
@@ -148,6 +167,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
     if _has_list_directory_args(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
+    if _has_system_info_args(value):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
     if _has_command(_extract_loose_command_object(text)):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     for line in text.splitlines():
@@ -158,6 +179,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
             return RouteDecision(ToolRoute.FILESYSTEM, ("fetch_url",))
         if _has_list_directory_args(value):
             return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
+        if _has_system_info_args(value):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
     return None
 
 
@@ -175,13 +198,14 @@ def command_stream_state(text: str, *, max_prefix_chars: int = ROUTE_STREAM_PREF
         or _is_partial_prefix(stripped, '{"command"')
         or _is_partial_prefix(stripped, '{"url"')
         or _is_partial_prefix(stripped, '{"path"')
+        or _is_partial_prefix(stripped, '{"include_')
     ):
         return "pending"
     if stripped.startswith("<|tool_call>"):
         if "<tool_call|>" in stripped:
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
-    if stripped.startswith('{"command"') or stripped.startswith('{"url"') or stripped.startswith('{"path"'):
+    if stripped.startswith('{"command"') or stripped.startswith('{"url"') or stripped.startswith('{"path"') or stripped.startswith('{"include_'):
         if _looks_like_complete_json_object(stripped):
             return "route" if parse_tool_command(stripped) is not None else "not_command"
         return "pending"
@@ -236,14 +260,14 @@ class CommandStreamFilter:
 def tool_names_for_decision(route: ToolRoute, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if route == ToolRoute.FILESYSTEM:
-        return ("exec_shell_full_command", "fetch_url", "list_directory")
+        return ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
     return ()
 
 
 def decision_tool_names(decision: RouteDecision, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if decision.tool_names:
-        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url", "list_directory"})
+        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url", "list_directory", "system_info"})
     return tool_names_for_decision(decision.route)
 
 
@@ -269,7 +293,9 @@ def _parse_raw_tool_call_decision(text: str) -> ToolRoute | None:
         return ToolRoute.FILESYSTEM
     if _extract_raw_tool_call_list_directory(text):
         return ToolRoute.FILESYSTEM
-    if "exec_shell_full_command" in text or "call:shell" in text or "command" in text or "list_directory" in text:
+    if _extract_raw_tool_call_system_info(text) is not None:
+        return ToolRoute.FILESYSTEM
+    if "exec_shell_full_command" in text or "call:shell" in text or "command" in text or "list_directory" in text or "system_info" in text:
         return ToolRoute.FILESYSTEM
     return None
 
@@ -331,6 +357,27 @@ def _extract_raw_tool_call_list_directory(content: str) -> dict[str, Any] | None
     return None
 
 
+def _extract_raw_tool_call_system_info(content: str) -> dict[str, Any] | None:
+    text = content.replace('<|"|>', '"')
+    match = re.search(
+        r"<\|tool_call\>\s*call:(?P<name>[A-Za-z0-9_-]+)\s*(?P<args>\{.*?\})\s*<tool_call\|>",
+        text,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return None
+    name = match.group("name")
+    if name not in SYSTEM_INFO_TOOL_ALIASES:
+        return None
+    raw_args = match.group("args")
+    value = _parse_command_json_object(raw_args)
+    if value is None:
+        value = _extract_last_json_object(raw_args) or _extract_loose_key_value_object(raw_args)
+    if _valid_system_info_args(value):
+        return _system_info_args(value)
+    return None
+
+
 def _web_search_command_from_args(value: dict[str, Any] | None) -> str | None:
     if not isinstance(value, dict):
         return None
@@ -352,6 +399,24 @@ def _has_list_directory_args(value: dict[str, Any] | None) -> bool:
 
 def _list_directory_args(value: dict[str, Any]) -> dict[str, Any]:
     return {key: value[key] for key in LIST_DIRECTORY_KEYS if key in value}
+
+
+def _has_system_info_args(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict) or _has_command(value) or _has_url(value) or _has_list_directory_args(value):
+        return False
+    if not any(key in value for key in SYSTEM_INFO_KEYS):
+        return False
+    return _valid_system_info_args(value)
+
+
+def _valid_system_info_args(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return all(key in SYSTEM_INFO_KEYS and isinstance(arg, bool) for key, arg in value.items())
+
+
+def _system_info_args(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: value[key] for key in SYSTEM_INFO_KEYS if key in value}
 
 
 def _extract_loose_key_value_object(content: str) -> dict[str, Any] | None:

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -37,21 +37,25 @@ For shell:
 For compact directory listing:
 {{"path":".","recursive":false}}
 
+For compact local machine specs:
+{{"include_cpu":true,"include_memory":true,"include_disks":true,"include_os":true}}
+
 Environment: OS={os_name}; shell={shell_name}.
 
-Use given paths exactly. Use native commands in workdir. For compact directory listings, prefer the list_directory JSON shape over shell commands like ls -R, find, or tree. Generic web search: orbit-web-search "query". For explicit URL fetch/read/explain/summarize/analyze requests, prefer the fetch_url tool; shell fetch commands such as curl are still allowed when needed. Quote spaced paths.
+Use given paths exactly. Use native commands in workdir. For compact directory listings, prefer the list_directory JSON shape over shell commands like ls -R, find, or tree. For local machine specs, prefer the system_info JSON shape over noisy shell commands like lscpu, free, df, uname, or cat /proc/*. Generic web search: orbit-web-search "query". For explicit URL fetch/read/explain/summarize/analyze requests, prefer the fetch_url tool; shell fetch commands such as curl are still allowed when needed. Quote spaced paths.
 
 Do not claim no access for local/system/web.
 Never use <|tool_call>, call:shell, markdown, fences, or prose for shell.
 
 Example:
-specs of this computer -> {{"command":"uname -a; lscpu; free -h; df -h"}}
+specs of this computer -> {{"include_cpu":true,"include_memory":true,"include_disks":true,"include_os":true}}
 
 For analysis, prefer content, source, binaries, strings, logs, archives, or fetched data, not metadata."""
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())
 TOOL_CALL_SYSTEM_PROMPT = (
     "Call exactly one available tool and output no prose. "
     "Prefer list_directory for compact directory listings. "
+    "Prefer system_info for compact local machine specs such as OS, CPU, RAM, disk, and Python runtime. "
     "Prefer fetch_url for explicit URL fetch/read/explain/summarize/analyze requests. "
     'Use orbit-web-search "query" for generic web search. '
     "Use exec_shell_full_command for local/system tasks or when another tool is more appropriate. "

--- a/src/orbit/runtime/system_info.py
+++ b/src/orbit/runtime/system_info.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def system_info_definition() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "system_info",
+            "description": (
+                "Return compact local machine specifications such as OS, CPU, RAM, disk capacity, "
+                "and Python runtime. Prefer this over noisy shell commands like lscpu, free, df, "
+                "uname, or cat /proc/* when the user asks for computer specs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "include_disks": {"type": "boolean", "default": True},
+                    "include_cpu": {"type": "boolean", "default": True},
+                    "include_memory": {"type": "boolean", "default": True},
+                    "include_os": {"type": "boolean", "default": True},
+                    "include_runtime": {"type": "boolean", "default": True},
+                    "include_gpu": {"type": "boolean", "default": False},
+                    "human_readable": {"type": "boolean", "default": True},
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def execute_system_info(arguments: dict[str, Any]) -> str:
+    include_disks = _bool_arg(arguments.get("include_disks"), default=True)
+    include_cpu = _bool_arg(arguments.get("include_cpu"), default=True)
+    include_memory = _bool_arg(arguments.get("include_memory"), default=True)
+    include_os = _bool_arg(arguments.get("include_os"), default=True)
+    include_runtime = _bool_arg(arguments.get("include_runtime"), default=True)
+    include_gpu = _bool_arg(arguments.get("include_gpu"), default=False)
+    human_readable = _bool_arg(arguments.get("human_readable"), default=True)
+
+    warnings: list[str] = []
+    lines = ["system_info:"]
+
+    if include_os:
+        lines.append(f"OS: {_os_summary()}")
+    if include_cpu:
+        lines.append(f"CPU: {_cpu_summary(warnings=warnings)}")
+    if include_memory:
+        lines.append(f"RAM: {_memory_summary(human_readable=human_readable, warnings=warnings)}")
+    if include_disks:
+        lines.append("Disk:")
+        lines.extend(f"- {line}" for line in _disk_summaries(human_readable=human_readable, warnings=warnings))
+    if include_runtime:
+        lines.append(f"Python: {platform.python_version()}")
+    if include_gpu:
+        lines.append("GPU: not detected by the standard-library system_info tool")
+        warnings.append("GPU detection is limited; no external GPU tools were run.")
+    if warnings:
+        lines.append("Warnings:")
+        lines.extend(f"- {warning}" for warning in dict.fromkeys(warnings))
+    return "\n".join(lines)
+
+
+def _os_summary() -> str:
+    system = platform.system() or "unknown"
+    release = platform.release() or "unknown"
+    machine = platform.machine() or "unknown"
+    return f"{system} {release} {machine}"
+
+
+def _cpu_summary(*, warnings: list[str]) -> str:
+    cpu = _read_linux_cpuinfo(Path("/proc/cpuinfo"))
+    model = cpu.get("model") or platform.processor() or "unknown"
+    logical = os.cpu_count()
+    architecture = platform.machine() or "unknown"
+    parts = [model]
+    physical = cpu.get("physical_cores")
+    if physical and logical:
+        parts.append(f"{physical} physical cores / {logical} logical cores")
+    elif logical:
+        parts.append(f"{logical} logical cores")
+    else:
+        warnings.append("CPU core count unavailable.")
+    parts.append(f"architecture {architecture}")
+    return ", ".join(parts)
+
+
+def _memory_summary(*, human_readable: bool, warnings: list[str]) -> str:
+    memory = _read_linux_meminfo(Path("/proc/meminfo"))
+    total = memory.get("MemTotal")
+    available = memory.get("MemAvailable")
+    if total is None:
+        warnings.append("RAM total unavailable.")
+        return "unavailable"
+    if available is None:
+        return f"{_format_bytes(total, human_readable=human_readable)} total, available unavailable"
+    return (
+        f"{_format_bytes(total, human_readable=human_readable)} total, "
+        f"{_format_bytes(available, human_readable=human_readable)} available"
+    )
+
+
+def _disk_summaries(*, human_readable: bool, warnings: list[str]) -> list[str]:
+    try:
+        usage = shutil.disk_usage("/")
+    except OSError as exc:
+        warnings.append(f"Disk usage unavailable: {exc}")
+        return ["unavailable"]
+    percent = int(round((usage.used / usage.total) * 100)) if usage.total else 0
+    return [
+        (
+            f"/: {_format_bytes(usage.total, human_readable=human_readable)} total, "
+            f"{_format_bytes(usage.used, human_readable=human_readable)} used, "
+            f"{_format_bytes(usage.free, human_readable=human_readable)} available, {percent}% used"
+        )
+    ]
+
+
+def _read_linux_meminfo(path: Path) -> dict[str, int]:
+    values: dict[str, int] = {}
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return values
+    for line in content.splitlines():
+        if ":" not in line:
+            continue
+        key, raw_value = line.split(":", 1)
+        parts = raw_value.strip().split()
+        if not parts:
+            continue
+        try:
+            value = int(parts[0])
+        except ValueError:
+            continue
+        unit = parts[1].lower() if len(parts) > 1 else ""
+        values[key] = value * 1024 if unit == "kb" else value
+    return values
+
+
+def _read_linux_cpuinfo(path: Path) -> dict[str, Any]:
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    model = ""
+    physical_core_ids: set[tuple[str, str]] = set()
+    current: dict[str, str] = {}
+    for raw_line in content.splitlines() + [""]:
+        line = raw_line.strip()
+        if not line:
+            model = model or current.get("model name", "")
+            physical_id = current.get("physical id")
+            core_id = current.get("core id")
+            if physical_id is not None and core_id is not None:
+                physical_core_ids.add((physical_id, core_id))
+            current = {}
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        current[key.strip()] = value.strip()
+    result: dict[str, Any] = {}
+    if model:
+        result["model"] = model
+    if physical_core_ids:
+        result["physical_cores"] = len(physical_core_ids)
+    return result
+
+
+def _format_bytes(value: int, *, human_readable: bool) -> str:
+    if not human_readable:
+        return f"{value} B"
+    amount = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
+        if amount < 1024 or unit == "PiB":
+            return f"{amount:.1f} {unit}" if unit != "B" else f"{int(amount)} B"
+        amount /= 1024
+    return f"{value} B"
+
+
+def _bool_arg(value: object, *, default: bool) -> bool:
+    return value if isinstance(value, bool) else default

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -52,7 +52,7 @@ class HybridToolExecutor:
     ) -> ToolExecution:
         if name not in self.allowed_tool_names:
             return ToolExecution(ToolResult(name=name, content=f"error: tool not available for this turn: {name}"), "orbit")
-        if name not in {"exec_shell_full_command", "fetch_url", "list_directory"}:
+        if name not in {"exec_shell_full_command", "fetch_url", "list_directory", "system_info"}:
             return ToolExecution(ToolResult(name=name, content=f"error: unknown tool: {name}"), "orbit")
         parsed = parse_tool_arguments(arguments)
         if isinstance(parsed, str):

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from orbit.runtime.directory_listing import execute_list_directory, list_directory_definition
 from orbit.runtime.shell_guardrails import exec_shell_full_definition, execute_exec_shell_full_command
+from orbit.runtime.system_info import execute_system_info, system_info_definition
 from orbit.runtime.tool_arguments import parse_tool_arguments
 from orbit.runtime.web import execute_fetch_url, fetch_url_definition
 
@@ -16,7 +17,7 @@ class ToolResult:
     content: str
 
 
-TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory")
+TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
 DEFAULT_TOOL_NAMES = TOOL_NAMES
 
 
@@ -29,7 +30,7 @@ def default_tool_names() -> tuple[str, ...]:
 
 
 def tool_definitions(names: tuple[str, ...] | None = None) -> list[dict[str, Any]]:
-    definitions = [exec_shell_full_definition(), fetch_url_definition(), list_directory_definition()]
+    definitions = [exec_shell_full_definition(), fetch_url_definition(), list_directory_definition(), system_info_definition()]
     if names is None:
         return definitions
     allowed = set(names)
@@ -54,4 +55,6 @@ def execute_tool(
         return ToolResult(name=name, content=execute_fetch_url(parsed))
     if name == "list_directory":
         return ToolResult(name=name, content=execute_list_directory(parsed, workdir=workdir))
+    if name == "system_info":
+        return ToolResult(name=name, content=execute_system_info(parsed))
     return ToolResult(name=name, content=execute_exec_shell_full_command(parsed, workdir=workdir, user_prompt=user_prompt))

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -14,6 +14,7 @@ DISPLAY_TOOL_NAMES = {
     "exec_shell_full_command": "exec",
     "fetch_url": "fetch_url",
     "list_directory": "list_directory",
+    "system_info": "system_info",
 }
 
 
@@ -35,6 +36,8 @@ def format_tool_call_event(name: str, args: str) -> str:
         if path:
             suffix = " recursive" if recursive else ""
             return f"ListDir{suffix}: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
+    if name == "system_info":
+        return "SystemInfo"
     return f"{display_tool_name(name)} {args}"
 
 
@@ -160,6 +163,9 @@ def _tool_result_preview(content: str | None) -> str | None:
             return f"directory listing {status or 'error'}"
         preview = _lines_preview(content)
         return preview or "directory listing"
+    if content.startswith("system_info:"):
+        preview = _lines_preview(content)
+        return preview or "system info"
     path = _metadata_value(content, "path")
     if "shell_output_pdf_text: true" in content:
         preview = _body_preview(content, marker="content:")

--- a/src/orbit/terminal/tool_mode.py
+++ b/src/orbit/terminal/tool_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 ToolSpec = str
 
-DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory")
+DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
 
 SPECIAL_TOOL_SPECS = ("off", "on")
 USAGE = "off|on"

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -51,12 +51,22 @@ class RouteRequestTests(unittest.TestCase):
     def test_parse_tool_command_accepts_raw_list_directory_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call:list_directory{"path":".","recursive":true}<tool_call|>'), ToolRoute.FILESYSTEM)
 
+    def test_parse_tool_command_accepts_raw_system_info_tool_call(self) -> None:
+        self.assertEqual(parse_tool_command('<|tool_call>call:system_info{"include_cpu":true}<tool_call|>'), ToolRoute.FILESYSTEM)
+
     def test_parse_command_decision_keeps_raw_list_directory_tool_scope(self) -> None:
         decision = parse_command_decision('<|tool_call>call:list_directory{"path":".","recursive":true}<tool_call|>')
 
         self.assertIsNotNone(decision)
         assert decision is not None
         self.assertEqual(decision_tool_names(decision), ("list_directory",))
+
+    def test_parse_command_decision_keeps_raw_system_info_tool_scope(self) -> None:
+        decision = parse_command_decision('<|tool_call>call:system_info{}<tool_call|>')
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision_tool_names(decision), ("system_info",))
 
     def test_parse_tool_command_accepts_parenthesized_shell_tool_call(self) -> None:
         self.assertEqual(parse_tool_command('<|tool_call>call(shell, "orbit-web-search \\"Mario Nobile\\"")<tool_call|>'), ToolRoute.FILESYSTEM)
@@ -109,6 +119,22 @@ class RouteRequestTests(unittest.TestCase):
         self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
         self.assertEqual(decision_tool_names(decision), ("list_directory",))
 
+    def test_parse_command_decision_from_tool_calls_accepts_system_info_arguments(self) -> None:
+        decision = parse_command_decision_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "system_info", "arguments": '{"include_cpu":true}'},
+                }
+            ]
+        )
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
+        self.assertEqual(decision_tool_names(decision), ("system_info",))
+
     def test_command_tool_call_from_content_uses_shell_command_json(self) -> None:
         tool_call = command_tool_call_from_content('{"command":"ls -F"}', ("exec_shell_full_command",))
 
@@ -132,6 +158,14 @@ class RouteRequestTests(unittest.TestCase):
         assert tool_call is not None
         self.assertEqual(tool_call["function"]["name"], "list_directory")
         self.assertEqual(json.loads(tool_call["function"]["arguments"]), {"path": ".", "recursive": True})
+
+    def test_command_tool_call_from_content_uses_system_info_json(self) -> None:
+        tool_call = command_tool_call_from_content('{"include_cpu": true, "include_memory": true}', ("exec_shell_full_command", "system_info"))
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "system_info")
+        self.assertEqual(json.loads(tool_call["function"]["arguments"]), {"include_cpu": True, "include_memory": True})
 
     def test_command_tool_call_from_content_converts_raw_orbit_web_search(self) -> None:
         tool_call = command_tool_call_from_content(
@@ -284,6 +318,23 @@ EOF"}"""
         self.assertEqual(tool_call["function"]["name"], "list_directory")
         self.assertEqual(tool_call["function"]["arguments"], '{"path":".","recursive":true}')
 
+    def test_command_tool_call_from_tool_calls_keeps_system_info_tool_call(self) -> None:
+        tool_call = command_tool_call_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "system_info", "arguments": '{"include_cpu":true}'},
+                }
+            ],
+            ("exec_shell_full_command", "system_info"),
+        )
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "system_info")
+        self.assertEqual(tool_call["function"]["arguments"], '{"include_cpu":true}')
+
     def test_command_tool_call_from_tool_calls_accepts_shell_alias(self) -> None:
         tool_call = command_tool_call_from_tool_calls(
             [
@@ -356,7 +407,7 @@ EOF"}""",
         self.assertIsNone(tool_call)
 
     def test_tool_names_for_decision_are_bounded(self) -> None:
-        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url", "list_directory"))
+        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
         self.assertEqual(tool_names_for_decision(ToolRoute.FILE_EDIT), ())
         self.assertEqual(tool_names_for_decision(ToolRoute.WEB), ())
 
@@ -371,6 +422,10 @@ EOF"}""",
     def test_command_stream_state_detects_complete_list_directory_json(self) -> None:
         self.assertEqual(command_stream_state('{"path":".","recursive":true}'), "route")
         self.assertEqual(command_stream_state('{"path"'), "pending")
+
+    def test_command_stream_state_detects_complete_system_info_json(self) -> None:
+        self.assertEqual(command_stream_state('{"include_cpu":true}'), "route")
+        self.assertEqual(command_stream_state('{"include_'), "pending")
 
     def test_command_stream_filter_suppresses_command_json(self) -> None:
         emitted: list[str] = []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,7 +66,7 @@ class CommandTests(unittest.TestCase):
         self.assertIn("Model\n-------", status)
         self.assertIn("tools_mode: n/a", status)
         self.assertIn("thinking_mode: off", status)
-        self.assertIn("model_tools: exec_shell_full_command, fetch_url, list_directory", status)
+        self.assertIn("model_tools: exec_shell_full_command, fetch_url, list_directory, system_info", status)
         self.assertIn("memory_refresh_threshold: 6963/8192", status)
         self.assertIn("memory_refreshes: 0", status)
         self.assertIn("last_refresh_outcome: none", status)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,7 @@ class ConfigTests(unittest.TestCase):
         self.assertIn("Environment: OS=", DEFAULT_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", DEFAULT_SYSTEM_PROMPT)
         self.assertIn("prefer the fetch_url tool", DEFAULT_SYSTEM_PROMPT)
+        self.assertIn("system_info", DEFAULT_SYSTEM_PROMPT)
         self.assertIn("curl are still allowed", DEFAULT_SYSTEM_PROMPT)
 
     def test_command_system_prompt_sends_local_hardware_queries_to_shell(self) -> None:
@@ -34,6 +35,7 @@ class ConfigTests(unittest.TestCase):
         self.assertIn("Environment: OS=", ROUTE_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", ROUTE_SYSTEM_PROMPT)
         self.assertIn("prefer the fetch_url tool", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("system_info", ROUTE_SYSTEM_PROMPT)
         self.assertIn("Quote spaced paths", ROUTE_SYSTEM_PROMPT)
         self.assertIn("not metadata", ROUTE_SYSTEM_PROMPT)
 
@@ -46,6 +48,7 @@ class ConfigTests(unittest.TestCase):
     def test_tool_call_prompt_mentions_quoted_shell_paths(self) -> None:
         self.assertIn("Call exactly one available tool", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("Prefer fetch_url", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("Prefer system_info", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("exec_shell_full_command", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("Quote paths containing spaces", TOOL_CALL_SYSTEM_PROMPT)
@@ -130,10 +133,10 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "tools"):
             load_app_config(_parse("--tools", "browser"))
 
-    def test_tools_on_uses_shell_fetch_url_and_list_directory(self) -> None:
+    def test_tools_on_uses_shell_fetch_url_list_directory_and_system_info(self) -> None:
         names = allowed_tool_names_for_spec("on")
 
-        self.assertEqual(names, ("exec_shell_full_command", "fetch_url", "list_directory"))
+        self.assertEqual(names, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
 
     def test_legacy_tools_object_config_key_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -601,7 +601,7 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.ask_auto_calls, 1)
         self.assertEqual(runtime.ask_chat_calls, 0)
         self.assertIsNotNone(runtime.last_allowed_tool_names)
-        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url", "list_directory"))
+        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
 
     def test_repl_reads_queued_prompt_before_new_input(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import getpass
+import os
+import socket
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.system_info import execute_system_info, system_info_definition
+
+
+class SystemInfoTests(unittest.TestCase):
+    def test_default_output_includes_compact_core_sections(self) -> None:
+        output = execute_system_info({})
+
+        self.assertIn("system_info:", output)
+        self.assertIn("OS:", output)
+        self.assertIn("CPU:", output)
+        self.assertIn("RAM:", output)
+        self.assertIn("Disk:", output)
+        self.assertIn("Python:", output)
+
+    def test_include_flags_exclude_sections(self) -> None:
+        output = execute_system_info({"include_cpu": False, "include_memory": False, "include_disks": False})
+
+        self.assertIn("OS:", output)
+        self.assertNotIn("CPU:", output)
+        self.assertNotIn("RAM:", output)
+        self.assertNotIn("Disk:", output)
+
+    def test_output_avoids_common_sensitive_identifiers(self) -> None:
+        output = execute_system_info({})
+        username = getpass.getuser()
+        hostname = socket.gethostname()
+
+        if username:
+            self.assertNotIn(username, output)
+        if hostname:
+            self.assertNotIn(hostname, output)
+        self.assertNotIn("HOME=", output)
+        self.assertNotIn("PATH=", output)
+        self.assertNotRegex(output, r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
+        self.assertNotRegex(output, r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+    def test_memory_fallback_when_proc_meminfo_unavailable(self) -> None:
+        with patch("orbit.runtime.system_info._read_linux_meminfo", return_value={}):
+            output = execute_system_info({"include_os": False, "include_cpu": False, "include_disks": False, "include_runtime": False})
+
+        self.assertIn("RAM: unavailable", output)
+        self.assertIn("RAM total unavailable", output)
+
+    def test_cpu_fallback_when_proc_cpuinfo_unavailable(self) -> None:
+        with patch("orbit.runtime.system_info._read_linux_cpuinfo", return_value={}):
+            with patch("orbit.runtime.system_info.platform.processor", return_value="fallback-cpu"):
+                with patch("orbit.runtime.system_info.os.cpu_count", return_value=8):
+                    output = execute_system_info({"include_os": False, "include_memory": False, "include_disks": False, "include_runtime": False})
+
+        self.assertIn("CPU: fallback-cpu", output)
+        self.assertIn("8 logical cores", output)
+
+    def test_disk_output_is_compact(self) -> None:
+        output = execute_system_info({"include_os": False, "include_cpu": False, "include_memory": False, "include_runtime": False})
+        lines = [line for line in output.splitlines() if line.strip()]
+
+        self.assertLessEqual(len(lines), 3)
+        self.assertIn("Disk:", output)
+        self.assertIn("- /:", output)
+
+    def test_definition_mentions_preferred_usage(self) -> None:
+        definition = system_info_definition()
+        description = definition["function"]["description"]
+
+        self.assertIn("machine specifications", description.lower())
+        self.assertIn("lscpu", description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_backends.py
+++ b/tests/test_tool_backends.py
@@ -187,6 +187,20 @@ class HybridToolExecutorTests(unittest.TestCase):
         self.assertIn("status: ok", execution.result.content)
         self.assertIn("Hello web", execution.result.content)
 
+    def test_system_info_runs_internal_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            executor = HybridToolExecutor(
+                backend=FakeServerTools(),
+                workdir=Path(tmp),
+                allowed_tool_names=("system_info",),
+            )
+
+            execution = executor.execute("system_info", {"include_disks": False}, chunk_budget={})
+
+        self.assertEqual(execution.source, "orbit")
+        self.assertIn("system_info:", execution.result.content)
+        self.assertNotIn("Disk:", execution.result.content)
+
     def test_fetch_url_plain_text_returns_text(self) -> None:
         class FakeHeaders:
             def get_content_type(self) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,16 +16,17 @@ from orbit.runtime.tools import default_tool_names, execute_tool, tool_definitio
 
 class ToolTests(unittest.TestCase):
     def test_shell_and_fetch_url_are_exposed(self) -> None:
-        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory"))
-        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory"))
+        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
+        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
         definitions = tool_definitions()
-        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url", "list_directory"])
+        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url", "list_directory", "system_info"])
 
     def test_tool_definitions_respect_allowed_names(self) -> None:
         self.assertEqual(tool_definitions(("read_file",)), [])
         self.assertEqual(len(tool_definitions(("exec_shell_full_command",))), 1)
         self.assertEqual(len(tool_definitions(("fetch_url",))), 1)
         self.assertEqual(len(tool_definitions(("list_directory",))), 1)
+        self.assertEqual(len(tool_definitions(("system_info",))), 1)
 
     def test_unknown_tool_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -89,6 +90,14 @@ class ToolTests(unittest.TestCase):
 
         self.assertIn("directory_listing:", result.content)
         self.assertIn("[file] README.md", result.content)
+
+    def test_system_info_runs_with_compact_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = execute_tool("system_info", {}, workdir=Path(tmp))
+
+        self.assertIn("system_info:", result.content)
+        self.assertIn("OS:", result.content)
+        self.assertIn("CPU:", result.content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Adds an explicit model-facing system_info tool for compact local machine specifications.
- Covers OS, CPU, RAM, root disk usage, Python runtime, and optional GPU warning without collecting hostname, username, IP, MAC, env vars, or process lists.
- Keeps exec_shell_full_command available and does not auto-route or replace shell commands deterministically.
- Updates route/tool prompts and terminal tool event display so the model can choose system_info for local specs requests.
- Uses Python standard library plus Linux /proc fallbacks; no psutil dependency.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_tool_backends tests.test_tool_loop_state tests.test_repl tests.test_cli -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Smoke:
- tools on + tell me the specs of this computer: PASS, model used SystemInfo, compact 281-char tool result.
- tools on + how much RAM does this machine have?: PASS, model used SystemInfo and answered from RAM evidence.
- tools on + list files in the workdir: PASS, list_directory still used.
- tools on + read README.md and explain it: PASS, content evidence via cat README.md.

Notes:
- Runtime remains model-guided; system_info is available when tools are on, but the model chooses whether to call it.
- No backend/native/MTP/final policy changes.