### PR TITLE
Add opt-in route KV prefix anchor experiment

### DIFF
--- a/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md
+++ b/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md
@@ -1,0 +1,202 @@
+# KV Route Prefix Anchor Runtime Experiment
+
+## Scope
+
+This experiment adds an opt-in native KV prefix-anchor path for Orbit route calls.
+
+Feature flag:
+
+```text
+ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1
+```
+
+Default is off. With the flag off, the payload, prompt rendering, routing, tool selection, final policy, and native cache behavior stay on the baseline path.
+
+The only eligible production path is:
+
+- tools on
+- route phase
+- no explicit native tool schema parameter
+- no thinking mode
+- no multimodal payload
+
+The experiment does not apply to `chat_final`, `final_from_tool`, or `tool_call`.
+File-read, web/fetch, and directory-listing requests may benefit only from the
+shared route prefix before the model decides which tool to use. They are not
+special-cased and no post-route tool/final path is anchored.
+
+## Design
+
+The runtime already marks model calls with phase metadata. When the feature flag is enabled, the HTTP backend adds a metadata-only `route_prefix_anchor=true` payload field only while the current model call context is `phase=route` and `tools_mode=on`.
+
+The native client then performs conservative validation before attempting anchor use:
+
+- Render the normal prompt exactly as before.
+- Build `RoutePromptSegments` for the same messages.
+- Require `segments.full_prompt_text == prompt`.
+- Tokenize `segments.stable_prefix_text`.
+- Require the stable-prefix tokens to be an exact prefix of the full prompt tokens.
+- Compute a prefix-anchor key from model/template identity and stable-prefix hashes.
+- Restore only if the stored checkpoint has the same key and token count.
+- Fallback to baseline prefill on any mismatch or native error.
+- Keep only one route anchor checkpoint per native client instance.
+
+The model receives the same prompt text. The route decision remains model-guided.
+
+## Memory And Invalidation
+
+The implementation stores at most one checkpoint in each `NativeLlamaClient`.
+There is no map of per-prompt anchors and no unbounded growth. Capturing a new
+valid route prefix replaces the previous state.
+
+For the tested Gemma 4 12B Q4_K_M model at `ctx=8192`, the route checkpoint was:
+
+- prefix token count: 693
+- checkpoint size: 238,454,176 bytes
+
+This is a material memory cost and is the main reason the experiment remains
+opt-in. The checkpoint is invalidated or bypassed if any compatibility input
+changes:
+
+- prefix hash
+- token count
+- model id
+- template id
+- tool schema hash
+- capability summary hash
+- runtime policy hash
+- route contract hash
+- backend/native version
+- tools mode
+
+If an existing checkpoint fails validation or restore, the current request falls
+back to the full baseline prompt path. It does not expose an error to the user.
+The next compatible request may capture a fresh checkpoint.
+
+## Boundary
+
+The route token-boundary probe previously verified the real native tokenizer:
+
+- stable route prefix: 693 tokens
+- token LCP with full route prompt: 693 tokens
+- tested scenarios: short chat, trivial chat, medium no-tool, listing, file-read, web, fetch
+- result: `route_boundary_token_prefix_ok=true`
+
+This experiment uses that boundary but still validates every runtime call before restore.
+
+## Fallback
+
+Fallback reasons are metadata-only and include:
+
+- `route_prompt_mismatch`
+- `route_boundary_unavailable`
+- `token_boundary_mismatch`
+- `anchor_invalid`
+- `checkpoint_restore_failed`
+- `checkpoint_capture_failed`
+
+Fallback never raises a visible user error. It rebuilds the full prompt through the baseline path.
+
+## Diagnostics
+
+When `ORBIT_KV_DIAG=1`, the native backend emits `kv_diag_route_prefix_anchor` events containing only metadata:
+
+- `route_anchor_enabled`
+- `route_anchor_attempted`
+- `route_anchor_hit`
+- `route_anchor_miss`
+- `capture_attempted`
+- `restore_attempted`
+- `restore_used`
+- `fallback_reason`
+- `prefix_hash`
+- `prefix_token_count`
+- `checkpoint_size`
+- `checkpoint_size_bytes`
+- `checkpoint_age_ms`
+- `anchor_invalidated`
+- `invalidation_reason`
+- `cached_tokens`
+- `evaluated_tokens`
+- `lcp_tokens`
+- `phase`
+
+The diagnostics do not log raw prompt text, raw token ids, user content, tool output, file content, or web content.
+
+## Benchmark
+
+Environment:
+
+- model: `/home/guelfoweb/LAB/orbit/models/ggml-org--gemma-4-12B-it-GGUF/gemma-4-12B-it-Q4_K_M.gguf`
+- backend: native Orbit server, CPU, `ctx=8192`
+- server port: local dedicated test server
+- `ORBIT_KV_DIAG=1`
+
+Observed route-prefix checkpoint:
+
+- prefix token count: 693
+- checkpoint size: 238,454,176 bytes
+- first eligible route: capture miss
+- later eligible routes: restore hit
+- server-side route anchor events: metadata-only
+
+The run used one dedicated local native server. Other unrelated local Orbit
+servers were stopped before the main smoke to avoid unnecessary memory pressure.
+
+Representative results:
+
+| Scenario | Flag | Phases | Route cached/evaluated | Request cached/evaluated | Wall | Outcome |
+| --- | --- | --- | --- | --- | --- | --- |
+| `hi` | off | `route -> chat_final` | `0 / 706` | `4 / 736` | ~61s | `CHAT` |
+| `hi` first eligible | on | `route -> chat_final` | `0 / 706` | `4 / 736` | ~62s | capture miss |
+| `hi` repeat | on | `route -> chat_final` | `693 / 13` | `697 / 43` | ~8.6s | restore hit |
+| `what is 2+2?` | on | `route` | `693 / 19` | `693 / 19` | ~2.4s | direct route final |
+| medium no-tool 1 | off warm | `route -> chat_final` | `696 / 27` | `700 / 74` | ~36s | warm baseline control |
+| medium no-tool 1 | on | `route -> chat_final` | `693 / 30` | `697 / 77` | ~37s | restore hit |
+| medium no-tool 2 | off | `route -> chat_final` | `4 / 714` | `8 / 756` | ~95s | cache miss |
+| medium no-tool 2 | on | `route -> chat_final` | `693 / 25` | `697 / 67` | ~39s | restore hit |
+| `list files in the workdir` | on | `route -> final_from_tool` | `693 / 18` | `1386 / 149` | ~35s | `list_directory` preserved |
+| `read edit-target.txt and explain it` | on | `route -> tool_call -> tool_call -> final_from_tool` | `693 / 21` | `1055 / 896` | ~120s | content-read path preserved |
+| `fetch https://example.com and summarize it` | on | `route -> final_from_tool` | `693 / 21` | `1386 / 169` | ~34s | fetch path preserved |
+| web search prompt | on | `route -> final_from_tool` | `693 / 21` | `1386 / 457` | ~60s | web path preserved |
+
+The medium no-tool scenarios used synthetic prompts:
+
+- `Explain in two short paragraphs how a local AI runtime can reduce latency after the first turn.`
+- `Explain the tradeoff between correctness and latency in a local agent runtime.`
+
+Notes:
+
+- The first `on` request must pay capture cost. The benefit appears after the checkpoint exists.
+- One medium smoke used a small output budget and stopped final generation with `finish_reason=length`; the route phase still completed normally and did not enter repair/retry.
+- File-read correctness was checked with an existing fixture file. The route selected a content-reading path, not `list_directory`.
+- Web/fetch stayed at `route -> final_from_tool`.
+- `route_no_decision_length_retry` was not observed in the tested scenarios.
+- The A/B run was intentionally bounded for CPU runtime. It is sufficient to
+  validate the opt-in experiment and known risks, but not sufficient to promote
+  the feature to default.
+
+## Current Verdict
+
+Promote as opt-in experiment, not default.
+
+The route-prefix anchor is technically effective and preserves the tested
+model-guided control flow. It significantly reduces evaluated route tokens after
+the first capture miss, including a measured cache-miss medium route changing
+from `4 / 714` cached/evaluated to `693 / 25`.
+
+It should remain behind `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` because:
+
+- the first capture miss is expensive;
+- checkpoint memory is large for this model and context;
+- more repeated-run data is needed before considering any default behavior;
+- the benchmark should be repeated with a longer final budget for medium prompts.
+
+Merge criteria for the opt-in experiment are satisfied:
+
+- flag off preserves baseline payload and behavior;
+- flag on is limited to route tools-on on the native backend;
+- no deterministic routing, tool selection, final policy, or evidence policy changes;
+- fallback returns to baseline on validation or restore failure;
+- file-read, web/fetch, and listing paths remain model-guided and evidence-safe;
+- diagnostics are metadata-only.

--- a/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md
+++ b/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md
@@ -131,6 +131,8 @@ Environment:
 - backend: native Orbit server, CPU, `ctx=8192`
 - server port: local dedicated test server
 - `ORBIT_KV_DIAG=1`
+- workdir: repository root
+- max tokens: 64 for all smoke prompts
 
 Observed route-prefix checkpoint:
 
@@ -147,18 +149,23 @@ Representative results:
 
 | Scenario | Flag | Phases | Route cached/evaluated | Request cached/evaluated | Wall | Outcome |
 | --- | --- | --- | --- | --- | --- | --- |
-| `hi` | off | `route -> chat_final` | `0 / 706` | `4 / 736` | ~61s | `CHAT` |
-| `hi` first eligible | on | `route -> chat_final` | `0 / 706` | `4 / 736` | ~62s | capture miss |
+| `hi` | off | `route -> chat_final` | `0 / 706` | `4 / 736` | ~60s | `CHAT` |
+| `hi` first eligible | on | `route -> chat_final` | `0 / 706` | `4 / 736` | ~64s | capture miss |
 | `hi` repeat | on | `route -> chat_final` | `693 / 13` | `697 / 43` | ~8.6s | restore hit |
+| `what is 2+2?` | off | `route` | `4 / 708` | `4 / 708` | ~59s | direct route final |
 | `what is 2+2?` | on | `route` | `693 / 19` | `693 / 19` | ~2.4s | direct route final |
