### PR TITLE
Normalize web search alias and prefer latest user turn

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1003,6 +1003,7 @@ def _route_retry_messages(messages: list[Message], *, explicit_web_search: bool)
     reminder = (
         "The user explicitly asked for an online/web search. "
         "Do not answer from memory. "
+        "Use the latest user request only, and ignore older tool results or file/page content unless that latest request refers to them. "
         "Return exactly one shell tool call now that performs the search. Output no prose."
         if explicit_web_search
         else

--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -10,7 +10,7 @@ from typing import Any
 from orbit.runtime.tool_arguments import parse_tool_arguments_or_empty
 
 SHELL_TOOL_ALIASES = {"exec_shell_full_command", "shell"}
-WEB_SEARCH_TOOL_ALIASES = {"orbit-web-search"}
+WEB_SEARCH_TOOL_ALIASES = {"orbit-web-search", "orbit_web_search"}
 FETCH_URL_TOOL_ALIASES = {"fetch_url"}
 LIST_DIRECTORY_TOOL_ALIASES = {"list_directory"}
 LIST_DIRECTORY_KEYS = ("path", "recursive", "max_depth", "max_entries", "include_hidden", "dirs_first", "files_only", "dirs_only")

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -79,6 +79,8 @@ For analysis, prefer content, source, binaries, strings, logs, archives, or fetc
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())
 TOOL_CALL_SYSTEM_PROMPT = (
     "Call exactly one available tool and output no prose. "
+    "Operate on the latest user request only. "
+    "Ignore older tool results, file/page content, or prior task context unless the latest user request explicitly refers to them. "
     "Prefer list_directory for compact directory listings. "
     "Prefer system_info for compact local machine specs such as OS, CPU, RAM, disk, and Python runtime. "
     "Prefer fetch_url for explicit URL fetch/read/explain/summarize/analyze requests. "

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -413,6 +413,37 @@ EOF"}""",
         self.assertEqual(tool_call["function"]["name"], "exec_shell_full_command")
         self.assertEqual(tool_call["function"]["arguments"], "{\"command\": \"orbit-web-search 'Dante Alighieri'\"}")
 
+    def test_command_tool_call_from_tool_calls_accepts_orbit_web_search_underscore_alias(self) -> None:
+        tool_call = command_tool_call_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "orbit_web_search", "arguments": '{"query":"sample topic"}'},
+                }
+            ],
+            ("exec_shell_full_command",),
+        )
+
+        self.assertIsNotNone(tool_call)
+        assert tool_call is not None
+        self.assertEqual(tool_call["function"]["name"], "exec_shell_full_command")
+        self.assertEqual(tool_call["function"]["arguments"], "{\"command\": \"orbit-web-search 'sample topic'\"}")
+
+    def test_command_tool_call_from_tool_calls_rejects_unknown_web_search_like_name(self) -> None:
+        tool_call = command_tool_call_from_tool_calls(
+            [
+                {
+                    "id": "raw-tool-call-1",
+                    "type": "function",
+                    "function": {"name": "orbit_websearch", "arguments": '{"query":"sample topic"}'},
+                }
+            ],
+            ("exec_shell_full_command",),
+        )
+
+        self.assertIsNone(tool_call)
+
     def test_command_tool_call_from_tool_calls_rejects_alias_without_command(self) -> None:
         tool_call = command_tool_call_from_tool_calls(
             [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,6 +91,8 @@ class ConfigTests(unittest.TestCase):
         self.assertIn("Prefer system_info", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("orbit-web-search", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("exec_shell_full_command", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("latest user request", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("Ignore older tool results", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("Quote paths containing spaces", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("collect direct evidence", TOOL_CALL_SYSTEM_PROMPT)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from shutil import copyfile
 import sys
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -1801,6 +1802,149 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(result.content, "Mario Nobile is an Italian public official.")
         self.assertEqual(backend.calls, 3)
 
+    def test_ask_with_tools_normalizes_orbit_web_search_underscore_tool_call(self) -> None:
+        class RoutedBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "orbit_web_search",
+                                    "arguments": '{"query":"sample topic"}',
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="sample result",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = RoutedBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+            with patch("orbit.runtime.shell_guardrails.search_web", return_value="web_search_results: true\nquery: sample topic"):
+                result = runtime.ask_with_tools(
+                    "search online for sample topic",
+                    temperature=0,
+                    max_tokens=64,
+                    workdir=Path(tmp),
+                )
+
+        self.assertEqual(result.content, "sample result")
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertEqual(tool_messages[0]["name"], "exec_shell_full_command")
+        self.assertIn("web_search_results: true", str(tool_messages[0]["content"]))
+        self.assertNotIn("tool not available", str(tool_messages[0]["content"]))
+
+    def test_new_web_turn_uses_latest_tool_evidence_not_previous_local_result(self) -> None:
+        class RoutedBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.final_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-web",
+                                "type": "function",
+                                "function": {
+                                    "name": "orbit_web_search",
+                                    "arguments": '{"query":"sample topic"}',
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                self.final_messages = messages
+                return ChatResult(
+                    content="sample web answer",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=7,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = RoutedBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+            runtime.messages.extend(
+                [
+                    {"role": "user", "content": "read local fixture"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-old",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat fixture.txt"}),
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-old",
+                        "name": "exec_shell_full_command",
+                        "content": "old_local_fixture_evidence: true\ncontent:\nold local content",
+                    },
+                    {"role": "assistant", "content": "old local answer"},
+                ]
+            )
+            with patch("orbit.runtime.shell_guardrails.search_web", return_value="web_search_results: true\nquery: sample topic\nresults:\n- current web evidence"):
+                result = runtime.ask_with_tools(
+                    "search online for sample topic",
+                    temperature=0,
+                    max_tokens=64,
+                    workdir=Path(tmp),
+                )
+
+        self.assertEqual(result.content, "sample web answer")
+        self.assertIsNotNone(backend.final_messages)
+        final_rendered = "\n".join(str(message.get("content", "")) for message in backend.final_messages or [])
+        self.assertIn("current web evidence", final_rendered)
+        self.assertNotIn("old_local_fixture_evidence", final_rendered)
+
     def test_ask_auto_retries_route_as_tool_call_after_length_without_decision(self) -> None:
         class RoutedBackend:
             def __init__(self) -> None:
@@ -1944,6 +2088,8 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(backend.calls, 5)
         self.assertIsNotNone(backend.retry_messages)
         self.assertEqual(backend.retry_messages[0]["content"], TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("latest user request only", backend.retry_messages[-1]["content"])
+        self.assertIn("ignore older tool results", backend.retry_messages[-1]["content"])
 
     def test_shell_full_analysis_metadata_only_command_gets_one_model_retry(self) -> None:
         class ShellFullAnalysisBackend:


### PR DESCRIPTION
This PR fixes a tool-loop compatibility issue where the model could emit `orbit_web_search` instead of the canonical `orbit-web-search`. The runtime now treats this as a narrow alias for the existing web search command path, without introducing fuzzy tool-name matching or deterministic routing.

It also tightens the tool-call contract so the latest user turn is the primary context and older tool results are ignored unless the latest user turn explicitly refers to them. This prevents stale local/PDF evidence from being reused for a new explicit web request.

Scope:

* narrow alias normalization for `orbit_web_search`
* latest-user-turn contract hardening
* targeted regression tests
* no prompt rewrite
* no routing policy change
* no final policy change
* no evidence policy weakening
* no KV default change

Validation:

* `PYTHONPATH=src python3 -m unittest tests.test_command_request tests.test_config tests.test_runtime -q`: PASS
* `PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q`: PASS
* `PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q`: PASS
* `python3 -m unittest discover -s tests -q`: PASS
* `python3 -m compileall -q src tests scripts`: PASS
* `git diff --check`: PASS

Smoke:

* KV OFF: PDF/local context followed by explicit web request executes `Web: orbit-web-search ...`
* KV ON: same scenario remains correct with prefix-anchor enabled
* read/list/web/fetch paths preserved
* no `tool not available` for `orbit_web_search`
* no stale local/PDF evidence reused for explicit web request

Notes:

* `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT` remains unchanged and is not promoted by this PR.
* `workdir/.miktex/` is local cache and is not included.
