### PR TITLE
Add v0.0.1-rc5 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc5-release-plan.md
+++ b/docs/releases/v0.0.1-rc5-release-plan.md
@@ -1,0 +1,80 @@
+# Orbit v0.0.1-rc5 Release Plan
+
+This is an operational plan only. Do not execute the tag or release commands
+until publication is explicitly confirmed.
+
+## Pre-Release Checks
+
+- `main` must point to the final commit that includes the RC5 release notes.
+- `git status --short` must be clean except for local untracked cache such as
+  `workdir/.miktex/`.
+- Full unit tests must pass.
+- `python3 -m compileall -q src tests scripts` must pass.
+- `git diff --check` must pass.
+- Minimum native MTP smoke must pass:
+  - start `orbit server --mtp`;
+  - confirm bootstrap succeeds;
+  - confirm mmproj/multimodal capability detection if configured;
+  - confirm KV prefix prewarm/session reuse availability or no KV error;
+  - confirm runtime libraries resolve from the packaged vendor runtime;
+  - confirm legacy `vendor/lib/libllama.so` is not loaded in parallel;
+  - send one short `/v1/chat/completions` request;
+  - shut down cleanly with exit code `0`;
+  - observe no double-free, `SIGABRT`, or segmentation fault.
+
+## Tag Plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc5
+```
+
+Recommended type: annotated tag.
+
+Commands to run only after explicit release approval:
+
+```bash
+git tag -a v0.0.1-rc5 -m "Orbit v0.0.1-rc5"
+git push origin v0.0.1-rc5
+```
+
+## GitHub Release Plan
+
+- Title: `Orbit v0.0.1-rc5`
+- Body: `docs/releases/v0.0.1-rc5.md`
+- Prerelease: yes
+- Latest: no, if supported by the GitHub release command used
+- Attachments: none
+- Do not attach cache, local artifacts, benchmark scratch files, or workdir
+  contents.
+
+## Rollback And Runtime Configuration
+
+MTP is explicit. To avoid native MTP, do not start the server with `--mtp`.
+
+Disable startup prewarm only:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Disable tools at server startup:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+## Release Safety Notes
+
+- `v0.0.1-rc4` must remain unchanged.
+- Do not modify existing tags.
+- Do not modify any existing GitHub Release.
+- Do not publish RC5 until explicitly approved.
+- RC5 is a prerelease and should not be marked as latest.

--- a/docs/releases/v0.0.1-rc5.md
+++ b/docs/releases/v0.0.1-rc5.md
@@ -1,0 +1,192 @@
+# Orbit v0.0.1-rc5 Release Notes
+
+## Summary
+
+Orbit v0.0.1-rc5 is a post-RC4 release candidate focused on native MTP
+correctness and runtime stability.
+
+RC5 includes the MTP stabilization work from PR #72 and PR #73:
+
+- native persistent MTP restore/logits correctness;
+- unified llama.cpp runtime loading for target-only and MTP paths;
+- safer native library lifetime handling;
+- metadata-only MTP diagnostics;
+- validation for `orbit server --mtp` startup with mmproj and KV capabilities.
+
+RC5 does not make MTP a production-default feature, does not claim final MTP
+performance tuning, does not update the vendored llama.cpp copy, and does not
+add any dependency on `llama-server`.
+
+RC5 does not change prompts, routing policy, tool selection policy,
+final-answer policy, or evidence policy.
+
+## Highlights
+
+### Native Persistent MTP Restore Correctness
+
+The request-boundary restore path in native persistent MTP could restore an
+apparently coherent target KV/frontier but still leave the final target logits
+row non-equivalent to a fresh prompt prefill. That made the first sample after
+restore diverge from the fresh MTP path.
+
+RC5 fixes that correctness issue by refilling the effective target prompt after
+request-boundary restore before the first sample. The fix is confined to the
+request-boundary restore path.
+
+Observed before/after result:
+
+- before: MTP first and MTP second could have the same prompt hash/frontier but
+  different final logits, first sample, and output hash;
+- after: prompt hash, final logits hash, first sample hash, and output hash are
+  stable between the prompt-effective target control, MTP first request, and
+  MTP second request.
+
+This is a correctness-first fix. The refill has a cost and is not a performance
+optimization.
+
+### Native MTP Runtime Linkage Stability
+
+The persistent MTP shim is linked against the packaged vendored llama.cpp
+runtime that provides the expected SONAME libraries.
+
+RC5 keeps the llama.cpp backend lifetime process-wide:
+
+- the persistent MTP shim resolves the packaged vendor runtime with matching
+  SONAMEs;
+- Python native bindings cache loaded `CDLL` handles;
+- `RTLD_NODELETE` is used where available to avoid unsafe unload/reload of the
+  process-global native runtime;
+- the llama.cpp backend is not freed per client.
+
+This avoids treating process-wide llama.cpp globals as if they were owned by a
+single Python client instance.
+
+### Unified llama.cpp Runtime For Target-Only And MTP
+
+PR #73 fixes a separate mixed-runtime teardown failure. Target-only Python
+clients and the persistent MTP shim could load different llama.cpp runtime
+libraries in the same process:
+
+- target-only path: legacy `vendor/lib` runtime;
+- MTP shim path: packaged `vendor/build/llama.cpp/bin` runtime with SONAMEs.
+
+That mixed process could complete requests correctly and then abort during
+teardown with heap corruption.
+
+RC5 changes native runtime resolution so the Python client prefers the packaged
+vendor build directory when it contains the expected SONAME libraries:
+
+- `libllama.so.0`;
+- `libllama-common.so.0`.
+
+The legacy `vendor/lib` directory remains a fallback when the packaged vendor
+build runtime is not available.
+
+### Metadata-Only MTP Diagnostics
+
+`ORBIT_MTP_TRACE=1` remains metadata-only. It is intended for correctness and
+stability diagnostics, not for exposing raw model content.
+
+Diagnostics must not include:
+
+- raw token ids;
+- token pieces;
+- raw prompts;
+- user content;
+- file, web, or tool output content.
+
+The retained diagnostics focus on hashes, counts, timing fields, and runtime
+state metadata needed to verify MTP behavior safely.
+
+### Preserved Behavior
+
+RC5 preserves these invariants:
+
+- no prompt changes;
+- no routing policy changes;
+- no tool selection policy changes;
+- no final-answer policy changes;
+- no evidence policy weakening;
+- no deterministic task routing;
+- no system prompt anchor;
+- no multiple anchors;
+- no vendored llama.cpp update;
+- no dependency on `llama-server`.
+
+## Validation
+
+Core checks:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+MTP-focused checks covered the native persistent MTP tests, native MTP probe
+tests, native path/bootstrap tests, and the full unittest suite.
+
+Observed validation for the RC5 content:
+
+- full unittest suite: PASS;
+- compileall: PASS;
+- `git diff --check`: PASS;
+- `orbit server --mtp` bootstrap: PASS;
+- mmproj/multimodal capabilities detected: PASS;
+- KV prefix prewarm/session reuse availability: PASS;
+- target-only and MTP runtime use the same packaged vendor runtime: PASS;
+- legacy `vendor/lib/libllama.so` not loaded in parallel during smoke: PASS;
+- short `/v1/chat/completions` request: PASS;
+- clean server shutdown: PASS;
+- no double-free, `SIGABRT`, or segmentation fault observed in the smoke.
+
+The smoke validates startup, runtime loading, a short text completion, and clean
+shutdown. It does not claim full coverage of streaming, cancellation, stop
+sequence handling, or end-to-end multimodal input behavior.
+
+## Known Limitations
+
+- Native MTP remains experimental and must be enabled explicitly.
+- RC5 is not a final MTP performance release.
+- The request-boundary refill is correctness-first and adds runtime cost.
+- Streaming, cancellation, and stop-sequence behavior need dedicated MTP
+  validation.
+- Multimodal capability detection was validated, but real multimodal input was
+  not validated end-to-end for RC5.
+- The vendored llama.cpp copy is not aligned with current upstream master.
+- Future MTP work should continue to prioritize output equivalence and process
+  stability before speculative decoding performance.
+
+## Upgrade Notes
+
+Users who do not enable MTP should see the same RC4 default posture:
+
+- tools on by default;
+- startup route-prefix prewarm on by default;
+- `ORBIT_KV_PREFIX_ANCHOR=auto` by default.
+
+To test native MTP, start the native server with:
+
+```bash
+orbit server --mtp
+```
+
+To avoid startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+To disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`v0.0.1-rc4` remains unchanged. RC5 is intended as a new prerelease for native
+MTP correctness and runtime stability.
+
+## Release Status
+
+These release notes prepare Orbit v0.0.1-rc5. They do not publish RC5, create a
+tag, modify a tag, or create a GitHub Release.


### PR DESCRIPTION
This PR adds the v0.0.1-rc5 release notes and release plan that were used for the published prerelease.

Scope:
- docs/releases/v0.0.1-rc5.md
- docs/releases/v0.0.1-rc5-release-plan.md
- docs-only
- no runtime changes
- no prompt/routing/tool/final/evidence policy changes
- no vendor updates
- no tag or release changes

This PR exists to make the already-tagged RC5 release notes commit part of main history without modifying the v0.0.1-rc5 tag.