### PR TITLE
Add KV cache diagnostic instrumentation

### DIFF
--- a/docs/KV_CACHE_REUSE_PLAN.md
+++ b/docs/KV_CACHE_REUSE_PLAN.md
@@ -94,6 +94,14 @@ Metrics to record:
 
 Use `orbit bench-core` for public regression coverage and add temporary local scripts only for deeper profiling.
 
+For phase-1 cache diagnostics, use:
+
+```bash
+ORBIT_KV_DIAG=1 python3 scripts/bench_kv_diag.py
+```
+
+The script writes raw diagnostic JSONL and a compact Markdown summary under `benchmarks/`. Benchmark outputs are local artifacts and should not be committed unless explicitly requested.
+
 ## Invalidation Risks
 
 KV reuse risks:

--- a/scripts/bench_kv_diag.py
+++ b/scripts/bench_kv_diag.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+FOOTER_RE = re.compile(
+    r"model: (?P<model>.*?) \| ctx: (?P<ctx>\d+)/(?:\d+) \((?P<ctx_pct>\d+)%\) \| "
+    r"tks: (?P<prompt_tokens>\d+)->(?P<generated_tokens>\d+), cached (?P<cached_tokens>\d+) \| "
+    r"cache: (?P<cache_pct>\d+)% \| pf (?P<prefill_tps>[0-9.]+)/s \| gen (?P<generation_tps>[0-9.]+)/s \| "
+    r"stop: (?P<finish_reason>\S+) \| time: (?P<footer_time>[^\n\r]+)"
+)
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    args: tuple[str, ...]
+    stdin: str | None = None
+    timeout: int = 240
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Orbit KV diagnostic benchmark scenarios.")
+    parser.add_argument("--orbit-bin", default=sys.executable, help="Python executable or orbit command to run.")
+    parser.add_argument("--module", default="orbit.terminal.cli", help="Python module when --orbit-bin is Python.")
+    parser.add_argument("--workdir", default="workdir")
+    parser.add_argument("--output-dir", default="benchmarks")
+    parser.add_argument("--max-tokens", default="120")
+    parser.add_argument("--timeout", type=int, default=240)
+    args = parser.parse_args(argv)
+
+    root = Path.cwd()
+    output_dir = root / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    diag_path = output_dir / f"kv_diag_{stamp}.jsonl"
+    summary_path = output_dir / f"kv_diag_{stamp}.md"
+
+    scenarios = _scenarios(max_tokens=args.max_tokens, timeout=args.timeout)
+    env = os.environ.copy()
+    env["ORBIT_KV_DIAG"] = "1"
+    env["ORBIT_KV_DIAG_FILE"] = str(diag_path)
+    env.setdefault("PYTHONPATH", "src")
+
+    rows: list[dict[str, object]] = []
+    for scenario in scenarios:
+        row = _run_scenario(
+            scenario,
+            orbit_bin=args.orbit_bin,
+            module=args.module,
+            workdir=args.workdir,
+            env=env,
+            root=root,
+        )
+        rows.append(row)
+        print(json.dumps(row, sort_keys=True), flush=True)
+
+    _write_summary(summary_path, rows, diag_path)
+    print(f"diag_jsonl={diag_path}")
+    print(f"summary_md={summary_path}")
+    return 0
+
+
+def _scenarios(*, max_tokens: str, timeout: int) -> list[Scenario]:
+    base = ("--no-render-markdown", "--max-tokens", max_tokens)
+    return [
+        Scenario("tools_off_repeat", (*base, "--tools", "off"), "hi\nhi\n", timeout),
+        Scenario("tools_on_repeat_no_tool_needed", (*base, "--tools", "on"), "hi\nhi\n", timeout),
+        Scenario("tools_on_same_prompt_repeat", (*base, "--tools", "on"), "tell me the specs of this computer\ntell me the specs of this computer\n", timeout),
+        Scenario("tools_on_after_reset", (*base, "--tools", "on"), "hi\n/reset\nhi\n", timeout),
+        Scenario("tools_on_off_switch", (*base, "--tools", "off"), "hi\n/tools on\nhi\n/tools off\nhi\n", timeout),
+        Scenario("list_directory_repeat", (*base, "--tools", "on"), "list files in the workdir\nlist files in the workdir\n", timeout),
+        Scenario("system_info_repeat", (*base, "--tools", "on"), "tell me the specs of this computer\ntell me the specs of this computer\n", timeout),
+    ]
+
+
+def _run_scenario(
+    scenario: Scenario,
+    *,
+    orbit_bin: str,
+    module: str,
+    workdir: str,
+    env: dict[str, str],
+    root: Path,
+) -> dict[str, object]:
+    cmd = _command(orbit_bin, module) + ["--workdir", workdir, *scenario.args]
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=scenario.stdin,
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=scenario.timeout,
+        )
+        raw = proc.stdout + proc.stderr
+        timeout = False
+        returncode = proc.returncode
+    except subprocess.TimeoutExpired as exc:
+        raw = _to_text(exc.stdout) + _to_text(exc.stderr)
+        timeout = True
+        returncode = None
+    elapsed = round(time.monotonic() - started, 2)
+    footer = _last_footer(raw)
+    return {
+        "scenario": scenario.name,
+        "returncode": returncode,
+        "timeout": timeout,
+        "elapsed_s": elapsed,
+        **footer,
+    }
+
+
+def _command(orbit_bin: str, module: str) -> list[str]:
+    name = Path(orbit_bin).name
+    if name.startswith("python"):
+        return [orbit_bin, "-m", module]
+    return [orbit_bin]
+
+
+def _last_footer(raw: str) -> dict[str, object]:
+    cleaned = ANSI_RE.sub("", raw).replace("\r", "\n")
+    matches = list(FOOTER_RE.finditer(cleaned))
+    if not matches:
+        return {}
+    data: dict[str, object] = matches[-1].groupdict()
+    for key in ("ctx", "ctx_pct", "prompt_tokens", "generated_tokens", "cached_tokens", "cache_pct"):
+        data[key] = int(data[key])
+    for key in ("prefill_tps", "generation_tps"):
+        data[key] = float(data[key])
+    return data
+
+
+def _write_summary(path: Path, rows: list[dict[str, object]], diag_path: Path) -> None:
+    lines = [
+        "# KV Diagnostic Benchmark",
+        "",
+        f"Raw diagnostic JSONL: `{diag_path}`",
+        "",
+        "| Scenario | Tokens | Cached | Cache | Prefill/s | Gen/s | Stop | Wall |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: |",
+    ]
+    for row in rows:
+        tokens = "-"
+        if "prompt_tokens" in row:
+            tokens = f"{row.get('prompt_tokens')}->{row.get('generated_tokens')}"
+        lines.append(
+            "| {scenario} | {tokens} | {cached} | {cache} | {pf} | {gen} | {stop} | {wall} |".format(
+                scenario=row["scenario"],
+                tokens=tokens,
+                cached=row.get("cached_tokens", "-"),
+                cache=f"{row.get('cache_pct')}%" if "cache_pct" in row else "-",
+                pf=row.get("prefill_tps", "-"),
+                gen=row.get("generation_tps", "-"),
+                stop="timeout" if row.get("timeout") else row.get("finish_reason", "-"),
+                wall=row.get("elapsed_s", "-"),
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _to_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -29,6 +29,7 @@ from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
 )
 from orbit.runtime.file_input_resolver import FileInputResolver
+from orbit.runtime.kv_diag import instrument_backend, model_call_context
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
@@ -111,6 +112,7 @@ class ChatRuntime:
     local_capabilities: LocalCapabilities = field(default_factory=discover_local_capabilities)
 
     def __post_init__(self) -> None:
+        self.backend = instrument_backend(self.backend)
         if hasattr(self.backend, "thinking"):
             self.thinking_mode = bool(getattr(self.backend, "thinking"))
         if not self.messages and self.system_prompt:
@@ -303,17 +305,18 @@ class ChatRuntime:
         with self._temporary_backend_thinking(False):
             if on_phase_start:
                 on_phase_start(ModelPhaseStart("route", streamed=False, attempt=1, reason="tool_decision"))
-            if on_progress is None:
-                first = self.backend.chat(command_messages, temperature=temperature, max_tokens=command_max_tokens)
-            else:
-                route_stream_filter = CommandStreamFilter(route_streamed_chunks.append) if on_final_delta is not None else None
-                first = self.backend.chat_stream(
-                    command_messages,
-                    temperature=temperature,
-                    max_tokens=command_max_tokens,
-                    on_delta=route_stream_filter.write if route_stream_filter is not None else (lambda _text: None),
-                    on_progress=on_progress,
-                )
+            with model_call_context(phase="route", tools_mode="on"):
+                if on_progress is None:
+                    first = self.backend.chat(command_messages, temperature=temperature, max_tokens=command_max_tokens)
+                else:
+                    route_stream_filter = CommandStreamFilter(route_streamed_chunks.append) if on_final_delta is not None else None
+                    first = self.backend.chat_stream(
+                        command_messages,
+                        temperature=temperature,
+                        max_tokens=command_max_tokens,
+                        on_delta=route_stream_filter.write if route_stream_filter is not None else (lambda _text: None),
+                        on_progress=on_progress,
+                    )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=1, result=first, phase="route"))
         command_content = first.content
