### PR TITLE
Add explicit MTP allow flag for internal completions

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -47,6 +47,7 @@ class LlamaServerBackend:
                 thinking=self.thinking,
                 tools=tools,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
             )
         )
         if native_backend:
@@ -82,6 +83,7 @@ class LlamaServerBackend:
                 tools=tools,
                 stream=True,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
             )
         )
         if native_backend:
@@ -703,3 +705,14 @@ def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:
     if not prefix_anchor_enabled():
         return False
     return current_phase() == "route" and current_tools_mode() == "on"
+
+
+def _allow_mtp_experimental_requested(*, native_backend: bool) -> bool | None:
+    if not native_backend:
+        return None
+    if current_tools_mode() != "on":
+        return None
+    phase = current_phase()
+    if phase == "chat_final_retry" or phase.startswith("final_from_tool"):
+        return False
+    return None

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -16,6 +16,7 @@ class ChatPayloadOptions:
     stream: bool = False
     cache_prompt: bool = True
     route_prefix_anchor: bool = False
+    allow_mtp_experimental: bool | None = None
 
 
 def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
@@ -32,6 +33,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["stream"] = True
     if options.route_prefix_anchor:
         payload["route_prefix_anchor"] = True
+    if options.allow_mtp_experimental is not None:
+        payload["allow_mtp_experimental"] = options.allow_mtp_experimental
     if options.tools:
         payload["tools"] = options.tools
         payload["tool_choice"] = "auto"

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -530,6 +530,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        allow_mtp_experimental: bool | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -573,6 +574,8 @@ class NativeLlamaClient:
             prompt=prompt,
         ) if route_prefix_anchor else None
         allow_mtp = not tools and route_anchor_segments is None
+        if allow_mtp_experimental is False:
+            allow_mtp = False
         return self.complete_prompt(
             prompt,
             max_tokens=max_tokens,
@@ -593,6 +596,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        allow_mtp_experimental: bool | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -605,6 +609,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            allow_mtp_experimental=allow_mtp_experimental,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
@@ -649,6 +654,7 @@ class NativeLlamaClient:
         tools: list[dict] | None,
         thinking: bool,
         route_prefix_anchor: bool = False,
+        allow_mtp_experimental: bool | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -714,6 +720,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            allow_mtp_experimental=allow_mtp_experimental,
             on_progress=on_progress,
             on_token=collect,
             should_cancel=should_cancel,

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -75,6 +75,7 @@ class OrbitNativeServer:
                 tools=request.tools,
                 thinking=thinking,
                 route_prefix_anchor=request.route_prefix_anchor,
+                allow_mtp_experimental=request.allow_mtp_experimental,
                 on_progress=on_progress,
                 on_token=collect,
                 should_cancel=should_cancel,

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -19,6 +19,7 @@ class ChatRequest:
     stream: bool
     tools: list[dict[str, Any]]
     route_prefix_anchor: bool
+    allow_mtp_experimental: bool | None
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         stream=payload.get("stream") is True,
         tools=_tools_from_payload(payload.get("tools")),
         route_prefix_anchor=payload.get("route_prefix_anchor") is True,
+        allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
     )
 
 
