### PR TITLE
Add native route prefix prefill-only probe

### DIFF
--- a/docs/NATIVE_ROUTE_PREFIX_PREFILL_ONLY_FEASIBILITY.md
+++ b/docs/NATIVE_ROUTE_PREFIX_PREFILL_ONLY_FEASIBILITY.md
@@ -1,0 +1,217 @@
+# Native Route Prefix Prefill-Only Feasibility
+
+## Objective
+
+This report verifies whether Orbit's native backend can prefill and checkpoint
+the stable route tools-on prefix without:
+
+- generating assistant output
+- sampling a token
+- passing through a fake user request
+- using a prompt workaround
+- touching the normal `/chat` or `/chat/stream` runtime path
+
+The goal is to prove the backend-native primitive needed before any future
+route-prefix prewarm integration. This is not runtime prewarm.
+
+## Result
+
+Result: feasible as an isolated backend-native probe.
+
+The native client can:
+
+1. construct the same stable route prefix used by route tools-on calls;
+2. tokenize it with the real native tokenizer;
+3. decode only the stable prefix tokens;
+4. capture a native KV checkpoint;
+5. stop without sampling or generating content.
+
+No runtime behavior is changed by this probe. There is no startup hook, no
+`/tools on` hook, no `/chat` integration, and no user-visible behavior change.
+
+## Code Inspected
+
+Relevant files:
+
+- `docs/FIRST_TURN_TOOLS_ON_PREFILL_ANALYSIS.md`
+- `docs/NATIVE_ROUTE_PREFIX_PREWARM_DESIGN.md`
+- `docs/KV_ROUTE_PREFIX_ANCHOR_RUNTIME_EXPERIMENT.md`
+- `src/orbit/native_llama/client.py`
+- `src/orbit/native_llama/prefix_anchor.py`
+- `src/orbit/native_llama/prefix_anchor_probe.py`
+- `src/orbit/native_llama/chat_template.py`
+- `src/orbit/native_server/app.py`
+- `src/orbit/native_server/protocol.py`
+- `src/orbit/backend/llama_server.py`
+- `src/orbit/runtime/chat.py`
+- `src/orbit/runtime/messages.py`
+
+Current runtime capture path:
+
+- `ChatRuntime._run_tool_loop()` marks route calls using
+  `model_call_context(phase="route", tools_mode="on")`.
+- `LlamaServerBackend` sends `route_prefix_anchor=true` only for eligible native
+  route/tools-on calls.
+- `NativeLlamaClient.complete_chat_text()` renders the route prompt.
+- `NativeLlamaClient._route_anchor_segments_for_prompt()` rebuilds
+  `RoutePromptSegments`.
+- `NativeLlamaClient._prepare_memory_with_route_anchor()` restores an existing
+  checkpoint or decodes the stable prefix and captures a new checkpoint.
+- `NativeLlamaClient._complete_prompt_standard()` then continues with the
+  dynamic suffix and calls `_generate_from_current_context()`.
+
+The prefill/decode primitive is `llama_decode`, reached through
+`_decode_prompt_range()` in the runtime and through the isolated probe helper in
+`prefix_anchor_probe.py`.
+
+Generation starts in `NativeLlamaClient._generate_from_current_context()`, where
+the sampler is reset, `llama_sampler_sample()` is called, and sampled tokens are
+decoded. The prefill-only probe does not call this function and does not receive
+a sampler.
+
+## Probe
+
+Implemented files:
+
+- `src/orbit/native_llama/prefix_anchor_probe.py`
+- `scripts/probe_native_route_prefix_prefill_only.py`
+- `tests/test_prefix_anchor_probe.py`
+
+The script is manual-only and is not imported or called by production runtime
+paths. It constructs route segments from the route system prompt only. The
+stable prefix boundary is the system route block; no user turn is needed to
+obtain that prefix.
+
+The probe emits only metadata:
+
+- `prefix_hash`
+- `prefix_token_count`
+- `checkpoint_size_bytes`
+- `prefill_ms`
+- `decode_calls`
+- `sampled_tokens`
+- `generated_tokens`
+- `sampler_touched`
+- `session_history_touched`
+- `probe_ok`
+
+It does not print raw prefix text, prompt text, tool specs, token ids, user
+content, tool output, file content, or web content.
+
+## Manual Probe Result
+
+Command:
+
+```bash
+PYTHONPATH=src python3 scripts/probe_native_route_prefix_prefill_only.py \
+  --model models/ggml-org--gemma-4-12B-it-GGUF/gemma-4-12B-it-Q4_K_M.gguf \
+  --ctx 8192 \
+  --threads 6 \
+  --threads-batch 6 \
+  --batch 256 \
+  --ubatch 128
+```
+
+Metadata output:
+
+```json
+{
+  "checkpoint_size_bytes": 238454176,
+  "decode_calls": 3,
+  "generated_tokens": 0,
+  "prefill_ms": 50211.951,
+  "prefix_hash": "16216b5e9e8f642e170bba51c2b94f13",
+  "prefix_token_count": 693,
+  "probe_ok": true,
+  "reason": null,
+  "sampled_tokens": 0,
+  "sampler_touched": false,
+  "seq_id": 0,
+  "session_history_touched": false
+}
+```
+
+Interpretation:
+
+- prefill-only capture is possible in an isolated native client;
+- the real stable route prefix is 693 tokens in this setup;
+- checkpoint size matches the runtime route-anchor checkpoint size observed in
+  prior smoke runs;
+- decode was chunked into three calls to respect the configured batch size;
+- no sampled tokens or generated tokens were produced.
+
+## Safety Constraints
+
+This probe intentionally does not:
+
+- register a server endpoint;
+- modify `/chat`, `/chat/stream`, `/tools on`, startup, reset, or route runtime;
+- use a fake user request;
+- pass through normal completion with a token budget trick;
+- change prompts;
+- change routing, tool selection, final policy, or evidence policy;
+- touch session history;
+- call the sampler.
+
+The probe creates a standalone native client process. Any KV memory it fills is
+local to that probe process and is released when the process exits.
+
+## Equivalence
+
+This PR does not add a new equivalence test.
+
+Reason: `KV_PREFIX_ANCHOR_EQUIVALENCE_PROBE.md` and the existing
+`probe_prefix_anchor_equivalence()` already cover the important behavioral
+property:
+
+- baseline `P + S`
+- checkpoint `P`, restore, then append `S`
+- compare next token and logits hash
+
+The new probe answers a narrower question: can Orbit perform only the `P`
+prefill and checkpoint capture without generation. Repeating the equivalence
+probe here would duplicate existing coverage without changing the runtime
+decision.
+
+## Blockers For Runtime Prewarm
+
+The backend-native primitive is feasible, but runtime prewarm still needs a
+separate implementation PR.
+
+Remaining blockers:
+
+- there is no native-server prefill-only endpoint or lifecycle hook;
+- current production capture is still wired into the route completion path;
+- server lock and concurrent request behavior need explicit design;
+- cancellation and client disconnect behavior need explicit tests;
+- continuation readiness must be forced false after prewarm;
+- failure must fall back to baseline without user-visible errors;
+- prewarm must respect `ORBIT_KV_PREFIX_ANCHOR=off`;
+- non-native backends must remain unchanged.
+
+## Next PR
+
+Recommended next step: implement a bounded internal native prefill-only hook or
+endpoint.
+
+The next PR should:
+
+- expose an internal prefill-only operation, not a normal chat request;
+- keep runtime prewarm disabled unless explicitly wired in a later PR;
+- preserve one-checkpoint memory bounds;
+- validate prefix hash and token count before restore;
+- return metadata-only diagnostics;
+- test failure, cancellation, non-native, `off`, and mismatch paths;
+- smoke file/read/list/web/fetch and stale-evidence scenarios.
+
+Runtime prewarm remains out of scope until that hook is reviewed and measured.
+
+## Verdict
+
+Verdict: docs plus isolated probe.
+
+Prefill-only route prefix capture is feasible in a standalone native client.
+The probe validates the backend-native primitive without changing runtime
+behavior. Production prewarm should not be enabled until a separate PR adds a
+reviewed lifecycle hook or endpoint with concurrency, cancellation, invalidation,
+and fallback tests.

