### PR TITLE
Add v0.0.1-rc4 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc4-release-plan.md
+++ b/docs/releases/v0.0.1-rc4-release-plan.md
@@ -1,0 +1,82 @@
+# Orbit v0.0.1-rc4 Release Plan
+
+This is an operational plan only. Do not execute the tag or release commands
+until publication is explicitly confirmed.
+
+## Pre-Release Checks
+
+- `main` must point to the final commit that includes the RC4 release notes.
+- `git status --short` must be clean except for local untracked cache such as
+  `workdir/.miktex/`.
+- Full unit tests must pass.
+- `python3 -m compileall -q src tests scripts` must pass.
+- `git diff --check` must pass.
+- Minimum smoke should pass if requested:
+  - default environment absent: tools on and startup prewarm enabled
+  - `ORBIT_KV_PREFIX_PREWARM=off`
+  - `ORBIT_KV_PREFIX_ANCHOR=off`
+  - `ORBIT_TOOLS=off`
+  - `--tools off`
+  - `/tools off` and `/tools on`
+  - read/list/web/fetch paths
+  - listing followed by file read evidence
+  - read-only local evidence followed by fresh web evidence
+  - explicit edit request still allowed
+
+## Tag Plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc4
+```
+
+Recommended type: annotated tag.
+
+Commands to run only after explicit release approval:
+
+```bash
+git tag -a v0.0.1-rc4 -m "Orbit v0.0.1-rc4"
+git push origin v0.0.1-rc4
+```
+
+## GitHub Release Plan
+
+- Title: `Orbit v0.0.1-rc4`
+- Body: `docs/releases/v0.0.1-rc4.md`
+- Prerelease: yes
+- Latest: no, if supported by the GitHub release command used
+- Attachments: none
+- Do not attach cache, local artifacts, benchmark scratch files, or workdir
+  contents.
+
+## Rollback And Runtime Configuration
+
+Disable tools at server startup:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+Disable startup prewarm only:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`--tools off` and `/tools off` remain useful for client/session tool mode, but
+they do not necessarily prevent a startup prewarm that has already happened in
+the server.
+
+## Release Safety Notes
+
+- `v0.0.1-rc3` must remain unchanged.
+- Do not modify existing tags.
+- Do not modify any existing GitHub Release.
+- Do not publish RC4 until explicitly approved.

--- a/docs/releases/v0.0.1-rc4.md
+++ b/docs/releases/v0.0.1-rc4.md
@@ -1,0 +1,224 @@
+# Orbit v0.0.1-rc4 Release Notes
+
+## Summary
+
+Orbit v0.0.1-rc4 contains the post-RC3 default change that makes the native
+server start in a more agentic-ready posture:
+
+- tools are enabled by default;
+- native startup route-prefix prewarm is enabled by default;
+- tools and prewarm can still be disabled explicitly;
+- `v0.0.1-rc3` remains unchanged.
+
+RC4 does not change prompts, routing policy, tool selection policy, final-answer
+policy, or file/web/fetch evidence policy.
+
+## Highlights
+
+### Tools On By Default
+
+Orbit now starts with tools enabled by default. The intent is to make the native
+server ready for local tool use without requiring an initial tools-on step.
+
+This is not deterministic routing. The model still decides whether to answer
+directly or use an available tool, and the tool selection policy is unchanged.
+
+Configuration:
+
+- default: tools on;
+- server-startup tools off: `ORBIT_TOOLS=off`;
+- client/session tools off: `--tools off`;
+- runtime toggles, when available: `/tools off` and `/tools on`.
+
+Important distinction: `--tools off` acts on the client/session path. It does
+not necessarily prevent a server startup prewarm that has already happened. To
+avoid route tools-on prewarm at server startup, use `ORBIT_TOOLS=off` or disable
+prewarm with `ORBIT_KV_PREFIX_PREWARM=off`.
+
+### Startup Route-Prefix Prewarm By Default
+
+Startup route-prefix prewarm is now enabled by default for eligible native
+server startup.
+
+The prewarmed prefix is the stable route tools-on prefix. It contains the route
+system/policy material, route contract, tool specs, capabilities, and route
+guardrails needed for the model-guided tools-on decision.
+
+The prewarm uses a real native KV checkpoint. It does not generate assistant
+content:
+
+- `sampled_tokens=0`;
+- `generated_tokens=0`;
+- no fake request;
+- no prompt workaround;
+- no system prompt anchor;
+- no multiple anchors.
+
+Configuration:
+
+- unset `ORBIT_KV_PREFIX_PREWARM` behaves like startup prewarm;
+- `ORBIT_KV_PREFIX_PREWARM=startup` keeps startup prewarm explicit;
+- `ORBIT_KV_PREFIX_PREWARM=off` disables only startup prewarm;
+- `ORBIT_KV_PREFIX_ANCHOR=off` disables route prefix-anchor and startup prewarm.
+
+Startup prewarm remains native-backend-only and route-tools-on-prefix-only.
+Non-native compatibility backends do not use it.
+
+### Tradeoff
+
+Startup prewarm does not remove the prefill cost. It moves that cost from the
+first user prompt to native server startup.
+
+Observed on the tested CPU-only Gemma 4 12B setup:
+
+```text
+without startup prewarm:
+  first tools-on cold route: cached/evaluated = 4/746
+  first request wall time:   about 70s
+
+with startup prewarm:
+  startup prewarm time:      about 50-60s
+  checkpoint size:           about 238 MB
+  first real route:          cached/evaluated = about 697/53
+  first request wall time:   about 17s
+```
+
+It is like warming the oven before baking bread: the oven still needs time to
+reach temperature, but the first bake no longer starts from cold.
+
+This tradeoff is useful when slower server readiness is acceptable in exchange
+for a faster first eligible tools-on route.
+
+### Preserved Behavior
+
+RC4 preserves these invariants:
+
+- no prompt changes;
+- no routing policy changes;
+- no tool selection policy changes;
+- no final-answer policy changes;
+- no evidence policy weakening;
+- no deterministic task routing;
+- no system prompt anchor;
+- no multiple anchors;
+- read/list/web/fetch behavior preserved;
+- read-only mutation guardrail preserved;
+- explicit edit requests remain possible.
+
+## Configuration Summary
+
+Defaults:
+
+- tools on;
+- startup prewarm on;
+- `ORBIT_KV_PREFIX_ANCHOR=auto`.
+
+Disable tools at server startup:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+Disable startup prewarm only:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Disable tools for a client/session:
+
+```bash
+orbit --tools off "hello"
+```
+
+Inside an interactive session:
+
+```text
+/tools off
+/tools on
+```
+
+`--tools off` and `/tools off` do not necessarily prevent startup prewarm that
+has already happened inside a running server. Use `ORBIT_TOOLS=off` or
+`ORBIT_KV_PREFIX_PREWARM=off` when the goal is to avoid startup prewarm.
+
+## Validation
+
+Core checks:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Post-merge validation for the RC4 behavior covered:
+
+- full unittest suite: PASS;
+- compileall: PASS;
+- `git diff --check`: PASS;
+- default environment absent smoke: PASS;
+- `ORBIT_KV_PREFIX_PREWARM=off` smoke: PASS;
+- `ORBIT_KV_PREFIX_ANCHOR=off` smoke: PASS;
+- `ORBIT_TOOLS=off` smoke: PASS;
+- `--tools off` smoke: PASS;
+- `/tools off` and `/tools on` smoke: PASS;
+- read/list/web/fetch regressions: PASS;
+- listing followed by file read: PASS;
+- read-only local evidence followed by fresh web: PASS;
+- explicit edit allowed: PASS;
+- simple direct answer remains possible: PASS.
+
+Web results can still depend on network and provider behavior. The validation
+checks Orbit's tool path and evidence handling, not the availability of a
+specific upstream answer.
+
+## Known Limitations
+
+- Startup is slower when startup prewarm is enabled.
+- The checkpoint cost was about 238 MB in the tested setup.
+- The main benefit is the first eligible route tools-on call after startup.
+- Tool execution, web providers, file reads, and generation speed are not made
+  faster by prewarm.
+- Web results can depend on network and provider behavior.
+- Background prewarm is not implemented.
+- Automatic `/tools on` prewarm is not implemented.
+- System prompt anchor is not implemented.
+- Multiple anchors are not implemented.
+- Non-native compatibility backends do not use startup prewarm.
+
+## Upgrade Notes
+
+RC4 changes the default behavior compared with RC3.
+
+If you want to avoid tools at server startup:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+If you want tools enabled but want to avoid startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+If you want to disable route prefix-anchor and startup prewarm entirely:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`v0.0.1-rc3` remains unchanged. RC4 is intended as a new prerelease for the
+post-RC3 default change.
+
+## Release Status
+
+These release notes prepare Orbit v0.0.1-rc4. They do not publish RC4, create a
+tag, modify a tag, or create a GitHub Release.


### PR DESCRIPTION
This PR prepares release notes and a publication plan for Orbit v0.0.1-rc4.

Scope:

* adds RC4 release notes
* adds RC4 release plan
* docs-only
* no runtime changes
* no prompt/config changes
* no tag/release changes

Highlights:

* tools on by default
* startup route-prefix prewarm by default
* ORBIT_TOOLS=off to disable tools at server startup
* ORBIT_KV_PREFIX_PREWARM=off to disable startup prewarm
* ORBIT_KV_PREFIX_ANCHOR=off to disable anchor/prewarm
* no system prompt anchor
* no multi-anchor
* no prompt/routing/tool/final/evidence policy changes

Validation:

* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS

Notes:

* v0.0.1-rc3 remains unchanged.
* v0.0.1-rc4 is not published by this PR.
* No tags are created or modified.