### PR TITLE
Improve CLI streaming and route retry UX

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1910,6 +1910,8 @@ class _ControlChannelStreamFilter:
 
 
 class _LeadingThoughtLabelFilter:
+    _LABEL = "thought"
+
     def __init__(self) -> None:
         self._buffer = ""
         self._resolved = False
@@ -1920,6 +1922,11 @@ class _LeadingThoughtLabelFilter:
         self._buffer += text
         newline_index = self._find_newline(self._buffer)
         if newline_index < 0:
+            if not self._could_still_be_plain_thought_label(self._buffer):
+                self._resolved = True
+                buffered = self._buffer
+                self._buffer = ""
+                return [buffered]
             return []
         first_line = self._buffer[:newline_index]
         rest = self._buffer[newline_index + 1 :]
@@ -1944,3 +1951,8 @@ class _LeadingThoughtLabelFilter:
             if idx >= 0:
                 return idx if marker == "\n" else idx + (0 if marker == "\r" else 1)
         return -1
+
+    @classmethod
+    def _could_still_be_plain_thought_label(cls, text: str) -> bool:
+        stripped = text.strip().lower()
+        return bool(stripped) and cls._LABEL.startswith(stripped)

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -42,8 +42,8 @@ from orbit.runtime.messages import (
 )
 
 from orbit.runtime.command_request import (
-    CommandStreamFilter,
     ToolRoute,
+    command_stream_state,
     decision_tool_names,
     parse_command_decision,
     parse_command_decision_from_tool_calls,
@@ -313,8 +313,7 @@ class ChatRuntime:
         command_max_tokens = CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS)
         streamed_final_retry = False
         retried_empty_final = False
-        route_stream_filter = None
-        route_streamed_chunks: list[str] = []
+        route_abort_reason: str | None = None
         command_messages = with_command_system_prompt(self.messages)
         with self._temporary_backend_thinking(False):
             if on_phase_start:
@@ -323,14 +322,28 @@ class ChatRuntime:
                 if on_progress is None:
                     first = self.backend.chat(command_messages, temperature=temperature, max_tokens=command_max_tokens)
                 else:
-                    route_stream_filter = CommandStreamFilter(route_streamed_chunks.append) if on_final_delta is not None else None
-                    first = self.backend.chat_stream(
-                        command_messages,
-                        temperature=temperature,
-                        max_tokens=command_max_tokens,
-                        on_delta=route_stream_filter.write if route_stream_filter is not None else (lambda _text: None),
-                        on_progress=on_progress,
-                    )
+                    route_stream_filter = _RouteDecisionStreamAbort()
+                    try:
+                        first = self.backend.chat_stream(
+                            command_messages,
+                            temperature=temperature,
+                            max_tokens=command_max_tokens,
+                            on_delta=route_stream_filter.write,
+                            on_progress=on_progress,
+                        )
+                    except _RouteNotCommandAbort as exc:
+                        route_abort_reason = "route_not_command"
+                        first = ChatResult(
+                            content=exc.content,
+                            model=None,
+                            finish_reason="length",
+                            tool_calls=[],
+                            prompt_tokens=None,
+                            completion_tokens=exc.chunks,
+                            cached_tokens=None,
+                            prompt_tokens_per_second=None,
+                            generation_tokens_per_second=None,
+                        )
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=1, result=first, phase="route"))
         command_content = first.content
@@ -437,14 +450,24 @@ class ChatRuntime:
                     )
                     retried_empty_final = True
                 if first.finish_reason == "length":
+                    retry_reason = route_abort_reason or "length_without_decision"
                     if not route_outcome_emitted:
                         _emit_route_outcome_for_result(
                             first,
                             decision=None,
                             outcome="route_no_decision_length_retry",
-                            retry_reason="length_without_decision",
+                            retry_reason=retry_reason,
                         )
                         route_outcome_emitted = True
+                    if on_phase_start:
+                        on_phase_start(
+                            ModelPhaseStart(
+                                "chat_final_retry",
+                                streamed=on_final_delta is not None,
+                                attempt=2,
+                                reason=retry_reason,
+                            )
+                        )
                     if on_final_delta is None:
                         with model_call_context(phase="chat_final_retry", tools_mode="on"):
                             first = self.backend.chat(self.messages, temperature=temperature, max_tokens=max_tokens)
@@ -489,12 +512,7 @@ class ChatRuntime:
                     )
                 self.messages.append({"role": "assistant", "content": first.content})
                 if on_final_delta and not streamed_final_retry and not retried_empty_final:
-                    if route_stream_filter is not None:
-                        route_stream_filter.finish()
-                        for chunk in route_streamed_chunks:
-                            on_final_delta(chunk)
-                    else:
-                        on_final_delta(first.content)
+                    on_final_delta(first.content)
                 return self._remember_visible_result(first)
         if decision.route == ToolRoute.CHAT:
             chat_messages = with_chat_system_prompt(self.messages)
