### PR TITLE
Add KV backend and native cache diagnostics

### DIFF
--- a/docs/KV_BACKEND_ENVELOPE_DIAGNOSTICS.md
+++ b/docs/KV_BACKEND_ENVELOPE_DIAGNOSTICS.md
@@ -1,0 +1,114 @@
+# KV Backend Envelope Diagnostics
+
+## Purpose
+
+`ORBIT_KV_DIAG=1` can now record metadata about the backend-visible request envelope for each model call. This diagnostic is intended to explain why a logically stable prompt prefix can have low reported KV/cache reuse in some tools-on paths.
+
+This is diagnostics only. It does not change prompt content, routing, tool selection, backend behavior, cache behavior, or final answers.
+
+## What Is Recorded
+
+Each `kv_diag_model_call` event includes a `request_envelope` object with metadata such as:
+
+- backend class name
+- endpoint/path when it can be inferred from already-cached backend state
+- `stream`
+- `cache_prompt`
+- `continue_current`
+- hashed runtime session key, when available
+- message count
+- role sequence only, for example `["system", "user"]`
+- whether a tools parameter was present
+- tool count
+- prompt-layout common-token estimate, when available
+
+The diagnostics also keep the existing model-call fields:
+
+- `request_id`
+- `model_call_id`
+- `phase`
+- `tools_mode`
+- `prompt_tokens`
+- `cached_tokens`
+- `evaluated_tokens`
+- prompt-layout hashes and common-prefix metadata
+
+## Privacy And Safety
+
+The envelope diagnostic must not record:
+
+- raw prompts
+- user message content
+- tool output
+- file content
+- web content
+- full local paths
+- personal data
+
+`role_sequence` records only roles, never message text. Session identity is represented only as an existing hash from the diagnostic request context.
+
+## How To Run
+
+Example:
+
+```bash
+ORBIT_KV_DIAG=1 ORBIT_KV_DIAG_FILE=/tmp/orbit_kv_envelope.jsonl orbit --workdir workdir
+```
+
+Then run repeated tools-on scenarios in the same session, for example:
+
+```text
+/tools on
+hi
+hi
+list files in the workdir
+list files in the workdir
+```
+
+Inspect only JSON metadata:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+for line in Path("/tmp/orbit_kv_envelope.jsonl").read_text().splitlines():
+    event = json.loads(line)
+    if event.get("event") != "kv_diag_model_call":
+        continue
+    envelope = event.get("request_envelope", {})
+    print(
+        event.get("request_id"),
+        event.get("phase"),
+        event.get("cached_tokens"),
+        event.get("prompt_tokens"),
+        envelope.get("endpoint"),
+        envelope.get("stream"),
+        envelope.get("tools_parameter_present"),
+        envelope.get("tool_count"),
+        envelope.get("message_count"),
+        envelope.get("role_sequence"),
+    )
+PY
+```
+
+## Interpreting Cache Hits And Misses
+
+If cache-hit and cache-miss calls have the same:
+
+- endpoint
+- stream mode
+- `cache_prompt`
+- tools parameter presence
+- tool count
+- role sequence shape
+- stable prompt-layout common prefix
+
+but still report very different `cached_tokens`, the likely cause is backend cache/session behavior rather than prompt-layout instability.
+
+If low-cache calls differ in endpoint, stream mode, tools parameter presence, role sequence, or message count, those differences should be investigated before any KV optimization.
+
+## Candidate Patch This Can Inform
+
+This diagnostic can justify a later, separate patch only if the metadata shows a clear backend-visible difference between cache-hit and cache-miss requests. Possible later work could include explicit backend cache identity or prompt-layout changes, but neither should be implemented without benchmark evidence.
+

--- a/docs/KV_BACKEND_NATIVE_CACHE_DIAGNOSTICS.md
+++ b/docs/KV_BACKEND_NATIVE_CACHE_DIAGNOSTICS.md
@@ -1,0 +1,129 @@
+# KV Backend Native Cache Diagnostics
+
+## Purpose
+
+The runtime and backend-envelope diagnostics can show that two tools-on calls have the same endpoint, stream mode, and `cache_prompt=true`, while native `cached_tokens` still differs sharply. Native cache diagnostics add one lower-level event from the native llama client to explain whether the backend token cache actually sees a reusable token prefix.
+
+This is diagnostics only. It does not change runtime behavior, prompt content, tool selection, backend cache behavior, or final answer generation.
+
+## Event
+
+When `ORBIT_KV_DIAG=1` is set, the native standard completion path emits:
+
+```json
+{"event":"kv_diag_native_cache","endpoint":"/chat/stream","cache_prompt":true,"prompt_tokens":706,"previous_prompt_tokens":0,"longest_common_prefix_tokens":0,"cached_tokens":0,"cache_miss_reason":"no_previous_prompt"}
+```
+
+The event contains only metadata:
+
+- backend request id generated inside the native server
+- endpoint, stream flag, and received `cache_prompt`
+- hashed session/cache key
+- slot id
+- message count
+- role sequence only
+- tools parameter presence and tool count
+- backend-visible prompt token count
+- previous cached prompt token count
+- tokenized prompt hash
+- tokenized common-prefix hash and length
+- longest common prefix token count
+- first mismatch token position, when the current and previous prompts diverge
+- reused/cached/evaluated token counts
+- cache miss reason when deducible
+
+## Privacy And Safety
+
+The diagnostic does not log:
+
+- raw prompt text
+- raw token ids
+- user message content
+- tool output
+- file content
+- web content
+- full local paths
+- personal data
+
+Token hashes are one-way diagnostic hashes over token sequences. They are intended only for comparing whether two backend-visible prompts are identical or share a prefix.
+
+## How To Run
+
+Start Orbit normally, then run the client with diagnostics:
+
+```bash
+ORBIT_KV_DIAG=1 ORBIT_KV_DIAG_FILE=/tmp/orbit_native_kv.jsonl orbit --workdir workdir
+```
+
+Suggested smoke scenarios:
+
+```text
+/tools on
+hi
+hi
+what is 2+2?
+what is 2+2?
+list files in the workdir
+list files in the workdir
+read README.md and explain it
+read README.md and explain it
+fetch https://example.com and summarize it briefly
+```
+
+Inspect only metadata:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+for line in Path("/tmp/orbit_native_kv.jsonl").read_text().splitlines():
+    event = json.loads(line)
+    if event.get("event") != "kv_diag_native_cache":
+        continue
+    print(
+        event.get("endpoint"),
+        event.get("prompt_tokens"),
+        event.get("previous_prompt_tokens"),
+        event.get("longest_common_prefix_tokens"),
+        event.get("cached_tokens"),
+        event.get("cache_miss_reason"),
+        event.get("role_sequence"),
+    )
+PY
+```
+
+## Interpreting Results
+
+If `longest_common_prefix_tokens` is high and `cached_tokens` is also high, native KV reuse is working for that request.
+
+If `longest_common_prefix_tokens` is high but `cached_tokens` is low, the next suspect is a bug in cache reuse accounting or memory invalidation after the LCP calculation.
+
+If both `longest_common_prefix_tokens` and `cached_tokens` are low, the backend-visible prompt is not prefix-stable at token level. In that case the candidate patch is prompt-layout work, not KV slot work.
+
+`first_mismatch_token` identifies the token position where the current backend-visible prompt first diverges from the previous prompt in the same native session. A low value such as `4` means the backend cannot reuse the large logical runtime/tool prefix because the tokenized request changes before that prefix becomes common.
+
+If `previous_prompt_tokens` is zero, the native client has no previous prompt cache for that slot/session. The event should report `no_previous_prompt`.
+
+If `cache_prompt=false`, the event should report `cache_disabled`; this records the received envelope but does not change current backend behavior.
+
+## Initial Local Finding
+
+Local smoke runs showed that cache hits and misses used the same native slot (`default`), endpoint (`/chat/stream`), and `cache_prompt=true`.
+
+The important difference was tokenized LCP:
+
+- cache-hit cases had high `longest_common_prefix_tokens`, and `cached_tokens` matched it closely
+- cache-miss cases had low `longest_common_prefix_tokens`, often `0` or `4`, and `cached_tokens` matched that low value
+
+This suggests the native cache is behaving consistently with the tokenized prompt it receives. The low reuse is more likely caused by backend-visible prompt shape differences between phases or requests, not by a missing cache slot identity.
+
+## Patch Decision This Enables
+
+Use this diagnostic before any KV optimization:
+
+- If hit and miss requests use different slot/session metadata, the candidate patch is stable cache identity or slot reuse.
+- If slot/session metadata is stable but tokenized LCP is low, the candidate patch is prompt-layout stabilization.
+- If slot/session metadata is stable and tokenized LCP is high but `cached_tokens` is low, the candidate patch is native cache accounting or memory reuse validation.
+
+No performance patch should be implemented until this event identifies which of those cases applies.

