### PR TITLE
Add isolated KV prefix anchor equivalence probe

### DIFF
--- a/docs/KV_PREFIX_ANCHOR_EQUIVALENCE_PROBE.md
+++ b/docs/KV_PREFIX_ANCHOR_EQUIVALENCE_PROBE.md
@@ -1,0 +1,147 @@
+# KV Prefix Anchor Equivalence Probe
+
+Commit analyzed: `6eb3acc`
+
+## Goal
+
+This probe checks a narrower question than full runtime integration:
+
+- can the native backend save a checkpoint for a stable prefix `P`
+- restore that checkpoint later
+- append the same suffix `S`
+- and produce the same next-step behavior as baseline `P+S`
+
+The probe is intentionally isolated from the production runtime path.
+
+It does **not** change routing, prompt construction, tool selection, final
+policy, or cache behavior in normal Orbit execution.
+
+## Scope
+
+The probe is implemented in `src/orbit/native_llama/prefix_anchor_probe.py`.
+
+It uses only metadata-safe inputs and outputs:
+
+- token counts
+- checkpoint size
+- token ids for the immediate next token
+- logits row hashes
+- restore used / restore failed
+
+It does **not** log:
+
+- raw prompt text
+- raw tokens
+- user content
+- tool output
+- file/web content
+
+## Method
+
+Given:
+
+- `prefix_text`
+- `full_text`
+
+the probe first verifies that `tokenize(prefix_text)` is a true token-prefix of
+`tokenize(full_text)`.
+
+If that boundary is valid:
+
+1. decode prefix tokens `P`
+2. capture native seq checkpoint for `P`
+3. decode suffix tokens `S`
+4. record:
+   - baseline next token
+   - baseline logits hash
+5. clear the context memory
+6. restore checkpoint `P`
+7. decode the same suffix tokens `S`
+8. record:
+   - restored next token
+   - restored logits hash
+
+The probe passes only if restore succeeds and the post-suffix behavior matches.
+
+## APIs Used
+
+The probe relies on native llama.cpp APIs already exposed through bindings:
+
+- `llama_state_seq_get_size`
+- `llama_state_seq_get_data`
+- `llama_state_seq_set_data`
+- `llama_batch_init`
+- `llama_batch_free`
+- `llama_decode`
+- `llama_synchronize`
+- `llama_get_logits_ith`
+- `llama_vocab_n_tokens`
+
+## What The Probe Proves
+
+If the probe passes for a chosen synthetic prefix/suffix pair, it shows:
+
+- checkpoint capture/restore can be behaviorally equivalent for that isolated
+  token prefix and suffix
+- the mismatch is not automatically caused by restore itself
+
+This is a stronger result than the earlier route-wide no-go, but it is still
+not enough to wire prefix-anchor into the standard runtime path.
+
+## Limits
+
+This probe still does **not** prove:
+
+- that shared-lineage restore in the production route path is safe
+- that later phases remain unaffected after a restore-enabled route pass
+- that the rendered route prompt always exposes a token-prefix boundary usable
+  for capture/restore
+
+So a passing probe is a prerequisite for the next phase, not final proof.
+
+## Next Step If The Probe Passes
+
+The next acceptable patch would be a bounded runtime experiment for the
+tools-on route phase only, behind a default-off flag, with:
+
+- prefix boundary validation
+- restore fallback to baseline
+- strict regression checks on:
+  - route outcome
+  - model call count
+  - retry/repair count
+  - file/web/fetch evidence paths
+
+## Next Step If The Probe Fails
+
+If baseline `P+S` and restore(`P`)+`S` diverge in this isolated probe, then the
+blocker is lower-level:
+
+- sequence checkpoint semantics are not equivalent enough in practice, or
+- additional native state outside the saved seq payload is required.
+
+## Local Result In This Worktree
+
+One real local probe was executed against the standard native backend in a
+dedicated subprocess, using a neutral synthetic prefix and suffix with no
+person names or user data.
+
+Observed result:
+
+- split boundary valid at token level
+- prefix tokens: `11`
+- suffix tokens: `10`
+- full tokens: `21`
+- checkpoint size: `3786160`
+- restore used: `true`
+- baseline next token == restored next token
+- baseline logits hash == restored logits hash
+
+This means the isolated `seq_id=0` checkpoint/restore path can reproduce the
+same next-step behavior for at least one small synthetic case.
+
+That is enough to reject the old blanket no-go.
+
+It is **not** enough to claim production safety yet, because the standard
+runtime still needs a route-wide boundary plus a shared-lineage safety story
+before any runtime hookup is acceptable.

