### PR TITLE
Add v0.0.1-rc9 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ Linux is the main target environment. macOS may work. Windows is not a target.
 
 - local CLI and native HTTP server for Gemma 4 12B
 - CPU-first native backend
-- shell tools when tools mode is enabled
+- explicit shell tools when tools mode is enabled
 - streaming terminal output and compact progress phases
 - route-prefix KV anchor and startup prewarm enabled by default
 - optional multimodal image/audio support when the matching `mmproj` is loaded
-- experimental native MTP with `orbit server --mtp`
+- native MTP with runtime guardrails through `orbit server --mtp`
+- EvidenceStore-backed post-tool evidence handling
 
-MTP is supported for local testing, but it remains experimental. Do not treat it
-as production-ready or as a guaranteed performance win.
+MTP is supported in the native server path with runtime guardrails. It is not
+always-on for every internal completion and is not a guaranteed performance win.
 
 ## Requirements
 
@@ -76,7 +77,13 @@ The current release gate expects:
 In another terminal:
 
 ```bash
-.venv/bin/orbit --workdir workdir --tools on --think off "hi, how are you?"
+.venv/bin/orbit --workdir workdir --think off "hi, how are you?"
+```
+
+Enable tools only when you want to expose model-driven shell access:
+
+```bash
+.venv/bin/orbit --workdir workdir --tools on --think off
 ```
 
 For route/KV diagnostics:
@@ -89,12 +96,11 @@ ORBIT_KV_DIAG=1 .venv/bin/orbit --workdir workdir --tools on --think off "hi"
 
 ## Tools
 
-Tools are enabled by default in the current server/client flow.
+Tools are off by default. Tools-on mode exposes unrestricted local shell access
+through the model-facing shell tool. Use it only in an isolated lab or safe
+workdir.
 
-Tools mode exposes unrestricted local shell access through the model-facing
-shell tool. Use it only in an isolated lab or safe workdir.
-
-Disable tools at server startup:
+Keep tools disabled at server startup:
 
 ```bash
 ORBIT_TOOLS=off .venv/bin/orbit server --mtp
@@ -115,6 +121,23 @@ Interactive toggles:
 
 `--tools off` is client/session-side. If a server was already started with
 tools enabled, it may already have performed startup route-prefix prewarm.
+
+## Tool Evidence
+
+Orbit keeps tool results auditable without putting large raw outputs back into
+the prompt.
+
+After a tool runs:
+
+- raw evidence is preserved in runtime memory and sidecar files
+- prompt history stores bounded audit markers, not large raw tool output
+- route/final/retry prompts receive compact EvidenceStore projections
+- web, shell, grep/search, read, and unknown outputs use bounded evidence cards
+- `/reset` clears in-memory evidence for the current session
+
+This keeps post-tool follow-ups model-driven while reducing prompt bloat. The
+model still decides whether to answer or use a tool; the runtime only enforces
+size, safety, and tool-contract boundaries.
 
 ## KV Prefix Anchor and Prewarm
 
@@ -193,13 +216,21 @@ Multimodal capability should be visible through `/v1/models` and `/props`.
 
 Orbit targets local CPU-first operation. Some paths are expected to be slow:
 
-- web-search final answers with large evidence
-- `read` over large files
+- final/retry completions with low KV reuse
+- web/read over large or noisy evidence
 - visible thinking
 - first requests after cold server startup
-- experimental MTP paths
+- MTP paths that do not benefit a specific completion
 
 Do not interpret MTP as a general speed guarantee. Measure the actual workload.
+For post-tool issues, first check whether raw evidence is leaking into the
+prompt, whether a redundant tool call happened, and whether the final footer
+shows a large prompt or simply slow CPU prefill.
+
+Future work includes a Dynamic Completion Budget Policy: route, tool, final,
+and repair calls should get per-completion-kind output budgets so Orbit can
+avoid both truncation and overly long internal generations without changing
+prompt policy.
 
 ## Compatibility
 
@@ -229,4 +260,17 @@ or comparison path, not the primary product path.
 python3 -m unittest discover -s tests -q
 python3 -m compileall -q src tests scripts
 git diff --check
+```
+
+Useful local smoke before a release candidate:
+
+```text
+/tools on
+/think off
+run pwd
+what directory was that?
+run command_that_does_not_exist_123
+what happened?
+search online for information about OpenAI
+what did the search results say?
 ```