@@ -336,19 +339,21 @@ class ChatRuntime:
                             )
                         )
                     if on_progress is None:
-                        route_retry = self.backend.chat(
-                            route_retry_messages,
-                            temperature=temperature,
-                            max_tokens=command_max_tokens,
-                        )
+                        with model_call_context(phase="route_retry", tools_mode="on"):
+                            route_retry = self.backend.chat(
+                                route_retry_messages,
+                                temperature=temperature,
+                                max_tokens=command_max_tokens,
+                            )
                     else:
-                        route_retry = self.backend.chat_stream(
-                            route_retry_messages,
-                            temperature=temperature,
-                            max_tokens=command_max_tokens,
-                            on_delta=lambda _text: None,
-                            on_progress=on_progress,
-                        )
+                        with model_call_context(phase="route_retry", tools_mode="on"):
+                            route_retry = self.backend.chat_stream(
+                                route_retry_messages,
+                                temperature=temperature,
+                                max_tokens=command_max_tokens,
+                                on_delta=lambda _text: None,
+                                on_progress=on_progress,
+                            )
                 if on_model_step:
                     on_model_step(ModelStepMetrics.from_result(loop=2, result=route_retry, phase="route_retry"))
                 retry_decision = parse_command_decision_from_tool_calls(route_retry.tool_calls) or parse_command_decision(route_retry.content)
