### PR TITLE
Avoid repair for non-empty plain incomplete stop finals

### DIFF
--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -116,6 +116,8 @@ class TransportEnvironment:
         completeness = classify_final_answer_completeness(result.content, messages=messages)
         if not repair_incomplete_final and not is_empty_final_response(result):
             return result
+        if _is_acceptable_plain_stop_final(result, completeness):
+            return result
         if not is_empty_final_response(result) and completeness.is_complete:
             return result
 
@@ -853,6 +855,12 @@ def merge_chat_results(first: ChatResult, second: ChatResult) -> ChatResult:
 
 def is_empty_final_response(result: ChatResult) -> bool:
     return not result.tool_calls and result.finish_reason == "stop" and not result.content.strip()
+
+
+def _is_acceptable_plain_stop_final(result: ChatResult, completeness) -> bool:
+    if result.finish_reason != "stop" or is_empty_final_response(result):
+        return False
+    return completeness.status == "incomplete_stub" and completeness.detail == "plain_incomplete"
 
 
 def unsupported_tool_mode_result(result: ChatResult) -> ChatResult:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1611,6 +1611,38 @@ class RuntimeTests(unittest.TestCase):
             ],
         )
 
+    def test_chat_final_does_not_repair_plain_stop_answer(self) -> None:
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content="The output contains sequential lines from line-0 through line-119",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=10,
+                    completion_tokens=12,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+            ]
+        )
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+        result = runtime._transport_environment().chat_final(
+            [{"role": "user", "content": "summarize that output"}],
+            temperature=0,
+            max_tokens=64,
+            on_final_delta=None,
+            on_progress=None,
+            on_model_step=None,
+            on_phase_start=None,
+            loop=1,
+        )
+
+        self.assertEqual(result.content, "The output contains sequential lines from line-0 through line-119")
+        self.assertEqual(len(backend.messages_by_call), 1)
+
     def test_ask_chat_does_not_retry_complete_markdown_answer_with_trailing_bold_closer(self) -> None:
         class MarkdownCompleteBackend(FakeBackend):
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Avoid running `chat_final_completion_repair` for final answers that already stopped cleanly and produced non-empty output when the completeness classifier returns `incomplete_stub/plain_incomplete`.

## Motivation

The repair path was triggered for structurally completed final answers, adding an expensive extra model call. In the medium-output smoke, this avoided an unnecessary repair call of about 793 prompt tokens and roughly 74 seconds.

## Change

Skip repair only when all of these are true:

- `finish_reason=stop`
- output is non-empty
- completeness status is `incomplete_stub`
- completeness detail is `plain_incomplete`

The following repair paths remain unchanged:

- empty final
- reasoning-like output
- malformed markdown/backtick
- too short after large tool
- length/incomplete cases outside the narrow plain-incomplete stop case

## Validation

- PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q: PASS, 179
- python3 -m unittest discover -s tests -q: PASS, 895
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

MTP smoke:
- medium shell output + summarize
- repair_executed: no
- finish_reason: stop
- raw leak: no
- no redundant tool
- no crash/double-free/SIGABRT

## Out of scope

- route length/drift
- final/retry cache reuse
- MTP/KV/vendor changes
- prompt-policy or semantic routing changes