### PR TITLE
Enable tools and startup route prewarm by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Minimal local CLI for running Gemma 4 with the native `orbit server` backend.
 
-Orbit is designed for local execution, streaming output, optional shell tools, and a simple terminal workflow. The normal setup uses Orbit's native backend and does not require an external `llama-server` process at runtime.
+Orbit is designed for local execution, streaming output, shell tools, and a simple terminal workflow. The normal setup uses Orbit's native backend and does not require an external `llama-server` process at runtime.
 
 The native backend still depends on native libraries derived from `llama.cpp`/`ggml`, built either from Orbit's vendored sources or from a documented developer fallback such as `--llama-root`. Zero-build packaging remains future work. See [docs/NATIVE_PACKAGING_ROADMAP.md](docs/NATIVE_PACKAGING_ROADMAP.md).
 
@@ -12,7 +12,7 @@ Linux is the main target environment. macOS may work. Windows is not a target en
 
 - chats with a local model through a small terminal CLI
 - streams answers and runtime metrics
-- exposes unrestricted local shell only when `/tools on` is enabled
+- exposes unrestricted local shell tools by default, with explicit `/tools off`, `--tools off`, or `ORBIT_TOOLS=off` controls
 - keeps the tool loop model-driven
 - supports local image and audio input when the backend is started with multimodal support
 - supports native MTP when target and draft models are available
@@ -112,6 +112,28 @@ Stable default server, with MTP disabled:
 
 ```bash
 orbit server
+```
+
+By default, the native server performs startup route-prefix prewarm for the
+tools-on route prefix. This shifts the first tools-on route prefill cost to
+startup. To disable only startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off orbit server
+```
+
+To disable route prefix-anchor and prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off orbit server
+```
+
+The terminal client starts with tools enabled by default. To start without local
+shell tools:
+
+```bash
+ORBIT_TOOLS=off orbit
+orbit --tools off "hello"
 ```
 
 To get a reasonable CPU/RAM starting profile, you can first run `scripts/suggest-server-profile.sh`; it checks local CPU and RAM and prints conservative environment-variable suggestions to review before export.

--- a/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
+++ b/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
@@ -5,16 +5,20 @@
 This document describes the first controlled runtime integration for native route
 prefix prewarm.
 
-The feature is opt-in and does not change default runtime behavior.
+The feature now runs by default when the native server starts with tools enabled.
+It can still be disabled explicitly.
 
 ```bash
-ORBIT_KV_PREFIX_PREWARM=off      # default
-ORBIT_KV_PREFIX_PREWARM=startup  # opt-in synchronous startup prewarm
+ORBIT_KV_PREFIX_PREWARM=startup  # default synchronous startup prewarm
+ORBIT_KV_PREFIX_PREWARM=off      # disable startup prewarm
 ```
 
 `ORBIT_KV_PREFIX_ANCHOR=off` disables startup prewarm even when
-`ORBIT_KV_PREFIX_PREWARM=startup` is set. The legacy
-`ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` does not override `off`.
+`ORBIT_KV_PREFIX_PREWARM=startup` is set or the prewarm variable is unset. The
+legacy `ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT=1` does not override `off`.
+
+`ORBIT_TOOLS=off` disables startup route tools-on prewarm because there is no
+tools-on route prefix to prepare for startup.
 
 Invalid `ORBIT_KV_PREFIX_PREWARM` values fall back to `off`.
 
@@ -40,7 +44,6 @@ No model response is generated during prewarm.
 
 Startup prewarm does not introduce:
 
-- automatic default prewarm
 - background prewarm
 - `/tools on` lifecycle integration
 - `/chat` or `/chat/stream` integration
@@ -59,8 +62,8 @@ Startup prewarm does not introduce:
 
 ## Lifecycle
 
-`ORBIT_KV_PREFIX_PREWARM=startup` runs after the native model/client is loaded and
-before the HTTP server starts serving requests.
+`ORBIT_KV_PREFIX_PREWARM=startup` runs after the native model/client is loaded
+and before the HTTP server starts serving requests.
 
 This location is intentional:
 
@@ -79,7 +82,8 @@ observed around 49-59 seconds.
 
 Startup prewarm is eligible only when:
 
-- `ORBIT_KV_PREFIX_PREWARM=startup`
+- `ORBIT_KV_PREFIX_PREWARM` is unset or `startup`
+- tools are enabled for startup
 - `ORBIT_KV_PREFIX_ANCHOR` is not `off`
 - native backend/client is loaded
 - route prefix-anchor support is available
