### PR TITLE
Tighten bounded evidence excerpts

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -21,6 +21,7 @@ RECENT_EVIDENCE_LIMIT = 2
 RAW_EXCERPT_CHARS = 900
 COMPACT_FINAL_RAW_EXCERPT_CHARS = 500
 POST_TOOL_ROUTE_TEXT_CHARS = 180
+POST_TOOL_ROUTE_OUTPUT_CHARS = 80
 ROUTE_OUTPUT_EXCERPT_CHARS = 400
 WEB_FINAL_SNIPPET_CHARS = 220
 
@@ -250,12 +251,13 @@ def build_compact_final_evidence_context(store: EvidenceStore | None, *, limit: 
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
         parts.append(_compact_final_card(record))
-        parts.append("bounded_raw_excerpt:")
-        parts.append(
-            store.raw_excerpt(record, max_chars=COMPACT_FINAL_RAW_EXCERPT_CHARS)
-            if store is not None
-            else f"raw_evidence_unavailable: {record.raw_ref}"
-        )
+        if _compact_final_context_needs_raw_excerpt(record):
+            parts.append("bounded_raw_excerpt:")
+            parts.append(
+                store.raw_excerpt(record, max_chars=COMPACT_FINAL_RAW_EXCERPT_CHARS)
+                if store is not None
+                else f"raw_evidence_unavailable: {record.raw_ref}"
+            )
     return "\n".join(parts)
 
 
@@ -464,6 +466,14 @@ def _final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
     return True
 
 
+def _compact_final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
+    if record.status != "error" and record.kind in {"shell", "unknown"} and (
+        record.metadata.get("stdout_excerpt") or record.metadata.get("stderr_excerpt")
+    ):
+        return False
+    return _final_context_needs_raw_excerpt(record)
+
+
 def _post_tool_route_card(record: EvidenceRecord) -> str:
     fields = [
         "tool_evidence_card=true",
@@ -486,11 +496,18 @@ def _post_tool_route_card(record: EvidenceRecord) -> str:
         value = record.metadata.get(key)
         if value in (None, "", [], {}):
             continue
+        if key in {"stdout_chars", "stderr_chars"} and value == 0:
+            continue
+        max_chars = (
+            POST_TOOL_ROUTE_OUTPUT_CHARS
+            if key in {"stdout_excerpt", "stderr_excerpt"}
+            else POST_TOOL_ROUTE_TEXT_CHARS
+        )
         if isinstance(value, list):
-            items = [_bounded_text(str(item), POST_TOOL_ROUTE_TEXT_CHARS) for item in value[:1]]
+            items = [_bounded_text(str(item), max_chars) for item in value[:1]]
             fields.append(f"{_route_key(key)}={' | '.join(items)}")
         else:
-            fields.append(f"{_route_key(key)}={_bounded_text(str(value), POST_TOOL_ROUTE_TEXT_CHARS)}")
+            fields.append(f"{_route_key(key)}={_bounded_text(str(value), max_chars)}")
     return "; ".join(fields)
 
 
@@ -623,8 +640,13 @@ def _bounded_text(content: str, max_chars: int) -> str:
     stripped = content.strip()
     if len(stripped) <= max_chars:
         return stripped
-    head_chars = max(0, max_chars - TAIL_CHARS - 40)
-    return f"{stripped[:head_chars].rstrip()}\n[...bounded...]\n{stripped[-TAIL_CHARS:].lstrip()}"
+    marker = "\n[...bounded...]\n"
+    if max_chars <= len(marker) + 20:
+        return stripped[:max_chars].rstrip()
+    remaining = max_chars - len(marker)
+    tail_chars = min(TAIL_CHARS, max(10, remaining // 2))
+    head_chars = max(0, remaining - tail_chars)
+    return f"{stripped[:head_chars].rstrip()}{marker}{stripped[-tail_chars:].lstrip()}"
 
 
 def _route_output_excerpt(content: str | None) -> str:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -12,6 +12,7 @@ if str(SRC) not in sys.path:
 
 from orbit.runtime.evidence import (
     EvidenceStore,
+    build_compact_final_evidence_context,
     build_final_evidence_context,
     build_post_tool_route_evidence_context,
     build_route_evidence_context,
@@ -134,6 +135,17 @@ class EvidenceTests(unittest.TestCase):
         self.assertIn("head", record.route_card)
         self.assertIn("tail", record.route_card)
         self.assertNotIn("x" * 1000, record.route_card)
+
+    def test_post_tool_route_excerpt_respects_small_cap(self) -> None:
+        content = "\n".join(f"line-{index}" for index in range(120))
+        record = build_evidence_record("exec_shell_full_command", content, {"command": "python3 print-lines.py"})
+        context = build_post_tool_route_evidence_context(_store_with(record, content)) or ""
+
+        self.assertIn("stdout_excerpt=", context)
+        excerpt = context.split("stdout_excerpt=", 1)[1]
+        self.assertLessEqual(len(excerpt), 80)
+        self.assertIn("[...bounded...]", excerpt)
+        self.assertNotIn("line-20 | line-21 | line-22 | line-23 | line-24", excerpt)
 
     def test_unknown_small_output_has_bounded_route_excerpt(self) -> None:
         record = build_evidence_record("custom_tool", "useful value\n", {})
@@ -377,6 +389,41 @@ class EvidenceTests(unittest.TestCase):
             self.assertIn(record.raw_ref, context)
             self.assertIn("AI research and deployment.", context)
             self.assertNotIn("bounded_raw_excerpt:", context)
+
+    def test_compact_final_context_does_not_duplicate_shell_excerpt(self) -> None:
+        raw = "\n".join(f"line-{index}" for index in range(120))
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": "python3 print-lines.py"},
+            )
+
+            context = build_compact_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn(record.raw_ref, context)
+            self.assertIn(record.raw_sha256[:16], context)
+            self.assertIn("stdout_excerpt:", context)
+            self.assertIn("line-0", context)
+            self.assertIn("line-119", context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+
+    def test_compact_final_context_keeps_error_raw_excerpt(self) -> None:
+        raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\nmissing command\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            store.add("exec_shell_full_command", raw, metadata={"command": "missing-command"})
+
+            context = build_compact_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("bounded_raw_excerpt:", context)
+            self.assertIn("shell_command_failed: true", context)
+            self.assertIn("missing command", context)
 
     def test_web_final_context_is_structured_bounded_and_keeps_refs(self) -> None:
         raw = "\n".join(


### PR DESCRIPTION
## Summary

Tighten bounded evidence projections to reduce post-tool prompt size without changing route/tool/final policy.

## Changes

- Make `_bounded_text()` respect small caps correctly.
- Cap post-tool route stdout/stderr excerpts to 80 chars.
- Omit zero stdout/stderr counters from post-tool route cards.
- Deduplicate shell/unknown non-error compact final evidence when stdout/stderr excerpts are already present.
- Preserve bounded raw excerpts for shell-error evidence.

## Validation

Tests:

- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q`: PASS, 185
- `python3 -m unittest discover -s tests -q`: PASS, 901
- `python3 -m compileall -q src tests scripts`: PASS
- `git diff --check`: PASS

Smoke highlights:

- medium first final: 814 -> 493 tokens
- medium final retry: 784 -> 465/475/506 tokens
- medium flow completed without timeout
- pwd follow-up in clean session: final_retry 416 tokens
- no raw leak
- no redundant tool

## Out of scope

- max_tokens policy
- MTP/KV/vendor changes
- route/tool/final decision policy
- final/retry cache reuse
- model-side quality on exact referential wording