### PR TITLE
Require file content evidence after listing

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -75,6 +75,14 @@ _EXPLICIT_WEB_SEARCH_RE = re.compile(
     r"\b(?:search\s+(?:online|the\s+web|web)|web\s+search|look\s+up\s+online|find\s+online|cerca\s+(?:online|sul\s+web|nel\s+web))\b",
     re.IGNORECASE,
 )
+_FILE_CONTENT_ACTION_RE = re.compile(
+    r"\b(?:read|show|print|explain|summari[sz]e|analy[sz]e|review|inspect|open|cat|leggi|spiega|riassumi|analizza|mostra)\b",
+    re.IGNORECASE,
+)
+_FILE_LIKE_REFERENCE_RE = re.compile(
+    r"(?:[\"'`])[^\"'`\n]+?\.[A-Za-z0-9]{1,8}(?:[\"'`])|(?:^|[\s(])[A-Za-z0-9_./-]+?\.[A-Za-z0-9]{1,8}(?=$|[\s),:;])",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -333,18 +341,27 @@ class ChatRuntime:
             route_outcome_emitted = True
         if decision is None:
             explicit_web_search = _requires_explicit_web_search_tool(prompt, allowed_tool_names)
+            file_content_evidence = _requires_file_content_evidence_retry(prompt, allowed_tool_names, first.finish_reason)
             if _should_force_tool_route_retry(prompt, allowed_tool_names, first.finish_reason):
+                retry_reason = (
+                    "explicit_web_search"
+                    if explicit_web_search
+                    else "file_content_evidence"
+                    if file_content_evidence
+                    else "length_without_decision_tool_related"
+                )
                 _emit_route_outcome_for_result(
                     first,
                     decision=None,
                     outcome="route_other_retry",
-                    retry_reason="explicit_web_search" if explicit_web_search else "length_without_decision_tool_related",
+                    retry_reason=retry_reason,
                 )
                 route_outcome_emitted = True
                 with self._temporary_backend_thinking(False):
                     route_retry_messages = _route_retry_messages(
                         self.messages,
                         explicit_web_search=explicit_web_search,
+                        file_content_evidence=file_content_evidence,
                     )
                     if on_phase_start:
                         on_phase_start(
@@ -352,7 +369,7 @@ class ChatRuntime:
                                 "route_retry",
                                 streamed=False,
                                 attempt=2,
-                                reason="explicit_web_search" if explicit_web_search else "length_without_decision",
+                                reason=retry_reason,
                             )
                         )
                     if on_progress is None:
@@ -382,7 +399,7 @@ class ChatRuntime:
                     command_content = route_retry.content
                     decision = retry_decision
             if decision is None:
