### PR TITLE
Unify native runtime loading for target-only and MTP

### DIFF
--- a/docs/MTP_UNRESOLVED_ISSUES.md
+++ b/docs/MTP_UNRESOLVED_ISSUES.md
@@ -51,6 +51,7 @@ to explain is:
 | MTP-027 | First-request MTP target suffix prefill is required in the current persistent path. | Without a compatible request-boundary checkpoint, Orbit clears/replays target and draft memory, then decodes the prompt suffix to place target KV at the prompt frontier before validation. | Treating this as avoidable without a valid prefix/request-boundary checkpoint can leave target KV missing or stale. | Investigate reuse/persistent prompt frontier separately; do not remove suffix prefill from the MTP path. |
 | MTP-028 | MTP output is not yet proven equivalent to target-only under a prompt-matched control. | Phase 4 target-only with the MTP-prepared prompt used `23` prompt tokens and produced a stable hash different from MTP first-run and second-run hashes. | Any performance optimization before equivalence is explained can preserve a fast but wrong path. | Build a metadata-only equivalence harness around the exact prompt text hash/length, sampler config hash, first-sample state, and per-step frontier. |
 | MTP-029 | Phase 4 alignment trace did not show target/draft KV frontier mismatch. | Across three first-run and three second-run MTP traces, `ctx_tgt` and `ctx_dft` frontier min/max matched before each validate; draft origin was consistently `fresh`; replay-before appeared once at request start. | Acceptance may still be low due to sampler/config or draft quality, but not due to the basic frontier mismatch fields collected here. | Do not patch frontier/KV rollback logic based on current data. |
+| MTP-030 | Mixed target-only/MTP benchmark still aborts at process teardown. | The first post-PR #72 validation benchmark completed 18 rows, wrote metadata JSON, then exited with `double free or corruption (!prev)` and exit code 134. | MTP cannot be considered stable for broader use until repeated mixed-client/session lifetimes exit cleanly. | Reproduce the 18-row harness with lifetime counters; isolate whether target-only client, MTP reset, mmproj context, CDLL cache, or process-global llama.cpp cleanup still owns memory twice. |
 
 ## Candidate Fix Points, Without Patching Runtime
 
@@ -989,6 +990,75 @@ Residual risks:
   Orbit/vendor changes. Future vendor refreshes should record the upstream commit
   explicitly and rerun the lifecycle harness.
 
+## Post-PR 72 Validation Benchmark
+
+After PR #72 was merged, a short validation benchmark was run against `main`
+`b6ad0481b6302b1c79f04f1403aaa1b101df0a35`.
+
+The temporary harness:
+
+- used `ORBIT_MTP_TRACE=1`;
+- loaded target-only and MTP-enabled native clients in one Python process;
+- used repository models under `models/`;
+- used `ctx=8192`, `threads=6`, `threads-batch=6`, `batch=256`,
+  `ubatch=128`;
+- ran three repetitions each for `response_short` and `response_medium`;
+- collected target-only baseline, MTP first request, and MTP second identical
+  request rows;
+- wrote only metadata hashes, counts, and timings.
+
+The harness produced a complete JSON result with 18 completion rows, then
+aborted during teardown:
+
+```text
+double free or corruption (!prev)
+exit code: 134
+```
+
+This reopens the lifetime/teardown blocker for mixed target-only/MTP benchmark
+processes. The previous PR #72 linkage/lifetime changes remain necessary, but
+they are not sufficient for this longer mixed-client benchmark.
+
+Aggregated results before teardown:
+
+| Prompt | Scenario | Runs | Wall ms avg | Refill ms avg | Spec loop ms avg | Target validate ms avg | Draft ms avg | Generation ms avg | Acceptance |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| response_short | target-only baseline | 3 | 9139.895 | n/a | n/a | n/a | n/a | 6588.005 | n/a |
+| response_short | MTP first request | 3 | 7381.530 | 1394.750 | 5985.537 | 5193.330 | 595.129 | 7380.301 | 0.381 |
+| response_short | MTP second identical | 3 | 7814.371 | 1588.383 | 6224.740 | 5253.133 | 608.663 | 7813.138 | 0.381 |
+| response_medium | target-only baseline | 3 | 16906.423 | n/a | n/a | n/a | n/a | 13701.029 | n/a |
+| response_medium | MTP first request | 3 | 12749.564 | 2256.660 | 10491.033 | 9153.290 | 1092.203 | 12747.715 | 0.462 |
+| response_medium | MTP second identical | 3 | 12691.774 | 2162.367 | 10527.433 | 9043.203 | 1083.620 | 12689.795 | 0.462 |
+
+Correctness observations from the completed rows:
+
+- each scenario had stable output hashes across its three runs;
+- MTP first and second identical requests had matching output-token-hash
+  sequence hashes for each prompt;
+- MTP first and second identical requests had matching first-sample hashes for
+  each prompt;
+- no per-completion MTP fallback occurred.
+
+Stability verdict:
+
+- FAIL for this pass because process teardown aborted after the benchmark.
+
+Performance verdict:
+
+- Inconclusive for defaults. MTP showed lower end-to-end wall time than
+  target-only for the two prompts in this short run, but stability failure blocks
+  any default-enablement conclusion.
+- Target validate remains the dominant loop cost.
+- The request-boundary target refill cost is material and should remain tracked.
+
+Recommendation:
+
+- keep MTP explicit/experimental;
+- do not optimize acceptance, validate rows, or refill until the teardown abort
+  is resolved;
+- next patch candidate is a narrow lifetime reproducer and fix for the 18-row
+  mixed target-only/MTP benchmark.
+
 ## Minimal Test And Benchmark Plan
 
 ### Local Unit Suite