@@ -388,16 +393,18 @@ class ChatRuntime:
                     retried_empty_final = True
                 if first.finish_reason == "length":
                     if on_final_delta is None:
-                        first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
+                        with model_call_context(phase="chat_final_retry", tools_mode="on"):
+                            first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
                     else:
                         streamed_final_retry = True
-                        first = self.backend.chat_stream(
-                            self.messages,
-                            temperature=temperature,
-                            max_tokens=max_tokens,
-                            on_delta=on_final_delta,
-                            on_progress=on_progress,
-                        )
+                        with model_call_context(phase="chat_final_retry", tools_mode="on"):
+                            first = self.backend.chat_stream(
+                                self.messages,
+                                temperature=temperature,
+                                max_tokens=max_tokens,
+                                on_delta=on_final_delta,
+                                on_progress=on_progress,
+                            )
                     if on_model_step:
                         on_model_step(ModelStepMetrics.from_result(loop=2, result=first, phase="chat_final_retry"))
                 if _is_empty_final_response(first):
@@ -423,16 +430,17 @@ class ChatRuntime:
                 return self._remember_visible_result(first)
         if decision.route == ToolRoute.CHAT:
             chat_messages = with_chat_system_prompt(self.messages)
-            result = self._chat_final(
-                chat_messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                on_final_delta=on_final_delta,
-                on_progress=on_progress,
-                on_model_step=on_model_step,
-                on_phase_start=on_phase_start,
-                loop=2,
-            )
+            with model_call_context(phase="chat_final", tools_mode="on"):
+                result = self._chat_final(
+                    chat_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
+                    loop=2,
+                )
             self.messages.append({"role": "assistant", "content": result.content})
             return self._remember_visible_result(result)
         if decision.route == ToolRoute.MEDIA:
@@ -625,13 +633,14 @@ class ChatRuntime:
         with self._transport_environment().backend_thinking(True):
             if on_phase_start:
                 on_phase_start(ModelPhaseStart("tool_plan", streamed=True, attempt=1, reason="pre_tool_thinking"))
-            result = self.backend.chat_stream(
-                planning_messages,
-                temperature=temperature,
-                max_tokens=CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS),
-                on_delta=thought_filter.write,
-                on_progress=on_progress,
-            )
+            with model_call_context(phase="tool_plan", tools_mode="on"):
+                result = self.backend.chat_stream(
+                    planning_messages,
+                    temperature=temperature,
+                    max_tokens=CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS),
+                    on_delta=thought_filter.write,
+                    on_progress=on_progress,
+                )
         thought_filter.finish()
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="tool_plan"))

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -24,6 +24,7 @@ from orbit.runtime.final_policy import (
     last_user_text,
     looks_like_incomplete_final,
 )
+from orbit.runtime.kv_diag import current_tools_mode, model_call_context
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import TOOL_CALL_JSON_RETRY_PROMPT
 from orbit.runtime.thinking_mode import ThinkingMode, last_assistant_has_open_reasoning
@@ -102,13 +103,14 @@ class TransportEnvironment:
     ) -> ChatResult:
         if on_phase_start:
             on_phase_start(ModelPhaseStart("chat_final", streamed=on_final_delta is not None, attempt=1))
-        result = self.chat_once(
-            messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            on_final_delta=on_final_delta,
-            on_progress=on_progress,
-        )
+        with model_call_context(phase="chat_final", tools_mode=current_tools_mode() or "off"):
+            result = self.chat_once(
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+            )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="chat_final"))
         completeness = classify_final_answer_completeness(result.content, messages=messages)
