### PR TITLE
Add KV diagnostic request collector

### DIFF
--- a/docs/KV_CACHE_REUSE_PLAN.md
+++ b/docs/KV_CACHE_REUSE_PLAN.md
@@ -102,6 +102,28 @@ ORBIT_KV_DIAG=1 python3 scripts/bench_kv_diag.py
 
 The script writes raw diagnostic JSONL and a compact Markdown summary under `benchmarks/`. Benchmark outputs are local artifacts and should not be committed unless explicitly requested.
 
+## Phase 1B Collector
+
+Phase 1B keeps the same rule as Phase 1: diagnostics only, no cache or prompt behavior changes.
+
+When `ORBIT_KV_DIAG=1` is enabled, Orbit records per-request and per-model-call JSONL events:
+
+- `kv_diag_model_call`: one backend call, with `request_id`, `model_call_id`, `pass_index`, phase, prompt hashes, token metrics, and timing fields
+- `kv_diag_footer_metrics`: terminal footer metrics correlated back to the last model call that produced them
+- `kv_diag_request_summary`: aggregate counts, phases, token totals, and timing totals for one user request
+- `kv_diag_prefix_mismatch`: hash-only component mismatch when repeated calls in the same diagnostic scenario drift
+
+The collector logs hashes and lengths only. It must not log raw prompts, raw tool output, or user-visible content.
+
+The purpose of Phase 1B is to distinguish:
+
+- prompt instability
+- metric ambiguity
+- backend cache behavior
+- invalidation from reset, tool mode, or session changes
+
+It is not an optimization phase.
+
 ## Invalidation Risks
 
 KV reuse risks:

--- a/scripts/bench_kv_diag.py
+++ b/scripts/bench_kv_diag.py
@@ -38,6 +38,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output-dir", default="benchmarks")
     parser.add_argument("--max-tokens", default="120")
     parser.add_argument("--timeout", type=int, default=240)
+    parser.add_argument("--include-slow", action="store_true", help="Include slow network-dependent scenarios.")
     args = parser.parse_args(argv)
 
     root = Path.cwd()
@@ -47,7 +48,7 @@ def main(argv: list[str] | None = None) -> int:
     diag_path = output_dir / f"kv_diag_{stamp}.jsonl"
     summary_path = output_dir / f"kv_diag_{stamp}.md"
 
-    scenarios = _scenarios(max_tokens=args.max_tokens, timeout=args.timeout)
+    scenarios = _scenarios(max_tokens=args.max_tokens, timeout=args.timeout, include_slow=args.include_slow)
     env = os.environ.copy()
     env["ORBIT_KV_DIAG"] = "1"
     env["ORBIT_KV_DIAG_FILE"] = str(diag_path)
@@ -62,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
             workdir=args.workdir,
             env=env,
             root=root,
+            diag_path=diag_path,
         )
         rows.append(row)
         print(json.dumps(row, sort_keys=True), flush=True)
@@ -72,17 +74,27 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _scenarios(*, max_tokens: str, timeout: int) -> list[Scenario]:
+def _scenarios(*, max_tokens: str, timeout: int, include_slow: bool = False) -> list[Scenario]:
     base = ("--no-render-markdown", "--max-tokens", max_tokens)
