### PR TITLE
Add KV prompt layout diagnostics

### DIFF
--- a/docs/KV_PROMPT_LAYOUT_DIAGNOSTICS.md
+++ b/docs/KV_PROMPT_LAYOUT_DIAGNOSTICS.md
@@ -1,0 +1,126 @@
+# KV Prompt Layout Diagnostics
+
+Status: diagnostics only.
+
+This document describes the prompt layout diagnostics added after the post-route
+KV baseline. The goal is to understand why a logically stable tools-on route
+prefix can still show low backend cache reuse.
+
+## Problem
+
+The post-route baseline showed:
+
+- `route_no_decision_length_retry = 0`
+- valid web and fetch requests stay on `route -> final_from_tool`
+- the tools-on route prompt is still large, around 700 tokens
+- the logical stable prefix hash is stable
+- backend cache reuse for route calls can still drop to only a few cached tokens
+
+This suggests that the logical stable prefix might not map to a reusable prefix
+in the serialized/tokenized prompt, or that dynamic conversation content changes
+before the backend's reusable prefix boundary.
+
+## What The Diagnostics Measure
+
+When `ORBIT_KV_DIAG=1` is enabled, each `kv_diag_model_call` event includes
+prompt layout metadata:
+
+- `prompt_layout_hash`
+- `prompt_layout_order`
+- `prompt_layout`
+- `prompt_layout_common_prefix`
+
+The purpose is to determine whether Orbit's logically stable prefix is also the
+real serialized/tokenized prefix that the backend can reuse. These diagnostics do
+not imply any KV optimization by themselves.
+
+Each prompt layout block contains only metadata:
+
+- block index
+- component name, such as `runtime_policy`, `user_message`, `tool_schema_parameter`
+- source, such as `messages` or `tools_parameter`
+- role, if the block comes from a message
+- content/schema hash
+- character length estimate
+- token estimate
+- estimated character range
+- estimated token range
+
+For repeated calls in the same diagnostic scenario, Orbit also reports the
+metadata-only common prefix between the previous and current layout:
+
+- whether a previous comparable call exists
+- number of common blocks
+- estimated common prefix characters
+- estimated common prefix tokens
+- hash of the common block prefix
+- current first divergent component
+- previous first divergent component
+
+If a layout divergence is detected, Orbit emits:
+
+```json
+{"event":"kv_diag_prompt_layout_mismatch","common_blocks":1,"first_divergence_component":"assistant_history","previous_first_divergence_component":"user_message"}
+```
+
+## Privacy And Safety
+
+The diagnostics do not log:
+
+- raw prompt text
+- user messages
+- assistant content
+- tool output
+- file contents
+- fetched web content
+- raw tool schemas
+
+The logs include hashes, lengths, estimated positions, component labels, and
+tool counts. They are intended to answer layout questions without exposing
+content.
+
+## How To Run
+
+Example:
+
+```bash
+ORBIT_KV_DIAG=1 \
+ORBIT_KV_DIAG_FILE=/tmp/orbit_kv_layout.jsonl \
+PYTHONPATH=src \
+python3 -m orbit.terminal.cli --workdir workdir --tools on --no-render-markdown "hi"
+```
+
+For repeat scenarios, run multiple turns in one session or run controlled
+benchmark scripts with the same `ORBIT_KV_DIAG_FILE`.
+
+## How To Interpret Results
+
+Start with `kv_diag_model_call`:
+
+1. Check `stable_prefix_hash`.
+2. Check `prompt_layout_order`.
+3. Check whether stable components appear before dynamic components.
+4. Compare `prompt_layout_common_prefix.common_tokens_estimate` across repeated calls.
+5. Inspect `kv_diag_prompt_layout_mismatch` events for the first divergent component.
+
+Useful patterns:
+
+- If `runtime_policy` is first and stable but the backend still reports low cache,
+  the issue may be backend cache behavior or tokenizer/session semantics.
+- If `user_message`, `assistant_history`, or `tool_result` appears before a stable
+  tool/policy block, prompt layout may prevent longest-prefix reuse.
+- If `user_message` appears before `tool_schema_parameter`, treat that as a signal
+  to verify the serialized layout and backend cache semantics. It is not itself a
+  runtime fix or permission to change routing behavior.
+- If `conversation_prefix` changes while `stable_prefix_hash` stays stable,
+  Orbit may need better token-position diagnostics before any optimization.
+
+## Next Decision
+
+Do not implement KV optimization from these diagnostics alone.
+
+The next decision should be based on whether the stable route/tool policy is
+actually at the beginning of the serialized prompt seen by the backend. If it is
+not, the next candidate is a no-semantics-change prompt layout experiment in a
+separate branch. If it is already first, the likely blocker is backend cache
+behavior rather than Orbit prompt assembly.

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -13,7 +13,7 @@ from itertools import count
 from typing import Any, Callable, Iterator
 
 from orbit.backend.base import ChatResult, Message, StreamProgress