-| medium no-tool 1 | off warm | `route -> chat_final` | `696 / 27` | `700 / 74` | ~36s | warm baseline control |
-| medium no-tool 1 | on | `route -> chat_final` | `693 / 30` | `697 / 77` | ~37s | restore hit |
-| medium no-tool 2 | off | `route -> chat_final` | `4 / 714` | `8 / 756` | ~95s | cache miss |
-| medium no-tool 2 | on | `route -> chat_final` | `693 / 25` | `697 / 67` | ~39s | restore hit |
-| `list files in the workdir` | on | `route -> final_from_tool` | `693 / 18` | `1386 / 149` | ~35s | `list_directory` preserved |
-| `read edit-target.txt and explain it` | on | `route -> tool_call -> tool_call -> final_from_tool` | `693 / 21` | `1055 / 896` | ~120s | content-read path preserved |
-| `fetch https://example.com and summarize it` | on | `route -> final_from_tool` | `693 / 21` | `1386 / 169` | ~34s | fetch path preserved |
-| web search prompt | on | `route -> final_from_tool` | `693 / 21` | `1386 / 457` | ~60s | web path preserved |
+| medium no-tool 1 | off warm | `route -> chat_final` | `693 / 30` | `697 / 77` | ~27s | warm baseline control |
+| medium no-tool 1 | on | `route -> chat_final` | `693 / 30` | `697 / 77` | ~28s | restore hit |
+| medium no-tool 2 | off | `route -> chat_final` | `4 / 714` | `8 / 756` | ~79s | cache miss |
+| medium no-tool 2 | on | `route -> chat_final` | `693 / 25` | `697 / 67` | ~26s | restore hit |
+| `list files in the workdir` | off | `route -> final_from_tool` | `4 / 707` | `711 / 874` | ~93s | `list_directory` preserved |
+| `list files in the workdir` | on | `route -> final_from_tool` | `693 / 18` | `1386 / 199` | ~41s | `list_directory` preserved |
+| `read README.md and explain it` | off warm | `route -> final_from_tool` | `696 / 16` | `1404 / 424` | ~64s | `Read` content evidence preserved |
+| `read README.md and explain it` | on | `route -> final_from_tool` | `693 / 19` | `1386 / 442` | ~64s | `Read` content evidence preserved |
+| web search prompt | off warm | `route -> final_from_tool` | `696 / 18` | `1406 / 447` | ~59s | `orbit-web-search` preserved |
+| web search prompt | on | `route -> final_from_tool` | `693 / 21` | `1386 / 467` | ~62s | `orbit-web-search` preserved |
+| `fetch https://example.com and summarize it` | off warm | `route -> final_from_tool` | `696 / 18` | `1406 / 149` | ~32s | fetch path preserved |
+| `fetch https://example.com and summarize it` | on | `route -> final_from_tool` | `693 / 21` | `1386 / 169` | ~33s | fetch path preserved |
 
 The medium no-tool scenarios used synthetic prompts:
 
@@ -169,7 +176,7 @@ Notes:
 
 - The first `on` request must pay capture cost. The benefit appears after the checkpoint exists.
 - One medium smoke used a small output budget and stopped final generation with `finish_reason=length`; the route phase still completed normally and did not enter repair/retry.
-- File-read correctness was checked with an existing fixture file. The route selected a content-reading path, not `list_directory`.
+- File-read correctness was checked with `README.md`. The route selected a content-reading path, not `list_directory`.
 - Web/fetch stayed at `route -> final_from_tool`.
 - `route_no_decision_length_retry` was not observed in the tested scenarios.
 - The A/B run was intentionally bounded for CPU runtime. It is sufficient to

--- a/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_NO_GO.md
+++ b/docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_NO_GO.md
@@ -1,0 +1,155 @@
+# KV Route Prefix Anchor Runtime No-Go
+
+Commit analyzed: `806968a`
+
+## Goal
+
+Evaluate whether Orbit can safely wire a real native KV prefix-anchor into the
+production route path for tools-on requests.
+
+The intended scope was deliberately narrow:
+
+- route phase only
+- tools-on only
+- no chat-final, final-from-tool, or tool-call hookup
+- no file, web, fetch, or listing special-casing
+- no semantic prompt changes
+- no runtime pre-classification before the route pass
+
+This route-wide anchor would be model-guided if implemented correctly: the
+runtime would restore only the stable route prefix, then append the same dynamic
+suffix and let the model make the same route decision.
+
+## What Is Valid In Principle
+
+A route-wide prefix anchor is not deterministic routing.
+
+The route phase is common to tools-on requests. If the backend can restore the
+same stable route prefix and then process the same dynamic suffix, the model
+still decides whether to answer directly, return `CHAT`, or select a tool.
+
+So the conceptual target is valid:
+
+1. stable route prefix is already decoded in native KV state
+2. dynamic route suffix is decoded normally
+3. the model produces the route decision
+4. downstream file, web, fetch, listing, and chat behavior stays unchanged
+
+## Route Path Inspection
+
+The current tools-on route path builds route messages in
+`src/orbit/runtime/chat.py`:
+
+- the user turn is appended to `self.messages`
+- `with_command_system_prompt(self.messages)` replaces or inserts the route
+  system prompt
+- the backend receives the full route message list
+
+The native client then renders and tokenizes the full prompt in
+`src/orbit/native_llama/client.py`:
+
+- `complete_chat(...)` calls `apply_chat_template(...)`
+- `apply_chat_template(...)` returns one rendered prompt string
+- `complete_prompt(...)` calls `_complete_prompt_standard(...)`
+- `_complete_prompt_standard(...)` tokenizes the entire prompt
+- `_prepare_memory_for_prompt(...)` compares the whole prompt against
+  `cached_prompt_tokens`
+
+At that point the backend has only one token list for the entire rendered
+prompt. It does not receive a separate stable prefix token range.
+
+## Real Blocker
+
+The blocker is not that the route comes before the model decision.
+
+The blocker is that Orbit does not currently expose a safe backend-visible split
+between:
+
+- stable route prefix tokens
+- dynamic route suffix tokens
+
+The runtime has a logical message-level layout, but the native production path
+operates on the fully rendered chat-template prompt. Chat-template rendering can
+add framing tokens around roles and message boundaries. A message-level prefix
+hash is not enough to prove a token-prefix boundary in the final rendered
+backend prompt.
+
+Without a backend-visible token split, a route anchor hookup would need to infer
+or reconstruct the split after rendering. That is exactly the kind of fragile
+prompt-shape dependency this line has been avoiding.
+
+## Shared-Lineage Risk
+
+The standard native path also uses one active lineage:
+
+- one `ctx_tgt`
+- one sequence id in production
+- one `cached_prompt_tokens` list
+- one active memory state
+
+The isolated equivalence probe proves that checkpoint(`P`) + suffix(`S`) can
+match baseline `P+S` for a synthetic case. It does not prove that restoring a
+route checkpoint inside this shared production lineage is safe across:
+
+- later route calls
+- route retry paths
+- direct route final answers
+- `CHAT` handoff
+- final-from-tool handoff
+- continuation readiness
+- subsequent prompt-cache behavior
+
+This is especially important because `_prepare_memory_for_prompt(...)` mutates
+the same native memory and `cached_prompt_tokens` state based on the LCP of the
+full prompt.
+
+## Why No Runtime Patch Was Applied
+
+A safe implementation would need all of these at once:
+
+- a validated token-prefix boundary for the rendered route prompt
+- capture only after decoding that exact prefix
+- restore only when the same rendered prefix identity is proven
+- suffix decode that is byte/token equivalent to baseline
+- correct update of `cached_prompt_tokens`
+- no contamination of later phases sharing the same native context
+- fallback to baseline on any mismatch
+
+The first item is not present in the production interface today. The native
+backend accepts full messages or a full rendered prompt, not a verified
+`prefix_tokens + suffix_tokens` route request.
+
+So this phase does not connect prefix-anchor to runtime behavior.
+
+## Required Minimal Next Patch
+
+The next safe patch is not route optimization yet. It is a boundary-validation
+patch.
+
+A minimal acceptable next step would add an internal, feature-gated probe that:
+
+1. renders the route prompt exactly as production does
+2. constructs the candidate stable route prefix exactly as production would
+3. tokenizes both with the same native tokenizer
+4. verifies that prefix tokens are a true prefix of full route tokens
+5. reports only metadata:
+   - prefix hash
+   - prefix token count
+   - suffix token count
+   - split valid true/false
+   - failure reason
+
+That probe must not alter the runtime path.
+
+Only after that boundary is measured as stable should Orbit attempt a bounded
+route-prefix-anchor runtime experiment behind `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`.
+
+## Verdict
+
+No-go for runtime hookup in this phase.
+
+Reason: the route-wide anchor is conceptually valid, but the production native
+path does not yet expose a safe rendered-token prefix/suffix boundary, and
+restore would operate inside the shared standard lineage.
+
+No benchmark A/B was run because no runtime patch was applied.

--- a/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
+++ b/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
@@ -78,6 +78,49 @@ Current status:
 - isolated token-boundary probe: PASS
 - real native tokenizer boundary: not executed in this worktree
 
+## Real Tokenizer Attempt
+
+Worktree:
+
+```text
+/home/guelfoweb/LAB/orbit-kv-route-anchor-runtime
+```
+
+Environment discovery:
+
+```text
+ORBIT_LLAMA_LIB_DIR: unset
+ORBIT_LLAMA_ROOT: unset
+```
+
+`resolve_paths()` failed before model loading:
+
+```text
+libllama.so not found.
+Searched: /home/guelfoweb/LAB/orbit-kv-route-anchor-runtime/src/orbit/native_llama/vendor/lib/libllama.so.
+Provide ORBIT_LLAMA_LIB_DIR, --llama-root, or ORBIT_LLAMA_ROOT, or package native libraries under orbit/native_llama/vendor/lib.
+```
+
+Scenarios requested for real-tokenizer probing:
+
+| Scenario | Result |
+| --- | --- |
+| short chat route | not executed, native library unavailable |
+| trivial route | not executed, native library unavailable |
+| medium no-tool route | not executed, native library unavailable |
+| listing route | not executed, native library unavailable |
+| file-read route | not executed, native library unavailable |
+| web/fetch route | not executed, native library unavailable |
+
+Boundary verdict for the real native tokenizer:
+
+```text
+BLOCKED_BY_ENVIRONMENT
+```
+
+This is not a technical FAIL of the boundary. It means the real tokenizer could
+not be loaded in this worktree.
+
 ## Implication
 
 The next route-prefix-anchor step is blocked until this probe is run against the

--- a/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
+++ b/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
@@ -61,18 +61,16 @@ The unit tests cover both outcomes with synthetic tokenizers:
 The tests also verify that metadata does not contain raw prompt text or raw
 token arrays.
 
-## Local Native Tokenizer Result
+## Initial Local Native Tokenizer Attempt
 
-The real native tokenizer check was attempted in this worktree, but the native
-runtime library was not available:
+The first real native tokenizer check was attempted in this worktree, but the
+native runtime library was not available:
 
 ```text
 libllama.so not found
 ```
 
-Therefore this report does **not** claim a real backend-tokenizer PASS or FAIL.
-
-Current status:
+Initial status:
 
 - text boundary: PASS
 - isolated token-boundary probe: PASS
@@ -112,7 +110,7 @@ Scenarios requested for real-tokenizer probing:
 | file-read route | not executed, native library unavailable |
 | web/fetch route | not executed, native library unavailable |
 
