### PR TITLE
Guard read-only requests from mutating tools

### DIFF
--- a/docs/READONLY_MUTATION_GUARDRAIL_ANALYSIS.md
+++ b/docs/READONLY_MUTATION_GUARDRAIL_ANALYSIS.md
@@ -1,0 +1,77 @@
+# Read-Only Mutation Guardrail Analysis
+
+## Scenario
+
+During PR #67 review, a read-only file inspection turn was followed by a fresh web-search turn. The first turn read the requested fixture file, but the model then emitted an additional mutating shell edit command before answering.
+
+Expected behavior:
+
+- Read-only file requests may read file content.
+- Listing evidence must not become file-content evidence.
+- Mutating commands must not run unless the latest user turn explicitly asks for a modification.
+- A following web request must use the web path and must not reuse stale local evidence.
+
+## Matrix
+
+| Condition | Branch/config | Result | Classification |
+| --- | --- | --- | --- |
+| A | `main`, `ORBIT_KV_PREFIX_PREWARM` unset, `ORBIT_KV_PREFIX_ANCHOR` unset | Reproduced: read command ran, then a mutating shell edit command ran. Fixture diff was saved and restored. | FAIL on main |
+| B | PR #67 branch, prewarm unset/off | Reproduced the same read-then-mutate pattern. Fixture diff was saved and restored. | FAIL without startup prewarm |
+| C | PR #67 branch, startup prewarm | The original PR #67 review smoke observed the same failure under startup prewarm. After A and B reproduced the same bug without prewarm, C is not the root cause. | Not prewarm-specific |
+
+Saved diffs:
+
+- `/home/guelfoweb/LAB/orbit-backups/readonly-mutation-investigation/A_main_default.edit-target.diff`
+- `/home/guelfoweb/LAB/orbit-backups/readonly-mutation-investigation/B_pr67_off.edit-target.diff`
+
+## Diagnosis
+
+This is a pre-existing read-only safety gap in the shell tool loop.
+
+The runtime already classified mutating shell commands for post-mutation verification, but it did not reject a mutating shell command before execution when the latest user turn was read-only. As a result, a model-emitted edit command could run even though the user only requested inspection.
+
+A follow-up smoke exposed a second detail: the intent detector treated the `edit` substring inside a path-like filename as a mutation verb. The fix now removes path-like tokens and URLs before checking for mutation intent, so filenames do not change read-only classification.
+
+This is not caused by:
+
+- PR #67 startup prewarm.
+- Route KV prefix-anchor.
+- `ORBIT_KV_PREFIX_ANCHOR=auto`.
+- Tool alias normalization from PR #59.
+
+## Fix
+
+The fix adds a pre-execution guardrail:
+
+- If the latest user turn is read-only and does not explicitly request modification, mutating shell commands are rejected before execution.
+- The guardrail uses existing generic shell mutation detection; it does not hardcode the fixture path or a specific utility.
+- `exec_shell_full_command` remains available for non-mutating reads, web search, fetch-style shell commands, and explicit mutation requests.
+- Explicit edit requests still allow mutating shell commands and retain existing mutation verification behavior.
+
+The retry remains model-guided. The runtime does not choose a replacement command; it only rejects the unsafe side effect and asks the model to answer from existing evidence or provide a non-mutating evidence command.
+
+The shell write-operator detector was also tightened so quoted angle brackets inside command arguments are not mistaken for shell redirection.
+
+## Validation Plan
+
+Required tests:
+
+- Read-only request rejects mutating shell commands before execution.
+- Read-only request rejects Python file writes before execution.
+- Explicit edit request still permits mutating shell commands.
+- Read file path remains valid.
+- Listing remains valid.
+- Web/fetch regressions remain valid.
+- PR #59 stale-evidence scenario remains valid.
+- PR #62 listing-to-read evidence scenario remains valid.
+- KV/prewarm is not changed.
+
+Required smoke:
+
+- Read-only local file turn followed by fresh web turn.
+- Explicit edit request still mutates only when requested.
+- Read/list/web/fetch baseline regressions.
+
+## Release State
+
+No tag or GitHub Release changes are required. `v0.0.1-rc2` remains a historical prerelease tag and release.

--- a/docs/READONLY_MUTATION_GUARDRAIL_ANALYSIS.md
+++ b/docs/READONLY_MUTATION_GUARDRAIL_ANALYSIS.md
@@ -21,8 +21,8 @@ Expected behavior:
 
 Saved diffs:
 