--- a/docs/KV_PREFIX_CACHE_FEASIBILITY.md
+++ b/docs/KV_PREFIX_CACHE_FEASIBILITY.md
@@ -1,0 +1,118 @@
+## KV Prefix Cache Feasibility
+
+Commit analyzed: `8a7cdb8`
+
+### Goal
+
+Find a stable way to improve tools-on prefill by reusing KV for the stable system/tools/capabilities prefix without changing the semantic prompt seen by the model.
+
+### Current native path
+
+The native standard path currently keeps one live prompt-cache state for the default session:
+
+- `NativeSessionState.cached_prompt_tokens` stores only one tokenized prompt history.
+- `_prepare_memory_for_prompt()` computes a single longest common token prefix against that one cached prompt.
+- `llama_memory_clear()` or `llama_memory_seq_rm()` mutates the active memory in place.
+- `_ensure_prompt_cache_mode()` resets the session state when the cache mode changes.
+- `validate_session_id()` accepts only the default session.
+
+This means the backend can reuse KV only for the single prompt lineage that is currently resident in the active llama context.
+
+### Why the obvious options are not safe today
+
+#### Option A: backend prefix prefill anchor
+
+Not currently feasible in the standard path.
+
+Reason:
+
+- The standard native client does not expose a generic "prefill stable prefix once, then append different suffixes later" anchor API.
+- The runtime can compute logical stable components, but the backend only reuses KV from the currently resident token sequence.
+- Implementing an anchor without native checkpoint/restore would require replaying the anchor tokens on each switch, which is not real KV reuse.
+
+#### Option B: stable prefix cache by prefix hash
+
+Not currently feasible in the standard path.
+
+Reason:
+
+- A prefix hash alone is not enough.
+- The client has no generic snapshot/restore of prompt KV for standard chat.
+- There is no stored backend state object keyed by prefix hash.
+- Adding a runtime-side mapping from prefix hash to token list would be a fake cache unless the backend can restore the corresponding KV state.
+
+#### Option C: separate cache modes or lanes for route/chat_final
+
+Not safe with the current standard implementation.
+
+Reason:
+
+- The client has one active llama context and one `cached_prompt_tokens` lineage.
+- Separate logical lanes would still need real KV state restore when switching lanes.
+- The current code can reset the active state, but it cannot restore a previous standard-chat KV snapshot for another lane.
+- Rebuilding a lane by replaying its full prompt would increase work instead of reducing it.
+
+### Existing support that does not solve this
+
+There is persistent session machinery for experimental MTP, including checkpoint/restore counters, but that support is specific to the MTP path and is not wired as a generic standard-chat KV snapshot facility.
+
+So the required primitive exists only in a specialized path, not in the normal tools-on chat path we need to accelerate.
+
+### Technical no-go
+
+With the current standard native backend, a safe prefix-cache patch is not available without adding at least one of these new backend capabilities:
+
+1. Generic standard-chat KV checkpoint/save and restore.
+2. Multiple real cache lanes or session states backed by distinct restorable KV memory.
+3. A native prefix-anchor API that can materialize a cached stable prefix once and reuse it across later compatible prompts.
+
+Without one of those, any "prefix cache" patch in the runtime would either:
+
+- replay tokens instead of reusing KV,
+- change semantic prompt shape,
+- or introduce hidden backend behavior not justified by the existing architecture.
+
+### Recommendation
+
+Verdict: `no-go`
+
+Do not implement a runtime-level prefix cache patch on top of the current standard path.
+
+The next safe lever is backend-native:
+
+- add a generic KV checkpoint/restore primitive for the standard chat path,
+- keep it feature-flagged,
+- and benchmark it first on tools-on no-tool chat before promoting it.
+
+### Smallest credible next patch
+
+If work continues, the smallest credible patch is:
+
+- native backend support for saving and restoring standard-chat KV state keyed by a runtime-provided cache namespace or stable prefix hash,
+- with diagnostics proving that restore reuses tokenized prefix KV instead of replaying tokens.
+
+That patch should stay off by default and must preserve:
+
+- prompt semantics,
+- model call counts,
+- routing behavior,
+- file/web evidence policy,
+- and visible output.
+
+### Benchmark required before accepting any future patch
+
+Any future implementation should compare OFF vs ON for:
+
+- repeated tools-on short chat,
+- repeated tools-on medium no-tool chat that goes through `chat_final`,
+- listing,
+- file read,
+- valid web search,
+- valid `fetch_url`.
+
+Acceptance should require:
+
+- higher `cached_tokens` or lower `evaluated_tokens` on tools-on no-tool paths,
+- no increase in model calls or retries,
+- no regression in file/web/listing correctness,
+- and no semantic prompt changes.