@@ -87,8 +91,9 @@ Startup prewarm is eligible only when:
 
 It is skipped when:
 
-- `ORBIT_KV_PREFIX_PREWARM` is unset or `off`
+- `ORBIT_KV_PREFIX_PREWARM=off`
 - `ORBIT_KV_PREFIX_PREWARM` has an unrecognized value
+- `ORBIT_TOOLS=off`
 - `ORBIT_KV_PREFIX_ANCHOR=off`
 - a native client request/context is already active
 - the prefix-anchor hook reports an ineligible state
@@ -117,6 +122,8 @@ When `ORBIT_KV_DIAG=1` is enabled, startup prewarm emits metadata only:
 
 - `prewarm_enabled`
 - `prewarm_mode`
+- `tools_default_enabled`
+- `tools_startup_enabled`
 - `prewarm_attempted`
 - `prewarm_succeeded`
 - `prewarm_skipped_reason`
@@ -147,10 +154,11 @@ cache tool results, file contents, web results, PDF contents, or user history.
 
 Required validation for this integration:
 
-- default/unset `ORBIT_KV_PREFIX_PREWARM` does not prewarm
+- default/unset `ORBIT_KV_PREFIX_PREWARM` prewarms when tools are enabled
 - `ORBIT_KV_PREFIX_PREWARM=off` does not prewarm
 - `ORBIT_KV_PREFIX_PREWARM=startup` invokes the native prefill-only hook
 - `ORBIT_KV_PREFIX_ANCHOR=off` skips startup prewarm
+- `ORBIT_TOOLS=off` skips startup prewarm
 - invalid prewarm values fall back to `off`
 - hook success yields `restore_ready=true`
 - hook failure leaves the server usable with `restore_ready=false`

