### PR TITLE
Fix web-search finalization handling

### DIFF
--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -415,7 +415,8 @@ class FinalFromToolEnvironment:
         call_messages = self.runtime._with_final_tool_prompt() if use_tool_prompt else self.runtime.messages
         policy = build_final_tool_policy(call_messages, max_tokens=max_tokens, streamed=on_final_delta is not None)
         stream_buffer = _BufferedDeltaSink() if on_final_delta is not None and policy.incomplete_retry_allowed else None
-        final_delta = stream_buffer.write if stream_buffer is not None else on_final_delta
+        direct_delta = _ForwardingDeltaSink(on_final_delta) if on_final_delta is not None and stream_buffer is None else None
+        final_delta = stream_buffer.write if stream_buffer is not None else (direct_delta.write if direct_delta is not None else on_final_delta)
         used_retry_or_repair_pass = False
         repair_attempt = 0
         repair_failed = False
@@ -454,7 +455,10 @@ class FinalFromToolEnvironment:
             used_retry_or_repair_pass = True
             previous_result = result
             retry_messages = [*policy.messages, final_tool_retry_instruction()]
-            retry_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
+            retry_max_tokens = final_tool_retry_max_tokens(
+                max_tokens,
+                web_fetch_result=policy.web_fetch_result or policy.web_search_result,
+            )
             if on_phase_start:
                 on_phase_start(
                     ModelPhaseStart(
@@ -610,6 +614,8 @@ class FinalFromToolEnvironment:
             else:
                 for chunk in stream_buffer.chunks:
                     on_final_delta(chunk)
+        elif direct_delta is not None and on_final_delta is not None and not direct_delta.chunks and result.content:
+            on_final_delta(result.content)
         self.runtime.messages.append({"role": "assistant", "content": result.content})
         return FinalAnswerResult(
             result=result,
@@ -927,6 +933,18 @@ class _BufferedDeltaSink:
     def write(self, text: str) -> None:
         if text:
             self.chunks.append(text)
+
+
+class _ForwardingDeltaSink:
+    def __init__(self, on_delta: Callable[[str], None]) -> None:
+        self._on_delta = on_delta
+        self.chunks: list[str] = []
+
+    def write(self, text: str) -> None:
+        if not text:
+            return
+        self.chunks.append(text)
+        self._on_delta(text)
 
 
 def _prefer_compact_retry_result(candidate: ChatResult, original: ChatResult, *, messages: list[Message]) -> bool:

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -69,6 +69,7 @@ class FinalToolPolicy:
     length_retry_allowed: bool
     incomplete_retry_allowed: bool
     web_fetch_result: bool
+    web_search_result: bool
 
 
 @dataclass(frozen=True)
@@ -87,6 +88,7 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
     large_file_excerpt = has_large_file_excerpt(call_messages)
     exhaustive_document_request = is_exhaustive_document_request(prompt)
     web_fetch_result = has_html_cleaned_tool_result(call_messages)
+    web_search_result = has_web_search_tool_result(call_messages)
     pdf_text_result = has_pdf_text_tool_result(call_messages)
     list_like_result = has_list_like_tool_result(call_messages) and is_compact_list_request(prompt)
     shell_full_result = has_tool_result(call_messages, "exec_shell_full_command")
@@ -226,6 +228,7 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
             large_file_excerpt=large_file_excerpt,
             exhaustive_document_request=exhaustive_document_request,
             web_fetch_result=web_fetch_result,
+            web_search_result=web_search_result,
             pdf_text_result=pdf_text_result,
             list_like_result=list_like_result,
             operational_status_result=operational_status_result,
@@ -234,8 +237,9 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
             brief_request=brief_request,
         ),
         length_retry_allowed=(not streamed and (large_file_excerpt or web_fetch_result)),
-        incomplete_retry_allowed=shell_full_result and not (web_fetch_result or list_like_result or operational_status_result),
+        incomplete_retry_allowed=shell_full_result and not (web_fetch_result or web_search_result or list_like_result or operational_status_result),
         web_fetch_result=web_fetch_result,
+        web_search_result=web_search_result,
     )
 
 
@@ -245,6 +249,7 @@ def final_tool_max_tokens(
     large_file_excerpt: bool,
     exhaustive_document_request: bool,
     web_fetch_result: bool,
+    web_search_result: bool,
     pdf_text_result: bool,
     list_like_result: bool,
     operational_status_result: bool = False,
@@ -254,7 +259,7 @@ def final_tool_max_tokens(
 ) -> int:
     if large_file_excerpt:
         return min(max_tokens, EXHAUSTIVE_LARGE_FILE_FINAL_MAX_TOKENS if exhaustive_document_request else LARGE_FILE_FINAL_MAX_TOKENS)
-    if web_fetch_result:
+    if web_fetch_result or web_search_result:
         return min(max_tokens, WEB_FETCH_FINAL_MAX_TOKENS)
     if pdf_text_result:
         return min(max_tokens, PDF_BRIEF_FINAL_MAX_TOKENS if brief_request else PDF_FINAL_MAX_TOKENS)
@@ -435,6 +440,8 @@ def final_from_tool_retry_reason(
 
 
 def final_from_tool_compact_retry_reason(result: ChatResult, *, messages: list[Message]) -> str | None:
+    if has_web_search_tool_result(messages):
+        return None
     if not _has_long_shell_tool_result(messages):
         return None
     if result.finish_reason == "length" and result.content.strip():
@@ -612,6 +619,22 @@ def has_html_cleaned_tool_result(messages: list[Message]) -> bool:
         content = message.get("content")
         return isinstance(content, str) and "shell_output_html_cleaned: true" in content
     return False
+
+
+def has_web_search_tool_result(messages: list[Message]) -> bool:
+    tool_message, command = last_successful_shell_result_and_command(messages)
+    if tool_message is None:
+        return False
+    content = tool_message.get("content")
+    if isinstance(content, str) and "web_search_results: true" in content:
+        return True
+    if not command:
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    return bool(tokens and tokens[0] == "orbit-web-search")
 
 
 def has_pdf_text_tool_result(messages: list[Message]) -> bool:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -589,7 +589,7 @@ def run_tool_loop(
                         on_model_step=on_model_step,
                         on_phase_start=on_phase_start,
                         loop=state.tool_rounds + 1,
-                        use_tool_prompt=state.used_tool_call_prompt,
+                        use_tool_prompt=state.used_tool_call_prompt or _is_empty_web_search_result(tool_result),
                     )
         if (
             not repair.shell_error_final_pending
@@ -915,7 +915,7 @@ def run_tool_loop(
                     on_model_step=on_model_step,
                     on_phase_start=on_phase_start,
                     loop=loop_index + 1,
-                    use_tool_prompt=state.used_tool_call_prompt,
+                    use_tool_prompt=state.used_tool_call_prompt or _is_empty_web_search_result(tool_result),
                 )
         if repair.shell_error_final_pending:
             turn.mark_finalizable()
@@ -970,6 +970,16 @@ def _tool_call_max_tokens(max_tokens: int, *, mutative: bool, file_recovery: boo
 
 def _is_empty_final_response(result: ChatResult) -> bool:
     return not result.tool_calls and result.finish_reason == "stop" and not result.content.strip()
+
+
+def _is_empty_web_search_result(tool_result) -> bool:
+    if getattr(tool_result, "name", None) != "exec_shell_full_command":
+        return False
+    content = getattr(tool_result, "content", None)
+    if not isinstance(content, str):
+        return False
+    lowered = content.lower()
+    return "web_search_results: true" in lowered and re.search(r"(?m)^results:\s*none\s*$", lowered) is not None
 
 
 def _last_user_text(messages: list[Message]) -> str | None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1862,6 +1862,66 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn("web_search_results: true", str(tool_messages[0]["content"]))
         self.assertNotIn("tool not available", str(tool_messages[0]["content"]))
 
+    def test_empty_web_search_route_uses_brief_final_prompt(self) -> None:
+        class EmptyWebSearchBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.max_tokens_seen: list[int] = []
+                self.final_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.max_tokens_seen.append(max_tokens)
+                if self.calls == 1:
+                    return ChatResult(
+                        content='{"command":"orbit-web-search \\"sample topic\\""}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=10,
+                        completion_tokens=8,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                self.final_messages = messages
+                return ChatResult(
+                    content="No web search results were found for the query.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=38,
+                    completion_tokens=10,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = EmptyWebSearchBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            with patch(
+                "orbit.runtime.shell_guardrails.search_web",
+                return_value="web_search_results: true\nresults: none",
+            ):
+                result = runtime.ask_auto(
+                    "search online for sample topic",
+                    temperature=0,
+                    max_tokens=512,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command",),
+                )
+
+        self.assertEqual(result.content, "No web search results were found for the query.")
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(backend.max_tokens_seen, [128, 72])
+        self.assertIsNotNone(backend.final_messages)
+        self.assertEqual(backend.final_messages[0]["content"], FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.final_messages or [])
+        self.assertIn("web_search_results: true", rendered)
+        self.assertIn("results: none", rendered)
+        self.assertNotIn("Decide compactly whether the user request needs local tools", rendered)
+
     def test_new_web_turn_uses_latest_tool_evidence_not_previous_local_result(self) -> None:
         class RoutedBackend:
             def __init__(self) -> None:
@@ -6724,6 +6784,72 @@ EOF"""
         self.assertEqual(result.content, "Mario Nobile is an Italian public official.")
         self.assertEqual(emitted, ["Mario Nobile is an Italian public official."])
         self.assertEqual(backend.chat_stream_calls, 2)
+
+    def test_final_from_web_search_streams_and_stops_on_length_without_hidden_retry(self) -> None:
+        class WebSearchLengthBackend:
+            def __init__(self) -> None:
+                self.chat_stream_calls = 0
+                self.max_tokens_seen: list[int] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                raise AssertionError("streaming path expected")
+
+            def chat_stream(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None, on_delta=None, on_progress=None) -> ChatResult:
+                self.chat_stream_calls += 1
+                self.max_tokens_seen.append(max_tokens)
+                if self.chat_stream_calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "exec_shell_full_command", "arguments": "{\"command\":\"orbit-web-search 'sample topic'\"}"},
+                            }
+                        ],
+                        prompt_tokens=None,
+                        completion_tokens=None,
+                        cached_tokens=None,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                assert on_delta is not None
+                on_delta("partial web search answer")
+                return ChatResult(
+                    content="partial web search answer",
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=72,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        emitted: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = WebSearchLengthBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            with patch(
+                "orbit.runtime.shell_guardrails.search_web",
+                return_value="web_search_results: true\nquery: sample topic\nresults:\n- one result",
+            ):
+                result = runtime.ask_with_tools(
+                    "search online for sample topic",
+                    temperature=0,
+                    max_tokens=512,
+                    workdir=Path(tmp),
+                    on_final_delta=emitted.append,
+                )
+
+        self.assertEqual(result.content, "partial web search answer")
+        self.assertEqual(result.finish_reason, "length")
+        self.assertEqual(emitted, ["partial web search answer"])
+        self.assertEqual(backend.chat_stream_calls, 2)
+        self.assertEqual(backend.max_tokens_seen, [96, 72])
 
     def test_ask_with_tools_emits_tool_call_event(self) -> None:
         events: list[tuple[str, str]] = []


### PR DESCRIPTION
This PR fixes a local correctness/UX issue in final-from-tool handling for web-search results.

Root cause:
`orbit-web-search` results were treated as generic long shell output. In the route initial-tool path, `results:none` could also inherit the large route/tools prompt because `use_tool_prompt=False`. This produced an oversized final prompt for an empty web result and could leave the CLI with poor finalization behavior.

Changes:
- classify `web_search_results: true` / `orbit-web-search` as web-search tool results
- apply web-search final caps and exclude web-search from shell-long retry/buffering behavior
- use the short final prompt only for technical `web_search_results:true` + `results:none`
- preserve direct streaming and emit returned content if a backend returns content without deltas
- add regression tests for `finish_reason=length`, `results:none`, and no-delta streaming

Validation:
- runtime tests PASS
- full unittest suite PASS
- compileall PASS
- git diff --check PASS
- local `results:none` smoke reduced final prompt size and terminates cleanly

Known residual:
This is not a general performance optimization. Web-search with full results can still be slow on CPU. If the backend emits no deltas, token-by-token streaming is not available and the fallback emits returned content at the end.

Scope:
- no routing/tool-selection changes
- no global prompt changes
- no vendor llama.cpp changes
- no performance optimization
- no query-specific hardcode