### PR TITLE
Add v0.0.1-rc6 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc6-release-plan.md
+++ b/docs/releases/v0.0.1-rc6-release-plan.md
@@ -1,0 +1,78 @@
+# Orbit v0.0.1-rc6 Release Plan
+
+This is an operational plan only. Do not execute tag or release commands until
+publication is explicitly confirmed.
+
+## Pre-Release Checks
+
+- `main` must point to the final commit that includes the RC6 release notes.
+- `git status --short` must be clean except for local untracked cache such as
+  `workdir/.miktex/`.
+- Full unit tests must pass.
+- `python3 -m compileall -q src tests scripts` must pass.
+- `git diff --check` must pass.
+- Minimum smoke must pass:
+  - start `orbit server --mtp`;
+  - run a tools-on, think-off CLI prompt;
+  - confirm `route_anchor_hit=true`;
+  - confirm `restore_used=true`;
+  - confirm route cached/evaluated is around `694/18`;
+  - shut down cleanly with exit code `0`;
+  - observe no double-free, `SIGABRT`, or segmentation fault.
+
+## Tag Plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc6
+```
+
+Recommended type: annotated tag.
+
+Commands to run only after explicit release approval:
+
+```bash
+git tag -a v0.0.1-rc6 -m "Orbit v0.0.1-rc6"
+git push origin v0.0.1-rc6
+```
+
+## GitHub Release Plan
+
+- Title: `Orbit v0.0.1-rc6`
+- Body: `docs/releases/v0.0.1-rc6.md`
+- Prerelease: yes
+- Latest: no, if supported by the GitHub release command used
+- Attachments: none
+- Do not attach cache, local artifacts, benchmark scratch files, or workdir
+  contents.
+
+## Rollback And Runtime Configuration
+
+To avoid native MTP, do not start the server with `--mtp`.
+
+Disable startup prewarm only:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+Disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Disable tools at server startup:
+
+```bash
+ORBIT_TOOLS=off
+```
+
+## Release Safety Notes
+
+- `v0.0.1-rc5` must remain unchanged.
+- Do not modify existing tags.
+- Do not modify any existing GitHub Release.
+- Do not publish RC6 until explicitly approved.
+- RC6 is a prerelease and should not be marked as latest.

--- a/docs/releases/v0.0.1-rc6.md
+++ b/docs/releases/v0.0.1-rc6.md
@@ -1,0 +1,127 @@
+# Orbit v0.0.1-rc6 Release Notes
+
+## Summary
+
+Orbit v0.0.1-rc6 is a post-RC5 release candidate that fixes a regression in the
+native MTP + tools-on route-prefix prewarm path.
+
+In RC5, `orbit server --mtp` could let MTP short-circuit a route completion
+before the route-prefix anchor restore path was used. A simple tools-on CLI
+prompt could therefore evaluate almost the full route prompt cold even though
+startup prewarm had prepared the route prefix.
+
+RC6 fixes that regression without changing prompts, routing policy, tool
+selection policy, final-answer policy, evidence policy, or vendored llama.cpp.
+
+RC6 is not a production-default MTP release and is not a final MTP performance
+release.
+
+## Fix
+
+The fix is technical:
+
+- MTP is disabled only for completions that have `route_anchor_segments`;
+- route-prefix anchor completions stay on the standard completion path;
+- the standard path can restore the startup route-prefix checkpoint;
+- normal non-anchor completions can still use MTP.
+
+The rule does not inspect user text and does not add a hardcoded fast path for
+greetings or simple chat.
+
+## Observed Impact
+
+Problem observed after RC5:
+
+| Scenario | Route cached/evaluated | Route prefill | Total wall |
+| --- | ---: | ---: | ---: |
+| tools on, think off, `orbit server --mtp` | `4/701` | about `64011 ms` | about `74 s` |
+
+Observed after the RC6 fix:
+
+| Scenario | Route cached/evaluated | Route prefill | Total wall |
+| --- | ---: | ---: | ---: |
+| tools on, think off | `694/18` | about `2.5-3.1 s` | about `12-14 s` |
+| tools on, think on | `694/18` | about `3.1 s` | about `51 s` |
+| tools off, think on | n/a | n/a | about `35 s` |
+
+For tools-on route calls, diagnostics showed:
+
+- `route_anchor_hit=true`;
+- `restore_used=true`;
+- startup prewarm prefix tokens: about `694`;
+- no double-free, `SIGABRT`, or segmentation fault in smoke.
+
+Think-on remains slower because it uses additional thinking/final/repair phases.
+That is not addressed by RC6.
+
+## Validation
+
+Core checks:
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 -m compileall -q src tests scripts
+git diff --check
+```
+
+Targeted validation:
+
+- native MTP experimental tests: PASS;
+- native server/bootstrap/path/persistent MTP tests: PASS;
+- full unittest suite: PASS;
+- compileall: PASS;
+- `git diff --check`: PASS;
+- `orbit server --mtp` tools-on think-off smoke: PASS;
+- route-prefix restore after startup prewarm: PASS.
+
+## Preserved Behavior
+
+RC6 preserves:
+
+- no prompt changes;
+- no routing policy changes;
+- no tool selection policy changes;
+- no final-answer policy changes;
+- no evidence policy weakening;
+- no deterministic greeting/simple-chat fast path;
+- no vendored llama.cpp update;
+- no dependency on `llama-server`;
+- MTP remains available for normal non-anchor completions.
+
+## Known Limitations
+
+- Native MTP remains experimental.
+- Think-on remains expensive and needs separate investigation/optimization.
+- Streaming, cancellation, and stop-sequence behavior need dedicated MTP
+  validation.
+- Real multimodal input is not validated end-to-end for this RC.
+- The request-boundary refill from RC5 remains correctness-first and still has a
+  runtime cost.
+- The vendored llama.cpp copy is not aligned with current upstream master.
+
+## Upgrade Notes
+
+Users who run `orbit server --mtp` with tools enabled should get the intended
+startup route-prefix prewarm benefit again.
+
+To avoid native MTP, do not start the server with `--mtp`.
+
+To disable startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_PREWARM=off
+```
+
+To disable route prefix-anchor and startup prewarm:
+
+```bash
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+`v0.0.1-rc5` remains unchanged. RC6 is intended as a new prerelease for the
+post-RC5 route-prefix anchor + MTP regression fix.
+
+## Release Status
+
+These release notes prepare Orbit v0.0.1-rc6. They do not publish RC6, create a
+tag, modify a tag, or create a GitHub Release.


### PR DESCRIPTION
This PR adds the v0.0.1-rc6 release notes and release plan to main.

Scope:
- docs/releases/v0.0.1-rc6.md
- docs/releases/v0.0.1-rc6-release-plan.md

No code/runtime changes. No tag or release changes.