### PR TITLE
Add RC2 hardening reviews

### DIFF
--- a/docs/KV_INDEX.md
+++ b/docs/KV_INDEX.md
@@ -1,0 +1,69 @@
+# KV Documentation Index
+
+This index maps the KV/cache work after `v0.0.1-rc1`. It is a navigation aid
+only. It does not replace the detailed reports and does not change any runtime
+policy.
+
+## Current Opt-In Path
+
+- `KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md` documents the current
+  `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` route-prefix anchor experiment.
+- The experiment is default OFF.
+- Scope is native backend, tools-on route pass only.
+- It must not be broadened to `chat_final`, `final_from_tool`, `tool_call`, or
+  file/web/listing special paths without new benchmark evidence.
+
+## Baseline And Analysis
+
+- `KV_CACHE_REUSE_PLAN.md` defines the original phase plan and measurement
+  questions.
+- `KV_CACHE_PHASE_2_ANALYSIS.md` analyzes route pass count and multi-pass cost.
+- `KV_PREFIX_REUSE_POST_ROUTE_BASELINE.md` records the post-route-fix baseline.
+- `KV_LAYOUT_CACHE_ANALYSIS.md` compares logical prompt layout with backend
+  cache behavior.
+- `KV_BACKEND_CACHE_PATH_ANALYSIS.md` documents backend-visible cache path
+  findings.
+
+## Diagnostics
+
+- `KV_PROMPT_LAYOUT_DIAGNOSTICS.md` describes prompt block layout metadata.
+- `KV_BACKEND_ENVELOPE_DIAGNOSTICS.md` describes request-envelope metadata.
+- `KV_BACKEND_NATIVE_CACHE_DIAGNOSTICS.md` describes native cache/LCP metadata.
+- `ROUTE_OUTCOME_OBSERVABILITY.md` documents route outcome classification.
+
+## Prefix Anchor Feasibility And Proofs
+
+- `KV_PREFIX_ANCHOR_FEASIBILITY.md` explains why runtime-only prefix cache is a
+  no-go.
+- `KV_PREFIX_ANCHOR_IMPLEMENTATION_PLAN.md` records the native binding
+  preparation plan.
+- `KV_PREFIX_ANCHOR_LIFECYCLE_PHASE_1.md` documents isolated lifecycle
+  scaffolding.
+- `KV_PREFIX_ANCHOR_EQUIVALENCE_PROBE.md` documents checkpoint/restore
+  equivalence in an isolated native probe.
+- `KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md` records the route prefix token-boundary
+  validation used by the runtime experiment.
+
+## Rejected Or Historical Branches
+
+- `KV_PROMPT_SHAPE_EXPERIMENT.md` is a rejected prompt-shape experiment. It
+  improved some short-chat cache metrics but introduced repair/retry risk.
+- `KV_PREFIX_CACHE_FEASIBILITY.md` rejects fake runtime-only prefix cache.
+- `KV_PREFIX_ANCHOR_RUNTIME_NO_GO.md` and
+  `KV_ROUTE_PREFIX_ANCHOR_RUNTIME_NO_GO.md` are historical no-go reports. They
+  should remain as context unless a future cleanup explicitly preserves their
+  safety rationale elsewhere.
+
+## Cleanup Review
+
+- `KV_POST_MERGE_CLEANUP_REVIEW.md` lists safe cleanup candidates, risky
+  cleanup candidates, and items that should not be touched before RC2.
+
+## Release Guidance
+
+For RC2 preparation, treat the prefix-anchor experiment as opt-in only:
+
+- keep `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT` default OFF
+- keep historical no-go/reject reports available
+- keep the isolated probe while the experiment remains active
+- require unit tests, compile checks, and native OFF/ON smoke before any release