--- a/docs/STARTUP_TOOLS_ON_AND_PREWARM_DEFAULT.md
+++ b/docs/STARTUP_TOOLS_ON_AND_PREWARM_DEFAULT.md
@@ -1,0 +1,147 @@
+# Startup Tools-On And Prewarm Defaults
+
+## Summary
+
+Orbit now starts in an agentic-ready default mode:
+
+- tools are enabled by default;
+- native route tools-on prefix prewarm is enabled by default at server startup;
+- explicit configuration can disable either behavior.
+
+This changes startup posture, not model policy. Orbit remains model-guided and
+does not add deterministic routing, system prompt anchors, or multiple anchors.
+
+## Tools Default
+
+Default:
+
+```bash
+ORBIT_TOOLS=on
+```
+
+When `ORBIT_TOOLS` is unset, Orbit behaves as tools-on.
+
+Disable tools for startup/session defaults:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+CLI and interactive controls remain available:
+
+```bash
+orbit --tools off "prompt"
+/tools off
+/tools on
+```
+
+`/tools off` still disables tools in the current interactive session. `/tools
+on` still re-enables them.
+
+## Startup Route Prefix Prewarm Default
+
+Default:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=startup
+```
+
+When `ORBIT_KV_PREFIX_PREWARM` is unset, native `orbit server` performs startup
+prewarm for the stable route tools-on prefix, provided tools are enabled and the
+route prefix-anchor is not disabled.
+
+Disable startup prewarm only:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+If tools are disabled at startup with `ORBIT_TOOLS=off`, route tools-on prewarm
+is skipped.
+
+## Scope
+
+Startup prewarm is limited to:
+
+- native backend only;
+- route tools-on prefix only;
+- the existing native prefill-only hook;
+- metadata-only diagnostics.
+
+It does not implement:
+
+- system prompt anchor;
+- chat-final anchor;
+- final-from-tool anchor;
+- tool-call anchor;
+- multiple anchors;
+- prompt changes;
+- routing policy changes;
+- tool selection policy changes;
+- final-answer policy changes;
+- file/web/fetch evidence-policy changes.
+
+Non-native compatibility backends do not use startup prewarm.
+
+## Tradeoff
+
+Startup prewarm does not remove the prefill cost. It moves that cost from the
+first tools-on request to server startup.
+
+Observed on the tested CPU-only Gemma 4 12B setup:
+
+- startup prewarm cost: about 50-60 seconds;
+- checkpoint size: about 238 MB;
+- first tools-on cold request without prewarm: about 70 seconds;
+- first tools-on request after startup prewarm: about 17 seconds.
+
+It is like warming the oven before baking bread: the oven still needs time to
+reach temperature, but the first bake no longer starts from cold.
+
+## Failure And Fallback
+
+If startup prewarm fails:
+
+- the server remains usable;
+- no user-facing error is required;
+- the next real route call falls back to the baseline capture path;
+- checkpoint state is valid only after complete prewarm success.
+
+`ORBIT_KV_DIAG=1` reports metadata such as:
+
+- `tools_default_enabled`
+- `tools_startup_enabled`
+- `prewarm_enabled`
+- `prewarm_mode`
+- `prewarm_attempted`
+- `prewarm_succeeded`
+- `prewarm_skipped_reason`
+- `prewarm_failed_reason`
+- `prewarm_prefix_token_count`
+- `prewarm_checkpoint_size_bytes`
+- `prewarm_ms`
+- `restore_ready`
+
+Diagnostics must not include raw prompt text, raw tokens, user content, tool
+output, file content, or web content.
+
+## Validation Expectations
+
+Required validation for changes in this area:
+
+- default tools-on path;
+- explicit tools-off path;
+- default startup prewarm path;
+- explicit prewarm-off path;
+- `ORBIT_KV_PREFIX_ANCHOR=off` kill switch;
+- read/list/web/fetch regressions;
+- listing followed by file read evidence;
+- read-only local evidence followed by fresh web evidence;
+- explicit edit remains possible;
+- no system prompt anchor or multi-anchor behavior.

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -160,6 +160,8 @@ def emit_route_prefix_prewarm_event(metadata: dict[str, Any]) -> None:
         return
     event = {
         "event": "kv_diag_route_prefix_prewarm",
+        "tools_default_enabled": bool(metadata.get("tools_default_enabled")),
+        "tools_startup_enabled": bool(metadata.get("tools_startup_enabled")),
         "prewarm_enabled": bool(metadata.get("prewarm_enabled")),
         "prewarm_mode": _safe_str(metadata.get("prewarm_mode")),
         "prewarm_attempted": bool(metadata.get("prewarm_attempted")),

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -44,6 +44,7 @@ DEFAULT_ALIAS = "gemma4:12b-it-native"
 PREFIX_PREWARM_ENV = "ORBIT_KV_PREFIX_PREWARM"
 PREFIX_PREWARM_OFF = "off"
 PREFIX_PREWARM_STARTUP = "startup"
+TOOLS_ENV = "ORBIT_TOOLS"
 
 
 class OrbitNativeServer:
@@ -590,23 +591,38 @@ def run_server(argv: list[str] | None = None) -> int:
 
 def route_prefix_prewarm_mode(environ: Mapping[str, str] | None = None) -> str:
     env = os.environ if environ is None else environ
-    value = env.get(PREFIX_PREWARM_ENV, PREFIX_PREWARM_OFF).strip().lower()
-    if value in {"", PREFIX_PREWARM_OFF}:
+    value = env.get(PREFIX_PREWARM_ENV, PREFIX_PREWARM_STARTUP).strip().lower()
+    if value == PREFIX_PREWARM_OFF:
         return PREFIX_PREWARM_OFF
-    if value == PREFIX_PREWARM_STARTUP:
+    if value in {"", PREFIX_PREWARM_STARTUP}:
         return PREFIX_PREWARM_STARTUP
     return PREFIX_PREWARM_OFF
 
 
+def tools_startup_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    env = os.environ if environ is None else environ
+    value = env.get(TOOLS_ENV, "on").strip().lower()
+    if value == "on":
+        return True
+    if value == "off":
+        return False
+    return False
+
+
 def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefixPrefillResult:
     mode = route_prefix_prewarm_mode()
+    tools_enabled = tools_startup_enabled()
     if mode != PREFIX_PREWARM_STARTUP:
         result = _startup_prewarm_skipped("disabled")
-        _emit_startup_prewarm_diag(mode=mode, result=result)
+        _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
+        return result
+    if not tools_enabled:
+        result = _startup_prewarm_skipped("tools_disabled")
+        _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
         return result
     if not prefix_anchor_enabled():
         result = _startup_prewarm_skipped("anchor_disabled")
-        _emit_startup_prewarm_diag(mode=mode, result=result)
+        _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
         return result
     try:
         segments = render_gemma4_route_prompt_segments(
@@ -622,7 +638,7 @@ def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefix
             failed_reason=f"startup_prewarm_failed:{type(exc).__name__}",
             restore_ready=False,
         )
-    _emit_startup_prewarm_diag(mode=mode, result=result)
+    _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
     return result
 
 
@@ -640,10 +656,12 @@ def _startup_prewarm_skipped(reason: str) -> NativeRoutePrefixPrefillResult:
     )
 
 
-def _emit_startup_prewarm_diag(*, mode: str, result: NativeRoutePrefixPrefillResult) -> None:
+def _emit_startup_prewarm_diag(*, mode: str, tools_enabled: bool, result: NativeRoutePrefixPrefillResult) -> None:
     emit_route_prefix_prewarm_event(
         {
-            "prewarm_enabled": mode == PREFIX_PREWARM_STARTUP,
+            "tools_default_enabled": tools_startup_enabled({}),
+            "tools_startup_enabled": tools_enabled,
+            "prewarm_enabled": mode == PREFIX_PREWARM_STARTUP and tools_enabled,
             "prewarm_mode": mode,
             "prewarm_attempted": result.attempted,
             "prewarm_succeeded": result.succeeded,

--- a/src/orbit/terminal/config.py
+++ b/src/orbit/terminal/config.py
@@ -19,7 +19,8 @@ MIN_MAX_TOKENS = 32
 MAX_MAX_TOKENS = 4096
 MIN_CONTEXT_TOKENS = 512
 MAX_CONTEXT_TOKENS = 262_144
-DEFAULT_TOOLS = "off"
+DEFAULT_TOOLS = "on"
+TOOLS_ENV = "ORBIT_TOOLS"
 MARKDOWN_RENDER_MODES = {"plain", "live"}
 
 
@@ -224,10 +225,22 @@ def _bool_value_or_spec(values: dict[str, Any], key: str, default: bool) -> bool
 
 
 def _tool_spec_value(values: dict[str, Any]) -> ToolSpec:
-    value = values.get("tool_mode", values.get("tools", DEFAULT_TOOLS))
+    env_value = os.environ.get(TOOLS_ENV)
+    if env_value is not None:
+        return _tool_spec_from_env(env_value)
+    value = values.get("tool_mode", values.get("tools"))
+    if value is None:
+        value = DEFAULT_TOOLS
     if isinstance(value, dict):
         value = DEFAULT_TOOLS
     return normalize_tool_spec(value, key="tool_mode")
+
+
+def _tool_spec_from_env(value: str) -> ToolSpec:
+    try:
+        return normalize_tool_spec(value, key=TOOLS_ENV)
+    except ValueError:
+        return "off"
 
 
 def _markdown_mode_value(values: dict[str, Any]) -> str:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -48,6 +48,13 @@ class Repl:
             self.history.load()
         print(dim("orbit interactive mode. Type /help for commands."))
         print(dim(f"tools: {self.tools_mode}"))
+        if tools_are_enabled(self.tools_mode or "off"):
+            print(
+                danger(
+                    "warning: tools on gives the model unrestricted local shell access. Commands may read, modify, delete files, execute programs, or access network. "
+                    "Use only in an isolated lab."
+                )
+            )
         print(dim(f"think: {'on' if self.config.think else 'off'}"))
         if has_existing_session_context(self.runtime.messages):
             print(dim("recent session context:"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("", "/tools")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("tools: off", completed.stdout)
+        self.assertIn("tools: on", completed.stdout)
         self.assertIn("/tools off = chat only", completed.stdout)
         self.assertIn("/tools on  = unrestricted local shell", completed.stdout)
         self.assertNotIn("/tools files", completed.stdout)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,8 +110,30 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.workdir, Path(".").resolve())
         self.assertEqual(config.max_tokens, 512)
         self.assertIsNone(config.context_tokens)
-        self.assertEqual(config.tools, "off")
+        self.assertEqual(config.tools, "on")
         self.assertEqual(config.render_markdown, "live")
+
+    def test_orbit_tools_env_can_disable_default_tools(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_TOOLS": "off"}):
+            config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json"))
+
+        self.assertEqual(config.tools, "off")
+
+    def test_invalid_orbit_tools_env_falls_back_to_off(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_TOOLS": "browser"}):
+            config = load_app_config(_parse("--config", "/tmp/orbit-missing-config.json"))
+
+        self.assertEqual(config.tools, "off")
+
+    def test_orbit_tools_env_overrides_config_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            path.write_text(json.dumps({"tools": "on"}), encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"ORBIT_TOOLS": "off"}):
+                config = load_app_config(_parse("--config", str(path)))
+
+        self.assertEqual(config.tools, "off")
 
     def test_config_file_sets_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -231,7 +253,7 @@ class ConfigTests(unittest.TestCase):
 
             config = load_app_config(_parse("--config", str(path)))
 
-        self.assertEqual(config.tools, "off")
+        self.assertEqual(config.tools, "on")
 
     def test_legacy_model_config_key_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -18,6 +18,7 @@ from orbit.native_server.app import (
     resolve_bootstrap_paths,
     route_prefix_prewarm_mode,
     run_server,
+    tools_startup_enabled,
 )
 
 
@@ -166,24 +167,39 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
         self.assertEqual(args.port, 12120)
 
-    def test_route_prefix_prewarm_defaults_to_off(self) -> None:
-        self.assertEqual(route_prefix_prewarm_mode({}), PREFIX_PREWARM_OFF)
+    def test_route_prefix_prewarm_defaults_to_startup(self) -> None:
+        self.assertEqual(route_prefix_prewarm_mode({}), PREFIX_PREWARM_STARTUP)
 
     def test_route_prefix_prewarm_accepts_startup(self) -> None:
         self.assertEqual(route_prefix_prewarm_mode({"ORBIT_KV_PREFIX_PREWARM": "startup"}), PREFIX_PREWARM_STARTUP)
+
+    def test_route_prefix_prewarm_accepts_off(self) -> None:
+        self.assertEqual(route_prefix_prewarm_mode({"ORBIT_KV_PREFIX_PREWARM": "off"}), PREFIX_PREWARM_OFF)
 
     def test_route_prefix_prewarm_invalid_value_falls_back_to_off(self) -> None:
         self.assertEqual(route_prefix_prewarm_mode({"ORBIT_KV_PREFIX_PREWARM": "soon"}), PREFIX_PREWARM_OFF)
 
     @mock.patch.dict("os.environ", {}, clear=True)
-    def test_startup_prewarm_default_off_skips_without_capture(self) -> None:
+    def test_tools_startup_enabled_defaults_to_true(self) -> None:
+        self.assertTrue(tools_startup_enabled())
+
+    @mock.patch.dict("os.environ", {"ORBIT_TOOLS": "off"}, clear=True)
+    def test_tools_startup_enabled_accepts_off(self) -> None:
+        self.assertFalse(tools_startup_enabled())
+
+    @mock.patch.dict("os.environ", {"ORBIT_TOOLS": "browser"}, clear=True)
+    def test_tools_startup_enabled_invalid_value_falls_back_to_false(self) -> None:
+        self.assertFalse(tools_startup_enabled())
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_startup_prewarm_default_invokes_native_hook(self) -> None:
         client = _FakeNativeClient()
 
         result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
 
-        self.assertTrue(result.skipped)
-        self.assertEqual(result.skip_reason, "disabled")
-        self.assertEqual(client.capture_calls, 0)
+        self.assertTrue(result.succeeded)
+        self.assertTrue(result.restore_ready)
+        self.assertEqual(client.capture_calls, 1)
 
     @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
     def test_startup_prewarm_explicit_off_skips_without_capture(self) -> None:
@@ -193,6 +209,16 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
         self.assertTrue(result.skipped)
         self.assertEqual(result.skip_reason, "disabled")
+        self.assertEqual(client.capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_TOOLS": "off"}, clear=True)
+    def test_startup_prewarm_tools_off_skips_without_capture(self) -> None:
+        client = _FakeNativeClient()
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "tools_disabled")
         self.assertEqual(client.capture_calls, 0)
 
     @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
@@ -327,25 +353,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertIn("--llama-root", output)
 
     @mock.patch.dict("os.environ", {}, clear=True)
-    def test_run_server_default_does_not_startup_prewarm(self) -> None:
-        _FakeNativeClient.instances.clear()
-        _FakeHTTPServer.instances.clear()
-        with (
-            mock.patch("orbit.native_server.app.resolve_bootstrap_paths", return_value=SimpleNamespace()),
-            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
-            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
-            mock.patch("sys.stdout", new_callable=io.StringIO),
-        ):
-            code = run_server([])
-
-        self.assertEqual(code, 0)
-        self.assertEqual(len(_FakeNativeClient.instances), 1)
-        self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 0)
-        self.assertTrue(_FakeNativeClient.instances[0].closed)
-        self.assertTrue(_FakeHTTPServer.instances[0].closed)
-
-    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
-    def test_run_server_startup_prewarm_invokes_hook_before_serving(self) -> None:
+    def test_run_server_default_startup_prewarm_invokes_hook_before_serving(self) -> None:
         _FakeNativeClient.instances.clear()
         _FakeHTTPServer.instances.clear()
         with (
@@ -359,6 +367,24 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(len(_FakeNativeClient.instances), 1)
         self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 1)
+        self.assertTrue(_FakeNativeClient.instances[0].closed)
+        self.assertTrue(_FakeHTTPServer.instances[0].closed)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_run_server_explicit_prewarm_off_skips_hook(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths", return_value=SimpleNamespace()),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(_FakeNativeClient.instances), 1)
+        self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 0)
         self.assertIsNotNone(_FakeHTTPServer.instances[0].orbit_state)
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -154,7 +154,8 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(code, 0)
         output = stdout.getvalue()
         self.assertIn("\033[2morbit interactive mode. Type /help for commands.\033[0m", output)
-        self.assertIn("\033[2mtools: off\033[0m", output)
+        self.assertIn("\033[2mtools: on\033[0m", output)
+        self.assertIn("warning: tools on", output)
         self.assertIn("recent session context:", output)
         self.assertIn("user: first question", output)
         self.assertIn("assistant: first answer", output)
@@ -182,7 +183,7 @@ class ReplTests(unittest.TestCase):
         repl = Repl(
             runtime=runtime,
             backend=backend,
-            config=AppConfig(workdir=Path(".")),
+            config=AppConfig(workdir=Path("."), tools="off"),
         )
         before = list(runtime.messages)
         stdout = io.StringIO()
@@ -579,9 +580,20 @@ class ReplTests(unittest.TestCase):
         self.assertTrue(repl.can_continue)
         self.assertIn("/continue", stdout.getvalue())
 
-    def test_tools_are_off_by_default_and_chat_path_is_used(self) -> None:
+    def test_tools_are_on_by_default_and_auto_path_is_used(self) -> None:
         runtime = CountingRuntime()
         repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            repl._ask("hello")
+
+        self.assertEqual(repl.tools_mode, "on")
+        self.assertEqual(runtime.ask_auto_calls, 1)
+        self.assertEqual(runtime.ask_chat_calls, 0)
+
+    def test_explicit_tools_off_uses_chat_path(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path("."), tools="off"))
 
         with contextlib.redirect_stdout(io.StringIO()):
             repl._ask("hello")
@@ -622,7 +634,7 @@ class ReplTests(unittest.TestCase):
         runtime = CountingRuntime()
         repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
 
-        self.assertIn("tools: off", repl._handle_tools_command("/tools"))
+        self.assertIn("tools: on", repl._handle_tools_command("/tools"))
         tools_on = repl._handle_tools_command("/tools on")
         self.assertIn("tools: on", tools_on)
         self.assertIn("warning: tools on", tools_on)


### PR DESCRIPTION
This PR makes Orbit server start in tools-on mode by default and enables startup route prefix prewarm by default.

Behavior:

* tools are enabled by default
* unset ORBIT_KV_PREFIX_PREWARM behaves like startup
* ORBIT_KV_PREFIX_PREWARM=startup remains explicit
* ORBIT_KV_PREFIX_PREWARM=off disables startup prewarm
* ORBIT_KV_PREFIX_ANCHOR=off disables anchor and prewarm
* backend non-native remains unsupported/skipped
* only the route tools-on prefix is prewarmed
* ORBIT_TOOLS=off and --tools off remain explicit ways to start without tools

Scope:

* no prompt changes
* no routing/tool/final/evidence policy changes
* no system prompt anchor
* no multi-anchor
* no tag/release changes

Tradeoff:

* startup is slower by about 50-60s in the tested setup
* first real tools-on route avoids cold route prefill
* checkpoint memory remains about 238 MB
* the cost is shifted to startup, not removed

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_native_server_bootstrap tests.test_kv_diag tests.test_config tests.test_runtime -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_prefix_anchor tests.test_prefix_anchor_probe tests.test_llama_server_backend tests.test_runtime tests.test_config -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_native_bindings tests.test_kv_diag tests.test_native_chat_template -q: PASS
* PYTHONPATH=src python3 -m unittest tests.test_payloads tests.test_native_server_protocol tests.test_native_server_think tests.test_command_request -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS
* default tools-on + startup prewarm smoke PASS
* explicit prewarm off smoke PASS
* anchor off smoke PASS
* tools off smoke PASS
* read/list/web/fetch regressions PASS
* read-only mutation guardrail PASS
* explicit edit still allowed PASS

Notes:

* v0.0.1-rc3 tag/release is not modified.
* workdir/.miktex/ remains local cache and is not included.