### PR TITLE
Add opt-in startup route prefix prewarm

### DIFF
--- a/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
+++ b/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
@@ -1,0 +1,169 @@
+# Native Route Prefix Startup Prewarm
+
+## Status
+
+This document describes the first controlled runtime integration for native route
+prefix prewarm.
+
+The feature is opt-in and does not change default runtime behavior.
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off      # default
+ORBIT_KV_PREFIX_PREWARM=startup  # opt-in synchronous startup prewarm
+```
+
+`ORBIT_KV_PREFIX_ANCHOR=off` disables startup prewarm even when
+`ORBIT_KV_PREFIX_PREWARM=startup` is set. The legacy
+`ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` does not override `off`.
+
+Invalid `ORBIT_KV_PREFIX_PREWARM` values fall back to `off`.
+
+## What It Does
+
+When enabled, startup prewarm uses the internal native prefill-only hook to
+prepare the stable route tools-on prefix before the server starts accepting
+requests.
+
+The prewarmed prefix is the same route tools-on prefix used by real route calls:
+
+- route system contract
+- route tool schema
+- stable route template boundary
+
+The hook tokenizes the prefix with the native tokenizer, decodes only the prefix,
+captures a real KV checkpoint, and marks the checkpoint restore-ready only after
+full success.
+
+No model response is generated during prewarm.
+
+## What It Does Not Do
+
+Startup prewarm does not introduce:
+
+- automatic default prewarm
+- background prewarm
+- `/tools on` lifecycle integration
+- `/chat` or `/chat/stream` integration
+- system-prompt anchor
+- chat-final anchor
+- final-from-tool anchor
+- tool-call anchor
+- multiple anchors
+- fake user request
+- prompt workaround
+- `max_tokens=0` through the normal generation path
+- deterministic routing
+- tool-selection changes
+- final-answer policy changes
+- file/web/fetch evidence-policy changes
+
+## Lifecycle
+
+`ORBIT_KV_PREFIX_PREWARM=startup` runs after the native model/client is loaded and
+before the HTTP server starts serving requests.
+
+This location is intentional:
+
+- model, tokenizer, template, and native context are ready
+- no user request is in flight
+- no tool loop is active
+- no session history is present
+- the hook can use the native client's existing prefill lock
+
+Because this is synchronous startup work, server readiness is delayed by the
+prewarm duration when the feature is enabled. With the tested Gemma 4 12B CPU
+setup, the prefill-only capture for the 693-token stable route prefix has been
+observed around 49-59 seconds.
+
+## Guardrails
+
+Startup prewarm is eligible only when:
+
+- `ORBIT_KV_PREFIX_PREWARM=startup`
+- `ORBIT_KV_PREFIX_ANCHOR` is not `off`
+- native backend/client is loaded
+- route prefix-anchor support is available
+- route tools-on stable prefix boundary is valid
+
+It is skipped when:
+
+- `ORBIT_KV_PREFIX_PREWARM` is unset or `off`
+- `ORBIT_KV_PREFIX_PREWARM` has an unrecognized value
+- `ORBIT_KV_PREFIX_ANCHOR=off`
+- a native client request/context is already active
+- the prefix-anchor hook reports an ineligible state
+
+Failures are not user-facing. A failed prewarm leaves the server usable; the
+first real route call falls back to the existing baseline/capture path.
+
+## Locking, Cancellation, And Failure
+
+The startup integration relies on the internal
+`NativeLlamaClient.capture_route_prefix_prefill_only(...)` lock and validity
+rules:
+
+- concurrent capture on the same native client is rejected
+- checkpoint is valid only after complete prefix decode and capture
+- decode/capture failure clears target memory and invalidates the route anchor
+- cancellation or incomplete prefill returns `restore_ready=false`
+- sampler and session history are not touched
+
+The startup lifecycle runs before serving requests, so there should be no
+request/prewarm race in the normal startup path.
+
+## Diagnostics
+
+When `ORBIT_KV_DIAG=1` is enabled, startup prewarm emits metadata only:
+
+- `prewarm_enabled`
+- `prewarm_mode`
+- `prewarm_attempted`
+- `prewarm_succeeded`
+- `prewarm_skipped_reason`
+- `prewarm_failed_reason`
+- `prewarm_prefix_token_count`
+- `prewarm_checkpoint_size_bytes`
+- `prewarm_ms`
+- `decode_calls`
+- `sampled_tokens`
+- `generated_tokens`
+- `sampler_touched`
+- `session_history_touched`
+- `restore_ready`
+
+Diagnostics must not include raw prompt text, raw token ids, tool specs, user
+content, tool output, file content, or web content.
+
+## Memory And Startup Tradeoff
+
+The route prefix checkpoint is large. On the tested Gemma 4 12B CPU setup, the
+checkpoint size is about 238 MB.
+
+Startup prewarm trades startup readiness time for lower first-route latency on
+eligible tools-on requests. It does not make tool execution faster and does not
+cache tool results, file contents, web results, PDF contents, or user history.
+
+## Validation Scope
+
+Required validation for this integration:
+
+- default/unset `ORBIT_KV_PREFIX_PREWARM` does not prewarm
+- `ORBIT_KV_PREFIX_PREWARM=off` does not prewarm
+- `ORBIT_KV_PREFIX_PREWARM=startup` invokes the native prefill-only hook
+- `ORBIT_KV_PREFIX_ANCHOR=off` skips startup prewarm
+- invalid prewarm values fall back to `off`
+- hook success yields `restore_ready=true`
+- hook failure leaves the server usable with `restore_ready=false`
+- diagnostics stay metadata-only
+- existing read/list/web/fetch behavior is unchanged
+- stale-evidence and listing-to-read guardrails remain intact
+
+## Next Steps
+
+Possible future work requires separate benchmark evidence:
+
+- background prewarm with explicit lock/readiness semantics
+- explicit operator-triggered internal prewarm
+- `/tools on` lifecycle integration
+
+None of those are part of this startup-only opt-in integration.

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -155,6 +155,30 @@ def emit_route_prefix_anchor_event(metadata: dict[str, Any]) -> None:
     _emit(event)
 
 
+def emit_route_prefix_prewarm_event(metadata: dict[str, Any]) -> None:
+    if not enabled():
+        return
+    event = {
+        "event": "kv_diag_route_prefix_prewarm",
+        "prewarm_enabled": bool(metadata.get("prewarm_enabled")),
+        "prewarm_mode": _safe_str(metadata.get("prewarm_mode")),
+        "prewarm_attempted": bool(metadata.get("prewarm_attempted")),
+        "prewarm_succeeded": bool(metadata.get("prewarm_succeeded")),
+        "prewarm_skipped_reason": _safe_str(metadata.get("prewarm_skipped_reason")),
+        "prewarm_failed_reason": _safe_str(metadata.get("prewarm_failed_reason")),
+        "prewarm_prefix_token_count": _safe_int(metadata.get("prewarm_prefix_token_count")),
+        "prewarm_checkpoint_size_bytes": _safe_int(metadata.get("prewarm_checkpoint_size_bytes")),
+        "prewarm_ms": _safe_int(metadata.get("prewarm_ms")),
+        "decode_calls": _safe_int(metadata.get("decode_calls")),
+        "sampled_tokens": _safe_int(metadata.get("sampled_tokens")),
+        "generated_tokens": _safe_int(metadata.get("generated_tokens")),
+        "sampler_touched": bool(metadata.get("sampler_touched")),
+        "session_history_touched": bool(metadata.get("session_history_touched")),
+        "restore_ready": bool(metadata.get("restore_ready")),
+    }
+    _emit(event)
+
+
 def _cache_miss_reason(
     *,
     cache_prompt: bool | None,

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import select
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -9,11 +10,18 @@ import socket
 import sys
 import threading
 import time
-from typing import Any
+from typing import Any, Mapping
 
-from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _has_open_thought_channel
-from orbit.native_llama.kv_diag import request_context as native_kv_request_context
+from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
+from orbit.native_llama.client import (
+    NativeClientConfig,
+    NativeLlamaClient,
+    NativeRoutePrefixPrefillResult,
+    _has_open_thought_channel,
+)
+from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_context as native_kv_request_context
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
+from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.native_server.protocol import (
     ContinueRequest,
     DEFAULT_SESSION_ID,
@@ -27,11 +35,15 @@ from orbit.native_server.protocol import (
     trim_at_stop,
     validate_session_id,
 )
+from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
 
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 12120
 DEFAULT_ALIAS = "gemma4:12b-it-native"
+PREFIX_PREWARM_ENV = "ORBIT_KV_PREFIX_PREWARM"
+PREFIX_PREWARM_OFF = "off"
+PREFIX_PREWARM_STARTUP = "startup"
 
 
 class OrbitNativeServer:
@@ -558,6 +570,7 @@ def run_server(argv: list[str] | None = None) -> int:
         if not args.verbose_llama_log:
             client.set_quiet_logging()
         client.load()
+        prewarm_startup_route_prefix(client)
     except (FileNotFoundError, RuntimeError) as exc:
         print(_format_native_bootstrap_error(exc), file=sys.stderr)
         return 1
@@ -573,6 +586,80 @@ def run_server(argv: list[str] | None = None) -> int:
         client.close()
         httpd.server_close()
     return 0
+
+
+def route_prefix_prewarm_mode(environ: Mapping[str, str] | None = None) -> str:
+    env = os.environ if environ is None else environ
+    value = env.get(PREFIX_PREWARM_ENV, PREFIX_PREWARM_OFF).strip().lower()
+    if value in {"", PREFIX_PREWARM_OFF}:
+        return PREFIX_PREWARM_OFF
+    if value == PREFIX_PREWARM_STARTUP:
+        return PREFIX_PREWARM_STARTUP
+    return PREFIX_PREWARM_OFF
+
+
+def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefixPrefillResult:
+    mode = route_prefix_prewarm_mode()
+    if mode != PREFIX_PREWARM_STARTUP:
+        result = _startup_prewarm_skipped("disabled")
+        _emit_startup_prewarm_diag(mode=mode, result=result)
+        return result
+    if not prefix_anchor_enabled():
+        result = _startup_prewarm_skipped("anchor_disabled")
+        _emit_startup_prewarm_diag(mode=mode, result=result)
+        return result
+    try:
+        segments = render_gemma4_route_prompt_segments(
+            [{"role": "system", "content": ROUTE_SYSTEM_PROMPT}],
+            thinking=False,
+        )
+        result = client.capture_route_prefix_prefill_only(segments, tools_mode="on")
+    except Exception as exc:
+        result = NativeRoutePrefixPrefillResult(
+            attempted=True,
+            succeeded=False,
+            skipped=False,
+            failed_reason=f"startup_prewarm_failed:{type(exc).__name__}",
+            restore_ready=False,
+        )
+    _emit_startup_prewarm_diag(mode=mode, result=result)
+    return result
+
+
+def _startup_prewarm_skipped(reason: str) -> NativeRoutePrefixPrefillResult:
+    return NativeRoutePrefixPrefillResult(
+        attempted=False,
+        succeeded=False,
+        skipped=True,
+        skip_reason=reason,
+        sampled_tokens=0,
+        generated_tokens=0,
+        sampler_touched=False,
+        session_history_touched=False,
+        restore_ready=False,
+    )
+
+
+def _emit_startup_prewarm_diag(*, mode: str, result: NativeRoutePrefixPrefillResult) -> None:
+    emit_route_prefix_prewarm_event(
+        {
+            "prewarm_enabled": mode == PREFIX_PREWARM_STARTUP,
+            "prewarm_mode": mode,
+            "prewarm_attempted": result.attempted,
+            "prewarm_succeeded": result.succeeded,
+            "prewarm_skipped_reason": result.skip_reason,
+            "prewarm_failed_reason": result.failed_reason,
+            "prewarm_prefix_token_count": result.prefix_token_count,
+            "prewarm_checkpoint_size_bytes": result.checkpoint_size_bytes,
+            "prewarm_ms": int(result.prefill_ms) if result.prefill_ms is not None else None,
+            "decode_calls": result.decode_calls,
+            "sampled_tokens": result.sampled_tokens,
+            "generated_tokens": result.generated_tokens,
+            "sampler_touched": result.sampler_touched,
+            "session_history_touched": result.session_history_touched,
+            "restore_ready": result.restore_ready,
+        }
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -5,10 +5,88 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
+from orbit.native_llama.client import NativeRoutePrefixPrefillResult
 from orbit.native_llama.native_names import runtime_library_filename
-from orbit.native_server.app import build_parser, resolve_bootstrap_paths, run_server
+from orbit.native_server.app import (
+    PREFIX_PREWARM_OFF,
+    PREFIX_PREWARM_STARTUP,
+    build_parser,
+    prewarm_startup_route_prefix,
+    resolve_bootstrap_paths,
+    route_prefix_prewarm_mode,
+    run_server,
+)
+
+
+class _FakeNativeClient:
+    instances: list["_FakeNativeClient"] = []
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.loaded = False
+        self.closed = False
+        self.capture_calls = 0
+        self.raise_on_capture = False
+        _FakeNativeClient.instances.append(self)
+
+    def set_quiet_logging(self) -> None:
+        return None
+
+    def load(self) -> None:
+        self.loaded = True
+
+    def close(self) -> None:
+        self.closed = True
+
+    def capture_route_prefix_prefill_only(self, segments, *, tools_mode: str = "on", should_cancel=None):
+        del should_cancel
+        self.capture_calls += 1
+        if self.raise_on_capture:
+            raise RuntimeError("synthetic capture failure")
+        if tools_mode != "on":
+            return NativeRoutePrefixPrefillResult(
+                attempted=False,
+                succeeded=False,
+                skipped=True,
+                skip_reason="tools_mode_ineligible",
+            )
+        if not getattr(segments, "boundary_available", False):
+            return NativeRoutePrefixPrefillResult(
+                attempted=True,
+                succeeded=False,
+                skipped=False,
+                failed_reason="route_boundary_unavailable",
+            )
+        return NativeRoutePrefixPrefillResult(
+            attempted=True,
+            succeeded=True,
+            skipped=False,
+            prefix_hash="prefix-hash-alpha",
+            prefix_token_count=693,
+            checkpoint_size_bytes=238454176,
+            prefill_ms=12.0,
+            decode_calls=3,
+            restore_ready=True,
+        )
+
+
+class _FakeHTTPServer:
+    instances: list["_FakeHTTPServer"] = []
+
+    def __init__(self, address, handler) -> None:
+        self.address = address
+        self.handler = handler
+        self.orbit_state = None
+        self.closed = False
+        _FakeHTTPServer.instances.append(self)
+
+    def serve_forever(self) -> None:
+        return None
+
+    def server_close(self) -> None:
+        self.closed = True
 
 
 class NativeServerBootstrapTests(unittest.TestCase):
@@ -87,6 +165,76 @@ class NativeServerBootstrapTests(unittest.TestCase):
         args = build_parser().parse_args([])
 
         self.assertEqual(args.port, 12120)
+
+    def test_route_prefix_prewarm_defaults_to_off(self) -> None:
+        self.assertEqual(route_prefix_prewarm_mode({}), PREFIX_PREWARM_OFF)
+
+    def test_route_prefix_prewarm_accepts_startup(self) -> None:
+        self.assertEqual(route_prefix_prewarm_mode({"ORBIT_KV_PREFIX_PREWARM": "startup"}), PREFIX_PREWARM_STARTUP)
+
+    def test_route_prefix_prewarm_invalid_value_falls_back_to_off(self) -> None:
+        self.assertEqual(route_prefix_prewarm_mode({"ORBIT_KV_PREFIX_PREWARM": "soon"}), PREFIX_PREWARM_OFF)
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_startup_prewarm_default_off_skips_without_capture(self) -> None:
+        client = _FakeNativeClient()
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "disabled")
+        self.assertEqual(client.capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_startup_prewarm_explicit_off_skips_without_capture(self) -> None:
+        client = _FakeNativeClient()
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "disabled")
+        self.assertEqual(client.capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
+    def test_startup_prewarm_invokes_native_hook(self) -> None:
+        client = _FakeNativeClient()
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.succeeded)
+        self.assertTrue(result.restore_ready)
+        self.assertEqual(result.sampled_tokens, 0)
+        self.assertEqual(result.generated_tokens, 0)
+        self.assertEqual(client.capture_calls, 1)
+
+    @mock.patch.dict(
+        "os.environ",
+        {"ORBIT_KV_PREFIX_PREWARM": "startup", "ORBIT_KV_PREFIX_ANCHOR": "off", "ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"},
+        clear=True,
+    )
+    def test_startup_prewarm_anchor_off_wins_without_capture(self) -> None:
+        client = _FakeNativeClient()
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "anchor_disabled")
+        self.assertEqual(client.capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
+    def test_startup_prewarm_failure_is_metadata_only_and_safe(self) -> None:
+        client = _FakeNativeClient()
+        client.raise_on_capture = True
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+        rendered = str(result.to_metadata())
+
+        self.assertTrue(result.attempted)
+        self.assertFalse(result.succeeded)
+        self.assertFalse(result.restore_ready)
+        self.assertEqual(result.failed_reason, "startup_prewarm_failed:RuntimeError")
+        self.assertNotIn("synthetic capture failure", rendered)
+        self.assertNotIn("route policy", rendered)
 
     def test_bootstrap_supports_legacy_direct_model_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -177,6 +325,41 @@ class NativeServerBootstrapTests(unittest.TestCase):
         output = stderr.getvalue()
         self.assertIn("error: native MTP shim inputs are missing.", output)
         self.assertIn("--llama-root", output)
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_server_default_does_not_startup_prewarm(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths", return_value=SimpleNamespace()),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(_FakeNativeClient.instances), 1)
+        self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 0)
+        self.assertTrue(_FakeNativeClient.instances[0].closed)
+        self.assertTrue(_FakeHTTPServer.instances[0].closed)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
+    def test_run_server_startup_prewarm_invokes_hook_before_serving(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths", return_value=SimpleNamespace()),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(_FakeNativeClient.instances), 1)
+        self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 1)
+        self.assertIsNotNone(_FakeHTTPServer.instances[0].orbit_state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds opt-in startup prewarm for the native route tools-on prefix.

Scope:

* opt-in only: ORBIT_KV_PREFIX_PREWARM=startup
* default off
* native backend only
* route tools-on prefix only
* no system prompt anchor
* no automatic default prewarm
* no prompt changes
* no routing/tool/final/evidence policy changes
* no tag/release changes

Safety:

* uses internal prefill-only hook
* no fake user request
* no prompt workaround
* no generation/sampling during prewarm
* ORBIT_KV_PREFIX_ANCHOR=off disables prewarm
* failures fall back to baseline
* checkpoint valid only after full success
* metadata-only diagnostics

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_llama_server_backend tests.test_runtime tests.test_config -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_kv_diag tests.test_native_chat_template -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_command_request -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS
* startup prewarm smoke: PASS
* kill-switch smoke: PASS
* read/list/web/fetch regressions checked
* PR #59 and PR #62 scenarios preserved or unchanged by this patch

Observed smoke:

* default/unset: no startup prewarm, first tools-on route remains cold capture miss
* startup prewarm: prefix_token_count=693, checkpoint_size_bytes=238454176, sampled_tokens=0, generated_tokens=0, restore_ready=true
* first real tools-on route after startup prewarm: cached 693, evaluated 18, restore hit
* kill switch: ORBIT_KV_PREFIX_ANCHOR=off skips prewarm and uses baseline path

Notes:

* startup readiness is delayed when ORBIT_KV_PREFIX_PREWARM=startup is enabled
* checkpoint memory cost remains about 238 MB on the tested Gemma 4 12B CPU setup
* workdir/.miktex/ remains local cache and is not included