@@ -147,13 +149,14 @@ class TransportEnvironment:
             )
         retry_context = self.backend_thinking(False) if with_final_only_retry else nullcontext()
         with retry_context:
-            retry = self.chat_once(
-                retry_messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                on_final_delta=on_final_delta,
-                on_progress=on_progress,
-            )
+            with model_call_context(phase=retry_phase, tools_mode=current_tools_mode() or "off"):
+                retry = self.chat_once(
+                    retry_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop + 1, result=retry, phase=retry_phase))
         retry_completeness = classify_final_answer_completeness(retry.content, messages=retry_messages)
@@ -222,31 +225,33 @@ class TransportEnvironment:
     ) -> ChatResult:
         try:
             with self.backend_thinking(False):
+                with model_call_context(phase="tool_call", tools_mode="on"):
+                    if on_final_delta is None:
+                        return self.runtime.backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+                    return self.runtime.backend.chat_stream(
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        on_delta=on_final_delta,
+                        on_progress=on_progress,
+                    )
+        except RuntimeError as exc:
+            if not is_tool_argument_json_error(exc):
+                raise
+        retry_messages = [*messages, {"role": "system", "content": TOOL_CALL_JSON_RETRY_PROMPT}]
+        with self.backend_thinking(False):
+            with model_call_context(phase="tool_call_json_retry", tools_mode="on"):
                 if on_final_delta is None:
-                    return self.runtime.backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+                    return self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
                 return self.runtime.backend.chat_stream(
-                    messages,
+                    retry_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
                     tools=tools,
                     on_delta=on_final_delta,
                     on_progress=on_progress,
                 )
-        except RuntimeError as exc:
-            if not is_tool_argument_json_error(exc):
-                raise
-        retry_messages = [*messages, {"role": "system", "content": TOOL_CALL_JSON_RETRY_PROMPT}]
-        with self.backend_thinking(False):
-            if on_final_delta is None:
-                return self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
-            return self.runtime.backend.chat_stream(
-                retry_messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                on_delta=on_final_delta,
-                on_progress=on_progress,
-            )
 
     @contextmanager
     def backend_thinking(self, value: bool):
@@ -297,13 +302,14 @@ class PureChatEnvironment:
             if on_phase_start:
                 on_phase_start(ModelPhaseStart("tool_plan", streamed=on_final_delta is not None, attempt=1, reason="chat_thinking"))
             with self.transport.backend_thinking(True):
-                thinking_result = self.transport.chat_once(
-                    thinking_messages,
-                    temperature=temperature,
-                    max_tokens=thinking_max_tokens,
-                    on_final_delta=on_final_delta,
-                    on_progress=on_progress,
-                )
+                with model_call_context(phase="chat_thinking", tools_mode="off"):
+                    thinking_result = self.transport.chat_once(
+                        thinking_messages,
+                        temperature=temperature,
+                        max_tokens=thinking_max_tokens,
+                        on_final_delta=on_final_delta,
+                        on_progress=on_progress,
+                    )
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=loop, result=thinking_result, phase="chat_thinking"))
             final_messages = [
@@ -424,16 +430,17 @@ class FinalFromToolEnvironment:
                 )
             )
         with self.transport.backend_thinking(False):
-            if on_final_delta is None:
-                result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
-            else:
-                result = self.runtime.backend.chat_stream(
-                    policy.messages,
-                    temperature=temperature,
-                    max_tokens=policy.max_tokens,
-                    on_delta=final_delta,
-                    on_progress=on_progress,
-                )
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                if on_final_delta is None:
+                    result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
+                else:
+                    result = self.runtime.backend.chat_stream(
+                        policy.messages,
+                        temperature=temperature,
+                        max_tokens=policy.max_tokens,
+                        on_delta=final_delta,
+                        on_progress=on_progress,
+                    )
         best_non_empty_result = result if result.content.strip() else None
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="final_from_tool"))
@@ -458,16 +465,17 @@ class FinalFromToolEnvironment:
                     )
                 )
             with self.transport.backend_thinking(False):
-                if on_final_delta is None:
-                    retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
-                else:
-                    retry_candidate = self.runtime.backend.chat_stream(
-                        retry_messages,
-                        temperature=temperature,
-                        max_tokens=retry_max_tokens,
-                        on_delta=final_delta,
-                        on_progress=on_progress,
-                    )
+                with model_call_context(phase="final_from_tool_retry", tools_mode="on"):
+                    if on_final_delta is None:
+                        retry_candidate = self.runtime.backend.chat(retry_messages, temperature=temperature, max_tokens=retry_max_tokens)
+                    else:
+                        retry_candidate = self.runtime.backend.chat_stream(
+                            retry_messages,
+                            temperature=temperature,
+                            max_tokens=retry_max_tokens,
+                            on_delta=final_delta,
+                            on_progress=on_progress,
+                        )
             if retry_candidate.content.strip():
                 best_non_empty_result = retry_candidate
             result = _prefer_non_empty_retry_result(previous_result, retry_candidate)
