### PR TITLE
Compact previous shell evidence in final prompts

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -25,6 +25,7 @@ POST_TOOL_ROUTE_OUTPUT_CHARS = 80
 POST_TOOL_ROUTE_SMALL_RAW_CHARS = 200
 ROUTE_OUTPUT_EXCERPT_CHARS = 400
 WEB_FINAL_SNIPPET_CHARS = 220
+PREVIOUS_SHELL_FINAL_COMPACT_CHARS = 120
 
 
 @dataclass(frozen=True)
@@ -235,8 +236,13 @@ def build_final_evidence_context(store: EvidenceStore | None, *, limit: int = RE
     if not records:
         return None
     parts = ["evidence_context:"]
+    compact_previous_shell = _should_compact_previous_shell_in_final_context(records)
+    latest_index = len(records) - 1
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
+        if compact_previous_shell and index - 1 == latest_index - 1:
+            parts.append(_previous_shell_final_compact_line(record))
+            continue
         parts.append(record.final_card)
         if _final_context_needs_raw_excerpt(record):
             parts.append("bounded_raw_excerpt:")
@@ -456,6 +462,64 @@ def _compact_final_card(record: EvidenceRecord) -> str:
     ]
     lines.extend(_card_metadata_lines(record, compact=True))
     return "\n".join(lines)
+
+
+def _should_compact_previous_shell_in_final_context(records: list[EvidenceRecord]) -> bool:
+    if len(records) != 2:
+        return False
+    previous, latest = records
+    if previous.kind != "shell" or latest.kind != "shell":
+        return False
+    if latest.status != "ok":
+        return False
+    return bool(
+        latest.metadata.get("stdout_excerpt")
+        or latest.metadata.get("stderr_excerpt")
+        or latest.metadata.get("head_excerpt")
+    )
+
+
+def _previous_shell_final_compact_line(record: EvidenceRecord) -> str:
+    if record.status == "error":
+        return _previous_failed_shell_final_compact_block(record)
+    fields = ["previous_tool_evidence_compact: kind=shell", f"status={record.status}"]
+    command = str(record.metadata.get("command") or "").strip()
+    if command:
+        fields.append(f'observed_cmd="{_single_line_bounded_text(command, POST_TOOL_ROUTE_TEXT_CHARS)}"')
+    exit_code = str(record.metadata.get("exit_code") or "").strip()
+    if exit_code:
+        fields.append(f"exit_code={exit_code}")
+    observation = _compact_shell_observation(record)
+    if observation:
+        fields.append(f'observation="{observation}"')
+    return " ".join(fields)
+
+
+def _previous_failed_shell_final_compact_block(record: EvidenceRecord) -> str:
+    lines = [
+        "previous_failed_tool_result_compact:",
+        "kind=shell",
+        "status=error",
+        "failed=true",
+    ]
+    command = str(record.metadata.get("command") or "").strip()
+    if command:
+        lines.append(f'observed_cmd="{_single_line_bounded_text(command, POST_TOOL_ROUTE_TEXT_CHARS)}"')
+    exit_code = str(record.metadata.get("exit_code") or "").strip()
+    if exit_code:
+        lines.append(f"exit_code={exit_code}")
+    error_summary = _compact_shell_observation(record)
+    if error_summary:
+        lines.append(f'error_summary="{error_summary}"')
+    return "\n".join(lines)
+
+
+def _compact_shell_observation(record: EvidenceRecord) -> str:
+    for key in ("stderr_excerpt", "stdout_excerpt"):
+        value = str(record.metadata.get(key) or "").strip()
+        if value:
+            return _single_line_bounded_text(value, PREVIOUS_SHELL_FINAL_COMPACT_CHARS)
+    return ""
 
 
 def _final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
@@ -680,6 +744,10 @@ def _route_output_excerpt(content: str | None) -> str:
     if not stripped or stripped == "(empty)":
         return ""
     return _bounded_text(stripped, ROUTE_OUTPUT_EXCERPT_CHARS).replace("\n", " | ")
+
+
+def _single_line_bounded_text(content: str, max_chars: int) -> str:
+    return _bounded_text(content, max_chars).replace("\n", " | ")
 
 
 def _compat_excerpt(record: EvidenceRecord) -> str:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -168,6 +168,87 @@ class EvidenceTests(unittest.TestCase):
         self.assertNotIn("observed_cmd=python3 print-lines.py", context)
         self.assertIn("stdout_excerpt=", context)
 
