### PR TITLE
Add route outcome diagnostics

### DIFF
--- a/docs/ROUTE_OUTCOME_OBSERVABILITY.md
+++ b/docs/ROUTE_OUTCOME_OBSERVABILITY.md
@@ -1,0 +1,90 @@
+# Route Outcome Observability
+
+Status: diagnostics only. This adds no runtime, prompt, routing, tool-selection, backend, final-policy, or KV/cache behavior changes.
+
+## Purpose
+
+The tools-on route pass can either:
+
+- finish a simple no-tool answer in one pass
+- parse a tool or chat decision
+- produce invalid/truncated output and require a retry/final pass
+
+`ORBIT_KV_DIAG=1` now records a non-content event for this outcome so repeated benchmarks can measure pass count without logging prompt text or model output.
+
+## Event
+
+Event name:
+
+```json
+{"event":"kv_diag_route_outcome"}
+```
+
+Fields:
+
+- `request_id`
+- `model_call_id`
+- `pass_index`
+- `phase`
+- `tools_mode`
+- `finish_reason`
+- `decision_type`
+- `output_chars`
+- `output_tokens`
+- `retry_reason`
+- `outcome`
+
+No raw prompt, raw route output, raw tool output, or user-visible content is logged.
+
+## Classifications
+
+| Outcome | Meaning |
+| --- | --- |
+| `route_direct_final_stop` | Route produced no parsed decision, stopped normally, and was accepted as the visible final answer. |
+| `route_no_decision_length_retry` | Route produced no parsed decision and hit `finish_reason=length`; Orbit rejects the truncated route output and runs `chat_final_retry`. |
+| `route_parsed_tool` | Route produced a parsed non-chat route, such as filesystem/web/media/tool access. |
+| `route_parsed_chat` | Route explicitly selected chat/final-answer handling. |
+| `route_invalid_output` | Route produced invalid control/empty output requiring a repair/final pass. |
+| `route_other_retry` | Route required another model-guided routing attempt, such as explicit web search or tool-related length retry. |
+
+## Example
+
+```json
+{
+  "event": "kv_diag_route_outcome",
+  "request_id": "req_000001",
+  "model_call_id": "mc_000001",
+  "pass_index": 1,
+  "phase": "route",
+  "tools_mode": "on",
+  "finish_reason": "length",
+  "decision_type": null,
+  "output_chars": 512,
+  "output_tokens": 128,
+  "retry_reason": "length_without_decision",
+  "outcome": "route_no_decision_length_retry"
+}
+```
+
+## Validation
+
+Unit coverage verifies:
+
+- direct route finalization emits `route_direct_final_stop` without changing the final answer
+- length-limited route output emits `route_no_decision_length_retry` without changing retry behavior
+- parsed/invalid/other classifications can be emitted as metadata-only events
+- event payloads include request/model-call correlation
+- event payloads do not include raw prompt or raw output content
+
+## Next Step
+
+Use this metric in route pass-count benchmarks with a normal output budget.
+
+Recommended analysis before any behavior change:
+
+- count `route_direct_final_stop` versus `route_no_decision_length_retry`
+- compare output token counts for route-direct final answers
+- identify prompts where route writes long prose instead of producing `CHAT`
+- only then decide whether a route prompt/contract change is worth benchmarking
+
+Do not mix this observability with KV reuse work.

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -29,7 +29,7 @@ from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
 )
 from orbit.runtime.file_input_resolver import FileInputResolver
-from orbit.runtime.kv_diag import instrument_backend, model_call_context, user_request
+from orbit.runtime.kv_diag import emit_route_outcome, instrument_backend, model_call_context, user_request
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
@@ -327,9 +327,20 @@ class ChatRuntime:
             on_model_step(ModelStepMetrics.from_result(loop=1, result=first, phase="route"))
         command_content = first.content
         decision = parse_command_decision_from_tool_calls(first.tool_calls) or parse_command_decision(command_content)
+        route_outcome_emitted = False
+        if decision is not None:
+            _emit_route_outcome_for_result(first, decision=decision, outcome=_route_parsed_outcome(decision))
+            route_outcome_emitted = True
         if decision is None:
             explicit_web_search = _requires_explicit_web_search_tool(prompt, allowed_tool_names)
             if _should_force_tool_route_retry(prompt, allowed_tool_names, first.finish_reason):