--- a/docs/KV_POST_MERGE_CLEANUP_REVIEW.md
+++ b/docs/KV_POST_MERGE_CLEANUP_REVIEW.md
@@ -1,0 +1,253 @@
+# KV Post-Merge Cleanup Review
+
+Commit reviewed: `7e810a5` (`origin/main`, PR #57 merged).
+
+This review is intentionally non-destructive. It does not change runtime
+behavior, prompts, tool selection, final policy, evidence policy, or KV/cache
+behavior. It only records cleanup candidates found after the KV diagnostics and
+prefix-anchor work landed on `main`.
+
+## Summary
+
+The KV line now contains three categories of material:
+
+- production opt-in experiment code for `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
+- diagnostics/probe code used to justify and validate that experiment
+- historical analysis documents that explain rejected/no-go branches
+
+No high-confidence dead production path was found. The most plausible cleanup is
+small import cleanup plus possible documentation consolidation. Code removal is
+riskier because several helpers are intentionally isolated from production but
+still covered by tests and referenced by docs.
+
+## Cleanup Safe
+
+### Remove obviously unused imports after static confirmation
+
+Candidate files:
+
+- `src/orbit/native_llama/client.py`
+- `src/orbit/native_llama/prefix_anchor_probe.py`
+
+Observed candidates:
+
+- `src/orbit/native_llama/client.py` imports `c_float` from `ctypes`, but local
+  usage search only finds it on the import line in this file.
+- `src/orbit/native_llama/prefix_anchor_probe.py` imports `LlamaBatch` and
+  `PrefixAnchorState`, but local usage search only finds them on import lines.
+
+Why this is safe:
+
+- These are local imports only; removing them should not alter runtime behavior.
+- The expected validation is fast and direct.
+
+Required validation before removal:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q
+PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Extra validation:
+
+- run `rg "c_float" src/orbit/native_llama/client.py`
+- run `rg "LlamaBatch|PrefixAnchorState" src/orbit/native_llama/prefix_anchor_probe.py`
+
+### Add a docs index instead of deleting historical documents
+
+Candidate:
+
+- add or update a single index section in `docs/KV_CACHE_REUSE_PLAN.md` or a new
+  `docs/KV_DOCS_INDEX.md`
+
+Why this is safe:
+
+- The docs set is large and hard to navigate after the phase-by-phase work.
+- An index can label documents as current, historical, rejected, no-go, probe,
+  or production opt-in without deleting technical evidence.
+
+Required validation:
+
+```bash
+git diff --check
+```
+
+## Cleanup Risky
+
+### Remove historical no-go/reject reports
+
+Potentially redundant documents:
+
+- `docs/KV_PROMPT_SHAPE_EXPERIMENT.md`
+- `docs/KV_PREFIX_CACHE_FEASIBILITY.md`
+- `docs/KV_PREFIX_ANCHOR_RUNTIME_NO_GO.md`
+- `docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_NO_GO.md`
+- `docs/KV_ROUTE_PREFIX_TOKEN_BOUNDARY.md`
+
+Why risky:
+
+- These documents explain why prompt-shape hacks, runtime-only fake prefix cache,
+  and early route-anchor attempts were rejected.
+- They are useful guardrails against reintroducing unsafe performance shortcuts.
+- Some documents are superseded technically, but still preserve benchmark and
+  safety rationale.
+
+Recommendation:
+
+- Do not delete these now.
+- If cleanup is desired, archive them under a clearly named docs section or add
+  a phase index that marks them as historical.
+
+Required validation if moving/renaming:
+
+```bash
+rg "KV_PROMPT_SHAPE_EXPERIMENT|KV_PREFIX_CACHE_FEASIBILITY|KV_PREFIX_ANCHOR_RUNTIME_NO_GO|KV_ROUTE_PREFIX_ANCHOR_RUNTIME_NO_GO|KV_ROUTE_PREFIX_TOKEN_BOUNDARY" docs README.md
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+### Remove probe code because production does not call it
+
+Candidate files:
+
+- `src/orbit/native_llama/prefix_anchor_probe.py`
+- `tests/test_prefix_anchor_probe.py`
+
+Why risky:
+
+- The probe is intentionally isolated from production, so lack of production
+  imports is not proof that it is dead.
+- It documents and tests the checkpoint/restore equivalence property used to
+  justify the route-prefix-anchor experiment.
+- Removing it would weaken regression coverage for the native state APIs.
+
+Recommendation:
+
+- Do not remove.
+- Keep as a tested diagnostic/proof harness until the prefix-anchor experiment is
+  either promoted, redesigned, or retired.
+
+### Remove boundary diagnostics
+
+Candidate files/areas:
+
+- `src/orbit/native_llama/chat_template.py` route prompt segment helpers
+- `tests/test_native_chat_template.py` boundary tests
+- `src/orbit/runtime/kv_diag.py` layout/boundary metadata
+
+Why risky:
+
+- The route-prefix-anchor experiment depends on the invariant that the stable
+  route prefix boundary is byte- and token-prefix compatible.
+- These helpers are part of the safety argument that the prompt semantics are
+  unchanged.
+
+Recommendation:
+
+- Do not remove while `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT` exists.
+
+## Things To Not Touch
+
+### Feature flag default
+
+Do not change `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT` default behavior.
+
+Reason:
+
+- The experiment is explicitly opt-in.
+- Checkpoint memory cost is material, about 238 MB in the local benchmark.
+- The first capture miss remains expensive.
+
+### Route/tools gating
+
+Do not broaden route-prefix-anchor usage beyond:
+
+- native backend
+- `phase=route`
+- `tools_mode=on`
+- explicit `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
+
+Reason:
+
+- The merge-ready evidence only covers route tools-on.
+- `chat_final`, `final_from_tool`, `tool_call`, file-read, web/fetch, and listing
+  must stay behaviorally unchanged.
+
+### Rejected prompt-shape experiment
+
+Do not resurrect or partially reapply `ORBIT_KV_PROMPT_SHAPE_EXPERIMENT`.
+
+Reason:
+
+- It improved short chat cache behavior but introduced repair/retry risk on
+  medium no-tool prompts.
+- It changed prompt shape semantically enough to be rejected.
+
+### Runtime-only fake prefix cache
+
+Do not introduce replay-token or runtime-only cache masquerading as KV reuse.
+
+Reason:
+
+- The accepted path relies on backend-native checkpoint/restore only.
+
+## Candidate Removal List
+
+No file is recommended for immediate removal.
+
+Low-risk edit candidates, not removals:
+
+- remove unused import `c_float` from `src/orbit/native_llama/client.py` if a
+  targeted diff confirms no usage
+- remove unused imports `LlamaBatch` and `PrefixAnchorState` from
+  `src/orbit/native_llama/prefix_anchor_probe.py` if a targeted diff confirms no
+  usage
+- add a KV docs index to reduce navigation cost without deleting evidence
+
+## Test Matrix For Any Future Cleanup
+
+For import-only cleanup:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q
+PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+For documentation-only cleanup:
+
+```bash
+git diff --check
+```
+
+For any removal touching prefix-anchor, boundary, or probe code:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q
+PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Also run a native smoke if the removal touches runtime-facing prefix-anchor code:
+
+- OFF tools-on `hi`: no anchor event
+- ON tools-on first `hi`: capture miss
+- ON tools-on repeat `hi`: restore hit
+- file-read: content evidence preserved
+- listing: `list_directory` preserved
+- web/fetch: `route -> final_from_tool` preserved
+
+## Recommendation
+
+Do not perform code removal yet. The safest immediate cleanup is limited to
+unused imports and a documentation index. Keep the historical KV reports and the
+isolated probe code until the opt-in prefix-anchor experiment is either promoted
+or explicitly retired.

--- a/docs/PROMPTS_RELEASE_HARDENING_REVIEW.md
+++ b/docs/PROMPTS_RELEASE_HARDENING_REVIEW.md
@@ -1,0 +1,130 @@
+# Prompts Release Hardening Review
+
+Commit reviewed: `7e810a5` (`origin/main`, PR #57 merged).
+
+This is a strategic prompt review before a possible RC2. It does not publish
+RC2 and does not change prompt text.
+
+## Files Analyzed
+
+- `docs/PROMPTS.md`
+- `src/orbit/runtime/messages.py`
+- `src/orbit/runtime/tools.py`
+- `src/orbit/runtime/capabilities.py`
+- `src/orbit/runtime/command_request.py`
+- `src/orbit/native_llama/chat_template.py`
+- related tests: `tests/test_messages.py`, `tests/test_config.py`,
+  `tests/test_command_request.py`, `tests/test_native_chat_template.py`
+
+## Findings
+
+### Route Prompt
+
+The route prompt remains model-guided. It asks the model to decide whether a
+request needs local tools and explicitly avoids runtime-authored task answers.
+No deterministic user-task mapping was found.
+
+Current route constraints are consistent with the post-PR #51 behavior:
+
+- direct route answers are allowed only for no-tool, no-evidence requests that
+  fit in one short sentence
+- normal/long no-tool answers should return `{"route":"CHAT"}`
+- file read/explain/summarize/analyze requests require content-reading command
+  decisions
+- directory listing is separated from file content evidence
+- web/search/latest/current/online and URL fetch/read/open/explain/summarize
+  requests are tool tasks
+- long prose in the route pass is explicitly forbidden
+
+No route prompt rewrite is recommended before RC2.
+
+### Tool Specs And Capability Summary
+
+`src/orbit/runtime/tools.py` exposes tools in a stable tuple order:
+
+```text
+exec_shell_full_command, fetch_url, list_directory, system_info
+```
+
+`src/orbit/runtime/capabilities.py` uses a stable tuple of local capability
+names and formats available/unavailable summaries deterministically from that
+tuple. The summary can vary by machine, but its order is stable for a given
+environment.
+
+No timestamp, counter, session id, or dynamic path was found in the stable
+route prefix. This preserves the route-prefix boundary needed by the opt-in KV
+prefix-anchor experiment.
+
+### Chat Final And Tool Final
+
+`CHAT_SYSTEM_PROMPT` is intentionally short and separate from the route prompt.
+`FINAL_FROM_TOOL_SYSTEM_PROMPT` keeps final answers model-generated from tool
+results and does not allow tool calls in finalization.
+
+No prompt-level cause for unnecessary repair was found in this review.
+
+### Manual Regression Prompts
+
+`docs/PROMPTS.md` covers:
+
+- chat without tools
+- visible thinking
+- local tools
+- file read/content evidence
+- online optional smoke
+- tools plus thinking
+
+It already distinguishes optional online checks from required local release
+checks. No broad rewrite is recommended before RC2.
+
+## Risks
+
+- The route prompt is necessarily dense because it encodes evidence boundaries,
+  tool distinctions, and no-long-prose behavior. Compressing it before RC2 would
+  risk regressing file/web/listing correctness.
+- The tools-on prompt remains large. The opt-in prefix-anchor experiment helps
+  repeated route passes, but the first capture miss remains expensive.
+- Generic web smoke can vary with provider/network behavior and should remain
+  optional or interpreted conservatively.
+
+## Patch Recommendations
+
+Applied:
+
+- no prompt patch
+- import-only cleanup in native KV code
+- documentation-only KV index and release reviews
+
+Recommended but not applied:
+
+- add a compact docs index for KV reports, now done as `KV_INDEX.md`
+
+Rejected for this phase:
+
+- route contract rewrite
+- tool spec compression
+- prompt-shape changes for cache behavior
+- removal of historical no-go/reject documents
+
+## Impact
+
+Stability:
+
+- No prompt behavior changed.
+- Existing evidence and routing guarantees are preserved.
+
+Performance:
+
+- No prompt token reduction was attempted.
+- Route prefix-anchor remains default OFF and opt-in only.
+
+KV:
+
+- Stable route prefix assumptions remain intact.
+- No timestamp, counter, or dynamic path was introduced into the stable prefix.
+
+## Recommendation
+
+Proceed to release validation without prompt changes. If later performance work
+targets prompt size, require a dedicated benchmark branch with file-read,
+listing, web/fetch, and route outcome regression checks.

--- a/docs/RC2_READINESS_REVIEW.md
+++ b/docs/RC2_READINESS_REVIEW.md
@@ -1,0 +1,118 @@
+# RC2 Readiness Review
+
+Commit analyzed: `7e810a5` (`origin/main`, PR #57 merged).
+
+This document prepares for a possible RC2. It does not publish a release, create
+a tag, or change version metadata.
+
+## Feature State
+
+`ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` is available as an opt-in experiment.
+
+- Default: OFF
+- Scope: native backend, tools-on route pass only
+- Excluded: `chat_final`, `final_from_tool`, `tool_call`
+- No deterministic routing
+- No file/web/fetch/listing special-casing
+- No prompt semantic change
+- Fallback: baseline behavior on mismatch, restore failure, invalid checkpoint,
+  or unsupported backend path
+
+Checkpoint memory observed locally: about `238 MB`.
+
+## Tests
+
+Required release-hardening tests:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q
+PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Status: PASS in this branch.
+
+## Smoke OFF/ON
+
+Native smoke should be run with the same model and workdir used for PR #57:
+
+- OFF: `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT` unset
+- ON: `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
+
+Scenarios:
+
+1. `hi`
+2. `hi` repeat
+3. `what is 2+2?`
+4. `Explain in two short paragraphs how a local AI runtime can reduce latency after the first turn.`
+5. `Explain the tradeoff between correctness and latency in a local agent runtime.`
+6. `list files in the workdir`
+7. `read README.md and explain it`
+8. valid web search
+9. valid `fetch_url`
+
+Status: PASS in this branch.
+
+| Scenario | Flag | Phases | Route cached/evaluated | Request cached/evaluated | Wall ms | Outcome |
+| --- | --- | --- | --- | --- | ---: | --- |
+| `hi` | OFF | `route -> chat_final` | `0/706` | `4/736` | 54193 | baseline, no anchor |
+| `hi` repeat | OFF | `route -> chat_final` | `4/702` | `8/732` | 62879 | baseline, no anchor |
+| `what is 2+2?` | OFF | `route` | `4/708` | `4/708` | 63996 | direct route |
+| medium latency prompt | OFF | `route -> chat_final` | `696/27` | `700/74` | 53721 | no route retry |
+| medium tradeoff prompt | OFF | `route -> chat_final` | `4/714` | `8/756` | 178828 | cache miss, no route retry |
+| listing | OFF | `route -> final_from_tool` | `4/707` | `711/886` | 141956 | `ListDir` preserved |
+| README read | OFF | `route -> final_from_tool` | `696/16` | `1404/424` | 92601 | `Read:` content evidence |
+| web search | OFF | `route -> final_from_tool` | `696/18` | `1406/455` | 116654 | `orbit-web-search` |
+| fetch URL | OFF | `route -> final_from_tool` | `696/18` | `1406/149` | 51892 | `Fetch:` |
+| `hi` | ON | `route -> chat_final` | `0/706` | `4/736` | 94347 | capture miss |
+| `hi` repeat | ON | `route -> chat_final` | `693/13` | `697/43` | 13694 | restore hit |
+| `what is 2+2?` | ON | `route` | `693/19` | `693/19` | 3613 | direct route, restore hit |
+| medium latency prompt | ON | `route -> chat_final` | `693/30` | `697/77` | 45297 | restore hit, no route retry |
+| medium tradeoff prompt | ON | `route -> chat_final` | `693/25` | `697/67` | 47442 | restore hit |
+| listing | ON | `route -> final_from_tool` | `693/18` | `1386/211` | 62310 | `ListDir` preserved |
+| README read | ON | `route -> final_from_tool` | `693/19` | `1386/442` | 113071 | `Read:` content evidence |
+| web search | ON | `route -> final_from_tool` | `693/21` | `1386/455` | 123467 | `orbit-web-search` |
+| fetch URL | ON | `route -> final_from_tool` | `693/21` | `1386/169` | 51595 | `Fetch:` |
+
+ON anchor events:
+
+- first ON route: capture miss, `checkpoint_size_bytes=238454176`
+- subsequent ON routes: restore hit, `restore_used=true`
+- route prefix: `693` cached tokens on restore
+- `route_no_decision_length_retry`: `0` in all smoke scenarios
+
+The two medium final answers ended with `finish_reason=length` because the smoke
+used `--max-tokens 64`; this was not a route retry or repair path.
+
+## Expected Acceptance Criteria
+
+- OFF remains baseline.
+- ON produces restore hits on repeated tools-on route calls.
+- ON does not increase `model_calls`.
+- ON does not increase repair/retry.
+- `route_no_decision_length_retry` remains zero or does not regress.
+- file-read preserves content evidence and does not use directory listing as a
+  substitute.
+- listing preserves `list_directory`.
+- web/fetch remain `route -> final_from_tool` when provider/network succeeds.
+- checkpoint memory cost remains documented.
+- prefix-anchor remains default OFF.
+
+## Risks
+
+- First capture miss remains expensive.
+- Checkpoint memory cost is material.
+- Web smoke depends on provider/network behavior.
+- The experiment is not ready to be default.
+
+## Recommendation
+
+Recommendation: ready for RC2 after normal release packaging checks.
+
+Do not publish RC2 until:
+
+- no unexpected worktree changes remain
+- release notes explicitly state that prefix-anchor is opt-in and default OFF
+- the release command/tagging step is explicitly authorized

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import codecs
-from ctypes import POINTER, byref, c_char, cast, c_float, c_ubyte, create_string_buffer, c_void_p, sizeof
+from ctypes import POINTER, byref, c_char, cast, c_ubyte, create_string_buffer, c_void_p, sizeof
 from dataclasses import dataclass, replace
 from pathlib import Path
 import threading

--- a/src/orbit/native_llama/prefix_anchor_probe.py
+++ b/src/orbit/native_llama/prefix_anchor_probe.py
@@ -5,10 +5,9 @@ from dataclasses import dataclass
 import hashlib
 from typing import Any, Callable
 
-from .bindings import LlamaBatch, llama_pos, llama_seq_id, llama_token
+from .bindings import llama_pos, llama_seq_id, llama_token
 from .chat_template import RoutePromptSegments
 from .prefix_anchor import (
-    PrefixAnchorState,
     capture_prefix_anchor,
     compute_prefix_anchor_key,
     restore_prefix_anchor,


### PR DESCRIPTION
This PR prepares Orbit for a possible RC2 after the opt-in route KV prefix-anchor experiment.

Changes:
- removes unused KV prefix-anchor imports
- adds KV post-merge cleanup review
- adds PROMPTS.md / prompt hardening review
- adds RC2 readiness review
- adds KV documentation index
- does not change runtime behavior
- does not change prompt semantics
- does not change tool selection, final policy, evidence policy, or KV defaults

Validation:
- PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q: PASS
- PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q: PASS
- python3 -m unittest discover -s tests -q: PASS
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS
- OFF/ON smoke: PASS

Notes:
- ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT remains default OFF.
- The route KV prefix-anchor remains opt-in.
- RC2 is not published by this PR.
- No tags are modified.