+    def test_final_context_compacts_previous_failed_shell_record(self) -> None:
+        failed = "\n".join(
+            [
+                "shell_command_failed: true",
+                "exit_code: 127",
+                "STDOUT:",
+                "(empty)",
+                "STDERR:",
+                "command not found",
+            ]
+        )
+        latest = "\n".join(f"line-{index}" for index in range(20))
+        failed_record = build_evidence_record(
+            "exec_shell_full_command",
+            failed,
+            {"command": "command_that_does_not_exist_123"},
+        )
+        latest_record = build_evidence_record(
+            "exec_shell_full_command",
+            latest,
+            {"command": "python3 -c 'for i in range(20): print(i)'"},
+        )
+        context = build_final_evidence_context(_store_with_records((failed_record, failed), (latest_record, latest))) or ""
+
+        self.assertIn("previous_failed_tool_result_compact:", context)
+        self.assertIn("status=error", context)
+        self.assertIn("failed=true", context)
+        self.assertIn("exit_code=127", context)
+        self.assertIn('observed_cmd="command_that_does_not_exist_123"', context)
+        self.assertIn('error_summary="command not found"', context)
+        self.assertIn("line-19", context)
+        self.assertNotIn("raw_ref: evidence:", context.split("previous_failed_tool_result_compact:", 1)[1].split("- evidence 2:", 1)[0])
+        self.assertNotIn("sha256:", context.split("previous_failed_tool_result_compact:", 1)[1].split("- evidence 2:", 1)[0])
+
+    def test_final_context_compacts_previous_successful_shell_record_generically(self) -> None:
+        previous = "previous output\n"
+        latest = "\n".join(f"line-{index}" for index in range(20))
+        previous_record = build_evidence_record(
+            "exec_shell_full_command",
+            previous,
+            {"command": "printf previous"},
+        )
+        latest_record = build_evidence_record(
+            "exec_shell_full_command",
+            latest,
+            {"command": "python3 -c 'for i in range(20): print(i)'"},
+        )
+        context = build_final_evidence_context(_store_with_records((previous_record, previous), (latest_record, latest))) or ""
+
+        self.assertIn("previous_tool_evidence_compact: kind=shell status=ok", context)
+        self.assertNotIn("previous_failed_tool_result_compact:", context)
+
+    def test_final_context_does_not_compact_when_latest_shell_is_error(self) -> None:
+        previous = "previous output\n"
+        latest = "\n".join(
+            [
+                "shell_command_failed: true",
+                "exit_code: 127",
+                "STDOUT:",
+                "(empty)",
+                "STDERR:",
+                "command not found",
+            ]
+        )
+        previous_record = build_evidence_record(
+            "exec_shell_full_command",
+            previous,
+            {"command": "printf previous"},
+        )
+        latest_record = build_evidence_record(
+            "exec_shell_full_command",
+            latest,
+            {"command": "command_that_does_not_exist_123"},
+        )
+        context = build_final_evidence_context(_store_with_records((previous_record, previous), (latest_record, latest))) or ""
+
+        self.assertNotIn("previous_tool_evidence_compact:", context)
+        self.assertNotIn("previous_failed_tool_result_compact:", context)
+        self.assertIn("command: command_that_does_not_exist_123", context)
+        self.assertIn("stderr_excerpt: command not found", context)
+
     def test_unknown_small_output_has_bounded_route_excerpt(self) -> None:
         record = build_evidence_record("custom_tool", "useful value\n", {})
 
@@ -442,6 +523,94 @@ class EvidenceTests(unittest.TestCase):
             self.assertIn("AI research and deployment.", context)
             self.assertNotIn("bounded_raw_excerpt:", context)
 
