### PR TITLE
Add native route prefix prefill-only hook

### DIFF
--- a/docs/NATIVE_ROUTE_PREFIX_PREFILL_HOOK.md
+++ b/docs/NATIVE_ROUTE_PREFIX_PREFILL_HOOK.md
@@ -1,0 +1,174 @@
+# Native Route Prefix Prefill Hook
+
+## Scope
+
+This document describes the first internal hook for native route prefix
+prefill-only capture.
+
+The hook is intentionally not a runtime prewarm feature. It is not called from
+server startup, `/tools on`, `/reset`, `/chat`, `/chat/stream`, or the normal
+route path. It is an internal primitive that can be invoked explicitly by probe
+or test code to validate the lifecycle needed by a future prewarm integration.
+
+## What It Introduces
+
+- `NativeLlamaClient.capture_route_prefix_prefill_only(...)`
+- Metadata-only result reporting through `NativeRoutePrefixPrefillResult`
+- A manual probe script path that invokes the hook directly
+- Mocked unit coverage for success, skip, failure, lock, and metadata behavior
+
+The hook:
+
+- uses the same stable route tools-on prefix structure used by the runtime route
+  prefix anchor
+- tokenizes with the native tokenizer
+- decodes only the stable prefix
+- captures a real KV checkpoint after the prefix decode
+- returns explicit metadata
+- sets `restore_ready=true` only after complete success
+
+## What It Does Not Introduce
+
+- no automatic prewarm
+- no startup integration
+- no `/tools on` integration
+- no `/chat` or `/chat/stream` integration
+- no fake user request
+- no prompt workaround
+- no `max_tokens=0` completion path
+- no model output generation
+- no prompt change
+- no routing, tool selection, final-answer, or evidence policy change
+- no public stable endpoint
+- no release or tag change
+
+## Guardrails
+
+The hook is native-client-only. Non-native backends have no production path to
+call it.
+
+The hook skips without decode or checkpoint capture when:
+
+- `ORBIT_KV_PREFIX_ANCHOR=off`
+- tools mode is not `on`
+- another native request is in flight
+- a continuation or cached prompt context is active
+- another prefill-only capture is already running on the same client
+
+Legacy compatibility follows the existing prefix-anchor configuration:
+
+- if `ORBIT_KV_PREFIX_ANCHOR` is unset, `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1`
+  still enables auto behavior
+- `ORBIT_KV_PREFIX_ANCHOR=off` wins over the legacy flag
+
+## Locking And State Safety
+
+The hook uses a non-blocking per-client lock. A concurrent call skips with
+`prefill_in_flight` instead of waiting or sharing mutable decode state.
+
+The hook is idle-only. It refuses to run when the native client has an active
+request, continuation state, or cached prompt tokens. This avoids destroying an
+active completion context and keeps the hook out of normal user-visible
+interaction.
+
+Checkpoint state is published only after the full prefix decode and checkpoint
+capture succeed. Decode failure, cancellation, invalid prefix boundary, or
+checkpoint failure clear partial decode state and return `restore_ready=false`.
+
+## Cancellation And Failure
+
+Cancellation during decode returns a failed result and does not mark the
+checkpoint as valid.
+
+Failure modes are reported as metadata-only reasons such as:
+
+- `anchor_disabled`
+- `tools_mode_ineligible`
+- `native_client_not_loaded`
+- `native_request_in_flight`
+- `active_context_present`
+- `prefill_in_flight`
+- `route_boundary_unavailable`
+- `route_anchor_plan_unavailable`
+- `prefix_decode_failed:<error-type>`
+- `cancelled`
+- checkpoint capture failure reason from the prefix-anchor lifecycle
+
+No user-facing runtime error is introduced because the hook is not called by
+the normal runtime.
+
+## Metadata
+
+The result object reports:
+
+- `attempted`
+- `succeeded`
+- `skipped`
+- `skip_reason`
+- `failed_reason`
+- `prefix_hash`
+- `prefix_token_count`
+- `checkpoint_size_bytes`
+- `prefill_ms`
+- `decode_calls`
+- `sampled_tokens`
+- `generated_tokens`
+- `sampler_touched`
+- `session_history_touched`
+- `restore_ready`
+
+The hook does not print raw prompt text, raw tokens, user content, tool output,
+file content, web content, or full tool specs.
+
+## Manual Probe Path
+
+`scripts/probe_native_route_prefix_prefill_only.py` now invokes the internal
+hook directly after building the stable route tools-on prefix. It remains a
+manual probe and is not part of the runtime lifecycle.
+
+Expected successful probe properties:
+
+- `sampled_tokens=0`
+- `generated_tokens=0`
+- `sampler_touched=false`
+- `session_history_touched=false`
+- `restore_ready=true`
+
+The previously observed native probe values remain the reference baseline for
+the tested setup:
+
+- prefix token count: 693
+- checkpoint size: 238454176 bytes
+- sampled tokens: 0
+- generated tokens: 0
+
+## Tests
+
+Unit tests cover:
+
+- `ORBIT_KV_PREFIX_ANCHOR=off` skips without decode
+- `ORBIT_KV_PREFIX_ANCHOR=off` wins over legacy experiment mode
+- legacy experiment mode still enables the hook when the new variable is unset
+- tools-off skips
+- mocked success produces `restore_ready=true`
+- decode failure returns `restore_ready=false`
+- active context skips
+- concurrent prefill skips
+- metadata stays content-free
+
+The standard test suite does not require a real model.
+
+## Next Step
+
+The next PR can decide whether to expose a controlled internal lifecycle trigger.
+That future work must still prove:
+
+- explicit lifecycle trigger semantics
+- lock and cancellation behavior under real server concurrency
+- invalidation on model, tokenizer, template, tools, capabilities, backend, or
+  config changes
+- fallback to baseline on every failure
+- unchanged file/read/list/web/fetch behavior
+- unchanged prompt, routing, tool selection, final-answer, and evidence policy
+
+Runtime prewarm remains out of scope for this hook PR.

