### PR TITLE
Centralize dynamic completion budgets

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -9,7 +9,7 @@ from orbit.backend import ChatBackend, ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.runtime.capabilities import LocalCapabilities, discover_local_capabilities
 from orbit.runtime.client_state import ClientState
-from orbit.runtime.completion_budget import CompletionBudget
+from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.environments import (
     ContinueEnvironment,
     FileInputEnvironment,
@@ -74,8 +74,6 @@ from orbit.runtime.tool_result_compaction import (
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
-ROUTE_MAX_TOKENS = 128
-EVIDENCE_CHAT_FINAL_RETRY_MIN_TOKENS = 192
 FINAL_FROM_TOOL_COMPACT_MIN_RAW_CHARS = 512
 FINAL_SMALL_EVIDENCE_MAX_RAW_CHARS = 500
 FINAL_SMALL_EVIDENCE_KINDS = {"shell", "unknown", "grep_search"}
@@ -323,7 +321,7 @@ class ChatRuntime:
                 tool_names=("exec_shell_full_command",),
             )
             return self._remember_visible_result(_tool_loop_result_value(bundle))
-        command_max_tokens = CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS)
+        command_max_tokens = resolve_max_tokens("route", max_tokens)
         streamed_final_retry = False
         retried_empty_final = False
         route_abort_reason: str | None = None
@@ -459,7 +457,7 @@ class ChatRuntime:
                     first = self._transport_environment().chat_final(
                         self._with_final_evidence_context(with_chat_system_prompt(self.messages)),
                         temperature=temperature,
-                        max_tokens=max_tokens,
+                        max_tokens=resolve_max_tokens("chat", max_tokens),
                         on_final_delta=on_final_delta,
                         on_progress=on_progress,
                         on_model_step=on_model_step,
@@ -487,7 +485,10 @@ class ChatRuntime:
                             )
                         )
                     retry_messages = self._chat_final_retry_messages()