@@ -1063,3 +1133,84 @@ Collect:
 - Fallback after MTP failure must still use standard generation.
 - Tools, routing, final policy, evidence policy, and prompts must remain
   untouched.
+
+## MTP-030 Follow-Up: Mixed Teardown Root Cause And Fix
+
+The mixed target-only/MTP teardown abort was reduced with a temporary
+process-per-scenario harness.
+
+Minimal reproducer:
+
+```text
+target-only completion -> MTP completion -> explicit client cleanup
+ORBIT_MTP_TRACE=0
+mmproj disabled
+```
+
+Reduction matrix:
+
+| Scenario | Runtime path | Trace | Result |
+| --- | --- | --- | --- |
+| target-only only, repeated | split runtime | off | PASS |
+| MTP first only, repeated | split runtime | off | PASS |
+| MTP first+second, repeated | split runtime | off | PASS |
+| target-only then MTP | split runtime | off | FAIL, exit 134 |
+| target-only then MTP | split runtime | on | FAIL, exit 134 |
+| target-only then MTP | unified runtime bin | off | PASS, 3/3 |
+
+Root cause:
+
+- `resolve_paths()` selected `src/orbit/native_llama/vendor/lib` for the
+  target-only Python client runtime.
+- The persistent MTP shim linked against
+  `src/orbit/native_llama/vendor/build/llama.cpp/bin` because that directory
+  contains the required SONAME entries (`libllama.so.0`,
+  `libllama-common.so.0`, and ggml SONAMEs).
+- A mixed process could therefore load two llama.cpp runtime instances with
+  separate process-wide backend/global state.
+- Teardown after using both paths could double-free or corrupt shared global
+  state.
+
+Fix:
+
+- Native runtime resolution now prefers the packaged vendor build bin when it
+  exposes the SONAME runtime needed by the MTP shim.
+- `vendor/lib` remains the fallback when no packaged SONAME runtime is
+  available.
+- This keeps target-only and MTP shim usage on the same llama.cpp runtime
+  path in the local packaged build.
+
+Post-fix reproduction:
+
+```text
+target-only completion -> MTP completion -> explicit client cleanup
+ORBIT_MTP_TRACE=0
+mmproj disabled
+3/3 runs exited 0
+```
+
+Post-fix 18-row benchmark:
+
+| Prompt | Scenario | Runs | Exit codes | Wall ms avg | Refill ms avg | Spec loop ms avg | Target validate ms avg | Draft ms avg | Generation ms avg | Acceptance |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| response_short | target-only baseline | 3 | 0 | 6778.707 | n/a | n/a | n/a | n/a | 5044.464 | n/a |
+| response_short | MTP first request | 3 | 0 | 5215.916 | 1073.164 | 4141.823 | 3566.127 | 446.265 | 5214.993 | 0.381 |
+| response_short | MTP second identical | 3 | 0 | 5255.835 | 1061.765 | 4193.210 | 3510.967 | 446.878 | 5254.986 | 0.381 |
+| response_medium | target-only baseline | 3 | 0 | 12038.292 | n/a | n/a | n/a | n/a | 9767.841 | n/a |
+| response_medium | MTP first request | 3 | 0 | 8914.028 | 1502.527 | 7409.923 | 6435.117 | 807.487 | 8912.465 | 0.462 |
+| response_medium | MTP second identical | 3 | 0 | 9032.386 | 1536.167 | 7495.057 | 6421.367 | 802.408 | 9031.243 | 0.462 |
+
+Correctness/stability observations after the fix:
+
+- MTP first and second identical requests kept matching output-token-hash
+  sequence hashes for each prompt.
+- MTP first and second identical requests kept matching first-sample hashes for
+  each prompt.
+- No per-completion MTP fallback occurred.
+- The full mixed 18-row benchmark exited 0.
+
+Status:
+
+- Stability blocker resolved for the current text-generation mixed benchmark.
+- Performance remains scenario-dependent and should not be generalized from
+  this short run.