--- a/scripts/probe_native_route_prefix_prefill_only.py
+++ b/scripts/probe_native_route_prefix_prefill_only.py
@@ -14,9 +14,7 @@ if str(SRC) not in sys.path:
 
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
 from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
-from orbit.native_llama.native_names import runtime_library_filename
 from orbit.native_llama.paths import DEFAULT_MODEL_ID, resolve_legacy_paths, resolve_paths
-from orbit.native_llama.prefix_anchor_probe import probe_route_prefix_prefill_only
 from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
 
 
@@ -55,24 +53,11 @@ def main(argv: list[str] | None = None) -> int:
             if not segments.boundary_available:
                 print(json.dumps({"probe_ok": False, "reason": "route_boundary_unavailable"}, sort_keys=True))
                 return 2
-            result = probe_route_prefix_prefill_only(
-                lib=client.lib.lib,
-                ctx=client._session.ctx_tgt,
-                tokenize=client.tokenize,
-                prefix_text=segments.stable_prefix_text,
-                prefix_hash=segments.stable_prefix_hash,
-                model_id=str(paths.model),
-                template_id="gemma4-route-prefix-v1",
-                tool_schema_hash=segments.stable_prefix_hash,
-                capability_summary_hash=segments.stable_prefix_hash,
-                runtime_policy_hash=segments.stable_prefix_hash,
-                route_contract_hash=segments.stable_prefix_hash,
-                backend_version="orbit-native",
-                native_version=runtime_library_filename("llama"),
-                tools_mode="on",
-            )
-            print(json.dumps(result.to_metadata(), sort_keys=True))
-            return 0 if result.ok else 2
+            result = client.capture_route_prefix_prefill_only(segments)
+            metadata = result.to_metadata()
+            metadata["probe_ok"] = result.succeeded
+            print(json.dumps(metadata, sort_keys=True))
+            return 0 if result.succeeded else 2
         finally:
             client.close()
     except Exception as exc:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -73,6 +73,44 @@ class _RouteAnchorRuntimePlan:
     metadata: dict[str, object]
 
 