--- a/docs/KV_PREFIX_ANCHOR_RUNTIME_NO_GO.md
+++ b/docs/KV_PREFIX_ANCHOR_RUNTIME_NO_GO.md
@@ -1,0 +1,138 @@
+# KV Prefix Anchor Runtime No-Go
+
+Commit analyzed: `6eb3acc`
+
+## Correction To The Previous Rejection
+
+The earlier blocker was too strict.
+
+A route-wide prefix anchor is **not** deterministic routing by itself.
+
+If Orbit restores only a stable tools-on route prefix and then still appends the
+same dynamic suffix, the model still makes the same route decision in the same
+model-guided way.
+
+So this line is conceptually valid:
+
+- tools-on route pass
+- stable route prefix restored from real native KV state
+- dynamic suffix decoded normally
+- model still decides CHAT, file, listing, web, fetch, or other tool paths
+
+That part is **not** the blocker anymore.
+
+## Stable Route Prefix Boundary
+
+For the current route path, the useful stable prefix is the first system message:
+
+- route system prompt
+- route contract
+- stable surrounding template framing
+
+The dynamic suffix is the remaining conversation:
+
+- prior history
+- current user turn
+- any other non-stable messages
+
+So the route boundary is conceptually available.
+
+## Real Blocker
+
+Verdict is still `no-go`, but for a different reason:
+
+### 1. Route currently shares the normal chat lineage
+
+In the standard native path, the route pass is sent through the same native chat
+path that also serves other non-tool completions.
+
+It does **not** have a dedicated cache lane or dedicated native sequence in the
+standard path.
+
+### 2. The active lineage is still single-context and mutable
+
+The standard path relies on one live `llama_context` plus one active prompt
+lineage:
+
+- one `ctx_tgt`
+- one `cached_prompt_tokens`
+- one active memory state
+
+Injecting route-prefix checkpoint restore into that same active lineage would
+mutate the context that later phases also rely on.
+
+### 3. Safe restore semantics are still unproven in this shared path
+
+What is still missing is not the abstract route boundary.
+
+What is missing is a proven safe invariant for this exact standard path:
+
+1. restore route-prefix checkpoint
+2. append dynamic route suffix
+3. complete route normally
+4. continue subsequent phases with no change in:
+   - logits
+   - route outcome
+   - retry behavior
+   - continuation readiness
+   - later cache behavior
+
+That invariant is not established yet for the single shared standard lineage.
+
+### 4. The current cache mode does not isolate route from later phases
+
+The route pass currently goes through the standard native chat path rather than
+a dedicated route-specific native mode.
+
+So a route-prefix restore experiment would need either:
+
+- a route-specific isolated native lane, or
+- a proven restore contract showing that shared-lineage restore is behaviorally
+  identical across repeated route calls and later phases
+
+Neither exists yet in a small measured form.
+
+## What This Means
+
+The conceptual objection is removed:
+
+- route-wide prefix anchor is allowed in principle
+- no no-tool preclassification is required
+- no prompt semantic rewrite is required
+
+But the implementation is still blocked because the restore would happen inside
+the same shared native lineage used by later standard-chat behavior.
+
+Without a stronger native isolation or restore guarantee, this is not yet safe
+to wire into production runtime flow, even behind a flag.
+
+## Smallest Next Patch That Would Change The Decision
+
+The next acceptable patch must solve one of these two technical issues first:
+
+1. **Shared-lineage proof path**
+   - show, with a bounded experiment, that restoring a route-prefix checkpoint
+     into the current standard lineage is behaviorally identical to baseline
+   - prove no regressions in:
+     - model call count
+     - repair/retry
+     - route outcome
+     - file/web/fetch evidence behavior
+     - later phase cache behavior
+
+2. **Route-isolated native lane**
+   - add a dedicated native route lineage or safe sequence boundary
+   - keep the restored route prefix out of later unrelated standard-chat state
+
+## Current Recommendation
+
+Do not wire route-prefix restore into the runtime yet.
+
+Keep:
+
+- the native bindings
+- the lifecycle scaffolding
+- the documentation
+
+Do not add a production runtime hookup until the shared-lineage restore safety
+question is answered directly.

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -222,6 +222,8 @@ class LlamaLibrary:
 
         lib.llama_model_get_vocab.argtypes = [c_void_p]
         lib.llama_model_get_vocab.restype = c_void_p