-from orbit.runtime.session_memory import estimate_message_tokens
+from orbit.runtime.session_memory import estimate_message_tokens, estimate_text_tokens
 
 
 _PHASE: contextvars.ContextVar[str | None] = contextvars.ContextVar("orbit_kv_diag_phase", default=None)
@@ -22,6 +22,7 @@ _REQUEST: contextvars.ContextVar["_RequestState | None"] = contextvars.ContextVa
 _CALL_IDS = count(1)
 _REQUEST_IDS = count(1)
 _LAST_BY_SCENARIO: dict[str, dict[str, str | None]] = {}
+_LAST_LAYOUT_BY_SCENARIO: dict[str, list[dict[str, Any]]] = {}
 _LAST_MODEL_CALL: dict[str, Any] | None = None
 
 
@@ -37,6 +38,8 @@ class PromptFingerprint:
     capability_summary_hash: str | None
     runtime_policy_hash: str | None
     conversation_prefix_hash: str
+    prompt_layout_hash: str
+    prompt_layout: list[dict[str, Any]]
 
 
 @dataclass
@@ -58,6 +61,7 @@ def reset_diagnostics_for_tests() -> None:
     _CALL_IDS = count(1)
     _REQUEST_IDS = count(1)
     _LAST_BY_SCENARIO.clear()
+    _LAST_LAYOUT_BY_SCENARIO.clear()
     _LAST_MODEL_CALL = None
 
 
@@ -115,6 +119,7 @@ def instrument_backend(backend: Any) -> Any:
 def fingerprint_prompt(messages: list[Message], tools: list[dict[str, Any]] | None = None) -> PromptFingerprint:
     rendered_messages = _canonical_json(messages)
     tool_schema = _canonical_json(tools or [])
+    prompt_layout = _prompt_layout(messages, tools or [])
     runtime_policy = _runtime_policy(messages)
     capability_summary = _capability_summary(messages)
     stable_components = {
@@ -135,6 +140,8 @@ def fingerprint_prompt(messages: list[Message], tools: list[dict[str, Any]] | No
         capability_summary_hash=_hash(capability_summary) if capability_summary is not None else None,
         runtime_policy_hash=_hash(runtime_policy) if runtime_policy is not None else None,
         conversation_prefix_hash=_hash(conversation_prefix),
+        prompt_layout_hash=_hash(_layout_identity(prompt_layout)),
+        prompt_layout=prompt_layout,
     )
 
 
@@ -234,6 +241,7 @@ class _DiagnosticBackend:
         started = time.monotonic()
         result = invoke()
         components = _component_changes(call_context["request_id"], phase, tools_mode, fingerprint)
+        layout_common_prefix = _layout_common_prefix(call_context["request_id"], phase, tools_mode, fingerprint)
         event = {
             "event": "kv_diag_model_call",
             **call_context,
@@ -248,6 +256,10 @@ class _DiagnosticBackend:
             "capability_summary_hash": fingerprint.capability_summary_hash,
             "runtime_policy_hash": fingerprint.runtime_policy_hash,
             "conversation_prefix_hash": fingerprint.conversation_prefix_hash,
+            "prompt_layout_hash": fingerprint.prompt_layout_hash,
+            "prompt_layout_order": [block["component"] for block in fingerprint.prompt_layout],
+            "prompt_layout": fingerprint.prompt_layout,
+            "prompt_layout_common_prefix": layout_common_prefix,
             "changed_components": components,
             "wall_ms": _elapsed_ms(started),
             "prefill_ms": progress_timings.prefill_ms(started) if progress_timings is not None else None,
@@ -422,6 +434,10 @@ def _empty_prompt_fingerprint_fields() -> dict[str, Any]:
         "capability_summary_hash": None,
         "runtime_policy_hash": None,
         "conversation_prefix_hash": None,
+        "prompt_layout_hash": None,
+        "prompt_layout_order": [],
+        "prompt_layout": [],
+        "prompt_layout_common_prefix": None,
         "changed_components": [],
     }
 
@@ -482,6 +498,150 @@ def _component_changes(request_id: str | None, phase: str, tools_mode: str | Non
             }
         )
     return changed