@@ -158,6 +160,12 @@ def _tools_from_payload(value: object) -> list[dict[str, Any]]:
 
 
 def _thinking_mode(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _optional_bool(value: object) -> bool | None:
     if isinstance(value, bool):
         return value
     return None

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -308,6 +308,71 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertNotIn("route_prefix_anchor", backend.payloads[2])
         self.assertNotIn("route_prefix_anchor", backend.payloads[3])
 
+    def test_allow_mtp_false_payload_is_limited_to_native_tools_final_fallbacks(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payloads: list[dict[str, object]] = []
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "orbit-native"}
+
+            def _post_native_stream(self, _path: str, payload: dict[str, object], *, on_delta, on_progress) -> ChatResult:
+                self.payloads.append(payload)
+                return ChatResult(
+                    content="ok",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = Backend()
+        backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with model_call_context(phase="chat_final_retry", tools_mode="on"):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with model_call_context(phase="final_from_tool", tools_mode="on"):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with model_call_context(phase="final_from_tool_retry", tools_mode="on"):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with model_call_context(phase="chat_final_retry", tools_mode="off"):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertNotIn("allow_mtp_experimental", backend.payloads[0])
+        self.assertFalse(backend.payloads[1]["allow_mtp_experimental"])
+        self.assertFalse(backend.payloads[2]["allow_mtp_experimental"])
+        self.assertFalse(backend.payloads[3]["allow_mtp_experimental"])
+        self.assertNotIn("allow_mtp_experimental", backend.payloads[4])
+
+    def test_allow_mtp_payload_is_not_sent_to_non_native_backend(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payload: dict[str, object] | None = None
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "openai-compatible"}
+
+            def _post_json(self, _path: str, payload: dict[str, object]) -> dict[str, object]:
+                self.payload = payload
+                return {
+                    "model": "fake",
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+
+        backend = Backend()
+        with model_call_context(phase="chat_final_retry", tools_mode="on"):
+            backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertIsNotNone(backend.payload)
+        assert backend.payload is not None
+        self.assertNotIn("allow_mtp_experimental", backend.payload)
+
     def test_route_prefix_anchor_legacy_experiment_flag_still_enables_auto_mode(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -328,6 +328,55 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         self.assertTrue(kwargs["allow_mtp_experimental"])
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_complete_chat_respects_explicit_allow_mtp_false(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client.apply_chat_template = mock.Mock(return_value="prompt")
+        expected = NativeTimings(
+            prompt_tokens=10,
+            output_tokens=2,
+            reused_prompt_tokens=3,
+            evaluated_prompt_tokens=7,
+            prefill_ms=12.0,
+            generation_ms=34.0,
+        )
+        client.complete_prompt = mock.Mock(return_value=expected)
+
+        result = client.complete_chat(
+            [{"role": "user", "content": "hello"}],
+            max_tokens=16,
+            allow_mtp_experimental=False,
+        )
+
+        self.assertEqual(result, expected)
+        kwargs = client.complete_prompt.call_args.kwargs
+        self.assertFalse(kwargs["allow_mtp_experimental"])
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_complete_chat_does_not_force_mtp_on_when_explicit_true_conflicts_with_tools(self, _mocked_lib) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client.apply_chat_template = mock.Mock(return_value="prompt")
+        expected = NativeTimings(
+            prompt_tokens=10,
+            output_tokens=2,
+            reused_prompt_tokens=3,
+            evaluated_prompt_tokens=7,
+            prefill_ms=12.0,
+            generation_ms=34.0,
+        )
+        client.complete_prompt = mock.Mock(return_value=expected)
+
+        result = client.complete_chat(
+            [{"role": "user", "content": "read note.txt"}],
+            max_tokens=16,
+            tools=[{"type": "function", "function": {"name": "exec_shell_full_command"}}],
+            allow_mtp_experimental=True,
+        )
+
+        self.assertEqual(result, expected)
+        kwargs = client.complete_prompt.call_args.kwargs
+        self.assertFalse(kwargs["allow_mtp_experimental"])
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_complete_chat_disables_mtp_during_tool_call_rounds(self, _mocked_lib) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         client.apply_chat_template = mock.Mock(return_value="prompt")

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -31,6 +31,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(request.stop, ())
         self.assertEqual(request.tools, [])
         self.assertFalse(request.route_prefix_anchor)
+        self.assertIsNone(request.allow_mtp_experimental)
 
     def test_parse_chat_request_accepts_thinking_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "thinking": True})
@@ -68,6 +69,15 @@ class NativeServerProtocolTests(unittest.TestCase):
     def test_parse_chat_request_accepts_route_prefix_anchor_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "route_prefix_anchor": True})
         self.assertTrue(request.route_prefix_anchor)
+
+    def test_parse_chat_request_accepts_allow_mtp_flag(self) -> None:
+        disabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "allow_mtp_experimental": False})
+        enabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "allow_mtp_experimental": True})
+        ignored = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "allow_mtp_experimental": "false"})
+
+        self.assertFalse(disabled.allow_mtp_experimental)
+        self.assertTrue(enabled.allow_mtp_experimental)
+        self.assertIsNone(ignored.allow_mtp_experimental)
 
     def test_parse_chat_request_rejects_malformed_payloads(self) -> None:
         bad_payloads = [

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -37,6 +37,7 @@ class _FakeClient:
         self.mtp_decode_probe = type("Probe", (), {"enabled": False, "success": False, "error": None})()
         self.last_mtp_completion = type("Probe", (), {"success": False})()
         self.mtp_fallback_reason = None
+        self.allow_mtp_calls: list[bool | None] = []
 
     def complete_chat_text(
         self,
@@ -47,11 +48,13 @@ class _FakeClient:
         tools,
         thinking,
         route_prefix_anchor=False,
+        allow_mtp_experimental=None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
     ):
         self.calls.append(thinking)
+        self.allow_mtp_calls.append(allow_mtp_experimental)
         return _FakeCompletion()
 
     def session_snapshot(self, session_id: str):
@@ -125,6 +128,16 @@ class NativeServerThinkTests(unittest.TestCase):
 
         self.assertEqual(result["finish_reason"], "stop")
         self.assertEqual(server.client.calls, [True])
+
+    def test_allow_mtp_flag_is_passed_to_native_client(self) -> None:
+        server = OrbitNativeServer(client=_FakeClient(thinking=False), model_alias="m")
+
+        result = server.complete(
+            parse_chat_request({"messages": [{"role": "user", "content": "hello"}], "allow_mtp_experimental": False})
+        )
+
+        self.assertEqual(result["finish_reason"], "stop")
+        self.assertEqual(server.client.allow_mtp_calls, [False])
 
     def test_server_returns_postprocessed_completion_content_not_raw_chunks(self) -> None:
         client = _FakeClient(thinking=False)

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -75,5 +75,27 @@ class PayloadTests(unittest.TestCase):
         self.assertNotIn("route_prefix_anchor", baseline)
         self.assertTrue(experimental["route_prefix_anchor"])
 
+    def test_build_chat_payload_includes_allow_mtp_only_when_explicit(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+            )
+        )
+        disabled = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+                allow_mtp_experimental=False,
+            )
+        )
+
+        self.assertNotIn("allow_mtp_experimental", baseline)
+        self.assertFalse(disabled["allow_mtp_experimental"])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds an explicit per-completion `allow_mtp_experimental` control from the runtime to the native server.

The goal is to keep MTP enabled and available in the native server path while allowing the runtime to veto MTP for internal tools-on finalization paths where local measurements showed MTP is not consistently beneficial.

Behavior:
- missing flag preserves existing behavior
- `false` vetoes MTP for that completion
- `true` does not force MTP beyond existing guardrails
- route-prefix anchor and KV/prewarm behavior are unchanged
- normal non-anchor completions remain MTP-capable

The runtime uses the veto conservatively for tools-on finalization paths such as `chat_final_retry` and `final_from_tool`.

Validation:
- payload/protocol/backend/native-client tests PASS
- runtime/streaming tests PASS
- full unittest suite PASS
- compileall PASS
- git diff --check PASS
- local server --mtp smoke with mmproj/KV/route anchor PASS

Scope:
- no prompt/routing/tool/final/evidence policy changes
- no ROUTE_MAX_TOKENS change
- no vendor llama.cpp update
- no MTP internals change
- no tag/release

Known residual:
This is a stability/control-plane change, not a general CPU performance optimization. Web/read/think-on can still be slow on CPU.