--- a/docs/KV_PROMPT_SHAPE_EXPERIMENT.md
+++ b/docs/KV_PROMPT_SHAPE_EXPERIMENT.md
@@ -1,0 +1,142 @@
+# KV Prompt Shape Experiment
+
+## Scope
+
+Commit under test: local branch `kv-backend-envelope-diagnostics` on top of `origin/main` `8a7cdb8`, plus the local experiment patch.
+
+This experiment is feature-flagged by:
+
+```bash
+ORBIT_KV_PROMPT_SHAPE_EXPERIMENT=1
+```
+
+The flag is off by default. With the flag off, prompt construction is unchanged.
+
+The experiment does not change routing, tool selection, final policy, backend decoding, cache logic, or visible runtime behavior by default.
+
+## Hypothesis
+
+Diagnostics showed that low KV reuse in tools-on no-tool paths is caused by low backend-visible tokenized longest common prefix (LCP), not by slot identity, endpoint, stream mode, or `cache_prompt`.
+
+The common miss pattern is:
+
+```text
+route prompt -> chat_final prompt -> next route prompt
+```
+
+The route prompt starts with the route/system/tools contract. The chat final prompt starts with the short chat system prompt. The next route call then shares only a very small token prefix with the previous chat final prompt.
+
+## Medium prompts used
+
+- `Explain in two short paragraphs how a local AI runtime can reduce latency after the first turn.`
+- `Explain the tradeoff between correctness and latency in a local agent runtime.`
+
+These prompts are:
+
+- no-tool
+- no-web
+- no-file
+- no-URL
+- no-system-info
+- neutral and non-personal
+
+Both were verified with `ORBIT_KV_DIAG=1` to use `route -> chat_final` on the first turn.
+
+## Experiment
+
+When `ORBIT_KV_PROMPT_SHAPE_EXPERIMENT=1`, tools-on `chat_final` uses a route-prefixed final-answer system prompt:
+
+```text
+<route contract prefix>
+
+Final answer phase: ... answer normally ... do not return JSON ... do not call tools ...
+```
+
+This keeps the backend-visible prefix stable between:
+
+```text
+route -> chat_final -> route
+```
+
+The first attempted version also applied the same shape to `final_from_tool`. That was rejected locally because it enlarged tool-final prompts and produced a timeout on the file-read repeat scenario. The narrower version only targeted tools-on `chat_final` no-tool paths.
+
+## Benchmark
+
+Server: native `orbit server`, no-MTP default, warm process.
+
+Max output tokens: 96.
+
+Diagnostics: `ORBIT_KV_DIAG=1`.
+
+Scenario names intentionally avoid raw user prompt content.
+
+Each scenario was run as three same-session turns per flag. The table reports aggregate request-level cached/evaluated token sums from `kv_diag_request_summary`.
+
+### OFF Baseline
+
+| Scenario | Phase sequence | Request cached/evaluated summary | Result |
+| --- | --- | --- | --- |
+| short chat | `route -> chat_final -> route -> route` | `4/736`, `4/722`, `722/24` | cache miss on route after chat final |
+| trivial chat | `route -> route -> route` | `696/16`, `708/22`, `726/22` | already efficient |
+| medium direct chat | `route -> route -> route` | `696/15`, `707/26`, `729/26` | route direct final, not the target path |
+| listing | `route -> final_from_tool -> route -> route_retry -> final_from_tool -> route` | `1403/132`, `828/1419`, `704/299` | listing behavior preserved |
+| file read | `route -> tool_call -> tool_call -> final_from_tool -> route -> final_from_tool -> route` | `1175/897`, `827/923`, `823/172` | content evidence preserved |
+| web search | `route -> final_from_tool` repeated 3 times | `1406/455`, `1705/923`, `1420/2484` | valid 2-call web path |
+| fetch URL | `route -> final_from_tool` repeated 3 times | `1410/153`, `1719/172`, `2047/172` | valid 2-call fetch path |
+
+### ON Restricted
+
+| Scenario | Phase sequence | Request cached/evaluated summary | Result |
+| --- | --- | --- | --- |
+| short chat | `route -> chat_final -> route -> route` | `1387/63`, `691/35`, `722/24` | improved target path |
+| trivial chat | `route -> route -> route` | `696/16`, `708/22`, `726/22` | unchanged |
+| medium direct chat | `route -> route -> route` | `696/15`, `707/26`, `729/26` | unchanged direct route |
+| listing | `route -> final_from_tool -> route -> route_retry -> final_from_tool -> route` | `1403/132`, `828/1419`, `704/299` | unchanged |
+| file read | `route -> tool_call -> tool_call -> final_from_tool -> route -> final_from_tool -> route` | `1175/897`, `827/923`, `823/172` | unchanged, content evidence preserved |
+| web search | `route -> final_from_tool` repeated 3 times | `1406/455`, `1705/857`, `1420/2322` | unchanged 2-call web path |
+| fetch URL | `route -> final_from_tool` repeated 3 times | `1410/153`, `1719/172`, `2047/172` | unchanged 2-call fetch path |
+
+### Medium no-tool prompts that actually use `chat_final`
+
+| Scenario | Flag | Request cached/evaluated summary | Extra passes | Result |
+| --- | --- | --- | --- | --- |
+| medium latency | `OFF` | `8/766`, `818/812`, `1717/97` | 2 x `route_no_decision_length_retry` | unstable |
+| medium latency | `ON` | `2143/138`, `1451/71`, `1609/97` | 1 x `chat_final_completion_repair`, 2 x `route_no_decision_length_retry` | lower cost, but more phases |
+| medium prefix | `OFF` | `701/63`, `808/802`, `1692/92` | 2 x `route_no_decision_length_retry` | unstable |
+| medium prefix | `ON` | `2138/128`, `1441/61`, `1584/92` | 1 x `chat_final_completion_repair`, 2 x `route_no_decision_length_retry` | lower cost, but more phases |
+
+## Findings
+
+- `cached_tokens` continues to match backend tokenized LCP.
+- The restricted experiment increases cached tokens in tools-on no-tool chat paths where route and chat-final phases alternate.
+- The improvement is visible on the short chat target path: request one went from `4/736` cached/evaluated to `1387/63`.
+- Trivial and direct-route chat paths were already efficient and remain unchanged.
+- Valid web and fetch paths remain `route -> final_from_tool`.
+- File-read evidence behavior remains model-guided and still obtains content evidence.
+- The broad `final_from_tool` version should not be promoted: it increased prompt size and caused a timeout in local file-read repeat testing.
+- The restricted `chat_final` version still introduces an extra `chat_final_completion_repair` pass on both medium no-tool prompts.
+- The restricted version does not reduce `route_no_decision_length_retry` on the repeated medium prompts; it only makes the repeated passes cheaper once they happen.
+
+## Risks
+
+- The route-prefixed chat final prompt is semantically more complex than the default short chat prompt.
+- Although it explicitly says not to return JSON or call tools, it still includes the route contract earlier in the same system message.
+- The extra `chat_final_completion_repair` pass is a visible control-flow regression even when the final answer remains correct.
+
+## Recommendation
+
+Reject.
+
+The smaller scoped experiment is not safe to promote in its current form. It improves cache reuse and wall time on the short chat target, but it also adds a completion-repair pass on medium no-tool prompts and does not remove repeated `route_no_decision_length_retry` on those scenarios.
+
+The code patch should be removed. The report is still useful as evidence that:
+
+- prompt-shape alignment can materially increase backend-visible LCP;
+- broad prompt-shape changes around final phases are risky;
+- future work should target a smaller semantic delta or a backend-side reuse mechanism instead of reusing the route contract inside `chat_final`.
+
+Removal criteria met:
+
+- extra phase introduced on medium no-tool prompts;
+- no reduction of `route_no_decision_length_retry` on repeated medium prompts;
+- benefit is strong but too narrow and too fragile for promotion.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -19,6 +19,7 @@ from .bindings import (
 )
 from .chat_template import NativeMessage, render_gemma4_chat
 from .events import NativeCompletion, NativeProgress, NativeTimings
