### PR TITLE
Add compact web final evidence view

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -31,6 +31,7 @@ from orbit.runtime.evidence import (
     build_final_evidence_context,
     build_post_tool_route_evidence_context,
     build_route_evidence_context,
+    build_web_final_evidence_context,
 )
 from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
@@ -934,6 +935,26 @@ class ChatRuntime:
         if not context:
             return final_messages
         return [*final_messages, {"role": "system", "content": context}]
+
+    def _web_final_from_tool_messages(self) -> list[Message]:
+        messages: list[Message] = []
+        latest_user = _latest_user_message(self.messages)
+        if latest_user is not None:
+            messages.append(latest_user)
+        final_messages = with_final_tool_system_prompt(messages)
+        context = build_web_final_evidence_context(self.evidence_store)
+        if not context:
+            return final_messages
+        return [*final_messages, {"role": "system", "content": context}]
+
+    def _should_use_web_final_view(self, *, use_tool_prompt: bool) -> bool:
+        if use_tool_prompt or self.evidence_store is None:
+            return False
+        record = next(iter(self.evidence_store.recent_records(1)), None)
+        if record is None or record.kind != "web_search":
+            return False
+        snippets = record.metadata.get("top_snippets")
+        return isinstance(snippets, list) and bool(snippets)
 
     def _should_use_final_small_evidence_view(self, *, use_tool_prompt: bool) -> bool:
         if use_tool_prompt or self.evidence_store is None:

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -417,7 +417,9 @@ class FinalFromToolEnvironment:
         use_tool_prompt: bool,
         compact_window: bool = False,
     ) -> FinalAnswerResult:
-        if (
+        if self.runtime._should_use_web_final_view(use_tool_prompt=use_tool_prompt):
+            call_messages = self.runtime._web_final_from_tool_messages()
+        elif (
             compact_window
             or self.runtime._should_use_final_small_evidence_view(use_tool_prompt=use_tool_prompt)
             or self.runtime._should_compact_final_from_tool_window()

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -22,6 +22,7 @@ RAW_EXCERPT_CHARS = 900
 COMPACT_FINAL_RAW_EXCERPT_CHARS = 500
 POST_TOOL_ROUTE_TEXT_CHARS = 180
 ROUTE_OUTPUT_EXCERPT_CHARS = 400
+WEB_FINAL_SNIPPET_CHARS = 220
 
 
 @dataclass(frozen=True)
@@ -255,6 +256,39 @@ def build_compact_final_evidence_context(store: EvidenceStore | None, *, limit: 
             if store is not None
             else f"raw_evidence_unavailable: {record.raw_ref}"
         )
+    return "\n".join(parts)
+
+
+def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
+    record = next(iter(store.recent_records(1)), None) if store is not None else None
+    if record is None or record.kind != "web_search":
+        return None
+    snippets = record.metadata.get("top_snippets")
+    if not isinstance(snippets, list) or not snippets:
+        return None
+    parts = [
+        "evidence_context:",
+        "- evidence 1:",
+        "tool_evidence_card: true",
+        "web_search_evidence: true",
+        f"tool: {record.tool_name}",
+        f"kind: {record.kind}",
+        f"status: {record.status}",
+        f"raw_ref: {record.raw_ref}",
+        f"sha256: {record.raw_sha256[:16]}",
+        f"size: {record.raw_chars} chars, {record.raw_lines} lines",
+    ]
+    for key in ("query", "result_count", "top_domains", "top_titles"):
+        value = record.metadata.get(key)
+        if value in (None, "", [], {}):
+            continue
+        if isinstance(value, list):
+            parts.append(f"{key}: {'; '.join(str(item) for item in value[:3])}")
+        else:
+            parts.append(f"{key}: {value}")
+    parts.append("top_snippets:")
+    for item in snippets[:3]:
+        parts.append(f"- {_bounded_text(str(item), WEB_FINAL_SNIPPET_CHARS)}")
     return "\n".join(parts)
 
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -15,6 +15,7 @@ from orbit.runtime.evidence import (
     build_final_evidence_context,
     build_post_tool_route_evidence_context,
     build_route_evidence_context,
+    build_web_final_evidence_context,
     build_evidence_record,
     tool_evidence_ref,
 )
@@ -376,6 +377,38 @@ class EvidenceTests(unittest.TestCase):
             self.assertIn(record.raw_ref, context)
             self.assertIn("AI research and deployment.", context)
             self.assertNotIn("bounded_raw_excerpt:", context)
+
+    def test_web_final_context_is_structured_bounded_and_keeps_refs(self) -> None:
+        raw = "\n".join(
+            [
+                "web_search_results: true",
+                "query: OpenAI",
+                "results:",
+                "1. title: OpenAI",
+                "   url: https://openai.com/",
+                "   snippet: " + ("AI research and deployment " * 40),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'orbit-web-search "OpenAI"'},
+            )
+
+            context = build_web_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("web_search_evidence: true", context)
+            self.assertIn("query: OpenAI", context)
+            self.assertIn(record.raw_ref, context)
+            self.assertIn(record.raw_sha256[:16], context)
+            self.assertIn(f"size: {record.raw_chars} chars", context)
+            self.assertIn("top_snippets:", context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+            self.assertNotIn("AI research and deployment " * 20, context)
 
 
 def _store_with(record, content: str) -> EvidenceStore:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -711,6 +711,71 @@ class RuntimeTests(unittest.TestCase):
             runtime.messages = [{"role": "user", "content": "read"}, {"role": "tool", "content": tool_evidence_ref(medium_record)}]
             self.assertFalse(runtime._should_use_final_small_evidence_view(use_tool_prompt=False))
 
+    def test_web_final_from_tool_uses_compact_web_view_without_full_history(self) -> None:
+        class MaxTokenBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.max_tokens_seen: list[int] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.max_tokens_seen.append(max_tokens)
+                return super().chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+
+        raw = "\n".join(
+            [
+                "web_search_results: true",
+                "query: OpenAI",
+                "results:",
+                "1. title: OpenAI",
+                "   url: https://openai.com/",
+                "   snippet: AI research and deployment.",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'orbit-web-search "OpenAI"'},
+            )
+            backend = MaxTokenBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "search online for OpenAI"},
+                {"role": "assistant", "content": "previous answer " * 100},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(record) + "\nlegacy raw " + raw,
+                    "evidence_id": record.evidence_id,
+                },
+            ]
+
+            runtime._answer_from_tool_results(
+                temperature=0,
+                max_tokens=128,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                loop=1,
+                use_tool_prompt=False,
+            )
+
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.messages)
+        self.assertTrue(runtime._should_use_web_final_view(use_tool_prompt=False))
+        self.assertFalse(runtime._should_use_web_final_view(use_tool_prompt=True))
+        self.assertEqual(backend.max_tokens_seen, [256])
+        self.assertIn("search online for OpenAI", rendered)
+        self.assertIn("evidence_context:", rendered)
+        self.assertIn("web_search_evidence: true", rendered)
+        self.assertIn("AI research and deployment.", rendered)
+        self.assertIn(record.raw_ref, rendered)
+        self.assertIn(record.raw_sha256[:16], rendered)
+        self.assertNotIn("legacy raw", rendered)
+        self.assertNotIn("previous answer previous answer", rendered)
+        self.assertFalse(any(message.get("role") == "tool" for message in backend.messages))
+
     def test_final_from_tool_without_evidence_store_keeps_legacy_window(self) -> None:
         backend = FakeBackend()
         runtime = ChatRuntime(backend=backend, system_prompt=None)


### PR DESCRIPTION
## Summary

Add a compact `WEB_FINAL_VIEW` for `final_from_tool` web-search evidence.

The web final path now consumes structured EvidenceStore data directly instead of going through the legacy/full-ish final prompt window.

## Motivation

A web search for OpenAI produced a final prompt of 1864 tokens for a 1090-char tool result. This caused a CPU-only finalization latency of about 4m42s.

## Change

For web finalization with structured evidence, include only:

- current user request
- query/status/result_count
- bounded top title/domain/snippet evidence
- raw_ref/hash/size

Exclude:

- full history
- long tool history
- raw tool output
- tools schema

Route, route_retry, tool_loop, MTP/KV/vendor behavior are unchanged.

## Validation

Tests:

- PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q: PASS, 178
- python3 -m unittest discover -s tests -q: PASS, 894
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

MTP smoke:

Scenario:
`/tools on`, `/think off`, `search online for information about OpenAI`

Before:

- final_from_tool prompt: 1864 tokens
- evaluated: 1860
- wall: ~4m42s

After:

- final_from_tool prompt: 358 tokens
- evaluated: 354
- wall: ~56s
- finish_reason: stop
- web calls: 1
- raw leak: no

## Out of scope

- MTP/KV/vendor changes
- route/route_retry/tool_loop changes
- final/retry cache reuse
- shell/read/grep compaction