--- a/docs/releases/v0.0.1-rc9-release-plan.md
+++ b/docs/releases/v0.0.1-rc9-release-plan.md
@@ -1,0 +1,130 @@
+# Orbit v0.0.1-rc9 Release Plan
+
+This plan is for publishing Orbit v0.0.1-rc9 as a prerelease after the RC9
+release notes are merged to main.
+
+Do not run the tag or release commands until publication is explicitly
+confirmed.
+
+## Pre-release checks
+
+- main points to the final commit containing these RC9 release notes
+- `git status --short` is clean except for local `workdir/.miktex/`
+- targeted runtime/evidence/tool tests pass
+- full unittest suite passes
+- `python3 -m compileall -q src tests scripts` passes
+- `git diff --check` passes
+- `orbit server --mtp` smoke passes
+- MTP initializes
+- mmproj/multimodal capability is loaded or detected
+- KV route-prefix prewarm succeeds
+- route prefix token count is 694 for the current native route prefix
+- route-prefix anchor restore is used for tools-on route calls
+- EvidenceStore post-tool validation matrix passes without blockers
+- no raw tool evidence is reinserted into route/final prompts
+- no redundant tool loop is observed in validated post-tool follow-ups
+- no duplicate llama runtime is observed
+- no double-free, SIGABRT, or segfault is observed
+- server shutdown is clean
+
+## Tag plan
+
+Proposed tag:
+
+```text
+v0.0.1-rc9
+```
+
+Tag type: annotated tag.
+
+Commands to run only after explicit publication approval:
+
+```bash
+git tag -a v0.0.1-rc9 -m "Orbit v0.0.1-rc9"
+git push origin v0.0.1-rc9
+```
+
+## GitHub Release plan
+
+- title: `v0.0.1-rc9`
+- tag: `v0.0.1-rc9`
+- body: `docs/releases/v0.0.1-rc9.md`
+- prerelease: yes
+- latest: false, if supported by the GitHub CLI command used
+
+Example command to run only after explicit publication approval:
+
+```bash
+gh release create v0.0.1-rc9 \
+  --title "v0.0.1-rc9" \
+  --notes-file docs/releases/v0.0.1-rc9.md \
+  --prerelease \
+  --latest=false
+```
+
+If the installed `gh` version does not support `--latest=false`, create the
+release as a prerelease and verify the latest status afterwards.
+
+## Validation recap
+
+Final validation before preparing these notes:
+
+- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q`: PASS, 187
+- `python3 -m unittest discover -s tests -q`: PASS, 903
+- `python3 -m compileall -q src tests scripts`: PASS
+- `git diff --check`: PASS
+
+MTP validation:
+
+- `mtp_initialized=true`
+- `mmproj/multimodal detected=true`
+- `prewarm_succeeded=true`
+- `prefix_token_count=694`
+- `route_anchor_hit=true`
+- `restore_used=true`
+- shutdown clean
+- no crash, double-free, or SIGABRT
+
+Post-tool evidence validation matrix:
+
+- chat simple: PASS
+- shell small + follow-up: PASS/PARTIAL
+- shell error + follow-up: PASS
+- shell medium + referential follow-ups: PASS
+- grep/search + follow-up: PASS
+- web search + follow-up: PASS
+- read/direct-content + follow-up: PARTIAL, non-blocking
+
+## Rollback and configuration controls
+
+Runtime controls available without code changes:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+```
+
+Diagnostics:
+
+```bash
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only and should not be documented as required
+for enabling KV behavior.
+
+## Residual risks
+
+- final/retry cache reuse remains low with the current single active KV slot
+- read/direct-content referential follow-up can remain partial
+- web/read large outputs can remain CPU-costly
+- model-side exact reference quality can vary
+- multimodal real-input tasks need separate end-to-end validation
+
+Follow-up work:
+
+- Dynamic Completion Budget Policy for route/tool/final/repair completion
+  kinds
+- goal: avoid truncation and overly long internal generations without changing
+  prompt policy

--- a/docs/releases/v0.0.1-rc9.md
+++ b/docs/releases/v0.0.1-rc9.md
@@ -1,0 +1,155 @@
+# Orbit v0.0.1-rc9 Release Notes
+
+Orbit v0.0.1-rc9 closes the post-tool evidence flow stabilization phase after
+v0.0.1-rc8.
+
+RC9 keeps the native MTP stable-with-guardrails posture from RC8. It does not
+change MTP, KV behavior, vendored llama.cpp, route policy, tool policy, or the
+model-driven decision boundary.
+
+## Highlights
+
+### Tool evidence separated from prompt history
+
+Orbit now stores tool evidence as runtime state instead of relying on raw tool
+results in conversation history.
+
+The new EvidenceStore flow:
+
+- preserves raw tool output in RAM and sidecar files
+- stores bounded audit markers in promptable history
+- uses per-event evidence ids to avoid collisions
+- keeps `raw_sha256` as the content audit hash
+- reloads sidecar indexes for existing sessions
+- degrades clearly when raw sidecar content is unavailable
+- clears in-memory EvidenceStore state on `/reset`
+
+This reduces post-tool prompt bloat while preserving auditability and raw
+evidence outside the prompt.
+
+### Bounded post-tool prompt views
+
+RC9 adds bounded route, final, retry, and repair prompt views derived from
+EvidenceStore projections.
+
+The runtime now avoids reinserting large raw tool results into route/final
+prompts and uses compact evidence cards for:
+
+- shell output and shell errors
+- grep/search matches
+- web search results
+- read/direct-content outputs
+- unknown tool output
+
+History remains useful for audit and compatibility, but EvidenceStore is the
+primary source for operational evidence.
+
+### Web finalization compact view
+
+Web `final_from_tool` now uses a compact `WEB_FINAL_VIEW` when structured web
+evidence is available.
+
+The view includes the current user request, query/status/result count, bounded
+top title/domain/snippet evidence, and audit references. It excludes full
+history, long tool history, raw tool output, and tools schema.
+
+Local smoke reduced the OpenAI web final prompt from roughly 1864 tokens to
+roughly 369 tokens while preserving a single web search and `finish_reason=stop`.
+
+### Evidence projection cleanup
+
+RC9 includes focused prompt-size reductions without changing model decisions:
+
+- deduplicate structured final evidence for web and grep/search
+- tighten bounded excerpts for shell/unknown evidence
+- preserve bounded raw excerpts for shell-error evidence
+- compact post-tool route inventory by removing route-unneeded audit metadata
+- keep raw refs and hashes in sidecar/final/audit views
+
+These changes are structural context reductions, not semantic shortcuts.
+
+### Repair and retry guardrails
+
+RC9 reduces expensive internal retries that do not add useful information:
+
+- skip final repair for non-empty `finish_reason=stop` answers classified only
+  as `incomplete_stub/plain_incomplete`
+- keep repair for empty, malformed, reasoning-like, length, and too-short
+  large-tool answers
+- skip route repair for blank/non-repairable route length output
+- preserve route prose rejection and model-guided TOOL/FINAL decisions
+
+### Search and shell evidence quality
+
+Grep/search evidence cards now preserve useful facts such as file paths, line
+numbers, match excerpts, match counts, and file counts when available.
+
+Shell route projections include bounded stdout/stderr excerpts for small output,
+which keeps useful follow-up evidence visible without reintroducing raw bloat.
+
+## Validation
+
+Local validation on main after PR #89:
+
+- targeted runtime/evidence/tool tests: PASS, 187
+- full unittest suite: PASS, 903
+- `python3 -m compileall -q src tests scripts`: PASS
+- `git diff --check`: PASS
+- `orbit server --mtp`: PASS
+- MTP initialized: yes
+- mmproj/multimodal detected: yes
+- route-prefix prewarm succeeded: yes
+- route prefix token count: 694
+- `route_anchor_hit=true`: yes
+- `restore_used=true`: yes
+- double-free/SIGABRT/segfault observed: no
+- server shutdown: clean
+
+Validation matrix:
+
+- chat simple: PASS
+- shell small + follow-up: PASS/PARTIAL
+- shell error + follow-up: PASS
+- shell medium + referential follow-ups: PASS, no timeout
+- grep/search + follow-up: PASS
+- web search + follow-up: PASS
+- read/direct-content + follow-up: PARTIAL, non-blocking
+
+## Known limitations
+
+- Final/retry cache reuse remains low because the active KV slot is usually
+  warm on the prior route prompt, not final prompts.
+- Read/direct-content referential follow-up quality can still be partial even
+  when evidence is visible.
+- Web/read large outputs can remain CPU-costly.
+- Model-side quality on exact references can vary.
+- Real multimodal input tasks still need separate end-to-end validation.
+- MTP remains guarded and is not a performance guarantee for every completion.
+
+Follow-up work:
+
+- Dynamic Completion Budget Policy for route/tool/final/repair completion
+  kinds, so Orbit can avoid truncation and overly long internal generations
+  without changing prompt policy.
+
+## Upgrade notes
+
+For the current native workflow:
+
+```bash
+orbit server --mtp
+```
+
+Useful controls remain:
+
+```bash
+ORBIT_TOOLS=off
+ORBIT_KV_PREFIX_PREWARM=off
+ORBIT_KV_PREFIX_ANCHOR=off
+ORBIT_KV_DIAG=1
+```
+
+`ORBIT_KV_DIAG=1` is diagnostic only. It is not required to enable KV behavior.
+
+RC9 is a new prerelease candidate. Previous RC tags and releases remain
+unchanged.


### PR DESCRIPTION
## Summary

Adds RC9 release notes, release plan, and README updates for the stabilized post-tool evidence flow.

## Included

- EvidenceStore + sidecar documentation
- Raw tool results moved out of prompt history
- Bounded route/final/retry views
- EvidenceStore lifecycle fixes
- WEB_FINAL_VIEW
- Structured evidence dedup
- Repair gate for plain incomplete stop finals
- Route blank repair guard
- Bounded evidence cap/dedup
- Route evidence inventory compaction
- MTP stable-with-guardrails wording

## Follow-up documented

- Dynamic Completion Budget Policy is documented as future work only.
- No runtime implementation is included in this PR.

## Validation

- PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q: PASS, 187
- python3 -m unittest discover -s tests -q: PASS, 903
- python3 -m compileall -q src tests scripts: PASS
- git diff --check: PASS

## Out of scope

- Runtime/code changes
- MTP/KV/vendor changes
- Tag/release creation