+        lib.llama_vocab_n_tokens.argtypes = [c_void_p]
+        lib.llama_vocab_n_tokens.restype = c_int32
         lib.llama_model_chat_template.argtypes = [c_void_p, c_char_p]
         lib.llama_model_chat_template.restype = c_char_p
         lib.llama_chat_apply_template.argtypes = [
@@ -242,10 +244,18 @@ class LlamaLibrary:
 
         lib.llama_batch_get_one.argtypes = [POINTER(llama_token), c_int32]
         lib.llama_batch_get_one.restype = LlamaBatch
+        lib.llama_batch_init.argtypes = [c_int32, c_int32, c_int32]
+        lib.llama_batch_init.restype = LlamaBatch
+        lib.llama_batch_free.argtypes = [LlamaBatch]
+        lib.llama_batch_free.restype = None
         lib.llama_decode.argtypes = [c_void_p, LlamaBatch]
         lib.llama_decode.restype = c_int32
+        lib.llama_synchronize.argtypes = [c_void_p]
+        lib.llama_synchronize.restype = None
         lib.llama_time_us.argtypes = []
         lib.llama_time_us.restype = ctypes.c_int64
+        lib.llama_get_logits_ith.argtypes = [c_void_p, c_int32]
+        lib.llama_get_logits_ith.restype = POINTER(c_float)
 
         lib.llama_sampler_chain_init.argtypes = [LlamaSamplerChainParams]
         lib.llama_sampler_chain_init.restype = c_void_p

--- a/src/orbit/native_llama/prefix_anchor_probe.py
+++ b/src/orbit/native_llama/prefix_anchor_probe.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from ctypes import POINTER, c_float, cast, pointer
+from dataclasses import dataclass
+import hashlib
+from typing import Any, Callable
+
+from .bindings import LlamaBatch, llama_pos, llama_seq_id, llama_token
+from .prefix_anchor import (
+    PrefixAnchorState,
+    capture_prefix_anchor,
+    compute_prefix_anchor_key,
+    restore_prefix_anchor,
+)
+
+
+TokenizeFn = Callable[[str], list[int]]
+
+
+@dataclass(frozen=True)
+class PrefixAnchorProbeResult:
+    ok: bool
+    reason: str | None
+    prefix_token_count: int
+    suffix_token_count: int
+    full_token_count: int
+    checkpoint_size: int
+    restore_used: bool
+    baseline_next_token: int | None
+    restored_next_token: int | None
+    logits_hash_baseline: str | None
+    logits_hash_restored: str | None
+    logits_match: bool | None
+    seq_id: int = 0
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "probe_ok": self.ok,
+            "reason": self.reason,
+            "prefix_token_count": self.prefix_token_count,
+            "suffix_token_count": self.suffix_token_count,
+            "full_token_count": self.full_token_count,
+            "checkpoint_size": self.checkpoint_size,
+            "restore_used": self.restore_used,
+            "baseline_next_token": self.baseline_next_token,
+            "restored_next_token": self.restored_next_token,
+            "logits_hash_baseline": self.logits_hash_baseline,
+            "logits_hash_restored": self.logits_hash_restored,
+            "logits_match": self.logits_match,
+            "seq_id": self.seq_id,
+        }
+
+
+def split_prompt_by_token_prefix(
+    *,
+    tokenize: TokenizeFn,
+    prefix_text: str,
+    full_text: str,
+) -> tuple[list[int], list[int], list[int], str | None]:
+    prefix_tokens = list(tokenize(prefix_text))
+    full_tokens = list(tokenize(full_text))
+    if not prefix_tokens:
+        return prefix_tokens, [], full_tokens, "empty_prefix_tokens"
+    if len(full_tokens) < len(prefix_tokens):
+        return prefix_tokens, [], full_tokens, "full_shorter_than_prefix"
+    if full_tokens[: len(prefix_tokens)] != prefix_tokens:
+        return prefix_tokens, [], full_tokens, "prefix_not_token_prefix"
+    suffix_tokens = full_tokens[len(prefix_tokens) :]
+    return prefix_tokens, suffix_tokens, full_tokens, None
+
+
+def probe_prefix_anchor_equivalence(
+    *,
+    lib: Any,
+    ctx: Any,
+    vocab: Any,
+    sampler: Any,
+    tokenize: TokenizeFn,
+    prefix_text: str,
+    full_text: str,
+    seq_id: int = 0,
+    model_id: str | None = None,
+    template_id: str | None = None,
+    tool_schema_hash: str | None = None,
+    capability_summary_hash: str | None = None,
+    runtime_policy_hash: str | None = "probe-runtime-policy",
+    route_contract_hash: str | None = "probe-route-contract",
+    backend_version: str | None = None,
+    native_version: str | None = None,
+    tools_mode: str | None = "tools-on-route",
+) -> PrefixAnchorProbeResult:
+    prefix_tokens, suffix_tokens, full_tokens, split_reason = split_prompt_by_token_prefix(
+        tokenize=tokenize,
+        prefix_text=prefix_text,
+        full_text=full_text,
+    )
+    if split_reason is not None:
+        return PrefixAnchorProbeResult(
+            ok=False,
+            reason=split_reason,
+            prefix_token_count=len(prefix_tokens),
+            suffix_token_count=len(suffix_tokens),
+            full_token_count=len(full_tokens),
+            checkpoint_size=0,
+            restore_used=False,
+            baseline_next_token=None,
+            restored_next_token=None,
+            logits_hash_baseline=None,
+            logits_hash_restored=None,
+            logits_match=None,
+            seq_id=seq_id,
+        )
+    if not suffix_tokens:
+        return PrefixAnchorProbeResult(
+            ok=False,
+            reason="empty_suffix_tokens",
+            prefix_token_count=len(prefix_tokens),
+            suffix_token_count=0,
+            full_token_count=len(full_tokens),
+            checkpoint_size=0,
+            restore_used=False,
+            baseline_next_token=None,
+            restored_next_token=None,
+            logits_hash_baseline=None,
+            logits_hash_restored=None,
+            logits_match=None,
+            seq_id=seq_id,
+        )
+
+    prefix_hash = compute_prefix_anchor_key(
+        model_id=model_id,
+        template_id=template_id,
+        tool_schema_hash=tool_schema_hash,
+        capability_summary_hash=capability_summary_hash,
+        runtime_policy_hash=runtime_policy_hash,
+        route_contract_hash=route_contract_hash,
+        backend_version=backend_version,
+        native_version=native_version,
+        tools_mode=tools_mode,
+    )
+    anchor_kwargs = {
+        "model_id": model_id,
+        "template_id": template_id,
+        "tool_schema_hash": tool_schema_hash,
+        "capability_summary_hash": capability_summary_hash,
+        "runtime_policy_hash": runtime_policy_hash,
+        "route_contract_hash": route_contract_hash,
+        "backend_version": backend_version,
+        "native_version": native_version,
+        "tools_mode": tools_mode,
+    }
+
+    _clear_context(lib, ctx)
+    _decode_tokens(lib, ctx, prefix_tokens, seq_id=seq_id, start_pos=0)
+    state, capture_meta = capture_prefix_anchor(
+        lib=lib,
+        ctx=ctx,
+        seq_id=seq_id,
+        prefix_hash=prefix_hash,
+        token_count=len(prefix_tokens),
+        enabled=True,
+        **anchor_kwargs,
+    )
+    if not state.valid:
+        return PrefixAnchorProbeResult(
+            ok=False,
+            reason=capture_meta.get("fallback_reason") or state.invalidation_reason or "capture_failed",
+            prefix_token_count=len(prefix_tokens),
+            suffix_token_count=len(suffix_tokens),
+            full_token_count=len(full_tokens),
+            checkpoint_size=0,
+            restore_used=False,
+            baseline_next_token=None,
+            restored_next_token=None,
+            logits_hash_baseline=None,
+            logits_hash_restored=None,
+            logits_match=None,
+            seq_id=seq_id,
+        )
+
+    _decode_tokens(lib, ctx, suffix_tokens, seq_id=seq_id, start_pos=len(prefix_tokens))
+    baseline_next_token = _sample_next_token(lib, sampler, ctx)
+    logits_hash_baseline = _logits_hash(lib, ctx, vocab)
+
+    _clear_context(lib, ctx)
+    ok, restored_state, restore_meta = restore_prefix_anchor(
+        state,
+        lib=lib,
+        ctx=ctx,
+        seq_id=seq_id,
+        prefix_hash=prefix_hash,
+        enabled=True,
+        **anchor_kwargs,
+    )
+    if not ok:
+        return PrefixAnchorProbeResult(
+            ok=False,
+            reason=restore_meta.get("fallback_reason") or restored_state.invalidation_reason or "restore_failed",
+            prefix_token_count=len(prefix_tokens),
+            suffix_token_count=len(suffix_tokens),
+            full_token_count=len(full_tokens),
+            checkpoint_size=state.checkpoint_size,
+            restore_used=False,
+            baseline_next_token=baseline_next_token,
+            restored_next_token=None,
+            logits_hash_baseline=logits_hash_baseline,
+            logits_hash_restored=None,
+            logits_match=None,
+            seq_id=seq_id,
+        )
+
+    _decode_tokens(lib, ctx, suffix_tokens, seq_id=seq_id, start_pos=len(prefix_tokens))
+    restored_next_token = _sample_next_token(lib, sampler, ctx)
+    logits_hash_restored = _logits_hash(lib, ctx, vocab)
+    logits_match = logits_hash_baseline == logits_hash_restored
+    return PrefixAnchorProbeResult(
+        ok=(baseline_next_token == restored_next_token and logits_match is not False),
+        reason=None if (baseline_next_token == restored_next_token and logits_match is not False) else "equivalence_mismatch",
+        prefix_token_count=len(prefix_tokens),
+        suffix_token_count=len(suffix_tokens),
+        full_token_count=len(full_tokens),
+        checkpoint_size=state.checkpoint_size,
+        restore_used=bool(restore_meta.get("restore_used")),
+        baseline_next_token=baseline_next_token,
+        restored_next_token=restored_next_token,
+        logits_hash_baseline=logits_hash_baseline,
+        logits_hash_restored=logits_hash_restored,
+        logits_match=logits_match,
+        seq_id=seq_id,
+    )
+
+
+def _clear_context(lib: Any, ctx: Any) -> None:
+    mem = lib.llama_get_memory(ctx)
+    if mem:
+        lib.llama_memory_clear(mem, True)
+
+
+def _decode_tokens(
+    lib: Any,
+    ctx: Any,
+    tokens: list[int],
+    *,
+    seq_id: int,
+    start_pos: int,
+) -> None:
+    if not tokens:
+        return
+    if seq_id == 0 and hasattr(lib, "llama_batch_get_one"):
+        token_array = (llama_token * len(tokens))(*tokens)
+        batch = lib.llama_batch_get_one(token_array, len(tokens))
+        rc = int(lib.llama_decode(ctx, batch))
+        if rc != 0:
+            raise RuntimeError(f"llama_decode failed in prefix-anchor probe: {rc}")
+        if hasattr(lib, "llama_synchronize"):
+            lib.llama_synchronize(ctx)
+        return
+    batch = lib.llama_batch_init(len(tokens), 0, 1)
+    batch.n_tokens = len(tokens)
+    seq_value = llama_seq_id(seq_id)
+    seq_ptr = cast(pointer(seq_value), POINTER(llama_seq_id))
+    try:
+        for index, token in enumerate(tokens):
+            batch.token[index] = llama_token(token)
+            batch.pos[index] = llama_pos(start_pos + index)
+            batch.n_seq_id[index] = 1
+            batch.seq_id[index] = seq_ptr
+            batch.logits[index] = 1 if index == (len(tokens) - 1) else 0
+        rc = int(lib.llama_decode(ctx, batch))
+        if rc != 0:
+            raise RuntimeError(f"llama_decode failed in prefix-anchor probe: {rc}")
+        if hasattr(lib, "llama_synchronize"):
+            lib.llama_synchronize(ctx)
+    finally:
+        lib.llama_batch_free(batch)
+
+
+def _sample_next_token(lib: Any, sampler: Any, ctx: Any) -> int:
+    lib.llama_sampler_reset(sampler)
+    token = int(lib.llama_sampler_sample(sampler, ctx, -1))
+    return token
+
+
+def _logits_hash(lib: Any, ctx: Any, vocab: Any) -> str | None:
+    if not hasattr(lib, "llama_get_logits_ith") or not hasattr(lib, "llama_vocab_n_tokens"):
+        return None
+    vocab_size = int(lib.llama_vocab_n_tokens(vocab))
+    if vocab_size <= 0:
+        return None
+    ptr = lib.llama_get_logits_ith(ctx, -1)
+    if not ptr:
+        return None
+    row_type = c_float * vocab_size
+    row = cast(ptr, POINTER(row_type)).contents
+    return hashlib.sha256(bytes(row)).hexdigest()[:32]