-Boundary verdict for the real native tokenizer:
+Boundary verdict for that attempt:
 
 ```text
 BLOCKED_BY_ENVIRONMENT
@@ -121,18 +119,62 @@ BLOCKED_BY_ENVIRONMENT
 This is not a technical FAIL of the boundary. It means the real tokenizer could
 not be loaded in this worktree.
 
+## Real Tokenizer Attempt With Configured Native Library
+
+The tokenizer check was rerun with the native library configured explicitly:
+
+```text
+ORBIT_LLAMA_LIB_DIR=/home/guelfoweb/LAB/orbit/src/orbit/native_llama/vendor/lib
+```
+
+Resolved environment:
+
+| Field | Value |
+| --- | --- |
+| Native library | `/home/guelfoweb/LAB/orbit/src/orbit/native_llama/vendor/lib/libllama.so` |
+| Model id | `gemma4-12b-it-q4km` |
+| Tokenizer API | `NativeLlamaClient.tokenize` |
+
+The probe used neutral synthetic route prompts and recorded metadata only.
+
+| Scenario | token prefix ok | stable tokens | full tokens | LCP with stable | divergence |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| short chat route | true | 693 | 707 | 693 | none |
+| trivial route | true | 693 | 712 | 693 | none |
+| medium no-tool route | true | 693 | 722 | 693 | none |
+| listing route | true | 693 | 711 | 693 | none |
+| file-read route | true | 693 | 712 | 693 | none |
+| web route | true | 693 | 714 | 693 | none |
+| fetch route | true | 693 | 715 | 693 | none |
+
+Metadata hashes:
+
+| Scenario | stable prefix hash | full prompt hash |
+| --- | --- | --- |
+| short chat route | `16216b5e9e8f642e170bba51c2b94f13` | `74dbcc3158d62908f8c13857156935a8` |
+| trivial route | `16216b5e9e8f642e170bba51c2b94f13` | `31b7ccd1158d9b7cb04029d6302bcb88` |
+| medium no-tool route | `16216b5e9e8f642e170bba51c2b94f13` | `b1835d8363ca448eb7690b12681d56e1` |
+| listing route | `16216b5e9e8f642e170bba51c2b94f13` | `c5443a543919c9cd40ebc526111a41a5` |
+| file-read route | `16216b5e9e8f642e170bba51c2b94f13` | `9aa39b271c9244d9b3ee37d2753835b3` |
+| web route | `16216b5e9e8f642e170bba51c2b94f13` | `e3772f6fd62762d655cb9f74fc1db15d` |
+| fetch route | `16216b5e9e8f642e170bba51c2b94f13` | `8a0a01742957f3fdd55099ed22b1c650` |
+
+Boundary verdict for the configured real native tokenizer:
+
+```text
+PASS
+```
+
+The stable route prefix is a true token-prefix of the rendered full route prompt
+for all tested scenarios.
+
 ## Implication
 
-The next route-prefix-anchor step is blocked until this probe is run against the
-real native tokenizer in an environment where the native library and target
-model are available.
+The next route-prefix-anchor step is now a bounded route-prefix
+checkpoint/restore runtime experiment behind
+`ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`.
 
-If the real tokenizer result is PASS:
-
-- next step is a bounded route-prefix checkpoint/restore experiment behind
-  `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
-
-If the real tokenizer result is FAIL:
+If a future scenario fails this token-prefix invariant:
 
 - next step is a boundary/tokenization fix that preserves the exact rendered
   prompt semantics