@@ -945,6 +963,29 @@ class _ThoughtOnlyDeltaFilter:
                 break
             self._buffer = self._buffer[start + len(self._THOUGHT_START) :]
             self._in_thought = True
+
+
+class _RouteNotCommandAbort(Exception):
+    def __init__(self, content: str, *, chunks: int) -> None:
+        super().__init__("route stream produced non-command prose")
+        self.content = content
+        self.chunks = chunks
+
+
+class _RouteDecisionStreamAbort:
+    """Stop an internal route stream once it cannot still become a route decision."""
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._chunks = 0
+
+    def write(self, text: str) -> None:
+        if not text:
+            return
+        self._chunks += 1
+        self._buffer += text
+        if command_stream_state(self._buffer) == "not_command":
+            raise _RouteNotCommandAbort(self._buffer, chunks=self._chunks)
 
 
 class _BufferedDeltaSink:

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -231,11 +231,12 @@ class StreamRenderer:
 
     def _working_phase_detail(self) -> str | None:
         if self._progress is not None:
+            prefix = f"{self._phase_label} " if self._phase_label else ""
             if self._progress.phase == "prefill":
-                return "prefill"
+                return f"{prefix}prefill"
             if self._progress.phase == "generation":
-                return "generation"
-            return self._progress.phase
+                return f"{prefix}generation"
+            return f"{prefix}{self._progress.phase}"
         if self._prefill_estimate_seconds and self._prefill_estimate_seconds >= 1:
             return "prefill estimate"
         return None

--- a/tests/test_native_streaming.py
+++ b/tests/test_native_streaming.py
@@ -45,6 +45,16 @@ class NativeStreamingTests(unittest.TestCase):
 
         self.assertEqual("".join(deltas), "I was developed by Google DeepMind.")
 
+    def test_leading_thought_label_filter_streams_plain_answer_without_newline(self) -> None:
+        stream = _LeadingThoughtLabelFilter()
+
+        deltas: list[str] = []
+        deltas.extend(stream.write("I cannot"))
+        deltas.extend(stream.write(" confirm that."))
+        deltas.extend(stream.finish())
+
+        self.assertEqual(deltas, ["I cannot", " confirm that."])
+
     def test_stop_filter_does_not_emit_stop_sequence(self) -> None:
         emitted: list[str] = []
         stream = _StopSequenceStreamFilter(("STOP",), emit=emitted.append)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -15,7 +15,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from orbit.backend.base import ChatResult, Message
+from orbit.backend.base import ChatResult, Message, StreamProgress
 from orbit.runtime import ChatRuntime
 from orbit.runtime.sessions import SessionStore
 from orbit.terminal.config import AppConfig