-- `/home/guelfoweb/LAB/orbit-backups/readonly-mutation-investigation/A_main_default.edit-target.diff`
-- `/home/guelfoweb/LAB/orbit-backups/readonly-mutation-investigation/B_pr67_off.edit-target.diff`
+- `orbit-backups/readonly-mutation-investigation/A_main_default.edit-target.diff`
+- `orbit-backups/readonly-mutation-investigation/B_pr67_off.edit-target.diff`
 
 ## Diagnosis
 

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -28,10 +28,18 @@ SEARCH_SHELL_OUTPUT_BYTES = 800
 SHELL_FAILURE_STREAM_CHARS = 1200
 SHELL_READ_FILE_THRESHOLD_BYTES = 8 * 1024
 SHELL_FULL_CONTRACT_ERROR_PREFIX = "error: shell-full analysis requests require content/source/string evidence"
+SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX = "error: read-only request rejected mutating shell command"
 SHELL_FULL_CONTRACT_RETRY_PROMPT = (
     "The previous shell-full command was rejected because it only listed metadata. "
     "Use the available exec_shell_full_command tool now to inspect source/content/string evidence. "
     "Return only the tool call."
+)
+SHELL_FULL_READ_ONLY_MUTATION_RETRY_PROMPT = (
+    "The previous shell-full command was rejected because the latest user request only asks to read, inspect, search, "
+    "summarize, or explain content, but the command would modify local state.\n\n"
+    "Do not write, edit, replace, delete, move, rename, install, commit, or otherwise mutate files or system state for this turn.\n\n"
+    "Either answer from existing valid evidence, or return exactly one non-mutating tool call that gathers the missing evidence:\n\n"
+    '{"command":"..."}'
 )
 SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT = (
     "Your previous command inspected only metadata or listings.\n\n"
@@ -311,6 +319,20 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
     return None
 
 
+def validate_read_only_shell_mutation(arguments: dict[str, Any], *, user_prompt: str | None) -> str | None:
+    raw_command = arguments.get("command")
+    if not isinstance(raw_command, str) or not raw_command.strip():
+        return None
+    if not is_read_only_user_request(user_prompt):
+        return None
+    if not is_mutating_shell_command(raw_command):
+        return None
+    return (
+        f"{SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX}. "
+        "Use a non-mutating command or answer from existing evidence unless the latest user request explicitly asks for a change."
+    )
+
+
 def _requires_direct_content_evidence(user_prompt: str) -> bool:
     if _ANALYSIS_PROMPT_RE.search(user_prompt):
         return True
@@ -392,6 +414,10 @@ def looks_like_url_content_evidence(text: str | None) -> bool:
 
 def is_shell_full_contract_error(content: str) -> bool:
     return content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX)