+
+
+def _layout_common_prefix(
+    request_id: str | None,
+    phase: str,
+    tools_mode: str | None,
+    fingerprint: PromptFingerprint,
+) -> dict[str, Any]:
+    scenario = f"{phase}:{tools_mode or 'unknown'}:{fingerprint.first_user_message_hash or 'no_user'}"
+    current = fingerprint.prompt_layout
+    previous = _LAST_LAYOUT_BY_SCENARIO.get(scenario)
+    _LAST_LAYOUT_BY_SCENARIO[scenario] = current
+    if previous is None:
+        return {
+            "previous_seen": False,
+            "common_blocks": 0,
+            "common_chars_estimate": 0,
+            "common_tokens_estimate": 0,
+            "common_prefix_hash": None,
+            "first_divergence_component": None,
+            "previous_first_divergence_component": None,
+        }
+    common = 0
+    for previous_block, current_block in zip(previous, current):
+        if previous_block.get("hash") != current_block.get("hash") or previous_block.get("component") != current_block.get("component"):
+            break
+        common += 1
+    common_blocks = current[:common]
+    current_divergence = current[common].get("component") if common < len(current) else None
+    previous_divergence = previous[common].get("component") if common < len(previous) else None
+    event = {
+        "previous_seen": True,
+        "common_blocks": common,
+        "common_chars_estimate": sum(int(block.get("chars", 0)) for block in common_blocks),
+        "common_tokens_estimate": sum(int(block.get("tokens_estimate", 0)) for block in common_blocks),
+        "common_prefix_hash": _hash(_layout_identity(common_blocks)) if common_blocks else None,
+        "first_divergence_component": current_divergence,
+        "previous_first_divergence_component": previous_divergence,
+    }
+    if current_divergence or previous_divergence:
+        _emit(
+            {
+                "event": "kv_diag_prompt_layout_mismatch",
+                "request_id": request_id,
+                "phase": phase,
+                "tools_mode": tools_mode,
+                **event,
+            }
+        )
+    return event
+
+
+def _prompt_layout(messages: list[Message], tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    char_offset = 0
+    token_offset = 0
+    for index, message in enumerate(messages):
+        component = _message_component(message, index=index)
+        serialized = _canonical_json(message)
+        tokens = estimate_message_tokens([message])
+        block = _layout_block(
+            index=len(blocks),
+            component=component,
+            source="messages",
+            role=str(message.get("role") or "unknown"),
+            serialized=serialized,
+            token_estimate=tokens,
+            char_offset=char_offset,
+            token_offset=token_offset,
+        )
+        blocks.append(block)
+        char_offset = block["end_char_estimate"]
+        token_offset = block["end_token_estimate"]
+    if tools:
+        serialized = _canonical_json(tools)
+        tokens = estimate_text_tokens(serialized)
+        block = _layout_block(
+            index=len(blocks),
+            component="tool_schema_parameter",
+            source="tools_parameter",
+            role=None,
+            serialized=serialized,
+            token_estimate=tokens,
+            char_offset=char_offset,
+            token_offset=token_offset,
+        )
+        block["tool_count"] = len(tools)
+        blocks.append(block)
+    return blocks
+
+
+def _layout_block(
+    *,
+    index: int,
+    component: str,
+    source: str,
+    role: str | None,
+    serialized: str,
+    token_estimate: int,
+    char_offset: int,
+    token_offset: int,
+) -> dict[str, Any]:
+    chars = len(serialized)
+    return {
+        "index": index,
+        "component": component,
+        "source": source,
+        "role": role,
+        "hash": _hash(serialized),
+        "chars": chars,
+        "tokens_estimate": token_estimate,
+        "start_char_estimate": char_offset,
+        "end_char_estimate": char_offset + chars,
+        "start_token_estimate": token_offset,
+        "end_token_estimate": token_offset + token_estimate,
+    }
+
+
+def _message_component(message: Message, *, index: int) -> str:
+    role = str(message.get("role") or "unknown")
+    content = message.get("content")
+    if role == "system" and isinstance(content, str):
+        if content.startswith("Local tools available:"):
+            return "capability_summary"
+        return "runtime_policy" if index == 0 else "system_instruction"
+    if role == "user":
+        return "user_message"
+    if role == "assistant":
+        return "assistant_history"
+    if role == "tool":
+        return "tool_result"
+    return f"{role}_message"
+
+
+def _layout_identity(layout: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "component": block.get("component"),
+            "source": block.get("source"),
+            "role": block.get("role"),
+            "hash": block.get("hash"),
+        }
+        for block in layout
+    ]
 
 
 def _emit(payload: dict[str, Any]) -> None:

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -78,7 +78,7 @@ class KVDiagTests(unittest.TestCase):
             log_path = Path(tmp) / "diag.jsonl"
             with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "0", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
                 runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