--- a/docs/MTP_VALIDATION_BENCHMARK_PLAN.md
+++ b/docs/MTP_VALIDATION_BENCHMARK_PLAN.md
@@ -1,0 +1,198 @@
+# MTP Validation And Benchmark Plan
+
+Status: first validation pass after PR #72. This document is a test and
+benchmark matrix only; it does not change runtime behavior.
+
+## Scope
+
+The goal is to prove native MTP correctness and stability before treating it as
+a performance feature.
+
+Do not use this plan to justify prompt, routing, tool, final, evidence, vendor,
+or speculative optimization changes. If a benchmark exposes a correctness or
+stability failure, stop and diagnose before patching.
+
+## Metrics
+
+Separate every run into three classes of metrics.
+
+Correctness metrics:
+
+- exit code
+- fallback count and reason
+- generated token count
+- output hash or output-token-hash sequence hash
+- first-sample hash when `ORBIT_MTP_TRACE=1`
+- stop/cancel status
+- streaming final-content equivalence when streaming is used
+
+Stability metrics:
+
+- process exit status
+- native aborts or teardown failures
+- MTP fallback reason
+- restore used
+- session reuse state
+- repeated-run consistency across at least three runs where practical
+
+Performance metrics:
+
+- wall ms
+- prefill ms
+- request-boundary target refill ms
+- speculative loop ms
+- target validate ms
+- draft generation ms
+- generation ms
+- tokens/sec
+- accepted total
+- draft total
+- acceptance ratio
+
+## Scenario Matrix
+
+| Scenario | Purpose | Required setup | Minimum checks |
+| --- | --- | --- | --- |
+| target-only baseline | Compare correctness and end-to-end latency without MTP. | `use_mtp_experimental=False`, same prompt and cap. | output hash, token count, wall/prefill/generation ms. |
+| MTP first request | Validate cold MTP request behavior. | `use_mtp_experimental=True`, reset session before run. | fallback=0, output hash, first sample hash, phase timing. |
+| MTP second identical request | Validate request-boundary restore and refill path. | Same MTP client, same prompt immediately repeated. | `restore_used=true`, first/output hashes stable, refill cost measured. |
+| MTP + KV/session reuse | Verify MTP does not corrupt session cache or later requests. | Repeat same prompt and then a different prompt on one client. | no fallback, no stale output, stable process exit. |
+| MTP + tools on default | Verify runtime integration when tools are available. | Native server default tools-on mode. | tool-call rounds must not use MTP; final generation may use MTP only when eligible. |
+| MTP + `ORBIT_KV_PREFIX_PREWARM=startup` | Verify startup prewarm does not change MTP correctness. | Native server with default/explicit startup prewarm. | prewarm succeeds or skips safely; MTP output remains stable. |
+| MTP + `ORBIT_KV_PREFIX_PREWARM=off` | Verify prewarm-off baseline. | Native server with prewarm disabled. | no startup prewarm; MTP behavior unchanged after startup. |
+| MTP + `ORBIT_TOOLS=off` | Verify no-tools server path. | Native server started with tools disabled. | no route tools-on prewarm; generation MTP behavior unchanged. |
+| MTP + streaming | Verify token callback and final content alignment. | `/chat/stream` or native callback path. | streamed visible content hash matches final content hash. |
+| MTP + cancel during generation | Verify cancellation does not corrupt later requests. | Start generation, cancel mid-run, then run a normal request. | cancel status, no crash, next request succeeds. |
+| MTP + stop sequence | Verify stop filter does not diverge from final text. | Completion with explicit stop sequence. | stopped status, final output hash, no hidden extra content. |
+| MTP + mmproj/multimodal | Verify linkage/lifetime with multimodal context loaded. | Target model plus mmproj present. | load/complete/close exits 0; MTP fallback or success is explicit. |
+
+## First Short Benchmark
+
+Command used: a temporary metadata-only benchmark harness outside the repository
+with `ORBIT_MTP_TRACE=1`.
+
+The temporary harness:
+
+- loads the target model once;
+- loads a separate MTP-enabled client once;
+- uses `ctx=8192`, `threads=6`, `threads-batch=6`, `batch=256`,
+  `ubatch=128`;
+- runs three repetitions for `response_short` and `response_medium`;
+- resets session state before each target-only and MTP-first repetition;
+- runs an identical second MTP request immediately after each MTP-first request;
+- records metadata only.
+
+The harness wrote a complete JSON result file with 18 completion rows, then the
+process aborted during teardown:
+
+```text
+double free or corruption (!prev)
+exit code: 134
+```
+
+Because the process did not exit cleanly, the stability verdict for this pass is
+FAIL even though per-completion metadata was written.
+
+## First Short Benchmark Results
+
+All numbers are averages across three runs.
+
+| Prompt | Scenario | Wall ms | Prefill ms | Refill ms | Spec loop ms | Target validate ms | Draft ms | Generation ms | Tokens/sec | Acceptance |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| response_short | target-only baseline | 9139.895 | 2550.368 | n/a | n/a | n/a | n/a | 6588.005 | 2.432 | n/a |
+| response_short | MTP first request | 7381.530 | 0.000 | 1394.750 | 5985.537 | 5193.330 | 595.129 | 7380.301 | 2.169 | 0.381 |
+| response_short | MTP second identical | 7814.371 | 0.000 | 1588.383 | 6224.740 | 5253.133 | 608.663 | 7813.138 | 2.050 | 0.381 |
+| response_medium | target-only baseline | 16906.423 | 3204.657 | n/a | n/a | n/a | n/a | 13701.029 | 2.336 | n/a |
+| response_medium | MTP first request | 12749.564 | 0.000 | 2256.660 | 10491.033 | 9153.290 | 1092.203 | 12747.715 | 2.511 | 0.462 |
+| response_medium | MTP second identical | 12691.774 | 0.000 | 2162.367 | 10527.433 | 9043.203 | 1083.620 | 12689.795 | 2.522 | 0.462 |
+
+Correctness observations:
+
+- Each scenario produced stable output hashes within its own three-run group.
+- MTP first and MTP second produced matching output-token-hash sequence hashes
+  for both prompts.
+- MTP first and MTP second produced matching first-sample hashes for both
+  prompts.
+- No per-completion MTP fallback occurred.
+
+Stability observation:
+
+- The process aborted at teardown after writing all benchmark rows.
+- This is a blocker for enabling MTP beyond explicit experimental use.
+
+Performance observations:
+
+- For `response_short`, MTP end-to-end wall time improved over target-only
+  baseline, but MTP generation tokens/sec was lower and stability failed.
+- For `response_medium`, MTP end-to-end wall time improved over target-only
+  baseline in this run.
+- Target validate remains the dominant MTP loop cost.
+- The request-boundary refill cost was material: about `1.4-1.6s` for
+  `response_short` and `2.1-2.3s` for `response_medium`.
+
+## Verdict For This Pass
+
+Correctness verdict: PASS for the limited text-generation rows collected.
+
+Stability verdict: FAIL due to teardown abort after the repeated mixed
+target-only/MTP benchmark.
+
+Performance verdict: inconclusive for product defaults. MTP improved end-to-end
+wall time in this short run, but the process abort prevents treating the result
+as production-ready performance evidence.
+
+## Recommendation
+
+Keep MTP env/flag-gated and experimental.
+
+Do not enable MTP by default.
+
+Next patch candidate: isolate and fix the teardown double-free reproduced by the
+18-row mixed target-only/MTP benchmark. Do not optimize refill, acceptance, or
+validate rows until this stability blocker is resolved.
+
+## Follow-Up After Runtime Path Unification
+
+The teardown crash was traced to split native runtime loading:
+
+- target-only Python client resolved llama.cpp from `vendor/lib`;
+- the persistent MTP shim linked to the SONAME runtime in
+  `vendor/build/llama.cpp/bin`;
+- mixed target-only/MTP use in one process could load two llama.cpp runtime
+  instances and corrupt process-wide teardown state.
+
+After changing native runtime resolution to prefer the packaged SONAME build
+bin when available, the minimal reducer passed:
+
+```text
+target-only completion -> MTP completion -> explicit client cleanup
+ORBIT_MTP_TRACE=0
+mmproj disabled
+3/3 runs exited 0
+```
+
+The same 18-row short benchmark was repeated. The process exited 0.
+
+| Prompt | Scenario | Wall ms | Prefill ms | Refill ms | Spec loop ms | Target validate ms | Draft ms | Generation ms | Tokens/sec | Acceptance |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| response_short | target-only baseline | 6778.707 | 1733.729 | n/a | n/a | n/a | n/a | 5044.464 | 3.172 | n/a |
+| response_short | MTP first request | 5215.916 | 0.000 | 1073.164 | 4141.823 | 3566.127 | 446.265 | 5214.993 | 3.079 | 0.381 |
+| response_short | MTP second identical | 5255.835 | 0.000 | 1061.765 | 4193.210 | 3510.967 | 446.878 | 5254.986 | 3.057 | 0.381 |
+| response_medium | target-only baseline | 12038.292 | 2269.837 | n/a | n/a | n/a | n/a | 9767.841 | 3.276 | n/a |
+| response_medium | MTP first request | 8914.028 | 0.000 | 1502.527 | 7409.923 | 6435.117 | 807.487 | 8912.465 | 3.591 | 0.462 |
+| response_medium | MTP second identical | 9032.386 | 0.000 | 1536.167 | 7495.057 | 6421.367 | 802.408 | 9031.243 | 3.543 | 0.462 |
+
+Post-fix verdict for this short text-generation matrix:
+
+- Correctness: PASS for hash-stable MTP first/second rows.
+- Stability: PASS for the 18-row mixed benchmark, exit 0.
+- Performance: positive signal for these two prompts, still insufficient for a
+  default-enablement decision.
+
+Remaining validation before broader MTP use:
+
+- streaming;
+- cancel;
+- stop sequence;
+- session reuse with tools and route-prefix prewarm;
+- multimodal/mmproj generation path.

