### PR TITLE
Use compact web final view for no-result searches

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -949,10 +949,14 @@ class ChatRuntime:
         return [*final_messages, {"role": "system", "content": context}]
 
     def _should_use_web_final_view(self, *, use_tool_prompt: bool) -> bool:
-        if use_tool_prompt or self.evidence_store is None:
+        if self.evidence_store is None:
             return False
         record = next(iter(self.evidence_store.recent_records(1)), None)
         if record is None or record.kind != "web_search":
+            return False
+        if record.status == "none":
+            return True
+        if use_tool_prompt:
             return False
         snippets = record.metadata.get("top_snippets")
         return isinstance(snippets, list) and bool(snippets)

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -267,7 +267,7 @@ def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
     if record is None or record.kind != "web_search":
         return None
     snippets = record.metadata.get("top_snippets")
-    if not isinstance(snippets, list) or not snippets:
+    if (not isinstance(snippets, list) or not snippets) and record.status != "none":
         return None
     parts = [
         "evidence_context:",
@@ -289,9 +289,10 @@ def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
             parts.append(f"{key}: {'; '.join(str(item) for item in value[:3])}")
         else:
             parts.append(f"{key}: {value}")
-    parts.append("top_snippets:")
-    for item in snippets[:3]:
-        parts.append(f"- {_bounded_text(str(item), WEB_FINAL_SNIPPET_CHARS)}")
+    if isinstance(snippets, list) and snippets:
+        parts.append("top_snippets:")
+        for item in snippets[:3]:
+            parts.append(f"- {_bounded_text(str(item), WEB_FINAL_SNIPPET_CHARS)}")
     return "\n".join(parts)
 
 
@@ -346,7 +347,7 @@ def _status_for(kind: str, content: str, metadata: dict[str, object]) -> str:
 def _enriched_metadata(kind: str, content: str, metadata: dict[str, object]) -> dict[str, object]:
     enriched = dict(metadata)
     if kind == "web_search":
-        enriched.update(_web_metadata(content))
+        enriched.update(_web_metadata(content, metadata))
     elif kind in {"shell", "grep_search", "unknown"}:
         enriched.update(_shell_metadata(content))
     if kind == "grep_search":
@@ -355,8 +356,8 @@ def _enriched_metadata(kind: str, content: str, metadata: dict[str, object]) -> 
     return enriched
 
 
-def _web_metadata(content: str) -> dict[str, object]:
-    query = _line_value(content, "query")
+def _web_metadata(content: str, metadata: dict[str, object]) -> dict[str, object]:
+    query = _line_value(content, "query") or _web_query_from_command(str(metadata.get("command") or ""))
     titles = re.findall(r"^\d+\.\s+title:\s*(.+)$", content, re.MULTILINE)
     urls = re.findall(r"^\s+url:\s*(.+)$", content, re.MULTILINE)
     snippets = re.findall(r"^\s+snippet:\s*(.+)$", content, re.MULTILINE)
@@ -622,6 +623,22 @@ def _grep_query_from_command(command: str) -> str:
                 if candidate.startswith("-"):
                     continue
                 return candidate
+    return ""
+
+
+def _web_query_from_command(command: str) -> str:
+    if not command:
+        return ""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return ""
+    if not parts:
+        return ""
+    for index, part in enumerate(parts):
+        if part in {"orbit-web-search", "orbit_web_search"} or part.endswith(("/orbit-web-search", "/orbit_web_search")):
+            if index + 1 < len(parts):
+                return parts[index + 1]
     return ""
 
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -478,6 +478,31 @@ class EvidenceTests(unittest.TestCase):
             self.assertNotIn("bounded_raw_excerpt:", context)
             self.assertNotIn("AI research and deployment " * 20, context)
 
+    def test_web_final_context_handles_results_none_without_raw_excerpt(self) -> None:
+        raw = "web_search_results: true\nresults: none"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'orbit-web-search "OpenAI information"'},
+            )
+
+            context = build_web_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("web_search_evidence: true", context)
+            self.assertIn("status: none", context)
+            self.assertIn("query: OpenAI information", context)
+            self.assertIn("result_count: 0", context)
+            self.assertIn(record.raw_ref, context)
+            self.assertIn(record.raw_sha256[:16], context)
+            self.assertNotIn("top_snippets:", context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+            self.assertNotIn("web_search_results: true", context)
+            self.assertNotIn("results: none", context)
+
 
 def _store_with(record, content: str) -> EvidenceStore:
     store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2909,8 +2909,13 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIsNotNone(backend.final_messages)
         self.assertEqual(backend.final_messages[0]["content"], FINAL_FROM_TOOL_SYSTEM_PROMPT)
         rendered = "\n".join(str(message.get("content", "")) for message in backend.final_messages or [])
-        self.assertIn("web_search_results: true", rendered)
-        self.assertIn("results: none", rendered)
+        self.assertTrue(runtime._should_use_web_final_view(use_tool_prompt=True))
+        self.assertIn("web_search_evidence: true", rendered)
+        self.assertIn("status: none", rendered)
+        self.assertIn("query: sample topic", rendered)
+        self.assertIn("result_count: 0", rendered)
+        self.assertNotIn("web_search_results: true", rendered)
+        self.assertNotIn("results: none", rendered)
         self.assertNotIn("Decide compactly whether the user request needs local tools", rendered)
 
     def test_new_web_turn_uses_latest_tool_evidence_not_previous_local_result(self) -> None:


### PR DESCRIPTION
## Summary

Extends `WEB_FINAL_VIEW` to web-search results with no returned snippets/results.

## Root cause

Web searches with `results:none` did not have `top_snippets`, so they bypassed `WEB_FINAL_VIEW` and fell back to a more expensive legacy final path, especially when `use_tool_prompt=True`.

## Change

- `build_web_final_evidence_context()` now handles `web_search` records with `status=none`.
- The query is recovered structurally from the `orbit-web-search` command.
- `_should_use_web_final_view()` enables `WEB_FINAL_VIEW` for no-result web evidence.
- No long raw excerpt is reinserted.

## Validation

- targeted rollback/web: PASS, 183
- required targeted suite: PASS, 260
- full unittest: PASS, 911
- compileall: PASS
- git diff --check: PASS

MTP smoke:
- live web search with real results still uses compact final path
- final prompt: 347 tokens
- finish_reason: stop
- no raw leak

No-result web path is covered by mocked tests.

## Out of scope

- SessionWorkingContext
- MTP/KV/vendor changes
- route/tool/final decision policy changes
- semantic routing or keyword heuristics