### PR TITLE
Clean route-only evidence prompts and cap operational assistant history

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1020,7 +1020,7 @@ class ChatRuntime:
         if self.evidence_store is None or not self.evidence_store.recent_records(1):
             return self._with_final_evidence_context(with_chat_system_prompt(self.messages))
         messages: list[Message] = []
-        assistant = _latest_short_assistant_message(self.messages)
+        assistant = _latest_operational_assistant_message(self.messages)
         if assistant is not None:
             messages.append(assistant)
         latest_user = _latest_user_message(self.messages)
@@ -1040,7 +1040,10 @@ class ChatRuntime:
     def _chat_final_retry_messages(self) -> list[Message]:
         messages: list[Message] = []
         latest_user = _latest_user_message(self.messages)
-        assistant = _latest_short_assistant_message(self.messages)
+        if self.evidence_store is not None and self.evidence_store.recent_records(1):
+            assistant = _latest_operational_assistant_message(self.messages)
+        else:
+            assistant = _latest_short_assistant_message(self.messages)
         if assistant is not None:
             messages.append(assistant)
         if latest_user is not None:
@@ -1321,6 +1324,10 @@ def _latest_short_assistant_message(messages: list[Message], *, max_chars: int =
         if isinstance(content, str) and content.strip() and len(content) <= max_chars:
             return {"role": "assistant", "content": content}
     return None
+
+
+def _latest_operational_assistant_message(messages: list[Message], *, max_chars: int = 160) -> Message | None:
+    return _latest_assistant_excerpt_message(messages, max_chars=max_chars)
 
 
 def _latest_assistant_excerpt_message(messages: list[Message], *, max_chars: int = 140) -> Message | None:

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -216,7 +216,7 @@ def build_route_evidence_context(store: EvidenceStore | None, *, limit: int = RE
     parts = ["available_evidence:"]
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
-        parts.append(record.route_card)
+        parts.append(_route_operational_card(record))
     return "\n".join(parts)
 
 
@@ -477,13 +477,16 @@ def _compact_final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
 
 
 def _post_tool_route_card(record: EvidenceRecord) -> str:
+    return _route_operational_card(record)
+
+
+def _route_operational_card(record: EvidenceRecord) -> str:
     tool_name = _short_tool_name(record.tool_name)
     fields = [
         "tool_evidence_card=true",
         "result_available=true",
         f"k={record.kind}",
         f"st={record.status}",
-        f"sz={record.raw_chars}c/{record.raw_lines}l",
     ]
     if tool_name != record.kind:
         fields.insert(1, f"t={tool_name}")

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -154,11 +154,11 @@ class EvidenceTests(unittest.TestCase):
 
         self.assertIn("tool_evidence_card=true", context)
         self.assertIn("result_available=true", context)
-        self.assertIn("sz=", context)
         self.assertIn("observed_cmd=printf useful", context)
         self.assertIn("stdout_excerpt=useful value", context)
         self.assertNotIn("raw_ref=", context)
         self.assertNotIn("hash=", context)
+        self.assertNotIn("sha256", context)
 
     def test_post_tool_route_omits_command_for_medium_shell_output(self) -> None:
         content = "\n".join(f"line-{index}" for index in range(120))
@@ -319,7 +319,7 @@ class EvidenceTests(unittest.TestCase):
         self.assertNotIn("tool_evidence_card: true", marker)
         self.assertNotIn("raw raw raw", marker)
 
-    def test_route_context_exposes_store_cards_without_raw_or_policy_instruction(self) -> None:
+    def test_route_context_exposes_operational_cards_without_audit_metadata_or_raw(self) -> None:
         raw = "web_search_results: true\nquery: OpenAI\nresults:\n" + ("raw-result " * 500)
         with tempfile.TemporaryDirectory() as tmp:
             store = EvidenceStore(Path(tmp) / "session.evidence")
@@ -330,12 +330,43 @@ class EvidenceTests(unittest.TestCase):
             self.assertIsNotNone(context)
             assert context is not None
             self.assertIn("available_evidence:", context)
-            self.assertIn("tool_evidence_card: true", context)
-            self.assertIn(record.raw_ref, context)
+            self.assertIn("tool_evidence_card=true", context)
+            self.assertIn("result_available=true", context)
+            self.assertIn("k=web_search", context)
+            self.assertIn("st=ok", context)
+            self.assertIn("query=OpenAI", context)
+            self.assertIn("results=", context)
+            self.assertNotIn(record.raw_ref, context)
+            self.assertNotIn("raw_ref", context)
+            self.assertNotIn(record.raw_sha256[:16], context)
+            self.assertNotIn("sha256", context)
             self.assertNotIn("choose CHAT", context)
             self.assertNotIn("choose FINAL", context)
             self.assertNotIn(raw, context)
             self.assertLess(len(context), len(raw))
+
+    def test_route_context_preserves_shell_error_operational_details(self) -> None:
+        raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\nmissing command\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add("exec_shell_full_command", raw, metadata={"command": "missing-command"})
+
+            context = build_route_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("tool_evidence_card=true", context)
+            self.assertIn("result_available=true", context)
+            self.assertIn("k=shell", context)
+            self.assertIn("st=error", context)
+            self.assertIn("observed_cmd=missing-command", context)
+            self.assertIn("exit=127", context)
+            self.assertIn("stderr_excerpt=missing command", context)
+            self.assertNotIn(record.raw_ref, context)
+            self.assertNotIn("raw_ref", context)
+            self.assertNotIn(record.raw_sha256[:16], context)
+            self.assertNotIn("sha256", context)
+            self.assertNotIn(raw, context)
 
     def test_final_context_uses_bounded_excerpt_and_degrades_when_sidecar_missing(self) -> None:
         raw = "head\n" + ("body " * 500) + "\ntail"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -219,7 +219,9 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("evidence_context:", final_rendered)
         self.assertIn("evidence_excerpt", final_rendered)
         self.assertNotIn("tool_evidence_ref: true", final_rendered)
-        self.assertNotIn("OpenAI is an AI company. OpenAI is an AI company.", final_rendered)
+        self.assertNotIn("OpenAI is an AI company. " * 20, final_rendered)
+        self.assertIn("OpenAI is an AI company.", final_rendered)
+        self.assertIn("...", final_rendered)
 
     def test_post_tool_route_window_excludes_full_history_and_audit_marker(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
@@ -284,6 +286,74 @@ class RuntimeTests(unittest.TestCase):
         self.assertNotIn("previous final answer previous final answer", route_rendered)
         self.assertFalse(any(message.get("role") == "tool" for message in route_messages))
 
+    def test_explicit_shell_run_after_web_evidence_still_executes_tool(self) -> None:
+        web_raw = "\n".join(
+            [
+                "web_search_results: true",
+                "query: OpenAI",
+                "results:",
+                "1. title: OpenAI",
+                "   url: https://openai.com/",
+                "   snippet: AI research and deployment.",
+            ]
+        )
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content='{"command":"python3 -c \\"print(42)\\""}',
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=1,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+                ChatResult(
+                    content="The command printed 42.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=5,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            web_record = store.add(
+                "exec_shell_full_command",
+                web_raw,
+                metadata={"command": 'orbit-web-search "OpenAI"'},
+            )
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "search online for OpenAI"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(web_record), "evidence_id": web_record.evidence_id},
+                {"role": "assistant", "content": "OpenAI is an AI company."},
+            ]
+
+            result = runtime.ask_auto(
+                'run python3 -c "print(42)"',
+                temperature=0,
+                max_tokens=32,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "The command printed 42.")
+        self.assertEqual(len(backend.messages_by_call), 2)
+        self.assertEqual(store.recent_records(1)[0].kind, "shell")
+        self.assertEqual(store.recent_records(1)[0].metadata.get("stdout_excerpt"), "42")
+        route_rendered = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[0])
+        self.assertIn('run python3 -c "print(42)"', route_rendered)
+        self.assertIn("available_evidence:", route_rendered)
+        self.assertIn("tool_evidence_card=true", route_rendered)
+        self.assertNotIn(web_record.raw_ref, route_rendered)
+
     def test_post_tool_chat_final_uses_evidence_window_without_full_history(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
         backend = SequenceBackend(
@@ -342,7 +412,9 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn(record.raw_ref, final_rendered)
         self.assertNotIn("legacy raw", final_rendered)
         self.assertNotIn("tool_evidence_ref: true", final_rendered)
-        self.assertNotIn("previous final answer previous final answer", final_rendered)
+        self.assertNotIn("previous final answer " * 20, final_rendered)
+        self.assertIn("previous final answer", final_rendered)
+        self.assertIn("...", final_rendered)
         self.assertFalse(any(message.get("role") == "tool" for message in final_messages))
 
     def test_post_tool_chat_final_keeps_short_previous_assistant_for_reference(self) -> None:
@@ -546,6 +618,57 @@ class RuntimeTests(unittest.TestCase):
         self.assertNotIn("legacy raw", rendered)
         self.assertFalse(any(message.get("role") == "tool" for message in messages))
 
+    def test_chat_final_retry_excerpts_long_assistant_when_evidence_is_available(self) -> None:
+        raw = "\n".join(f"line-{index}" for index in range(20))
+        assistant_lines = "\n".join(f"assistant-copy-{index}" for index in range(20))
+        assistant_answer = f"The previous answer copied the output:\n{assistant_lines}"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": "python3 -c 'for i in range(20): print(i)'"},
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "run the line printer"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(record),
+                    "evidence_id": record.evidence_id,
+                },
+                {"role": "assistant", "content": assistant_answer},
+                {"role": "user", "content": "summarize the output"},
+            ]
+
+            messages = runtime._chat_final_retry_messages()
+
+        assistant_messages = [message for message in messages if message.get("role") == "assistant"]
+        self.assertEqual(len(assistant_messages), 1)
+        assistant_content = str(assistant_messages[0].get("content", ""))
+        self.assertLessEqual(len(assistant_content), 203)
+        self.assertTrue(assistant_content.endswith("..."))
+        self.assertNotIn("assistant-copy-19", assistant_content)
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("evidence_context:", rendered)
+        self.assertIn(record.raw_ref, rendered)
+        self.assertIn("line-19", rendered)
+
+    def test_chat_final_retry_without_evidence_keeps_short_assistant_unchanged(self) -> None:
+        runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+        runtime.messages = [
+            {"role": "assistant", "content": "short assistant context"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        messages = runtime._chat_final_retry_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("short assistant context", rendered)
+        self.assertNotIn("short assistant context...", rendered)
+
     def test_chat_final_retry_medium_evidence_uses_compact_context(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
         with tempfile.TemporaryDirectory() as tmp:
@@ -579,7 +702,9 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("line-0", rendered)
         self.assertIn("line-119", rendered)
         self.assertNotIn("legacy raw", rendered)
-        self.assertNotIn("previous final answer previous final answer", rendered)
+        self.assertNotIn("previous final answer " * 20, rendered)
+        self.assertIn("previous final answer", rendered)
+        self.assertIn("...", rendered)
         self.assertFalse(any(message.get("role") == "tool" for message in messages))
 
     def test_final_from_tool_with_evidence_uses_compact_window(self) -> None:


### PR DESCRIPTION
## Summary

This PR reduces prompt-view bloat in operational runtime prompts without changing routing behavior.

Changes:
- uses a route-only operational evidence projection for route contexts
- removes audit-only metadata such as raw refs and hashes from route-only prompt views
- preserves EvidenceStore storage, sidecars, and final/audit metadata
- caps the latest assistant message in operational final/retry prompts when recent evidence exists
- keeps the primary route contract and tool behavior unchanged

## Motivation

Post-RC10 measurement showed that route prefix cost is dominated by the stable route anchor, while smaller operational prompt bloat remained in route evidence views and assistant-tail history.

The main measurable improvement is on shell-output follow-ups:

- chat_final_retry shell20: 851 -> 558 tokens

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime tests.test_final_policy -q`
- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_evidence tests.test_tool_message tests.test_runtime tests.test_final_policy tests.test_native_mtp_experimental -q`
- `python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

MTP smoke:
- `mtp_initialized=true`
- mmproj/multimodal detected
- `prewarm_succeeded=true`
- `prefix_token_count=694`
- `route_anchor_hit=true`
- `restore_used=true`
- clean shutdown
- no crash/SIGABRT/double-free

Regression smoke:
- explicit shell after web still executes as a real tool
- no fake tool output
- `run pwd` follow-up repeated 5/5 full-path correct
- no redundant tool call on pwd follow-up
- shell error preserved
- no raw leak

## Notes

No recall mechanism, selector, evidence_request, route evidence guard, or hidden evidence index is introduced.