--- a/tests/test_native_bindings.py
+++ b/tests/test_native_bindings.py
@@ -35,14 +35,19 @@ def _stub_library() -> SimpleNamespace:
         "llama_state_seq_get_data",
         "llama_state_seq_set_data",
         "llama_model_get_vocab",
+        "llama_vocab_n_tokens",
         "llama_model_chat_template",
         "llama_chat_apply_template",
         "llama_tokenize",
         "llama_token_to_piece",
         "llama_vocab_is_eog",
         "llama_batch_get_one",
+        "llama_batch_init",
+        "llama_batch_free",
         "llama_decode",
+        "llama_synchronize",
         "llama_time_us",
+        "llama_get_logits_ith",
         "llama_sampler_chain_init",
         "llama_sampler_chain_add",
         "llama_sampler_init_greedy",
@@ -71,6 +76,11 @@ class NativeBindingsTests(unittest.TestCase):
         self.assertEqual(len(library.lib.llama_state_seq_get_size.argtypes), 2)
         self.assertEqual(len(library.lib.llama_state_seq_get_data.argtypes), 4)
         self.assertEqual(len(library.lib.llama_state_seq_set_data.argtypes), 4)
+        self.assertEqual(len(library.lib.llama_vocab_n_tokens.argtypes), 1)
+        self.assertEqual(len(library.lib.llama_batch_init.argtypes), 3)
+        self.assertEqual(len(library.lib.llama_batch_free.argtypes), 1)
+        self.assertEqual(len(library.lib.llama_synchronize.argtypes), 1)
+        self.assertEqual(len(library.lib.llama_get_logits_ith.argtypes), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from ctypes import c_float
+import unittest
+
+from orbit.native_llama.prefix_anchor_probe import (
+    PrefixAnchorProbeResult,
+    probe_prefix_anchor_equivalence,
+    split_prompt_by_token_prefix,
+)
+
+
+def _token_value(value: object) -> int:
+    if isinstance(value, (bytes, bytearray)):
+        return int.from_bytes(value, byteorder="little", signed=True)
+    raw = getattr(value, "value", value)
+    return int(raw)
+
+
+class _FakeBatch:
+    def __init__(self, n_tokens: int) -> None:
+        self.n_tokens = n_tokens
+        self.token = [0] * n_tokens
+        self.pos = [0] * n_tokens
+        self.n_seq_id = [0] * n_tokens
+        self.seq_id = [None] * n_tokens
+        self.logits = [0] * n_tokens
+
+
+class _FakeLib:
+    def __init__(self) -> None:
+        self.current_tokens: list[int] = []
+        self.state_payload = b""
+        self.logits_rows: list[object] = []
+        self.clears = 0
+
+    def llama_get_memory(self, _ctx):
+        return object()
+
+    def llama_memory_clear(self, _mem, _full: bool) -> None:
+        self.current_tokens = []
+        self.clears += 1
+
+    def llama_batch_init(self, n_tokens: int, _embd: int, _n_seq_max: int):
+        return _FakeBatch(n_tokens)
+
+    def llama_batch_free(self, _batch) -> None:
+        return None
+
+    def llama_decode(self, _ctx, batch) -> int:
+        for index in range(batch.n_tokens):
+            self.current_tokens.append(_token_value(batch.token[index]))
+        return 0
+
+    def llama_synchronize(self, _ctx) -> None:
+        return None
+
+    def llama_state_seq_get_size(self, _ctx, _seq_id: int) -> int:
+        payload = ",".join(str(token) for token in self.current_tokens).encode("ascii")
+        self.state_payload = payload
+        return len(payload)
+
+    def llama_state_seq_get_data(self, _ctx, buffer, size: int, _seq_id: int) -> int:
+        if size != len(self.state_payload):
+            return 0
+        for index, byte in enumerate(self.state_payload):
+            buffer[index] = byte
+        return len(self.state_payload)
+
+    def llama_state_seq_set_data(self, _ctx, buffer, size: int, _seq_id: int) -> int:
+        payload = bytes(buffer[:size])
+        if not payload:
+            self.current_tokens = []
+            return 0
+        self.current_tokens = [int(item) for item in payload.decode("ascii").split(",") if item]
+        return size
+
+    def llama_sampler_reset(self, _sampler) -> None:
+        return None
+
+    def llama_sampler_sample(self, _sampler, _ctx, _index: int) -> int:
+        return sum(self.current_tokens) % 97
+
+    def llama_vocab_n_tokens(self, _vocab) -> int:
+        return 4
+
+    def llama_get_logits_ith(self, _ctx, _index: int):
+        base = float(sum(self.current_tokens))
+        row = (c_float * 4)(base, base + 1.0, base + 2.0, base + 3.0)
+        self.logits_rows.append(row)
+        return row
+
+
+class _FailingRestoreLib(_FakeLib):
+    def llama_state_seq_set_data(self, _ctx, buffer, size: int, _seq_id: int) -> int:
+        _ = bytes(buffer[:size])
+        return size - 1
+
+
+class PrefixAnchorProbeTests(unittest.TestCase):
+    def test_split_prompt_by_token_prefix_rejects_non_prefix_boundary(self) -> None:
+        def tokenize(text: str) -> list[int]:
+            mapping = {
+                "prefix": [10, 11],
+                "prefix+suffix": [10, 99, 12],
+            }
+            return mapping[text]
+
+        prefix_tokens, suffix_tokens, full_tokens, reason = split_prompt_by_token_prefix(
+            tokenize=tokenize,
+            prefix_text="prefix",
+            full_text="prefix+suffix",
+        )
+
+        self.assertEqual(prefix_tokens, [10, 11])
+        self.assertEqual(full_tokens, [10, 99, 12])
+        self.assertEqual(suffix_tokens, [])
+        self.assertEqual(reason, "prefix_not_token_prefix")
+
+    def test_probe_reports_equivalent_restore_for_stable_tokens(self) -> None:
+        mapping = {
+            "prefix": [1, 2],
+            "full": [1, 2, 3, 4],
+        }
+        result = probe_prefix_anchor_equivalence(
+            lib=_FakeLib(),
+            ctx=object(),
+            vocab=object(),
+            sampler=object(),
+            tokenize=lambda text: mapping[text],
+            prefix_text="prefix",
+            full_text="full",
+            model_id="model-alpha",
+            template_id="template-alpha",
+            tool_schema_hash="tool-hash-alpha",
+            capability_summary_hash="caps-hash-alpha",
+            backend_version="backend-alpha",
+            native_version="native-alpha",
+        )
+
+        self.assertTrue(result.ok)
+        self.assertIsNone(result.reason)
+        self.assertTrue(result.restore_used)
+        self.assertEqual(result.prefix_token_count, 2)
+        self.assertEqual(result.suffix_token_count, 2)
+        self.assertEqual(result.full_token_count, 4)
+        self.assertEqual(result.baseline_next_token, result.restored_next_token)
+        self.assertTrue(result.logits_match)
+
+    def test_probe_falls_back_on_restore_failure(self) -> None:
+        mapping = {
+            "prefix": [5, 6],
+            "full": [5, 6, 7],
+        }
+        result = probe_prefix_anchor_equivalence(
+            lib=_FailingRestoreLib(),
+            ctx=object(),
+            vocab=object(),
+            sampler=object(),
+            tokenize=lambda text: mapping[text],
+            prefix_text="prefix",
+            full_text="full",
+            model_id="model-alpha",
+            template_id="template-alpha",
+            tool_schema_hash="tool-hash-alpha",
+            capability_summary_hash="caps-hash-alpha",
+            backend_version="backend-alpha",
+            native_version="native-alpha",
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "checkpoint_restore_size_mismatch")
+        self.assertFalse(result.restore_used)
+
+    def test_probe_metadata_stays_content_free(self) -> None:
+        result = PrefixAnchorProbeResult(
+            ok=True,
+            reason=None,
+            prefix_token_count=3,
+            suffix_token_count=2,
+            full_token_count=5,
+            checkpoint_size=12,
+            restore_used=True,
+            baseline_next_token=7,
+            restored_next_token=7,
+            logits_hash_baseline="abc123",
+            logits_hash_restored="abc123",
+            logits_match=True,
+        )
+        metadata = result.to_metadata()
+        rendered = str(metadata)
+        self.assertNotIn("prefix text", rendered)
+        self.assertNotIn("full text", rendered)
+        self.assertNotIn("placeholder", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds an isolated backend-native KV prefix-anchor equivalence probe.

Changes:
- documents why runtime hookup remains no-go in the shared standard path
- adds an isolated checkpoint/restore equivalence probe
- adds native binding wrappers needed by the probe
- adds tests for the probe and bindings

Key result:
- checkpoint/restore is equivalent in the isolated micro-test:
  - restored next token matches baseline
  - restored logits hash matches baseline
  - probe_ok=True

Important limitation:
- this does not enable prefix-anchor in the production runtime path
- no production runtime path uses prefix_anchor_probe
- the next step is a bounded route runtime experiment behind a feature flag

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS
- privacy/name/Unicode/raw-content scan: PASS

No changes to:
- prompt
- routing
- tool selection
- final policy
- production KV/cache behavior
- production runtime behavior