--- a/src/orbit/native_llama/paths.py
+++ b/src/orbit/native_llama/paths.py
@@ -11,6 +11,7 @@ from .native_names import runtime_library_filename
 
 DEFAULT_VENDOR_LIB_DIR = PACKAGE_NATIVE_ROOT / "lib"
 DEFAULT_VENDOR_SHIM_DIR = PACKAGE_NATIVE_ROOT / "shim"
+DEFAULT_VENDOR_BUILD_BIN = PACKAGE_NATIVE_ROOT / "build" / "llama.cpp" / "bin"
 BUNDLED_SOURCE_ROOT = PACKAGE_NATIVE_ROOT / "source" / "llama.cpp"
 DEFAULT_LLAMA_LIB_DIR = Path(os.environ["ORBIT_LLAMA_LIB_DIR"]).expanduser().resolve() if os.environ.get("ORBIT_LLAMA_LIB_DIR") else None
 BUNDLED_SOURCE_ROOT = PACKAGE_NATIVE_ROOT / "source" / "llama.cpp"
@@ -120,6 +121,9 @@ def _resolve_model(
 
 def _resolve_native_runtime(llama_root: Path | None) -> tuple[Path | None, Path, Path]:
     library_name = runtime_library_filename("llama")
+    vendored_soname_library = DEFAULT_VENDOR_BUILD_BIN / library_name
+    if _has_packaged_soname_runtime(DEFAULT_VENDOR_BUILD_BIN) and vendored_soname_library.exists():
+        return None, DEFAULT_VENDOR_BUILD_BIN, vendored_soname_library
     vendored_library = DEFAULT_VENDOR_LIB_DIR / library_name
     if vendored_library.exists():
         return None, DEFAULT_VENDOR_LIB_DIR, vendored_library
@@ -142,6 +146,10 @@ def _resolve_native_runtime(llama_root: Path | None) -> tuple[Path | None, Path,
         f"Searched: {searched_text}. "
         "Provide ORBIT_LLAMA_LIB_DIR, --llama-root, or ORBIT_LLAMA_ROOT, or package native libraries under orbit/native_llama/vendor/lib."
     )
+
+
+def _has_packaged_soname_runtime(path: Path) -> bool:
+    return (path / "libllama.so.0").exists() and (path / "libllama-common.so.0").exists()
 
 
 def _resolve_build_source_root(llama_root: Path | None) -> Path | None:

--- a/tests/test_native_paths.py
+++ b/tests/test_native_paths.py
@@ -6,7 +6,13 @@ import unittest
 from unittest import mock
 
 from orbit.native_llama.native_names import runtime_library_filename
-from orbit.native_llama.paths import BUNDLED_SOURCE_ROOT, DEFAULT_VENDOR_LIB_DIR, LEGACY_MODEL_ID, resolve_legacy_paths, resolve_paths
+from orbit.native_llama.paths import (
+    BUNDLED_SOURCE_ROOT,
+    DEFAULT_VENDOR_LIB_DIR,
+    LEGACY_MODEL_ID,
+    resolve_legacy_paths,
+    resolve_paths,
+)
 
 
 class NativePathsTests(unittest.TestCase):
@@ -25,6 +31,8 @@ class NativePathsTests(unittest.TestCase):
             mmproj.write_text("mmproj", encoding="utf-8")
 
             with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"
+            ), mock.patch(
                 "orbit.native_llama.paths.BUNDLED_SOURCE_ROOT", root / "missing-bundled-source"
             ):
                 paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