--- a/scripts/probe_native_route_prefix_prefill_only.py
+++ b/scripts/probe_native_route_prefix_prefill_only.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.native_names import runtime_library_filename
+from orbit.native_llama.paths import DEFAULT_MODEL_ID, resolve_legacy_paths, resolve_paths
+from orbit.native_llama.prefix_anchor_probe import probe_route_prefix_prefill_only
+from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        paths = (
+            resolve_legacy_paths(llama_root=args.llama_root, model=args.model, mmproj=args.mmproj)
+            if args.model is not None
+            else resolve_paths(
+                llama_root=args.llama_root,
+                model_id=args.model_id,
+                mmproj=args.mmproj,
+                models_dir=args.models_dir,
+                hf_cache=args.hf_cache,
+            )
+        )
+        client = NativeLlamaClient(
+            paths,
+            NativeClientConfig(
+                context_tokens=args.ctx,
+                threads=args.threads,
+                threads_batch=args.threads_batch,
+                batch_size=args.batch,
+                ubatch_size=args.ubatch,
+            ),
+        )
+        if not args.verbose_llama_log:
+            client.set_quiet_logging()
+        client.load()
+        try:
+            segments = render_gemma4_route_prompt_segments(
+                [{"role": "system", "content": ROUTE_SYSTEM_PROMPT}],
+                thinking=False,
+            )
+            if not segments.boundary_available:
+                print(json.dumps({"probe_ok": False, "reason": "route_boundary_unavailable"}, sort_keys=True))
+                return 2
+            result = probe_route_prefix_prefill_only(
+                lib=client.lib.lib,
+                ctx=client._session.ctx_tgt,
+                tokenize=client.tokenize,
+                prefix_text=segments.stable_prefix_text,
+                prefix_hash=segments.stable_prefix_hash,
+                model_id=str(paths.model),
+                template_id="gemma4-route-prefix-v1",
+                tool_schema_hash=segments.stable_prefix_hash,
+                capability_summary_hash=segments.stable_prefix_hash,
+                runtime_policy_hash=segments.stable_prefix_hash,
+                route_contract_hash=segments.stable_prefix_hash,
+                backend_version="orbit-native",
+                native_version=runtime_library_filename("llama"),
+                tools_mode="on",
+            )
+            print(json.dumps(result.to_metadata(), sort_keys=True))
+            return 0 if result.ok else 2
+        finally:
+            client.close()
+    except Exception as exc:
+        print(json.dumps({"probe_ok": False, "reason": type(exc).__name__}, sort_keys=True))
+        return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="probe_native_route_prefix_prefill_only.py",
+        description="Probe native route prefix prefill-only checkpoint capture. Emits metadata only.",
+    )
+    parser.add_argument("--llama-root", type=Path)
+    parser.add_argument("--model-id", default=DEFAULT_MODEL_ID)
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--mmproj", type=Path)
+    parser.add_argument("--models-dir", type=Path)
+    parser.add_argument("--hf-cache", type=Path)
+    parser.add_argument("--ctx", type=int, default=8192)
+    parser.add_argument("--threads", type=int, default=6)
+    parser.add_argument("--threads-batch", type=int, default=6)
+    parser.add_argument("--batch", type=int, default=256)
+    parser.add_argument("--ubatch", type=int, default=128)
+    parser.add_argument("--verbose-llama-log", action="store_true")
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/native_llama/prefix_anchor_probe.py
+++ b/src/orbit/native_llama/prefix_anchor_probe.py
@@ -75,6 +75,38 @@ class RouteBoundaryTokenProbeResult:
         }
 
 