+@dataclass(frozen=True)
+class NativeRoutePrefixPrefillResult:
+    attempted: bool
+    succeeded: bool
+    skipped: bool
+    skip_reason: str | None = None
+    failed_reason: str | None = None
+    prefix_hash: str | None = None
+    prefix_token_count: int | None = None
+    checkpoint_size_bytes: int | None = None
+    prefill_ms: float | None = None
+    decode_calls: int | None = None
+    sampled_tokens: int = 0
+    generated_tokens: int = 0
+    sampler_touched: bool = False
+    session_history_touched: bool = False
+    restore_ready: bool = False
+
+    def to_metadata(self) -> dict[str, object]:
+        return {
+            "attempted": self.attempted,
+            "succeeded": self.succeeded,
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
+            "failed_reason": self.failed_reason,
+            "prefix_hash": self.prefix_hash,
+            "prefix_token_count": self.prefix_token_count,
+            "checkpoint_size_bytes": self.checkpoint_size_bytes,
+            "prefill_ms": self.prefill_ms,
+            "decode_calls": self.decode_calls,
+            "sampled_tokens": self.sampled_tokens,
+            "generated_tokens": self.generated_tokens,
+            "sampler_touched": self.sampler_touched,
+            "session_history_touched": self.session_history_touched,
+            "restore_ready": self.restore_ready,
+        }
+
+
 class NativeLlamaClient:
     def __init__(self, paths: NativeLlamaPaths, config: NativeClientConfig | None = None) -> None:
         self.paths = paths
@@ -101,6 +139,7 @@ class NativeLlamaClient:
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
+        self._route_prefix_prefill_lock = threading.Lock()
 
     def session_snapshot(self, session_id: str = DEFAULT_NATIVE_SESSION_ID) -> NativeSessionSnapshot:
         if session_id != self._session.session_id:
@@ -359,6 +398,122 @@ class NativeLlamaClient:
             on_token=on_token,
             should_cancel=should_cancel,
         )
