### PR TITLE
Skip route repair for blank non-repairable length output

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1143,6 +1143,8 @@ class _RouteNotCommandAbort(Exception):
 class _RouteDecisionStreamAbort:
     """Stop an internal route stream once it cannot still become a route decision."""
 
+    _MAX_PENDING_WHITESPACE_CHUNKS = 8
+
     def __init__(self) -> None:
         self._buffer = ""
         self._chunks = 0
@@ -1152,6 +1154,8 @@ class _RouteDecisionStreamAbort:
             return
         self._chunks += 1
         self._buffer += text
+        if not self._buffer.strip() and self._chunks >= self._MAX_PENDING_WHITESPACE_CHUNKS:
+            raise _RouteNotCommandAbort(self._buffer, chunks=self._chunks)
         if command_stream_state(self._buffer) == "not_command":
             raise _RouteNotCommandAbort(self._buffer, chunks=self._chunks)
 
@@ -1222,6 +1226,8 @@ def _should_skip_route_repair(result: ChatResult) -> bool:
     if result.finish_reason != "length" or _should_attempt_route_repair(result):
         return False
     text = result.content.strip()
+    if not text:
+        return True
     if result.completion_tokens is not None:
         return result.completion_tokens <= 2 and len(text) <= 16
     return len(text) <= 16

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -23,7 +23,13 @@ from orbit.runtime.evidence import (
     tool_evidence_ref,
 )
 from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, MEDIA_SYSTEM_PROMPT, TOOL_CALL_JSON_RETRY_PROMPT, TOOL_CALL_SYSTEM_PROMPT
-from orbit.runtime.chat import _has_list_like_tool_result, _should_attempt_route_repair
+from orbit.runtime.chat import (
+    _RouteDecisionStreamAbort,
+    _RouteNotCommandAbort,
+    _has_list_like_tool_result,
+    _should_attempt_route_repair,
+    _should_skip_route_repair,
+)
 from orbit.runtime.capabilities import LocalCapabilities, LocalCapability
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.tool_loop import _should_guard_existing_file_rewrite
@@ -970,6 +976,38 @@ class RuntimeTests(unittest.TestCase):
                     tool_calls=[],
                     prompt_tokens=None,
                     completion_tokens=1,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+            )
+        )
+
+    def test_route_repair_skips_empty_length_output_without_artifact(self) -> None:
+        self.assertTrue(
+            _should_skip_route_repair(
+                ChatResult(
+                    content="",
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=128,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+            )
+        )
+        self.assertFalse(
+            _should_skip_route_repair(
+                ChatResult(
+                    content='{"command"',
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=128,
                     cached_tokens=None,
                     prompt_tokens_per_second=None,
                     generation_tokens_per_second=None,
@@ -5537,6 +5575,22 @@ EOF"""
         self.assertEqual(progress, [("generation", 12, 128, 9), ("generation", 12, 128, 9)])
         self.assertEqual(backend.chat_calls, 0)
         self.assertEqual(backend.chat_stream_calls, 2)
+
+    def test_route_stream_abort_stops_whitespace_only_route(self) -> None:
+        route_filter = _RouteDecisionStreamAbort()
+
+        with self.assertRaises(_RouteNotCommandAbort) as raised:
+            for _ in range(8):
+                route_filter.write(" ")
+
+        self.assertEqual(raised.exception.chunks, 8)
+
+    def test_route_stream_abort_allows_whitespace_before_command_prefix(self) -> None:
+        route_filter = _RouteDecisionStreamAbort()
+
+        for _ in range(3):
+            route_filter.write(" ")
+        route_filter.write("{")
 
     def test_ask_auto_discards_route_thought_and_runs_chat_final(self) -> None:
         class StreamingRouteThoughtBackend:


### PR DESCRIPTION
## Summary

Avoid expensive route repair when a route completion reaches length with blank/non-command output and no structurally repairable artifact.

## Motivation

A route stream could generate whitespace/non-command output up to `ROUTE_MAX_TOKENS`. When `content.strip()` was empty but `completion_tokens` was high, Orbit still attempted route repair, causing a costly retry prompt without any artifact to repair.

## Change

- Abort whitespace-only route streams after a small bounded pending chunk threshold.
- Skip route repair when:
  - `finish_reason=length`
  - there is no repairable route/tool artifact
  - `content.strip()` is empty

This is structural control-flow. It does not inspect user intent, does not force FINAL/TOOL, and does not accept route prose as final.

## Validation

- PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q: PASS, 182
- python3 -m unittest discover -s tests -q: PASS, 898
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

MTP smoke:
- route_retry with ~1492-token prefill removed in the observed medium follow-up path
- blank/non-command route length output reduced from 128 generated tokens to 1 observed token
- no raw leak
- no redundant tool
- no crash/double-free/SIGABRT

## Out of scope

- final/retry cache reuse
- medium evidence final latency
- MTP/KV/vendor changes
- prompt-policy or semantic routing changes