-    return [
+    scenarios = [
         Scenario("tools_off_repeat", (*base, "--tools", "off"), "hi\nhi\n", timeout),
         Scenario("tools_on_repeat_no_tool_needed", (*base, "--tools", "on"), "hi\nhi\n", timeout),
-        Scenario("tools_on_same_prompt_repeat", (*base, "--tools", "on"), "tell me the specs of this computer\ntell me the specs of this computer\n", timeout),
+        Scenario("tools_on_same_session_repeat", (*base, "--tools", "on"), "hi, tell me something about yourself\nhi, tell me something about yourself\n", timeout),
         Scenario("tools_on_after_reset", (*base, "--tools", "on"), "hi\n/reset\nhi\n", timeout),
         Scenario("tools_on_off_switch", (*base, "--tools", "off"), "hi\n/tools on\nhi\n/tools off\nhi\n", timeout),
         Scenario("list_directory_repeat", (*base, "--tools", "on"), "list files in the workdir\nlist files in the workdir\n", timeout),
         Scenario("system_info_repeat", (*base, "--tools", "on"), "tell me the specs of this computer\ntell me the specs of this computer\n", timeout),
     ]
+    if include_slow:
+        scenarios.append(
+            Scenario(
+                "fetch_url_smoke_slow",
+                (*base, "--tools", "on", "--max-tokens", "256"),
+                "fetch https://www.vatican.va/content/leo-xiv/it/encyclicals/documents/20260515-magnifica-humanitas.html and explain the central thesis in Italian\n",
+                max(timeout, 360),
+            )
+        )
+    return scenarios
 
 
 def _run_scenario(
@@ -93,13 +105,15 @@ def _run_scenario(
     workdir: str,
     env: dict[str, str],
     root: Path,
+    diag_path: Path,
 ) -> dict[str, object]:
     cmd = _command(orbit_bin, module) + ["--workdir", workdir, *scenario.args]
+    diag_offset = diag_path.stat().st_size if diag_path.exists() else 0
     started = time.monotonic()
     try:
         proc = subprocess.run(
             cmd,
-            input=scenario.stdin,
+            input=_with_exit(scenario.stdin),
             cwd=root,
             env=env,
             text=True,
@@ -115,12 +129,15 @@ def _run_scenario(
         returncode = None
     elapsed = round(time.monotonic() - started, 2)
     footer = _last_footer(raw)
+    diag_events = _read_diag_events(diag_path, offset=diag_offset)
+    diag_summary = _summarize_diag_events(diag_events)
     return {
         "scenario": scenario.name,
         "returncode": returncode,
         "timeout": timeout,
         "elapsed_s": elapsed,
         **footer,
+        **diag_summary,
     }
 
 
@@ -150,26 +167,70 @@ def _write_summary(path: Path, rows: list[dict[str, object]], diag_path: Path) -
         "",
         f"Raw diagnostic JSONL: `{diag_path}`",
         "",
-        "| Scenario | Tokens | Cached | Cache | Prefill/s | Gen/s | Stop | Wall |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: |",
+        "| Scenario | Requests | Calls | Phases | Tokens/call | Cached/call | Footer corr | Stop | Wall |",
+        "| --- | ---: | ---: | --- | --- | --- | --- | --- | ---: |",
     ]
     for row in rows:
         tokens = "-"
-        if "prompt_tokens" in row:
+        if row.get("prompt_tokens_by_call"):
+            tokens = str(row.get("prompt_tokens_by_call"))
+        elif "prompt_tokens" in row:
             tokens = f"{row.get('prompt_tokens')}->{row.get('generated_tokens')}"
         lines.append(
-            "| {scenario} | {tokens} | {cached} | {cache} | {pf} | {gen} | {stop} | {wall} |".format(
+            "| {scenario} | {requests} | {calls} | {phases} | {tokens} | {cached} | {footer} | {stop} | {wall} |".format(
                 scenario=row["scenario"],
+                requests=row.get("requests", "-"),
+                calls=row.get("model_calls", "-"),
+                phases=row.get("phases", "-"),
                 tokens=tokens,
-                cached=row.get("cached_tokens", "-"),
-                cache=f"{row.get('cache_pct')}%" if "cache_pct" in row else "-",
-                pf=row.get("prefill_tps", "-"),
-                gen=row.get("generation_tps", "-"),
+                cached=row.get("cached_tokens_by_call", row.get("cached_tokens", "-")),
+                footer="yes" if row.get("footer_correlation_present") else "no",
                 stop="timeout" if row.get("timeout") else row.get("finish_reason", "-"),
                 wall=row.get("elapsed_s", "-"),
             )
         )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _with_exit(stdin: str | None) -> str:
+    text = stdin or ""
+    if not text.endswith("\n"):
+        text += "\n"
+    return text + "/exit\n"
+
+
+def _read_diag_events(path: Path, *, offset: int) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        handle.seek(offset)
+        events = []
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return events
+
+
+def _summarize_diag_events(events: list[dict[str, object]]) -> dict[str, object]:
+    calls = [event for event in events if event.get("event") == "kv_diag_model_call"]
+    summaries = [event for event in events if event.get("event") == "kv_diag_request_summary"]
+    footers = [event for event in events if event.get("event") == "kv_diag_footer_metrics"]
+    call_ids = {event.get("model_call_id") for event in calls}
+    footer_correlation = any(event.get("model_call_id") in call_ids for event in footers)
+    return {
+        "requests": len(summaries) or len({event.get("request_id") for event in calls if event.get("request_id")}),
+        "model_calls": len(calls),
+        "phases": ",".join(str(event.get("phase")) for event in calls) if calls else "-",
+        "prompt_tokens_by_call": ",".join(str(event.get("prompt_tokens")) for event in calls) if calls else "",
+        "cached_tokens_by_call": ",".join(str(event.get("cached_tokens")) for event in calls) if calls else "",
+        "evaluated_tokens_by_call": ",".join(str(event.get("evaluated_tokens")) for event in calls) if calls else "",
+        "footer_correlation_present": footer_correlation,
+    }
 
 
 def _to_text(value: str | bytes | None) -> str:

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -29,7 +29,7 @@ from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
 )
 from orbit.runtime.file_input_resolver import FileInputResolver
-from orbit.runtime.kv_diag import instrument_backend, model_call_context
+from orbit.runtime.kv_diag import instrument_backend, model_call_context, user_request
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
@@ -110,6 +110,7 @@ class ChatRuntime:
     content_evidence_guard_successes: int = 0
     content_evidence_guard_failures: int = 0
     local_capabilities: LocalCapabilities = field(default_factory=discover_local_capabilities)
+    diagnostic_session_id: str = "default"
 
     def __post_init__(self) -> None:
         self.backend = instrument_backend(self.backend)
@@ -122,6 +123,7 @@ class ChatRuntime:
         self.local_capabilities = discover_local_capabilities()
         return self.local_capabilities
 
+    @user_request
     def ask(
         self,
         prompt: str,
@@ -149,6 +151,7 @@ class ChatRuntime:
         )
         return self._remember_visible_result(result)
 
+    @user_request
     def ask_chat(
         self,
         prompt: str,
@@ -176,6 +179,7 @@ class ChatRuntime:
         )
         return self._remember_visible_result(result)
 
+    @user_request
     def continue_last_response(
         self,
         *,
@@ -196,6 +200,7 @@ class ChatRuntime:
         )
         return self._remember_visible_result(_tool_loop_result_value(result))
 
+    @user_request
     def ask_with_tools(
         self,
         prompt: str,
@@ -238,6 +243,7 @@ class ChatRuntime:
         )
         return self._remember_visible_result(result.result)
 
+    @user_request
     def ask_auto(
         self,
         prompt: str,

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -7,7 +7,8 @@ import json
 import os
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import wraps
 from itertools import count
 from typing import Any, Callable, Iterator
 
@@ -17,8 +18,11 @@ from orbit.runtime.session_memory import estimate_message_tokens
 
 _PHASE: contextvars.ContextVar[str | None] = contextvars.ContextVar("orbit_kv_diag_phase", default=None)
 _TOOLS_MODE: contextvars.ContextVar[str | None] = contextvars.ContextVar("orbit_kv_diag_tools_mode", default=None)
+_REQUEST: contextvars.ContextVar["_RequestState | None"] = contextvars.ContextVar("orbit_kv_diag_request", default=None)
 _CALL_IDS = count(1)
+_REQUEST_IDS = count(1)
 _LAST_BY_SCENARIO: dict[str, dict[str, str | None]] = {}
+_LAST_MODEL_CALL: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -35,19 +39,57 @@ class PromptFingerprint:
     conversation_prefix_hash: str
 
 
+@dataclass
+class _RequestState:
+    session_id_hash: str
+    request_id: str
+    started: float
+    pass_index: int = 0
+    model_calls: list[dict[str, Any]] = field(default_factory=list)
+
+
 def enabled() -> bool:
     value = os.environ.get("ORBIT_KV_DIAG", "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def reset_diagnostics_for_tests() -> None:
-    global _CALL_IDS
+    global _CALL_IDS, _REQUEST_IDS, _LAST_MODEL_CALL
     _CALL_IDS = count(1)
+    _REQUEST_IDS = count(1)
     _LAST_BY_SCENARIO.clear()
+    _LAST_MODEL_CALL = None
 
 
 def current_tools_mode() -> str | None:
     return _TOOLS_MODE.get()
+
+
+@contextlib.contextmanager
+def request_context(*, session_id: str | None = None) -> Iterator[None]:
+    if not enabled() or _REQUEST.get() is not None:
+        yield
+        return
+    state = _RequestState(
+        session_id_hash=_hash(session_id or "default"),
+        request_id=f"req_{next(_REQUEST_IDS):06d}",
+        started=time.monotonic(),
+    )
+    token = _REQUEST.set(state)
+    try:
+        yield
+    finally:
+        _emit_request_summary(state)
+        _REQUEST.reset(token)
+
+
+def user_request(method: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(method)
+    def wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
+        with request_context(session_id=getattr(self, "diagnostic_session_id", "default")):
+            return method(self, *args, **kwargs)
+
+    return wrapped
 
 
 @contextlib.contextmanager
@@ -159,19 +201,21 @@ class _DiagnosticBackend:
         )
 
     def continue_current(self, *args: Any, **kwargs: Any) -> ChatResult:
+        call_context = _next_call_context(_PHASE.get() or "continue", _TOOLS_MODE.get())
         started = time.monotonic()
         result = self._backend.continue_current(*args, **kwargs)
-        _emit(
-            {
-                "event": "kv_diag_model_call",
-                "call_id": next(_CALL_IDS),
-                "phase": _PHASE.get() or "continue",
-                "tools_mode": _TOOLS_MODE.get(),
-                "streamed": kwargs.get("on_delta") is not None,
-                "wall_ms": _elapsed_ms(started),
-                **_result_metrics(result),
-            }
-        )
+        event = {
+            "event": "kv_diag_model_call",
+            **call_context,
+            "phase": call_context["phase"],
+            "tools_mode": call_context["tools_mode"],
+            "streamed": kwargs.get("on_delta") is not None,
+            **_empty_prompt_fingerprint_fields(),
+            "wall_ms": _elapsed_ms(started),
+            **_result_metrics(result),
+        }
+        _record_model_call(event)
+        _emit(event)
         return result
 
     def _record_call(
@@ -183,37 +227,35 @@ class _DiagnosticBackend:
         invoke: Callable[[], ChatResult],
         progress_timings: "_ProgressTimings | None" = None,
     ) -> ChatResult:
-        call_id = next(_CALL_IDS)
         phase = _PHASE.get() or "unknown"
         tools_mode = _TOOLS_MODE.get() or ("on" if tools else "off")
+        call_context = _next_call_context(phase, tools_mode)
         fingerprint = fingerprint_prompt(messages, tools)
         started = time.monotonic()
         result = invoke()
-        components = _component_changes(phase, tools_mode, fingerprint)
-        _emit(
-            {
-                "event": "kv_diag_model_call",
-                "call_id": call_id,
-                "phase": phase,
-                "tools_mode": tools_mode,
-                "streamed": streamed,
-                "prompt_chars": fingerprint.prompt_chars,
-                "prompt_tokens_estimate": fingerprint.prompt_tokens_estimate,
-                "stable_prefix_chars": fingerprint.stable_prefix_chars,
-                "stable_prefix_hash": fingerprint.stable_prefix_hash,
-                "full_prompt_hash": fingerprint.full_prompt_hash,
-                "first_user_message_hash": fingerprint.first_user_message_hash,
-                "tool_schema_hash": fingerprint.tool_schema_hash,
-                "capability_summary_hash": fingerprint.capability_summary_hash,
-                "runtime_policy_hash": fingerprint.runtime_policy_hash,
-                "conversation_prefix_hash": fingerprint.conversation_prefix_hash,
-                "changed_components": components,
-                "wall_ms": _elapsed_ms(started),
-                "prefill_ms": progress_timings.prefill_ms(started) if progress_timings is not None else None,
-                "generation_ms": progress_timings.generation_ms() if progress_timings is not None else None,
-                **_result_metrics(result),
-            }
-        )
+        components = _component_changes(call_context["request_id"], phase, tools_mode, fingerprint)
+        event = {
+            "event": "kv_diag_model_call",
+            **call_context,
+            "streamed": streamed,
+            "prompt_chars": fingerprint.prompt_chars,
+            "prompt_tokens_estimate": fingerprint.prompt_tokens_estimate,
+            "stable_prefix_chars": fingerprint.stable_prefix_chars,
+            "stable_prefix_hash": fingerprint.stable_prefix_hash,
+            "full_prompt_hash": fingerprint.full_prompt_hash,
+            "first_user_message_hash": fingerprint.first_user_message_hash,
+            "tool_schema_hash": fingerprint.tool_schema_hash,
+            "capability_summary_hash": fingerprint.capability_summary_hash,
+            "runtime_policy_hash": fingerprint.runtime_policy_hash,
+            "conversation_prefix_hash": fingerprint.conversation_prefix_hash,
+            "changed_components": components,
+            "wall_ms": _elapsed_ms(started),
+            "prefill_ms": progress_timings.prefill_ms(started) if progress_timings is not None else None,
+            "generation_ms": progress_timings.generation_ms() if progress_timings is not None else None,
+            **_result_metrics(result),
+        }
+        _record_model_call(event)
+        _emit(event)
         return result
 
 
@@ -261,7 +303,129 @@ def _result_metrics(result: ChatResult) -> dict[str, Any]:
     }
 
 
-def _component_changes(phase: str, tools_mode: str | None, fingerprint: PromptFingerprint) -> list[str]:
+def emit_footer_metrics(
+    result: ChatResult,
+    *,
+    elapsed_seconds: float | None = None,
+    estimated_context_tokens: int | None = None,
+    context_tokens: int | None = None,
+) -> None:
+    if not enabled() or _LAST_MODEL_CALL is None:
+        return
+    prompt_tokens = result.prompt_tokens
+    cache_percent = None
+    if prompt_tokens and result.cached_tokens is not None:
+        cache_percent = (result.cached_tokens / prompt_tokens) * 100
+    _emit(
+        {
+            "event": "kv_diag_footer_metrics",
+            "session_id_hash": _LAST_MODEL_CALL.get("session_id_hash"),
+            "request_id": _LAST_MODEL_CALL.get("request_id"),
+            "model_call_id": _LAST_MODEL_CALL.get("model_call_id"),
+            "call_id": _LAST_MODEL_CALL.get("call_id"),
+            "pass_index": _LAST_MODEL_CALL.get("pass_index"),
+            "phase": _LAST_MODEL_CALL.get("phase"),
+            "footer": {
+                "model": result.model,
+                "ctx_used": estimated_context_tokens,
+                "ctx_total": context_tokens,
+                "input_tokens": result.prompt_tokens,
+                "output_tokens": result.completion_tokens,
+                "cached_tokens": result.cached_tokens,
+                "cache_percent": cache_percent,
+                "prefill_tok_s": result.prompt_tokens_per_second,
+                "generation_tok_s": result.generation_tokens_per_second,
+                "finish_reason": result.finish_reason,
+                "wall_ms": int(elapsed_seconds * 1000) if elapsed_seconds is not None else None,
+            },
+        }
+    )
+
+
+def _next_call_context(phase: str, tools_mode: str | None) -> dict[str, Any]:
+    request = _REQUEST.get()
+    call_id = next(_CALL_IDS)
+    model_call_id = f"mc_{call_id:06d}"
+    if request is None:
+        return {
+            "session_id_hash": None,
+            "request_id": None,
+            "model_call_id": model_call_id,
+            "call_id": call_id,
+            "pass_index": None,
+            "phase": phase,
+            "tools_mode": tools_mode,
+        }
+    request.pass_index += 1
+    return {
+        "session_id_hash": request.session_id_hash,
+        "request_id": request.request_id,
+        "model_call_id": model_call_id,
+        "call_id": call_id,
+        "pass_index": request.pass_index,
+        "phase": phase,
+        "tools_mode": tools_mode,
+    }
+
+
+def _record_model_call(event: dict[str, Any]) -> None:
+    global _LAST_MODEL_CALL
+    _LAST_MODEL_CALL = {
+        key: event.get(key)
+        for key in ("session_id_hash", "request_id", "model_call_id", "call_id", "pass_index", "phase")
+    }
+    request = _REQUEST.get()
+    if request is not None:
+        request.model_calls.append(event)
+
+
+def _empty_prompt_fingerprint_fields() -> dict[str, Any]:
+    return {
+        "prompt_chars": None,
+        "prompt_tokens_estimate": None,
+        "stable_prefix_chars": None,
+        "stable_prefix_hash": None,
+        "full_prompt_hash": None,
+        "first_user_message_hash": None,
+        "tool_schema_hash": None,
+        "capability_summary_hash": None,
+        "runtime_policy_hash": None,
+        "conversation_prefix_hash": None,
+        "changed_components": [],
+    }
+
+
+def _emit_request_summary(state: _RequestState) -> None:
+    calls = state.model_calls
+    _emit(
+        {
+            "event": "kv_diag_request_summary",
+            "session_id_hash": state.session_id_hash,
+            "request_id": state.request_id,
+            "model_calls": len(calls),
+            "phases": [call.get("phase") for call in calls],
+            "total_prompt_tokens": _sum_optional(call.get("prompt_tokens") for call in calls),
+            "total_cached_tokens": _sum_optional(call.get("cached_tokens") for call in calls),
+            "total_evaluated_tokens": _sum_optional(call.get("evaluated_tokens") for call in calls),
+            "total_prefill_ms": _sum_optional(call.get("prefill_ms") for call in calls),
+            "total_generation_ms": _sum_optional(call.get("generation_ms") for call in calls),
+            "wall_ms": _elapsed_ms(state.started),
+            "finish_reasons": [call.get("finish_reason") for call in calls],
+        }
+    )
+
+
+def _sum_optional(values: Iterator[Any]) -> int | None:
+    total = 0
+    seen = False
+    for value in values:
+        if isinstance(value, (int, float)):
+            total += int(value)
+            seen = True
+    return total if seen else None
+
+
+def _component_changes(request_id: str | None, phase: str, tools_mode: str | None, fingerprint: PromptFingerprint) -> list[str]:
     scenario = f"{phase}:{tools_mode or 'unknown'}:{fingerprint.first_user_message_hash or 'no_user'}"
     current = {
         "stable_prefix": fingerprint.stable_prefix_hash,
@@ -275,7 +439,18 @@ def _component_changes(phase: str, tools_mode: str | None, fingerprint: PromptFi
     _LAST_BY_SCENARIO[scenario] = current
     if previous is None:
         return []
-    return [name for name, value in current.items() if previous.get(name) != value]
+    changed = [name for name, value in current.items() if previous.get(name) != value]
+    for name in changed:
+        _emit(
+            {
+                "event": "kv_diag_prefix_mismatch",
+                "request_id": request_id,
+                "component": name,
+                "previous_hash": previous.get(name),
+                "current_hash": current.get(name),
+            }
+        )
+    return changed
 
 
 def _emit(payload: dict[str, Any]) -> None:

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -80,6 +80,7 @@ def main(argv: list[str] | None = None) -> int:
             backend=backend,
             system_prompt=None if config.no_system else config.system,
             context_tokens=context_tokens,
+            diagnostic_session_id=str(config.workdir),
         )
         prompt = " ".join(args.prompt)
         command_result = _handle_one_shot_command(prompt, runtime, config, backend)
@@ -111,6 +112,7 @@ def main(argv: list[str] | None = None) -> int:
         system_prompt=None if config.no_system else config.system,
         messages=session_messages or [],
         context_tokens=context_tokens,
+        diagnostic_session_id=str(config.workdir),
     )
     history = PromptHistory.for_workdir(config.workdir)
     return Repl(runtime=runtime, backend=backend, config=config, session=session, history=history).run()

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from orbit.backend.base import ChatResult
+from orbit.runtime.kv_diag import emit_footer_metrics
 from orbit.runtime.session_memory import MemoryRefresh, estimate_message_tokens
 from orbit.terminal.streaming import format_elapsed
 
@@ -12,6 +13,12 @@ def format_turn_status(
     estimated_context_tokens: int | None = None,
     context_tokens: int | None = None,
 ) -> str:
+    emit_footer_metrics(
+        result,
+        elapsed_seconds=elapsed_seconds,
+        estimated_context_tokens=estimated_context_tokens,
+        context_tokens=context_tokens,
+    )
     parts = []
     if result.model:
         parts.append(f"model: {result.model}")

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -9,7 +9,8 @@ from unittest import mock
 
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
-from orbit.runtime.kv_diag import fingerprint_prompt, reset_diagnostics_for_tests
+from orbit.runtime.kv_diag import fingerprint_prompt, instrument_backend, model_call_context, request_context, reset_diagnostics_for_tests
+from orbit.terminal.status import format_turn_status
 
 
 class FakeBackend:
@@ -58,6 +59,9 @@ class KVDiagTests(unittest.TestCase):
             payload = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
 
         self.assertEqual(payload["event"], "kv_diag_model_call")
+        self.assertIn("request_id", payload)
+        self.assertIn("model_call_id", payload)
+        self.assertEqual(payload["pass_index"], 1)
         self.assertEqual(payload["phase"], "chat_final")
         self.assertIn("stable_prefix_hash", payload)
         self.assertIn("full_prompt_hash", payload)
@@ -117,9 +121,98 @@ class KVDiagTests(unittest.TestCase):
                 runtime.ask_chat("same prompt", temperature=0, max_tokens=32)
 
             lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            calls = [line for line in lines if line["event"] == "kv_diag_model_call"]
 
-        self.assertEqual(lines[0]["changed_components"], [])
-        self.assertEqual(lines[1]["changed_components"], [])
+        self.assertEqual(calls[0]["changed_components"], [])
+        self.assertEqual(calls[1]["changed_components"], [])
+
+    def test_pass_index_increments_inside_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                messages = [{"role": "user", "content": "prompt"}]
+                with request_context(session_id="session"):
+                    with model_call_context(phase="first", tools_mode="off"):
+                        backend.chat(messages, temperature=0, max_tokens=32)
+                    with model_call_context(phase="second", tools_mode="off"):
+                        backend.chat(messages, temperature=0, max_tokens=32)
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            calls = [line for line in lines if line["event"] == "kv_diag_model_call"]
+            summaries = [line for line in lines if line["event"] == "kv_diag_request_summary"]
+
+        self.assertEqual([call["pass_index"] for call in calls], [1, 2])
+        self.assertEqual(calls[0]["request_id"], calls[1]["request_id"])
+        self.assertNotEqual(calls[0]["model_call_id"], calls[1]["model_call_id"])
+        self.assertEqual(summaries[0]["model_calls"], 2)
+        self.assertEqual(summaries[0]["phases"], ["first", "second"])
+        self.assertEqual(summaries[0]["total_prompt_tokens"], 20)
+        self.assertEqual(summaries[0]["total_cached_tokens"], 8)
+        self.assertEqual(summaries[0]["total_evaluated_tokens"], 12)
+
+    def test_each_user_turn_gets_distinct_request_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                runtime.ask_chat("first", temperature=0, max_tokens=32)
+                runtime.ask_chat("second", temperature=0, max_tokens=32)
+
+            calls = [
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if json.loads(line)["event"] == "kv_diag_model_call"
+            ]
+
+        self.assertNotEqual(calls[0]["request_id"], calls[1]["request_id"])
+        self.assertEqual(calls[0]["pass_index"], 1)
+        self.assertEqual(calls[1]["pass_index"], 1)
+
+    def test_footer_metrics_correlate_to_last_model_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+                result = runtime.ask_chat("footer prompt", temperature=0, max_tokens=32)
+                format_turn_status(result, elapsed_seconds=1.5, estimated_context_tokens=20, context_tokens=100)
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            call = next(line for line in lines if line["event"] == "kv_diag_model_call")
+            footer = next(line for line in lines if line["event"] == "kv_diag_footer_metrics")
+
+        self.assertEqual(footer["request_id"], call["request_id"])
+        self.assertEqual(footer["model_call_id"], call["model_call_id"])
+        self.assertEqual(footer["pass_index"], call["pass_index"])
+        self.assertEqual(footer["footer"]["input_tokens"], 10)
+        self.assertEqual(footer["footer"]["wall_ms"], 1500)
+
+    def test_prefix_mismatch_event_contains_only_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                first = [
+                    {"role": "system", "content": "Local tools available: python3."},
+                    {"role": "user", "content": "same user prompt"},
+                ]
+                second = [
+                    {"role": "system", "content": "Local tools available: python3, file."},
+                    {"role": "user", "content": "same user prompt"},
+                ]
+                with request_context(session_id="session"):
+                    with model_call_context(phase="tool_call", tools_mode="on"):
+                        backend.chat(first, temperature=0, max_tokens=32)
+                    with model_call_context(phase="tool_call", tools_mode="on"):
+                        backend.chat(second, temperature=0, max_tokens=32)
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            mismatches = [line for line in lines if line["event"] == "kv_diag_prefix_mismatch"]
+            raw_log = json.dumps(lines)
+
+        self.assertTrue(any(event["component"] == "capability_summary" for event in mismatches))
+        self.assertNotIn("same user prompt", raw_log)
+        self.assertNotIn("python3, file", raw_log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Adds request/model-call correlation to KV diagnostics with request_id, model_call_id, pass_index, phase, tools mode, hashes, timings, and token metrics.
- Adds footer metrics events correlated to the model call that produced the terminal footer.
- Adds per-request summary events for model-call counts, phases, token totals, timings, and finish reasons.
- Adds hash-only prefix mismatch events and keeps raw prompts/tool outputs out of logs.
- Updates the KV diagnostic benchmark script to summarize per-request/per-call metrics and append an explicit /exit to avoid hanging interactive runners.
- Documents Phase 1B as diagnostics-only collector work.

Validation:
- python3 -m unittest discover -s tests -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_kv_diag tests.test_runtime tests.test_tool_backends tests.test_tool_loop_state tests.test_repl tests.test_cli -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Benchmark diag:
- scripts/bench_kv_diag.py --max-tokens 32 --timeout 90: executed against local server.
- Footer correlation present in all completed/partial scenarios.
- tools_on_same_session_repeat exposed 4 model calls across 2 requests: route + chat_final_retry per request.
- list_directory_repeat and system_info_repeat hit the 90s runner timeout after emitting correlated diagnostic data; no runtime behavior changed.

Scope:
- Diagnostics only.
- No prompt content changes.
- No routing/tool-selection changes.
- No backend/native/MTP changes.
- No cache behavior changes.
- No final policy changes.