### PR TITLE
Stabilize native MTP restore and linkage

### DIFF
--- a/docs/MTP_STATE_MACHINE_ANALYSIS.md
+++ b/docs/MTP_STATE_MACHINE_ANALYSIS.md
@@ -1,0 +1,501 @@
+# MTP State Machine Analysis
+
+Status: analysis-only. No runtime, prompt, routing, tool-selection, final-policy,
+evidence-policy, KV, streaming, or MTP code changes are included here.
+
+## Repository State
+
+- Branch inspected: `main`
+- HEAD inspected: `a10413cab2f26e32acf21068e5345bcdf82a70e6`
+- `origin/main`: `a10413cab2f26e32acf21068e5345bcdf82a70e6`
+- Release tag present on HEAD: `v0.0.1-rc4`
+- Working tree before this analysis: no tracked diffs; only `workdir/.miktex/`
+  was untracked and was not touched.
+
+## Relevant File Map
+
+### Runtime Entrypoints
+
+- `src/orbit/native_server/app.py`
+  - exposes `--mtp` / `--enable-mtp-experimental`
+  - constructs `NativeClientConfig(use_mtp_experimental=...)`
+  - exposes MTP state in `/props`
+  - routes `/chat`, `/chat/stream`, continuation, cancel, and health requests
+- `src/orbit/native_server/protocol.py`
+  - packages native usage and timing fields, including `generation_ms`
+
+### Native Python Client
+
+- `src/orbit/native_llama/client.py`
+  - owns the target model/context/session state
+  - initializes probe helpers and the persistent MTP runtime
+  - decides whether a completion may attempt MTP
+  - falls back to standard generation when MTP is disabled, unavailable, failed,
+    cancelled, or blocked by thinking/tool-call conditions
+  - maps successful MTP completion into `NativeTimings`
+- `src/orbit/native_llama/session_state.py`
+  - exposes session snapshot fields for `mtp_enabled`, `mtp_initialized`,
+    `mtp_failure_reason`, cached token count, in-flight state, and cancellation
+
+### Python MTP Wrappers
+
+- `src/orbit/native_llama/persistent_mtp.py`
+  - loads or builds `liborbit-persistent-mtp.so`
+  - creates, resets, frees, and calls a persistent target/draft MTP session
+  - maps C shim counters into `MtpCompletionResult`
+- `src/orbit/native_llama/mtp_completion.py`
+  - one-shot helper wrapper around `orbit-mtp-completion`
+- `src/orbit/native_llama/mtp_probe.py`
+  - load/init probe wrapper; no generation
+- `src/orbit/native_llama/mtp_dry_run.py`
+  - draft-generation dry-run wrapper; no accept loop
+- `src/orbit/native_llama/mtp_accept_probe.py`
+  - single accept-loop probe wrapper
+- `src/orbit/native_llama/mtp_decode_probe.py`
+  - decode-loop probe wrapper over a fixed prompt set
+
+### Native Shim Sources
+
+- `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+  - persistent target/draft speculative decoding implementation
+  - owns draft generation, target validation, acceptance, partial restore,
+    live partial commit, replay fallback, checkpointing, `seq_rm`, and tracing
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_completion.cpp`
+  - one-shot MTP completion helper
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_probe.cpp`
+  - target/draft load/init probe
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_dry_run.cpp`
+  - draft generation dry-run
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_accept_probe.cpp`
+  - accept-loop probe
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_decode_probe.cpp`
+  - decode-loop probe
+- `src/orbit/native_llama/vendor/shim/orbit_mtp_step_trace.cpp`
+  - trace-oriented helper
+
+### Tests
+
+- `tests/test_native_mtp_experimental.py`
+  - parser flag, fallback paths, thinking-mode skip, streaming callback behavior,
+    cached prompt token accounting, tool-call-round MTP suppression
+- `tests/test_native_persistent_mtp.py`
+  - persistent shim discovery, stale shim rebuild, init/reset/free behavior, and
+    wrapper result extraction
+- `tests/test_native_mtp_probe.py`
+  - load/init probe wrapper
+- `tests/test_native_mtp_dry_run.py`
+  - draft dry-run wrapper
+- `tests/test_native_mtp_accept_probe.py`
+  - accept probe wrapper
+- `tests/test_native_mtp_decode_probe.py`
+  - decode probe wrapper
+- `tests/test_native_session_state.py`
+  - MTP state visibility in session snapshots
+- `tests/test_native_thinking.py`
+  - MTP interaction with visible-thinking and continuation paths
+
+### Docs And Scripts
+
+- `README.md`
+  - documents `orbit server --mtp` as explicit experimental MTP mode
+- `docs/PERFORMANCE.md`
+  - describes MTP as generation-oriented and benchmark-sensitive on CPU
+- `docs/NATIVE_PACKAGING_ROADMAP.md`
+  - lists MTP shims as native packaging artifacts
+- `scripts/suggest-server-profile.sh`
+  - mentions `orbit server --mtp`
+
+## Upstream llama.cpp Check
+
+Checked on 2026-06-30 against `ggml-org/llama.cpp`.
+
+Relevant upstream facts:
+
+- Upstream `master` has merged Gemma 4 MTP support through PR #23398,
+  `llama : add Gemma4 MTP`, merged on 2026-06-07.
+- Upstream `docs/speculative.md` documents `draft-mtp` as a supported
+  speculative decoding type.
+- The following upstream branches exist and are relevant comparison candidates:
+  - `gg/spec-mtp-experiments`
+  - `gg/spec-ckpt-test`
+  - `gg/server-fix-spec`
+  - `gg/server-fix-spec-ctx-shift`
+  - `gg/server-reenable-swa-spec`
+  - `gg/spec-refactor-ctx`
+- GitHub compare metadata shows those `gg/spec-*` branches are currently
+  diverged from `master`, not cleanly newer replacements for `master`.
+
+Implication for Orbit:
+
+- MTP compatibility itself is no longer only an out-of-tree idea upstream;
+  `draft-mtp` exists on `llama.cpp` `master`.
+- There is not yet evidence from this pass that upstream has a merged fix for
+  Orbit's specific extra small validate (`n_tok=2`) or the residual latency.
+- The next safe step is source comparison, not blind porting:
+  - compare Orbit's `orbit_persistent_mtp.cpp` against upstream
+    `common/speculative` / server speculative paths;
+  - inspect `gg/spec-mtp-experiments` first for MTP-specific changes;
+  - inspect `gg/spec-ckpt-test` and `gg/spec-refactor-ctx` for checkpoint,
+    rollback, and context-lifecycle changes;
+  - inspect `gg/server-fix-spec*` only for server integration behavior.
+
+Sources:
+
+- https://github.com/ggml-org/llama.cpp/pull/23398
+- https://github.com/ggml-org/llama.cpp/blob/master/docs/speculative.md
+- https://github.com/ggml-org/llama.cpp/tree/gg/spec-mtp-experiments
+- https://github.com/ggml-org/llama.cpp/tree/gg/spec-ckpt-test
+- https://github.com/ggml-org/llama.cpp/tree/gg/server-fix-spec
+- https://github.com/ggml-org/llama.cpp/tree/gg/spec-refactor-ctx
+
+## Activation And Top-Level Flow
+
+1. `orbit server --mtp` sets `NativeClientConfig.use_mtp_experimental=True`.
+2. `NativeLlamaClient.load()` initializes the target model/context and then calls
+   `_initialize_persistent_mtp_session()`.
+3. `_initialize_persistent_mtp_session()`:
+   - exits if MTP is not enabled;
+   - exits with a fallback reason if the draft MTP model is unavailable;
+   - exits with failure if the target context is missing;
+   - otherwise creates a persistent MTP session with target context, draft
+     context, context size, batch size, ubatch size, and thread settings.
+4. During `complete_prompt(...)`, Orbit attempts MTP only when:
+   - `allow_mtp_experimental=True`;
+   - thinking mode is off;
+   - no immediate cancellation is requested;
+   - `use_mtp_experimental=True`;
+   - draft artifacts are available;
+   - the persistent runtime is initialized and still marked enabled.
+5. If MTP returns success, the result becomes the request's `NativeTimings`.
+6. If MTP returns failure or is not eligible, Orbit falls back to standard target
+   generation.
+
+Important guardrail: `complete_chat(...)` disables MTP for tool-call rounds by
+passing `allow_mtp_experimental=not tools`. Final-from-tool history can still use
+MTP when no new tool call is being requested.
+
+## Persistent MTP Session State
+
+The C++ shim stores a persistent `orbit_mtp_session` with:
+
+- draft model and draft context;
+- shared speculative state (`common_speculative`);
+- target/draft request-boundary checkpoints;
+- target prompt tokens for boundary restore eligibility;
+- cached prompt tokens;
+- last completion counters;
+- acceptance, replay, restore, checkpoint, and `seq_rm` counters;
+- phase timing aggregates;
+- optional debug trace JSON strings.
+
+The original Python result object read the main counters and aggregate timings,
+but did not expose metadata needed to compare prompt/logits/sample equivalence.
+
+The consolidated patch keeps a narrow env-gated metadata bridge for
+`ORBIT_MTP_TRACE=1`: phase timing JSON, generated output token hashes, and
+first-sample prompt/frontier/logits/sample hashes. Heavy step, validate, and
+target-decode JSON strings are not exposed because retrieving them reproduced a
+process-exit teardown crash in the lifecycle harness. This bridge is
+diagnostics-only. It does not change prompt rendering, routing, tool selection,
+final policy, evidence policy, decode, sampling, KV mutation, boundary split,
+replay, or acceptance behavior.
+
+## Completion State Machine
+
+### State 0. Reset Per-Request State
+
+`orbit_mtp_session_complete(...)` clears per-request counters, traces, timing
+aggregates, output content, acceptance totals, and replay state. It then
+tokenizes the rendered prompt and initializes a deterministic reference sampler.
+
+Generation is capped in the Python wrapper to `max(1, min(max_tokens, 32))`.
+The C++ shim also uses that effective cap in the loop.
+
+### State 1. Replay Or Restore Prompt Frontier
+
+The loop starts with `need_replay=true`.
+
+On replay:
+
+- target and draft memories are cleared;
+- if an existing request-boundary checkpoint is compatible with the current
+  prompt prefix, it is restored into both target and draft contexts;
+- otherwise the prompt is decoded on the target in chunks;
+- the same prompt chunk stream is processed through `common_speculative_process`
+  so the speculative state sees the target prompt;
+- on the first generated token of a request, a request-boundary checkpoint is
+  captured for target and draft contexts.
+
+If this is the first output token, the target sampler samples one token from the
+prefilled target context, accepts it into sampler state, emits it, and then the
+MTP loop proceeds.
+
+### State 2. Draft Generation
+
+When no residual draft is available, the shim:
+
+1. checkpoints the current target/draft frontier;
+2. sets `common_speculative_get_draft_params(...)` with:
+   - enabled `true`;
+   - `n_max=min(3, remaining_generation_cap)`;
+   - `n_past`;
+   - `id_last`;
+   - pointers to the target prompt frontier and draft buffer;
+3. calls `common_speculative_draft(...)`;
+4. records one draft decode call;
+5. records the number of fresh draft tokens;
+6. restores and trims the draft context back to the checkpoint frontier using
+   `llama_memory_seq_rm(...)`;
+7. marks the checkpoint as available for partial handling.
+
+The hard-coded native draft maximum is currently `ORBIT_MTP_DRAFT_N_MAX = 3`.
+
+### State 3. Build Validate Batch
+
+The validate batch is always:
+
+```text
+[id_last] + draft_tokens
+```
+
+with `validate_pos0 = n_past`.
+
+The validate batch requests logits for every row. The shim records batch size,
+logits row count, target KV min/max before and after decode, and decode timing.
+
+### State 4. Optional Boundary Split / Live Logical Commit
+
+If `ORBIT_MTP_BOUNDARY_SPLIT` is unset or non-zero, and the checkpoint/frontier
+preconditions are satisfied, the shim tentatively appends `id_last + draft` to
+`prompt_tgt` before validation. This is the `boundary_committed_live` path.
+
+The intended effect is to let a partial accept commit the accepted frontier
+without replaying the whole target/draft prompt.
+
+Preconditions include:
+
+- checkpoint exists;
+- draft is non-empty;
+- `n_past == prompt_tgt.size()`;
+- target and draft KV max positions match `n_past - 1`.
+
+### State 5. Target Validate
+
+`resolve_validate_accept_restore(...)`:
+
+1. builds a target validate batch for `[id_last] + draft`;
+2. runs `llama_decode(ctx_tgt, validate)`;
+3. increments target decode counters;
+4. runs `common_speculative_process(...)` against the validate batch;
+5. optionally clones the sampler if a checkpoint is available;
+6. calls `common_sampler_sample_and_accept_n(...)` over all validate rows and the
+   draft vector.
+
+The resulting `ids` represent accepted output ids. The number of accepted draft
+tokens is `ids.size() - 1`.
+
+### State 6. Resolution
+
+There are four non-error resolutions:
+
+- `full_accept`
+  - all draft tokens are accepted;
+  - `common_speculative_accept(...)` commits the accepted draft span;
+  - accepted ids are emitted;
+  - target and draft KV tails beyond the new frontier are removed with
+    `llama_memory_seq_rm(...)`;
+  - draft/checkpoint state is cleared.
+- `live_partial`
+  - boundary split is active and partial commit is safe;
+  - accepted ids are emitted;
+  - target and draft KV are trimmed to the accepted frontier;
+  - no replay is required on the next iteration;
+  - residual draft is cleared and the next draft is marked fresh.
+- `restored_partial`
+  - sampler and target/draft contexts are restored to the checkpoint;
+  - `draft = ids`, so the accepted ids become a residual draft for the next
+    iteration;
+  - no tokens are emitted in that iteration;
+  - the next loop reuses the residual draft.
+- `replay_fallback`
+  - used when partial rollback/restore cannot be safely completed;
+  - any tentative boundary split is reverted;
+  - accepted ids are emitted;
+  - next iteration enters prompt replay.
+
+An error resolution stops MTP and returns failure to Python; the Python client
+then disables MTP for that session and falls back to standard generation.
+
+### State 7. Emission
+
+For all emitting resolutions, each accepted id is:
+
+1. checked for EOG;
+2. appended to the generated token vector;
+3. converted to text with `llama_token_to_piece(...)`;
+4. appended to `last_content`;
+5. passed to the token callback when non-empty.
+
+The Python MTP path strips control-channel output after the C++ completion when
+thinking is off. If the C++ path already streamed tokens, Python avoids
+double-emitting the final string.
+
+### State 8. Finish
+
+The loop exits when:
+
+- max generation cap is reached;
+- EOG is sampled;
+- an error occurs.
+
+At finish, the shim stores output content, token counts, acceptance ratios,
+decode counts, elapsed time, tokens/sec, output token hashes, first-sample
+metadata, and phase timing JSON. The heavy step/validate/target-decode trace
+strings are not part of the retained Python-facing diagnostics.
+
+## Diagnostics And Trace Surfaces
+
+Available C++ environment-gated diagnostics:
+
+- `ORBIT_MTP_PARTIAL_DEBUG`
+  - frontier and partial state traces
+- `ORBIT_MTP_VALIDATE_DEBUG`
+  - validate pre/decode/result/replay traces
+- `ORBIT_MTP_DRAFT_TRACE`
+  - draft token and draft-context traces
+- `ORBIT_MTP_BOUNDARY_SPLIT=0`
+  - disables boundary split for comparison
+
+Available counters returned through Python today:
+
+- `draft_tokens_total`
+- `accepted_tokens_total`
+- `rejected_tokens_total`
+- reused draft/accepted/rejected totals
+- `acceptance_ratio`
+- `fresh_acceptance_ratio`
+- `consumed_acceptance_ratio`
+- `target_decode_calls`
+- `draft_decode_calls`
+- `elapsed_ms`
+- `tokens_per_second`
+- `full_accept_steps`
+- `replay_steps`
+- `partial_accept_steps`
+- `partial_no_replay_steps`
+- `replay_fallback_steps`
+- `seq_rm_supported`
+- `rollback_tokens_total`
+- `checkpoint_count`
+- `restore_count`
+
+Python-facing diagnostics now available when `ORBIT_MTP_TRACE=1`:
+
+- phase timing JSON;
+- generated output token hashes;
+- first-sample prompt hash/count;
+- target frontier hash/range;
+- final prompt logits hash;
+- first-sample hash;
+- request-boundary restore/refill markers.
+
+These fields remain unset by default.
+
+## Known Observations To Revalidate
+
+The investigation starts from these external observations:
+
+- Orbit MTP on `response_medium` produced equivalent output but was slower than
+  the reference `llama-server` MTP run.
+- Reference `llama-server` MTP: about `6.26s generation_ms`, `16` validate
+  calls.
+- Orbit MTP: about `10.16s generation_ms`, `17` validate calls.
+- Orbit appears to perform one extra small validate with `n_tok=2`.
+- The residual latency is not explained by that extra validate alone.
+- Boundary split and live partial propagation looked promising but need
+  revalidation with current `main`.
+
+## State-Machine Invariants
+
+Any future MTP patch should preserve:
+
+- output equivalence with the target-only greedy reference for the same rendered
+  prompt, sampler, stop conditions, and max tokens;
+- no changes to user prompts, route prompts, tool policy, final policy, or
+  evidence policy;
+- no model-facing deterministic semantic fast paths;
+- no unvalidated draft token emitted as final user-visible content;
+- no duplicated or missing streamed token fragments;
+- cancellation must not leave target/draft KV or sampler state marked valid;
+- fallback must return to standard target generation when MTP fails;
+- tool-call rounds remain non-MTP unless explicitly redesigned and benchmarked;
+- thinking mode remains non-MTP unless explicitly redesigned and tested.
+
+## Candidate Fix Points For Later Patches
+
+No fix is applied in this analysis. Candidate investigation points are:
+
+1. Redesign heavy step/validate/target-decode diagnostics so ownership and
+   teardown are stable before exposing them through Python.
+2. Compare the Orbit validate sequence with `llama-server` for the same prompt:
+   per-step `n_tok`, accepted count, rejected count, full/partial/replay
+   resolution, target decode time, draft decode time, `seq_rm` count, and
+   checkpoint/restore count.
+3. Determine whether the extra `n_tok=2` validate is:
+   - required for correctness;
+   - caused by boundary split/live partial residual propagation;
+   - caused by residual draft reuse after partial restore;
+   - caused by final cap/EOG handling;
+   - an avoidable duplicate validate.
+4. Attribute the unexplained latency to target validate, draft generation,
+   checkpoint/restore, `seq_rm`, sampler clone/restore, replay, detokenization,
+   or Python/C callback overhead.
+5. Revalidate `ORBIT_MTP_BOUNDARY_SPLIT=0` vs default boundary split on the same
+   fixed CPU setup.
+6. Revalidate live partial against restored partial and replay fallback paths,
+   especially after partial accept.
+7. Add a benchmark harness that compares Orbit no-MTP, Orbit MTP, and
+   `llama-server` MTP with identical prompt, model artifacts, CPU affinity, and
+   thread/batch settings.
+
+## Minimal Test And Benchmark Plan
+
+Static/unit checks:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_mtp_experimental tests.test_native_persistent_mtp -q
+PYTHONPATH=src python3 -m unittest tests.test_native_mtp_probe tests.test_native_mtp_dry_run tests.test_native_mtp_accept_probe tests.test_native_mtp_decode_probe -q
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Real MTP benchmark matrix:
+
+- fixed setup: Gemma 4 12B target, matching MTP draft, CPU-only, fixed affinity
+  such as `taskset -c 0-5`;
+- same `ctx=8192`, `threads=6`, `threads-batch=6`, `batch=256`,
+  `ubatch=128`;
+- same rendered prompt and max token cap;
+- compare:
+  - Orbit target-only native generation;
+  - Orbit `--mtp`;
+  - reference `llama-server` MTP;
+- record:
+  - normalized output equivalence;
+  - `generation_ms`;
+  - output tokens;
+  - target decode calls;
+  - draft decode calls;
+  - validate count and per-validate `n_tok`;
+  - accepted/rejected draft counts;
+  - full/live/restored/replay resolutions;
+  - checkpoint/restore count;
+  - `seq_rm` count;
+  - phase timing totals.
+
+Streaming/cancel checks:
+
+- stream an MTP response and confirm no duplicated or missing fragments;
+- interrupt/cancel during draft, validate, and after partial accept if possible;
+- verify a later non-MTP request still works and does not reuse corrupt state.