-                if explicit_web_search:
+                if explicit_web_search or file_content_evidence:
                     bundle = self._run_tool_loop(
                         temperature=temperature,
                         max_tokens=max_tokens,
@@ -972,7 +989,17 @@ def _requires_explicit_web_search_tool(prompt: str, allowed_tool_names: tuple[st
 def _should_force_tool_route_retry(prompt: str, allowed_tool_names: tuple[str, ...] | None, finish_reason: str | None) -> bool:
     if _requires_explicit_web_search_tool(prompt, allowed_tool_names):
         return True
+    if _requires_file_content_evidence_retry(prompt, allowed_tool_names, finish_reason):
+        return True
     return finish_reason == "length" and _should_retry_route_as_tool_call(prompt, allowed_tool_names)
+
+
+def _requires_file_content_evidence_retry(prompt: str, allowed_tool_names: tuple[str, ...] | None, finish_reason: str | None) -> bool:
+    if finish_reason != "stop":
+        return False
+    if "exec_shell_full_command" not in set(allowed_tool_names or ()):
+        return False
+    return bool(_FILE_CONTENT_ACTION_RE.search(prompt) and _FILE_LIKE_REFERENCE_RE.search(prompt))
 
 
 def _route_parsed_outcome(decision: RouteDecision) -> str:
@@ -999,19 +1026,34 @@ def _emit_route_outcome_for_result(
     )
 
 
-def _route_retry_messages(messages: list[Message], *, explicit_web_search: bool) -> list[Message]:
-    reminder = (
-        "The user explicitly asked for an online/web search. "
-        "Do not answer from memory. "
-        "Use the latest user request only, and ignore older tool results or file/page content unless that latest request refers to them. "
-        "Return exactly one shell tool call now that performs the search. Output no prose."
-        if explicit_web_search
-        else
-        "The previous routing pass did not return a valid decision. "
-        "Return exactly one shell tool call now if shell/web/file access is needed. Output no prose."
-    )
+def _route_retry_messages(
+    messages: list[Message],
+    *,
+    explicit_web_search: bool,
+    file_content_evidence: bool = False,
+) -> list[Message]:
+    if explicit_web_search:
+        reminder = (
+            "The user explicitly asked for an online/web search. "
+            "Do not answer from memory. "
+            "Use the latest user request only, and ignore older tool results or file/page content unless that latest request refers to them. "
+            "Return exactly one shell tool call now that performs the search. Output no prose."
+        )
+    elif file_content_evidence:
+        reminder = (
+            "The latest user request asks for a specific file's contents. "
+            "Do not answer from directory listings, older tool results, or assumptions. "
+            'Return a compact JSON command decision such as {"command":"cat requested-file"} that reads the requested file content. '
+            "Output no prose."
+        )
+    else:
+        reminder = (
+            "The previous routing pass did not return a valid decision. "
+            "Return exactly one shell tool call now if shell/web/file access is needed. Output no prose."
+        )
+    retry_messages = with_command_system_prompt(messages) if file_content_evidence else with_tool_call_system_prompt(messages)
     return [
-        *with_tool_call_system_prompt(messages),
+        *retry_messages,
         {"role": "user", "content": reminder},
     ]
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4921,6 +4921,178 @@ EOF"""
         self.assertNotIn("I cannot confirm the content of the file yet.", str(backend.messages_seen[3]))
         self.assertNotIn("I still cannot confirm the content of the file.", str(backend.messages_seen[4]))
 
+    def test_ask_auto_retries_direct_final_when_latest_turn_requires_file_content_after_listing(self) -> None:
+        class FileEvidenceRouteBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="README.md contains project documentation.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    if "specific file's contents" not in messages[-1]["content"]:
+                        raise AssertionError(messages[-1]["content"])
+                    return ChatResult(
+                        content='{"command":"cat README.md"}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The README content was read and summarized.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=8,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "README.md").write_text("Orbit README content", encoding="utf-8")
+            backend = FileEvidenceRouteBackend()
+            runtime = ChatRuntime(
+                backend=backend,
+                system_prompt="route system",
+                messages=[
+                    {"role": "system", "content": "route system"},
+                    {"role": "user", "content": "list files in the workdir"},
+                    {"role": "assistant", "content": "", "tool_calls": []},
+                    {"role": "tool", "name": "list_directory", "tool_call_id": "call-list", "content": "README.md"},
+                    {"role": "assistant", "content": "README.md"},
+                ],
+            )
+
+            result = runtime.ask_auto(
+                "read README.md and explain it",
+                temperature=0,
+                max_tokens=32,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "The README content was read and summarized.")
+        self.assertEqual(backend.calls, 3)
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(tool_messages[-1]["name"], "exec_shell_full_command")
+        self.assertIn("Orbit README content", tool_messages[-1]["content"])
+
+    def test_ask_auto_uses_tool_loop_when_file_content_route_retry_still_has_no_decision(self) -> None:
+        class FileEvidenceToolLoopBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.tools_seen: list[object] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.tools_seen.append(tools)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="README.md appears to be documentation.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=6,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="I should inspect the file first.",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=7,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 3:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"cat README.md\"}"},
+                            }
+                        ],
+                        prompt_tokens=8,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The README content was read after the fallback.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=9,
+                    completion_tokens=3,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "README.md").write_text("Orbit README content", encoding="utf-8")
+            backend = FileEvidenceToolLoopBackend()
+            runtime = ChatRuntime(
+                backend=backend,
+                system_prompt="route system",
+                messages=[
+                    {"role": "system", "content": "route system"},
+                    {"role": "user", "content": "list files in the workdir"},
+                    {"role": "tool", "name": "list_directory", "tool_call_id": "call-list", "content": "README.md"},
+                    {"role": "assistant", "content": "README.md"},
+                ],
+            )
+
+            result = runtime.ask_auto(
+                "read README.md and explain it",
+                temperature=0,
+                max_tokens=32,
+                workdir=workdir,
+                allowed_tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(result.content, "The README content was read after the fallback.")
+        self.assertEqual(backend.calls, 4)
+        self.assertIsNone(backend.tools_seen[0])
+        self.assertIsNone(backend.tools_seen[1])
+        self.assertIsNotNone(backend.tools_seen[2])
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(tool_messages[-1]["name"], "exec_shell_full_command")
+        self.assertIn("Orbit README content", tool_messages[-1]["content"])
+
     def test_ask_with_tools_requires_real_url_fetch_before_answering(self) -> None:
         class UrlRecoveryBackend:
             def __init__(self) -> None:


### PR DESCRIPTION
This PR fixes a semantic ambiguity found in post-release smoke testing for v0.0.1-rc2.

Scenario:

1. list files in the workdir
2. read README.md and explain it

Previously, the second turn could close as a direct route final without performing a content-read, reusing listing context instead of file content evidence.

This PR adds a guardrail so direct final answers are not accepted when the latest user turn explicitly requires file content evidence and no content-read evidence is available.

Scope:

* no deterministic tool routing
* no README hardcoding
* no prompt rewrite unless strictly necessary and documented
* no KV/default change
* no tag/release change
* listing remains listing evidence, not file content evidence

Validation:

* targeted runtime tests PASS
* full unit suite PASS
* compileall PASS
* git diff --check PASS
* default auto smoke PASS
* KV off smoke PASS
* read/list/web/fetch paths preserved
* PR #59 stale-evidence scenario preserved

Notes:

* v0.0.1-rc2 tag/release is not modified by this PR.
* workdir/.miktex/ remains local cache and is not included.