-                runtime.ask_chat("secret prompt text", temperature=0, max_tokens=32)
+                runtime.ask_chat("placeholder payload alpha", temperature=0, max_tokens=32)
 
             self.assertFalse(log_path.exists())
 
@@ -87,7 +87,7 @@ class KVDiagTests(unittest.TestCase):
             log_path = Path(tmp) / "diag.jsonl"
             with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
                 runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
-                runtime.ask_chat("secret prompt text", temperature=0, max_tokens=32)
+                runtime.ask_chat("placeholder payload alpha", temperature=0, max_tokens=32)
 
             payload = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
 
@@ -98,11 +98,79 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(payload["phase"], "chat_final")
         self.assertIn("stable_prefix_hash", payload)
         self.assertIn("full_prompt_hash", payload)
+        self.assertIn("prompt_layout_hash", payload)
+        self.assertIn("prompt_layout", payload)
+        self.assertIn("prompt_layout_common_prefix", payload)
         self.assertEqual(payload["prompt_tokens"], 10)
         self.assertEqual(payload["cached_tokens"], 4)
         self.assertEqual(payload["reused_tokens"], 4)
         self.assertEqual(payload["evaluated_tokens"], 6)
-        self.assertNotIn("secret prompt text", json.dumps(payload))
+        self.assertNotIn("placeholder payload alpha", json.dumps(payload))
+
+    def test_prompt_layout_diagnostics_are_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                messages = [
+                    {"role": "system", "content": "policy text"},
+                    {"role": "user", "content": "placeholder payload beta"},
+                ]
+                tools = [{"type": "function", "function": {"name": "system_info", "parameters": {"placeholder": "schema metadata"}}}]
+                with request_context(session_id="session"):
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat(messages, temperature=0, max_tokens=32, tools=tools)
+
+            payload = next(
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if json.loads(line)["event"] == "kv_diag_model_call"
+            )
+            raw_log = json.dumps(payload)
+
+        self.assertEqual(payload["prompt_layout_order"], ["runtime_policy", "user_message", "tool_schema_parameter"])
+        self.assertEqual(payload["prompt_layout"][0]["source"], "messages")
+        self.assertEqual(payload["prompt_layout"][-1]["source"], "tools_parameter")
+        self.assertEqual(payload["prompt_layout"][-1]["tool_count"], 1)
+        self.assertIn("start_token_estimate", payload["prompt_layout"][0])
+        self.assertIn("end_token_estimate", payload["prompt_layout"][0])
+        self.assertFalse(payload["prompt_layout_common_prefix"]["previous_seen"])
+        self.assertNotIn("placeholder payload beta", raw_log)
+        self.assertNotIn("schema metadata", raw_log)
+        self.assertNotIn("policy text", raw_log)
+
+    def test_prompt_layout_mismatch_event_contains_only_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                first = [
+                    {"role": "system", "content": "policy"},
+                    {"role": "user", "content": "placeholder repeated payload"},
+                ]
+                second = [
+                    {"role": "system", "content": "policy"},
+                    {"role": "assistant", "content": "placeholder assistant payload"},
+                    {"role": "user", "content": "placeholder repeated payload"},
+                ]
+                with request_context(session_id="session"):
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat(first, temperature=0, max_tokens=32)
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat(second, temperature=0, max_tokens=32)
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            mismatch = next(line for line in lines if line["event"] == "kv_diag_prompt_layout_mismatch")
+            second_call = [line for line in lines if line["event"] == "kv_diag_model_call"][-1]
+            raw_log = json.dumps(lines)
+
+        self.assertEqual(mismatch["common_blocks"], 1)
+        self.assertEqual(mismatch["first_divergence_component"], "assistant_history")
+        self.assertEqual(mismatch["previous_first_divergence_component"], "user_message")
+        self.assertTrue(second_call["prompt_layout_common_prefix"]["previous_seen"])
+        self.assertEqual(second_call["prompt_layout_common_prefix"]["common_blocks"], 1)
+        self.assertNotIn("placeholder repeated payload", raw_log)
+        self.assertNotIn("placeholder assistant payload", raw_log)
 
     def test_stable_prefix_hash_is_stable_for_identical_inputs(self) -> None:
         messages = [
@@ -227,11 +295,11 @@ class KVDiagTests(unittest.TestCase):
                 backend = instrument_backend(FakeBackend())
                 first = [
                     {"role": "system", "content": "Local tools available: python3."},
-                    {"role": "user", "content": "same user prompt"},
+                    {"role": "user", "content": "placeholder repeated payload"},
                 ]
                 second = [
                     {"role": "system", "content": "Local tools available: python3, file."},
-                    {"role": "user", "content": "same user prompt"},
+                    {"role": "user", "content": "placeholder repeated payload"},
                 ]
                 with request_context(session_id="session"):
                     with model_call_context(phase="tool_call", tools_mode="on"):
@@ -244,7 +312,7 @@ class KVDiagTests(unittest.TestCase):
             raw_log = json.dumps(lines)
 
         self.assertTrue(any(event["component"] == "capability_summary" for event in mismatches))
-        self.assertNotIn("same user prompt", raw_log)
+        self.assertNotIn("placeholder repeated payload", raw_log)
         self.assertNotIn("python3, file", raw_log)
 
     def test_route_direct_final_stop_is_observed_without_behavior_change(self) -> None:
@@ -311,7 +379,7 @@ class KVDiagTests(unittest.TestCase):
                 backend = instrument_backend(FakeBackend())
                 with request_context(session_id="session"):
                     with model_call_context(phase="route", tools_mode="on"):
-                        backend.chat([{"role": "user", "content": "secret prompt"}], temperature=0, max_tokens=32)
+                        backend.chat([{"role": "user", "content": "placeholder payload gamma"}], temperature=0, max_tokens=32)
                     for outcome, decision_type, retry_reason in (
                         ("route_parsed_tool", "FILESYSTEM", None),
                         ("route_parsed_chat", "CHAT", None),
@@ -337,7 +405,7 @@ class KVDiagTests(unittest.TestCase):
         )
         self.assertTrue(all(event["request_id"] for event in outcomes))
         self.assertTrue(all(event["model_call_id"] for event in outcomes))
-        self.assertNotIn("secret prompt", raw_log)
+        self.assertNotIn("placeholder payload gamma", raw_log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds env-gated KV prompt layout diagnostics.

Changes:
- extends ORBIT_KV_DIAG metadata with prompt layout information
- records block order, hashes, estimated lengths/ranges, and common-prefix metadata
- avoids raw prompt, user content, tool output, file/web content, and personal data
- adds tests for metadata-only diagnostics and env-gated behavior
- documents how to interpret prompt layout diagnostics

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_kv_diag -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS
- privacy/name/Unicode scan: PASS

No runtime behavior, prompt, backend, KV/cache behavior, tool selection, final policy, or MTP changes.