### PR TITLE
Add v0.0.1-rc3 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc3-release-plan.md
+++ b/docs/releases/v0.0.1-rc3-release-plan.md
@@ -1,0 +1,71 @@
+# Orbit v0.0.1-rc3 Release Plan
+
+This is an operational plan only. Do not execute the tag or release commands
+until publication is explicitly confirmed.
+
+## Pre-Release Checks
+
+- `main` must point to the final commit that includes the RC3 release notes.
+- `git status --short` must be clean except for local untracked cache such as
+  `workdir/.miktex/`.
+- Full unit tests must pass.
+- `python3 -m compileall -q src tests scripts` must pass.
+- `git diff --check` must pass.
+- Minimum smoke must pass:
+  - default prewarm off/unset
+  - opt-in startup prewarm
+  - `ORBIT_KV_PREFIX_ANCHOR=off` kill switch
+  - read/list/web/fetch paths
+  - listing followed by file read evidence
+  - read-only local evidence followed by fresh web evidence
+  - explicit edit request still allowed
+
+## Tag Plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc3
+```
+
+Recommended type: annotated tag.
+
+Commands to run only after explicit release approval:
+
+```bash
+git tag -a v0.0.1-rc3 -m "Orbit v0.0.1-rc3"
+git push origin v0.0.1-rc3
+```
+
+## GitHub Release Plan
+
+- Title: `Orbit v0.0.1-rc3`
+- Body: `docs/releases/v0.0.1-rc3.md`
+- Prerelease: yes
+- Latest: no, if supported by the GitHub release command used
+- Attachments: none
+- Do not attach cache, local artifacts, benchmark scratch files, or workdir
+  contents.
+
+## Rollback And Runtime Configuration
+
+If startup prewarm causes unacceptable startup latency or memory pressure:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+If route prefix-anchor itself needs to be disabled:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`ORBIT_KV_PREFIX_ANCHOR=off` also disables startup prewarm.
+
+## Release Safety Notes
+
+- `v0.0.1-rc2` must remain unchanged.
+- Do not modify existing tags.
+- Do not modify the existing GitHub Release for `v0.0.1-rc2`.
+- Do not publish RC3 until explicitly approved.

--- a/docs/releases/v0.0.1-rc3.md
+++ b/docs/releases/v0.0.1-rc3.md
@@ -1,0 +1,228 @@
+# Orbit v0.0.1-rc3 Release Notes
+
+## Summary
+
+Orbit v0.0.1-rc3 collects the post-RC2 safety fixes, diagnostics, and bounded
+native backend improvements that landed after `v0.0.1-rc2`.
+
+The focus areas are:
+
+- evidence safety
+- read-only tool guardrails
+- first-turn tools-on prefill analysis
+- native route prefix prefill-only infrastructure
+- opt-in startup route prefix prewarm
+
+RC3 keeps Orbit model-guided. It does not change prompts, routing policy, tool
+selection policy, final-answer policy, or file/web/fetch evidence policy.
+
+## Highlights
+
+### Read-Only Mutation Guardrail
+
+Post-RC2 smoke testing found a read-only safety gap: a turn that asked only to
+inspect local file content could also produce a mutating shell command.
+
+The issue was already present on `main`. It was not caused by KV prefix-anchor,
+startup prewarm, or the PR that introduced startup prewarm.
+
+RC3 adds a pre-execution guardrail:
+
+- read-only turns do not accept mutating tools such as edit, write, replace,
+  append, delete, or mutating shell commands;
+- mutating tools remain available when the latest user turn explicitly requests
+  a modification;
+- the guardrail is generic and does not hardcode a fixture path or a specific
+  shell utility;
+- the runtime does not choose a replacement command or route deterministically.
+
+The loop remains model-guided. The runtime only rejects a tool action that is
+incompatible with the latest user turn.
+
+### File Evidence After Listing
+
+RC3 also includes the post-RC2 fix for listing-to-file evidence ambiguity.
+
+After a directory listing, a later request to read and explain a specific file
+must use real file content evidence. A directory listing is not file-content
+evidence.
+
+If the model tries to close with a direct final answer without valid content
+evidence, the runtime rejects that completion and lets the normal model-guided
+tool loop continue.
+
+### Startup Route Prefix Prewarm, Opt-In
+
+RC3 introduces opt-in startup prewarm for the native route tools-on prefix.
+
+Configuration:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off      # default
+ORBIT_KV_PREFIX_PREWARM=startup  # opt-in synchronous startup prewarm
+```
+
+Startup prewarm:
+
+- uses the internal native prefill-only hook;
+- applies only to the native backend;
+- applies only to the stable route tools-on prefix;
+- does not implement a system prompt anchor;
+- does not implement multiple anchors;
+- does not generate or sample model output during prewarm;
+- is disabled when `ORBIT_KV_PREFIX_ANCHOR=off`;
+- falls back to the baseline route/capture path if prewarm fails.
+
+Observed on the tested CPU-only Gemma 4 12B setup:
+
+```text
+without startup prewarm:
+  first tools-on cold route: cached/evaluated = 4/746
+  first request wall time:   about 70s
+
+with startup prewarm:
+  startup prewarm time:      about 53s
+  checkpoint size:           about 238 MB
+  first real route:          cached/evaluated = 697/53
+  first request wall time:   about 17s
+```
+
+The cost does not disappear. It moves from the first user prompt to startup.
+This is useful only when that startup tradeoff is acceptable.
+
+It is like warming the oven before baking bread: the oven still needs time to
+reach temperature, but the first bake no longer starts from cold.
+
+### Native Prefill-Only Infrastructure
+
+The startup prewarm work was staged through reviewed native infrastructure:
+
+- an isolated native route prefix prefill-only probe;
+- the internal `NativeLlamaClient.capture_route_prefix_prefill_only(...)` hook;
+- metadata-only result reporting;
+- mocked tests for skip, success, failure, lock, and content-free diagnostics.
+
+The probe and hook confirmed:
+
+- `sampled_tokens=0`
+- `generated_tokens=0`
+- `sampler_touched=false`
+- `session_history_touched=false`
+- `restore_ready=true` on success
+
+The hook is not a general agent feature and is not a public user-facing API.
+RC3 uses it only for the explicit `ORBIT_KV_PREFIX_PREWARM=startup` mode.
+
+### Preserved Invariants
+
+RC3 preserves these invariants:
+
+- no prompt changes
+- no routing policy changes
+- no tool selection policy changes
+- no final-answer policy changes
+- no evidence policy weakening
+- no deterministic task routing
+- no system prompt anchor
+- no multiple anchors
+- no RC2 tag or GitHub Release modification
+
+## Configuration
+
+Route prefix-anchor remains auto by default:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=auto
+```
+
+When unset, Orbit behaves as `auto`.
+
+Kill switch:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Startup prewarm remains off by default:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Opt-in startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=startup
+```
+
+`ORBIT_KV_PREFIX_ANCHOR=off` disables route prefix-anchor and also disables
+startup prewarm, even when `ORBIT_KV_PREFIX_PREWARM=startup` is set.
+
+Non-native compatibility backends do not use startup prewarm.
+
+## Validation
+
+Core checks:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Targeted and smoke validation covered:
+
+- full unittest suite
+- native prefix-anchor tests
+- native prefill-only probe tests
+- native server bootstrap tests
+- runtime tool-loop tests
+- read/list/web/fetch paths
+- local evidence followed by fresh web evidence
+- listing followed by file read evidence
+- read-only local evidence followed by fresh web evidence
+- explicit edit requests
+- startup prewarm success path
+- startup prewarm kill switch
+
+Web results can still depend on network and provider behavior. The validation
+checks the Orbit tool path and evidence handling, not the availability of a
+specific upstream answer.
+
+## Known Limitations
+
+- Startup prewarm is opt-in.
+- Startup prewarm delayed readiness by about 50-60 seconds in the tested setup.
+- The checkpoint memory cost was about 238 MB in the tested setup.
+- The benefit targets the first eligible route tools-on call after startup
+  prewarm, not every request.
+- Tool execution, web providers, file reads, and generation speed are not made
+  faster by prewarm.
+- System prompt anchor is not implemented.
+- Background prewarm is not implemented.
+- Automatic `/tools on` prewarm is not implemented.
+- Non-native compatibility backends do not use startup prewarm.
+
+## Upgrade Notes
+
+If you want the current behavior, do nothing. Startup prewarm is off by default.
+
+To try startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=startup
+```
+
+To disable route prefix-anchor entirely:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`v0.0.1-rc2` remains unchanged. RC3 is intended as a new prerelease containing
+the post-RC2 safety fixes, analysis, infrastructure, and opt-in startup prewarm.
+
+## Release Status
+
+These release notes prepare Orbit v0.0.1-rc3. They do not publish RC3, create a
+tag, modify a tag, or create a GitHub Release.


### PR DESCRIPTION
This PR prepares release notes and a publication plan for Orbit v0.0.1-rc3.

Scope:

* adds RC3 release notes
* adds RC3 release plan
* docs-only
* no runtime changes
* no prompt/config changes
* no tag/release changes

Highlights:

* read-only mutation guardrail
* file content evidence after listing
* native route prefix prefill-only infrastructure
* opt-in startup route prefix prewarm
* ORBIT_KV_PREFIX_PREWARM=startup
* startup prewarm remains opt-in and default off

Validation:

* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Notes:

* v0.0.1-rc2 remains unchanged.
* v0.0.1-rc3 is not published by this PR.
* No tags are created or modified.