### PR TITLE
Fix persistent MTP generation cap handling

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1013,7 +1013,7 @@ class NativeLlamaClient:
 
         mtp_prompt = _prepare_mtp_prompt(prompt, thinking=thinking)
         streamed_parts: list[str] = []
-        generation_cap = max(1, min(max_tokens, 32))
+        generation_cap = max(1, max_tokens)
         self._last_completion_generation_cap = generation_cap
         result = run_persistent_mtp_completion(
             llama_root=self.paths.llama_root,

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -342,7 +342,7 @@ def run_persistent_mtp_completion(
         runtime.handle,
         ctx_tgt,
         prompt.encode(),
-        max(1, min(max_tokens, 32)),
+        max(1, max_tokens),
         token_cb,
         progress_cb,
         None,

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -1692,8 +1692,9 @@ extern "C" bool orbit_mtp_session_complete(
         set_error("failed to initialize common sampler");
         return false;
     }
+    const int generation_limit = std::max(1, (int) max_tokens);
     std::vector<llama_token> generated;
-    generated.reserve((size_t) std::max(1, std::min(32, (int) max_tokens)));
+    generated.reserve((size_t) generation_limit);
     const auto t0 = std::chrono::steady_clock::now();
     const int32_t progress_prefill_phase = 0;
     const int32_t progress_generation_phase = 1;
@@ -1733,7 +1734,7 @@ extern "C" bool orbit_mtp_session_complete(
     bool request_boundary_logits_refreshed = false;
     int last_target_prefill_batch_n_tokens = 0;
 
-    while ((int) generated.size() < std::max(1, std::min(32, (int) max_tokens))) {
+    while ((int) generated.size() < generation_limit) {
         const auto loop_phase_start = std::chrono::steady_clock::now();
         const bool loop_need_replay_before = need_replay;
         if (need_replay) {
@@ -2054,7 +2055,7 @@ extern "C" bool orbit_mtp_session_complete(
                         common_sampler_prev_str(smpl, ctx_tgt, 8),
                         &tok));
                 }
-                if ((int) generated.size() >= std::max(1, std::min(32, (int) max_tokens))) {
+                if ((int) generated.size() >= generation_limit) {
                     goto done;
                 }
             }
@@ -2093,7 +2094,7 @@ extern "C" bool orbit_mtp_session_complete(
 
             common_speculative_get_draft_params(session->spec, 0) = {
                 true,
-                std::min(ORBIT_MTP_DRAFT_N_MAX, std::max(1, std::min(32, (int) max_tokens)) - (int) generated.size()),
+                std::min(ORBIT_MTP_DRAFT_N_MAX, generation_limit - (int) generated.size()),
                 (llama_pos) n_past,
                 id_last,
                 &prompt_tgt,
@@ -2304,7 +2305,7 @@ extern "C" bool orbit_mtp_session_complete(
         trace_step.kv_dft_before_max = llama_memory_seq_pos_max(mem_dft, 0);
         trace_step.ctx_tgt_frontier_hash = stable_hash_frontier(trace_step.kv_tgt_before_min, trace_step.kv_tgt_before_max);
         trace_step.ctx_dft_frontier_hash = stable_hash_frontier(trace_step.kv_dft_before_min, trace_step.kv_dft_before_max);
-        trace_step.remaining_generation_cap = std::max(0, std::max(1, std::min(32, (int) max_tokens)) - (int) generated.size());
+        trace_step.remaining_generation_cap = std::max(0, generation_limit - (int) generated.size());
         if (debug_partial) {
             trace_step.partial_state_before_json = partial_state_json(
                 vocab_tgt,
@@ -2456,7 +2457,7 @@ extern "C" bool orbit_mtp_session_complete(
             }
         }
 
-        for (size_t i = 0; i < ids.size() && (int) generated.size() < std::max(1, std::min(32, (int) max_tokens)); ++i) {
+        for (size_t i = 0; i < ids.size() && (int) generated.size() < generation_limit; ++i) {
             if (!boundary_committed_live) {
                 prompt_tgt.push_back(id_last);
             }

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -104,6 +104,31 @@ class NativeMtpExperimentalTests(unittest.TestCase):
 
     @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_try_complete_with_mtp_experimental_passes_full_budget_to_persistent_runner(self, _mocked_lib, mocked_run) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
+        client.tokenize = lambda prompt: [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="ok",
+            output_tokens=33,
+            elapsed_ms=12.5,
+        )
+
+        timings = client._try_complete_with_mtp_experimental("hello", max_tokens=128)
+
+        self.assertIsNotNone(timings)
+        self.assertEqual(mocked_run.call_args.kwargs["max_tokens"], 128)
+        self.assertEqual(client._last_completion_generation_cap, 128)
+        self.assertEqual(timings.output_tokens, 33)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_try_complete_with_mtp_experimental_strips_control_channel_tokens(self, _mocked_lib, mocked_run) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         client._vocab = object()


### PR DESCRIPTION
## Summary

Fixes persistent MTP generation cap handling so `max_tokens` above 32 is no longer clamped to 32 as the real generation limit.

## Root cause

The persistent MTP path used `min(max_tokens, 32)` as the actual generation cap. The server compared `output_tokens` against the higher request budget, so a response truncated by the internal 32-token cap could still report `finish_reason=stop`.

## Change

- Remove the real 32-token generation clamp from the persistent MTP path.
- Preserve the requested `max_tokens` as the actual generation limit.
- Add regression coverage ensuring `max_tokens=128` reaches the MTP runner without being clamped to 32.

## Validation

Tests:

- `PYTHONPATH=src python3 -m unittest tests.test_native_mtp_experimental -q`: PASS, 22
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_runtime -q`: PASS, 187
- `python3 -m unittest discover -s tests -q`: PASS, 904
- `python3 -m compileall -q src tests scripts`: PASS
- `git diff --check`: PASS

MTP smoke:

- `mtp_initialized=true`
- `mmproj/multimodal detected=true`
- `prewarm_succeeded=true`
- `prefix_token_count=694`
- route anchor restore OK
- shutdown clean
- no crash/SIGABRT/double-free

Cap validation:

- direct `/chat`, `max_tokens=96`
- output tokens: 96
- finish_reason: length
- output clearly exceeded 32 tokens

## Out of scope

- Dynamic Completion Budget Policy
- prompt/route/tool/final policy changes
- EvidenceStore changes
- MTP/KV architecture changes beyond this cap bugfix