### PR TITLE
Add v0.0.1-rc7 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc7-release-plan.md
+++ b/docs/releases/v0.0.1-rc7-release-plan.md
@@ -1,0 +1,80 @@
+# Orbit v0.0.1-rc7 Release Plan
+
+This plan is for publishing Orbit v0.0.1-rc7 as a prerelease after the RC7
+release notes are merged to main.
+
+Do not run the tag or release commands until publication is explicitly
+confirmed.
+
+## Pre-release checks
+
+- main points to the final commit containing these RC7 release notes
+- `git status --short` is clean except for local `workdir/.miktex/`
+- full unittest suite passes
+- `python3 -m compileall -q src tests scripts` passes
+- `git diff --check` passes
+- `orbit server --mtp` smoke passes
+- MTP initializes
+- mmproj/multimodal capability is loaded or detected
+- KV prewarm succeeds
+- route-prefix anchor restore is used for tools-on route calls
+- no duplicate llama runtime is observed
+- no double-free, SIGABRT, or segfault is observed
+- server shutdown is clean
+
+## Tag plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc7
+```
+
+Tag type: annotated tag.
+
+Commands to run only after explicit publication approval:
+
+```bash
+git tag -a v0.0.1-rc7 -m "Orbit v0.0.1-rc7"
+git push origin v0.0.1-rc7
+```
+
+## GitHub Release plan
+
+- title: `v0.0.1-rc7`
+- tag: `v0.0.1-rc7`
+- body: `docs/releases/v0.0.1-rc7.md`
+- prerelease: yes
+- latest: false, if supported by the GitHub CLI command used
+
+Example command to run only after explicit publication approval:
+
+```bash
+gh release create v0.0.1-rc7 \
+  --title "v0.0.1-rc7" \
+  --notes-file docs/releases/v0.0.1-rc7.md \
+  --prerelease \
+  --latest=false
+```
+
+If the installed `gh` version does not support `--latest=false`, create the
+release as a prerelease and verify the latest status afterwards.
+
+## Rollback and configuration controls
+
+Runtime controls available without code changes:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Diagnostics:
+
+```bash
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only and should not be documented as required
+for enabling KV behavior.

--- a/docs/releases/v0.0.1-rc7.md
+++ b/docs/releases/v0.0.1-rc7.md
@@ -1,0 +1,126 @@
+# Orbit v0.0.1-rc7 Release Notes
+
+Orbit v0.0.1-rc7 is a UX and correctness stabilization release candidate after
+v0.0.1-rc6. It focuses on web-search finalization, terminal streaming/progress,
+route retry behavior, and README alignment with the current native MTP workflow.
+
+RC7 is not a performance release and does not make MTP production-ready.
+
+## Highlights
+
+### Web-search finalization handling
+
+RC7 includes the web-search finalization fix from PR #76.
+
+Previously, `orbit-web-search` results could be handled like generic long shell
+output. In some final-from-tool paths this produced poor finalization behavior,
+including a CLI that appeared stuck after the model reached the token budget.
+
+RC7 classifies web-search output explicitly and keeps it out of shell-long
+retry/buffering behavior. For technical `web_search_results: true` responses
+with `results: none`, Orbit uses the short final prompt instead of carrying the
+large tools/route prompt into the final answer.
+
+The fix is not query-specific and does not change routing or tool selection.
+
+### CLI streaming and progress UX
+
+RC7 includes the terminal streaming/progress work from PR #78.
+
+The CLI now distinguishes internal and final phases more clearly:
+
+- `tool decision`
+- `final answer`
+- `final retry`
+
+Normal final text is streamed without waiting for a newline once it cannot be a
+thought-label prefix. Real thought-prefixed output remains suppressed when
+thinking is off.
+
+### Route-contract retry UX
+
+If an internal route stream clearly violates the route contract and becomes
+`not_command`, Orbit can abort that route generation early and move to the
+existing final-answer fallback.
+
+Important invariants:
+
+- route prose is not streamed as a final answer
+- route prose is not accepted as a final answer
+- `ROUTE_MAX_TOKENS` is unchanged
+- no intent classifier was added
+- no user-prompt hardcode was added
+- routing, tool, final, and evidence policy are unchanged
+
+This reduces wasted route generation in route-drift cases, but it does not
+solve every route-compliance or final-answer latency issue.
+
+### README workflow update
+
+RC7 includes the README cleanup from PR #79.
+
+The README now describes the current local workflow:
+
+- `orbit server --mtp` for the current smoke path
+- native vendored `llama.cpp` libraries instead of external `llama-server`
+- KV route-prefix prewarm defaults
+- `ORBIT_KV_DIAG=1` as diagnostics only
+- tools-on local shell access warning
+- MTP as supported but still experimental
+- CPU caveats for web, read, think-on, and MTP paths
+
+## Validation
+
+Final local gate on main:
+
+- full unittest suite: PASS, 842 tests
+- `python3 -m compileall -q src tests scripts`: PASS
+- `git diff --check`: PASS
+- `orbit server --mtp`: PASS
+- MTP initialized: yes
+- mmproj/multimodal loaded: yes
+- KV prewarm succeeded: yes
+- route prefix token count: 694
+- `route_anchor_hit=true`: yes
+- `restore_used=true`: yes
+- route cached/evaluated for `hi`: 694/18
+- route cached/evaluated for web route: 694/20
+- duplicate llama runtime observed: no
+- double-free/SIGABRT/segfault observed: no
+- server shutdown exit code: 0
+
+CLI smoke:
+
+- `hi, how are you?`: PASS, about 10.7s
+- `search online for information about Mario Nobile`: PASS, about 124.9s
+- no stuck 100% state observed
+- output printed in both cases
+
+## Known limitations
+
+- MTP remains experimental.
+- RC7 is not a final performance release.
+- Web-search final answers can still be slow on CPU.
+- Reading larger files can still be slow on CPU.
+- `think on` can still be slow on CPU.
+- Route-contract drift can still happen; RC7 improves fallback/UX and avoids
+  accepting route prose as final output.
+- Multimodal capability was loaded and detected; full multimodal task coverage
+  remains separate from this RC.
+- The vendored llama.cpp copy is not updated by this release candidate.
+
+## Upgrade notes
+
+Existing users do not need to change configuration to receive the UX and
+correctness fixes.
+
+Useful controls remain:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only. It is not required to enable KV behavior.


### PR DESCRIPTION
This docs-only PR adds the v0.0.1-rc7 release notes and release plan that were used for the published RC7 tag.

Scope:
- docs/releases/v0.0.1-rc7.md
- docs/releases/v0.0.1-rc7-release-plan.md
- no code changes
- no tag/release changes

This PR is intentionally merged with a merge commit so commit 4210de45783375a7eb775b44eb5a06cdc29ef746 remains an ancestor of main.