### PR TITLE
Add v0.0.1-rc8 release notes

### DIFF
--- a/docs/releases/v0.0.1-rc8-release-plan.md
+++ b/docs/releases/v0.0.1-rc8-release-plan.md
@@ -1,0 +1,89 @@
+# Orbit v0.0.1-rc8 Release Plan
+
+This plan is for publishing Orbit v0.0.1-rc8 as a prerelease after the RC8
+release notes are merged to main.
+
+Do not run the tag or release commands until publication is explicitly
+confirmed.
+
+## Pre-release checks
+
+- main points to the final commit containing these RC8 release notes
+- `git status --short` is clean except for local `workdir/.miktex/`
+- full unittest suite passes
+- `python3 -m compileall -q src tests scripts` passes
+- `git diff --check` passes
+- `orbit server --mtp` smoke passes
+- MTP initializes
+- mmproj/multimodal capability is loaded or detected
+- KV route-prefix prewarm succeeds
+- route-prefix anchor restore is used for tools-on route calls
+- runtime can veto MTP per completion with `allow_mtp_experimental=false`
+- no duplicate llama runtime is observed
+- no double-free, SIGABRT, or segfault is observed
+- server shutdown is clean
+
+## Tag plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc8
+```
+
+Tag type: annotated tag.
+
+Commands to run only after explicit publication approval:
+
+```bash
+git tag -a v0.0.1-rc8 -m "Orbit v0.0.1-rc8"
+git push origin v0.0.1-rc8
+```
+
+## GitHub Release plan
+
+- title: `v0.0.1-rc8`
+- tag: `v0.0.1-rc8`
+- body: `docs/releases/v0.0.1-rc8.md`
+- prerelease: yes
+- latest: false, if supported by the GitHub CLI command used
+
+Example command to run only after explicit publication approval:
+
+```bash
+gh release create v0.0.1-rc8 \
+  --title "v0.0.1-rc8" \
+  --notes-file docs/releases/v0.0.1-rc8.md \
+  --prerelease \
+  --latest=false
+```
+
+If the installed `gh` version does not support `--latest=false`, create the
+release as a prerelease and verify the latest status afterwards.
+
+## Rollback and configuration controls
+
+Runtime controls available without code changes:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Diagnostics:
+
+```bash
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only and should not be documented as required
+for enabling KV behavior.
+
+## Residual risks
+
+- web/read/think-on paths can still be slow on CPU
+- post-tool evidence bloat remains open
+- route-contract drift is mitigated, not eliminated
+- multimodal real-input tasks need separate end-to-end validation
+- MTP is not guaranteed to improve every completion

--- a/docs/releases/v0.0.1-rc8.md
+++ b/docs/releases/v0.0.1-rc8.md
@@ -1,0 +1,118 @@
+# Orbit v0.0.1-rc8 Release Notes
+
+Orbit v0.0.1-rc8 closes the current native MTP stabilization phase after
+v0.0.1-rc7.
+
+RC8 documents MTP as supported and stabilized in the native server path with
+runtime guardrails. It does not make MTP an always-on path for every completion,
+and it is not a final performance release.
+
+## Highlights
+
+### Native MTP stable with runtime guardrails
+
+Native MTP is supported in the `orbit server --mtp` path and has been validated
+with the current native server workflow.
+
+The runtime can now control MTP per completion with the explicit
+`allow_mtp_experimental` payload flag:
+
+- missing flag: preserves existing behavior
+- `false`: vetoes MTP for that completion
+- `true`: permits MTP only if the existing runtime/backend guardrails also allow it
+
+This is a control-plane guardrail. It does not change prompts, routing policy,
+tool policy, final-answer policy, evidence policy, or `ROUTE_MAX_TOKENS`.
+
+### MTP is not always-on everywhere
+
+MTP remains available in the native server path, but Orbit can disable it for
+specific internal completions where local measurements showed worse stability or
+latency.
+
+In particular, tools-on internal finalization paths such as `chat_final_retry`
+and `final_from_tool` can send `allow_mtp_experimental=false`.
+
+Route-prefix anchor, KV prewarm, and restore behavior remain compatible with
+this guardrail.
+
+### Native server, KV, and multimodal smoke
+
+The RC8 validation path uses:
+
+- `orbit server --mtp`
+- MTP initialized in the native server
+- mmproj/multimodal capability loaded or detected
+- KV route-prefix prewarm enabled
+- route-prefix anchor restore for tools-on route calls
+- unified vendored llama.cpp runtime
+
+Orbit continues to use vendored llama.cpp libraries directly. RC8 does not add a
+dependency on `llama-server` and does not update the vendored llama.cpp copy.
+
+### UX stabilization carried forward
+
+RC8 includes the RC7 UX/correctness work:
+
+- web-search finalization no longer gets stuck after max-token finalization
+- streaming/progress labels distinguish tool decision, final answer, and retry
+- route retry UX is clearer
+- internal route prose is not accepted as final output
+- README quickstart is aligned with `orbit server --mtp`
+
+## Validation
+
+Local validation on main after PR #80:
+
+- full unittest suite: PASS
+- `python3 -m compileall -q src tests scripts`: PASS
+- `git diff --check`: PASS
+- `orbit server --mtp`: PASS
+- MTP initialized: yes
+- mmproj/multimodal detected: yes
+- route-prefix prewarm succeeded: yes
+- route prefix token count: 694
+- `route_anchor_hit=true`: yes
+- `restore_used=true`: yes
+- duplicate llama runtime observed: no
+- double-free/SIGABRT/segfault observed: no
+- server shutdown: clean
+
+CLI smoke covered:
+
+- tools-on, think-off: `hi, how are you?`
+- tools-on, think-off multi-turn: `who designed you?`
+- tools-on: `run pwd`
+- tools-on: `search online for OpenAI`
+
+## Known limitations
+
+- MTP is guarded, not always-on everywhere.
+- MTP is not a performance guarantee for every completion.
+- Web, read, and `think on` paths can still be slow on CPU.
+- Post-tool evidence bloat remains an open UX/performance issue.
+- Route-contract drift is mitigated by retry/UX guardrails but not eliminated.
+- Real multimodal input tasks still need separate end-to-end validation.
+- The vendored llama.cpp copy is not updated in RC8.
+
+## Upgrade notes
+
+For the current native workflow:
+
+```bash
+orbit server --mtp
+```
+
+Useful controls remain:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only. It is not required to enable KV behavior.
+
+RC8 is a new prerelease candidate. Previous RC tags and releases remain
+unchanged.


### PR DESCRIPTION
Adds RC8 release notes and release plan documentation. Runtime, tests, MTP/KV/vendor code are unchanged.