@@ -32,6 +40,35 @@ class NativePathsTests(unittest.TestCase):
         self.assertIsNone(paths.llama_root)
         self.assertEqual(paths.build_bin, vendor_lib)
         self.assertEqual(paths.library, vendor_lib / runtime_library_filename("llama"))
+        self.assertEqual(paths.model, target)
+
+    def test_prefers_packaged_soname_runtime_when_available(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            vendor_lib = root / "vendor/lib"
+            vendor_build_bin = root / "vendor/build/llama.cpp/bin"
+            models_dir = root / "models"
+            target = models_dir / "ggml-org--gemma-4-12B-it-GGUF" / "gemma-4-12B-it-Q4_K_M.gguf"
+            mmproj = models_dir / "ggml-org--gemma-4-12B-it-GGUF" / "mmproj-gemma-4-12B-it-Q8_0.gguf"
+            vendor_lib.mkdir(parents=True)
+            vendor_build_bin.mkdir(parents=True)
+            library_name = runtime_library_filename("llama")
+            (vendor_lib / library_name).write_text("", encoding="utf-8")
+            (vendor_build_bin / library_name).write_text("", encoding="utf-8")
+            (vendor_build_bin / "libllama.so.0").write_text("", encoding="utf-8")
+            (vendor_build_bin / "libllama-common.so.0").write_text("", encoding="utf-8")
+            target.parent.mkdir(parents=True)
+            target.write_text("target", encoding="utf-8")
+            mmproj.write_text("mmproj", encoding="utf-8")
+
+            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", vendor_build_bin
+            ), mock.patch("orbit.native_llama.paths.BUNDLED_SOURCE_ROOT", root / "missing-bundled-source"):
+                paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
+
+        self.assertIsNone(paths.llama_root)
+        self.assertEqual(paths.build_bin, vendor_build_bin)
+        self.assertEqual(paths.library, vendor_build_bin / runtime_library_filename("llama"))
         self.assertEqual(paths.model, target)
 
     def test_resolves_runtime_from_orbit_llama_lib_dir_without_llama_root(self) -> None:
@@ -49,6 +86,7 @@ class NativePathsTests(unittest.TestCase):
 
             with (
                 mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", root / "missing-vendor-lib"),
+                mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"),
                 mock.patch("orbit.native_llama.paths.DEFAULT_LLAMA_LIB_DIR", env_lib),
             ):
                 paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
@@ -74,6 +112,8 @@ class NativePathsTests(unittest.TestCase):
             mmproj.write_text("mmproj", encoding="utf-8")
 
             with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"
+            ), mock.patch(
                 "orbit.native_llama.paths.BUNDLED_SOURCE_ROOT", bundled
             ):
                 paths = resolve_paths(llama_root=None, models_dir=models_dir, hf_cache=root / "hf")
@@ -135,7 +175,9 @@ class NativePathsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             missing_vendor = root / "vendor/lib"
-            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", missing_vendor):
+            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", missing_vendor), mock.patch(
+                "orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"
+            ):
                 with self.assertRaises(FileNotFoundError) as ctx:
                     resolve_paths(llama_root=None, models_dir=root / "models", hf_cache=root / "hf")
 

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -104,7 +104,9 @@ class NativeServerBootstrapTests(unittest.TestCase):
             target.write_text("target", encoding="utf-8")
             mmproj.write_text("mmproj", encoding="utf-8")
 