@@ -517,16 +525,17 @@ class FinalFromToolEnvironment:
                     )
                 )
             with self.transport.backend_thinking(False):
-                if on_final_delta is None:
-                    result = self.runtime.backend.chat(repair_messages, temperature=temperature, max_tokens=repair_max_tokens)
-                else:
-                    result = self.runtime.backend.chat_stream(
-                        repair_messages,
-                        temperature=temperature,
-                        max_tokens=repair_max_tokens,
-                        on_delta=final_delta,
-                        on_progress=on_progress,
-                    )
+                with model_call_context(phase="final_from_tool_completion_repair", tools_mode="on"):
+                    if on_final_delta is None:
+                        result = self.runtime.backend.chat(repair_messages, temperature=temperature, max_tokens=repair_max_tokens)
+                    else:
+                        result = self.runtime.backend.chat_stream(
+                            repair_messages,
+                            temperature=temperature,
+                            max_tokens=repair_max_tokens,
+                            on_delta=final_delta,
+                            on_progress=on_progress,
+                        )
             if result.content.strip():
                 best_non_empty_result = result
             if on_model_step:
@@ -564,16 +573,17 @@ class FinalFromToolEnvironment:
                     )
                 )
             with self.transport.backend_thinking(False):
-                if on_final_delta is None:
-                    candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
-                else:
-                    candidate = self.runtime.backend.chat_stream(
-                        compact_messages,
-                        temperature=temperature,
-                        max_tokens=compact_max_tokens,
-                        on_delta=final_delta,
-                        on_progress=on_progress,
-                    )
+                with model_call_context(phase="final_from_tool_compact_retry", tools_mode="on"):
+                    if on_final_delta is None:
+                        candidate = self.runtime.backend.chat(compact_messages, temperature=temperature, max_tokens=compact_max_tokens)
+                    else:
+                        candidate = self.runtime.backend.chat_stream(
+                            compact_messages,
+                            temperature=temperature,
+                            max_tokens=compact_max_tokens,
+                            on_delta=final_delta,
+                            on_progress=on_progress,
+                        )
             if candidate.content.strip():
                 best_non_empty_result = candidate
             if on_model_step:

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import hashlib
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Callable, Iterator
+
+from orbit.backend.base import ChatResult, Message, StreamProgress
+from orbit.runtime.session_memory import estimate_message_tokens
+
+
+_PHASE: contextvars.ContextVar[str | None] = contextvars.ContextVar("orbit_kv_diag_phase", default=None)
+_TOOLS_MODE: contextvars.ContextVar[str | None] = contextvars.ContextVar("orbit_kv_diag_tools_mode", default=None)
+_CALL_IDS = count(1)
+_LAST_BY_SCENARIO: dict[str, dict[str, str | None]] = {}
+
+
+@dataclass(frozen=True)
+class PromptFingerprint:
+    prompt_chars: int
+    prompt_tokens_estimate: int
+    stable_prefix_chars: int
+    stable_prefix_hash: str
+    full_prompt_hash: str
+    first_user_message_hash: str | None
+    tool_schema_hash: str
+    capability_summary_hash: str | None
+    runtime_policy_hash: str | None
+    conversation_prefix_hash: str
+
+
+def enabled() -> bool:
+    value = os.environ.get("ORBIT_KV_DIAG", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def reset_diagnostics_for_tests() -> None:
+    global _CALL_IDS
+    _CALL_IDS = count(1)
+    _LAST_BY_SCENARIO.clear()
+
+
+def current_tools_mode() -> str | None:
+    return _TOOLS_MODE.get()
+
+
+@contextlib.contextmanager
+def model_call_context(*, phase: str, tools_mode: str | None = None) -> Iterator[None]:
+    phase_token = _PHASE.set(phase)
+    tools_token = _TOOLS_MODE.set(tools_mode) if tools_mode is not None else None
+    try:
+        yield
+    finally:
+        _PHASE.reset(phase_token)
+        if tools_token is not None:
+            _TOOLS_MODE.reset(tools_token)
+
+
+def instrument_backend(backend: Any) -> Any:
+    if not enabled():
+        return backend
+    if getattr(backend, "_orbit_kv_diag_wrapped", False):
+        return backend
+    return _DiagnosticBackend(backend)
+
+
+def fingerprint_prompt(messages: list[Message], tools: list[dict[str, Any]] | None = None) -> PromptFingerprint:
+    rendered_messages = _canonical_json(messages)
+    tool_schema = _canonical_json(tools or [])
+    runtime_policy = _runtime_policy(messages)
+    capability_summary = _capability_summary(messages)
+    stable_components = {
+        "runtime_policy": runtime_policy,
+        "tool_schema": tool_schema,
+        "capability_summary": capability_summary,
+    }
+    first_user = _first_user_message(messages)
+    conversation_prefix = messages[:-1] if messages else []
+    return PromptFingerprint(
+        prompt_chars=len(rendered_messages) + len(tool_schema),
+        prompt_tokens_estimate=estimate_message_tokens(messages),
+        stable_prefix_chars=sum(len(value or "") for value in stable_components.values()),
+        stable_prefix_hash=_hash(stable_components),
+        full_prompt_hash=_hash({"messages": messages, "tools": tools or []}),
+        first_user_message_hash=_hash(first_user) if first_user is not None else None,
+        tool_schema_hash=_hash(tool_schema),
+        capability_summary_hash=_hash(capability_summary) if capability_summary is not None else None,
+        runtime_policy_hash=_hash(runtime_policy) if runtime_policy is not None else None,
+        conversation_prefix_hash=_hash(conversation_prefix),
+    )
+
+
+class _DiagnosticBackend:
+    _orbit_kv_diag_wrapped = True
+
+    def __init__(self, backend: Any) -> None:
+        object.__setattr__(self, "_backend", backend)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._backend, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "_backend":
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._backend, name, value)
+
+    def chat(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> ChatResult:
+        return self._record_call(
+            messages,
+            tools=tools,
+            streamed=False,
+            invoke=lambda: self._backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools),
+        )
+
+    def chat_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        timings = _ProgressTimings()
+
+        def wrapped_progress(progress: StreamProgress) -> None:
+            timings.observe(progress)
+            if on_progress is not None:
+                on_progress(progress)
+
+        return self._record_call(
+            messages,
+            tools=tools,
+            streamed=True,
+            progress_timings=timings,
+            invoke=lambda: self._backend.chat_stream(
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                on_delta=on_delta,
+                on_progress=wrapped_progress if on_progress is not None else None,
+            ),
+        )
+
+    def continue_current(self, *args: Any, **kwargs: Any) -> ChatResult:
+        started = time.monotonic()
+        result = self._backend.continue_current(*args, **kwargs)
+        _emit(
+            {
+                "event": "kv_diag_model_call",
+                "call_id": next(_CALL_IDS),
+                "phase": _PHASE.get() or "continue",
+                "tools_mode": _TOOLS_MODE.get(),
+                "streamed": kwargs.get("on_delta") is not None,
+                "wall_ms": _elapsed_ms(started),
+                **_result_metrics(result),
+            }
+        )
+        return result
+
+    def _record_call(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[dict[str, Any]] | None,
+        streamed: bool,
+        invoke: Callable[[], ChatResult],
+        progress_timings: "_ProgressTimings | None" = None,
+    ) -> ChatResult:
+        call_id = next(_CALL_IDS)
+        phase = _PHASE.get() or "unknown"
+        tools_mode = _TOOLS_MODE.get() or ("on" if tools else "off")
+        fingerprint = fingerprint_prompt(messages, tools)
+        started = time.monotonic()
+        result = invoke()
+        components = _component_changes(phase, tools_mode, fingerprint)
+        _emit(
+            {
+                "event": "kv_diag_model_call",
+                "call_id": call_id,
+                "phase": phase,
+                "tools_mode": tools_mode,
+                "streamed": streamed,
+                "prompt_chars": fingerprint.prompt_chars,
+                "prompt_tokens_estimate": fingerprint.prompt_tokens_estimate,
+                "stable_prefix_chars": fingerprint.stable_prefix_chars,
+                "stable_prefix_hash": fingerprint.stable_prefix_hash,
+                "full_prompt_hash": fingerprint.full_prompt_hash,
+                "first_user_message_hash": fingerprint.first_user_message_hash,
+                "tool_schema_hash": fingerprint.tool_schema_hash,
+                "capability_summary_hash": fingerprint.capability_summary_hash,
+                "runtime_policy_hash": fingerprint.runtime_policy_hash,
+                "conversation_prefix_hash": fingerprint.conversation_prefix_hash,
+                "changed_components": components,
+                "wall_ms": _elapsed_ms(started),
+                "prefill_ms": progress_timings.prefill_ms(started) if progress_timings is not None else None,
+                "generation_ms": progress_timings.generation_ms() if progress_timings is not None else None,
+                **_result_metrics(result),
+            }
+        )
+        return result
+
+
+class _ProgressTimings:
+    def __init__(self) -> None:
+        self.first_prefill_at: float | None = None
+        self.first_generation_at: float | None = None
+        self.last_generation_at: float | None = None
+
+    def observe(self, progress: StreamProgress) -> None:
+        now = time.monotonic()
+        if progress.phase == "prefill" and self.first_prefill_at is None:
+            self.first_prefill_at = now
+        if progress.phase == "generation":
+            if self.first_generation_at is None:
+                self.first_generation_at = now
+            self.last_generation_at = now
+
+    def prefill_ms(self, started: float) -> int | None:
+        if self.first_generation_at is None:
+            return None
+        return int((self.first_generation_at - started) * 1000)
+
+    def generation_ms(self) -> int | None:
+        if self.first_generation_at is None or self.last_generation_at is None:
+            return None
+        return int((self.last_generation_at - self.first_generation_at) * 1000)
+
+
+def _result_metrics(result: ChatResult) -> dict[str, Any]:
+    prompt_tokens = result.prompt_tokens
+    cached_tokens = result.cached_tokens
+    evaluated_tokens = None
+    if prompt_tokens is not None and cached_tokens is not None:
+        evaluated_tokens = max(0, prompt_tokens - cached_tokens)
+    return {
+        "prompt_tokens": prompt_tokens,
+        "evaluated_tokens": evaluated_tokens,
+        "reused_tokens": cached_tokens,
+        "cached_tokens": cached_tokens,
+        "completion_tokens": result.completion_tokens,
+        "prefill_tps": result.prompt_tokens_per_second,
+        "generation_tps": result.generation_tokens_per_second,
+        "finish_reason": result.finish_reason,
+    }
+
+
+def _component_changes(phase: str, tools_mode: str | None, fingerprint: PromptFingerprint) -> list[str]:
+    scenario = f"{phase}:{tools_mode or 'unknown'}:{fingerprint.first_user_message_hash or 'no_user'}"
+    current = {
+        "stable_prefix": fingerprint.stable_prefix_hash,
+        "tool_schema": fingerprint.tool_schema_hash,
+        "capability_summary": fingerprint.capability_summary_hash,
+        "runtime_policy": fingerprint.runtime_policy_hash,
+        "conversation_prefix": fingerprint.conversation_prefix_hash,
+        "full_prompt": fingerprint.full_prompt_hash,
+    }
+    previous = _LAST_BY_SCENARIO.get(scenario)
+    _LAST_BY_SCENARIO[scenario] = current
+    if previous is None:
+        return []
+    return [name for name, value in current.items() if previous.get(name) != value]
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    line = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    path = os.environ.get("ORBIT_KV_DIAG_FILE")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        return
+    print(line, file=sys.stderr, flush=True)
+
+
+def _runtime_policy(messages: list[Message]) -> str | None:
+    for message in messages:
+        if message.get("role") == "system":
+            content = message.get("content")
+            if isinstance(content, str) and not content.startswith("Local tools available:"):
+                return content
+    return None
+
+
+def _capability_summary(messages: list[Message]) -> str | None:
+    for message in messages:
+        if message.get("role") != "system":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.startswith("Local tools available:"):
+            return content
+    return None
+
+
+def _first_user_message(messages: list[Message]) -> object | None:
+    for message in messages:
+        if message.get("role") == "user":
+            return message.get("content")
+    return None
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _hash(value: object) -> str:
+    text = value if isinstance(value, str) else _canonical_json(value)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.monotonic() - started) * 1000)

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -10,6 +10,7 @@ from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.runtime.capabilities import LocalCapabilities
 from orbit.runtime.command_request import command_like_tool_call, command_tool_call_from_tool_calls