-                    retry_max_tokens = self._chat_final_retry_max_tokens(max_tokens)
+                    retry_max_tokens = self._chat_final_retry_max_tokens(
+                        max_tokens,
+                        previous_finish_reason=first.finish_reason,
+                    )
                     if on_final_delta is None:
                         with model_call_context(phase="chat_final_retry", tools_mode="on"):
                             first = self.backend.chat(
@@ -520,7 +521,7 @@ class ChatRuntime:
                     first = self._transport_environment().chat_final(
                         self._with_final_evidence_context(self.messages),
                         temperature=temperature,
-                        max_tokens=max_tokens,
+                        max_tokens=resolve_max_tokens("chat", max_tokens),
                         on_final_delta=on_final_delta,
                         on_progress=on_progress,
                         on_model_step=on_model_step,
@@ -747,7 +748,7 @@ class ChatRuntime:
                 result = self.backend.chat_stream(
                     planning_messages,
                     temperature=temperature,
-                    max_tokens=CompletionBudget(max_tokens).internal(ROUTE_MAX_TOKENS),
+                    max_tokens=resolve_max_tokens("route", max_tokens),
                     on_delta=thought_filter.write,
                     on_progress=on_progress,
                 )
@@ -795,7 +796,7 @@ class ChatRuntime:
         result = self._transport_environment().chat_final(
             messages,
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_tokens=resolve_max_tokens("chat", max_tokens),
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
@@ -1060,9 +1061,13 @@ class ChatRuntime:
         messages.append({"role": "user", "content": repair_instruction})
         return messages
 
-    def _chat_final_retry_max_tokens(self, max_tokens: int) -> int:
+    def _chat_final_retry_max_tokens(self, max_tokens: int, *, previous_finish_reason: str | None = None) -> int:
         if self.evidence_store is not None and self.evidence_store.recent_records(1):
-            return max(max_tokens, EVIDENCE_CHAT_FINAL_RETRY_MIN_TOKENS)
+            return resolve_max_tokens(
+                "chat_final_retry",
+                max_tokens,
+                previous_finish_reason=previous_finish_reason,
+            )
         return max_tokens
 
     def refresh_memory_if_needed(self, *, temperature: float, force: bool = False) -> bool:

--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -3,6 +3,27 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+DEFAULT_MAX_TOKENS = 256
+
+ROUTE_MAX_TOKENS = 64
+TOOL_CALL_MAX_TOKENS = 96
+FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = 64
+CHAT_DEFAULT_MAX_TOKENS = 192
+CHAT_MAX_TOKENS = 256
+
+FINAL_SMALL_MAX_TOKENS = 96
+FINAL_SHELL_ERROR_MAX_TOKENS = 128
+FINAL_MEDIUM_MAX_TOKENS = 192
+FINAL_WEB_SEARCH_MAX_TOKENS = 192
+FINAL_READ_MAX_TOKENS = 256
+
+CHAT_FINAL_RETRY_MAX_TOKENS = 128
+CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS = 192
+FINAL_REPAIR_MAX_TOKENS = 128
+FINAL_REPAIR_AFTER_LENGTH_MAX_TOKENS = 192
+FINAL_REPAIR_CAP_MAX_TOKENS = 160
+
+
 @dataclass(frozen=True)
 class CompletionBudget:
     requested_max_tokens: int
@@ -12,3 +33,73 @@ class CompletionBudget:
 
     def user_visible(self) -> int:
         return max(1, self.requested_max_tokens)
+
+
+def resolve_max_tokens(
+    completion_kind: str,
+    requested_max_tokens: int | None = None,
+    evidence_kind: str | None = None,
+    evidence_chars: int | None = None,
+    previous_finish_reason: str | None = None,
+) -> int:
+    """Resolve bounded output budgets from structural runtime state only."""
+
+    requested = _positive_or_none(requested_max_tokens)
+    kind = completion_kind.strip().lower()
+    evidence = (evidence_kind or "").strip().lower()
+    previous = (previous_finish_reason or "").strip().lower()
+
+    if kind == "route":
+        return _internal(requested, ROUTE_MAX_TOKENS)
+    if kind == "tool_call":
+        return _internal(requested, TOOL_CALL_MAX_TOKENS)
+    if kind == "tool_call_file_recovery":
+        return _internal(requested, FILE_RECOVERY_TOOL_CALL_MAX_TOKENS)
+    if kind == "chat":
+        if requested is None:
+            return CHAT_DEFAULT_MAX_TOKENS
+        return _floor_and_cap(requested, 64, CHAT_MAX_TOKENS)
+    if kind == "final_from_tool":
+        return _final_from_tool_tokens(requested, evidence, evidence_chars)
+    if kind == "chat_final_retry":
+        target = CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS if previous == "length" else CHAT_FINAL_RETRY_MAX_TOKENS
+        return _floor_and_cap(requested, target, target)
+    if kind == "final_from_tool_retry":
+        target = CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS if previous == "length" else CHAT_FINAL_RETRY_MAX_TOKENS
+        return _floor_and_cap(requested, target, target)
+    if kind == "repair":
+        target = FINAL_REPAIR_AFTER_LENGTH_MAX_TOKENS if previous == "length" else FINAL_REPAIR_MAX_TOKENS
+        cap = FINAL_REPAIR_AFTER_LENGTH_MAX_TOKENS if previous == "length" else FINAL_REPAIR_CAP_MAX_TOKENS
+        return _floor_and_cap(requested, target, cap)
+    return _floor_and_cap(requested, DEFAULT_MAX_TOKENS, DEFAULT_MAX_TOKENS)
+
+
+def _final_from_tool_tokens(requested: int | None, evidence_kind: str, evidence_chars: int | None) -> int:
+    if evidence_kind == "web_search":
+        return _floor_and_cap(requested, FINAL_WEB_SEARCH_MAX_TOKENS, FINAL_WEB_SEARCH_MAX_TOKENS)
+    if evidence_kind in {"read", "fetch"}:
+        return _floor_and_cap(requested, FINAL_READ_MAX_TOKENS, FINAL_READ_MAX_TOKENS)
+    if evidence_kind == "shell_error":
+        return _floor_and_cap(requested, FINAL_SHELL_ERROR_MAX_TOKENS, FINAL_SHELL_ERROR_MAX_TOKENS)
+    if evidence_kind in {"shell", "unknown", "grep_search"} and evidence_chars is not None and evidence_chars <= 500:
+        return _floor_and_cap(requested, FINAL_SMALL_MAX_TOKENS, FINAL_SMALL_MAX_TOKENS)
+    if evidence_kind in {"shell", "unknown", "grep_search"}:
+        return _floor_and_cap(requested, FINAL_MEDIUM_MAX_TOKENS, FINAL_MEDIUM_MAX_TOKENS)
+    return _floor_and_cap(requested, FINAL_MEDIUM_MAX_TOKENS, DEFAULT_MAX_TOKENS)
+
+
+def _internal(requested: int | None, cap: int) -> int:
+    if requested is None:
+        return cap
+    return max(1, min(requested, cap))
+
+
+def _floor_and_cap(requested: int | None, floor: int, cap: int) -> int:
+    base = floor if requested is None else max(requested, floor)
+    return max(1, min(base, cap))
+
+
+def _positive_or_none(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return max(1, int(value))

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -8,7 +8,7 @@ import re
 
 from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
-from orbit.runtime.completion_budget import CompletionBudget
+from orbit.runtime.completion_budget import CompletionBudget, resolve_max_tokens
 from orbit.runtime.continue_controller import ContinueController
 from orbit.runtime.file_input_resolver import FileInputResolver
 from orbit.runtime.final_policy import (
@@ -159,7 +159,11 @@ class TransportEnvironment:
                 retry = self.chat_once(
                     retry_messages,
                     temperature=temperature,
-                    max_tokens=max_tokens,
+                    max_tokens=resolve_max_tokens(
+                        "repair",
+                        max_tokens,
+                        previous_finish_reason=result.finish_reason,
+                    ),
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                 )
@@ -293,6 +297,7 @@ class PureChatEnvironment:
         self.runtime.messages.append({"role": "user", "content": user_content})
         if self.runtime.thinking_mode:
             thinking_max_tokens = CompletionBudget(max_tokens).internal(CHAT_THINKING_MAX_TOKENS)
+            chat_max_tokens = resolve_max_tokens("chat", max_tokens)
             thinking_messages = [
                 *call_messages,
                 {
@@ -335,7 +340,7 @@ class PureChatEnvironment:
                 result = self.transport.chat_final(
                     final_messages,
                     temperature=temperature,
-                    max_tokens=max_tokens,
+                    max_tokens=chat_max_tokens,
                     on_final_delta=on_final_delta,
                     on_progress=on_progress,
                     on_model_step=on_model_step,
@@ -347,7 +352,7 @@ class PureChatEnvironment:
         result = self.transport.chat_final(
             call_messages,
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_tokens=resolve_max_tokens("chat", max_tokens),
             on_final_delta=on_final_delta,
             on_progress=on_progress,
             on_model_step=on_model_step,
@@ -430,7 +435,14 @@ class FinalFromToolEnvironment:
         else:
             call_messages = self.runtime._with_final_tool_prompt() if use_tool_prompt else self.runtime.messages
             call_messages = self.runtime._with_final_evidence_context(call_messages)
-        policy = build_final_tool_policy(call_messages, max_tokens=max_tokens, streamed=on_final_delta is not None)
+        evidence_kind, evidence_chars = self._latest_evidence_budget_metadata()
+        policy = build_final_tool_policy(
+            call_messages,
+            max_tokens=max_tokens,
+            streamed=on_final_delta is not None,
+            evidence_kind=evidence_kind,
+            evidence_chars=evidence_chars,
+        )
         stream_buffer = _BufferedDeltaSink() if on_final_delta is not None and policy.incomplete_retry_allowed else None
         direct_delta = _ForwardingDeltaSink(on_final_delta) if on_final_delta is not None and stream_buffer is None else None
         final_delta = stream_buffer.write if stream_buffer is not None else (direct_delta.write if direct_delta is not None else on_final_delta)
@@ -474,7 +486,9 @@ class FinalFromToolEnvironment:
             retry_messages = [*policy.messages, final_tool_retry_instruction()]
             retry_max_tokens = final_tool_retry_max_tokens(
                 max_tokens,
-                web_fetch_result=policy.web_fetch_result or policy.web_search_result,
+                web_fetch_result=policy.web_fetch_result,
+                web_search_result=policy.web_search_result,
+                previous_finish_reason=result.finish_reason,
             )
             if on_phase_start:
                 on_phase_start(
@@ -535,7 +549,13 @@ class FinalFromToolEnvironment:
                 )
             )
             repair_messages = [*policy.messages, {"role": "user", "content": repair_instruction}]
-            repair_max_tokens = final_tool_retry_max_tokens(max_tokens, web_fetch_result=policy.web_fetch_result)
+            repair_max_tokens = resolve_max_tokens(
+                "repair",
+                max_tokens,
+                evidence_kind=evidence_kind,
+                evidence_chars=evidence_chars,
+                previous_finish_reason=result.finish_reason,
+            )
             if on_phase_start:
                 on_phase_start(
                     ModelPhaseStart(
@@ -642,6 +662,17 @@ class FinalFromToolEnvironment:
             compact_retry_attempted=compact_retry_attempted,
             compact_retry_failed=compact_retry_failed,
         )
+
+    def _latest_evidence_budget_metadata(self) -> tuple[str | None, int | None]:
+        store = self.runtime.evidence_store
+        if store is None:
+            return None, None
+        record = next(iter(store.recent_records(1)), None)
+        if record is None:
+            return None, None
+        if record.kind in {"shell", "unknown"} and record.status == "error":
+            return "shell_error", record.raw_chars
+        return record.kind, record.raw_chars
 
 
 @dataclass(frozen=True)

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from orbit.backend import ChatResult
 from orbit.backend.base import Message
+from orbit.runtime.completion_budget import resolve_max_tokens
 
 
 FINAL_FROM_TOOL_MIN_TOKENS = 256
@@ -82,7 +83,14 @@ class FinalAnswerCompleteness:
         return self.status == "complete"
 
 
-def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streamed: bool) -> FinalToolPolicy:
+def build_final_tool_policy(
+    messages: list[Message],
+    *,
+    max_tokens: int,
+    streamed: bool,
+    evidence_kind: str | None = None,
+    evidence_chars: int | None = None,
+) -> FinalToolPolicy:
     prompt = last_user_text(messages)
     call_messages = prepare_final_tool_messages(messages)
     large_file_excerpt = has_large_file_excerpt(call_messages)
@@ -235,6 +243,8 @@ def build_final_tool_policy(messages: list[Message], *, max_tokens: int, streame
             compact_shell_analysis_result=compact_shell_analysis_result,
             brief_shell_result=brief_shell_result,
             brief_request=brief_request,
+            evidence_kind=evidence_kind,
+            evidence_chars=evidence_chars,
         ),
         length_retry_allowed=(not streamed and (large_file_excerpt or web_fetch_result)),
         incomplete_retry_allowed=shell_full_result and not (web_fetch_result or web_search_result or list_like_result or operational_status_result),
@@ -256,22 +266,42 @@ def final_tool_max_tokens(
     compact_shell_analysis_result: bool = False,
     brief_shell_result: bool = False,
     brief_request: bool = False,
+    evidence_kind: str | None = None,
+    evidence_chars: int | None = None,
 ) -> int:
     if large_file_excerpt:
-        return min(max_tokens, EXHAUSTIVE_LARGE_FILE_FINAL_MAX_TOKENS if exhaustive_document_request else LARGE_FILE_FINAL_MAX_TOKENS)
-    if web_fetch_result or web_search_result:
+        if exhaustive_document_request:
+            return resolve_max_tokens("final_from_tool", max_tokens, evidence_kind="read", evidence_chars=evidence_chars)
+        return min(
+            resolve_max_tokens("final_from_tool", max_tokens, evidence_kind="read", evidence_chars=evidence_chars),
+            LARGE_FILE_FINAL_MAX_TOKENS,
+        )
+    if web_fetch_result and not web_search_result:
         return min(max_tokens, WEB_FETCH_FINAL_MAX_TOKENS)
+    if web_search_result:
+        return resolve_max_tokens("final_from_tool", max_tokens, evidence_kind="web_search", evidence_chars=evidence_chars)
     if pdf_text_result:
-        return min(max_tokens, PDF_BRIEF_FINAL_MAX_TOKENS if brief_request else PDF_FINAL_MAX_TOKENS)
+        if brief_request:
+            return min(max_tokens, PDF_BRIEF_FINAL_MAX_TOKENS)
+        return min(
+            resolve_max_tokens("final_from_tool", max_tokens, evidence_kind="read", evidence_chars=evidence_chars),
+            PDF_FINAL_MAX_TOKENS,
+        )
     if list_like_result:
         return min(max_tokens, LIST_FINAL_MAX_TOKENS)
     if operational_status_result:
         return min(max_tokens, OPERATIONAL_STATUS_FINAL_MAX_TOKENS)
     if compact_shell_analysis_result:
-        return min(max_tokens, LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS)
+        return min(
+            resolve_max_tokens("final_from_tool", max_tokens, evidence_kind=evidence_kind or "shell", evidence_chars=evidence_chars),
+            LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS,
+        )
     if brief_shell_result:
-        return min(max_tokens, BRIEF_SHELL_FINAL_MAX_TOKENS)
-    return max(max_tokens, FINAL_FROM_TOOL_MIN_TOKENS)
+        return min(
+            resolve_max_tokens("final_from_tool", max_tokens, evidence_kind=evidence_kind or "shell", evidence_chars=evidence_chars),
+            BRIEF_SHELL_FINAL_MAX_TOKENS,
+        )
+    return resolve_max_tokens("final_from_tool", max_tokens, evidence_kind=evidence_kind, evidence_chars=evidence_chars)
 
 
 def prepare_final_tool_messages(messages: list[Message]) -> list[Message]:
@@ -388,10 +418,26 @@ def _truncate_with_marker(text: str, *, head_chars: int, tail_chars: int) -> str
     return f"{head}\n{FINAL_TOOL_TRUNCATION_MARKER}\n{tail}"
 
 
-def final_tool_retry_max_tokens(max_tokens: int, *, web_fetch_result: bool) -> int:
-    return min(
-        max(max_tokens, FINAL_FROM_TOOL_MIN_TOKENS),
-        WEB_FETCH_FINAL_MAX_TOKENS if web_fetch_result else max(max_tokens, FINAL_FROM_TOOL_MIN_TOKENS),
+def final_tool_retry_max_tokens(
+    max_tokens: int,
+    *,
+    web_fetch_result: bool,
+    web_search_result: bool = False,
+    previous_finish_reason: str | None = None,
+) -> int:
+    if web_search_result:
+        return resolve_max_tokens(
+            "final_from_tool_retry",
+            max_tokens,
+            evidence_kind="web_search",
+            previous_finish_reason=previous_finish_reason,
+        )
+    if web_fetch_result:
+        return min(max_tokens, WEB_FETCH_FINAL_MAX_TOKENS)
+    return resolve_max_tokens(
+        "final_from_tool_retry",
+        max_tokens,
+        previous_finish_reason=previous_finish_reason,
     )
 
 
@@ -416,7 +462,7 @@ def final_tool_compact_retry_instruction() -> Message:
 
 
 def final_tool_compact_retry_max_tokens(max_tokens: int, *, messages: list[Message] | None = None) -> int:
-    return min(COMPACT_FINAL_RETRY_MAX_TOKENS, max(COMPACT_FINAL_RETRY_MIN_TOKENS, max_tokens))
+    return resolve_max_tokens("repair", max_tokens)
 
 
 def final_from_tool_retry_reason(

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -10,6 +10,7 @@ from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.runtime.capabilities import LocalCapabilities
 from orbit.runtime.command_request import command_like_tool_call, command_tool_call_from_tool_calls
+from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.messages import with_chat_system_prompt, with_tool_call_system_prompt
@@ -991,9 +992,11 @@ def _bounded_internal_max_tokens(max_tokens: int, internal_max: int) -> int:
 
 def _tool_call_max_tokens(max_tokens: int, *, mutative: bool, file_recovery: bool = False) -> int:
     if file_recovery:
-        return _bounded_internal_max_tokens(max_tokens, FILE_RECOVERY_TOOL_CALL_MAX_TOKENS)
+        return resolve_max_tokens("tool_call_file_recovery", max_tokens)
     internal_max = MUTATIVE_TOOL_CALL_MAX_TOKENS if mutative else TOOL_CALL_MAX_TOKENS
-    return _bounded_internal_max_tokens(max_tokens, internal_max)
+    if mutative:
+        return _bounded_internal_max_tokens(max_tokens, internal_max)
+    return resolve_max_tokens("tool_call", max_tokens)
 
 
 def _is_empty_final_response(result: ChatResult) -> bool:

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.completion_budget import resolve_max_tokens
+
+
+class CompletionBudgetPolicyTests(unittest.TestCase):
+    def test_route_budget(self) -> None:
+        self.assertEqual(resolve_max_tokens("route"), 64)
+        self.assertEqual(resolve_max_tokens("route", 32), 32)
+
+    def test_tool_call_budgets(self) -> None:
+        self.assertEqual(resolve_max_tokens("tool_call"), 96)
+        self.assertEqual(resolve_max_tokens("tool_call", 512), 96)
+        self.assertEqual(resolve_max_tokens("tool_call_file_recovery", 512), 64)
+
+    def test_chat_budget_respects_requested_with_cap(self) -> None:
+        self.assertEqual(resolve_max_tokens("chat"), 192)
+        self.assertEqual(resolve_max_tokens("chat", 32), 64)
+        self.assertEqual(resolve_max_tokens("chat", 512), 256)
+
+    def test_final_from_tool_structural_evidence_budgets(self) -> None:
+        self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=80), 96)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="unknown", evidence_chars=80), 96)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell_error", evidence_chars=120), 128)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=1200), 192)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="web_search", evidence_chars=1200), 192)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="read", evidence_chars=8000), 256)
+
+    def test_retry_and_repair_budgets(self) -> None:
+        self.assertEqual(resolve_max_tokens("chat_final_retry", 32), 128)
+        self.assertEqual(resolve_max_tokens("chat_final_retry", 32, previous_finish_reason="length"), 192)
+        self.assertEqual(resolve_max_tokens("final_from_tool_retry", 512, previous_finish_reason="length"), 192)
+        self.assertEqual(resolve_max_tokens("repair", 32), 128)
+        self.assertEqual(resolve_max_tokens("repair", 512), 160)
+        self.assertEqual(resolve_max_tokens("repair", 512, previous_finish_reason="length"), 192)
+
+    def test_no_user_text_required(self) -> None:
+        self.assertEqual(
+            resolve_max_tokens(
+                "final_from_tool",
+                requested_max_tokens=64,
+                evidence_kind="grep_search",
+                evidence_chars=1000,
+                previous_finish_reason="stop",
+            ),
+            192,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -300,7 +300,7 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertNotIn("'- Finding: ... Fix: ...'", policy.messages[-1]["content"])
         self.assertIn("Answer the latest user request directly and concisely", policy.messages[-1]["content"])
         self.assertIn("Prefer the most recent relevant shell result", policy.messages[-1]["content"])
-        self.assertEqual(policy.max_tokens, 256)
+        self.assertEqual(policy.max_tokens, 192)
 
     def test_compact_retry_max_tokens_stays_default_for_non_shell_policy(self) -> None:
         messages = [

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -771,7 +771,7 @@ class RuntimeTests(unittest.TestCase):
         rendered = "\n".join(str(message.get("content", "")) for message in backend.messages)
         self.assertTrue(runtime._should_use_web_final_view(use_tool_prompt=False))
         self.assertFalse(runtime._should_use_web_final_view(use_tool_prompt=True))
-        self.assertEqual(backend.max_tokens_seen, [256])
+        self.assertEqual(backend.max_tokens_seen, [192])
         self.assertIn("search online for OpenAI", rendered)
         self.assertIn("evidence_context:", rendered)
         self.assertIn("web_search_evidence: true", rendered)
@@ -2307,7 +2307,7 @@ class ToolRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result.content, "chat answer")
         self.assertEqual(emitted, ["chat answer"])
-        self.assertEqual(backend.max_tokens_seen, [128])
+        self.assertEqual(backend.max_tokens_seen, [64])
         self.assertIsNone(backend.tools)
 
     def test_ask_auto_streams_full_answer_after_truncated_probe(self) -> None:
@@ -2355,7 +2355,7 @@ class ToolRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result.content, "full answer")
         self.assertEqual(emitted, ["full ", "answer"])
-        self.assertEqual(backend.chat_max_tokens, [128])
+        self.assertEqual(backend.chat_max_tokens, [64])
         self.assertEqual(backend.stream_max_tokens, [512])
 
     def test_ask_auto_retries_empty_chat_response_once(self) -> None:
@@ -2904,7 +2904,7 @@ class ToolRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result.content, "No web search results were found for the query.")
         self.assertEqual(backend.calls, 2)
-        self.assertEqual(backend.max_tokens_seen, [128, 72])
+        self.assertEqual(backend.max_tokens_seen, [64, 192])
         self.assertIsNotNone(backend.final_messages)
         self.assertEqual(backend.final_messages[0]["content"], FINAL_FROM_TOOL_SYSTEM_PROMPT)
         rendered = "\n".join(str(message.get("content", "")) for message in backend.final_messages or [])
@@ -7847,7 +7847,7 @@ EOF"""
         self.assertEqual(result.finish_reason, "length")
         self.assertEqual(emitted, ["partial web search answer"])
         self.assertEqual(backend.chat_stream_calls, 2)
-        self.assertEqual(backend.max_tokens_seen, [96, 72])
+        self.assertEqual(backend.max_tokens_seen, [96, 192])
 
     def test_ask_with_tools_emits_tool_call_event(self) -> None:
         events: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary

Centralizes Orbit's internal `max_tokens` selection across route, tool-call, chat, final, retry, and repair completions.

The new policy uses structural runtime signals only:

- completion kind
- evidence kind
- evidence size
- previous finish reason

It does not inspect user text, use keyword heuristics, or change route/tool/final decisions.

## Budget policy

- route: 64
- tool_call: 96
- tool_call_file_recovery: 64
- chat: default 192, bounded 64..256
- final_from_tool:
  - shell small: 96
  - shell_error: 128
  - medium/web: 192
  - read/direct: 256
- chat_final_retry: 128, after length 192
- repair: 128/160, after length 192

## Motivation

Before this change, several runtime paths selected output budgets independently. This made internal completions less predictable and increased the risk of either truncation or overly long internal outputs.

## Validation

Tests:

- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_evidence tests.test_tool_message tests.test_runtime tests.test_final_policy -q`: PASS, 237
- `python3 -m unittest discover -s tests -q`: PASS, 909
- `python3 -m compileall -q src tests scripts`: PASS
- `git diff --check`: PASS

MTP smoke:

- mtp_initialized=true
- mmproj/multimodal detected=true
- prewarm_succeeded=true
- prefix_token_count=694
- route_anchor_hit=true
- shutdown clean
- no crash/double-free/SIGABRT
- no raw leak
- no observed tool loop
- no observed redundant tool

## Note on UI denominator 32

Some progress UI paths still display a denominator of 32. This comes from the existing native/MTP progress chunk clamp, not from the new completion budget policy. Outputs can exceed 32 tokens where the resolved budget is higher.

## Out of scope

- MTP/KV/vendor changes
- prompt text changes
- semantic routing or keyword heuristics
- final/retry KV cache reuse
- UI progress denominator cleanup