+
+    def capture_route_prefix_prefill_only(
+        self,
+        segments: RoutePromptSegments,
+        *,
+        tools_mode: str = "on",
+        should_cancel=None,
+    ) -> NativeRoutePrefixPrefillResult:
+        if tools_mode != "on":
+            return _route_prefix_prefill_skipped("tools_mode_ineligible")
+        if not prefix_anchor_enabled():
+            return _route_prefix_prefill_skipped("anchor_disabled")
+        if not self._session.ctx_tgt or not self._vocab:
+            return _route_prefix_prefill_failed("native_client_not_loaded")
+        if self._session.in_flight:
+            return _route_prefix_prefill_skipped("native_request_in_flight")
+        if self._session.continuation_ready or self._session.cached_prompt_tokens:
+            return _route_prefix_prefill_skipped("active_context_present")
+        if not self._route_prefix_prefill_lock.acquire(blocking=False):
+            return _route_prefix_prefill_skipped("prefill_in_flight")
+        try:
+            if self._session.in_flight:
+                return _route_prefix_prefill_skipped("native_request_in_flight")
+            if self._session.continuation_ready or self._session.cached_prompt_tokens:
+                return _route_prefix_prefill_skipped("active_context_present")
+            if not segments.boundary_available:
+                return _route_prefix_prefill_failed("route_boundary_unavailable")
+            prompt_tokens = self.tokenize(segments.full_prompt_text)
+            if not prompt_tokens:
+                return _route_prefix_prefill_failed("empty_full_prompt_tokens")
+            plan = self._route_anchor_plan(segments.full_prompt_text, prompt_tokens, segments)
+            if plan is None:
+                return _route_prefix_prefill_failed("route_anchor_plan_unavailable")
+
+            self.reset_cancel()
+            self._clear_target_memory()
+            token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
+            step = max(1, min(self.config.progress_step, self.config.batch_size))
+            processed = 0
+            decode_calls = 0
+            lib = self.lib.lib
+            start_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else 0
+            try:
+                while processed < len(plan.prefix_tokens) and not self.cancel_event.is_set():
+                    if should_cancel and should_cancel():
+                        self.cancel()
+                        break
+                    end = min(processed + step, len(plan.prefix_tokens))
+                    processed = self._decode_prompt_range(
+                        token_array,
+                        processed=processed,
+                        end=end,
+                        step=step,
+                        total=len(plan.prefix_tokens),
+                        on_progress=None,
+                        should_cancel=should_cancel,
+                    )
+                    decode_calls += 1
+            except Exception as exc:
+                self._clear_target_memory()
+                self._route_prefix_anchor_state = PrefixAnchorState()
+                return _route_prefix_prefill_failed(
+                    f"prefix_decode_failed:{type(exc).__name__}",
+                    prefix_hash=plan.prefix_hash,
+                    prefix_token_count=len(plan.prefix_tokens),
+                    decode_calls=max(1, decode_calls),
+                )
+            end_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else start_us
+            prefill_ms = max(0.0, (end_us - start_us) / 1000.0)
+            if processed != len(plan.prefix_tokens) or self.cancel_event.is_set():
+                self._clear_target_memory()
+                self._route_prefix_anchor_state = PrefixAnchorState()
+                return _route_prefix_prefill_failed(
+                    "cancelled",
+                    prefix_hash=plan.prefix_hash,
+                    prefix_token_count=len(plan.prefix_tokens),
+                    prefill_ms=prefill_ms,
+                    decode_calls=decode_calls,
+                )
+
+            state, capture_meta = capture_prefix_anchor(
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **self._route_anchor_state_kwargs(plan),
+            )
+            if not state.valid:
+                reason = str(capture_meta.get("fallback_reason") or state.invalidation_reason or "capture_failed")
+                self._clear_target_memory()
+                self._route_prefix_anchor_state = PrefixAnchorState()
+                return _route_prefix_prefill_failed(
+                    reason,
+                    prefix_hash=plan.prefix_hash,
+                    prefix_token_count=len(plan.prefix_tokens),
+                    prefill_ms=prefill_ms,
+                    decode_calls=decode_calls,
+                )
+
+            self._route_prefix_anchor_state = state
+            self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+            self._session.continuation_ready = False
+            return NativeRoutePrefixPrefillResult(
+                attempted=True,
+                succeeded=True,
+                skipped=False,
+                prefix_hash=plan.prefix_hash,
+                prefix_token_count=len(plan.prefix_tokens),
+                checkpoint_size_bytes=state.checkpoint_size,
+                prefill_ms=prefill_ms,
+                decode_calls=decode_calls,
+                restore_ready=True,
+            )
+        finally:
+            self._route_prefix_prefill_lock.release()
 
     def complete_chat(
         self,
@@ -1418,6 +1573,37 @@ def _route_anchor_metadata_from_prefix(metadata: dict[str, object], *, prefix_ha
         "anchor_invalidated": bool(metadata.get("anchor_invalidated")),
         "invalidation_reason": metadata.get("invalidation_reason"),
     }
+
+
+def _route_prefix_prefill_skipped(reason: str) -> NativeRoutePrefixPrefillResult:
+    return NativeRoutePrefixPrefillResult(
+        attempted=False,
+        succeeded=False,
+        skipped=True,
+        skip_reason=reason,
+    )
+
+
+def _route_prefix_prefill_failed(
+    reason: str,
+    *,
+    prefix_hash: str | None = None,
+    prefix_token_count: int | None = None,
+    checkpoint_size_bytes: int | None = None,
+    prefill_ms: float | None = None,
+    decode_calls: int | None = None,
+) -> NativeRoutePrefixPrefillResult:
+    return NativeRoutePrefixPrefillResult(
+        attempted=True,
+        succeeded=False,
+        skipped=False,
+        failed_reason=reason,
+        prefix_hash=prefix_hash,
+        prefix_token_count=prefix_token_count,
+        checkpoint_size_bytes=checkpoint_size_bytes,
+        prefill_ms=prefill_ms,
+        decode_calls=decode_calls,
+    )
 
 
 def _strip_control_channels(content: str) -> str:

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from ctypes import c_float
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+import threading
 import unittest
+from unittest.mock import patch
 
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, NativeRoutePrefixPrefillResult
 from orbit.native_llama.prefix_anchor_probe import (
     PrefixPrefillOnlyProbeResult,
     PrefixAnchorProbeResult,
@@ -14,6 +18,7 @@ from orbit.native_llama.prefix_anchor_probe import (
     split_prompt_by_token_prefix,
 )
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
 
 
 def _token_value(value: object) -> int:
@@ -53,6 +58,12 @@ class _FakeLib:
 
     def llama_batch_free(self, _batch) -> None:
         return None
+
+    def llama_batch_get_one(self, token_ptr, n_tokens: int):
+        batch = _FakeBatch(n_tokens)
+        for index in range(n_tokens):
+            batch.token[index] = token_ptr[index]
+        return batch
 
     def llama_decode(self, _ctx, batch) -> int:
         for index in range(batch.n_tokens):
@@ -106,6 +117,36 @@ class _FailingRestoreLib(_FakeLib):
     def llama_state_seq_set_data(self, _ctx, buffer, size: int, _seq_id: int) -> int:
         _ = bytes(buffer[:size])
         return size - 1
+
+
+class _FailingDecodeLib(_FakeLib):
+    def llama_decode(self, _ctx, batch) -> int:
+        _ = batch
+        return 1
+
+
+def _prefill_hook_client(segments, *, lib=None) -> NativeLlamaClient:
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    client.paths = SimpleNamespace(model=Path("model-alpha.gguf"))
+    client.config = NativeClientConfig(batch_size=2, progress_step=2)
+    client.lib = SimpleNamespace(lib=lib or _FakeLib())
+    client._vocab = object()
+    client.cancel_event = threading.Event()
+    client._session = SimpleNamespace(
+        ctx_tgt=object(),
+        cached_prompt_tokens=[],
+        continuation_ready=False,
+        in_flight=False,
+        cancel_requested=False,
+    )
+    client._route_prefix_anchor_state = PrefixAnchorState()
+    client._route_prefix_prefill_lock = threading.Lock()
+    mapping = {
+        segments.stable_prefix_text: [1, 2, 3, 4],
+        segments.full_prompt_text: [1, 2, 3, 4, 5],
+    }
+    client.tokenize = lambda text: mapping[text]
+    return client
 
 
 class PrefixAnchorProbeTests(unittest.TestCase):
@@ -329,6 +370,147 @@ class PrefixAnchorProbeTests(unittest.TestCase):
         self.assertNotIn("prefix text", rendered)
         self.assertNotIn("full text", rendered)
         self.assertNotIn("placeholder", rendered)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_native_prefill_hook_captures_checkpoint_without_generation(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        client = _prefill_hook_client(segments)
+
+        result = client.capture_route_prefix_prefill_only(segments)
+        metadata = result.to_metadata()
+
+        self.assertTrue(result.attempted)
+        self.assertTrue(result.succeeded)
+        self.assertFalse(result.skipped)
+        self.assertTrue(result.restore_ready)
+        self.assertEqual(result.prefix_token_count, 4)
+        self.assertGreater(result.checkpoint_size_bytes or 0, 0)
+        self.assertEqual(result.decode_calls, 2)
+        self.assertEqual(result.sampled_tokens, 0)
+        self.assertEqual(result.generated_tokens, 0)
+        self.assertFalse(result.sampler_touched)
+        self.assertFalse(result.session_history_touched)
+        self.assertTrue(client._route_prefix_anchor_state.valid)
+        self.assertEqual(client._session.cached_prompt_tokens, [1, 2, 3, 4])
+        self.assertNotIn("route policy placeholder", str(metadata))
+        self.assertNotIn("[1, 2, 3, 4]", str(metadata))
+
+    @patch.dict("os.environ", {"ORBIT_KV_PREFIX_ANCHOR": "off"}, clear=True)
+    def test_native_prefill_hook_skips_when_anchor_disabled(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        lib = _FakeLib()
+        client = _prefill_hook_client(segments, lib=lib)
+
+        result = client.capture_route_prefix_prefill_only(segments)
+
+        self.assertFalse(result.attempted)
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "anchor_disabled")
+        self.assertEqual(lib.current_tokens, [])
+        self.assertFalse(client._route_prefix_anchor_state.valid)
+
+    @patch.dict("os.environ", {"ORBIT_KV_PREFIX_ANCHOR": "off", "ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"}, clear=True)
+    def test_native_prefill_hook_off_wins_over_legacy_flag(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        result = _prefill_hook_client(segments).capture_route_prefix_prefill_only(segments)
+
+        self.assertFalse(result.attempted)
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "anchor_disabled")
+
+    @patch.dict("os.environ", {"ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"}, clear=True)
+    def test_native_prefill_hook_legacy_flag_enables_when_new_var_unset(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        result = _prefill_hook_client(segments).capture_route_prefix_prefill_only(segments)
+
+        self.assertTrue(result.succeeded)
+        self.assertTrue(result.restore_ready)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_native_prefill_hook_skips_tools_off(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        result = _prefill_hook_client(segments).capture_route_prefix_prefill_only(
+            segments,
+            tools_mode="off",
+        )
+
+        self.assertFalse(result.attempted)
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "tools_mode_ineligible")
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_native_prefill_hook_fails_safely_on_decode_error(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        client = _prefill_hook_client(segments, lib=_FailingDecodeLib())
+
+        result = client.capture_route_prefix_prefill_only(segments)
+
+        self.assertTrue(result.attempted)
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.failed_reason, "prefix_decode_failed:RuntimeError")
+        self.assertFalse(result.restore_ready)
+        self.assertFalse(client._route_prefix_anchor_state.valid)
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_native_prefill_hook_skips_when_context_is_active(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        client = _prefill_hook_client(segments)
+        client._session.cached_prompt_tokens = [9]
+
+        result = client.capture_route_prefix_prefill_only(segments)
+
+        self.assertFalse(result.attempted)
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "active_context_present")
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_native_prefill_hook_skips_concurrent_capture(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": "route policy placeholder"}]
+        )
+        client = _prefill_hook_client(segments)
+        self.assertTrue(client._route_prefix_prefill_lock.acquire(blocking=False))
+        try:
+            result = client.capture_route_prefix_prefill_only(segments)
+        finally:
+            client._route_prefix_prefill_lock.release()
+
+        self.assertFalse(result.attempted)
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "prefill_in_flight")
+
+    def test_native_prefill_result_metadata_stays_content_free(self) -> None:
+        result = NativeRoutePrefixPrefillResult(
+            attempted=True,
+            succeeded=True,
+            skipped=False,
+            prefix_hash="prefix-hash-alpha",
+            prefix_token_count=4,
+            checkpoint_size_bytes=12,
+            prefill_ms=3.5,
+            decode_calls=2,
+            restore_ready=True,
+        )
+        rendered = str(result.to_metadata())
+
+        self.assertNotIn("prompt body", rendered)
+        self.assertNotIn("token ids", rendered)
+        self.assertNotIn("command result", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an internal native backend hook for route prefix prefill-only capture.

Scope:

* internal hook/probe path only
* no automatic runtime prewarm
* no startup integration
* no /tools on integration
* no /chat or /chat/stream integration
* no prompt changes
* no routing/tool/final/evidence policy changes
* no tag/release changes

Safety:

* no fake user request
* no prompt workaround
* no generation
* sampled/generated tokens remain zero
* ORBIT_KV_PREFIX_ANCHOR=off disables the hook
* non-native backends are skipped/unsupported by having no production path to call the native-client hook
* failure falls back safely
* checkpoint valid only after complete success
* metadata-only diagnostics

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_llama_server_backend tests.test_runtime tests.test_config -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_kv_diag tests.test_native_chat_template -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_command_request -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Manual probe:

* prefix_token_count: 693
* checkpoint_size_bytes: 238454176
* prefill_ms: 59385.463
* decode_calls: 11
* sampled_tokens: 0
* generated_tokens: 0
* sampler_touched: false
* session_history_touched: false
* restore_ready: true

Smoke:

* branch server smoke confirms runtime behavior unchanged
* read/list/web/fetch paths preserved
* listing -> read README.md reaches content-read evidence
* local evidence -> fresh web reaches orbit-web-search
* no automatic hook invocation observed

Notes:

* v0.0.1-rc2 tag/release is not modified.
* workdir/.miktex/ remains local cache and is not included.