-            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib):
+            with mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", vendor_lib), mock.patch(
+                "orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"
+            ):
                 args = build_parser().parse_args(["--models-dir", str(models_dir), "--hf-cache", str(root / "hf")])
                 paths = resolve_bootstrap_paths(args)
 
@@ -127,6 +129,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
             with (
                 mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_LIB_DIR", root / "missing-vendor-lib"),
+                mock.patch("orbit.native_llama.paths.DEFAULT_VENDOR_BUILD_BIN", root / "missing-vendor-build-bin"),
                 mock.patch("orbit.native_llama.paths.DEFAULT_LLAMA_LIB_DIR", env_lib),
             ):
                 args = build_parser().parse_args(["--models-dir", str(models_dir), "--hf-cache", str(root / "hf")])


### PR DESCRIPTION
This PR fixes a native teardown stability issue found in mixed target-only + MTP benchmarks.

Root cause:
- target-only Python clients loaded llama.cpp from `vendor/lib`
- the persistent MTP shim linked against SONAME libraries from `vendor/build/llama.cpp/bin`
- mixed target-only/MTP use in one process could load two llama.cpp runtimes and corrupt process-wide teardown state

Fix:
- prefer the packaged vendor build bin when it exposes the expected SONAME runtime
- keep `vendor/lib` as fallback when the SONAME runtime is unavailable
- add tests for runtime path selection and bootstrap behavior

Scope:
- native runtime path resolution only
- no prompt changes
- no routing/tool/final/evidence policy changes
- no vendor llama.cpp update
- no performance optimization

Validation:
- targeted native path/MTP tests: PASS
- full unittest suite: PASS
- compileall: PASS
- git diff --check: PASS
- mixed 18-row target-only + MTP benchmark exits 0