+
+
+def is_shell_full_read_only_mutation_error(content: str) -> bool:
+    return content.startswith(SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX)
 
 
 def build_shell_full_file_recovery_guard_prompt(
@@ -542,23 +568,38 @@ def is_repairable_shell_error(content: str) -> bool:
 
 
 def should_verify_shell_mutation(command: str, *, user_prompt: str | None) -> bool:
-    if user_prompt and _READ_ONLY_PROMPT_RE.search(user_prompt) and not _MUTATION_PROMPT_RE.search(user_prompt):
+    if is_read_only_user_request(user_prompt):
         return False
     return is_mutating_shell_command(command)
+
+
+def is_read_only_user_request(user_prompt: str | None) -> bool:
+    if not user_prompt:
+        return False
+    if _NEGATED_MUTATION_PROMPT_RE.search(user_prompt):
+        return True
+    intent_text = _without_user_paths_and_urls(user_prompt)
+    return _READ_ONLY_PROMPT_RE.search(user_prompt) is not None and _MUTATION_PROMPT_RE.search(intent_text) is None
 
 
 def is_mutative_user_request(user_prompt: str | None) -> bool:
     if not user_prompt:
         return False
+    intent_text = _without_user_paths_and_urls(user_prompt)
     if _NEGATED_MUTATION_PROMPT_RE.search(user_prompt) and not re.search(
         r"\b(?:fix|update|change|create|write|rename|refactor|edit)\b.*\b(?:file|code|implementation|config|test)\b",
-        user_prompt,
+        intent_text,
         re.IGNORECASE,
     ):
         return False
-    if _READ_ONLY_PROMPT_RE.search(user_prompt) and not _MUTATION_PROMPT_RE.search(user_prompt):
+    if _READ_ONLY_PROMPT_RE.search(user_prompt) and not _MUTATION_PROMPT_RE.search(intent_text):
         return False
-    return _MUTATION_PROMPT_RE.search(user_prompt) is not None
+    return _MUTATION_PROMPT_RE.search(intent_text) is not None
+
+
+def _without_user_paths_and_urls(text: str) -> str:
+    without_urls = _URL_RE.sub(" ", text)
+    return _USER_PATH_RE.sub(" ", without_urls)
 
 
 def is_mutating_shell_command(command: str) -> bool:
@@ -970,8 +1011,38 @@ def _has_shell_write_operator(command: str) -> bool:
     try:
         tokens = shlex.split(command)
     except ValueError:
-        return ">" in command
-    return any(token in {">", ">>", "2>", "2>>", "&>", "&>>"} for token in tokens) or bool(re.search(r"(^|[^<>])>{1,2}[^&]", command))
+        return bool(re.search(r"(^|[^<>])>{1,2}[^&]", _without_shell_quoted_strings(command)))
+    return any(token in {">", ">>", "2>", "2>>", "&>", "&>>"} for token in tokens) or bool(
+        re.search(r"(^|[^<>])>{1,2}[^&]", _without_shell_quoted_strings(command))
+    )
+
+
+def _without_shell_quoted_strings(command: str) -> str:
+    chars: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for char in command:
+        if escaped:
+            chars.append(" " if quote else char)
+            escaped = False
+            continue
+        if char == "\\":
+            chars.append(" " if quote else char)
+            escaped = bool(quote)
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+                chars.append(char)
+            else:
+                chars.append(" ")
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            chars.append(char)
+            continue
+        chars.append(char)
+    return "".join(chars)
 
 
 def _looks_like_html(content: str) -> bool:

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-from orbit.runtime.shell_guardrails import validate_shell_full_contract
+from orbit.runtime.shell_guardrails import validate_read_only_shell_mutation, validate_shell_full_contract
 from orbit.runtime.tool_arguments import parse_tool_arguments
 from orbit.runtime.tools import ToolResult, execute_tool, tool_definitions
 
@@ -58,6 +58,9 @@ class HybridToolExecutor:
         if isinstance(parsed, str):
             return ToolExecution(ToolResult(name=name, content=parsed), "orbit")
         if name == "exec_shell_full_command":
+            read_only_mutation_error = validate_read_only_shell_mutation(parsed, user_prompt=self.user_prompt)
+            if read_only_mutation_error:
+                return ToolExecution(ToolResult(name=name, content=read_only_mutation_error), "orbit")
             contract_error = validate_shell_full_contract(parsed, user_prompt=self.user_prompt)
             if contract_error:
                 return ToolExecution(ToolResult(name=name, content=contract_error), "orbit")

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -34,9 +34,11 @@ from orbit.runtime.shell_guardrails import (
     is_mutative_user_request,
     is_repairable_shell_error,
     is_shell_full_contract_error,
+    is_shell_full_read_only_mutation_error,
     is_shell_full_execution_error,
     looks_like_broad_file_rewrite,
     requires_url_content_evidence,
+    SHELL_FULL_READ_ONLY_MUTATION_RETRY_PROMPT,
     shell_repair_prompt,
     should_verify_shell_mutation,
 )
@@ -330,6 +332,7 @@ def run_tool_loop(
         command = _shell_command_from_tool_call(tool_call)
         raw_arguments = _shell_raw_arguments_from_tool_call(tool_call)
         command_is_mutating = bool(command and is_mutating_shell_command(command))
+        read_only_mutation_rejected = is_shell_full_read_only_mutation_error(tool_result.content)
         command_is_content_evidence = bool(command and is_content_evidence_shell_command(command))
         command_is_url_fetch = bool(
             command
@@ -344,7 +347,7 @@ def run_tool_loop(
             turn.url_fetch_attempted = True
         if tool_result.name == "fetch_url":
             turn.url_fetch_attempted = True
-        if command_is_mutating:
+        if command_is_mutating and not read_only_mutation_rejected:
             turn.shell_mutation_attempted = True
         if is_content_evidence_guard:
             runtime.content_evidence_guard_commands += 1
@@ -371,6 +374,9 @@ def run_tool_loop(
                 runtime.completion_guard_successes += 1
             else:
                 runtime.completion_guard_failures += 1
+        if read_only_mutation_rejected:
+            repair.read_only_mutation_retry_pending = True
+            return
         if is_shell_full_contract_error(tool_result.content):
             if command and is_metadata_only_shell_command(command):
                 turn.metadata_only_rejections += 1
@@ -625,6 +631,7 @@ def run_tool_loop(
         executing_mutation_verification = repair.mutation_verification_pending
         executing_mutation_verification_repair = repair.mutation_verification_repair_pending
         executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending
+        executing_read_only_mutation_retry = repair.read_only_mutation_retry_pending
         executing_content_evidence_guard = turn.pending_content_evidence_guard
         executing_file_recovery_guard = turn.pending_file_recovery_guard
         executing_url_recovery_guard = turn.pending_url_recovery_guard
@@ -636,6 +643,8 @@ def run_tool_loop(
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT}]
         elif repair.mutation_semantic_repair_pending:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_SEMANTIC_REPAIR_PROMPT}]
+        elif repair.read_only_mutation_retry_pending:
+            call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_READ_ONLY_MUTATION_RETRY_PROMPT}]
         elif turn.pending_content_evidence_guard:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT}]
         elif turn.pending_analysis_completion_guard:
@@ -655,6 +664,7 @@ def run_tool_loop(
                 repair.shell_repair_prompt_pending is not None
                 or repair.shell_empty_result_check_pending
                 or repair.mutation_semantic_repair_pending
+                or repair.read_only_mutation_retry_pending
                 or turn.pending_content_evidence_guard
                 or turn.pending_analysis_completion_guard
                 or turn.pending_url_recovery_guard
@@ -793,6 +803,7 @@ def run_tool_loop(
                 executing_mutation_verification
                 or executing_mutation_verification_repair
                 or executing_mutation_semantic_repair
+                or executing_read_only_mutation_retry
                 or executing_content_evidence_guard
                 or executing_file_recovery_guard
                 or executing_url_recovery_guard

--- a/src/orbit/runtime/tool_loop_state.py
+++ b/src/orbit/runtime/tool_loop_state.py
@@ -33,6 +33,7 @@ class ToolRepairState:
     """
 
     contract_retry_pending: bool = False
+    read_only_mutation_retry_pending: bool = False
     shell_empty_result_check_pending: bool = False
     shell_empty_result_check_used: bool = False
     shell_error_final_pending: bool = False
@@ -49,6 +50,7 @@ class ToolRepairState:
     def has_pending(self) -> bool:
         return (
             self.contract_retry_pending
+            or self.read_only_mutation_retry_pending
             or self.shell_empty_result_check_pending
             or self.shell_repair_prompt_pending is not None
             or self.mutation_verification_pending
@@ -160,6 +162,7 @@ class ToolTurnState:
 
     def clear_pending_after_model_call(self) -> None:
         self.repair_state.shell_repair_prompt_pending = None
+        self.repair_state.read_only_mutation_retry_pending = False
         self.repair_state.shell_empty_result_check_pending = False
         self.repair_state.mutation_verification_pending = False
         self.repair_state.mutation_verification_repair_pending = False

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -26,6 +26,8 @@ from orbit.runtime.shell_guardrails import (
     SHELL_FULL_CONTENT_EVIDENCE_GUARD_PROMPT,
     SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT,
     SHELL_FULL_MINIMAL_PATCH_GUARD_PROMPT,
+    SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX,
+    SHELL_FULL_READ_ONLY_MUTATION_RETRY_PROMPT,
     SHELL_FULL_SEMANTIC_REPAIR_PROMPT,
     should_verify_shell_mutation,
 )
@@ -6285,6 +6287,87 @@ EOF"""
 
         self.assertEqual(result.content, "done")
         self.assertEqual(_last_tool_message(runtime)["content"], "")
+
+    def test_read_only_request_rejects_mutating_shell_command_before_execution(self) -> None:
+        class ReadOnlyMutationBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_seen: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_seen.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"sed -i 's/beta/delta/' note.txt\"}"},
+                            }
+                        ],
+                        prompt_tokens=10,
+                        completion_tokens=2,
+                        cached_tokens=8,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if self.calls == 2:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"cat note.txt\"}"},
+                            }
+                        ],
+                        prompt_tokens=12,
+                        completion_tokens=2,
+                        cached_tokens=8,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="read completed",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=20,
+                    completion_tokens=3,
+                    cached_tokens=10,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+            backend = ReadOnlyMutationBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+            result = runtime.ask_with_tools(
+                "read note.txt and explain it",
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+            content = (workdir / "note.txt").read_text(encoding="utf-8")
+
+        self.assertEqual(result.content, "read completed")
+        self.assertEqual(content, "alpha\nbeta\ngamma\n")
+        self.assertEqual(backend.calls, 3)
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertTrue(tool_messages)
+        self.assertIn(SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX, tool_messages[0]["content"])
+        self.assertIn("beta", tool_messages[-1]["content"])
+        self.assertEqual(backend.messages_seen[1][-1]["content"], SHELL_FULL_READ_ONLY_MUTATION_RETRY_PROMPT)
 
     def test_ask_with_tools_can_replace_unique_text_in_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_shell_guardrails.py
+++ b/tests/test_shell_guardrails.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import unittest
 
-from orbit.runtime.shell_guardrails import is_mutative_user_request
+from orbit.runtime.shell_guardrails import (
+    is_mutating_shell_command,
+    is_mutative_user_request,
+    validate_read_only_shell_mutation,
+)
 
 
 class ShellGuardrailsTests(unittest.TestCase):
@@ -13,6 +17,42 @@ class ShellGuardrailsTests(unittest.TestCase):
 
     def test_suggest_fixes_remains_read_only_when_negated(self) -> None:
         self.assertFalse(is_mutative_user_request("Suggest fixes for service.py but do not modify files."))
+
+    def test_read_only_request_rejects_mutating_shell_command(self) -> None:
+        error = validate_read_only_shell_mutation(
+            {"command": "sed -i 's/old/new/' note.txt"},
+            user_prompt="read note.txt and explain it",
+        )
+
+        self.assertIsNotNone(error)
+        self.assertIn("read-only request rejected", error or "")
+
+    def test_read_only_path_with_edit_in_filename_is_not_mutative_intent(self) -> None:
+        error = validate_read_only_shell_mutation(
+            {"command": "sed -i 's/beta/delta/' workdir/edit-target.txt"},
+            user_prompt="read workdir/edit-target.txt",
+        )
+
+        self.assertIsNotNone(error)
+
+    def test_read_only_request_rejects_python_file_write(self) -> None:
+        error = validate_read_only_shell_mutation(
+            {"command": "python3 -c 'from pathlib import Path; Path(\"note.txt\").write_text(\"new\")'"},
+            user_prompt="show note.txt",
+        )
+
+        self.assertIsNotNone(error)
+
+    def test_explicit_edit_request_allows_mutating_shell_command(self) -> None:
+        error = validate_read_only_shell_mutation(
+            {"command": "sed -i 's/old/new/' note.txt"},
+            user_prompt="change old to new in note.txt",
+        )
+
+        self.assertIsNone(error)
+
+    def test_quoted_angle_brackets_are_not_shell_writes(self) -> None:
+        self.assertFalse(is_mutating_shell_command("printf '<html><body>Hello</body></html>'"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a read-only safety issue found while reviewing PR #67.

Scenario:

1. read a tracked local fixture file
2. web search current weather in Reykjavik

A read-only file request could emit a mutating edit command. The fix adds a guardrail so mutating shell commands are not accepted when the latest user turn only asks to read, inspect, search, explain, or summarize content, unless the latest user turn explicitly requests modification.

Diagnosis:

* reproduced on main with default no prewarm
* reproduced on PR #67 branch with prewarm off
* original PR #67 startup-prewarm smoke also observed the issue
* therefore this is a pre-existing tool-loop guardrail gap, not a KV/prefix-anchor/prewarm regression
* a filename containing a mutation-looking word is now ignored for intent classification by stripping path-like tokens and URLs before mutation-intent checks

Scope:

* guardrail only
* no deterministic routing
* no hardcoded file
* no sed-specific fix
* no broad exec_shell block
* no KV/prewarm change
* no prompt rewrite
* no tag/release change

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_command_request tests.test_config tests.test_shell_guardrails -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_llama_server_backend tests.test_runtime tests.test_config -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_kv_diag tests.test_native_chat_template -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_command_request -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Smoke:

* read-only local file turn followed by fresh web turn: Read then Web, no Edit, fixture unchanged
* explicit edit request: mutating Edit remains possible, fixture restored after smoke
* read README smoke: Read path preserved

Notes:

* PR #67 remains unmerged and blocked pending separate review after this fix.
* v0.0.1-rc2 tag/release is not modified.
* workdir/.miktex/ remains local cache and is not included.