--- a/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
+++ b/docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md
@@ -1,0 +1,103 @@
+# KV Route Prefix Token Boundary
+
+Commit analyzed: `57c6a3e`
+
+## Goal
+
+Verify whether the route tools-on text boundary is also a backend-visible token
+boundary.
+
+The text boundary is already available from `RoutePromptSegments`:
+
+- `stable_prefix_text`
+- `dynamic_suffix_text`
+- `full_prompt_text`
+
+The required invariant for a future prefix-anchor runtime experiment is:
+
+```text
+tokenize(full_prompt_text).startswith(tokenize(stable_prefix_text))
+```
+
+If this invariant does not hold, restoring a checkpoint for
+`stable_prefix_text` would not be equivalent to pre-filling the full prompt.
+
+## Implementation
+
+This phase adds an isolated token-boundary probe:
+
+- `probe_route_boundary_token_prefix(...)`
+- `RouteBoundaryTokenProbeResult`
+
+The probe accepts a `RoutePromptSegments` value and a tokenizer function. That
+keeps it independent from production runtime behavior while still allowing the
+same function to be used with the real native tokenizer when available.
+
+The probe reports metadata only:
+
+- `route_boundary_token_prefix_ok`
+- `stable_prefix_token_count`
+- `full_prompt_token_count`
+- `token_lcp_with_stable_prefix`
+- `divergence_index`
+- `stable_prefix_hash`
+- `full_prompt_hash`
+
+It does not report:
+
+- raw prompt text
+- raw tokens
+- user content
+- tool output
+- file or web content
+
+## Unit Coverage
+
+The unit tests cover both outcomes with synthetic tokenizers:
+
+- valid token-prefix boundary
+- invalid token-prefix boundary with LCP and divergence index
+
+The tests also verify that metadata does not contain raw prompt text or raw
+token arrays.
+
+## Local Native Tokenizer Result
+
+The real native tokenizer check was attempted in this worktree, but the native
+runtime library was not available:
+
+```text
+libllama.so not found
+```
+
+Therefore this report does **not** claim a real backend-tokenizer PASS or FAIL.
+
+Current status:
+
+- text boundary: PASS
+- isolated token-boundary probe: PASS
+- real native tokenizer boundary: not executed in this worktree
+
+## Implication
+
+The next route-prefix-anchor step is blocked until this probe is run against the
+real native tokenizer in an environment where the native library and target
+model are available.
+
+If the real tokenizer result is PASS:
+
+- next step is a bounded route-prefix checkpoint/restore experiment behind
+  `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
+
+If the real tokenizer result is FAIL:
+
+- next step is a boundary/tokenization fix that preserves the exact rendered
+  prompt semantics
+- no checkpoint/restore runtime hookup should be attempted before that fix
+
+## Production Behavior
+
+No production runtime path uses this probe.
+
+No prompt, routing, tool selection, final policy, evidence policy, backend
+cache behavior, or visible output behavior changes in this phase.

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import replace
 from typing import Any, Callable
@@ -10,6 +11,7 @@ from urllib.request import Request, urlopen
 from .base import ChatResult, Message, ModelInfo, StreamProgress
 from .model_names import resolve_model_display_name
 from .payloads import ChatPayloadOptions, build_chat_payload
+from orbit.runtime.kv_diag import current_phase, current_tools_mode
 
 
 class LlamaServerError(RuntimeError):
@@ -35,6 +37,7 @@ class LlamaServerBackend:
         max_tokens: int,
         tools: list[dict[str, Any]] | None = None,
     ) -> ChatResult:
+        native_backend = self._is_orbit_native_backend()
         payload = build_chat_payload(
             ChatPayloadOptions(
                 model=self.request_model_name(),
@@ -43,9 +46,10 @@ class LlamaServerBackend:
                 max_tokens=max_tokens,
                 thinking=self.thinking,
                 tools=tools,
+                route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
             )
         )
-        if self._is_orbit_native_backend():
+        if native_backend:
             return self._with_display_model(
                 self._post_native_stream(
                     "/chat/stream",
@@ -67,6 +71,7 @@ class LlamaServerBackend:
         on_delta: Callable[[str], None],
         on_progress: Callable[[StreamProgress], None] | None = None,
     ) -> ChatResult:
+        native_backend = self._is_orbit_native_backend()
         payload = build_chat_payload(
             ChatPayloadOptions(
                 model=self.request_model_name(),
@@ -76,9 +81,10 @@ class LlamaServerBackend:
                 thinking=self.thinking,
                 tools=tools,
                 stream=True,
+                route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
             )
         )
-        if self._is_orbit_native_backend():
+        if native_backend:
             return self._with_display_model(
                 self._post_native_stream(
                     "/chat/stream",
@@ -689,3 +695,12 @@ def _int_or_none(value: object) -> int | None:
 
 def _float_or_none(value: object) -> float | None:
     return float(value) if isinstance(value, int | float) else None
+
+
+def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:
+    if not native_backend:
+        return False
+    value = os.environ.get("ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT", "")
+    if value.strip().lower() not in {"1", "true", "yes", "on"}:
+        return False
+    return current_phase() == "route" and current_tools_mode() == "on"

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -15,6 +15,7 @@ class ChatPayloadOptions:
     tools: list[dict[str, Any]] | None = None
     stream: bool = False
     cache_prompt: bool = True
+    route_prefix_anchor: bool = False
 
 
 def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
@@ -29,6 +30,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
     }
     if options.stream:
         payload["stream"] = True
+    if options.route_prefix_anchor:
+        payload["route_prefix_anchor"] = True
     if options.tools:
         payload["tools"] = options.tools
         payload["tool_choice"] = "auto"

--- a/src/orbit/native_llama/chat_template.py
+++ b/src/orbit/native_llama/chat_template.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import hashlib
 import json
 from typing import Any
 
 
 NativeMessage = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RoutePromptSegments:
+    stable_prefix_text: str
+    dynamic_suffix_text: str
+    full_prompt_text: str
+    stable_prefix_hash: str
+    full_prompt_hash: str
+    stable_prefix_char_len: int
+
+    @property
+    def boundary_available(self) -> bool:
+        return self.stable_prefix_text + self.dynamic_suffix_text == self.full_prompt_text
 
 
 def render_gemma4_chat(
@@ -14,7 +30,51 @@ def render_gemma4_chat(
     add_generation_prompt: bool = True,
     thinking: bool = False,
 ) -> str:
+    full, _stable_end = _render_gemma4_chat_with_boundary(
+        messages,
+        tools=tools,
+        add_generation_prompt=add_generation_prompt,
+        thinking=thinking,
+    )
+    return full
+
+
+def render_gemma4_route_prompt_segments(
+    messages: list[NativeMessage],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    add_generation_prompt: bool = True,
+    thinking: bool = False,
+) -> RoutePromptSegments:
+    """Render route prompt segments without changing the rendered prompt."""
+
+    full, stable_end = _render_gemma4_chat_with_boundary(
+        messages,
+        tools=tools,
+        add_generation_prompt=add_generation_prompt,
+        thinking=thinking,
+    )
+    stable = full[:stable_end]
+    suffix = full[stable_end:]
+    return RoutePromptSegments(
+        stable_prefix_text=stable,
+        dynamic_suffix_text=suffix,
+        full_prompt_text=full,
+        stable_prefix_hash=_hash_text(stable),
+        full_prompt_hash=_hash_text(full),
+        stable_prefix_char_len=len(stable),
+    )
+
+
+def _render_gemma4_chat_with_boundary(
+    messages: list[NativeMessage],
+    *,
+    tools: list[dict[str, Any]] | None,
+    add_generation_prompt: bool,
+    thinking: bool,
+) -> tuple[str, int]:
     chunks: list[str] = ["<bos>"]
+    stable_end = 0
     start = 0
     if messages and messages[0].get("role") in {"system", "developer"}:
         chunks.append("<|turn>system\n")
@@ -26,6 +86,7 @@ def render_gemma4_chat(
             chunks.append("\n\n")
             chunks.append(tool_text)
         chunks.append("<turn|>\n")
+        stable_end = len("".join(chunks))
         start = 1
     elif tools:
         chunks.append("<|turn>system\n")
@@ -33,8 +94,10 @@ def render_gemma4_chat(
             chunks.append("<|think|>\n")
         chunks.append(_render_tools(tools))
         chunks.append("<turn|>\n")
+        stable_end = len("".join(chunks))
     elif thinking:
         chunks.append("<|turn>system\n<|think|>\n<turn|>\n")
+        stable_end = len("".join(chunks))
 
     for message in messages[start:]:
         role = message.get("role")
@@ -57,7 +120,8 @@ def render_gemma4_chat(
         chunks.append("<|turn>model\n")
         if not thinking:
             chunks.append("<|channel>thought\n<channel|>")
-    return "".join(chunks)
+    full = "".join(chunks)
+    return full, stable_end
 
 
 def _content_text(message: NativeMessage) -> str:
@@ -185,3 +249,7 @@ def _strip_thinking(text: str) -> str:
         else:
             result += part
     return result
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -17,9 +17,9 @@ from .bindings import (
     llama_token,
     llama_pos,
 )
-from .chat_template import NativeMessage, render_gemma4_chat
+from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativeProgress, NativeTimings
-from .kv_diag import emit_prompt_cache_event
+from .kv_diag import emit_prompt_cache_event, emit_route_prefix_anchor_event
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
@@ -28,6 +28,13 @@ from .mtp_dry_run import MtpDryRunResult, run_mtp_dry_run
 from .mtp_probe import MtpProbeResult, run_mtp_probe
 from .native_names import runtime_library_filename
 from .paths import NativeLlamaPaths
+from .prefix_anchor import (
+    PrefixAnchorState,
+    capture_prefix_anchor,
+    compute_prefix_anchor_key,
+    prefix_anchor_enabled,
+    restore_prefix_anchor,
+)
 from .persistent_mtp import (
     PersistentMtpSessionRuntime,
     create_persistent_mtp_session,
@@ -58,6 +65,14 @@ class NativeClientConfig:
     use_mtp_experimental: bool = False
 
 
+@dataclass(frozen=True)
+class _RouteAnchorRuntimePlan:
+    segments: RoutePromptSegments
+    prefix_tokens: list[int]
+    prefix_hash: str
+    metadata: dict[str, object]
+
+
 class NativeLlamaClient:
     def __init__(self, paths: NativeLlamaPaths, config: NativeClientConfig | None = None) -> None:
         self.paths = paths
@@ -85,6 +100,7 @@ class NativeLlamaClient:
         self._persistent_mtp_runtime: PersistentMtpSessionRuntime | None = None
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = 0
+        self._route_prefix_anchor_state = PrefixAnchorState()
 
     def session_snapshot(self, session_id: str = DEFAULT_NATIVE_SESSION_ID) -> NativeSessionSnapshot:
         if session_id != self._session.session_id:
@@ -351,6 +367,7 @@ class NativeLlamaClient:
         max_tokens: int = 16,
         tools: list[dict] | None = None,
         thinking: bool | None = None,
+        route_prefix_anchor: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -387,11 +404,18 @@ class NativeLlamaClient:
             finally:
                 self._session.in_flight = False
         prompt = self.apply_chat_template(messages, tools=tools, thinking=thinking)
+        route_anchor_segments = self._route_anchor_segments_for_prompt(
+            messages,
+            tools=tools,
+            thinking=thinking,
+            prompt=prompt,
+        ) if route_prefix_anchor else None
         return self.complete_prompt(
             prompt,
             max_tokens=max_tokens,
             allow_mtp_experimental=not tools,
             thinking=thinking,
+            route_anchor_segments=route_anchor_segments,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
@@ -405,6 +429,7 @@ class NativeLlamaClient:
         stop: tuple[str, ...] = (),
         tools: list[dict] | None = None,
         thinking: bool | None = None,
+        route_prefix_anchor: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -416,6 +441,7 @@ class NativeLlamaClient:
             stop=stop,
             tools=tools,
             thinking=thinking,
+            route_prefix_anchor=route_prefix_anchor,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
@@ -459,6 +485,7 @@ class NativeLlamaClient:
         stop: tuple[str, ...],
         tools: list[dict] | None,
         thinking: bool,
+        route_prefix_anchor: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -523,6 +550,7 @@ class NativeLlamaClient:
             max_tokens=max_tokens,
             tools=tools,
             thinking=thinking,
+            route_prefix_anchor=route_prefix_anchor,
             on_progress=on_progress,
             on_token=collect,
             should_cancel=should_cancel,
@@ -735,6 +763,7 @@ class NativeLlamaClient:
         max_tokens: int = 16,
         allow_mtp_experimental: bool = True,
         thinking: bool | None = None,
+        route_anchor_segments: RoutePromptSegments | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -771,6 +800,7 @@ class NativeLlamaClient:
             timings = self._complete_prompt_standard(
                 prompt,
                 max_tokens=max_tokens,
+                route_anchor_segments=route_anchor_segments,
                 on_progress=on_progress,
                 on_token=on_token,
                 should_cancel=should_cancel,
@@ -868,6 +898,7 @@ class NativeLlamaClient:
         prompt: str,
         *,
         max_tokens: int = 16,
+        route_anchor_segments: RoutePromptSegments | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -882,29 +913,33 @@ class NativeLlamaClient:
             raise RuntimeError("failed to count prompt tokens")
 
         previous_prompt_tokens = list(self._session.cached_prompt_tokens)
-        reused = self._prepare_memory_for_prompt(prompt_tokens)
+        pf_start = lib.llama_time_us()
+        anchor_plan = self._route_anchor_plan(prompt, prompt_tokens, route_anchor_segments)
+        anchor_metadata: dict[str, object] | None = None
+        processed_start = 0
+        if anchor_plan is None:
+            reused = self._prepare_memory_for_prompt(prompt_tokens)
+        else:
+            processed_start, reused, anchor_metadata = self._prepare_memory_with_route_anchor(anchor_plan)
+            if processed_start < 0:
+                reused = self._prepare_memory_for_prompt(prompt_tokens)
+                processed_start = reused
         processed = 0
         step = max(1, min(self.config.progress_step, self.config.batch_size))
-        pf_start = lib.llama_time_us()
-        processed = reused
+        processed = processed_start if anchor_plan is not None and anchor_metadata is not None else reused
         if on_progress:
             on_progress(NativeProgress("prefill", processed, n_prompt))
         token_array = (llama_token * n_prompt)(*prompt_tokens)
         while processed < n_prompt and not self.cancel_event.is_set():
-            if should_cancel and should_cancel():
-                self.cancel()
-                break
-            n = min(step, n_prompt - processed)
-            token_ptr = cast(byref(token_array, processed * sizeof(llama_token)), POINTER(llama_token))
-            batch = lib.llama_batch_get_one(token_ptr, n)
-            decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
-            processed += n
-            if on_progress:
-                on_progress(NativeProgress("prefill", processed, n_prompt))
-            if decode_rc != 0:
-                if decode_rc == 2 and self.cancel_event.is_set():
-                    break
-                raise RuntimeError(f"llama_decode failed during prefill: {decode_rc}")
+            processed = self._decode_prompt_range(
+                token_array,
+                processed=processed,
+                end=n_prompt,
+                step=step,
+                total=n_prompt,
+                on_progress=on_progress,
+                should_cancel=should_cancel,
+            )
         pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
         generated, gen_ms, cancelled = self._generate_from_current_context(
             max_tokens=max_tokens,
@@ -920,6 +955,11 @@ class NativeLlamaClient:
             cancelled=cancelled,
             slot_id=self._session.session_id,
         )
+        if anchor_metadata is not None:
+            anchor_metadata["cached_tokens"] = reused
+            anchor_metadata["evaluated_tokens"] = n_prompt - reused
+            anchor_metadata["lcp_tokens"] = anchor_plan.metadata.get("prefix_token_count") if anchor_plan is not None else None
+            emit_route_prefix_anchor_event(anchor_metadata)
         return NativeTimings(
             prompt_tokens=n_prompt,
             output_tokens=generated,
@@ -929,6 +969,219 @@ class NativeLlamaClient:
             generation_ms=gen_ms,
             cancelled=cancelled,
         )
+
+    def _decode_prompt_range(
+        self,
+        token_array,
+        *,
+        processed: int,
+        end: int,
+        step: int,
+        total: int,
+        on_progress=None,
+        should_cancel=None,
+    ) -> int:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        lib = self.lib.lib
+        while processed < end and not self.cancel_event.is_set():
+            if should_cancel and should_cancel():
+                self.cancel()
+                break
+            n = min(step, end - processed)
+            token_ptr = cast(byref(token_array, processed * sizeof(llama_token)), POINTER(llama_token))
+            batch = lib.llama_batch_get_one(token_ptr, n)
+            decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            processed += n
+            if on_progress:
+                on_progress(NativeProgress("prefill", processed, total))
+            if decode_rc != 0:
+                if decode_rc == 2 and self.cancel_event.is_set():
+                    break
+                raise RuntimeError(f"llama_decode failed during prefill: {decode_rc}")
+        return processed
+
+    def _route_anchor_plan(
+        self,
+        prompt: str,
+        prompt_tokens: list[int],
+        segments: RoutePromptSegments | None,
+    ) -> _RouteAnchorRuntimePlan | None:
+        if segments is None or not prefix_anchor_enabled():
+            return None
+        metadata = _route_anchor_metadata(
+            enabled=True,
+            attempted=True,
+            prefix_hash=segments.stable_prefix_hash,
+            fallback_reason=None,
+        )
+        if not segments.boundary_available:
+            metadata["fallback_reason"] = "route_boundary_unavailable"
+            emit_route_prefix_anchor_event(metadata)
+            return None
+        if segments.full_prompt_text != prompt:
+            metadata["fallback_reason"] = "route_prompt_mismatch"
+            emit_route_prefix_anchor_event(metadata)
+            return None
+        prefix_tokens = self.tokenize(segments.stable_prefix_text)
+        if not prefix_tokens:
+            metadata["fallback_reason"] = "empty_prefix_tokens"
+            emit_route_prefix_anchor_event(metadata)
+            return None
+        if prompt_tokens[: len(prefix_tokens)] != prefix_tokens:
+            metadata["fallback_reason"] = "token_boundary_mismatch"
+            metadata["prefix_token_count"] = len(prefix_tokens)
+            emit_route_prefix_anchor_event(metadata)
+            return None
+        prefix_hash = self._route_anchor_key(segments)
+        metadata["prefix_hash"] = prefix_hash
+        metadata["prefix_token_count"] = len(prefix_tokens)
+        return _RouteAnchorRuntimePlan(
+            segments=segments,
+            prefix_tokens=prefix_tokens,
+            prefix_hash=prefix_hash,
+            metadata=metadata,
+        )
+
+    def _prepare_memory_with_route_anchor(self, plan: _RouteAnchorRuntimePlan) -> tuple[int, int, dict[str, object]]:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        metadata = dict(plan.metadata)
+        metadata["restore_attempted"] = True
+        state_kwargs = self._route_anchor_state_kwargs(plan)
+        if self._route_prefix_anchor_state.valid:
+            self._clear_target_memory()
+            ok, restored_state, restore_meta = restore_prefix_anchor(
+                self._route_prefix_anchor_state,
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **state_kwargs,
+            )
+            self._route_prefix_anchor_state = restored_state
+            metadata.update(_route_anchor_metadata_from_prefix(restore_meta, prefix_hash=plan.prefix_hash))
+            if ok:
+                self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+                return len(plan.prefix_tokens), len(plan.prefix_tokens), metadata
+            return -1, 0, metadata
+
+        self._clear_target_memory()
+        token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
+        step = max(1, min(self.config.progress_step, self.config.batch_size))
+        self._decode_prompt_range(
+            token_array,
+            processed=0,
+            end=len(plan.prefix_tokens),
+            step=step,
+            total=len(plan.prefix_tokens),
+            on_progress=None,
+            should_cancel=None,
+        )
+        self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+        state, capture_meta = capture_prefix_anchor(
+            lib=self.lib.lib,
+            ctx=self._session.ctx_tgt,
+            prefix_hash=plan.prefix_hash,
+            token_count=len(plan.prefix_tokens),
+            enabled=True,
+            **state_kwargs,
+        )
+        self._route_prefix_anchor_state = state
+        metadata.update(_route_anchor_metadata_from_prefix(capture_meta, prefix_hash=plan.prefix_hash))
+        metadata["route_anchor_miss"] = True
+        if not state.valid:
+            metadata["fallback_reason"] = metadata.get("fallback_reason") or state.invalidation_reason or "capture_failed"
+            self._clear_target_memory()
+            return -1, 0, metadata
+        return len(plan.prefix_tokens), 0, metadata
+
+    def _clear_target_memory(self) -> None:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        mem = self.lib.lib.llama_get_memory(self._session.ctx_tgt)
+        if mem:
+            self.lib.lib.llama_memory_clear(mem, True)
+        self._session.cached_prompt_tokens.clear()
+
+    def _route_anchor_state_kwargs(self, plan: _RouteAnchorRuntimePlan) -> dict[str, str | None]:
+        return {
+            "model_id": str(self.paths.model),
+            "template_id": "gemma4-route-prefix-v1",
+            "tool_schema_hash": plan.segments.stable_prefix_hash,
+            "capability_summary_hash": plan.segments.stable_prefix_hash,
+            "runtime_policy_hash": plan.segments.stable_prefix_hash,
+            "route_contract_hash": plan.segments.stable_prefix_hash,
+            "backend_version": "orbit-native",
+            "native_version": runtime_library_filename("llama"),
+            "tools_mode": "on",
+        }
+
+    def _route_anchor_key(self, segments: RoutePromptSegments) -> str:
+        return compute_prefix_anchor_key(
+            model_id=str(self.paths.model),
+            template_id="gemma4-route-prefix-v1",
+            tool_schema_hash=segments.stable_prefix_hash,
+            capability_summary_hash=segments.stable_prefix_hash,
+            runtime_policy_hash=segments.stable_prefix_hash,
+            route_contract_hash=segments.stable_prefix_hash,
+            backend_version="orbit-native",
+            native_version=runtime_library_filename("llama"),
+            tools_mode="on",
+        )
+
+    def _route_anchor_segments_for_prompt(
+        self,
+        messages: list[NativeMessage],
+        *,
+        tools: list[dict] | None,
+        thinking: bool,
+        prompt: str,
+    ) -> RoutePromptSegments | None:
+        if not prefix_anchor_enabled():
+            emit_route_prefix_anchor_event(
+                _route_anchor_metadata(
+                    enabled=False,
+                    attempted=True,
+                    prefix_hash=None,
+                    fallback_reason="anchor_disabled",
+                )
+            )
+            return None
+        if tools or thinking:
+            emit_route_prefix_anchor_event(
+                _route_anchor_metadata(
+                    enabled=True,
+                    attempted=True,
+                    prefix_hash=None,
+                    fallback_reason="route_anchor_ineligible_mode",
+                )
+            )
+            return None
+        try:
+            segments = render_gemma4_route_prompt_segments([dict(message) for message in messages], thinking=False)
+        except Exception:
+            emit_route_prefix_anchor_event(
+                _route_anchor_metadata(
+                    enabled=True,
+                    attempted=True,
+                    prefix_hash=None,
+                    fallback_reason="route_segment_render_failed",
+                )
+            )
+            return None
+        if segments.full_prompt_text != prompt:
+            emit_route_prefix_anchor_event(
+                _route_anchor_metadata(
+                    enabled=True,
+                    attempted=True,
+                    prefix_hash=segments.stable_prefix_hash,
+                    fallback_reason="route_prompt_mismatch",
+                )
+            )
+            return None
+        return segments
 
     def _continue_generation_from_current_context(
         self,
@@ -1114,6 +1367,57 @@ def _strip_thinking_prompt(prompt: str) -> str:
     if prompt.endswith(suffix):
         return prompt[: -len(suffix)]
     return prompt
+
+
+def _route_anchor_metadata(
+    *,
+    enabled: bool,
+    attempted: bool,
+    prefix_hash: str | None,
+    fallback_reason: str | None,
+) -> dict[str, object]:
+    return {
+        "phase": "route",
+        "route_anchor_enabled": enabled,
+        "route_anchor_attempted": attempted,
+        "route_anchor_hit": False,
+        "route_anchor_miss": False,
+        "capture_attempted": False,
+        "restore_attempted": False,
+        "restore_used": False,
+        "fallback_reason": fallback_reason,
+        "prefix_hash": prefix_hash,
+        "prefix_token_count": None,
+        "checkpoint_size": None,
+        "checkpoint_size_bytes": None,
+        "checkpoint_age_ms": None,
+        "anchor_invalidated": False,
+        "invalidation_reason": None,
+        "cached_tokens": None,
+        "evaluated_tokens": None,
+        "lcp_tokens": None,
+    }
+
+
+def _route_anchor_metadata_from_prefix(metadata: dict[str, object], *, prefix_hash: str) -> dict[str, object]:
+    return {
+        "phase": "route",
+        "route_anchor_enabled": bool(metadata.get("anchor_enabled")),
+        "route_anchor_attempted": True,
+        "route_anchor_hit": bool(metadata.get("anchor_hit")),
+        "route_anchor_miss": bool(metadata.get("anchor_miss")),
+        "capture_attempted": bool(metadata.get("capture_attempted")),
+        "restore_attempted": bool(metadata.get("restore_attempted")),
+        "restore_used": bool(metadata.get("restore_used")),
+        "fallback_reason": metadata.get("fallback_reason"),
+        "prefix_hash": prefix_hash,
+        "prefix_token_count": metadata.get("token_count"),
+        "checkpoint_size": metadata.get("checkpoint_size"),
+        "checkpoint_size_bytes": metadata.get("checkpoint_size_bytes"),
+        "checkpoint_age_ms": metadata.get("checkpoint_age_ms"),
+        "anchor_invalidated": bool(metadata.get("anchor_invalidated")),
+        "invalidation_reason": metadata.get("invalidation_reason"),
+    }
 
 
 def _strip_control_channels(content: str) -> str:

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -117,6 +117,44 @@ def emit_prompt_cache_event(
     _emit(event)
 
 
+def emit_route_prefix_anchor_event(metadata: dict[str, Any]) -> None:
+    if not enabled():
+        return
+    request = _CURRENT_REQUEST.get()
+    event = {
+        "event": "kv_diag_route_prefix_anchor",
+        "phase": _safe_str(metadata.get("phase")) or "route",
+        "backend_request_id": request.backend_request_id if request else None,
+        "endpoint": request.endpoint if request else None,
+        "stream": request.stream if request else None,
+        "cache_prompt": request.cache_prompt if request else None,
+        "session_id_hash": request.session_id_hash if request else None,
+        "message_count": request.message_count if request else None,
+        "role_sequence": request.role_sequence if request else [],
+        "tools_parameter_present": request.tools_parameter_present if request else False,
+        "tool_count": request.tool_count if request else 0,
+        "route_anchor_enabled": bool(metadata.get("route_anchor_enabled")),
+        "route_anchor_attempted": bool(metadata.get("route_anchor_attempted")),
+        "route_anchor_hit": bool(metadata.get("route_anchor_hit")),
+        "route_anchor_miss": bool(metadata.get("route_anchor_miss")),
+        "capture_attempted": bool(metadata.get("capture_attempted")),
+        "restore_attempted": bool(metadata.get("restore_attempted")),
+        "restore_used": bool(metadata.get("restore_used")),
+        "fallback_reason": _safe_str(metadata.get("fallback_reason")),
+        "prefix_hash": _safe_str(metadata.get("prefix_hash")),
+        "prefix_token_count": _safe_int(metadata.get("prefix_token_count")),
+        "checkpoint_size": _safe_int(metadata.get("checkpoint_size")),
+        "checkpoint_size_bytes": _safe_int(metadata.get("checkpoint_size_bytes")) or _safe_int(metadata.get("checkpoint_size")),
+        "checkpoint_age_ms": _safe_int(metadata.get("checkpoint_age_ms")),
+        "anchor_invalidated": bool(metadata.get("anchor_invalidated")),
+        "invalidation_reason": _safe_str(metadata.get("invalidation_reason")),
+        "cached_tokens": _safe_int(metadata.get("cached_tokens")),
+        "evaluated_tokens": _safe_int(metadata.get("evaluated_tokens")),
+        "lcp_tokens": _safe_int(metadata.get("lcp_tokens")),
+    }
+    _emit(event)
+
+
 def _cache_miss_reason(
     *,
     cache_prompt: bool | None,
@@ -162,6 +200,18 @@ def _hash_tokens(tokens: list[int]) -> str:
 
 def _hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _safe_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _safe_str(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None
 
 
 def _emit(payload: dict[str, Any]) -> None:

--- a/src/orbit/native_llama/prefix_anchor.py
+++ b/src/orbit/native_llama/prefix_anchor.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field, replace
 import hashlib
 import json
 import os
+import time
 from typing import Any
 
 
@@ -27,6 +28,7 @@ class PrefixAnchorState:
     native_version: str | None = None
     tools_mode: str | None = None
     checkpoint_size: int = 0
+    checkpoint_created_at_monotonic: float | None = None
     valid: bool = False
     invalidation_reason: str | None = None
     checkpoint_data: bytes | None = field(default=None, repr=False, compare=False)
@@ -63,6 +65,7 @@ def can_use_prefix_anchor(
     *,
     enabled: bool | None = None,
     prefix_hash: str,
+    token_count: int | None = None,
     model_id: str | None,
     template_id: str | None,
     tool_schema_hash: str | None,
@@ -81,6 +84,8 @@ def can_use_prefix_anchor(
         return False, state.invalidation_reason or "anchor_invalid"
     if state.prefix_hash != prefix_hash:
         return False, "prefix_hash_changed"
+    if token_count is not None and state.token_count != token_count:
+        return False, "token_count_changed"
     if state.model_id != model_id:
         return False, "model_id_changed"
     if state.template_id != template_id:
@@ -111,6 +116,7 @@ def invalidate_prefix_anchor(state: PrefixAnchorState, reason: str) -> PrefixAnc
         invalidation_reason=reason,
         checkpoint_data=None,
         checkpoint_size=0,
+        checkpoint_created_at_monotonic=None,
         token_count=0,
     )
 
@@ -142,6 +148,7 @@ def capture_prefix_anchor(
         restore_attempted=False,
         restore_used=False,
         checkpoint_size=0,
+        checkpoint_age_ms=None,
         token_count=token_count,
     )
     base_state = PrefixAnchorState(
@@ -161,41 +168,57 @@ def capture_prefix_anchor(
     )
     if not enabled:
         metadata["fallback_reason"] = "anchor_disabled"
+        metadata["invalidation_reason"] = "anchor_disabled"
         return invalidate_prefix_anchor(base_state, "anchor_disabled"), metadata
     if lib is None or ctx is None:
         metadata["fallback_reason"] = "native_handles_missing"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "native_handles_missing"
         return invalidate_prefix_anchor(base_state, "native_handles_missing"), metadata
     if token_count <= 0:
         metadata["fallback_reason"] = "invalid_token_count"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "invalid_token_count"
         return invalidate_prefix_anchor(base_state, "invalid_token_count"), metadata
     metadata["capture_attempted"] = True
     try:
         size = int(lib.llama_state_seq_get_size(ctx, seq_id))
     except Exception:
         metadata["fallback_reason"] = "checkpoint_size_failed"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "checkpoint_size_failed"
         return invalidate_prefix_anchor(base_state, "checkpoint_size_failed"), metadata
     if size <= 0:
         metadata["fallback_reason"] = "empty_checkpoint"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "empty_checkpoint"
         return invalidate_prefix_anchor(base_state, "empty_checkpoint"), metadata
     try:
         buffer = (c_ubyte * size)()
         written = int(lib.llama_state_seq_get_data(ctx, buffer, size, seq_id))
     except Exception:
         metadata["fallback_reason"] = "checkpoint_capture_failed"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "checkpoint_capture_failed"
         return invalidate_prefix_anchor(base_state, "checkpoint_capture_failed"), metadata
     if written != size:
         metadata["fallback_reason"] = "checkpoint_size_mismatch"
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "checkpoint_size_mismatch"
         return invalidate_prefix_anchor(base_state, "checkpoint_size_mismatch"), metadata
     checkpoint = bytes(buffer)
     state = replace(
         base_state,
         checkpoint_size=size,
+        checkpoint_created_at_monotonic=time.monotonic(),
         checkpoint_data=checkpoint,
         valid=True,
         invalidation_reason=None,
     )
     metadata["anchor_valid"] = True
     metadata["checkpoint_size"] = size
+    metadata["checkpoint_size_bytes"] = size
+    metadata["checkpoint_age_ms"] = 0
     metadata["anchor_hit"] = False
     metadata["anchor_miss"] = False
     return state, metadata
@@ -208,6 +231,7 @@ def restore_prefix_anchor(
     ctx: Any | None,
     seq_id: int = 0,
     prefix_hash: str,
+    token_count: int | None = None,
     model_id: str | None,
     template_id: str | None,
     tool_schema_hash: str | None,
@@ -225,6 +249,7 @@ def restore_prefix_anchor(
         state,
         enabled=enabled,
         prefix_hash=prefix_hash,
+        token_count=token_count,
         model_id=model_id,
         template_id=template_id,
         tool_schema_hash=tool_schema_hash,
@@ -242,15 +267,20 @@ def restore_prefix_anchor(
         restore_attempted=True,
         restore_used=False,
         checkpoint_size=state.checkpoint_size,
+        checkpoint_age_ms=_checkpoint_age_ms(state),
         token_count=state.token_count,
     )
     if not ok:
         metadata["fallback_reason"] = reason
         metadata["anchor_miss"] = True
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = reason
         return False, invalidate_prefix_anchor(state, reason or "anchor_invalid"), metadata
     if lib is None or ctx is None:
         metadata["fallback_reason"] = "native_handles_missing"
         metadata["anchor_miss"] = True
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "native_handles_missing"
         return False, invalidate_prefix_anchor(state, "native_handles_missing"), metadata
     try:
         assert state.checkpoint_data is not None
@@ -259,10 +289,14 @@ def restore_prefix_anchor(
     except Exception:
         metadata["fallback_reason"] = "checkpoint_restore_failed"
         metadata["anchor_miss"] = True
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "checkpoint_restore_failed"
         return False, invalidate_prefix_anchor(state, "checkpoint_restore_failed"), metadata
     if written != len(state.checkpoint_data):
         metadata["fallback_reason"] = "checkpoint_restore_size_mismatch"
         metadata["anchor_miss"] = True
+        metadata["anchor_invalidated"] = True
+        metadata["invalidation_reason"] = "checkpoint_restore_size_mismatch"
         return False, invalidate_prefix_anchor(state, "checkpoint_restore_size_mismatch"), metadata
     metadata["anchor_hit"] = True
     metadata["restore_used"] = True
@@ -289,12 +323,15 @@ def anchor_metadata(
         restore_attempted=restore_attempted,
         restore_used=restore_used,
         checkpoint_size=state.checkpoint_size,
+        checkpoint_age_ms=_checkpoint_age_ms(state),
         token_count=state.token_count,
     )
     metadata["anchor_valid"] = state.valid
+    metadata["anchor_invalidated"] = not state.valid
     metadata["anchor_hit"] = anchor_hit
     metadata["anchor_miss"] = anchor_miss
     metadata["fallback_reason"] = fallback_reason or state.invalidation_reason
+    metadata["invalidation_reason"] = state.invalidation_reason
     return metadata
 
 
@@ -306,12 +343,15 @@ def _metadata(
     restore_attempted: bool,
     restore_used: bool,
     checkpoint_size: int,
+    checkpoint_age_ms: int | None,
     token_count: int,
 ) -> dict[str, Any]:
+    anchor_invalidated = False
     return {
         "anchor_enabled": enabled,
         "anchor_key_hash": key_hash,
         "anchor_valid": False,
+        "anchor_invalidated": anchor_invalidated,
         "anchor_hit": False,
         "anchor_miss": False,
         "capture_attempted": capture_attempted,
@@ -319,8 +359,17 @@ def _metadata(
         "restore_used": restore_used,
         "fallback_reason": None,
         "checkpoint_size": checkpoint_size,
+        "checkpoint_size_bytes": checkpoint_size,
+        "checkpoint_age_ms": checkpoint_age_ms,
+        "invalidation_reason": None,
         "token_count": token_count,
     }
+
+
+def _checkpoint_age_ms(state: PrefixAnchorState) -> int | None:
+    if state.checkpoint_created_at_monotonic is None:
+        return None
+    return max(0, int((time.monotonic() - state.checkpoint_created_at_monotonic) * 1000))
 
 
 def _hash(payload: Any) -> str:

--- a/src/orbit/native_llama/prefix_anchor_probe.py
+++ b/src/orbit/native_llama/prefix_anchor_probe.py
@@ -6,6 +6,7 @@ import hashlib
 from typing import Any, Callable
 
 from .bindings import LlamaBatch, llama_pos, llama_seq_id, llama_token
+from .chat_template import RoutePromptSegments
 from .prefix_anchor import (
     PrefixAnchorState,
     capture_prefix_anchor,
@@ -51,6 +52,57 @@ class PrefixAnchorProbeResult:
         }
 
 
+@dataclass(frozen=True)
+class RouteBoundaryTokenProbeResult:
+    token_prefix_ok: bool
+    reason: str | None
+    stable_prefix_token_count: int
+    full_prompt_token_count: int
+    token_lcp_with_stable_prefix: int
+    divergence_index: int | None
+    stable_prefix_hash: str
+    full_prompt_hash: str
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "route_boundary_token_prefix_ok": self.token_prefix_ok,
+            "reason": self.reason,
+            "stable_prefix_token_count": self.stable_prefix_token_count,
+            "full_prompt_token_count": self.full_prompt_token_count,
+            "token_lcp_with_stable_prefix": self.token_lcp_with_stable_prefix,
+            "divergence_index": self.divergence_index,
+            "stable_prefix_hash": self.stable_prefix_hash,
+            "full_prompt_hash": self.full_prompt_hash,
+        }
+
+
+def probe_route_boundary_token_prefix(
+    *,
+    segments: RoutePromptSegments,
+    tokenize: TokenizeFn,
+) -> RouteBoundaryTokenProbeResult:
+    stable_tokens = list(tokenize(segments.stable_prefix_text))
+    full_tokens = list(tokenize(segments.full_prompt_text))
+    lcp = _longest_common_prefix(stable_tokens, full_tokens)
+    reason = None
+    if not stable_tokens:
+        reason = "empty_stable_prefix_tokens"
+    elif len(full_tokens) < len(stable_tokens):
+        reason = "full_shorter_than_stable_prefix"
+    elif lcp != len(stable_tokens):
+        reason = "stable_prefix_not_token_prefix"
+    return RouteBoundaryTokenProbeResult(
+        token_prefix_ok=reason is None,
+        reason=reason,
+        stable_prefix_token_count=len(stable_tokens),
+        full_prompt_token_count=len(full_tokens),
+        token_lcp_with_stable_prefix=lcp,
+        divergence_index=None if reason is None else lcp,
+        stable_prefix_hash=segments.stable_prefix_hash,
+        full_prompt_hash=segments.full_prompt_hash,
+    )
+
+
 def split_prompt_by_token_prefix(
     *,
     tokenize: TokenizeFn,
@@ -67,6 +119,14 @@ def split_prompt_by_token_prefix(
         return prefix_tokens, [], full_tokens, "prefix_not_token_prefix"
     suffix_tokens = full_tokens[len(prefix_tokens) :]
     return prefix_tokens, suffix_tokens, full_tokens, None
+
+
+def _longest_common_prefix(first: list[int], second: list[int]) -> int:
+    common = 0
+    max_common = min(len(first), len(second))
+    while common < max_common and first[common] == second[common]:
+        common += 1
+    return common
 
 
 def probe_prefix_anchor_equivalence(

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -61,6 +61,7 @@ class OrbitNativeServer:
                 stop=request.stop,
                 tools=request.tools,
                 thinking=thinking,
+                route_prefix_anchor=request.route_prefix_anchor,
                 on_progress=on_progress,
                 on_token=collect,
                 should_cancel=should_cancel,

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -18,6 +18,7 @@ class ChatRequest:
     stop: tuple[str, ...]
     stream: bool
     tools: list[dict[str, Any]]
+    route_prefix_anchor: bool
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         stop=_stop_sequences(payload.get("stop")),
         stream=payload.get("stream") is True,
         tools=_tools_from_payload(payload.get("tools")),
+        route_prefix_anchor=payload.get("route_prefix_anchor") is True,
     )
 
 

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -253,6 +253,7 @@ class _DiagnosticBackend:
         result = invoke()
         components = _component_changes(call_context["request_id"], phase, tools_mode, fingerprint)
         layout_common_prefix = _layout_common_prefix(call_context["request_id"], phase, tools_mode, fingerprint)
+        route_prefix_boundary = _route_prefix_boundary_metadata(phase, tools_mode, fingerprint)
         envelope = _request_envelope_metadata(
             self._backend,
             messages=messages,
@@ -282,6 +283,7 @@ class _DiagnosticBackend:
             "prompt_layout_order": [block["component"] for block in fingerprint.prompt_layout],
             "prompt_layout": fingerprint.prompt_layout,
             "prompt_layout_common_prefix": layout_common_prefix,
+            "route_prefix_boundary": route_prefix_boundary,
             "changed_components": components,
             "wall_ms": _elapsed_ms(started),
             "prefill_ms": progress_timings.prefill_ms(started) if progress_timings is not None else None,
@@ -511,6 +513,7 @@ def _empty_prompt_fingerprint_fields() -> dict[str, Any]:
         "prompt_layout_order": [],
         "prompt_layout": [],
         "prompt_layout_common_prefix": None,
+        "route_prefix_boundary": None,
         "changed_components": [],
     }
 
@@ -621,6 +624,51 @@ def _layout_common_prefix(
             }
         )
     return event
+
+
+def _route_prefix_boundary_metadata(
+    phase: str,
+    tools_mode: str | None,
+    fingerprint: PromptFingerprint,
+) -> dict[str, Any]:
+    if phase != "route" or tools_mode != "on":
+        return {
+            "route_prefix_boundary_available": False,
+            "failure_reason": "not_route_tools_on",
+        }
+    stable_blocks: list[dict[str, Any]] = []
+    for block in fingerprint.prompt_layout:
+        if block.get("source") == "messages" and block.get("role") == "system":
+            stable_blocks.append(block)
+            continue
+        break
+    if not stable_blocks:
+        return {
+            "route_prefix_boundary_available": False,
+            "failure_reason": "missing_leading_system_prefix",
+        }
+    stable_chars = sum(int(block.get("chars", 0)) for block in stable_blocks)
+    stable_tokens = sum(int(block.get("tokens_estimate", 0)) for block in stable_blocks)
+    return {
+        "route_prefix_boundary_available": True,
+        "failure_reason": None,
+        "stable_prefix_hash": _hash(
+            {
+                "blocks": _layout_identity(stable_blocks),
+                "tool_schema_hash": fingerprint.tool_schema_hash,
+                "capability_summary_hash": fingerprint.capability_summary_hash,
+            }
+        ),
+        "stable_prefix_char_len": stable_chars,
+        "stable_prefix_token_count_estimate": stable_tokens,
+        "dynamic_suffix_char_len": max(0, fingerprint.prompt_chars - stable_chars),
+        "full_prompt_hash": fingerprint.full_prompt_hash,
+        "first_dynamic_component": (
+            fingerprint.prompt_layout[len(stable_blocks)].get("component")
+            if len(stable_blocks) < len(fingerprint.prompt_layout)
+            else None
+        ),
+    }
 
 
 def _prompt_layout(messages: list[Message], tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -69,6 +69,10 @@ def current_tools_mode() -> str | None:
     return _TOOLS_MODE.get()
 
 
+def current_phase() -> str | None:
+    return _PHASE.get()
+
+
 @contextlib.contextmanager
 def request_context(*, session_id: str | None = None) -> Iterator[None]:
     if not enabled() or _REQUEST.get() is not None:

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -19,6 +19,7 @@ from orbit.runtime.kv_diag import (
 )
 from orbit.native_llama.kv_diag import (
     emit_prompt_cache_event as emit_native_prompt_cache_event,
+    emit_route_prefix_anchor_event as emit_native_route_prefix_anchor_event,
     request_context as native_request_context,
     reset_diagnostics_for_tests as reset_native_diagnostics_for_tests,
 )
@@ -657,6 +658,66 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(event["cache_miss_reason"], "prefix_mismatch_at_token_0")
         self.assertEqual(event["longest_common_prefix_tokens"], 0)
         self.assertEqual(event["first_mismatch_token"], 0)
+
+    def test_native_route_prefix_anchor_diagnostics_are_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            payload = {
+                "cache_prompt": True,
+                "stream": True,
+                "route_prefix_anchor": True,
+                "messages": [
+                    {"role": "system", "content": "runtime route policy placeholder"},
+                    {"role": "user", "content": "placeholder route request"},
+                ],
+            }
+            metadata = {
+                "route_anchor_enabled": True,
+                "route_anchor_attempted": True,
+                "route_anchor_hit": True,
+                "route_anchor_miss": False,
+                "capture_attempted": False,
+                "restore_attempted": True,
+                "restore_used": True,
+                "fallback_reason": None,
+                "prefix_hash": "prefix-hash-placeholder",
+                "prefix_token_count": 693,
+                "checkpoint_size": 2048,
+                "checkpoint_size_bytes": 2048,
+                "checkpoint_age_ms": 42,
+                "anchor_invalidated": False,
+                "invalidation_reason": None,
+                "cached_tokens": 693,
+                "evaluated_tokens": 21,
+                "lcp_tokens": 693,
+                "phase": "route",
+            }
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with native_request_context(endpoint="/chat/stream", payload=payload):
+                    emit_native_route_prefix_anchor_event(metadata)
+
+            event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            raw_log = json.dumps(event)
+
+        self.assertEqual(event["event"], "kv_diag_route_prefix_anchor")
+        self.assertEqual(event["phase"], "route")
+        self.assertTrue(event["route_anchor_enabled"])
+        self.assertTrue(event["route_anchor_attempted"])
+        self.assertTrue(event["route_anchor_hit"])
+        self.assertTrue(event["restore_attempted"])
+        self.assertTrue(event["restore_used"])
+        self.assertEqual(event["prefix_hash"], "prefix-hash-placeholder")
+        self.assertEqual(event["prefix_token_count"], 693)
+        self.assertEqual(event["cached_tokens"], 693)
+        self.assertEqual(event["evaluated_tokens"], 21)
+        self.assertEqual(event["lcp_tokens"], 693)
+        self.assertEqual(event["checkpoint_size_bytes"], 2048)
+        self.assertEqual(event["checkpoint_age_ms"], 42)
+        self.assertFalse(event["anchor_invalidated"])
+        self.assertIsNone(event["invalidation_reason"])
+        self.assertEqual(event["role_sequence"], ["system", "user"])
+        self.assertNotIn("runtime route policy placeholder", raw_log)
+        self.assertNotIn("placeholder route request", raw_log)
 
 
 if __name__ == "__main__":

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -238,6 +238,70 @@ class KVDiagTests(unittest.TestCase):
         self.assertNotIn("schema metadata", raw_log)
         self.assertNotIn("policy text", raw_log)
 
+    def test_route_prefix_boundary_diagnostics_are_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                backend = instrument_backend(FakeBackend())
+                messages = [
+                    {"role": "system", "content": "route policy placeholder"},
+                    {"role": "user", "content": "placeholder route payload"},
+                ]
+                with request_context(session_id="session"):
+                    with model_call_context(phase="route", tools_mode="on"):
+                        backend.chat(messages, temperature=0, max_tokens=32)
+
+            payload = next(
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if json.loads(line)["event"] == "kv_diag_model_call"
+            )
+            boundary = payload["route_prefix_boundary"]
+            raw_log = json.dumps(payload)
+
+        self.assertTrue(boundary["route_prefix_boundary_available"])
+        self.assertIsNone(boundary["failure_reason"])
+        self.assertIsInstance(boundary["stable_prefix_hash"], str)
+        self.assertGreater(boundary["stable_prefix_char_len"], 0)
+        self.assertGreater(boundary["stable_prefix_token_count_estimate"], 0)
+        self.assertGreater(boundary["dynamic_suffix_char_len"], 0)
+        self.assertEqual(boundary["first_dynamic_component"], "user_message")
+        self.assertNotIn("placeholder route payload", raw_log)
+        self.assertNotIn("route policy placeholder", raw_log)
+
+    def test_route_prefix_boundary_hash_changes_with_schema_and_capabilities(self) -> None:
+        messages = [
+            {"role": "system", "content": "route policy placeholder"},
+            {"role": "system", "content": "Local tools available: python3."},
+            {"role": "user", "content": "placeholder route payload"},
+        ]
+        first = fingerprint_prompt(
+            messages,
+            tools=[{"type": "function", "function": {"name": "tool_alpha", "parameters": {}}}],
+        )
+        second = fingerprint_prompt(
+            [
+                {"role": "system", "content": "route policy placeholder"},
+                {"role": "system", "content": "Local tools available: python3, file."},
+                {"role": "user", "content": "placeholder route payload"},
+            ],
+            tools=[{"type": "function", "function": {"name": "tool_alpha", "parameters": {}}}],
+        )
+        third = fingerprint_prompt(
+            messages,
+            tools=[{"type": "function", "function": {"name": "tool_beta", "parameters": {}}}],
+        )
+
+        from orbit.runtime.kv_diag import _route_prefix_boundary_metadata
+
+        first_boundary = _route_prefix_boundary_metadata("route", "on", first)
+        second_boundary = _route_prefix_boundary_metadata("route", "on", second)
+        third_boundary = _route_prefix_boundary_metadata("route", "on", third)
+
+        self.assertTrue(first_boundary["route_prefix_boundary_available"])
+        self.assertNotEqual(first_boundary["stable_prefix_hash"], second_boundary["stable_prefix_hash"])
+        self.assertNotEqual(first_boundary["stable_prefix_hash"], third_boundary["stable_prefix_hash"])
+
     def test_prompt_layout_mismatch_event_contains_only_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log_path = Path(tmp) / "diag.jsonl"

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 import json
+import os
 import tempfile
 from pathlib import Path
 import sys
@@ -19,8 +21,10 @@ from orbit.backend.llama_server import (
     _parse_model_info,
     _parse_native_stream,
 )
+from orbit.backend.base import ChatResult
 from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
 from orbit.backend import model_names
+from orbit.runtime.kv_diag import model_call_context
 from urllib.error import URLError
 
 
@@ -52,7 +56,7 @@ class LlamaServerBackendTests(unittest.TestCase):
         backend = LlamaServerBackend(base_url="http://127.0.0.1:12120", model="fake", timeout=1)
 
         with self.assertRaisesRegex(Exception, "cannot connect to backend server at http://127.0.0.1:12120"):
-            with unittest.mock.patch("orbit.backend.llama_server.urlopen", side_effect=URLError("[Errno 111] Connection refused")):
+            with mock.patch("orbit.backend.llama_server.urlopen", side_effect=URLError("[Errno 111] Connection refused")):
                 backend._get_json("/health")
 
     def test_continue_current_uses_native_continue_stream_endpoint_for_non_stream_call(self) -> None:
@@ -263,6 +267,67 @@ class LlamaServerBackendTests(unittest.TestCase):
         )
 
         self.assertTrue(payload["thinking"])
+
+    def test_route_prefix_anchor_payload_is_limited_to_route_tools_on(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payloads: list[dict[str, object]] = []
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "orbit-native"}
+
+            def _post_native_stream(self, _path: str, payload: dict[str, object], *, on_delta, on_progress) -> ChatResult:
+                self.payloads.append(payload)
+                return ChatResult(
+                    content="ok",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = Backend()
+        with mock.patch.dict(os.environ, {"ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"}, clear=False):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+            with model_call_context(phase="route", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertNotIn("route_prefix_anchor", backend.payloads[0])
+        self.assertTrue(backend.payloads[1]["route_prefix_anchor"])
+        self.assertNotIn("route_prefix_anchor", backend.payloads[2])
+
+    def test_route_prefix_anchor_payload_is_not_sent_to_non_native_backend(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payload: dict[str, object] | None = None
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "openai-compatible"}
+
+            def _post_json(self, _path: str, payload: dict[str, object]) -> dict[str, object]:
+                self.payload = payload
+                return {
+                    "model": "fake",
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+
+        backend = Backend()
+        with mock.patch.dict(os.environ, {"ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"}, clear=False):
+            with model_call_context(phase="route", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertIsNotNone(backend.payload)
+        assert backend.payload is not None
+        self.assertNotIn("route_prefix_anchor", backend.payload)
 
     def test_parse_chat_result_extracts_content_and_metrics(self) -> None:
         result = _parse_chat_result(

--- a/tests/test_native_chat_template.py
+++ b/tests/test_native_chat_template.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from orbit.native_llama.chat_template import render_gemma4_chat
+from orbit.native_llama.chat_template import render_gemma4_chat, render_gemma4_route_prompt_segments
 
 
 class NativeChatTemplateTests(unittest.TestCase):
@@ -127,6 +127,39 @@ class NativeChatTemplateTests(unittest.TestCase):
         )
 
         self.assertIn("Thinking mode is off. Do not reveal chain-of-thought.", prompt)
+
+    def test_route_prompt_segments_recompose_byte_identical_prompt(self) -> None:
+        messages = [
+            {"role": "system", "content": "route policy placeholder"},
+            {"role": "user", "content": "placeholder task payload"},
+        ]
+
+        baseline = render_gemma4_chat(messages)
+        segments = render_gemma4_route_prompt_segments(messages)
+
+        self.assertTrue(segments.boundary_available)
+        self.assertEqual(segments.full_prompt_text, baseline)
+        self.assertEqual(segments.stable_prefix_text + segments.dynamic_suffix_text, baseline)
+        self.assertTrue(segments.stable_prefix_text.startswith("<bos><|turn>system\n"))
+        self.assertIn("<|turn>user\n", segments.dynamic_suffix_text)
+        self.assertNotEqual(segments.stable_prefix_hash, segments.full_prompt_hash)
+
+    def test_route_prompt_segment_hash_changes_with_tool_schema(self) -> None:
+        messages = [
+            {"role": "system", "content": "route policy placeholder"},
+            {"role": "user", "content": "placeholder task payload"},
+        ]
+        first = render_gemma4_route_prompt_segments(
+            messages,
+            tools=[{"type": "function", "function": {"name": "tool_alpha", "parameters": {}}}],
+        )
+        second = render_gemma4_route_prompt_segments(
+            messages,
+            tools=[{"type": "function", "function": {"name": "tool_beta", "parameters": {}}}],
+        )
+
+        self.assertNotEqual(first.stable_prefix_hash, second.stable_prefix_hash)
+        self.assertEqual(first.dynamic_suffix_text, second.dynamic_suffix_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -30,6 +30,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertIsNone(request.thinking)
         self.assertEqual(request.stop, ())
         self.assertEqual(request.tools, [])
+        self.assertFalse(request.route_prefix_anchor)
 
     def test_parse_chat_request_accepts_thinking_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "thinking": True})
@@ -63,6 +64,10 @@ class NativeServerProtocolTests(unittest.TestCase):
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "tools": [tool, "bad"]})
 
         self.assertEqual(request.tools, [tool])
+
+    def test_parse_chat_request_accepts_route_prefix_anchor_flag(self) -> None:
+        request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "route_prefix_anchor": True})
+        self.assertTrue(request.route_prefix_anchor)
 
     def test_parse_chat_request_rejects_malformed_payloads(self) -> None:
         bad_payloads = [

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -38,7 +38,19 @@ class _FakeClient:
         self.last_mtp_completion = type("Probe", (), {"success": False})()
         self.mtp_fallback_reason = None
 
-    def complete_chat_text(self, messages, *, max_tokens, stop, tools, thinking, on_progress=None, on_token=None, should_cancel=None):
+    def complete_chat_text(
+        self,
+        messages,
+        *,
+        max_tokens,
+        stop,
+        tools,
+        thinking,
+        route_prefix_anchor=False,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ):
         self.calls.append(thinking)
         return _FakeCompletion()
 

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -53,5 +53,27 @@ class PayloadTests(unittest.TestCase):
         self.assertEqual(payload["messages"][0]["role"], "user")
         self.assertEqual(payload["messages"][0]["content"], "hello")
 
+    def test_build_chat_payload_includes_route_prefix_anchor_only_when_requested(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+            )
+        )
+        experimental = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+                route_prefix_anchor=True,
+            )
+        )
+
+        self.assertNotIn("route_prefix_anchor", baseline)
+        self.assertTrue(experimental["route_prefix_anchor"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prefix_anchor.py
+++ b/tests/test_prefix_anchor.py
@@ -161,6 +161,42 @@ class PrefixAnchorTests(unittest.TestCase):
         self.assertFalse(restored_state.valid)
         self.assertEqual(restored_state.invalidation_reason, "checkpoint_restore_size_mismatch")
         self.assertEqual(metadata["fallback_reason"], "checkpoint_restore_size_mismatch")
+        self.assertTrue(metadata["anchor_invalidated"])
+        self.assertEqual(metadata["invalidation_reason"], "checkpoint_restore_size_mismatch")
+
+    def test_restore_rejects_token_count_mismatch(self) -> None:
+        kwargs = self._stable_kwargs()
+        key = compute_prefix_anchor_key(**kwargs)
+        state = PrefixAnchorState(
+            prefix_hash=key,
+            token_count=24,
+            model_id=kwargs["model_id"],
+            template_id=kwargs["template_id"],
+            tool_schema_hash=kwargs["tool_schema_hash"],
+            capability_summary_hash=kwargs["capability_summary_hash"],
+            runtime_policy_hash=kwargs["runtime_policy_hash"],
+            route_contract_hash=kwargs["route_contract_hash"],
+            backend_version=kwargs["backend_version"],
+            native_version=kwargs["native_version"],
+            tools_mode=kwargs["tools_mode"],
+            checkpoint_size=4,
+            checkpoint_data=b"abcd",
+            valid=True,
+        )
+        ok, restored_state, metadata = restore_prefix_anchor(
+            state,
+            lib=_FakeLib(b"abcd"),
+            ctx=object(),
+            prefix_hash=key,
+            token_count=25,
+            enabled=True,
+            **kwargs,
+        )
+        self.assertFalse(ok)
+        self.assertFalse(restored_state.valid)
+        self.assertEqual(restored_state.invalidation_reason, "token_count_changed")
+        self.assertEqual(metadata["fallback_reason"], "token_count_changed")
+        self.assertTrue(metadata["anchor_invalidated"])
 
     def test_can_use_prefix_anchor_rejects_changed_capabilities(self) -> None:
         kwargs = self._stable_kwargs()
@@ -202,6 +238,8 @@ class PrefixAnchorTests(unittest.TestCase):
         metadata = anchor_metadata(state, enabled=True, anchor_hit=True, restore_attempted=True, restore_used=True)
         self.assertTrue(metadata["anchor_enabled"])
         self.assertEqual(metadata["anchor_key_hash"], "anchor-key-alpha")
+        self.assertEqual(metadata["checkpoint_size_bytes"], 12)
+        self.assertFalse(metadata["anchor_invalidated"])
         self.assertTrue(metadata["anchor_hit"])
         self.assertTrue(metadata["restore_attempted"])
         self.assertTrue(metadata["restore_used"])

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -5,9 +5,11 @@ import unittest
 
 from orbit.native_llama.prefix_anchor_probe import (
     PrefixAnchorProbeResult,
+    probe_route_boundary_token_prefix,
     probe_prefix_anchor_equivalence,
     split_prompt_by_token_prefix,
 )
+from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
 
 
 def _token_value(value: object) -> int:
@@ -98,6 +100,57 @@ class _FailingRestoreLib(_FakeLib):
 
 
 class PrefixAnchorProbeTests(unittest.TestCase):
+    def test_route_boundary_token_probe_reports_valid_token_prefix(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "route policy placeholder"},
+                {"role": "user", "content": "placeholder task payload"},
+            ]
+        )
+        mapping = {
+            segments.stable_prefix_text: [1, 2, 3],
+            segments.full_prompt_text: [1, 2, 3, 4, 5],
+        }
+        result = probe_route_boundary_token_prefix(
+            segments=segments,
+            tokenize=lambda text: mapping[text],
+        )
+        metadata = result.to_metadata()
+
+        self.assertTrue(result.token_prefix_ok)
+        self.assertIsNone(result.reason)
+        self.assertEqual(result.stable_prefix_token_count, 3)
+        self.assertEqual(result.full_prompt_token_count, 5)
+        self.assertEqual(result.token_lcp_with_stable_prefix, 3)
+        self.assertIsNone(result.divergence_index)
+        self.assertTrue(metadata["route_boundary_token_prefix_ok"])
+        self.assertNotIn("placeholder task payload", str(metadata))
+        self.assertNotIn("route policy placeholder", str(metadata))
+
+    def test_route_boundary_token_probe_reports_mismatch_without_raw_tokens(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "route policy placeholder"},
+                {"role": "user", "content": "placeholder task payload"},
+            ]
+        )
+        mapping = {
+            segments.stable_prefix_text: [1, 2, 3],
+            segments.full_prompt_text: [1, 2, 9, 4],
+        }
+        result = probe_route_boundary_token_prefix(
+            segments=segments,
+            tokenize=lambda text: mapping[text],
+        )
+        metadata = result.to_metadata()
+
+        self.assertFalse(result.token_prefix_ok)
+        self.assertEqual(result.reason, "stable_prefix_not_token_prefix")
+        self.assertEqual(result.token_lcp_with_stable_prefix, 2)
+        self.assertEqual(result.divergence_index, 2)
+        self.assertNotIn("[1, 2, 3]", str(metadata))
+        self.assertNotIn("placeholder task payload", str(metadata))
+
     def test_split_prompt_by_token_prefix_rejects_non_prefix_boundary(self) -> None:
         def tokenize(text: str) -> list[int]:
             mapping = {


### PR DESCRIPTION
This PR adds an opt-in route KV prefix anchor experiment behind ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1.

Default is OFF.

It uses a backend-native checkpoint/restore path for the stable route tools-on prefix only. It does not change prompt semantics, routing, tool selection, final policy, or file/web evidence behavior.

Scope:

* route + tools-on + native backend only
* excluded: chat_final, final_from_tool, tool_call
* no file/web/fetch/listing special-casing
* no deterministic pre-routing
* fallback to baseline on mismatch or restore failure

Key results:

* OFF hi: route 0/706 cached/evaluated, wall ~59-61s
* ON first hi: capture miss, route 0/706, wall ~62s
* ON repeat hi: restore hit, route 693/13, wall ~8.3-8.6s
* file-read content evidence preserved
* list_directory preserved
* web/fetch preserved as route -> final_from_tool, 2 calls
* route_no_decision_length_retry observed: 0

Limitations:

* first capture miss remains expensive
* checkpoint is large, about 238 MB
* experiment remains opt-in, not default

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q PASS
* python3 -m unittest discover -s tests -q PASS
* python3 -m compileall -q src tests scripts PASS
* git diff --check PASS
* privacy/name/Unicode/raw-content scan PASS

No changes to:

* default behavior
* prompt semantics
* routing
* tool selection
* final policy
* evidence policy
* non-native backend behavior
