### PR TITLE
Deduplicate structured evidence in final context

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -235,8 +235,9 @@ def build_final_evidence_context(store: EvidenceStore | None, *, limit: int = RE
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
         parts.append(record.final_card)
-        parts.append("bounded_raw_excerpt:")
-        parts.append(store.raw_excerpt(record) if store is not None else f"raw_evidence_unavailable: {record.raw_ref}")
+        if _final_context_needs_raw_excerpt(record):
+            parts.append("bounded_raw_excerpt:")
+            parts.append(store.raw_excerpt(record) if store is not None else f"raw_evidence_unavailable: {record.raw_ref}")
     return "\n".join(parts)
 
 
@@ -417,6 +418,16 @@ def _compact_final_card(record: EvidenceRecord) -> str:
     ]
     lines.extend(_card_metadata_lines(record, compact=True))
     return "\n".join(lines)
+
+
+def _final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
+    if record.kind == "web_search" and record.metadata.get("top_snippets"):
+        return False
+    if record.kind == "grep_search" and (
+        record.metadata.get("first_matches") or record.metadata.get("file_paths")
+    ):
+        return False
+    return True
 
 
 def _post_tool_route_card(record: EvidenceRecord) -> str:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -324,6 +324,59 @@ class EvidenceTests(unittest.TestCase):
             self.assertIn("raw_evidence_unavailable", missing)
             self.assertIn(record.raw_ref, missing)
 
+    def test_final_context_does_not_duplicate_structured_grep_raw_excerpt(self) -> None:
+        raw = "\n".join(
+            [
+                "STDOUT:",
+                "src/orbit/runtime/evidence.py:17:class EvidenceStore:",
+                "tests/test_evidence.py:23:EvidenceStore(Path(tmp))",
+                "STDERR:",
+                "(empty)",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'grep -R "EvidenceStore" src tests'},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn(record.raw_ref, context)
+            self.assertIn("src/orbit/runtime/evidence.py:17: class EvidenceStore:", context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+
+    def test_final_context_does_not_duplicate_structured_web_raw_excerpt(self) -> None:
+        raw = "\n".join(
+            [
+                "web_search_results: true",
+                "query: OpenAI",
+                "results:",
+                "1. title: OpenAI",
+                "   url: https://openai.com/",
+                "   snippet: AI research and deployment.",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'orbit-web-search "OpenAI"'},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn(record.raw_ref, context)
+            self.assertIn("AI research and deployment.", context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+
 
 def _store_with(record, content: str) -> EvidenceStore:
     store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))


### PR DESCRIPTION
## Summary

Avoid duplicating bounded raw excerpts in final evidence context when the structured final card already contains equivalent evidence.

This applies only to:
- web_search records with top_snippets
- grep_search records with first_matches or file_paths

Shell/read/unknown records continue to include bounded_raw_excerpt.

## Motivation

`build_final_evidence_context()` could include both structured evidence in `final_card` and an additional bounded raw excerpt. For web/grep records this duplicated content and increased final/retry prompt size.

## Validation

- PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q: PASS, 176
- python3 -m unittest discover -s tests -q: PASS, 892
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

MTP web smoke:
- no second web search
- no raw leak
- finish_reason stop
- retry prompt tokens: 826 -> 600
- retry evaluated tokens: 822 -> 596
- model-call wall: ~110.6s -> ~88.6s

## Out of scope

- MTP/KV/vendor changes
- route/tool/final policy changes
- shell/read/unknown compaction
- final/retry cache reuse