+    def test_final_context_compacts_previous_shell_when_latest_shell_ok(self) -> None:
+        previous_raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\ncommand not found\n"
+        latest_raw = "\n".join(f"line-{index}" for index in range(20))
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add(
+                "exec_shell_full_command",
+                previous_raw,
+                metadata={"command": "command_that_does_not_exist_123"},
+            )
+            latest = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": "python3 print-lines.py"},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn(
+                "previous_failed_tool_result_compact:",
+                context,
+            )
+            self.assertIn("status=error", context)
+            self.assertIn("failed=true", context)
+            self.assertIn("exit_code=127", context)
+            self.assertIn('observed_cmd="command_that_does_not_exist_123"', context)
+            self.assertIn('error_summary="command not found"', context)
+            self.assertIn(latest.raw_ref, context)
+            self.assertNotIn(previous.raw_ref, context)
+            self.assertNotIn(previous.raw_sha256[:16], context)
+            self.assertNotIn("shell_command_failed: true", context)
+            self.assertNotIn("command: command_that_does_not_exist_123", context)
+            self.assertIn("bounded_raw_excerpt:", context)
+            self.assertIn("line-0", context)
+            self.assertIn("line-19", context)
+
+    def test_final_context_does_not_compact_when_latest_shell_is_error(self) -> None:
+        previous_raw = "exit_code: 0\nSTDOUT:\n/home/example/project\nSTDERR:\n(empty)\n"
+        latest_raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\ncommand not found\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add("exec_shell_full_command", previous_raw, metadata={"command": "pwd"})
+            latest = store.add("exec_shell_full_command", latest_raw, metadata={"command": "missing-command"})
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertNotIn("previous_tool_evidence_compact:", context)
+            self.assertIn(previous.raw_ref, context)
+            self.assertIn(latest.raw_ref, context)
+            self.assertIn("exit_code: 127", context)
+
+    def test_final_context_does_not_compact_when_latest_is_non_shell(self) -> None:
+        previous_raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\ncommand not found\n"
+        latest_raw = "\n".join(
+            [
+                "web_search_results: true",
+                "query: OpenAI",
+                "results:",
+                "1. title: OpenAI",
+                "   url: https://openai.com/",
+                "   snippet: AI research and deployment.",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add(
+                "exec_shell_full_command",
+                previous_raw,
+                metadata={"command": "missing-command"},
+            )
+            latest = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": 'orbit-web-search "OpenAI"'},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertNotIn("previous_tool_evidence_compact:", context)
+            self.assertIn(previous.raw_ref, context)
+            self.assertIn(latest.raw_ref, context)
+
     def test_compact_final_context_does_not_duplicate_shell_excerpt(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
         with tempfile.TemporaryDirectory() as tmp:
@@ -539,6 +708,15 @@ def _store_with(record, content: str) -> EvidenceStore:
     store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))
     store.records[record.evidence_id] = record
     store.raw_cache[record.evidence_id] = content
+    return store
+
+
+def _store_with_records(*items: tuple[object, str]) -> EvidenceStore:
+    store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))
+    for record, content in items:
+        assert hasattr(record, "evidence_id")
+        store.records[record.evidence_id] = record
+        store.raw_cache[record.evidence_id] = content
     return store
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -223,6 +223,94 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("OpenAI is an AI company.", final_rendered)
         self.assertIn("...", final_rendered)
 