+                _emit_route_outcome_for_result(
+                    first,
+                    decision=None,
+                    outcome="route_other_retry",
+                    retry_reason="explicit_web_search" if explicit_web_search else "length_without_decision_tool_related",
+                )
+                route_outcome_emitted = True
                 with self._temporary_backend_thinking(False):
                     route_retry_messages = _route_retry_messages(
                         self.messages,
@@ -364,6 +375,9 @@ class ChatRuntime:
                     on_model_step(ModelStepMetrics.from_result(loop=2, result=route_retry, phase="route_retry"))
                 retry_decision = parse_command_decision_from_tool_calls(route_retry.tool_calls) or parse_command_decision(route_retry.content)
                 if retry_decision is not None:
+                    _emit_route_outcome_for_result(route_retry, decision=retry_decision, outcome=_route_parsed_outcome(retry_decision))
+                    route_outcome_emitted = True
+                if retry_decision is not None:
                     first = route_retry
                     command_content = route_retry.content
                     decision = retry_decision
@@ -386,6 +400,14 @@ class ChatRuntime:
                 initial_shell_tool_call = command_tool_call_from_tool_calls(first.tool_calls, ("exec_shell_full_command",)) or command_tool_call_from_content(command_content, ("exec_shell_full_command",))
                 route_requires_chat_final = contains_control_channel_markup(first.content)
                 if route_requires_chat_final and first.finish_reason != "length":
+                    if not route_outcome_emitted:
+                        _emit_route_outcome_for_result(
+                            first,
+                            decision=None,
+                            outcome="route_invalid_output",
+                            retry_reason="control_channel_markup",
+                        )
+                        route_outcome_emitted = True
                     first = self._transport_environment().chat_final(
                         with_chat_system_prompt(self.messages),
                         temperature=temperature,
@@ -398,6 +420,14 @@ class ChatRuntime:
                     )
                     retried_empty_final = True
                 if first.finish_reason == "length":
+                    if not route_outcome_emitted:
+                        _emit_route_outcome_for_result(
+                            first,
+                            decision=None,
+                            outcome="route_no_decision_length_retry",
+                            retry_reason="length_without_decision",
+                        )
+                        route_outcome_emitted = True
                     if on_final_delta is None:
                         with model_call_context(phase="chat_final_retry", tools_mode="on"):
                             first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
@@ -414,6 +444,14 @@ class ChatRuntime:
                     if on_model_step:
                         on_model_step(ModelStepMetrics.from_result(loop=2, result=first, phase="chat_final_retry"))
                 if _is_empty_final_response(first):
+                    if not route_outcome_emitted:
+                        _emit_route_outcome_for_result(
+                            first,
+                            decision=None,
+                            outcome="route_invalid_output",
+                            retry_reason="empty_response",
+                        )
+                        route_outcome_emitted = True
                     retried_empty_final = True
                     first = self._transport_environment().chat_final(
                         self.messages,
@@ -424,6 +462,13 @@ class ChatRuntime:
                         on_model_step=on_model_step,
                         on_phase_start=on_phase_start,
                         loop=2,
+                    )
+                if not route_outcome_emitted:
+                    _emit_route_outcome_for_result(
+                        first,
+                        decision=None,
+                        outcome="route_direct_final_stop",
+                        retry_reason=None,
                     )
                 self.messages.append({"role": "assistant", "content": first.content})
                 if on_final_delta and not streamed_final_retry and not retried_empty_final:
@@ -928,6 +973,30 @@ def _should_force_tool_route_retry(prompt: str, allowed_tool_names: tuple[str, .
     if _requires_explicit_web_search_tool(prompt, allowed_tool_names):
         return True
     return finish_reason == "length" and _should_retry_route_as_tool_call(prompt, allowed_tool_names)
+
+
+def _route_parsed_outcome(decision: RouteDecision) -> str:
+    if decision.route == ToolRoute.CHAT:
+        return "route_parsed_chat"
+    return "route_parsed_tool"
+
+
+def _emit_route_outcome_for_result(
+    result: ChatResult,
+    *,
+    decision: RouteDecision | None,
+    outcome: str,
+    retry_reason: str | None = None,
+) -> None:
+    decision_type = decision.route.value if decision is not None else None
+    emit_route_outcome(
+        outcome=outcome,
+        finish_reason=result.finish_reason,
+        decision_type=decision_type,
+        output_chars=len(result.content),
+        output_tokens=result.completion_tokens,
+        retry_reason=retry_reason,
+    )
 
 
 def _route_retry_messages(messages: list[Message], *, explicit_web_search: bool) -> list[Message]:

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -342,6 +342,37 @@ def emit_footer_metrics(
     )
 
 
+def emit_route_outcome(
+    *,
+    outcome: str,
+    finish_reason: str | None,
+    decision_type: str | None,
+    output_chars: int | None,
+    output_tokens: int | None,
+    retry_reason: str | None,
+) -> None:
+    if not enabled() or _LAST_MODEL_CALL is None:
+        return
+    _emit(
+        {
+            "event": "kv_diag_route_outcome",
+            "session_id_hash": _LAST_MODEL_CALL.get("session_id_hash"),
+            "request_id": _LAST_MODEL_CALL.get("request_id"),
+            "model_call_id": _LAST_MODEL_CALL.get("model_call_id"),
+            "call_id": _LAST_MODEL_CALL.get("call_id"),
+            "pass_index": _LAST_MODEL_CALL.get("pass_index"),
+            "phase": _LAST_MODEL_CALL.get("phase"),
+            "tools_mode": _LAST_MODEL_CALL.get("tools_mode"),
+            "finish_reason": finish_reason,
+            "decision_type": decision_type,
+            "output_chars": output_chars,
+            "output_tokens": output_tokens,
+            "retry_reason": retry_reason,
+            "outcome": outcome,
+        }
+    )
+
+
 def _next_call_context(phase: str, tools_mode: str | None) -> dict[str, Any]:
     request = _REQUEST.get()
     call_id = next(_CALL_IDS)
@@ -372,7 +403,7 @@ def _record_model_call(event: dict[str, Any]) -> None:
     global _LAST_MODEL_CALL
     _LAST_MODEL_CALL = {
         key: event.get(key)
-        for key in ("session_id_hash", "request_id", "model_call_id", "call_id", "pass_index", "phase")
+        for key in ("session_id_hash", "request_id", "model_call_id", "call_id", "pass_index", "phase", "tools_mode")
     }
     request = _REQUEST.get()
     if request is not None:

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -9,7 +9,14 @@ from unittest import mock
 
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
-from orbit.runtime.kv_diag import fingerprint_prompt, instrument_backend, model_call_context, request_context, reset_diagnostics_for_tests
+from orbit.runtime.kv_diag import (
+    emit_route_outcome,
+    fingerprint_prompt,
+    instrument_backend,
+    model_call_context,
+    request_context,
+    reset_diagnostics_for_tests,
+)
 from orbit.terminal.status import format_turn_status
 
 
@@ -34,6 +41,32 @@ class FakeBackend:
             prompt_tokens_per_second=12.5,
             generation_tokens_per_second=3.5,
         )
+
+
+class SequenceBackend:
+    def __init__(self, results: list[ChatResult]) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+        self.calls += 1
+        if not self.results:
+            raise AssertionError("unexpected backend call")
+        return self.results.pop(0)
+
+
+def _result(content: str, *, finish_reason: str, prompt_tokens: int = 10, completion_tokens: int = 2, cached_tokens: int = 0) -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=[],
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cached_tokens=cached_tokens,
+        prompt_tokens_per_second=10.0,
+        generation_tokens_per_second=3.0,
+    )
 
 
 class KVDiagTests(unittest.TestCase):
@@ -213,6 +246,98 @@ class KVDiagTests(unittest.TestCase):
         self.assertTrue(any(event["component"] == "capability_summary" for event in mismatches))
         self.assertNotIn("same user prompt", raw_log)
         self.assertNotIn("python3, file", raw_log)
+
+    def test_route_direct_final_stop_is_observed_without_behavior_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=SequenceBackend([_result("direct answer", finish_reason="stop")]), system_prompt=None)
+                result = runtime.ask_auto(
+                    "hi",
+                    temperature=0,
+                    max_tokens=32,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command", "fetch_url", "list_directory", "system_info"),
+                )
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcomes = [line for line in lines if line["event"] == "kv_diag_route_outcome"]
+
+        self.assertEqual(result.content, "direct answer")
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0]["outcome"], "route_direct_final_stop")
+        self.assertEqual(outcomes[0]["phase"], "route")
+        self.assertEqual(outcomes[0]["finish_reason"], "stop")
+        self.assertIsNone(outcomes[0]["decision_type"])
+        self.assertNotIn("direct answer", json.dumps(outcomes))
+
+    def test_route_no_decision_length_retry_is_observed_without_behavior_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            backend = SequenceBackend(
+                [
+                    _result("truncated route prose", finish_reason="length", prompt_tokens=12, completion_tokens=128, cached_tokens=8),
+                    _result("final answer", finish_reason="stop", prompt_tokens=20, completion_tokens=3, cached_tokens=19),
+                ]
+            )
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=backend, system_prompt=None)
+                result = runtime.ask_auto(
+                    "hi, tell me something about yourself",
+                    temperature=0,
+                    max_tokens=32,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command", "fetch_url", "list_directory", "system_info"),
+                )
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcomes = [line for line in lines if line["event"] == "kv_diag_route_outcome"]
+            calls = [line for line in lines if line["event"] == "kv_diag_model_call"]
+
+        self.assertEqual(result.content, "final answer")
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual([call["phase"] for call in calls], ["route", "chat_final_retry"])
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0]["outcome"], "route_no_decision_length_retry")
+        self.assertEqual(outcomes[0]["retry_reason"], "length_without_decision")
+        self.assertEqual(outcomes[0]["output_tokens"], 128)
+        self.assertNotIn("truncated route prose", json.dumps(outcomes))
+        self.assertNotIn("final answer", json.dumps(outcomes))
+
+    def test_route_outcome_event_is_metadata_only_for_required_classes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                with request_context(session_id="session"):
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat([{"role": "user", "content": "secret prompt"}], temperature=0, max_tokens=32)
+                    for outcome, decision_type, retry_reason in (
+                        ("route_parsed_tool", "FILESYSTEM", None),
+                        ("route_parsed_chat", "CHAT", None),
+                        ("route_invalid_output", None, "empty_response"),
+                        ("route_other_retry", None, "explicit_web_search"),
+                    ):
+                        emit_route_outcome(
+                            outcome=outcome,
+                            finish_reason="stop",
+                            decision_type=decision_type,
+                            output_chars=123,
+                            output_tokens=7,
+                            retry_reason=retry_reason,
+                        )
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcomes = [line for line in lines if line["event"] == "kv_diag_route_outcome"]
+            raw_log = json.dumps(lines)
+
+        self.assertEqual(
+            [event["outcome"] for event in outcomes],
+            ["route_parsed_tool", "route_parsed_chat", "route_invalid_output", "route_other_retry"],
+        )
+        self.assertTrue(all(event["request_id"] for event in outcomes))
+        self.assertTrue(all(event["model_call_id"] for event in outcomes))
+        self.assertNotIn("secret prompt", raw_log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Adds env-gated non-content route outcome diagnostics under ORBIT_KV_DIAG.
- Emits kv_diag_route_outcome events correlated with request_id, model_call_id, pass_index, phase, and tools_mode.
- Classifies route outcomes as route_direct_final_stop, route_no_decision_length_retry, route_parsed_tool, route_parsed_chat, route_invalid_output, or route_other_retry.
- Logs only metadata: finish reason, decision type, output length/token count, and retry reason.
- Does not log raw prompt, raw route output, raw tool output, or user-visible content.
- Documents the metric in docs/ROUTE_OUTCOME_OBSERVABILITY.md.

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_kv_diag -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

Scope:
- Diagnostics only
- No prompt changes
- No routing policy changes
- No tool-selection changes
- No backend/native/MTP changes
- No final policy changes
- No KV/cache behavior changes
- No visible behavior changes