+@dataclass(frozen=True)
+class PrefixPrefillOnlyProbeResult:
+    ok: bool
+    reason: str | None
+    prefix_hash: str
+    prefix_token_count: int
+    checkpoint_size: int
+    prefill_ms: float
+    decode_calls: int
+    sampled_tokens: int = 0
+    generated_tokens: int = 0
+    sampler_touched: bool = False
+    session_history_touched: bool = False
+    seq_id: int = 0
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "probe_ok": self.ok,
+            "reason": self.reason,
+            "prefix_hash": self.prefix_hash,
+            "prefix_token_count": self.prefix_token_count,
+            "checkpoint_size_bytes": self.checkpoint_size,
+            "prefill_ms": self.prefill_ms,
+            "decode_calls": self.decode_calls,
+            "sampled_tokens": self.sampled_tokens,
+            "generated_tokens": self.generated_tokens,
+            "sampler_touched": self.sampler_touched,
+            "session_history_touched": self.session_history_touched,
+            "seq_id": self.seq_id,
+        }
+
+
 def probe_route_boundary_token_prefix(
     *,
     segments: RoutePromptSegments,
@@ -118,6 +150,121 @@ def split_prompt_by_token_prefix(
         return prefix_tokens, [], full_tokens, "prefix_not_token_prefix"
     suffix_tokens = full_tokens[len(prefix_tokens) :]
     return prefix_tokens, suffix_tokens, full_tokens, None
+
+
+def probe_route_prefix_prefill_only(
+    *,
+    lib: Any,
+    ctx: Any,
+    tokenize: TokenizeFn,
+    prefix_text: str,
+    prefix_hash: str,
+    seq_id: int = 0,
+    model_id: str | None = None,
+    template_id: str | None = None,
+    tool_schema_hash: str | None = None,
+    capability_summary_hash: str | None = None,
+    runtime_policy_hash: str | None = "probe-runtime-policy",
+    route_contract_hash: str | None = "probe-route-contract",
+    backend_version: str | None = None,
+    native_version: str | None = None,
+    tools_mode: str | None = "tools-on-route",
+    decode_step: int = 256,
+) -> PrefixPrefillOnlyProbeResult:
+    prefix_tokens = list(tokenize(prefix_text))
+    if not prefix_tokens:
+        return PrefixPrefillOnlyProbeResult(
+            ok=False,
+            reason="empty_prefix_tokens",
+            prefix_hash=prefix_hash,
+            prefix_token_count=0,
+            checkpoint_size=0,
+            prefill_ms=0.0,
+            decode_calls=0,
+            seq_id=seq_id,
+        )
+
+    anchor_key = compute_prefix_anchor_key(
+        model_id=model_id,
+        template_id=template_id,
+        tool_schema_hash=tool_schema_hash,
+        capability_summary_hash=capability_summary_hash,
+        runtime_policy_hash=runtime_policy_hash,
+        route_contract_hash=route_contract_hash,
+        backend_version=backend_version,
+        native_version=native_version,
+        tools_mode=tools_mode,
+    )
+    anchor_kwargs = {
+        "model_id": model_id,
+        "template_id": template_id,
+        "tool_schema_hash": tool_schema_hash,
+        "capability_summary_hash": capability_summary_hash,
+        "runtime_policy_hash": runtime_policy_hash,
+        "route_contract_hash": route_contract_hash,
+        "backend_version": backend_version,
+        "native_version": native_version,
+        "tools_mode": tools_mode,
+    }
+
+    _clear_context(lib, ctx)
+    start_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else 0
+    decode_calls = 0
+    step = max(1, decode_step)
+    try:
+        for offset in range(0, len(prefix_tokens), step):
+            chunk = prefix_tokens[offset : offset + step]
+            _decode_tokens(lib, ctx, chunk, seq_id=seq_id, start_pos=offset)
+            decode_calls += 1
+    except Exception as exc:
+        return PrefixPrefillOnlyProbeResult(
+            ok=False,
+            reason=f"prefix_decode_failed:{type(exc).__name__}",
+            prefix_hash=prefix_hash,
+            prefix_token_count=len(prefix_tokens),
+            checkpoint_size=0,
+            prefill_ms=0.0,
+            decode_calls=max(1, decode_calls),
+            seq_id=seq_id,
+        )
+    end_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else start_us
+    prefill_ms = max(0.0, (end_us - start_us) / 1000.0)
+
+    state, capture_meta = capture_prefix_anchor(
+        lib=lib,
+        ctx=ctx,
+        seq_id=seq_id,
+        prefix_hash=anchor_key,
+        token_count=len(prefix_tokens),
+        enabled=True,
+        **anchor_kwargs,
+    )
+    if not state.valid:
+        return PrefixPrefillOnlyProbeResult(
+            ok=False,
+            reason=str(capture_meta.get("fallback_reason") or state.invalidation_reason or "capture_failed"),
+            prefix_hash=prefix_hash,
+            prefix_token_count=len(prefix_tokens),
+            checkpoint_size=0,
+            prefill_ms=prefill_ms,
+            decode_calls=decode_calls,
+            seq_id=seq_id,
+        )
+
+    return PrefixPrefillOnlyProbeResult(
+        ok=True,
+        reason=None,
+        prefix_hash=prefix_hash,
+        prefix_token_count=len(prefix_tokens),
+        checkpoint_size=state.checkpoint_size,
+        prefill_ms=prefill_ms,
+        decode_calls=decode_calls,
+        sampled_tokens=0,
+        generated_tokens=0,
+        sampler_touched=False,
+        session_history_touched=False,
+        seq_id=seq_id,
+    )
 
 
 def _longest_common_prefix(first: list[int], second: list[int]) -> int:

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from ctypes import c_float
+import importlib.util
+from pathlib import Path
 import unittest
 
 from orbit.native_llama.prefix_anchor_probe import (
+    PrefixPrefillOnlyProbeResult,
     PrefixAnchorProbeResult,
     probe_route_boundary_token_prefix,
+    probe_route_prefix_prefill_only,
     probe_prefix_anchor_equivalence,
     split_prompt_by_token_prefix,
 )
@@ -35,6 +39,7 @@ class _FakeLib:
         self.state_payload = b""
         self.logits_rows: list[object] = []
         self.clears = 0
+        self.time_us = 1000
 
     def llama_get_memory(self, _ctx):
         return object()
@@ -52,10 +57,14 @@ class _FakeLib:
     def llama_decode(self, _ctx, batch) -> int:
         for index in range(batch.n_tokens):
             self.current_tokens.append(_token_value(batch.token[index]))
+        self.time_us += 5000
         return 0
 
     def llama_synchronize(self, _ctx) -> None:
         return None
+
+    def llama_time_us(self) -> int:
+        return self.time_us
 
     def llama_state_seq_get_size(self, _ctx, _seq_id: int) -> int:
         payload = ",".join(str(token) for token in self.current_tokens).encode("ascii")
@@ -169,6 +178,81 @@ class PrefixAnchorProbeTests(unittest.TestCase):
         self.assertEqual(full_tokens, [10, 99, 12])
         self.assertEqual(suffix_tokens, [])
         self.assertEqual(reason, "prefix_not_token_prefix")
+
+    def test_prefill_only_probe_captures_checkpoint_without_sampling_or_generation(self) -> None:
+        result = probe_route_prefix_prefill_only(
+            lib=_FakeLib(),
+            ctx=object(),
+            tokenize=lambda text: {"prefix": [1, 2, 3]}[text],
+            prefix_text="prefix",
+            prefix_hash="prefix-hash-alpha",
+            model_id="model-alpha",
+            template_id="template-alpha",
+            tool_schema_hash="tool-hash-alpha",
+            capability_summary_hash="caps-hash-alpha",
+            backend_version="backend-alpha",
+            native_version="native-alpha",
+        )
+        metadata = result.to_metadata()
+
+        self.assertTrue(result.ok)
+        self.assertIsNone(result.reason)
+        self.assertEqual(result.prefix_token_count, 3)
+        self.assertGreater(result.checkpoint_size, 0)
+        self.assertEqual(result.decode_calls, 1)
+        self.assertEqual(result.sampled_tokens, 0)
+        self.assertEqual(result.generated_tokens, 0)
+        self.assertFalse(result.sampler_touched)
+        self.assertFalse(result.session_history_touched)
+        self.assertNotIn("raw prefix body", str(metadata))
+        self.assertNotIn("[1, 2, 3]", str(metadata))
+
+    def test_prefill_only_probe_decodes_prefix_in_chunks(self) -> None:
+        result = probe_route_prefix_prefill_only(
+            lib=_FakeLib(),
+            ctx=object(),
+            tokenize=lambda text: {"prefix": [1, 2, 3, 4, 5]}[text],
+            prefix_text="prefix",
+            prefix_hash="prefix-hash-alpha",
+            model_id="model-alpha",
+            template_id="template-alpha",
+            tool_schema_hash="tool-hash-alpha",
+            capability_summary_hash="caps-hash-alpha",
+            backend_version="backend-alpha",
+            native_version="native-alpha",
+            decode_step=2,
+        )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.decode_calls, 3)
+        self.assertEqual(result.sampled_tokens, 0)
+        self.assertEqual(result.generated_tokens, 0)
+
+    def test_prefill_only_probe_metadata_stays_content_free(self) -> None:
+        result = PrefixPrefillOnlyProbeResult(
+            ok=True,
+            reason=None,
+            prefix_hash="prefix-hash-alpha",
+            prefix_token_count=3,
+            checkpoint_size=12,
+            prefill_ms=5.0,
+            decode_calls=1,
+        )
+        rendered = str(result.to_metadata())
+
+        self.assertNotIn("prefix text", rendered)
+        self.assertNotIn("user content", rendered)
+        self.assertNotIn("tool output", rendered)
+
+    def test_prefill_only_probe_script_imports_without_running_probe(self) -> None:
+        script = Path(__file__).resolve().parents[1] / "scripts" / "probe_native_route_prefix_prefill_only.py"
+        spec = importlib.util.spec_from_file_location("probe_native_route_prefix_prefill_only", script)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        self.assertTrue(callable(module.main))
 
     def test_probe_reports_equivalent_restore_for_stable_tokens(self) -> None:
         mapping = {


### PR DESCRIPTION
This PR adds an isolated backend-native route prefix prefill-only probe.

Scope:

* docs + isolated probe
* no runtime integration
* no prompt changes
* no routing/tool/final/evidence policy changes
* no KV default changes
* no tag/release changes

The probe verifies that the native backend can prefill and checkpoint the stable route tools-on prefix without using fake user requests, prompt workarounds, normal chat completions, sampler calls, or generation.

Probe result with the local Gemma 4 12B setup:

* prefix_token_count: 693
* checkpoint_size_bytes: 238454176
* prefill_ms: 50211.951
* decode_calls: 3
* sampled_tokens: 0
* generated_tokens: 0
* sampler_touched: false
* session_history_touched: false
* probe_ok: true

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_kv_diag tests.test_native_chat_template -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_llama_server_backend -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Notes:

* this does not add a prewarm endpoint
* this does not enable runtime prewarm
* the next step remains a separate reviewed endpoint/hook PR with lifecycle, cancellation, concurrency, invalidation, and fallback tests
* v0.0.1-rc2 tag/release are not modified
* workdir/.miktex/ remains local cache and is not included