+from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.messages import with_chat_system_prompt, with_tool_call_system_prompt
 from orbit.runtime.session_memory import should_refresh_for_append
 from orbit.runtime.shell_guardrails import (
@@ -743,11 +744,13 @@ def run_tool_loop(
                 use_tool_prompt=state.used_tool_call_prompt,
             )
         if result.finish_reason == "length" and not result.tool_calls:
-            result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+            with model_call_context(phase="tool_call_retry", tools_mode="on"):
+                result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=loop_index + 1, result=result, phase="tool_call_retry" if result.tool_calls else None))
         if not result.tool_calls and _is_empty_final_response(result):
-            result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=tool_max_tokens, tools=tools)
+            with model_call_context(phase="tool_call_retry", tools_mode="on"):
+                result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=tool_max_tokens, tools=tools)
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=loop_index + 1, result=result, phase="tool_call_retry" if result.tool_calls else None))
             if not result.tool_calls and _is_empty_final_response(result):

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.backend.base import ChatResult, Message
+from orbit.runtime import ChatRuntime
+from orbit.runtime.kv_diag import fingerprint_prompt, reset_diagnostics_for_tests
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.messages: list[Message] = []
+        self.tools = None
+
+    def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+        self.calls += 1
+        self.messages = messages
+        self.tools = tools
+        return ChatResult(
+            content="ok",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=10,
+            completion_tokens=2,
+            cached_tokens=4,
+            prompt_tokens_per_second=12.5,
+            generation_tokens_per_second=3.5,
+        )
+
+
+class KVDiagTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_diagnostics_for_tests()
+
+    def test_diag_default_off_does_not_write_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "0", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                runtime.ask_chat("secret prompt text", temperature=0, max_tokens=32)
+
+            self.assertFalse(log_path.exists())
+
+    def test_diag_on_writes_hashes_not_raw_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                runtime.ask_chat("secret prompt text", temperature=0, max_tokens=32)
+
+            payload = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+
+        self.assertEqual(payload["event"], "kv_diag_model_call")
+        self.assertEqual(payload["phase"], "chat_final")
+        self.assertIn("stable_prefix_hash", payload)
+        self.assertIn("full_prompt_hash", payload)
+        self.assertEqual(payload["prompt_tokens"], 10)
+        self.assertEqual(payload["cached_tokens"], 4)
+        self.assertEqual(payload["reused_tokens"], 4)
+        self.assertEqual(payload["evaluated_tokens"], 6)
+        self.assertNotIn("secret prompt text", json.dumps(payload))
+
+    def test_stable_prefix_hash_is_stable_for_identical_inputs(self) -> None:
+        messages = [
+            {"role": "system", "content": "policy"},
+            {"role": "user", "content": "hello"},
+        ]
+        first = fingerprint_prompt(messages, tools=[])
+        second = fingerprint_prompt(messages, tools=[])
+
+        self.assertEqual(first.stable_prefix_hash, second.stable_prefix_hash)
+        self.assertEqual(first.tool_schema_hash, second.tool_schema_hash)
+        self.assertEqual(first.full_prompt_hash, second.full_prompt_hash)
+
+    def test_capability_summary_hash_changes_when_summary_changes(self) -> None:
+        base = [{"role": "system", "content": "policy"}, {"role": "user", "content": "hello"}]
+        with_python = [
+            *base,
+            {"role": "system", "content": "Local tools available: python3.\nUnavailable: pandoc."},
+        ]
+        with_pandoc = [
+            *base,
+            {"role": "system", "content": "Local tools available: python3, pandoc.\nUnavailable: none."},
+        ]
+
+        first = fingerprint_prompt(with_python, tools=[])
+        second = fingerprint_prompt(with_pandoc, tools=[])
+
+        self.assertNotEqual(first.capability_summary_hash, second.capability_summary_hash)
+        self.assertNotEqual(first.stable_prefix_hash, second.stable_prefix_hash)
+
+    def test_tool_schema_hash_changes_with_tools_on_off(self) -> None:
+        messages = [{"role": "system", "content": "policy"}, {"role": "user", "content": "hello"}]
+        off = fingerprint_prompt(messages, tools=[])
+        on = fingerprint_prompt(
+            messages,
+            tools=[{"type": "function", "function": {"name": "system_info", "parameters": {}}}],
+        )
+
+        self.assertNotEqual(off.tool_schema_hash, on.tool_schema_hash)
+        self.assertNotEqual(off.stable_prefix_hash, on.stable_prefix_hash)
+
+    def test_consecutive_same_prompt_reports_no_component_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                runtime.ask_chat("same prompt", temperature=0, max_tokens=32)
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                runtime.ask_chat("same prompt", temperature=0, max_tokens=32)
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+        self.assertEqual(lines[0]["changed_components"], [])
+        self.assertEqual(lines[1]["changed_components"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Adds env-gated KV diagnostic instrumentation via ORBIT_KV_DIAG=1.
- Logs one JSONL event per model call with phase, tools mode, prompt lengths, stable/full prompt hashes, tool schema hash, capability summary hash, token/cache metrics, and wall/prefill/generation timing when available.
- Keeps logs privacy-preserving: no raw prompt or tool content is emitted.
- Adds scripts/bench_kv_diag.py for controlled Phase 1 diagnostic scenarios.
- Does not change prompts, routing, tool selection, backend inference, cache behavior, MTP, or final-answer policy.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_tool_backends tests.test_tool_loop_state tests.test_repl tests.test_cli -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Benchmark diag:
- scripts/bench_kv_diag.py executed locally with ORBIT_KV_DIAG=1.
- Artifacts were written under benchmarks/ and intentionally not committed.

Initial findings:
- stable_prefix_hash remained stable across repeated diagnostic calls in the sample run.
- conversation_prefix_hash and full_prompt_hash changed across multi-turn calls as expected.
- current API exposes cached_tokens; diag maps reused_tokens to cached_tokens until the backend exposes a distinct reused_tokens metric.