@@ -35,6 +35,7 @@ from orbit.terminal.repl_input import (
 from orbit.terminal.repl import Repl
 from orbit.terminal.repl import _phase_progress_label, _phase_starts_final_output, _prefill_profile_for_turn
 from orbit.terminal.session_preview import format_recent_session_messages
+from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
 from orbit.runtime.turn_trace import ModelPhaseStart
@@ -324,6 +325,14 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(renderer.events, [])
         self.assertEqual(renderer.phase_label, "forced final")
         self.assertEqual(renderer.final_output_mode, [True, True, True])
+
+    def test_working_phase_detail_combines_phase_label_and_progress(self) -> None:
+        renderer = StreamRenderer()
+
+        renderer.set_phase_label("tool decision")
+        renderer.progress(StreamProgress(phase="generation", current=3, total=128, percent=2))
+
+        self.assertEqual(renderer._working_phase_detail(), "tool decision generation")
 
     def test_prefill_profile_for_turn_uses_chat_when_tools_off(self) -> None:
         self.assertEqual(_prefill_profile_for_turn([], tools_enabled=False), CHAT_PREFILL_PROFILE)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4548,7 +4548,7 @@ EOF"""
         self.assertEqual(backend.chat_calls, 0)
         self.assertEqual(backend.chat_stream_calls, 2)
 
-    def test_ask_auto_replays_streamed_route_answer_when_tools_are_on_and_no_tool_is_used(self) -> None:
+    def test_ask_auto_aborts_streamed_route_prose_and_streams_final_retry(self) -> None:
         class StreamingRouteAnswerBackend:
             def __init__(self) -> None:
                 self.chat_calls = 0
@@ -4563,9 +4563,22 @@ EOF"""
                 assert on_delta is not None
                 assert on_progress is not None
                 on_progress(type("P", (), {"phase": "generation", "current": 12, "total": 128, "percent": 9})())
-                on_delta("plain answer")
+                if self.chat_stream_calls == 1:
+                    on_delta("plain route prose")
+                    return ChatResult(
+                        content="plain route prose",
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=5,
+                        completion_tokens=3,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                on_delta("final answer")
                 return ChatResult(
-                    content="plain answer",
+                    content="final answer",
                     model="fake",
                     finish_reason="stop",
                     tool_calls=[],
@@ -4578,6 +4591,7 @@ EOF"""
 
         emitted: list[str] = []
         progress: list[tuple[str, int, int, int]] = []
+        phases: list[tuple[str, str | None]] = []
         backend = StreamingRouteAnswerBackend()
         runtime = ChatRuntime(backend=backend, system_prompt="route system")
 
@@ -4588,14 +4602,16 @@ EOF"""
             workdir=Path("."),
             on_final_delta=emitted.append,
             on_progress=lambda item: progress.append((item.phase, item.current, item.total, item.percent)),
+            on_phase_start=lambda phase: phases.append((phase.phase, phase.reason)),
             allowed_tool_names=("exec_shell_full_command",),
         )
 
-        self.assertEqual(result.content, "plain answer")
-        self.assertEqual(emitted, ["plain answer"])
-        self.assertEqual(progress, [("generation", 12, 128, 9)])
+        self.assertEqual(result.content, "final answer")
+        self.assertEqual(emitted, ["final answer"])
+        self.assertIn(("chat_final_retry", "route_not_command"), phases)
+        self.assertEqual(progress, [("generation", 12, 128, 9), ("generation", 12, 128, 9)])
         self.assertEqual(backend.chat_calls, 0)
-        self.assertEqual(backend.chat_stream_calls, 1)
+        self.assertEqual(backend.chat_stream_calls, 2)
 
     def test_ask_auto_discards_route_thought_and_runs_chat_final(self) -> None:
         class StreamingRouteThoughtBackend:
@@ -4698,6 +4714,7 @@ EOF"""
                 )
 
         emitted: list[str] = []
+        phases: list[tuple[str, bool, int | None, str | None]] = []
         backend = StreamingRouteLengthBackend()
         runtime = ChatRuntime(backend=backend, system_prompt="route system")
 
@@ -4708,11 +4725,13 @@ EOF"""
             workdir=Path("."),
             on_final_delta=emitted.append,
             on_progress=lambda _item: None,
+            on_phase_start=lambda phase: phases.append((phase.phase, phase.streamed, phase.attempt, phase.reason)),
             allowed_tool_names=("exec_shell_full_command",),
         )
 
         self.assertEqual(result.content, "<|channel>thought\nvisible thinking<channel|>visible answer")
         self.assertEqual(emitted, ["<|channel>thought\nvisible thinking", "<channel|>visible answer"])
+        self.assertIn(("chat_final_retry", True, 2, "route_not_command"), phases)
         self.assertEqual(backend.chat_calls, 0)
         self.assertEqual(backend.chat_stream_calls, 2)
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -578,7 +578,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer.set_phase_label("forced final")
         renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
 
-        self.assertEqual(renderer._working_phase_prefix(), " [prefill]")
+        self.assertEqual(renderer._working_phase_prefix(), " [forced final prefill]")
         self.assertEqual(renderer._working_status(5), "5s, 243/935 tk (25%)")
 
     def test_wait_timer_omits_repeated_generation_label_from_status(self) -> None:
@@ -593,7 +593,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer.set_phase_label("final answer")
         renderer.progress(StreamProgress(phase="generation", current=7, total=512, percent=1))
 
-        self.assertEqual(renderer._working_phase_prefix(), " [generation]")
+        self.assertEqual(renderer._working_phase_prefix(), " [final answer generation]")
 
     def test_wait_timer_names_generation_progress_explicitly(self) -> None:
         renderer = StreamRenderer()


### PR DESCRIPTION
This PR improves CLI streaming/progress behavior and avoids wasting a full route generation when the internal route stream has already violated the route contract.

Changes:
- release normal final text from the leading thought-label filter as soon as it cannot be a thought prefix
- preserve suppression for real thought-prefixed output
- show clearer progress labels for tool decision, final answer, and chat_final_retry phases
- emit chat_final_retry phase when route generation reaches length or is aborted as not_command
- abort internal route streaming early when the command stream parser determines the route output is not a valid command
- do not stream internal route prose as final answer
- do not accept route prose as final answer
- add regression tests for streaming, progress labels, route retry, and no thought leakage

Scope:
- no ROUTE_MAX_TOKENS change
- no prompt/routing/tool/final/evidence policy change
- no intent classifier
- no query-specific hardcode
- no MTP/KV/vendor change
- no release docs

Validation:
- targeted streaming/REPL/runtime tests PASS
- full unittest suite PASS
- compileall PASS
- git diff --check PASS

Known residual:
Route-contract drift under long history still exists. This PR reduces wasted route generation and improves UX, but does not solve route compliance or final answer latency in all cases.