--- a/docs/MTP_UNRESOLVED_ISSUES.md
+++ b/docs/MTP_UNRESOLVED_ISSUES.md
@@ -1,0 +1,1065 @@
+# MTP Unresolved Issues
+
+Status: consolidated MTP correctness/stability analysis. No prompt, routing,
+tool-selection, final-policy, evidence-policy, KV, or streaming behavior changes
+are included here.
+
+## Baseline Problem Statement
+
+The current MTP line is correctness-first and experimental. The target symptom
+to explain is:
+
+- reference `llama-server` MTP on the `response_medium` workload: about
+  `6.26s generation_ms`, `16` validates;
+- Orbit MTP on the same workload: about `10.16s generation_ms`, `17` validates;
+- output is equivalent;
+- Orbit has one extra small validate, reportedly `n_tok=2`;
+- the extra validate alone does not explain the full remaining latency;
+- boundary split and live partial propagation looked promising but need
+  revalidation against current `main`.
+
+## Issue Index
+
+| ID | Issue | Evidence | Risk | Candidate Fix Point |
+| --- | --- | --- | --- | --- |
+| MTP-001 | Orbit MTP is slower than reference `llama-server` despite equivalent output. | Observed `10.16s` vs `6.26s` generation time. | A correctness-preserving path may still be unusable on CPU if overhead exceeds draft savings. | Add comparable phase trace and benchmark matrix before changing behavior. |
+| MTP-002 | Orbit performs one extra validate. | Observed `17` validates vs reference `16`; one small validate has `n_tok=2`. | Removing it blindly can break equivalence at the partial/replay boundary. | Expose and compare per-step validate traces before deciding whether it is redundant. |
+| MTP-003 | Residual latency is not explained by the extra validate alone. | Extra `n_tok=2` should not account for roughly four seconds by itself. | Optimizing only validate count may leave most slowdown untouched. | Attribute time across target validate, draft generation, checkpoint/restore, `seq_rm`, sampler clone/restore, replay, detokenization, and callback overhead. |
+| MTP-004 | Rich step-level C++ traces are intentionally not exposed in the consolidated patch. | Retrieving the heavy step/validate/target-decode JSON was associated with process-exit `double free or corruption (!prev)` in the metadata harness. Stable timing, output-token-hash, and first-sample metadata remain exposed behind `ORBIT_MTP_TRACE=1`. | Re-enabling heavy trace getters can reintroduce teardown instability. | Keep retained diagnostics minimal; redesign heavy trace ownership/lifetime separately if needed. |
+| MTP-005 | Boundary split correctness/performance needs current validation. | `ORBIT_MTP_BOUNDARY_SPLIT` defaults enabled; known promising behavior must be rechecked after later changes. | Boundary split can alter partial accept state, `n_past`, target/draft KV shape, and replay needs. | A/B default vs `ORBIT_MTP_BOUNDARY_SPLIT=0` with output equivalence and phase timing. |
+| MTP-006 | Live partial propagation may change the next-step validate shape. | `live_partial` clears draft and avoids replay; previous trace fields track `next_validate_n_tok`. | A live partial win could hide an extra follow-up validate or corrupt frontier state if wrong. | Trace `live_partial`, `restored_partial`, and `replay_fallback` resolutions per step. |
+| MTP-007 | `seq_rm` and checkpoint/restore costs are unknown in the observed slowdown. | Shim times `seq_rm`, target/draft checkpoint, target/draft restore, but Python does not expose them. | CPU-only `seq_rm`/state restore may dominate when validates are few. | Surface phase timings and compare against `llama-server` speculative state handling. |
+| MTP-008 | Request-boundary checkpoint restore may interact with multi-turn reuse. | Shim stores `request_boundary_ckpt` and `request_boundary_prompt_tgt`; README says raw multi-turn MTP reuse remains debug-only. | Prefix restore can improve speed but risks stale frontier reuse if prefix compatibility is incomplete. | Keep raw reuse debug-only; benchmark single-turn and repeat-turn separately. |
+| MTP-009 | MTP generation cap is clamped to 32 tokens. | Python calls shim with `max(1, min(max_tokens, 32))`. | Longer answers may silently use shorter MTP segments and continuation behavior differs from standard generation. | Document/benchmark cap behavior; do not change until equivalence and continuation tests exist. |
+| MTP-010 | Tool-call rounds are intentionally non-MTP. | `complete_chat` passes `allow_mtp_experimental=not tools`. | Generation benchmarks with tools enabled may not exercise MTP at all during tool-call phases. | Separate plain chat/final-from-tool MTP tests from tool-call route tests. |
+| MTP-011 | Thinking mode is intentionally non-MTP. | Client sets fallback reason `thinking-mode`. | Visible-thinking measurements may compare different paths accidentally. | Keep thinking off in MTP generation benchmarks unless a separate design exists. |
+| MTP-012 | Sampler state equivalence after partial accept is not deeply tested. | Unit tests mock wrapper results; C++ sampler clone/restore is only real-runtime tested manually. | A partial accept bug can preserve output in one prompt but fail on another. | Add real probe cases that hit full accept, live partial, restored partial, and replay fallback. |
+| MTP-013 | Cancellation behavior inside the C++ shim is under-specified. | Python clears stale cancel before MTP and skips MTP if cancel is already true; the C++ loop itself has no visible `should_cancel` callback. | Long MTP validation may not be interruptible at the same granularity as standard generation. | Design cancellation propagation into the shim before treating MTP as stable. |
+| MTP-014 | Streaming correctness depends on callback and post-strip behavior. | Python avoids double emit when callbacks fire and strips control channels after completion. | If C++ streams text later stripped by Python, visible stream and final content can diverge. | Add real streaming MTP smoke with control-channel and stop-token boundaries. |
+| MTP-015 | Validation rows request logits for every validate token. | `fill_batch` sets `logits[i] = 1` for every row. | This may differ from `llama-server` and increase target validate cost. | Compare with reference speculative implementation before changing logits row selection. |
+| MTP-016 | Draft max is fixed at three. | `ORBIT_MTP_DRAFT_N_MAX = 3`. | Draft size may be suboptimal for Gemma 4 12B CPU-only. | Tune only after phase attribution and comparable benchmarks. |
+| MTP-017 | Prompt/cache accounting for MTP is approximate from Python tokenization. | MTP reports `prefill_ms=0.0` and `generation_ms=result.elapsed_ms`; prompt reuse is computed after shim completion. | Metrics may mix prefill/replay/generation costs and make comparison misleading. | Split prompt prefill, replay, draft, validate, and output phases in user-visible diagnostics. |
+| MTP-018 | Existing tests are wrapper-heavy and do not assert real output equivalence against a target-only decode. | Unit tests mock C/Python boundaries and parse synthetic JSON payloads. | The most important invariant is not protected by CI. | Add optional real-model smoke outside default CI; keep standard suite model-free. |
+| MTP-019 | Reference comparison workflow is not codified. | Known measurements were manual. | Future changes can regress or appear to improve due to CPU noise. | Add a repeatable benchmark note or script that records environment, affinity, prompt, and exact artifacts. |
+| MTP-020 | Upstream `llama.cpp` now has merged Gemma 4 MTP support, but Orbit's shim has not been re-diffed against current upstream. | PR #23398, `llama : add Gemma4 MTP`, is merged in upstream `master`; upstream docs list `draft-mtp`. | Orbit may carry old assumptions or extra local shim work that current upstream no longer needs. | Compare Orbit's persistent shim against current upstream `common/speculative` and server MTP paths before changing behavior. |
+| MTP-021 | Upstream speculative branches exist but are diverged from `master`. | `gg/spec-mtp-experiments`, `gg/spec-ckpt-test`, `gg/server-fix-spec`, and `gg/spec-refactor-ctx` are visible upstream comparison candidates. | Treating an experimental branch as a fix can import stale or incompatible changes. | Use branches as targeted diff sources only; require local equivalence and benchmark proof before porting. |
+| MTP-022 | The final `n_tok=2` validate is not proven to be a bug. | Current trace validates `[id_last] + draft`; at the generation cap tail only one draft token remains, so the final validate naturally has two tokens. | Removing it can drop the final fallback/sample row and break output equivalence. | Do not patch validate count until an upstream-equivalent trace proves redundancy. |
+| MTP-023 | Target validate dominates latency. | `response_medium_tradeoff`: `target_validate=8101.59 ms / 14 calls`, while `draft_generation=884.893 ms`, `seq_rm=0.284881 ms`, checkpoint/restore and sampler are small. | Optimizing rollback/checkpoint paths will not materially improve this prompt. | Focus diagnosis on target validate batch shape, logits rows, acceptance ratio, and metrics attribution. |
+| MTP-024 | Validate batches request logits for every `[id_last] + draft` row. | Orbit `fill_batch(...)` sets `batch.logits[i] = 1` for every validate token; trace reports `validate_batch_logits_count == validate_batch_n_tokens`. Upstream server also adds sampled token and speculative draft tokens with `logits=true` before calling `common_sampler_sample_and_accept_n(...)`. | These rows are likely required by the current sample-and-accept algorithm; reducing them blindly can make acceptance impossible or change fallback sampling. | Treat as equivalent to upstream until a narrower logits-row algorithm is designed and proven. |
+| MTP-025 | Acceptance ratio is low enough that target validation erodes draft savings. | `response_medium_tradeoff`: `accepted_tokens_total=18`, `rejected_tokens_total=21`, `acceptance_ratio=0.4615`. | Low acceptance can be normal for this target/draft/prompt, or it can indicate position, suffix, sampler, BOS, cache, or prompt-frontier divergence. | Add metadata-only alignment trace before changing sampler, prompt, positions, or cache behavior. |
+| MTP-026 | MTP `generation_ms` is not directly comparable with target-only `generation_ms`. | Target-only reports `prefill_ms=2132.187` and `generation_ms=10179.768`; MTP reports `prefill_ms=0.0` while `generation_ms=10738.387` includes `suffix_target_prefill=1580.72`. | Comparing only `generation_ms` can understate target-only cost or overstate MTP cost depending on which prefill phases are included. | Split MTP suffix prefill from speculative loop in diagnostics before making performance claims. |
+| MTP-027 | First-request MTP target suffix prefill is required in the current persistent path. | Without a compatible request-boundary checkpoint, Orbit clears/replays target and draft memory, then decodes the prompt suffix to place target KV at the prompt frontier before validation. | Treating this as avoidable without a valid prefix/request-boundary checkpoint can leave target KV missing or stale. | Investigate reuse/persistent prompt frontier separately; do not remove suffix prefill from the MTP path. |
+| MTP-028 | MTP output is not yet proven equivalent to target-only under a prompt-matched control. | Phase 4 target-only with the MTP-prepared prompt used `23` prompt tokens and produced a stable hash different from MTP first-run and second-run hashes. | Any performance optimization before equivalence is explained can preserve a fast but wrong path. | Build a metadata-only equivalence harness around the exact prompt text hash/length, sampler config hash, first-sample state, and per-step frontier. |
+| MTP-029 | Phase 4 alignment trace did not show target/draft KV frontier mismatch. | Across three first-run and three second-run MTP traces, `ctx_tgt` and `ctx_dft` frontier min/max matched before each validate; draft origin was consistently `fresh`; replay-before appeared once at request start. | Acceptance may still be low due to sampler/config or draft quality, but not due to the basic frontier mismatch fields collected here. | Do not patch frontier/KV rollback logic based on current data. |
+
+## Candidate Fix Points, Without Patching Runtime
+
+1. Diagnostics bridge:
+   - keep only stable env-gated metadata in Python results:
+     `timing_json`, output-token hashes, and first-sample metadata;
+   - do not expose heavy step/validate/target-decode JSON until its native
+     lifetime/teardown behavior is redesigned;
+   - do not change decode, sampler, prompt, or runtime policy.
+2. Validate sequence comparison:
+   - collect Orbit per-step `validate_batch_n_tokens`;
+   - collect reference `llama-server` validate count/shape if available;
+   - identify the step that creates the extra `n_tok=2` validate.
+3. Boundary split A/B:
+   - run current default boundary split;
+   - run `ORBIT_MTP_BOUNDARY_SPLIT=0`;
+   - compare output equivalence, validate count, phase timing, and resolutions.
+4. Live partial audit:
+   - confirm each `live_partial` has matching target/draft KV max positions after
+     commit;
+   - confirm no replay follows unless explicitly required;
+   - verify the next validate's token count is expected.
+5. Phase attribution:
+   - inspect phase totals for `target_validate`, `draft_generation`, `seq_rm`,
+     `ctx_tgt_checkpoint`, `ctx_tgt_restore`, `ctx_dft_checkpoint`,
+     `ctx_dft_restore`, `sampler_clone`, `sampler_restore`, `sampler_ops`,
+     `rollback_replay`, and `detokenize_output_bridge`.
+6. Reference implementation comparison:
+   - compare Orbit's `fill_batch`/logits-row strategy and partial rollback logic
+     to upstream `common/speculative` and the `llama-server` path used in the
+     baseline.
+7. Upstream compatibility diff:
+   - start from upstream `master` after Gemma 4 MTP support;
+   - diff MTP-specific code against `gg/spec-mtp-experiments`;
+   - inspect checkpoint/rollback changes in `gg/spec-ckpt-test` and
+     `gg/spec-refactor-ctx`;
+   - do not port branch code without output-equivalence and phase-timing proof.
+
+## Phase 2 Trace Evidence
+
+Captured on local CPU-only Gemma 4 12B using repository models under
+`models/`, `ctx=8192`, `threads=6`, `threads-batch=6`, `batch=256`,
+`ubatch=128`, `taskset -c 0-5`, `max_tokens=32`, thinking off, tools off for
+generation-only comparison.
+
+Instrumentation status:
+
+- The consolidated patch retains only stable env-gated metadata exposed through
+  Python when `ORBIT_MTP_TRACE=1`:
+  - phase timing JSON;
+  - generated output token hashes;
+  - first-sample prompt/frontier/logits/sample hashes.
+- Heavy step/validate/target-decode trace getters are not exposed by the Python
+  result object in the consolidated patch. Earlier experiments showed that
+  retrieving those large native JSON strings could reproduce process-exit heap
+  corruption in the lifecycle harness.
+- No prompt, routing, tool, final, evidence, decode, sampler, KV, or MTP state
+  machine behavior was changed by the diagnostics bridge.
+
+### Orbit Target-Only Control
+
+`response_medium_tradeoff` control, target-only:
+
+| Field | Value |
+| --- | ---: |
+| output tokens | 32 |
+| prompt tokens | 30 |
+| evaluated prompt tokens | 30 |
+| prefill ms | 2132.187 |
+| generation ms | 10179.768 |
+| wall ms | 12312.637 |
+
+The target-only control is not expected to expose validate sequence because it
+does not use speculative decoding.
+
+### Orbit MTP Trace: `response_medium_tradeoff`
+
+| Field | Value |
+| --- | ---: |
+| output tokens | 32 |
+| target decode calls | 15 |
+| draft decode calls | 14 |
+| validate count | 14 |
+| draft tokens total | 39 |
+| accepted tokens total | 18 |
+| rejected tokens total | 21 |
+| acceptance ratio | 0.4615 |
+| full accept steps | 6 |
+| partial accept steps | 8 |
+| replay fallback steps | 0 |
+| generation ms | 10738.387 |
+| wall ms | 10740.206 |
+
+Validate `n_tok` sequence:
+
+```text
+4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2
+```
+
+The final `n_tok=2` is visible in this run. It is not an unexplained duplicate
+by itself: Orbit validates `[id_last] + draft`, and at the generation cap tail
+the remaining draft budget is one token, so the validate batch naturally becomes
+two tokens.
+
+Phase timing totals:
+
+| Phase | Calls | Total ms |
+| --- | ---: | ---: |
+| target validate | 14 | 8101.59 |
+| draft generation | 14 | 884.893 |
+| suffix target prefill | 1 | 1580.72 |
+| target checkpoint | 15 | 34.0878 |
+| draft restore | 14 | 0.105214 |
+| sampler ops | 15 | 25.2337 |
+| seq_rm | 28 | 0.284881 |
+| speculative loop total | 14 | 10738.4 |
+
+Primary latency finding:
+
+- Residual latency is dominated by target validation, not `seq_rm`,
+  checkpoint/restore, sampler operations, or draft generation.
+- `seq_rm` is effectively negligible in this trace (`0.284881 ms` total).
+- Target validate averages roughly `578.7 ms` per call for this prompt.
+
+### Additional Orbit MTP Sweep
+
+| Label | Validates | `n_tok` sequence | Generation ms | Target validate ms | Draft ms | Acceptance |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| `response_medium_latency` | 13 | `4 x 13` | 7605.400 | 5180.27 | 730.55 | 0.4872 |
+| `response_medium_tradeoff` | 14 | `4 x 12, 3, 2` | 10738.387 | 8101.59 | 884.893 | 0.4615 |
+| `response_medium_cpu` | 11 | `4 x 11` | 9277.915 | 6749.24 | 762.029 | 0.5714 |
+
+The historical `17` validate count was not reproduced by these three prompt
+variants on current `main`, but the small tail validate (`n_tok=2`) was
+reproduced.
+
+### Reference `llama.cpp` Check
+
+Attempted local `llama-speculative` reference using the same target/draft GGUFs,
+`draft-mtp`, `n_predict=32`, and matching CPU/thread/batch settings. The local
+binary exited with `SIGSEGV` (`returncode=-11`) before exposing usable timing or
+validate metadata. The stock reference path therefore remains unavailable in
+this worktree for a direct per-validate sequence comparison.
+
+The known external reference remains:
+
+- `llama-server` MTP: about `6.26s generation_ms`, `16` validates.
+- Orbit historical MTP: about `10.16s generation_ms`, `17` validates.
+
+Current local evidence is enough to attribute Orbit's measured slowdown for the
+captured prompts to target validate cost, but not enough to prove the historical
+Orbit-vs-`llama-server` validate-count delta.
+
+## Phase 3 Bottleneck Diagnosis
+
+Phase 3 changes the working hypothesis:
+
+- the tail validate with `n_tok=2` is not demonstrated to be a bug;
+- `seq_rm`, target/draft checkpoint/restore, sampler operations, and draft
+  decode are not the dominant costs in the captured run;
+- the dominant cost is target-side validation;
+- the current metric split makes target-only and MTP `generation_ms` only
+  partially comparable.
+
+### Validate Batch Construction
+
+Orbit builds each target validate batch in
+`src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`:
+
+- `orbit_mtp_session_complete(...)` constructs:
+  - `validate_tokens = [id_last] + draft`
+  - `validate_pos0 = n_past`
+- `resolve_validate_accept_restore(...)` creates a `llama_batch` from those
+  tokens and calls `llama_decode(ctx_tgt, validate)`.
+- `fill_batch(...)` sets `batch.logits[i] = 1` for every validate row.
+- After target decode, Orbit passes row indices `0..validate_tokens.size()-1`
+  to `common_sampler_sample_and_accept_n(...)`.
+
+The current validate rows are therefore:
+
+```text
+row 0: logits after id_last
+row 1..N: logits after each draft token
+```
+
+That shape matches the current sample-and-accept algorithm. The sampler compares
+the target sample from each row to the corresponding draft token; if all draft
+tokens match, it also samples the final row to produce the next token. With a
+draft of three tokens, four rows are needed. With a final draft of one token,
+two rows are needed. This explains why the observed tail sequence can end with
+`n_tok=2` without implying an extra duplicate validate.
+
+### Upstream `llama.cpp` Comparison
+
+Checked against upstream `llama.cpp` `master` after Gemma 4 MTP support.
+
+Relevant upstream server/speculative behavior:
+
+- `server_n_outputs_max(...)` reserves `1 + common_speculative_n_max(...)`
+  output rows per sequence.
+- `server_slot::handle_last_sampled_token(...)` adds the sampled token and each
+  speculative draft token to the target batch with `logits=true`.
+- The server stores the batch row indices in `spec_i_batch`.
+- After `llama_decode`, the server calls
+  `common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt,
+  slot.spec_i_batch, slot.spec_draft)`.
+- `common_sampler_sample_and_accept_n(...)` requires `idxs.size() ==
+  draft.size() + 1`, samples one row per draft token until mismatch, and samples
+  the final row on full accept.
+
+Conceptual diff:
+
+| Area | Orbit persistent MTP | Upstream server MTP |
+| --- | --- | --- |
+| Validate token sequence | standalone `[id_last] + draft` batch | sampled token plus draft tokens in server batch |
+| Logits rows | all validate rows set `logits=1` | sampled and draft rows added with `logits=true` |
+| Sampler call | `common_sampler_sample_and_accept_n(..., rows, draft)` | same function with server batch row indices |
+| Final small validate | expected if only one draft token remains | expected under same `draft.size()+1` rule |
+| Scheduling | one standalone target validate decode per MTP step | validate rows integrated into server slot batch |
+
+Conclusion: Orbit is equivalent to upstream at the level that matters for
+validate rows and sample-and-accept semantics. The current evidence does not
+show Orbit validating extra logits rows beyond the rows needed by this upstream
+algorithm.
+
+### Why Target Validate Costs So Much
+
+The likely bottleneck is the combination of:
+
+1. every validate step asks the 12B target model to decode a small multi-row
+   batch with logits on every row;
+2. acceptance is low (`0.4615` on `response_medium_tradeoff`), so many expensive
+   target rows do not turn into accepted output;
+3. CPU-only target validation is much more expensive than draft decode, so the
+   acceptance ratio must be high enough to amortize target validate cost.
+
+For the captured `response_medium_tradeoff` run:
+
+```text
+target_validate       8101.59 ms / 14 calls
+draft_generation       884.893 ms / 14 calls
+suffix_target_prefill 1580.72 ms / 1 call
+ctx_tgt_checkpoint      34.0878 ms / 15 calls
+sampler_ops             25.2337 ms / 15 calls
+seq_rm                   0.2849 ms / 28 calls
+ctx_dft_restore          0.1052 ms / 14 calls
+```
+
+This rules out `seq_rm`, checkpoint/restore, and sampler operations as the main
+explanation for the measured latency.
+
+### Acceptance Ratio Diagnosis
+
+The observed `acceptance_ratio=0.4615` is not enough by itself to prove a bug.
+It can be normal for a weak or mismatched draft, but it can also indicate an
+alignment issue. The next trace should verify, without printing raw tokens:
+
+- target prompt token count versus MTP prompt token count;
+- `id_last` position and prompt-frontier position at each step;
+- draft `n_past` and target `n_past`;
+- target/draft KV max positions before draft, before validate, and after
+  accept;
+- sampler state hash before draft, before validate, and after accept;
+- draft `p_min`, temperature, top-k, top-p, and greedy/grammar-relevant config;
+- whether the prompt suffix used by target and draft is identical by hash and
+  length.
+
+No sampler, prompt, BOS, suffix, or position fix is justified until this
+alignment trace exists.
+
+### Suffix Target Prefill
+
+`suffix_target_prefill=1580.72 ms` is expected in the current first-request MTP
+path. The persistent session starts the request with `need_replay=true`. If no
+compatible request-boundary checkpoint is available, the shim clears target and
+draft memory, decodes the rendered prompt into the target context with
+`fill_target_prefill_batch(...)`, and only then enters speculative validation.
+
+This is necessary to put target KV at the correct prompt frontier. It may become
+avoidable only when a valid request-boundary checkpoint or persistent prompt
+frontier can be reused safely. Removing it from the first-request path would be
+a correctness risk.
+
+### Metric Comparability
+
+Target-only and MTP timing fields are not directly comparable:
+
+- target-only reports prompt prefill separately as `prefill_ms`;
+- MTP currently reports `prefill_ms=0.0`;
+- MTP `generation_ms` includes the suffix target prefill and the speculative
+  loop.
+
+For the captured run:
+
+```text
+target-only wall ~= prefill_ms 2132.187 + generation_ms 10179.768
+MTP wall         ~= generation_ms 10738.387
+MTP generation  includes suffix_target_prefill 1580.72
+```
+
+If `suffix_target_prefill` is subtracted only for diagnostic comparison, the
+MTP speculative loop is roughly `9157.7 ms`, which is modestly lower than the
+target-only generation phase. That does not prove a runtime speedup because the
+public metric currently includes different phase boundaries.
+
+## Phase 3 Fix Candidates, Without Patching
+
+These are candidate fix points only. None should be patched until the next
+targeted trace confirms the condition they depend on.
+
+### Candidate 1. Split MTP Timing Attribution
+
+- File/function:
+  - `src/orbit/native_llama/persistent_mtp.py::run_persistent_mtp_completion`
+  - `src/orbit/native_llama/client.py` MTP timing mapping
+  - C++ phase timing JSON in `orbit_persistent_mtp.cpp`
+- Minimal change:
+  - expose `suffix_target_prefill_ms` separately from speculative loop time in
+    user-visible diagnostics or `NativeTimings`;
+  - do not change decode behavior.
+- Risk:
+  - low runtime risk, but medium reporting risk because external benchmarks may
+    rely on current `generation_ms` semantics.
+- Correctness test:
+  - unit test that total elapsed still matches phase sum and output is
+    unchanged.
+- Expected benchmark effect:
+  - no speed change; makes target-only versus MTP comparisons valid.
+
+### Candidate 2. Draft/Target Alignment Trace
+
+- File/function:
+  - `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+  - trace construction around draft generation and
+    `resolve_validate_accept_restore(...)`
+- Minimal change:
+  - add env-gated metadata for prompt hash/length, suffix hash/length,
+    target/draft positions, sampler config hash, and KV frontier positions;
+  - keep token ids, prompt text, and token pieces out of the trace.
+- Risk:
+  - low if metadata-only; privacy risk if hashes are replaced by raw content.
+- Correctness test:
+  - tests assert raw token/prompt fields are absent and trace is disabled by
+    default.
+- Expected benchmark effect:
+  - no speed change; determines whether `0.4615` acceptance is normal or caused
+    by divergence.
+
+### Candidate 3. Validate Row Reduction Experiment
+
+- File/function:
+  - `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp::fill_batch`
+  - `resolve_validate_accept_restore(...)`
+- Minimal change:
+  - experimental branch only: attempt narrower logits row selection and replace
+    the acceptance algorithm if an upstream-equivalent method supports it.
+- Risk:
+  - high. The current upstream `common_sampler_sample_and_accept_n(...)`
+    requires `draft.size()+1` logits rows. Reducing rows without changing the
+    algorithm breaks acceptance or fallback sampling.
+- Correctness test:
+  - real-model target-only equivalence across full accept, partial accept,
+    reject, and generation cap tail cases.
+- Expected benchmark effect:
+  - possible validate speedup only if a mathematically equivalent lower-output
+    acceptance path exists; current upstream comparison does not show one.
+
+## Phase 4 Clean Metrics And Acceptance Diagnosis
+
+Phase 4 added metadata-only trace fields behind `ORBIT_MTP_TRACE=1`:
+
+- timing summary:
+  - `suffix_target_prefill_ms`
+  - `speculative_loop_ms`
+  - `speculative_loop_including_suffix_ms`
+  - `target_validate_ms`
+  - `draft_generation_ms`
+  - `checkpoint_restore_ms`
+  - `sampler_ms`
+  - `seq_rm_ms`
+  - `non_loop_overhead_ms`
+- per-step alignment metadata:
+  - `draft_count`, `accepted_draft`, `rejected_draft`
+  - `draft_origin`, `draft_is_fresh`
+  - `need_replay_before`, `post_step_need_replay`
+  - `validate_n_tok`, `validate_pos0`
+  - `old_n_past`, `new_n_past`
+  - `prompt_tgt_len`, `prompt_dft_len`
+  - target/draft KV frontier min/max and frontier hashes
+  - sampler state hashes before/after
+  - `remaining_generation_cap`
+
+The trace remains sanitized on the Python side. Token id arrays, token pieces,
+raw sampler summaries, prompt text, user content, file content, tool output, and
+web output are not exposed through the Python result object.
+
+### Phase 4 Benchmark Setup
+
+Local CPU-only Gemma 4 12B, repository models under `models/`, `ctx=8192`,
+`threads=6`, `threads-batch=6`, `batch=256`, `ubatch=128`, `taskset -c 0-5`,
+`max_tokens=32`, thinking off, tools off for generation-only comparison.
+
+Three runs were collected for each primary case:
+
+- target-only through normal `complete_chat_text`;
+- MTP first request through the persistent MTP session;
+- MTP second identical request on the same persistent MTP client.
+
+An additional target-only diagnostic used the same MTP-prepared prompt length
+(`23` tokens) so prompt accounting can be compared to MTP. That diagnostic is
+not a runtime behavior change.
+
+### Metric Summary
+
+| Case | Runs | Prompt tokens | Output tokens | Wall ms avg | Prefill ms avg | Generation ms avg | Suffix target prefill ms avg | Speculative loop ms avg |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| target-only normal prompt | 3 | 30 | 32 | 13188.973 | 2665.622 | 10522.632 | n/a | n/a |
+| target-only MTP-prepared prompt | 3 | 23 | 32 | 12263.795 | 2088.044 | 10175.415 | n/a | n/a |
+| MTP first request | 3 | 23 | 32 | 10881.980 | 0.000 | 10878.310 | 2107.363 | 8770.927 |
+| MTP second request | 3 | 23 | 32 | 7617.320 | 0.000 | 7614.183 | 0.000 | 7614.167 |
+
+Interpretation:
+
+- MTP `generation_ms` is now split into suffix prefill and speculative loop.
+- Compared to target-only on the MTP-prepared prompt, first-run MTP's loop-only
+  time is lower (`8770.927 ms` vs `10175.415 ms`), but first-run MTP still pays
+  `2107.363 ms` of suffix target prefill.
+- The second identical MTP request eliminates suffix target prefill in this
+  trace and improves wall time materially (`7617.320 ms` average).
+- This confirms that the request-boundary/persistent checkpoint reuse path is
+  valuable for repeated prompts.
+
+Important correctness caveat:
+
+- target-only normal prompt, target-only MTP-prepared prompt, MTP first request,
+  and MTP second request each produced stable hashes across their three runs;
+- the hashes differ across those cases;
+- therefore Phase 4 does not prove target-only/MTP output equivalence.
+
+No performance fix should be applied until that equivalence gap is understood.
+
+### MTP First Request Acceptance Trace
+
+Across all three runs the first-request trace was identical:
+
+```text
+validate_n_tok:
+4,4,4,4,4,4,4,4,4,4,4,4,4,3,2
+
+accepted_draft:
+3,3,3,1,2,0,0,0,0,1,0,2,1,0,1
+
+rejected_draft:
+0,0,0,2,1,3,3,3,3,2,3,1,2,2,0
+```
+
+Aggregate:
+
+| Metric | Value |
+| --- | ---: |
+| acceptance ratio | 0.4047619 |
+| target decode calls | 16 |
+| draft decode calls | 15 |
+| target validate ms avg | 7650.517 |
+| draft generation ms avg | 929.830 |
+| checkpoint/restore ms avg | 46.917 |
+| sampler ms avg | 31.341 |
+| seq_rm ms avg | 0.299 |
+
+Alignment observations:
+
+- `ctx_tgt` and `ctx_dft` frontier min/max matched before every validate.
+- `draft_origin` was consistently `fresh`.
+- `need_replay_before` appeared only on the request-start step.
+- No replay fallback occurred in the summarized trace.
+- The tail validates are explained by residual generation cap:
+  - step 13: remaining cap `4`, validate `4`, draft `3`;
+  - step 14: remaining cap `2`, validate `3`, draft `2`;
+  - step 15: remaining cap `1`, validate `2`, draft `1`.
+
+Conclusion: the final `n_tok=2` is explained by the generation cap tail in this
+trace.
+
+### MTP Second Request Acceptance Trace
+
+Across all three second-request runs the trace was also identical:
+
+```text
+validate_n_tok:
+4,4,4,4,4,4,4,4,4,4,4,4,3
+
+accepted_draft:
+0,0,0,3,3,3,3,2,0,0,0,3,2
+
+rejected_draft:
+3,3,3,0,0,0,0,1,3,3,3,0,0
+```
+
+Aggregate:
+
+| Metric | Value |
+| --- | ---: |
+| acceptance ratio | 0.5000000 |
+| target decode calls | 13 |
+| draft decode calls | 13 |
+| target validate ms avg | 6539.393 |
+| draft generation ms avg | 860.911 |
+| suffix target prefill ms avg | 0.000 |
+| checkpoint/restore ms avg | 34.397 |
+| sampler ms avg | 31.659 |
+| seq_rm ms avg | 0.275 |
+
+The second request is faster because the suffix target prefill cost is removed
+and the validate sequence is shorter. The trace does not show target/draft KV
+frontier mismatch.
+
+### Acceptance Diagnosis
+
+Current classification: acceptance is suspicious / data insufficient.
+
+Reasons:
+
+- basic target/draft frontier alignment looks coherent in the collected fields;
+- the low first-run acceptance ratio (`0.4047619`) could be draft weakness;
+- however, target-only with the same MTP-prepared prompt produced a stable
+  output hash different from MTP;
+- this means the next correctness question is equivalence of target-only and
+  MTP sampling/frontier, not raw speed.
+
+Known prompt accounting detail:
+
+- normal target-only chat path reports `30` prompt tokens;
+- MTP path uses `_prepare_mtp_prompt(...)` and reports `23` prompt tokens;
+- target-only on the MTP-prepared prompt also reports `23` prompt tokens.
+
+The prompt-length difference explains why normal target-only and MTP metrics are
+not directly comparable, but it does not explain why target-only on the
+MTP-prepared prompt and MTP produce different output hashes.
+
+## Phase 4 Fix Candidates, Without Patching
+
+No semantic or performance fix is justified yet. The data supports at most these
+two next steps:
+
+### Candidate 1. Output-Equivalence Harness
+
+- File/function:
+  - `src/orbit/native_llama/client.py::_try_complete_with_mtp_experimental`
+  - `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+- Minimal change:
+  - add a debug-only harness that runs target-only and MTP on the exact same
+    prompt hash/length and reports only output hash, output token count, timing,
+    and first divergence index if a token-hash stream can be exposed safely.
+- Risk:
+  - medium privacy/correctness risk if raw token ids or content leak; keep it
+    env-gated and metadata-only.
+- Correctness test:
+  - assert no raw prompt/token/content fields appear in the harness output.
+- Expected benchmark effect:
+  - no speed change; determines whether MTP is a correct optimization path.
+
+### Candidate 2. Sampler/First-Sample Alignment Trace
+
+- File/function:
+  - `src/orbit/native_llama/client.py::_generate_from_current_context`
+  - `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+- Minimal change:
+  - expose metadata-only sampler config hash and first-sample state hash for
+    target-only prepared-prompt control versus MTP before the first generated
+    token.
+- Risk:
+  - low if no raw sampler summaries or token ids are emitted.
+- Correctness test:
+  - model-free sanitizer tests plus one optional real-model smoke.
+- Expected benchmark effect:
+  - no speed change; explains whether output hash divergence comes from sampler
+    setup, prompt boundary, or MTP state machine.
+
+## Risks
+
+- Removing the extra validate without a state proof can break output
+  equivalence.
+- Optimizing boundary split can introduce missing/duplicated streamed tokens.
+- Reducing `seq_rm`/restore work can leave target or draft KV tails valid when
+  they should be invalid.
+- MTP can appear faster or slower because of CPU scheduler noise; single runs
+  are not strong evidence.
+- Making MTP useful for generation must not change prompt, route, tool,
+  evidence, or final-answer behavior.
+- Tool-call and thinking paths are deliberately not the same as plain MTP chat;
+  benchmark prompts must not mix these modes accidentally.
+- Any runtime fix that depends on a specific prompt such as `response_medium`
+  would be an invalid semantic hardcode.
+
+## Phase 5 Output-Equivalence Blocker
+
+Phase 5 added a metadata-only output-equivalence harness for target-only
+prepared-prompt generation versus persistent MTP. The harness reports prompt
+hashes, prompt token counts, canonical sampler config hashes, output hashes,
+per-output token hash digests, and first divergence indexes. It does not report
+raw prompt text, token ids, token pieces, user content, or model output.
+
+### Controlled Setup
+
+- Same prepared prompt was used for target-only and MTP.
+- Same max token cap was used: `32`.
+- Same canonical sampler config hash was reported for both paths:
+  `df8522360e5dfcea`.
+- `sampler_initial_state_hash` is not available yet.
+- `first_sample_state_hash` is a hash of the first generated token only, not a
+  raw token id.
+
+### Three-Run Result
+
+All three runs produced the same prepared prompt metadata:
+
+- `prompt_token_count`: `27`
+- `prompt_hash`: `589ef9d2af97baae`
+
+Output hashes were stable within each path but differed across paths:
+
+| Path | Output hash sequence | Token-hash digest sequence | First sample hash |
+| --- | --- | --- | --- |
+| target-only prompt-matched | `a465892fd4563b81` x3 | `b9e505e22dac86b1` x3 | `4194370396891896960` |
+| MTP first request | `db3387031e7c3d53` x3 | `42aa0d61a075f302` x3 | `11503514907415216418` |
+| MTP second identical request | `b75fc404db1d052c` x3 | `8c58843c4536586b` x3 | `1225426879707157548` |
+
+The first divergence index was stable:
+
+- MTP first request versus target-only: `0`
+- MTP second identical request versus target-only: `0`
+- MTP second identical request versus MTP first request: `0`
+
+### Timing Context
+
+The prompt-matched target-only generation and MTP loop are now separable:
+
+| Path | Wall avg | Generation avg | Suffix target prefill avg | Speculative loop avg | Target validate avg | Draft generation avg |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| target-only prompt-matched | `11999.770 ms` | `9806.816 ms` | n/a | n/a | n/a | n/a |
+| MTP first request | `6418.855 ms` | `6415.958 ms` | `1549.840 ms` | `4866.110 ms` | `4170.290 ms` | `534.852 ms` |
+| MTP second identical request | `7623.555 ms` | `7620.295 ms` | `0 ms` | `7620.277 ms` | `6601.570 ms` | `833.411 ms` |
+
+The MTP first-request loop can be faster than the target-only prompt-matched
+generation path, but this is not actionable until output equivalence is
+established.
+
+### Diagnosis
+
+The divergence happens before any validate/accept correctness question can be
+answered:
+
+- prompt hash and prompt token count are identical;
+- canonical sampler config hash is identical;
+- first generated token hash differs at index `0`;
+- MTP first and MTP second also diverge at index `0`.
+
+This points to one of the following unresolved causes:
+
+- the target-only harness is still not equivalent to the target path used inside
+  MTP despite matching prompt tokens;
+- the MTP path samples the first token from a different target-context state;
+- the MTP path's `common_sampler` setup is not bit-equivalent to Orbit's
+  standard greedy sampler chain;
+- a sampler initial state or target frontier detail is missing from the current
+  trace.
+
+Acceptance ratio and target validate cost must not be optimized until this
+first-sample equivalence blocker is resolved. The final `n_tok=2` validate tail
+remains a likely generation-cap effect, not a demonstrated bug.
+
+### Current Decision
+
+Do not patch performance, acceptance, validate rows, suffix prefill, or boundary
+split yet. The next safe step is narrower correctness instrumentation that
+proves whether the first-sample mismatch is caused by sampler implementation,
+target context state, or a non-equivalent target-only harness.
+
+## Phase 6 First-Sample Root Cause
+
+Phase 6 added metadata-only first-sample traces immediately before and after the
+first sample in both the target-only prepared-prompt path and the persistent MTP
+path. The trace includes prompt hash/count, KV frontier, last logits hash,
+sampler implementation id, sampler state hash when available, first sample hash,
+and whether request-boundary restore was used. It does not expose token ids,
+token pieces, prompt text, logits values, or model output.
+
+### Finding 1. The Phase 5 Target Harness Was Not Equivalent
+
+The earlier target-only "prompt-matched" comparison used a 27-token prompt, but
+the actual MTP C shim sampled from a 20-token prompt. The Python MTP entrypoint
+applies `_prepare_mtp_prompt(...)` again before calling the C shim, which strips
+the thought-channel suffix from an already-rendered prompt. Therefore the Phase
+5 target-only prompt was not the same prompt consumed by MTP.
+
+First divergent field in the invalid Phase 5 comparison:
+
+- effective internal prompt count:
+  - target-only harness: `27`
+  - MTP first request: `20`
+
+This makes the original target-only-vs-MTP-first output divergence a harness
+error, not an MTP validate/acceptance bug.
+
+### Corrected Harness Result
+
+The corrected harness uses the effective prompt that reaches the C shim. With
+that prompt, target-only and the first MTP request match at the first-sample
+boundary and in final output hash.
+
+| Path | Prompt count | Prompt hash | Frontier max | Last logits hash | First sample hash | Output hash |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| target-only effective prompt | `20` | `10014497124828543528` | `19` | `4957177649268112296` | `11503514907415216418` | `db3387031e7c3d53` |
+| MTP first request | `20` | `10014497124828543528` | `19` | `4957177649268112296` | `11503514907415216418` | `db3387031e7c3d53` |
+
+This falsifies the sampler-implementation mismatch hypothesis for the first
+request: despite `llama_sampler_chain+greedy` versus `common_sampler(top_k,temp)`
+metadata, the first request samples the same token from the same logits.
+
+### Finding 2. MTP Second Request Diverges At Restored Logits
+
+The second identical MTP request still diverges at index `0`, but the first
+divergent field is not prompt hash, prompt count, frontier, or sampler state
+hash before sample. It is `last_logits_hash`.
+
+| Path | Prompt count | Prompt hash | Frontier max | Request-boundary restore | Last logits hash | First sample hash | Output hash |
+| --- | ---: | ---: | ---: | --- | ---: | ---: | --- |
+| MTP first request | `20` | `10014497124828543528` | `19` | `false` | `4957177649268112296` | `11503514907415216418` | `db3387031e7c3d53` |
+| MTP second identical request | `20` | `10014497124828543528` | `19` | `true` | `9250577076402425798` | `1225426879707157548` | `b75fc404db1d052c` |
+
+The KV frontier hash is the same (`7521935930782995232`) and the sampler state
+hash before the first sample is the same (`1469598103934665603`), but the logits
+row used for sampling differs after loading the request-boundary checkpoint.
+
+Most likely root cause:
+
+- `common_prompt_checkpoint::load_tgt(...)` restores KV/state enough for
+  frontier accounting, but the logits row used by `common_sampler_sample(...)`
+  is not restored to the same value as a fresh target prefill.
+- The second request therefore samples from stale or otherwise non-equivalent
+  target logits even though the restored KV frontier looks correct.
+
+Relevant code point:
+
+- `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+  - `orbit_mtp_session_complete(...)`
+  - request-boundary restore branch using
+    `session->request_boundary_ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY)`
+  - first sample immediately after restore through
+    `common_sampler_sample(smpl, ctx_tgt, -1)`
+
+### Current Classification
+
+- Target-only versus MTP first: previous divergence was a non-equivalent harness.
+- MTP first versus MTP second: checkpoint/restore logits mismatch.
+- Sampler implementation mismatch: falsified for the first request.
+- Validate/acceptance mismatch: not implicated in the first-sample divergence.
+- Performance patching remains blocked until second-request restore equivalence
+  is fixed or request-boundary restore is excluded from equivalence benchmarks.
+
+## Phase 7: Restore/Logits Equivalence And Teardown Stability
+
+### Restore/Logits Root Cause
+
+The restored request-boundary path had the same effective prompt and KV frontier
+as fresh MTP, but the final logits row used by `common_sampler_sample(...)`
+differed:
+
+```text
+MTP first:
+  prompt_count=20
+  prompt_hash=10014497124828543528
+  frontier=0..19
+  last_logits_hash=4957177649268112296
+  first_sample_hash=11503514907415216418
+  output_hash=db3387031e7c3d53
+
+MTP second before fix:
+  prompt_count=20
+  prompt_hash=10014497124828543528
+  frontier=0..19
+  restore=true
+  last_logits_hash=9250577076402425798
+  first_sample_hash=1225426879707157548
+  output_hash=b75fc404db1d052c
+```
+
+Confirmed:
+
+- H1/H3: the request-boundary checkpoint restored enough KV/frontier state for
+  accounting, but did not restore a final logits row equivalent to fresh target
+  prefill.
+- H6: sampling after restore read a non-equivalent logits row even though the
+  frontier was correct.
+
+Rejected or narrowed:
+
+- H4 as a one-token refresh: removing and decoding only the final prompt token
+  after restore did not recover equivalence. The resulting logits still differed.
+- H5 as the only cause: the checkpoint can still be useful for draft/spec state,
+  but the target logits row cannot be trusted after partial restore.
+
+### Correctness Patch Applied
+
+The request-boundary restore branch now refreshes the target side by clearing
+target memory and decoding the effective target prompt again before the first
+sample. Draft/spec state is still restored from the request-boundary checkpoint.
+
+Relevant file/function:
+
+- `src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp`
+  - `orbit_mtp_session_complete(...)`
+  - request-boundary restore branch before first `common_sampler_sample(...)`
+
+Post-fix result:
+
+```text
+target-only effective:
+  prompt_hash=10014497124828543528
+  frontier=0..19
+  last_logits_hash=4957177649268112296
+  first_sample_hash=11503514907415216418
+  output_hash=db3387031e7c3d53
+
+MTP first:
+  prompt_hash=10014497124828543528
+  frontier=0..19
+  last_logits_hash=4957177649268112296
+  first_sample_hash=11503514907415216418
+  output_hash=db3387031e7c3d53
+
+MTP second:
+  prompt_hash=10014497124828543528
+  frontier=0..19
+  restore=true
+  request_boundary_logits_refreshed=true
+  last_logits_hash=4957177649268112296
+  first_sample_hash=11503514907415216418
+  output_hash=db3387031e7c3d53
+```
+
+Performance impact:
+
+- The fix is correctness-first and not a performance optimization.
+- MTP second now pays a target prompt refresh cost before sampling.
+- In the measured harness, MTP second had roughly `suffix_target_prefill_ms` in
+  the 1.7-2.4s range and a loop around 5.3-5.6s for the tested prompt/cap.
+- Future performance work must preserve the restored-logits equivalence above.
+
+### Teardown Double-Free Status
+
+The teardown abort was reproducible after repeated mixed target-only/MTP client
+lifetimes:
+
+```text
+target-only client -> MTP client -> repeated 3 times
+all completions and client.close() calls completed
+process aborted at exit with: double free or corruption (!prev)
+```
+
+The minimal single-client MTP path exited cleanly. A gdb run showed the abort
+inside libc exit handlers after all Orbit cleanup had completed, with a
+`common_log` worker thread still present from `libllama-common.so`. The issue was
+not a direct `orbit_mtp_session_free(...)` failure.
+
+Confirmed so far:
+
+- The crash happens after all completions and explicit `client.close()` calls
+  complete.
+- The crash is detected by libc during process-exit cleanup.
+- A single MTP client with completion and close exits cleanly.
+- Multiple MTP-only clients can exit cleanly.
+- Repeated mixed target-only/MTP clients without trace metadata can exit cleanly
+  after avoiding per-client backend global free.
+- The full metadata equivalence harness originally exited with `double free or
+  corruption (!prev)` after producing all expected rows.
+- For the consolidated patch, the retained `ORBIT_MTP_TRACE=1` surface is limited
+  to stable metadata (`timing_json`, output-token hashes, and first-sample
+  hashes). The same mixed target/MTP lifecycle reproducer exits cleanly with
+  that retained surface.
+- Heavy step/validate/target-decode JSON retrieval remains excluded from the
+  retained diagnostics because it can still reproduce the exit-134 teardown
+  failure.
+
+Fixes applied:
+
+- `NativeLlamaClient.close()` still frees the MTP session, sampler, contexts, and
+  model, but no longer frees llama.cpp process-global backend state per client.
+- Native `CDLL` handles are cached by absolute path so repeated client/shim use
+  does not repeatedly unload/reload the same runtime libraries.
+- `PersistentMtpSessionRuntime` retains the MTP shim library object for the
+  lifetime of the C++ session handle.
+- The persistent MTP shim build now links against the packaged vendor build bin
+  when the runtime lib directory does not expose `libllama.so.0` and
+  `libllama-common.so.0`. This avoids building or loading the shim against a
+  stale source-tree llama.cpp build while the Python runtime uses packaged
+  vendor libraries.
+
+Validation and residual blocker:
+
+```text
+single MTP client, one completion, close: exit 0
+target + MTP pair, close: exit 0
+3 MTP clients, two completions each: exit 0
+3 mixed target/MTP cycles before backend-free fix: exit 134
+3 mixed target/MTP cycles after backend-free fix: exit 0
+3 target/MTP cycles without mmproj: exit 0
+5 load/close cycles with mmproj only: exit 0
+3 target-only cycles with mmproj: exit 0
+3 MTP clients with mmproj: exit 0
+3 target/MTP cycles with mmproj after shim link-bin fix: exit 0
+2 target/MTP cycles with retained stable ORBIT_MTP_TRACE metadata: exit 0
+2 target/MTP cycles with heavy step/target-decode metadata retrieval: exit 134
+```
+
+The runtime-path double-free is resolved in the local repro matrix for normal
+MTP operation and for the retained stable diagnostics. One confirmed root cause
+was a runtime/linkage mismatch: the persistent MTP shim could be built against a
+different llama.cpp build than the runtime libraries loaded by `NativeLlamaClient`.
+That allowed incompatible llama.cpp/common runtime state to coexist in one Python
+process and abort during process-exit cleanup.
+
+The fix does not intentionally leak runtime objects: client-owned MTP sessions,
+samplers, contexts, models, and multimodal contexts are still released. The
+process-global llama.cpp backend is not freed per client, and native CDLL handles
+are cached with `RTLD_NODELETE` so the dynamic loader does not unload shared
+llama.cpp globals while other loaded components can still reference them.
+
+Residual risks:
+
+- Heavy step/validate/target-decode trace retrieval is not retained. It needs a
+  separate native lifetime/ownership audit before re-exposure.
+- The vendored llama.cpp source is not a Git submodule, and the local vendor tree
+  is not identical to current upstream `master`. It matches PR 23398 for several
+  MTP/sampler files, while `common/speculative.cpp` carries additional
+  Orbit/vendor changes. Future vendor refreshes should record the upstream commit
+  explicitly and rerun the lifecycle harness.
+
+## Minimal Test And Benchmark Plan
+
+### Local Unit Suite
+
+Run the MTP-specific model-free tests first:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_native_mtp_experimental tests.test_native_persistent_mtp -q
+PYTHONPATH=src python3 -m unittest tests.test_native_mtp_probe tests.test_native_mtp_dry_run tests.test_native_mtp_accept_probe tests.test_native_mtp_decode_probe -q
+```
+
+Then run the full safety net:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+### Real Model Benchmark
+
+Use the same target GGUF, MTP draft GGUF, prompt, and generation cap for all
+runs.
+
+Recommended fixed setup:
+
+```text
+ctx=8192
+threads=6
+threads-batch=6
+batch=256
+ubatch=128
+CPU affinity: taskset -c 0-5
+thinking=off
+tools disabled for the generation-only comparison
+```
+
+Compare:
+
+- Orbit native target-only;
+- Orbit native `--mtp`;
+- reference `llama-server` MTP.
+
+Collect:
+
+- normalized output equivalence;
+- total wall time;
+- `generation_ms`;
+- output token count;
+- validate count;
+- validate `n_tok` sequence;
+- target decode calls;
+- draft decode calls;
+- full/live/restored/replay resolution counts;
+- accepted/rejected draft totals;
+- phase timing totals;
+- checkpoint/restore counts;
+- `seq_rm` counts.
+
+### Focused A/B Checks
+
+- Default boundary split vs `ORBIT_MTP_BOUNDARY_SPLIT=0`.
+- `ORBIT_MTP_PARTIAL_DEBUG=1` for frontier transitions.
+- `ORBIT_MTP_VALIDATE_DEBUG=1` for validate shapes.
+- `ORBIT_MTP_DRAFT_TRACE=1` for draft positions and token counts.
+
+### Correctness Gates
+
+- Output must remain equivalent to target-only greedy reference.
+- Streamed content must match final content after filtering.
+- Cancel/interruption must not corrupt a later request.
+- Fallback after MTP failure must still use standard generation.
+- Tools, routing, final policy, evidence policy, and prompts must remain
+  untouched.

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -29,6 +29,26 @@ llama_token = c_int32
 llama_pos = c_int32
 llama_seq_id = c_int32
 
+
+_CDLL_CACHE: dict[tuple[str, int], CDLL] = {}
+
+
+def native_cdll_flags() -> int:
+    return (
+        getattr(os, "RTLD_GLOBAL", 0)
+        | getattr(os, "RTLD_NOW", 0)
+        | getattr(os, "RTLD_NODELETE", 0)
+    )
+
+
+def load_native_cdll(path: Path, *, mode: int) -> CDLL:
+    key = (str(path.resolve()), mode)
+    lib = _CDLL_CACHE.get(key)
+    if lib is None:
+        lib = ctypes.CDLL(str(path), mode=mode)
+        _CDLL_CACHE[key] = lib
+    return lib
+
 LlamaProgressCallback = CFUNCTYPE(c_bool, c_float, c_void_p)
 GgmlAbortCallback = CFUNCTYPE(c_bool, c_void_p)
 GgmlLogCallback = CFUNCTYPE(None, c_int, c_char_p, c_void_p)
@@ -159,7 +179,7 @@ class LlamaLibrary:
         self._configure_api()
 
     def _load_library(self, name: str) -> CDLL:
-        flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+        flags = native_cdll_flags()
         # Load dependencies explicitly because LD_LIBRARY_PATH cannot be changed
         # reliably after Python startup.
         for dep in platform_runtime_libs():
@@ -168,10 +188,10 @@ class LlamaLibrary:
             path = self.build_bin / dep
             if path.exists():
                 try:
-                    self._handles.append(ctypes.CDLL(str(path), mode=flags))
+                    self._handles.append(load_native_cdll(path, mode=flags))
                 except OSError:
                     pass
-        return ctypes.CDLL(str(self.build_bin / name), mode=flags)
+        return load_native_cdll(self.build_bin / name, mode=flags)
 
     def _configure_api(self) -> None:
         lib = self.lib
@@ -219,6 +239,14 @@ class LlamaLibrary:
         lib.llama_state_seq_get_data.restype = c_size_t
         lib.llama_state_seq_set_data.argtypes = [c_void_p, POINTER(c_ubyte), c_size_t, c_int32]
         lib.llama_state_seq_set_data.restype = c_size_t
+        lib.llama_get_memory.argtypes = [c_void_p]
+        lib.llama_get_memory.restype = c_void_p
+        if hasattr(lib, "llama_memory_seq_pos_min"):
+            lib.llama_memory_seq_pos_min.argtypes = [c_void_p, llama_seq_id]
+            lib.llama_memory_seq_pos_min.restype = llama_pos
+        if hasattr(lib, "llama_memory_seq_pos_max"):
+            lib.llama_memory_seq_pos_max.argtypes = [c_void_p, llama_seq_id]
+            lib.llama_memory_seq_pos_max.restype = llama_pos
 
         lib.llama_model_get_vocab.argtypes = [c_void_p]
         lib.llama_model_get_vocab.restype = c_void_p
@@ -275,8 +303,8 @@ class LlamaLibrary:
 
 class MtmdLibrary:
     def __init__(self, build_bin: Path) -> None:
-        flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
-        self.lib = ctypes.CDLL(str(build_bin / runtime_library_filename("mtmd")), mode=flags)
+        flags = native_cdll_flags()
+        self.lib = load_native_cdll(build_bin / runtime_library_filename("mtmd"), mode=flags)
         self._configure_api()
 
     def _configure_api(self) -> None:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import codecs
-from ctypes import POINTER, byref, c_char, cast, c_ubyte, create_string_buffer, c_void_p, sizeof
+import ctypes
+import hashlib
+from ctypes import POINTER, byref, c_char, c_float, cast, c_ubyte, create_string_buffer, c_void_p, sizeof
 from dataclasses import dataclass, replace
+import os
 from pathlib import Path
 import threading
 
@@ -138,6 +141,9 @@ class NativeLlamaClient:
         self._persistent_mtp_runtime: PersistentMtpSessionRuntime | None = None
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = 0
+        self.last_target_only_token_hashes: list[int] = []
+        self.last_target_only_first_sample_trace: dict[str, object] | None = None
+        self._last_prompt_decode_batch_n_tokens = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
         self._route_prefix_prefill_lock = threading.Lock()
 
@@ -179,7 +185,8 @@ class NativeLlamaClient:
         if self._model:
             lib.llama_model_free(self._model)
             self._model = None
-        lib.llama_backend_free()
+        # llama.cpp backend globals are process-wide; freeing them per client can
+        # corrupt teardown after mixed target-only/MTP client lifetimes.
 
     def cancel(self) -> None:
         self._session.cancel_requested = True
@@ -1144,6 +1151,7 @@ class NativeLlamaClient:
                 self.cancel()
                 break
             n = min(step, end - processed)
+            self._last_prompt_decode_batch_n_tokens = int(n)
             token_ptr = cast(byref(token_array, processed * sizeof(llama_token)), POINTER(llama_token))
             batch = lib.llama_batch_get_one(token_ptr, n)
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
@@ -1382,6 +1390,8 @@ class NativeLlamaClient:
             raise RuntimeError("native client not loaded")
         lib = self.lib.lib
         lib.llama_sampler_reset(self._session.sampler)
+        self.last_target_only_token_hashes = []
+        self.last_target_only_first_sample_trace = None
         generated = 0
         gen_start = lib.llama_time_us()
         decoder = codecs.getincrementaldecoder("utf-8")("replace")
@@ -1389,10 +1399,25 @@ class NativeLlamaClient:
             if should_cancel and should_cancel():
                 self.cancel()
                 break
+            first_sample_before = None
+            if generated == 0 and _mtp_trace_enabled():
+                first_sample_before = self._target_only_first_sample_metadata(path_name="target_only", generated_count=generated)
             token = lib.llama_sampler_sample(self._session.sampler, self._session.ctx_tgt, -1)
             lib.llama_sampler_accept(self._session.sampler, token)
             if lib.llama_vocab_is_eog(self._vocab, token):
                 break
+            self.last_target_only_token_hashes.append(_stable_token_hash(int(token)))
+            if first_sample_before is not None:
+                first_sample_after = self._target_only_first_sample_metadata(path_name="target_only", generated_count=generated + 1)
+                self.last_target_only_first_sample_trace = {
+                    **first_sample_before,
+                    "first_sample_hash": self.last_target_only_token_hashes[-1],
+                    "sampler_state_hash_after": None,
+                    "ctx_frontier_min_after": first_sample_after.get("ctx_frontier_min"),
+                    "ctx_frontier_max_after": first_sample_after.get("ctx_frontier_max"),
+                    "ctx_frontier_hash_after": first_sample_after.get("ctx_frontier_hash"),
+                    "generated_count_after": generated + 1,
+                }
             text = decoder.decode(self._token_to_bytes(token), final=False)
             if text and on_token:
                 on_token(text)
@@ -1411,6 +1436,56 @@ class NativeLlamaClient:
             on_token(text)
         gen_ms = (lib.llama_time_us() - gen_start) / 1000.0
         return generated, gen_ms, self.cancel_event.is_set()
+
+    def _target_only_first_sample_metadata(self, *, path_name: str, generated_count: int) -> dict[str, object]:
+        if not self._session.ctx_tgt or not self._vocab:
+            return {}
+        lib = self.lib.lib
+        mem = lib.llama_get_memory(self._session.ctx_tgt)
+        frontier_min = int(lib.llama_memory_seq_pos_min(mem, 0)) if mem and hasattr(lib, "llama_memory_seq_pos_min") else -1
+        frontier_max = int(lib.llama_memory_seq_pos_max(mem, 0)) if mem and hasattr(lib, "llama_memory_seq_pos_max") else -1
+        prompt_tokens = list(self._session.cached_prompt_tokens)
+        return {
+            "path_name": path_name,
+            "prompt_hash": _stable_tokens_hash_hex(prompt_tokens),
+            "prompt_count": len(prompt_tokens),
+            "ctx_n_past": frontier_max + 1 if frontier_max >= 0 else 0,
+            "ctx_frontier_min": frontier_min,
+            "ctx_frontier_max": frontier_max,
+            "ctx_frontier_hash": _stable_frontier_hash_hex(frontier_min, frontier_max),
+            "ctx_max_pos": frontier_max,
+            "batch_n_tokens": self._last_prompt_decode_batch_n_tokens,
+            "logits_row_count": 1,
+            "n_outputs": 1,
+            "last_logits_hash": self._last_logits_hash(),
+            "sampler_config_hash": _canonical_greedy_sampler_hash(),
+            "sampler_state_hash": None,
+            "sampler_chain_type": "llama_sampler_chain+greedy",
+            "seed_hash": None,
+            "temperature": 0.0,
+            "top_k": 1,
+            "top_p": 1.0,
+            "min_p": 0.0,
+            "repeat_penalty": 1.0,
+            "generated_count": generated_count,
+        }
+
+    def _last_logits_hash(self) -> int | None:
+        if not self._session.ctx_tgt or not self._vocab:
+            return None
+        lib = self.lib.lib
+        ptr = lib.llama_get_logits_ith(self._session.ctx_tgt, -1)
+        if not ptr:
+            return None
+        n_vocab = int(lib.llama_vocab_n_tokens(self._vocab))
+        if n_vocab <= 0:
+            return None
+        payload = ctypes.string_at(ptr, n_vocab * sizeof(c_float))
+        hash_value = 1469598103934665603
+        for byte in payload:
+            hash_value ^= byte
+            hash_value = (hash_value * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+        return hash_value
 
     def tokenize(self, prompt: str) -> list[int]:
         if not self._vocab:
@@ -1515,6 +1590,44 @@ def _prepare_mtp_prompt(prompt: str, *, thinking: bool = False) -> str:
             return prompt
         return _strip_thinking_prompt(prompt)
     return render_gemma4_chat([{"role": "user", "content": prompt}], thinking=thinking)
+
+
+def _canonical_greedy_sampler_hash() -> str:
+    return hashlib.sha256(b'{"min_p":0.0,"repeat_penalty":1.0,"sampler":"greedy","temperature":0.0,"top_k":1,"top_p":1.0}').hexdigest()[:16]
+
+
+def _mtp_trace_enabled() -> bool:
+    value = os.environ.get("ORBIT_MTP_TRACE")
+    return value not in (None, "", "0", "false", "False", "off", "OFF")
+
+
+def _stable_tokens_hash_hex(tokens: list[int]) -> int:
+    hash_value = 1469598103934665603
+    for token in tokens:
+        value = int(token) & 0xFFFFFFFF
+        for shift in range(0, 32, 8):
+            hash_value ^= (value >> shift) & 0xFF
+            hash_value = (hash_value * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return hash_value
+
+
+def _stable_frontier_hash_hex(frontier_min: int, frontier_max: int) -> int:
+    hash_value = 1469598103934665603
+    for pos in (frontier_min, frontier_max):
+        value = int(pos) & 0xFFFFFFFF
+        for shift in range(0, 32, 8):
+            hash_value ^= (value >> shift) & 0xFF
+            hash_value = (hash_value * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return hash_value
+
+
+def _stable_token_hash(token: int) -> int:
+    hash_value = 1469598103934665603
+    value = token & 0xFFFFFFFF
+    for shift in range(0, 32, 8):
+        hash_value ^= (value >> shift) & 0xFF
+        hash_value = (hash_value * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return hash_value
 
 
 def _strip_thinking_prompt(prompt: str) -> str:

--- a/src/orbit/native_llama/mtp_completion.py
+++ b/src/orbit/native_llama/mtp_completion.py
@@ -39,6 +39,12 @@ class MtpCompletionResult:
     rollback_tokens_total: int = 0
     checkpoint_count: int = 0
     restore_count: int = 0
+    trace_json: str | None = None
+    timing_json: str | None = None
+    validate_trace_json: str | None = None
+    target_decode_trace_json: str | None = None
+    output_token_hashes_json: str | None = None
+    first_sample_trace_json: str | None = None
 
 
 def run_mtp_completion(

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -7,7 +7,8 @@ import ctypes
 import os
 import subprocess
 
-from .build_support import compile_cpp_helper
+from .bindings import load_native_cdll, native_cdll_flags
+from .build_support import DEFAULT_VENDOR_BUILD_BIN, compile_cpp_helper
 from .mtp_completion import MtpCompletionResult
 from .native_artifacts import packaged_shim_path, require_legacy_llama_root
 from .native_names import persistent_mtp_shim_filename, platform_runtime_libs
@@ -16,6 +17,8 @@ from .paths import NativeLlamaPaths
 _REQUIRED_SHIM_SYMBOLS = (
     "orbit_mtp_session_complete",
     "orbit_mtp_session_set_followup_suffix_tokens",
+    "orbit_mtp_session_last_first_sample_trace_json",
+    "orbit_mtp_session_request_boundary_refill_marker",
 )
 
 MtpTokenCallback = CFUNCTYPE(None, c_char_p, c_void_p)
@@ -35,6 +38,7 @@ class PersistentMtpSessionRuntime:
     handle: c_void_p
     ctx_dft: c_void_p
     spec: c_void_p
+    library: object | None = None
     rss_before_kb: int | None = None
     rss_after_init_kb: int | None = None
     rss_peak_kb: int | None = None
@@ -49,12 +53,12 @@ class PersistentMtpLibrary:
         self._configure_api()
 
     def _load_library(self) -> CDLL:
-        flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+        flags = native_cdll_flags()
         for dep in platform_runtime_libs():
             path = self.build_bin / dep
             if path.exists():
-                self._handles.append(ctypes.CDLL(str(path), mode=flags))
-        return ctypes.CDLL(str(self.shim_path), mode=flags)
+                self._handles.append(load_native_cdll(path, mode=flags))
+        return load_native_cdll(self.shim_path, mode=flags)
 
     def _configure_api(self) -> None:
         lib = self.lib
@@ -134,6 +138,15 @@ class PersistentMtpLibrary:
         lib.orbit_mtp_session_last_checkpoint_count.restype = c_int32
         lib.orbit_mtp_session_last_restore_count.argtypes = [c_void_p]
         lib.orbit_mtp_session_last_restore_count.restype = c_int32
+        if hasattr(lib, "orbit_mtp_session_last_timing_json"):
+            lib.orbit_mtp_session_last_timing_json.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_timing_json.restype = c_char_p
+        if hasattr(lib, "orbit_mtp_session_last_output_token_hashes_json"):
+            lib.orbit_mtp_session_last_output_token_hashes_json.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_output_token_hashes_json.restype = c_char_p
+        if hasattr(lib, "orbit_mtp_session_last_first_sample_trace_json"):
+            lib.orbit_mtp_session_last_first_sample_trace_json.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_first_sample_trace_json.restype = c_char_p
 
 
 def build_persistent_mtp_shim(
@@ -162,12 +175,22 @@ def build_persistent_mtp_shim(
     )
 
 
+def _persistent_mtp_link_bin(paths: NativeLlamaPaths) -> Path:
+    """Choose a link directory with the SONAME symlinks required by the shim."""
+    build_bin = paths.build_bin
+    if (build_bin / "libllama.so.0").exists() and (build_bin / "libllama-common.so.0").exists():
+        return build_bin
+    if (DEFAULT_VENDOR_BUILD_BIN / "libllama.so.0").exists() and (DEFAULT_VENDOR_BUILD_BIN / "libllama-common.so.0").exists():
+        return DEFAULT_VENDOR_BUILD_BIN
+    return build_bin
+
+
 def _shim_exports_required_symbols(path: Path) -> bool:
     if not path.exists() or not path.is_file():
         return False
-    flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
+    flags = native_cdll_flags()
     try:
-        lib = ctypes.CDLL(str(path), mode=flags)
+        lib = load_native_cdll(path, mode=flags)
     except OSError:
         return False
     return all(hasattr(lib, symbol) for symbol in _REQUIRED_SHIM_SYMBOLS)
@@ -189,7 +212,12 @@ def create_persistent_mtp_session(
 ) -> PersistentMtpSessionRuntime:
     if not paths.mtp_available or paths.draft_mtp_model is None:
         raise RuntimeError(paths.fallback_reason or "draft-mtp-unavailable")
-    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir, runner=runner)
+    shim = build_persistent_mtp_shim(
+        llama_root=llama_root,
+        build_dir=build_dir,
+        build_bin=_persistent_mtp_link_bin(paths),
+        runner=runner,
+    )
     library = library_factory(paths.build_bin, shim)
     handle = library.lib.orbit_mtp_session_create(
         str(paths.draft_mtp_model).encode(),
@@ -206,10 +234,25 @@ def create_persistent_mtp_session(
         handle=c_void_p(handle),
         ctx_dft=library.lib.orbit_mtp_session_ctx_dft(handle),
         spec=library.lib.orbit_mtp_session_spec(handle),
+        library=library,
         rss_before_kb=_long_or_none(library.lib.orbit_mtp_session_rss_before_kb(handle)),
         rss_after_init_kb=_long_or_none(library.lib.orbit_mtp_session_rss_after_init_kb(handle)),
         rss_peak_kb=_long_or_none(library.lib.orbit_mtp_session_rss_peak_kb(handle)),
     )
+
+
+def _runtime_library(
+    *,
+    paths: NativeLlamaPaths,
+    runtime: PersistentMtpSessionRuntime,
+    build_dir: Path | None,
+    library_factory,
+    llama_root: Path,
+) -> object:
+    if runtime.library is not None and hasattr(runtime.library, "lib"):
+        return runtime.library
+    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir, build_bin=_persistent_mtp_link_bin(paths))
+    return library_factory(paths.build_bin, shim)
 
 
 def reset_persistent_mtp_session(
@@ -221,8 +264,13 @@ def reset_persistent_mtp_session(
     library_factory=PersistentMtpLibrary,
     llama_root: Path,
 ) -> PersistentMtpSessionRuntime:
-    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
-    library = library_factory(paths.build_bin, shim)
+    library = _runtime_library(
+        paths=paths,
+        runtime=runtime,
+        build_dir=build_dir,
+        library_factory=library_factory,
+        llama_root=llama_root,
+    )
     ok = library.lib.orbit_mtp_session_reset(runtime.handle, ctx_tgt)
     if not ok:
         raise RuntimeError(_decode_error(library.lib.orbit_mtp_last_error()))
@@ -230,6 +278,7 @@ def reset_persistent_mtp_session(
         handle=runtime.handle,
         ctx_dft=library.lib.orbit_mtp_session_ctx_dft(runtime.handle),
         spec=library.lib.orbit_mtp_session_spec(runtime.handle),
+        library=library,
         rss_before_kb=runtime.rss_before_kb,
         rss_after_init_kb=runtime.rss_after_init_kb,
         rss_peak_kb=runtime.rss_peak_kb,
@@ -244,8 +293,13 @@ def free_persistent_mtp_session(
     library_factory=PersistentMtpLibrary,
     llama_root: Path,
 ) -> None:
-    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
-    library = library_factory(paths.build_bin, shim)
+    library = _runtime_library(
+        paths=paths,
+        runtime=runtime,
+        build_dir=build_dir,
+        library_factory=library_factory,
+        llama_root=llama_root,
+    )
     library.lib.orbit_mtp_session_free(runtime.handle)
 
 
@@ -264,8 +318,13 @@ def run_persistent_mtp_completion(
 ) -> MtpCompletionResult:
     if runtime is None:
         return MtpCompletionResult(enabled=True, success=False, error="persistent-mtp-uninitialized")
-    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir)
-    library = library_factory(paths.build_bin, shim)
+    library = _runtime_library(
+        paths=paths,
+        runtime=runtime,
+        build_dir=build_dir,
+        library_factory=library_factory,
+        llama_root=llama_root,
+    )
     if on_token is not None:
         def _token_cb(text: bytes | None, _user_data) -> None:
             if text:
@@ -294,6 +353,7 @@ def run_persistent_mtp_completion(
             success=False,
             error=_decode_error(library.lib.orbit_mtp_last_error()),
         )
+    trace_enabled = _trace_enabled()
     return MtpCompletionResult(
         enabled=True,
         success=True,
@@ -322,6 +382,12 @@ def run_persistent_mtp_completion(
         rollback_tokens_total=int(library.lib.orbit_mtp_session_last_rollback_tokens_total(runtime.handle)),
         checkpoint_count=int(library.lib.orbit_mtp_session_last_checkpoint_count(runtime.handle)),
         restore_count=int(library.lib.orbit_mtp_session_last_restore_count(runtime.handle)),
+        trace_json=None,
+        timing_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_timing_json", runtime.handle) if trace_enabled else None,
+        validate_trace_json=None,
+        target_decode_trace_json=None,
+        output_token_hashes_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_output_token_hashes_json", runtime.handle) if trace_enabled else None,
+        first_sample_trace_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_first_sample_trace_json", runtime.handle) if trace_enabled else None,
     )
 
 
@@ -335,6 +401,18 @@ def _decode_text(value: bytes | None) -> str:
     if not value:
         return ""
     return value.decode(errors="replace")
+
+
+def _optional_trace_text(lib, name: str, handle: c_void_p) -> str | None:
+    getter = getattr(lib, name, None)
+    if getter is None:
+        return None
+    return _decode_text(getter(handle))
+
+
+def _trace_enabled() -> bool:
+    value = os.environ.get("ORBIT_MTP_TRACE")
+    return value is not None and value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
 def _long_or_none(value: int | None) -> int | None:

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -104,6 +104,58 @@ static uint64_t stable_hash_string(const std::string & value) {
     return hash;
 }
 
+static uint64_t stable_hash_tokens(const std::vector<llama_token> & tokens) {
+    uint64_t hash = 1469598103934665603ull;
+    for (llama_token token : tokens) {
+        const uint32_t value = (uint32_t) token;
+        for (int i = 0; i < 4; ++i) {
+            hash ^= (uint64_t) ((value >> (i * 8)) & 0xffu);
+            hash *= 1099511628211ull;
+        }
+    }
+    return hash;
+}
+
+static uint64_t stable_hash_token(llama_token token) {
+    const std::vector<llama_token> tokens = {token};
+    return stable_hash_tokens(tokens);
+}
+
+static uint64_t stable_hash_logits(llama_context * ctx, const llama_vocab * vocab) {
+    if (!ctx || !vocab) {
+        return 0;
+    }
+    const float * logits = llama_get_logits_ith(ctx, -1);
+    if (!logits) {
+        return 0;
+    }
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+    if (n_vocab <= 0) {
+        return 0;
+    }
+    const auto * bytes = reinterpret_cast<const unsigned char *>(logits);
+    uint64_t hash = 1469598103934665603ull;
+    const size_t size = (size_t) n_vocab * sizeof(float);
+    for (size_t i = 0; i < size; ++i) {
+        hash ^= (uint64_t) bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+static uint64_t stable_hash_frontier(int32_t min_pos, int32_t max_pos) {
+    uint64_t hash = 1469598103934665603ull;
+    const int32_t values[2] = {min_pos, max_pos};
+    for (int32_t pos : values) {
+        const uint32_t value = (uint32_t) pos;
+        for (int i = 0; i < 4; ++i) {
+            hash ^= (uint64_t) ((value >> (i * 8)) & 0xffu);
+            hash *= 1099511628211ull;
+        }
+    }
+    return hash;
+}
+
 static long rss_kb() {
     FILE * f = std::fopen("/proc/self/status", "r");
     if (!f) {
@@ -160,6 +212,9 @@ struct orbit_mtp_session {
     std::string last_timing_json;
     std::string last_validate_trace_json;
     std::string last_target_decode_trace_json;
+    std::vector<uint64_t> last_output_token_hashes;
+    std::string last_output_token_hashes_json;
+    std::string last_first_sample_trace_json;
     phase_stat phase_prefix_restore;
     phase_stat phase_suffix_decode_target;
     phase_stat phase_draft_generation;
@@ -208,10 +263,26 @@ struct orbit_trace_step {
     std::vector<llama_token> draft;
     std::vector<llama_token> accepted_ids;
     int accepted_draft = 0;
+    int rejected_draft = 0;
     int sampled_id = -1;
     int rejected_id = -1;
     std::string resolution;
     int validated_count = 0;
+    std::string draft_origin = "unknown";
+    bool draft_is_fresh = false;
+    bool need_replay_before = false;
+    int validate_n_tok = 0;
+    int32_t validate_pos0 = -1;
+    int32_t old_n_past = -1;
+    int32_t new_n_past = -1;
+    int32_t prompt_tgt_len = -1;
+    int32_t prompt_dft_len = -1;
+    uint64_t prompt_tgt_hash = 0;
+    uint64_t ctx_tgt_frontier_hash = 0;
+    uint64_t ctx_dft_frontier_hash = 0;
+    uint64_t sampler_state_hash_before = 0;
+    uint64_t sampler_state_hash_after = 0;
+    int remaining_generation_cap = 0;
     int checkpoint_total = 0;
     int restore_total = 0;
     int32_t kv_tgt_before_min = -1;
@@ -338,24 +409,19 @@ static std::vector<llama_token> tail_tokens(const std::vector<llama_token> & tok
 
 static std::string token_vec_json(const llama_vocab * vocab, const std::vector<llama_token> & tokens) {
     std::ostringstream out;
-    out << "[";
-    for (size_t i = 0; i < tokens.size(); ++i) {
-        if (i > 0) {
-            out << ",";
-        }
-        out << "{\"id\":" << (int) tokens[i] << ",\"piece\":\"" << token_piece_json(vocab, tokens[i]) << "\"}";
-    }
-    out << "]";
+    (void) vocab;
+    out << "{\"count\":" << tokens.size() << ",\"hash\":" << stable_hash_tokens(tokens) << "}";
     return out.str();
 }
 
 static std::string optional_rejected_json(const llama_vocab * vocab, const std::vector<llama_token> & draft, int accepted_draft) {
+    (void) vocab;
     if (accepted_draft < 0 || accepted_draft >= (int) draft.size()) {
         return "null";
     }
     std::ostringstream out;
     const auto tok = draft[(size_t) accepted_draft];
-    out << "{\"id\":" << (int) tok << ",\"piece\":\"" << token_piece_json(vocab, tok) << "\"}";
+    out << "{\"hash\":" << stable_hash_token(tok) << "}";
     return out.str();
 }
 
@@ -363,19 +429,35 @@ static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_
     std::ostringstream out;
     out
         << "{\"index\":" << step.index
-        << ",\"sampler_before\":\"" << json_escape(step.sampler_before) << "\""
-        << ",\"sampler_after\":\"" << json_escape(step.sampler_after) << "\""
         << ",\"sampler_before_hash\":" << step.sampler_before_hash
         << ",\"sampler_after_hash\":" << step.sampler_after_hash
-        << ",\"draft\":" << token_vec_json(vocab, step.draft)
-        << ",\"accepted_ids\":" << token_vec_json(vocab, step.accepted_ids)
+        << ",\"draft_count\":" << step.draft.size()
+        << ",\"draft_hash\":" << stable_hash_tokens(step.draft)
+        << ",\"accepted_id_count\":" << step.accepted_ids.size()
+        << ",\"accepted_hash\":" << stable_hash_tokens(step.accepted_ids)
         << ",\"accepted_draft\":" << step.accepted_draft
-        << ",\"sampled_id\":" << step.sampled_id
-        << ",\"rejected_id\":" << step.rejected_id
+        << ",\"rejected_draft\":" << step.rejected_draft
+        << ",\"sampled_hash\":" << (step.sampled_id >= 0 ? stable_hash_token((llama_token) step.sampled_id) : 0)
+        << ",\"rejected_hash\":" << (step.rejected_id >= 0 ? stable_hash_token((llama_token) step.rejected_id) : 0)
         << ",\"first_rejected\":" << optional_rejected_json(vocab, step.draft, step.accepted_draft)
         << ",\"resolution\":\"" << step.resolution << "\""
-        << ",\"id_last_before\":" << step.id_last_before
-        << ",\"id_last_after\":" << step.id_last_after
+        << ",\"draft_origin\":\"" << json_escape(step.draft_origin) << "\""
+        << ",\"draft_is_fresh\":" << (step.draft_is_fresh ? "true" : "false")
+        << ",\"need_replay_before\":" << (step.need_replay_before ? "true" : "false")
+        << ",\"validate_n_tok\":" << step.validate_n_tok
+        << ",\"validate_pos0\":" << step.validate_pos0
+        << ",\"old_n_past\":" << step.old_n_past
+        << ",\"new_n_past\":" << step.new_n_past
+        << ",\"prompt_tgt_len\":" << step.prompt_tgt_len
+        << ",\"prompt_dft_len\":" << step.prompt_dft_len
+        << ",\"prompt_tgt_hash\":" << step.prompt_tgt_hash
+        << ",\"ctx_tgt_frontier_hash\":" << step.ctx_tgt_frontier_hash
+        << ",\"ctx_dft_frontier_hash\":" << step.ctx_dft_frontier_hash
+        << ",\"sampler_state_hash_before\":" << step.sampler_state_hash_before
+        << ",\"sampler_state_hash_after\":" << step.sampler_state_hash_after
+        << ",\"remaining_generation_cap\":" << step.remaining_generation_cap
+        << ",\"id_last_before_hash\":" << stable_hash_token((llama_token) step.id_last_before)
+        << ",\"id_last_after_hash\":" << stable_hash_token((llama_token) step.id_last_after)
         << ",\"n_past_before\":" << step.n_past_before
         << ",\"n_past_after\":" << step.n_past_after
         << ",\"prompt_tgt_size_before\":" << step.prompt_tgt_size_before
@@ -383,7 +465,6 @@ static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_
         << ",\"prompt_tgt_pos_next_before\":" << step.prompt_tgt_pos_next_before
         << ",\"prompt_tgt_pos_next_after\":" << step.prompt_tgt_pos_next_after
         << ",\"residual_draft_size_after\":" << step.residual_draft_size_after
-        << ",\"residual_draft_after\":" << step.residual_draft_after_json
         << ",\"validated_count\":" << step.validated_count
         << ",\"checkpoint_total\":" << step.checkpoint_total
         << ",\"restore_total\":" << step.restore_total
@@ -409,7 +490,6 @@ static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_
             << ",\"next_draft_origin\":\"" << json_escape(step.next_draft_origin) << "\""
             << ",\"next_draft_is_fresh\":" << (step.next_draft_is_fresh ? "true" : "false")
             << ",\"next_draft_size\":" << step.next_draft_size
-            << ",\"next_draft_tokens\":" << step.next_draft_tokens_json
             << ",\"next_validate_n_tok\":" << step.next_validate_n_tok
             << ",\"fresh_draft_tokens_contrib\":" << step.fresh_draft_tokens_contrib
             << ",\"fresh_accepted_tokens_contrib\":" << step.fresh_accepted_tokens_contrib
@@ -426,8 +506,7 @@ static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_
             << ",\"memory_clear_count\":" << step.memory_clear_count
             << ",\"seq_rm_count\":" << step.seq_rm_count
             << ",\"replay_count\":" << step.replay_count
-            << ",\"prefill_count\":" << step.prefill_count
-            << ",\"pre_sample_state\":" << step.pre_sample_state_json;
+            << ",\"prefill_count\":" << step.prefill_count;
     }
     out << "}";
     return out.str();
@@ -486,6 +565,76 @@ static std::string int32_vec_json(const std::vector<int32_t> & values) {
     return out.str();
 }
 
+static std::string uint64_vec_json(const std::vector<uint64_t> & values) {
+    std::ostringstream out;
+    out << "[";
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << values[i];
+    }
+    out << "]";
+    return out.str();
+}
+
+static std::string first_sample_trace_json(
+    const char * path_name,
+    const std::vector<llama_token> & prompt_tgt,
+    llama_context * ctx_tgt,
+    const llama_vocab * vocab_tgt,
+    llama_memory_t mem_tgt,
+    int32_t n_past,
+    int last_prefill_batch_n_tokens,
+    int logits_row_count,
+    int n_outputs,
+    const std::string & sampler_before,
+    llama_token first_sample,
+    const std::string & sampler_after,
+    int generated_count_after,
+    bool request_boundary_restore_used,
+    bool request_boundary_logits_refreshed
+) {
+    const int32_t min_before = mem_tgt ? llama_memory_seq_pos_min(mem_tgt, 0) : -1;
+    const int32_t max_before = mem_tgt ? llama_memory_seq_pos_max(mem_tgt, 0) : -1;
+    std::ostringstream out;
+    out
+        << "{\"path_name\":\"" << json_escape(path_name ? path_name : "mtp") << "\""
+        << ",\"prompt_hash\":" << stable_hash_tokens(prompt_tgt)
+        << ",\"prompt_count\":" << prompt_tgt.size()
+        << ",\"ctx_n_past\":" << n_past
+        << ",\"ctx_frontier_min\":" << min_before
+        << ",\"ctx_frontier_max\":" << max_before
+        << ",\"ctx_frontier_hash\":" << stable_hash_frontier(min_before, max_before)
+        << ",\"ctx_max_pos\":" << max_before
+        << ",\"batch_n_tokens\":" << last_prefill_batch_n_tokens
+        << ",\"logits_row_count\":" << logits_row_count
+        << ",\"n_outputs\":" << n_outputs
+        << ",\"last_logits_hash\":" << stable_hash_logits(ctx_tgt, vocab_tgt)
+        << ",\"sampler_config_hash\":" << stable_hash_string("common_sampler:top_k=1:temp=0:top_p=1:min_p=0:repeat=1")
+        << ",\"sampler_state_hash\":" << stable_hash_string(sampler_before)
+        << ",\"sampler_chain_type\":\"common_sampler(top_k,temp)\""
+        << ",\"seed_hash\":null"
+        << ",\"temperature\":0"
+        << ",\"top_k\":1"
+        << ",\"top_p\":1"
+        << ",\"min_p\":0"
+        << ",\"repeat_penalty\":1"
+        << ",\"generated_count\":0"
+        << ",\"first_sample_hash\":" << stable_hash_token(first_sample)
+        << ",\"sampler_state_hash_after\":" << stable_hash_string(sampler_after)
+        << ",\"ctx_frontier_min_after\":" << (mem_tgt ? llama_memory_seq_pos_min(mem_tgt, 0) : -1)
+        << ",\"ctx_frontier_max_after\":" << (mem_tgt ? llama_memory_seq_pos_max(mem_tgt, 0) : -1)
+        << ",\"ctx_frontier_hash_after\":" << stable_hash_frontier(
+            mem_tgt ? llama_memory_seq_pos_min(mem_tgt, 0) : -1,
+            mem_tgt ? llama_memory_seq_pos_max(mem_tgt, 0) : -1)
+        << ",\"generated_count_after\":" << generated_count_after
+        << ",\"request_boundary_restore_used\":" << (request_boundary_restore_used ? "true" : "false")
+        << ",\"request_boundary_logits_refreshed\":" << (request_boundary_logits_refreshed ? "true" : "false")
+        << "}";
+    return out.str();
+}
+
 static std::string target_decode_trace_json(const llama_vocab * vocab, const std::vector<orbit_target_decode_trace> & items) {
     std::ostringstream out;
     out << "[";
@@ -505,8 +654,9 @@ static std::string target_decode_trace_json(const llama_vocab * vocab, const std
             << ",\"batch_n_outputs_requested\":" << item.batch_logits_count
             << ",\"logits_count\":" << item.batch_logits_count
             << ",\"output_reserve_n_outputs\":" << item.output_reserve_n_outputs
-            << ",\"logits_flags\":" << int_vec_json(item.logits_flags)
-            << ",\"token_ids\":" << token_vec_json(vocab, item.token_ids)
+            << ",\"logits_flag_count\":" << item.logits_flags.size()
+            << ",\"token_count\":" << item.token_ids.size()
+            << ",\"token_hash\":" << stable_hash_tokens(item.token_ids)
             << ",\"positions\":" << int32_vec_json(item.positions)
             << ",\"seq_ids\":" << int32_vec_json(item.seq_ids)
             << "}";
@@ -1298,6 +1448,10 @@ extern "C" const char * orbit_mtp_last_error() {
     return g_last_error.c_str();
 }
 
+extern "C" bool orbit_mtp_session_request_boundary_refill_marker() {
+    return true;
+}
+
 extern "C" void * orbit_mtp_session_create(
     const char * draft_model_path,
     void * ctx_tgt_ptr,
@@ -1481,6 +1635,9 @@ extern "C" bool orbit_mtp_session_complete(
     session->last_timing_json = "{}";
     session->last_validate_trace_json = "[]";
     session->last_target_decode_trace_json = "[]";
+    session->last_output_token_hashes.clear();
+    session->last_output_token_hashes_json = "[]";
+    session->last_first_sample_trace_json = "{}";
     session->phase_prefix_restore = {};
     session->phase_suffix_decode_target = {};
     session->phase_draft_generation = {};
@@ -1542,6 +1699,7 @@ extern "C" bool orbit_mtp_session_complete(
     const int32_t progress_generation_phase = 1;
     auto emit_output_token = [&](llama_token token) {
         session->last_output_tokens++;
+        session->last_output_token_hashes.push_back(stable_hash_token(token));
         if (progress_callback) {
             progress_callback(progress_generation_phase, session->last_output_tokens, max_tokens, callback_user_data);
         }
@@ -1567,14 +1725,17 @@ extern "C" bool orbit_mtp_session_complete(
     const bool debug_partial = partial_debug_enabled();
     bool frontier_trace_before_first_partial = true;
     const size_t reusable_request_prefix =
-        session->request_boundary_ckpt.empty() ? 0 : session->request_boundary_prompt_tgt.size();
+        session->request_boundary_ckpt.data_dft.empty() ? 0 : session->request_boundary_prompt_tgt.size();
     const bool can_restore_request_boundary =
-        !session->request_boundary_ckpt.empty() &&
+        !session->request_boundary_ckpt.data_dft.empty() &&
         is_token_prefix(session->request_boundary_prompt_tgt, prompt_tgt);
     bool used_request_boundary = false;
+    bool request_boundary_logits_refreshed = false;
+    int last_target_prefill_batch_n_tokens = 0;
 
     while ((int) generated.size() < std::max(1, std::min(32, (int) max_tokens))) {
         const auto loop_phase_start = std::chrono::steady_clock::now();
+        const bool loop_need_replay_before = need_replay;
         if (need_replay) {
             const bool replay_is_recovery = is_recovery_replay;
             const auto replay_phase_start = std::chrono::steady_clock::now();
@@ -1608,10 +1769,63 @@ extern "C" bool orbit_mtp_session_complete(
                 if (use_request_boundary) {
                     {
                         const auto phase_start = std::chrono::steady_clock::now();
-                        session->request_boundary_ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         session->request_boundary_ckpt.load_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         phase_add(session->phase_prefix_restore, phase_start);
                     }
+                    {
+                        const auto phase_start = std::chrono::steady_clock::now();
+                        llama_memory_clear(mem_tgt, true);
+                        phase_add(session->phase_seq_rm, phase_start);
+                    }
+                    session->debug_memory_clear_count++;
+                    const size_t chunk_size = (size_t) std::max<uint32_t>(1, session->n_batch);
+                    for (size_t offset = 0; offset < prompt_tgt.size(); offset += chunk_size) {
+                        const size_t count = std::min(chunk_size, prompt_tgt.size() - offset);
+                        std::vector<llama_token> chunk(
+                            prompt_tgt.begin() + (ptrdiff_t) offset,
+                            prompt_tgt.begin() + (ptrdiff_t) (offset + count));
+                        const auto batch_build_start = std::chrono::steady_clock::now();
+                        llama_batch refresh_tgt = llama_batch_init((int32_t) count, 0, 1);
+                        fill_target_prefill_batch(refresh_tgt, chunk, (int32_t) offset);
+                        last_target_prefill_batch_n_tokens = refresh_tgt.n_tokens;
+                        phase_add(session->phase_batch_build, batch_build_start);
+                        const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch()).count();
+                        double decode_ms = 0.0;
+                        session->debug_prefill_target_suffix_count++;
+                        {
+                            const auto phase_start = std::chrono::steady_clock::now();
+                            if (llama_decode(ctx_tgt, refresh_tgt) != 0) {
+                                decode_ms = elapsed_ms(phase_start);
+                                target_decode_traces.push_back(make_target_decode_trace(
+                                    "request_boundary_target_refill",
+                                    trace_step_index,
+                                    0,
+                                    0,
+                                    refresh_tgt,
+                                    decode_started_us,
+                                    decode_ms));
+                                phase_add(session->phase_suffix_decode_target, phase_start);
+                                llama_batch_free(refresh_tgt);
+                                common_sampler_free(smpl);
+                                set_error("failed to refill restored target prompt");
+                                return false;
+                            }
+                            decode_ms = elapsed_ms(phase_start);
+                            phase_add(session->phase_suffix_decode_target, phase_start);
+                        }
+                        target_decode_traces.push_back(make_target_decode_trace(
+                            "request_boundary_target_refill",
+                            trace_step_index,
+                            0,
+                            0,
+                            refresh_tgt,
+                            decode_started_us,
+                            decode_ms));
+                        session->last_target_decode_calls++;
+                        llama_batch_free(refresh_tgt);
+                    }
+                    request_boundary_logits_refreshed = true;
                     used_request_boundary = true;
                 } else {
                     const size_t chunk_size = (size_t) std::max<uint32_t>(1, session->n_batch);
@@ -1623,6 +1837,7 @@ extern "C" bool orbit_mtp_session_complete(
                         const auto batch_build_start = std::chrono::steady_clock::now();
                         llama_batch prefill_tgt = llama_batch_init((int32_t) count, 0, 1);
                         fill_target_prefill_batch(prefill_tgt, chunk, (int32_t) offset);
+                        last_target_prefill_batch_n_tokens = prefill_tgt.n_tokens;
                         phase_add(session->phase_batch_build, batch_build_start);
                         const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
                             std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -1690,6 +1905,7 @@ extern "C" bool orbit_mtp_session_complete(
                             const auto batch_build_start = std::chrono::steady_clock::now();
                             llama_batch prefill_tgt = llama_batch_init((int32_t) count, 0, 1);
                             fill_target_prefill_batch(prefill_tgt, chunk, process_pos0 + (int32_t) offset);
+                            last_target_prefill_batch_n_tokens = prefill_tgt.n_tokens;
                             phase_add(session->phase_batch_build, batch_build_start);
                             const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
                                 std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -1775,11 +1991,6 @@ extern "C" bool orbit_mtp_session_complete(
                         llama_memory_seq_pos_max(mem_tgt, 0));
                     {
                         const auto phase_start = std::chrono::steady_clock::now();
-                        session->request_boundary_ckpt.update_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
-                        phase_add(session->phase_ctx_tgt_checkpoint, phase_start);
-                    }
-                    {
-                        const auto phase_start = std::chrono::steady_clock::now();
                         session->request_boundary_ckpt.update_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         phase_add(session->phase_ctx_dft_checkpoint, phase_start);
                     }
@@ -1799,12 +2010,30 @@ extern "C" bool orbit_mtp_session_complete(
             draft_is_fresh = false;
             n_past = (int32_t) prompt_tgt.size();
             if (generated.empty()) {
+                const std::string first_sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
                 {
                     const auto phase_start = std::chrono::steady_clock::now();
                     id_last = common_sampler_sample(smpl, ctx_tgt, -1);
                     common_sampler_accept(smpl, id_last, true);
                     phase_add(session->phase_sampler_ops, phase_start);
                 }
+                const std::string first_sampler_after = common_sampler_prev_str(smpl, ctx_tgt, 8);
+                session->last_first_sample_trace_json = first_sample_trace_json(
+                    "mtp",
+                    prompt_tgt,
+                    ctx_tgt,
+                    vocab_tgt,
+                    mem_tgt,
+                    n_past,
+                    last_target_prefill_batch_n_tokens,
+                    1,
+                    1,
+                    first_sampler_before,
+                    id_last,
+                    first_sampler_after,
+                    1,
+                    used_request_boundary,
+                    request_boundary_logits_refreshed);
                 if (llama_vocab_is_eog(vocab_tgt, id_last)) {
                     goto done;
                 }
@@ -1911,8 +2140,8 @@ extern "C" bool orbit_mtp_session_complete(
                         << "{"
                         << "\"step_index\":" << (trace_step_index + 1)
                         << ",\"draft_index\":" << (int) i
-                        << ",\"input_token\":{\"id\":" << (int) input_token << ",\"piece\":\"" << token_piece_json(vocab_tgt, input_token) << "\"}"
-                        << ",\"sampled_draft_token\":{\"id\":" << (int) sampled_token << ",\"piece\":\"" << token_piece_json(vocab_tgt, sampled_token) << "\"}"
+                        << ",\"input_token_hash\":" << stable_hash_token(input_token)
+                        << ",\"sampled_draft_token_hash\":" << stable_hash_token(sampled_token)
                         << ",\"prompt_tgt_size\":" << prompt_tgt.size()
                         << ",\"n_past\":" << n_past
                         << ",\"ctx_tgt_max_before\":" << draft_ctx_tgt_max_before
@@ -2047,20 +2276,35 @@ extern "C" bool orbit_mtp_session_complete(
         trace_step.debug_enabled = debug_partial;
         trace_step.sampler_before = common_sampler_prev_str(smpl, ctx_tgt, 8);
         trace_step.sampler_before_hash = stable_hash_string(trace_step.sampler_before);
+        trace_step.sampler_state_hash_before = trace_step.sampler_before_hash;
         trace_step.draft = draft;
+        trace_step.draft_origin = draft.empty() ? "empty" : (draft_is_fresh ? "fresh" : "reused");
+        trace_step.draft_is_fresh = draft_is_fresh;
+        trace_step.need_replay_before = loop_need_replay_before;
         trace_step.sampled_id = -1;
         trace_step.rejected_id = -1;
         trace_step.validated_count = (int) validate_tokens.size();
+        trace_step.validate_n_tok = (int) validate_tokens.size();
+        trace_step.validate_pos0 = validate_pos0;
         trace_step.checkpoint_total = session->last_checkpoint_count;
         trace_step.restore_total = session->last_restore_count;
         trace_step.id_last_before = (int) id_last;
         trace_step.n_past_before = n_past;
+        trace_step.old_n_past = n_past;
         trace_step.prompt_tgt_size_before = (int32_t) prompt_tgt.size();
+        trace_step.prompt_tgt_len = (int32_t) prompt_tgt.size();
+        trace_step.prompt_dft_len = llama_memory_seq_pos_max(mem_dft, 0) >= 0
+            ? llama_memory_seq_pos_max(mem_dft, 0) + 1
+            : -1;
+        trace_step.prompt_tgt_hash = stable_hash_tokens(prompt_tgt);
         trace_step.prompt_tgt_pos_next_before = n_past;
         trace_step.kv_tgt_before_min = llama_memory_seq_pos_min(mem_tgt, 0);
         trace_step.kv_tgt_before_max = llama_memory_seq_pos_max(mem_tgt, 0);
         trace_step.kv_dft_before_min = llama_memory_seq_pos_min(mem_dft, 0);
         trace_step.kv_dft_before_max = llama_memory_seq_pos_max(mem_dft, 0);
+        trace_step.ctx_tgt_frontier_hash = stable_hash_frontier(trace_step.kv_tgt_before_min, trace_step.kv_tgt_before_max);
+        trace_step.ctx_dft_frontier_hash = stable_hash_frontier(trace_step.kv_dft_before_min, trace_step.kv_dft_before_max);
+        trace_step.remaining_generation_cap = std::max(0, std::max(1, std::min(32, (int) max_tokens)) - (int) generated.size());
         if (debug_partial) {
             trace_step.partial_state_before_json = partial_state_json(
                 vocab_tgt,
@@ -2142,6 +2386,7 @@ extern "C" bool orbit_mtp_session_complete(
         const int rejected = std::max(0, (int) trace_step.draft.size() - accepted);
         trace_step.accepted_ids = ids;
         trace_step.accepted_draft = accepted;
+        trace_step.rejected_draft = rejected;
         trace_step.fresh_draft_tokens_contrib = draft_is_fresh ? (int) trace_step.draft.size() : 0;
         trace_step.fresh_accepted_tokens_contrib = draft_is_fresh ? accepted : 0;
         trace_step.fresh_rejected_tokens_contrib = draft_is_fresh ? rejected : 0;
@@ -2156,6 +2401,7 @@ extern "C" bool orbit_mtp_session_complete(
             : 0.0;
         trace_step.sampler_after = common_sampler_prev_str(smpl, ctx_tgt, 8);
         trace_step.sampler_after_hash = stable_hash_string(trace_step.sampler_after);
+        trace_step.sampler_state_hash_after = trace_step.sampler_after_hash;
         trace_step.sampled_id = ids.empty() ? -1 : (int) ids.back();
         trace_step.rejected_id = (accepted >= 0 && accepted < (int) trace_step.draft.size()) ? (int) trace_step.draft[(size_t) accepted] : -1;
         trace_step.id_last_after = ids.empty() ? (int) id_last : (int) ids.back();
@@ -2186,6 +2432,7 @@ extern "C" bool orbit_mtp_session_complete(
             trace_step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
             trace_step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
             trace_step.n_past_after = n_past;
+            trace_step.new_n_past = n_past;
             trace_step.prompt_tgt_size_after = (int32_t) prompt_tgt.size();
             trace_step.prompt_tgt_pos_next_after = n_past;
             trace_step.residual_draft_size_after = (int32_t) draft.size();
@@ -2267,6 +2514,7 @@ extern "C" bool orbit_mtp_session_complete(
         trace_step.kv_dft_after_min = llama_memory_seq_pos_min(mem_dft, 0);
         trace_step.kv_dft_after_max = llama_memory_seq_pos_max(mem_dft, 0);
         trace_step.n_past_after = n_past;
+        trace_step.new_n_past = n_past;
         trace_step.prompt_tgt_size_after = (int32_t) prompt_tgt.size();
         trace_step.prompt_tgt_pos_next_after = n_past;
         trace_step.residual_draft_size_after = (int32_t) draft.size();
@@ -2306,10 +2554,37 @@ done:
     }
     session->last_validate_trace_json = validate_trace_json(validate_traces);
     session->last_target_decode_trace_json = target_decode_trace_json(vocab_tgt, target_decode_traces);
+    session->last_output_token_hashes_json = uint64_vec_json(session->last_output_token_hashes);
     {
+        const double suffix_target_prefill_ms = session->phase_suffix_decode_target.total_ms;
+        const double speculative_loop_including_suffix_ms = session->phase_loop_total.total_ms;
+        const double speculative_loop_ms = std::max(0.0, speculative_loop_including_suffix_ms - suffix_target_prefill_ms);
+        const double checkpoint_restore_ms =
+            session->phase_prefix_restore.total_ms +
+            session->phase_ctx_tgt_checkpoint.total_ms +
+            session->phase_ctx_tgt_restore.total_ms +
+            session->phase_ctx_dft_checkpoint.total_ms +
+            session->phase_ctx_dft_restore.total_ms;
+        const double sampler_ms =
+            session->phase_sampler_clone.total_ms +
+            session->phase_sampler_restore.total_ms +
+            session->phase_sampler_ops.total_ms;
+        const double non_loop_overhead_ms = std::max(0.0, session->last_elapsed_ms - speculative_loop_including_suffix_ms);
         std::ostringstream out;
         out
             << "{"
+            << "\"summary\":{"
+            << "\"total_wall_ms\":" << session->last_elapsed_ms << ","
+            << "\"suffix_target_prefill_ms\":" << suffix_target_prefill_ms << ","
+            << "\"speculative_loop_ms\":" << speculative_loop_ms << ","
+            << "\"speculative_loop_including_suffix_ms\":" << speculative_loop_including_suffix_ms << ","
+            << "\"target_validate_ms\":" << session->phase_target_validate.total_ms << ","
+            << "\"draft_generation_ms\":" << session->phase_draft_generation.total_ms << ","
+            << "\"checkpoint_restore_ms\":" << checkpoint_restore_ms << ","
+            << "\"sampler_ms\":" << sampler_ms << ","
+            << "\"seq_rm_ms\":" << session->phase_seq_rm.total_ms << ","
+            << "\"non_loop_overhead_ms\":" << non_loop_overhead_ms
+            << "},"
             << "\"prompt_prefix_restore\":" << phase_json(session->phase_prefix_restore) << ","
             << "\"suffix_decode_target\":" << phase_json(session->phase_suffix_decode_target) << ","
             << "\"draft_generation\":" << phase_json(session->phase_draft_generation) << ","
@@ -2484,4 +2759,14 @@ extern "C" const char * orbit_mtp_session_last_validate_trace_json(void * handle
 extern "C" const char * orbit_mtp_session_last_target_decode_trace_json(void * handle) {
     auto * session = static_cast<orbit_mtp_session *>(handle);
     return session ? session->last_target_decode_trace_json.c_str() : "[]";
+}
+
+extern "C" const char * orbit_mtp_session_last_output_token_hashes_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_output_token_hashes_json.c_str() : "[]";
+}
+
+extern "C" const char * orbit_mtp_session_last_first_sample_trace_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_first_sample_trace_json.c_str() : "{}";
 }

--- a/tests/test_native_persistent_mtp.py
+++ b/tests/test_native_persistent_mtp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -8,7 +9,12 @@ from unittest import mock
 from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
 from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.paths import NativeLlamaPaths
-from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime, build_persistent_mtp_shim, run_persistent_mtp_completion
+from orbit.native_llama.persistent_mtp import (
+    PersistentMtpSessionRuntime,
+    _persistent_mtp_link_bin,
+    build_persistent_mtp_shim,
+    run_persistent_mtp_completion,
+)
 
 
 class NativePersistentMtpTests(unittest.TestCase):
@@ -40,6 +46,51 @@ class NativePersistentMtpTests(unittest.TestCase):
 
         self.assertEqual(shim, packaged)
         mocked_compile.assert_called_once()
+
+    def test_persistent_mtp_link_bin_uses_runtime_bin_when_sonames_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp) / "bin"
+            build_bin.mkdir()
+            (build_bin / "libllama.so.0").write_text("", encoding="utf-8")
+            (build_bin / "libllama-common.so.0").write_text("", encoding="utf-8")
+            paths = self._paths()
+            paths = NativeLlamaPaths(
+                llama_root=paths.llama_root,
+                build_bin=build_bin,
+                library=build_bin / "libllama.so",
+                model=paths.model,
+                draft_mtp_model=paths.draft_mtp_model,
+                mtp_available=paths.mtp_available,
+                fallback_reason=paths.fallback_reason,
+                model_id=paths.model_id,
+            )
+
+            self.assertEqual(_persistent_mtp_link_bin(paths), build_bin)
+
+    def test_persistent_mtp_link_bin_falls_back_to_vendor_soname_bin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp) / "lib"
+            vendor_bin = Path(tmp) / "vendor-bin"
+            build_bin.mkdir()
+            vendor_bin.mkdir()
+            (build_bin / "libllama.so").write_text("", encoding="utf-8")
+            (build_bin / "libllama-common.so").write_text("", encoding="utf-8")
+            (vendor_bin / "libllama.so.0").write_text("", encoding="utf-8")
+            (vendor_bin / "libllama-common.so.0").write_text("", encoding="utf-8")
+            paths = self._paths()
+            paths = NativeLlamaPaths(
+                llama_root=paths.llama_root,
+                build_bin=build_bin,
+                library=build_bin / "libllama.so",
+                model=paths.model,
+                draft_mtp_model=paths.draft_mtp_model,
+                mtp_available=paths.mtp_available,
+                fallback_reason=paths.fallback_reason,
+                model_id=paths.model_id,
+            )
+
+            with mock.patch("orbit.native_llama.persistent_mtp.DEFAULT_VENDOR_BUILD_BIN", vendor_bin):
+                self.assertEqual(_persistent_mtp_link_bin(paths), vendor_bin)
 
     def _paths(self, *, mtp_available: bool = True, fallback_reason: str | None = None) -> NativeLlamaPaths:
         return NativeLlamaPaths(
@@ -258,6 +309,125 @@ class NativePersistentMtpTests(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
+        self.assertIsNone(result.trace_json)
+        self.assertIsNone(result.timing_json)
+        self.assertIsNone(result.validate_trace_json)
+        self.assertIsNone(result.target_decode_trace_json)
+        self.assertIsNone(result.output_token_hashes_json)
+        self.assertIsNone(result.first_sample_trace_json)
+
+    def test_run_persistent_mtp_completion_exposes_stable_metadata_trace_when_enabled(self) -> None:
+        class FakeLib:
+            def orbit_mtp_session_complete(self, _handle, _ctx_tgt, _prompt, _max_tokens, _token_cb, _progress_cb, _user_data):
+                return True
+
+            def orbit_mtp_session_last_content(self, _handle):
+                return b"ok"
+
+            def orbit_mtp_session_last_output_tokens(self, _handle):
+                return 1
+
+            def orbit_mtp_session_last_draft_tokens_total(self, _handle):
+                return 3
+
+            def orbit_mtp_session_last_accepted_tokens_total(self, _handle):
+                return 2
+
+            def orbit_mtp_session_last_rejected_tokens_total(self, _handle):
+                return 1
+
+            def orbit_mtp_session_last_reused_draft_tokens_total(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_reused_accepted_tokens_total(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_reused_rejected_tokens_total(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_acceptance_ratio(self, _handle):
+                return 2 / 3
+
+            def orbit_mtp_session_last_fresh_acceptance_ratio(self, _handle):
+                return 2 / 3
+
+            def orbit_mtp_session_last_consumed_acceptance_ratio(self, _handle):
+                return 0.0
+
+            def orbit_mtp_session_last_target_decode_calls(self, _handle):
+                return 2
+
+            def orbit_mtp_session_last_draft_decode_calls(self, _handle):
+                return 1
+
+            def orbit_mtp_session_last_elapsed_ms(self, _handle):
+                return 12.5
+
+            def orbit_mtp_session_last_tokens_per_second(self, _handle):
+                return 80.0
+
+            def orbit_mtp_session_last_full_accept_steps(self, _handle):
+                return 1
+
+            def orbit_mtp_session_last_replay_steps(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_partial_accept_steps(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_partial_no_replay_steps(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_replay_fallback_steps(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_seq_rm_supported(self, _handle):
+                return True
+
+            def orbit_mtp_session_last_rollback_tokens_total(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_checkpoint_count(self, _handle):
+                return 1
+
+            def orbit_mtp_session_last_restore_count(self, _handle):
+                return 0
+
+            def orbit_mtp_session_last_timing_json(self, _handle):
+                return b'{"target_validate":{"total_ms":10.0}}'
+
+            def orbit_mtp_session_last_output_token_hashes_json(self, _handle):
+                return b"[11,22]"
+
+            def orbit_mtp_session_last_first_sample_trace_json(self, _handle):
+                return b'{"path_name":"mtp","prompt_count":23,"last_logits_hash":999,"first_sample_hash":11}'
+
+        class FakeLibrary:
+            def __init__(self, _build_bin, _shim_path) -> None:
+                self.lib = FakeLib()
+
+        runtime = PersistentMtpSessionRuntime(handle=object(), ctx_dft=object(), spec=object())
+        with mock.patch.dict("os.environ", {"ORBIT_MTP_TRACE": "1"}), mock.patch(
+            "orbit.native_llama.persistent_mtp.build_persistent_mtp_shim",
+            return_value=Path("/tmp/fake.so"),
+        ):
+            result = run_persistent_mtp_completion(
+                llama_root=Path("/llama"),
+                paths=self._paths(),
+                runtime=runtime,
+                ctx_tgt=object(),
+                prompt="hello",
+                max_tokens=8,
+                library_factory=FakeLibrary,
+            )
+
+        self.assertTrue(result.success)
+        self.assertIsNone(result.trace_json)
+        self.assertIsNone(result.validate_trace_json)
+        self.assertIsNone(result.target_decode_trace_json)
+        self.assertEqual(result.timing_json, '{"target_validate":{"total_ms":10.0}}')
+        self.assertEqual(result.output_token_hashes_json, "[11,22]")
+        self.assertEqual(result.first_sample_trace_json, '{"path_name":"mtp","prompt_count":23,"last_logits_hash":999,"first_sample_hash":11}')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR stabilizes native persistent MTP correctness and runtime linkage without changing prompt, routing, tool, final, or evidence policy.

Scope:

* restore/logits correctness for request-boundary MTP restore
* native runtime linkage stability for the MTP shim
* metadata-only MTP diagnostics
* targeted tests and MTP state docs
* no speculative performance optimization
* no validate-row or acceptance-policy changes
* no llama.cpp vendor update
* no llama-server dependency

Correctness:

Request-boundary restore could restore an apparently coherent KV/frontier state while leaving the final target logits row non-equivalent to a fresh target prefill. The fix is intentionally narrow: after request-boundary restore, the shim refills the effective target prompt before the first sample so the restored path samples from logits equivalent to the fresh path.

This is confined to the request-boundary restore path.

Runtime stability:

The persistent MTP shim now resolves llama.cpp runtime libraries from the packaged vendor build directory that provides the expected SONAMEs:

* libllama.so.0
* libllama-common.so.0
* libggml*.so.0

The Python native loader keeps a CDLL cache and uses RTLD_NODELETE to avoid unsafe unload/reload behavior. NativeLlamaClient no longer calls llama_backend_free() per client because llama.cpp backend state is process-wide.

Diagnostics:

ORBIT_MTP_TRACE=1 keeps only metadata-only diagnostics needed for correctness validation:

* timing JSON
* output token hashes
* first-sample prompt/frontier/logits/sample hashes

It does not expose raw prompt text, raw token ids, token pieces, user content, file content, tool output, or web content.

Validation:

* PYTHONPATH=src python3 -m unittest tests.test_native_persistent_mtp tests.test_native_mtp_experimental tests.test_native_mtp_probe tests.test_native_mtp_dry_run tests.test_native_mtp_accept_probe tests.test_native_mtp_decode_probe -q: PASS
* python3 -m unittest discover -s tests -q: PASS
* python3 -m compileall -q src tests scripts: PASS
* git diff --check: PASS
* ORBIT_MTP_TRACE=1 real short target/MTP run: exit 0, stable metadata only

Residual risks:

* the vendored llama.cpp snapshot is PR #23398-ish and not aligned to current upstream master
* request-boundary restore now pays a target prompt refill cost, roughly +1.6-2.4s in the observed setup
* heavier step-level traces remain intentionally excluded from the Python bridge until lifetime ownership is audited separately