+from .kv_diag import emit_prompt_cache_event
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
@@ -880,6 +881,7 @@ class NativeLlamaClient:
         if not prompt_tokens:
             raise RuntimeError("failed to count prompt tokens")
 
+        previous_prompt_tokens = list(self._session.cached_prompt_tokens)
         reused = self._prepare_memory_for_prompt(prompt_tokens)
         processed = 0
         step = max(1, min(self.config.progress_step, self.config.batch_size))
@@ -909,6 +911,14 @@ class NativeLlamaClient:
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
+        )
+        emit_prompt_cache_event(
+            prompt_tokens=prompt_tokens,
+            previous_prompt_tokens=previous_prompt_tokens,
+            reused_prompt_tokens=reused,
+            output_tokens=generated,
+            cancelled=cancelled,
+            slot_id=self._session.session_id,
         )
         return NativeTimings(
             prompt_tokens=n_prompt,

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Iterator
+
+
+_REQUEST_IDS = count(1)
+_CURRENT_REQUEST: contextvars.ContextVar["NativeDiagRequest | None"] = contextvars.ContextVar(
+    "orbit_native_kv_diag_request",
+    default=None,
+)
+
+
+@dataclass(frozen=True)
+class NativeDiagRequest:
+    backend_request_id: str
+    endpoint: str | None
+    stream: bool | None
+    cache_prompt: bool | None
+    session_id_hash: str | None
+    tools_parameter_present: bool
+    tool_count: int
+    message_count: int
+    role_sequence: list[str]
+
+
+def enabled() -> bool:
+    value = os.environ.get("ORBIT_KV_DIAG", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def reset_diagnostics_for_tests() -> None:
+    global _REQUEST_IDS
+    _REQUEST_IDS = count(1)
+
+
+@contextlib.contextmanager
+def request_context(*, endpoint: str | None, payload: dict[str, Any]) -> Iterator[None]:
+    if not enabled() or _CURRENT_REQUEST.get() is not None:
+        yield
+        return
+    request = NativeDiagRequest(
+        backend_request_id=f"native_req_{next(_REQUEST_IDS):06d}",
+        endpoint=endpoint,
+        stream=payload.get("stream") is True,
+        cache_prompt=payload.get("cache_prompt") if isinstance(payload.get("cache_prompt"), bool) else None,
+        session_id_hash=_hash(str(payload.get("session_id") or "default")),
+        tools_parameter_present=isinstance(payload.get("tools"), list) and bool(payload.get("tools")),
+        tool_count=len(payload.get("tools")) if isinstance(payload.get("tools"), list) else 0,
+        message_count=len(payload.get("messages")) if isinstance(payload.get("messages"), list) else 0,
+        role_sequence=_role_sequence(payload.get("messages")),
+    )
+    token = _CURRENT_REQUEST.set(request)
+    try:
+        yield
+    finally:
+        _CURRENT_REQUEST.reset(token)
+
+
+def emit_prompt_cache_event(
+    *,
+    prompt_tokens: list[int],
+    previous_prompt_tokens: list[int],
+    reused_prompt_tokens: int,
+    output_tokens: int,
+    cancelled: bool,
+    slot_id: str,
+) -> None:
+    if not enabled():
+        return
+    request = _CURRENT_REQUEST.get()
+    common = _longest_common_prefix(prompt_tokens, previous_prompt_tokens)
+    prompt_count = len(prompt_tokens)
+    previous_count = len(previous_prompt_tokens)
+    first_mismatch_token = common if common < min(prompt_count, previous_count) else None
+    evaluated = max(0, prompt_count - reused_prompt_tokens)
+    event = {
+        "event": "kv_diag_native_cache",
+        "backend_request_id": request.backend_request_id if request else None,
+        "model_call_id": None,
+        "phase": None,
+        "endpoint": request.endpoint if request else None,
+        "stream": request.stream if request else None,
+        "cache_prompt": request.cache_prompt if request else None,
+        "slot_id": slot_id,
+        "session_cache_key_hash": request.session_id_hash if request else None,
+        "session_id_hash": request.session_id_hash if request else None,
+        "message_count": request.message_count if request else None,
+        "role_sequence": request.role_sequence if request else [],
+        "tools_parameter_present": request.tools_parameter_present if request else False,
+        "tool_count": request.tool_count if request else 0,
+        "prompt_tokens": prompt_count,
+        "previous_prompt_tokens": previous_count,
+        "tokenized_prompt_hash": _hash_tokens(prompt_tokens),
+        "tokenized_prefix_hash": _hash_tokens(prompt_tokens[:common]) if common else None,
+        "tokenized_prefix_length": common,
+        "longest_common_prefix_tokens": common,
+        "first_mismatch_token": first_mismatch_token,
+        "cached_tokens": reused_prompt_tokens,
+        "evaluated_tokens": evaluated,
+        "output_tokens": output_tokens,
+        "cancelled": cancelled,
+        "cache_miss_reason": _cache_miss_reason(
+            cache_prompt=request.cache_prompt if request else None,
+            previous_prompt_tokens=previous_count,
+            common_tokens=common,
+            reused_prompt_tokens=reused_prompt_tokens,
+        ),
+    }
+    _emit(event)
+
+
+def _cache_miss_reason(
+    *,
+    cache_prompt: bool | None,
+    previous_prompt_tokens: int,
+    common_tokens: int,
+    reused_prompt_tokens: int,
+) -> str | None:
+    if cache_prompt is False:
+        return "cache_disabled"
+    if previous_prompt_tokens <= 0:
+        return "no_previous_prompt"
+    if reused_prompt_tokens > 0:
+        return None
+    if common_tokens <= 0:
+        return "prefix_mismatch_at_token_0"
+    return f"prefix_mismatch_after_token_{common_tokens}"
+
+
+def _longest_common_prefix(left: list[int], right: list[int]) -> int:
+    common = 0
+    limit = min(len(left), len(right))
+    while common < limit and left[common] == right[common]:
+        common += 1
+    return common
+
+
+def _role_sequence(messages: object) -> list[str]:
+    if not isinstance(messages, list):
+        return []
+    roles: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            roles.append("unknown")
+            continue
+        role = message.get("role")
+        roles.append(role if isinstance(role, str) else "unknown")
+    return roles
+
+
+def _hash_tokens(tokens: list[int]) -> str:
+    return _hash(",".join(str(token) for token in tokens))
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    line = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    path = os.environ.get("ORBIT_KV_DIAG_FILE")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        return
+    print(line, file=sys.stderr, flush=True)

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 
 from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _has_open_thought_channel
+from orbit.native_llama.kv_diag import request_context as native_kv_request_context
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
 from orbit.native_server.protocol import (
     ContinueRequest,
@@ -271,7 +272,8 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
         try:
             if self.path == "/chat":
                 try:
-                    self._json(self._state().chat(payload))
+                    with native_kv_request_context(endpoint="/chat", payload=payload):
+                        self._json(self._state().chat(payload))
                 except RuntimeError as exc:
                     self._json(self._state().error_result(str(exc), payload), status=500)
                 return
@@ -299,7 +301,8 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                 self._openai_stream(payload)
             else:
                 try:
-                    self._json(openai_chat_response(self._state().chat(payload)))
+                    with native_kv_request_context(endpoint="/v1/chat/completions", payload=payload):
+                        self._json(openai_chat_response(self._state().chat(payload)))
                 except RuntimeError as exc:
                     self._json(openai_chat_response(self._state().error_result(str(exc), payload)), status=500)
                 except ValueError as exc:
@@ -362,11 +365,12 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             emit({"model": self._state().model_alias, "choices": [{"delta": {"content": text}}]})
 
         try:
-            result = self._state().chat(
-                payload,
-                on_token=on_token,
-                should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
-            )
+            with native_kv_request_context(endpoint="/v1/chat/completions", payload=payload):
+                result = self._state().chat(
+                    payload,
+                    on_token=on_token,
+                    should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
+                )
             disconnect.disarm()
             emit(openai_chat_response(result, content=""))
             self.wfile.write(sse_data("[DONE]"))
@@ -425,12 +429,13 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             )
 
         try:
-            result = self._state().complete(
-                request,
-                on_progress=on_progress,
-                on_token=on_token,
-                should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
-            )
+            with native_kv_request_context(endpoint="/chat/stream", payload=payload):
+                result = self._state().complete(
+                    request,
+                    on_progress=on_progress,
+                    on_token=on_token,
+                    should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
+                )
             disconnect.disarm()
             emit("metrics", {"usage": result["usage"], "timings": result["timings"], "native": result["native"]})
             emit("done", {"finish_reason": result["finish_reason"], "session_id": request.session_id})

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -211,12 +211,23 @@ class _DiagnosticBackend:
         call_context = _next_call_context(_PHASE.get() or "continue", _TOOLS_MODE.get())
         started = time.monotonic()
         result = self._backend.continue_current(*args, **kwargs)
+        envelope = _request_envelope_metadata(
+            self._backend,
+            messages=None,
+            tools=None,
+            streamed=kwargs.get("on_delta") is not None,
+            cache_prompt=None,
+            continue_current=True,
+            runtime_session_key_hash=call_context.get("session_id_hash"),
+            layout_common_prefix=None,
+        )
         event = {
             "event": "kv_diag_model_call",
             **call_context,
             "phase": call_context["phase"],
             "tools_mode": call_context["tools_mode"],
             "streamed": kwargs.get("on_delta") is not None,
+            "request_envelope": envelope,
             **_empty_prompt_fingerprint_fields(),
             "wall_ms": _elapsed_ms(started),
             **_result_metrics(result),
@@ -242,10 +253,21 @@ class _DiagnosticBackend:
         result = invoke()
         components = _component_changes(call_context["request_id"], phase, tools_mode, fingerprint)
         layout_common_prefix = _layout_common_prefix(call_context["request_id"], phase, tools_mode, fingerprint)
+        envelope = _request_envelope_metadata(
+            self._backend,
+            messages=messages,
+            tools=tools,
+            streamed=streamed,
+            cache_prompt=True,
+            continue_current=False,
+            runtime_session_key_hash=call_context.get("session_id_hash"),
+            layout_common_prefix=layout_common_prefix,
+        )
         event = {
             "event": "kv_diag_model_call",
             **call_context,
             "streamed": streamed,
+            "request_envelope": envelope,
             "prompt_chars": fingerprint.prompt_chars,
             "prompt_tokens_estimate": fingerprint.prompt_tokens_estimate,
             "stable_prefix_chars": fingerprint.stable_prefix_chars,
@@ -313,6 +335,57 @@ def _result_metrics(result: ChatResult) -> dict[str, Any]:
         "generation_tps": result.generation_tokens_per_second,
         "finish_reason": result.finish_reason,
     }
+
+
+def _request_envelope_metadata(
+    backend: Any,
+    *,
+    messages: list[Message] | None,
+    tools: list[dict[str, Any]] | None,
+    streamed: bool,
+    cache_prompt: bool | None,
+    continue_current: bool,
+    runtime_session_key_hash: str | None,
+    layout_common_prefix: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "backend_class": type(backend).__name__,
+        "endpoint": _backend_endpoint(backend, continue_current=continue_current),
+        "stream": streamed,
+        "cache_prompt": cache_prompt,
+        "continue_current": continue_current,
+        "session_identity_present": False,
+        "session_identity_hash": None,
+        "runtime_session_key_hash": runtime_session_key_hash,
+        "message_count": len(messages or []),
+        "role_sequence": _role_sequence(messages or []),
+        "tools_parameter_present": bool(tools),
+        "tool_count": len(tools or []),
+        "prompt_layout_common_tokens_estimate": (
+            layout_common_prefix.get("common_tokens_estimate") if isinstance(layout_common_prefix, dict) else None
+        ),
+    }
+
+
+def _backend_endpoint(backend: Any, *, continue_current: bool) -> str | None:
+    if type(backend).__name__ != "LlamaServerBackend":
+        return None
+    if continue_current:
+        return "/chat/continue/stream"
+    props = getattr(backend, "_props_cache", None)
+    if not isinstance(props, dict):
+        return None
+    if props.get("backend") == "orbit-native":
+        return "/chat/stream"
+    return "/v1/chat/completions"
+
+
+def _role_sequence(messages: list[Message]) -> list[str]:
+    roles: list[str] = []
+    for message in messages:
+        role = message.get("role")
+        roles.append(role if isinstance(role, str) else "unknown")
+    return roles
 
 
 def emit_footer_metrics(

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -17,6 +17,11 @@ from orbit.runtime.kv_diag import (
     request_context,
     reset_diagnostics_for_tests,
 )
+from orbit.native_llama.kv_diag import (
+    emit_prompt_cache_event as emit_native_prompt_cache_event,
+    request_context as native_request_context,
+    reset_diagnostics_for_tests as reset_native_diagnostics_for_tests,
+)
 from orbit.terminal.status import format_turn_status
 
 
@@ -93,6 +98,7 @@ def _result(content: str, *, finish_reason: str, prompt_tokens: int = 10, comple
 class KVDiagTests(unittest.TestCase):
     def setUp(self) -> None:
         reset_diagnostics_for_tests()
+        reset_native_diagnostics_for_tests()
 
     def test_diag_default_off_does_not_write_log(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -499,6 +505,94 @@ class KVDiagTests(unittest.TestCase):
         self.assertTrue(all(event["request_id"] for event in outcomes))
         self.assertTrue(all(event["model_call_id"] for event in outcomes))
         self.assertNotIn("placeholder payload gamma", raw_log)
+
+    def test_native_cache_diagnostics_default_off_does_not_write_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "0", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with native_request_context(endpoint="/chat/stream", payload={"cache_prompt": True}):
+                    emit_native_prompt_cache_event(
+                        prompt_tokens=[1, 2, 3],
+                        previous_prompt_tokens=[1, 2],
+                        reused_prompt_tokens=2,
+                        output_tokens=1,
+                        cancelled=False,
+                        slot_id="default",
+                    )
+
+            self.assertFalse(log_path.exists())
+
+    def test_native_cache_diagnostics_are_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            payload = {
+                "cache_prompt": True,
+                "stream": True,
+                "session_id": "session-key-placeholder",
+                "messages": [
+                    {"role": "system", "content": "runtime policy placeholder"},
+                    {"role": "user", "content": "placeholder payload epsilon"},
+                ],
+                "tools": [{"type": "function", "function": {"name": "fetch_url", "parameters": {"marker": "schema payload"}}}],
+            }
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with native_request_context(endpoint="/chat/stream", payload=payload):
+                    emit_native_prompt_cache_event(
+                        prompt_tokens=[11, 22, 33, 44],
+                        previous_prompt_tokens=[11, 22, 99],
+                        reused_prompt_tokens=2,
+                        output_tokens=3,
+                        cancelled=False,
+                        slot_id="default",
+                    )
+
+            event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            raw_log = json.dumps(event)
+
+        self.assertEqual(event["event"], "kv_diag_native_cache")
+        self.assertEqual(event["backend_request_id"], "native_req_000001")
+        self.assertEqual(event["endpoint"], "/chat/stream")
+        self.assertTrue(event["stream"])
+        self.assertTrue(event["cache_prompt"])
+        self.assertEqual(event["slot_id"], "default")
+        self.assertEqual(event["prompt_tokens"], 4)
+        self.assertEqual(event["previous_prompt_tokens"], 3)
+        self.assertEqual(event["tokenized_prefix_length"], 2)
+        self.assertEqual(event["longest_common_prefix_tokens"], 2)
+        self.assertEqual(event["first_mismatch_token"], 2)
+        self.assertEqual(event["cached_tokens"], 2)
+        self.assertEqual(event["evaluated_tokens"], 2)
+        self.assertEqual(event["output_tokens"], 3)
+        self.assertIsNone(event["cache_miss_reason"])
+        self.assertEqual(event["message_count"], 2)
+        self.assertEqual(event["role_sequence"], ["system", "user"])
+        self.assertTrue(event["tools_parameter_present"])
+        self.assertEqual(event["tool_count"], 1)
+        self.assertNotIn("placeholder payload epsilon", raw_log)
+        self.assertNotIn("runtime policy placeholder", raw_log)
+        self.assertNotIn("schema payload", raw_log)
+        self.assertNotIn("session-key-placeholder", raw_log)
+        self.assertNotIn("11, 22", raw_log)
+
+    def test_native_cache_miss_reason_reports_prefix_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with native_request_context(endpoint="/chat/stream", payload={"cache_prompt": True, "messages": []}):
+                    emit_native_prompt_cache_event(
+                        prompt_tokens=[5, 6, 7],
+                        previous_prompt_tokens=[1, 2, 3],
+                        reused_prompt_tokens=0,
+                        output_tokens=1,
+                        cancelled=False,
+                        slot_id="default",
+                    )
+
+            event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+
+        self.assertEqual(event["cache_miss_reason"], "prefix_mismatch_at_token_0")
+        self.assertEqual(event["longest_common_prefix_tokens"], 0)
+        self.assertEqual(event["first_mismatch_token"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -43,6 +43,27 @@ class FakeBackend:
         )
 
 
+class LlamaServerBackend(FakeBackend):
+    def __init__(self, *, native: bool = True) -> None:
+        super().__init__()
+        self._props_cache = {"backend": "orbit-native"} if native else {}
+
+
+class ContinueBackend:
+    def continue_current(self, *, max_tokens: int, on_delta=None, on_progress=None) -> ChatResult:
+        return ChatResult(
+            content="ok",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=3,
+            completion_tokens=1,
+            cached_tokens=1,
+            prompt_tokens_per_second=10.0,
+            generation_tokens_per_second=3.0,
+        )
+
+
 class SequenceBackend:
     def __init__(self, results: list[ChatResult]) -> None:
         self.results = list(results)
@@ -101,11 +122,83 @@ class KVDiagTests(unittest.TestCase):
         self.assertIn("prompt_layout_hash", payload)
         self.assertIn("prompt_layout", payload)
         self.assertIn("prompt_layout_common_prefix", payload)
+        self.assertIn("request_envelope", payload)
+        self.assertEqual(payload["request_envelope"]["message_count"], 2)
+        self.assertEqual(payload["request_envelope"]["role_sequence"], ["system", "user"])
+        self.assertFalse(payload["request_envelope"]["tools_parameter_present"])
         self.assertEqual(payload["prompt_tokens"], 10)
         self.assertEqual(payload["cached_tokens"], 4)
         self.assertEqual(payload["reused_tokens"], 4)
         self.assertEqual(payload["evaluated_tokens"], 6)
         self.assertNotIn("placeholder payload alpha", json.dumps(payload))
+
+    def test_request_envelope_diagnostics_are_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(LlamaServerBackend())
+                messages = [
+                    {"role": "system", "content": "runtime policy placeholder"},
+                    {"role": "user", "content": "placeholder payload delta"},
+                ]
+                tools = [{"type": "function", "function": {"name": "list_directory", "parameters": {"marker": "schema payload"}}}]
+                with request_context(session_id="session-key-placeholder"):
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat(messages, temperature=0, max_tokens=32, tools=tools)
+
+            payload = next(
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if json.loads(line)["event"] == "kv_diag_model_call"
+            )
+            envelope = payload["request_envelope"]
+            raw_log = json.dumps(payload)
+
+        self.assertEqual(envelope["backend_class"], "LlamaServerBackend")
+        self.assertEqual(envelope["endpoint"], "/chat/stream")
+        self.assertFalse(envelope["stream"])
+        self.assertTrue(envelope["cache_prompt"])
+        self.assertFalse(envelope["continue_current"])
+        self.assertFalse(envelope["session_identity_present"])
+        self.assertIsNone(envelope["session_identity_hash"])
+        self.assertEqual(envelope["message_count"], 2)
+        self.assertEqual(envelope["role_sequence"], ["system", "user"])
+        self.assertTrue(envelope["tools_parameter_present"])
+        self.assertEqual(envelope["tool_count"], 1)
+        self.assertIn("runtime_session_key_hash", envelope)
+        self.assertIn("prompt_layout_common_tokens_estimate", envelope)
+        self.assertNotIn("placeholder payload delta", raw_log)
+        self.assertNotIn("runtime policy placeholder", raw_log)
+        self.assertNotIn("schema payload", raw_log)
+        self.assertNotIn("session-key-placeholder", raw_log)
+
+    def test_continue_current_envelope_is_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(ContinueBackend())
+                with request_context(session_id="session-key-placeholder"):
+                    with model_call_context(phase="continue", tools_mode="off"):
+                        backend.continue_current(max_tokens=8)
+
+            payload = next(
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if json.loads(line)["event"] == "kv_diag_model_call"
+            )
+            envelope = payload["request_envelope"]
+            raw_log = json.dumps(payload)
+
+        self.assertEqual(envelope["backend_class"], "ContinueBackend")
+        self.assertIsNone(envelope["endpoint"])
+        self.assertFalse(envelope["stream"])
+        self.assertIsNone(envelope["cache_prompt"])
+        self.assertTrue(envelope["continue_current"])
+        self.assertEqual(envelope["message_count"], 0)
+        self.assertEqual(envelope["role_sequence"], [])
+        self.assertFalse(envelope["tools_parameter_present"])
+        self.assertEqual(envelope["tool_count"], 0)
+        self.assertNotIn("session-key-placeholder", raw_log)
 
     def test_prompt_layout_diagnostics_are_metadata_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR adds env-gated KV backend envelope and native cache diagnostics.

Changes:
- adds backend request-envelope metadata diagnostics under ORBIT_KV_DIAG=1
- adds native KV/cache diagnostics for slot, cache prompt, tokenized LCP, cached/evaluated tokens, and cache miss reasons
- records metadata only
- avoids raw prompt, raw tokens, user content, tool output, file/web content, personal data, and realistic person names
- adds tests for env-gated behavior and metadata-only logging
- documents backend envelope and native KV cache diagnostics

Key finding from local smoke:
- cache_prompt=true reaches the backend
- slot_id remains stable
- cached_tokens matches backend tokenized LCP
- cache misses are explained by low tokenized LCP, not by endpoint/stream/cache_prompt/slot changes

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_kv_diag -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS
- privacy/name/Unicode/raw-content scan: PASS

No prompt, routing, tool selection, final policy, decoding, streaming, slot/cache behavior, backend behavior, or visible runtime behavior changes.