### PR TITLE
Mark route evidence results as already available

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -479,6 +479,7 @@ def _post_tool_route_card(record: EvidenceRecord) -> str:
     tool_name = _short_tool_name(record.tool_name)
     fields = [
         "tool_evidence_card=true",
+        "result_available=true",
         f"k={record.kind}",
         f"st={record.status}",
         f"sz={record.raw_chars}c/{record.raw_lines}l",
@@ -520,7 +521,7 @@ def _short_tool_name(tool_name: str) -> str:
 
 def _route_key(key: str) -> str:
     return {
-        "command": "cmd",
+        "command": "observed_cmd",
         "exit_code": "exit",
         "stdout_chars": "stdout",
         "stderr_chars": "stderr",

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -153,8 +153,9 @@ class EvidenceTests(unittest.TestCase):
         context = build_post_tool_route_evidence_context(_store_with(record, content)) or ""
 
         self.assertIn("tool_evidence_card=true", context)
+        self.assertIn("result_available=true", context)
         self.assertIn("sz=", context)
-        self.assertIn("cmd=printf useful", context)
+        self.assertIn("observed_cmd=printf useful", context)
         self.assertIn("stdout_excerpt=useful value", context)
         self.assertNotIn("raw_ref=", context)
         self.assertNotIn("hash=", context)
@@ -164,7 +165,7 @@ class EvidenceTests(unittest.TestCase):
         record = build_evidence_record("exec_shell_full_command", content, {"command": "python3 print-lines.py"})
         context = build_post_tool_route_evidence_context(_store_with(record, content)) or ""
 
-        self.assertNotIn("cmd=python3 print-lines.py", context)
+        self.assertNotIn("observed_cmd=python3 print-lines.py", context)
         self.assertIn("stdout_excerpt=", context)
 
     def test_unknown_small_output_has_bounded_route_excerpt(self) -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -277,6 +277,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("summarize that output", route_rendered)
         self.assertIn("available_evidence:", route_rendered)
         self.assertIn("tool_evidence_card=true", route_rendered)
+        self.assertIn("result_available=true", route_rendered)
         self.assertNotIn(record.raw_ref, route_rendered)
         self.assertNotIn("legacy raw", route_rendered)
         self.assertNotIn("tool_evidence_ref: true", route_rendered)


### PR DESCRIPTION
## Summary

Clarifies post-tool route evidence by marking observed tool results as already available.

## Root cause

Shell-small route evidence used `cmd=...`, which was ambiguous inside a route prompt that decides whether to execute tools. The model could interpret it as a command to run rather than an observed command result.

## Change

- Add `result_available=true` to route evidence projections.
- Rename `cmd=` to `observed_cmd=`.
- Preserve stdout/stderr excerpts.

This is structural metadata only. It does not inspect user text, force FINAL/TOOL, skip route, or hardcode any command.

## Validation

Tests:

- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_evidence tests.test_tool_message tests.test_runtime tests.test_final_policy tests.test_native_mtp_experimental -q`: PASS
- `python3 -m unittest discover -s tests -q`: PASS, 910
- `python3 -m compileall -q src tests scripts`: PASS
- `git diff --check`: PASS

Smoke:

- `run pwd ; what directory was that?`
  - before: `pwd` executed twice
  - after: `pwd` executed once
  - no raw leak
  - no redundant tool
- shell error, medium shell, and web smoke showed no regression.

## Out of scope

- Model-side exact referential wording quality
- MTP/KV/vendor changes
- max_tokens policy
- route/tool/final decision changes