### PR TITLE
Add v0.0.1-rc2 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc2-release-plan.md
+++ b/docs/releases/v0.0.1-rc2-release-plan.md
@@ -1,0 +1,81 @@
+# Orbit v0.0.1-rc2 Release Plan
+
+This is an operational plan only. Do not execute the tag or GitHub Release steps
+until release publication is explicitly authorized.
+
+## Pre-release checks
+
+- `git status --short` is clean, except an ignored or intentionally untracked
+  local cache such as `workdir/.miktex/` may be present and must not be
+  committed.
+- `main` points to `55a62f2` or to a later commit that only adds the RC2 release
+  notes and release plan.
+- Full unit suite passes:
+
+```bash
+python3 -m unittest discover -s tests -q
+```
+
+- Compile check passes:
+
+```bash
+python3 -m compileall -q src tests scripts
+```
+
+- Whitespace check passes:
+
+```bash
+git diff --check
+```
+
+- Minimum native smoke passes:
+  - default auto mode
+  - `ORBIT_KV_PREFIX_ANCHOR=off` kill switch
+  - read-file content evidence
+  - directory listing
+  - web search path
+  - URL fetch path
+  - stale-evidence prevention
+- Manual local user test passes.
+
+## Tag plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc2
+```
+
+Recommended tag type: annotated tag.
+
+Commands to not execute yet:
+
+```bash
+git tag -a v0.0.1-rc2 -m "Orbit v0.0.1-rc2"
+git push origin v0.0.1-rc2
+```
+
+## GitHub release plan
+
+- Title: `Orbit v0.0.1-rc2`
+- Body: use `docs/releases/v0.0.1-rc2.md`
+- Mark as prerelease: yes
+- Mark as latest: no, if GitHub offers that choice
+- Do not attach cache directories, local benchmark artifacts, or files from
+  `workdir/.miktex/`.
+
+## Rollback note
+
+If regressions appear around route-prefix checkpoint memory or performance, set:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+That kill switch returns Orbit to the baseline prefill path without changing
+prompt, routing, tool selection, final-answer policy, or evidence policy.
+
+## Publication status
+
+This plan does not publish RC2, create or modify tags, or create a GitHub
+Release.

--- a/docs/releases/v0.0.1-rc2.md
+++ b/docs/releases/v0.0.1-rc2.md
@@ -1,0 +1,205 @@
+# Orbit v0.0.1-rc2 Release Notes
+
+## Summary
+
+Orbit v0.0.1-rc2 focuses on native backend stability, route performance,
+tool-loop correctness, and the CPU-only Gemma 4 12B local runtime.
+
+This release candidate keeps Orbit model-guided. It does not introduce
+deterministic routing, tool selection shortcuts, prompt-shape hacks, or changes
+to final-answer policy.
+
+## Highlights
+
+### Native route KV prefix-anchor auto mode
+
+The tools-on route pass is the first model call where Orbit asks the model to
+decide whether to answer directly or use a tool.
+
+That route prompt starts with a stable prefix containing:
+
+- system policy
+- route contract
+- tool specifications
+- capability summary
+
+Orbit now keeps a real native KV checkpoint for that stable route prefix. On a
+later compatible tools-on route call, the native backend can restore that
+checkpoint and evaluate only the dynamic suffix for the new request.
+
+The model still receives the same semantic prompt. The model still decides
+whether the next step is chat, file evidence, directory listing, web search, URL
+fetch, or another supported tool path.
+
+Observed repeat-route example:
+
+```text
+before/repeat without anchor: cached 4,   evaluated 722
+after/repeat with anchor:     cached 693, evaluated 33
+```
+
+This improves repeated eligible route prefill. It does not mean that web search
+itself is faster, that tools are smarter, or that tool decisions are hardcoded.
+Orbit does not cache tool results, PDF contents, web-search results, file
+contents, or user history in this prefix anchor.
+
+### Configuration
+
+Default:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=auto
+```
+
+When the variable is unset, Orbit behaves as `auto`.
+
+Kill switch:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Legacy compatibility/debug:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1
+```
+
+The legacy flag enables auto mode only when `ORBIT_KV_PREFIX_ANCHOR` is not set.
+`ORBIT_KV_PREFIX_ANCHOR=off` always wins over the legacy flag.
+
+### Eligible path and fallback
+
+Auto mode is limited to eligible native backend route calls with tools on.
+
+The route prefix-anchor is not used for:
+
+- non-native or external llama-server compatibility paths
+- tools-off calls
+- `chat_final`
+- `tool_call`
+- `final_from_tool`
+- file, web, fetch, or listing special cases
+
+File reads, web search, URL fetch, and directory listing may benefit from the
+shared route prefix before the model chooses a path, but those paths are not
+special-cased by the runtime.
+
+Orbit falls back to the baseline path on:
+
+- prefix mismatch
+- token-count mismatch
+- checkpoint capture failure
+- checkpoint restore failure
+- invalid checkpoint state
+- unsupported backend path
+- native memory/capture/restore errors
+
+Fallback is intended to be invisible to the user.
+
+### Tool-loop correctness fix
+
+This release candidate also includes a tool-loop compatibility fix.
+
+The model could emit `orbit_web_search` instead of the canonical
+`orbit-web-search`. Orbit now treats `orbit_web_search` as a narrow alias for the
+existing web-search command path.
+
+This is not fuzzy matching. Unknown tool names remain rejected. The runtime does
+not choose a web tool deterministically.
+
+The tool loop also treats the latest user turn as the primary context. Older
+tool results are ignored unless the latest user turn explicitly refers to them.
+This avoids reusing stale local or document evidence when a new request asks for
+web evidence.
+
+### Prompt and release hardening
+
+The prompt hardening review for RC2 did not identify a safe prompt rewrite that
+should be applied before release.
+
+The following remain unchanged:
+
+- routing policy
+- tool selection policy
+- final-answer policy
+- file/web/fetch evidence policy
+- model-guided tool choice
+
+### Documentation
+
+RC2 includes expanded documentation for:
+
+- KV documentation index
+- KV post-merge cleanup review
+- prompt release hardening review
+- RC2 readiness review
+- route KV prefix-anchor runtime behavior
+- historical no-go and rejected KV experiments
+
+Historical no-go and rejected-experiment documents remain available as context.
+
+## Validation
+
+Core checks:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Targeted suites covered:
+
+- native bindings
+- prefix-anchor state and mode handling
+- prefix-anchor equivalence probe
+- KV diagnostics
+- native chat template
+- native server protocol
+- llama-server backend compatibility
+- command request parsing
+- configuration prompts
+- runtime/tool-loop behavior
+
+Post-merge and manual smoke covered:
+
+- default auto mode
+- kill switch mode
+- legacy compatibility mode
+- off-wins precedence
+- read-file content evidence
+- directory listing
+- web search path
+- URL fetch path
+- stale evidence prevention after prior local tool results
+- manual local user testing
+
+## Known limitations
+
+- The first eligible route capture remains expensive.
+- The checkpoint memory cost is real. The tested setup observed about 238 MB for
+  the route prefix checkpoint.
+- Web smoke depends on network and upstream provider behavior. A provider
+  challenge page can still produce no web results.
+- The speedup targets repeated compatible tools-on route calls, not every
+  request.
+- Prefix-anchor does not replace model reasoning, tool choice, or evidence
+  requirements.
+
+## Upgrade notes
+
+- Route KV prefix-anchor is now default auto mode.
+- Set `ORBIT_KV_PREFIX_ANCHOR=off` to force the baseline prefill path.
+- `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` remains as legacy compatibility/debug
+  only when `ORBIT_KV_PREFIX_ANCHOR` is unset.
+- If the server restarts, or if the model, tools, template, or relevant runtime
+  configuration changes, the checkpoint must be recreated.
+- `/reset` clears conversation history and saved session state. If the same
+  server, model, tools, and configuration remain active, the route prefix-anchor
+  may still be available because it is not user history.
+
+## Release status
+
+These release notes prepare Orbit v0.0.1-rc2. They do not publish RC2, create a
+tag, modify a tag, or create a GitHub Release.


### PR DESCRIPTION
This PR prepares release notes and a publication plan for Orbit v0.0.1-rc2.

Scope:

* adds RC2 release notes
* adds RC2 release plan
* does not change runtime behavior
* does not change prompt behavior
* does not change KV configuration
* does not create or modify tags
* does not publish RC2

Release highlights:

* route KV prefix-anchor auto mode
* ORBIT_KV_PREFIX_ANCHOR=off kill switch
* legacy ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT compatibility
* tool-loop alias/stale-evidence fix
* prompt/release hardening
* validation summary and known limitations

Validation:

* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Notes:

* RC2 is not published by this PR.
* Tag v0.0.1-rc2 is not created by this PR.
* workdir/.miktex/ remains local cache and is not included.