+    def test_chat_final_retry_keeps_previous_failed_shell_signal_compact(self) -> None:
+        failed_raw = "\n".join(
+            [
+                "shell_command_failed: true",
+                "exit_code: 127",
+                "STDOUT:",
+                "(empty)",
+                "STDERR:",
+                "command not found",
+            ]
+        )
+        latest_raw = "\n".join(f"line-{index}" for index in range(20))
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content="This is prose, not route JSON.",
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=128,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+                ChatResult(
+                    content="The failed output came from the missing command with exit code 127.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=10,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            failed_record = store.add(
+                "exec_shell_full_command",
+                failed_raw,
+                metadata={"command": "command_that_does_not_exist_123"},
+            )
+            latest_record = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": "python3 -c 'for i in range(20): print(i)'"},
+            )
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "run command_that_does_not_exist_123"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(failed_record),
+                    "evidence_id": failed_record.evidence_id,
+                },
+                {"role": "assistant", "content": "The command failed because it was not found."},
+                {"role": "user", "content": "run python3 -c 'for i in range(20): print(i)'"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-2",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(latest_record),
+                    "evidence_id": latest_record.evidence_id,
+                },
+                {"role": "assistant", "content": "\n".join(f"line-{index}" for index in range(20))},
+            ]
+
+            result = runtime.ask_auto(
+                "summarize the failed output",
+                temperature=0,
+                max_tokens=32,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "The failed output came from the missing command with exit code 127.")
+        retry_rendered = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[1])
+        self.assertIn("previous_failed_tool_result_compact:", retry_rendered)
+        self.assertIn("failed=true", retry_rendered)
+        self.assertIn("exit_code=127", retry_rendered)
+        self.assertIn("command not found", retry_rendered)
+        self.assertNotIn("bounded_raw_excerpt:\n" + failed_raw, retry_rendered)
+        self.assertIn("line-19", retry_rendered)
+
     def test_post_tool_route_window_excludes_full_history_and_audit_marker(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
         backend = SequenceBackend(
@@ -654,6 +742,49 @@ class RuntimeTests(unittest.TestCase):
         rendered = "\n".join(str(message.get("content", "")) for message in messages)
         self.assertIn("evidence_context:", rendered)
         self.assertIn(record.raw_ref, rendered)
+        self.assertIn("line-19", rendered)
+
+    def test_chat_final_retry_compacts_previous_shell_when_latest_shell_ok(self) -> None:
+        previous_raw = "shell_command_failed: true\nexit_code: 127\nSTDOUT:\n(empty)\nSTDERR:\ncommand not found\n"
+        latest_raw = "\n".join(f"line-{index}" for index in range(20))
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add(
+                "exec_shell_full_command",
+                previous_raw,
+                metadata={"command": "command_that_does_not_exist_123"},
+            )
+            latest = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": "python3 print-lines.py"},
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "assistant", "content": "The command failed because it was not found."},
+                {"role": "user", "content": "run python3 print-lines.py"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-2",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(latest),
+                    "evidence_id": latest.evidence_id,
+                },
+                {"role": "assistant", "content": latest_raw},
+                {"role": "user", "content": "summarize the output"},
+            ]
+
+            messages = runtime._chat_final_retry_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("previous_failed_tool_result_compact:", rendered)
+        self.assertIn("status=error", rendered)
+        self.assertIn("failed=true", rendered)
+        self.assertIn("exit_code=127", rendered)
+        self.assertIn('observed_cmd="command_that_does_not_exist_123"', rendered)
+        self.assertIn(latest.raw_ref, rendered)
+        self.assertNotIn(previous.raw_ref, rendered)
+        self.assertNotIn("shell_command_failed: true", rendered)
         self.assertIn("line-19", rendered)
 
     def test_chat_final_retry_without_evidence_keeps_short_assistant_unchanged(self) -> None:


### PR DESCRIPTION
## Summary

This PR reduces cumulative final/retry prompt bloat when recent shell evidence contains both an older shell result and a newer successful shell result.

Changes:
- keeps the latest shell evidence full/bounded
- compacts the previous shell evidence in final/retry prompt views
- preserves failed previous shell evidence using an explicit compact block with:
  - status=error
  - failed=true
  - observed command
  - exit code
  - error summary
- leaves route behavior, tool behavior, EvidenceStore storage, sidecars, and final/audit metadata unchanged
- does not introduce recall, selectors, hidden indexes, or evidence_request

## Motivation

Post-PR #96 validation showed cumulative shell follow-ups remained correct but costly:

- shell20 cumulative final/retry: ~851 tokens

A naive `limit=1` reduced tokens but broke correctness. This PR keeps both recent shell records while compressing only the older shell record, preserving enough structure for references such as “failed output”.

Observed improvement:

- shell20 cumulative final/retry: ~851 -> ~636 tokens

## Validation

Tests:
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime tests.test_final_policy -q`
- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_evidence tests.test_tool_message tests.test_runtime tests.test_final_policy tests.test_native_mtp_experimental -q`
- `python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

MTP smoke:
- mmproj/multimodal detected
- `prewarm_succeeded=true`
- `prefix_token_count=694`
- `route_anchor_hit=true`
- `restore_used=true`
- clean shutdown
- no crash/SIGABRT/double-free

Regression smoke:
- failed command -> shell20 -> `summarize the output`: correct, summarizes latest 20-line output
- failed command -> shell20 -> `summarize the failed output`: correct, preserves failed command / exit_code=127
- web then shell: real web + real shell, no fake output
- shell error follow-up: error preserved, no loop
- pwd follow-up: no redundant tool; descriptive response matches known baseline behavior

## Notes

No route contract changes. No tool behavior changes. No recall mechanism, selector, hidden evidence index, route evidence guard, or evidence_request is introduced.
