### PR TITLE
Add dual shell final evidence view

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -234,6 +234,9 @@ def build_final_evidence_context(store: EvidenceStore | None, *, limit: int = RE
     records = store.recent_records(limit) if store is not None else []
     if not records:
         return None
+    dual_shell_view = _build_shell_dual_view(store, records)
+    if dual_shell_view is not None:
+        return dual_shell_view
     parts = ["evidence_context:"]
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
@@ -474,6 +477,87 @@ def _compact_final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:
     ):
         return False
     return _final_context_needs_raw_excerpt(record)
+
+
+def _build_shell_dual_view(store: EvidenceStore | None, records: list[EvidenceRecord]) -> str | None:
+    if store is None or len(records) != 2:
+        return None
+    previous, latest = records
+    if previous.kind != "shell" or latest.kind != "shell":
+        return None
+    if previous.status != "error" or latest.status != "ok":
+        return None
+    latest_stdout_excerpt = str(latest.metadata.get("stdout_excerpt") or "").strip()
+    if not latest_stdout_excerpt:
+        return None
+    parts = [
+        "evidence_context:",
+        "shell_dual_view:",
+        "The session has two recent shell results.",
+        "",
+        "previous_failed_shell:",
+        *_shell_dual_previous_failed_lines(previous),
+        "",
+        "latest_shell:",
+        *_shell_dual_latest_lines(store, latest),
+    ]
+    return "\n".join(parts)
+
+
+def _shell_dual_previous_failed_lines(record: EvidenceRecord) -> list[str]:
+    lines: list[str] = []
+    command = str(record.metadata.get("command") or "").strip()
+    if command:
+        lines.append(f'command="{_bounded_text(command, POST_TOOL_ROUTE_TEXT_CHARS)}"')
+    lines.append("status=error")
+    exit_code = record.metadata.get("exit_code")
+    if exit_code not in (None, ""):
+        lines.append(f"exit_code={exit_code}")
+    error_summary = _shell_error_summary(record)
+    if error_summary:
+        lines.append(f'error_summary="{error_summary}"')
+    stderr_excerpt = str(record.metadata.get("stderr_excerpt") or "").strip()
+    if stderr_excerpt:
+        lines.append(f'stderr_excerpt="{_bounded_text(stderr_excerpt, POST_TOOL_ROUTE_OUTPUT_CHARS)}"')
+    return lines
+
+
+def _shell_dual_latest_lines(store: EvidenceStore, record: EvidenceRecord) -> list[str]:
+    lines: list[str] = []
+    command = str(record.metadata.get("command") or "").strip()
+    if command:
+        lines.append(f'command="{_bounded_text(command, POST_TOOL_ROUTE_TEXT_CHARS)}"')
+    lines.append("status=ok")
+    output_lines = _shell_stdout_line_count(store, record)
+    if output_lines is not None:
+        lines.append(f"output_lines={output_lines}")
+    stdout_excerpt = str(record.metadata.get("stdout_excerpt") or "").strip()
+    if stdout_excerpt:
+        lines.append(f'stdout_excerpt="{_bounded_text(stdout_excerpt, ROUTE_OUTPUT_EXCERPT_CHARS)}"')
+    return lines
+
+
+def _shell_error_summary(record: EvidenceRecord) -> str:
+    stderr_excerpt = str(record.metadata.get("stderr_excerpt") or "").strip()
+    if stderr_excerpt:
+        return _bounded_text(stderr_excerpt, POST_TOOL_ROUTE_OUTPUT_CHARS)
+    stdout_excerpt = str(record.metadata.get("stdout_excerpt") or "").strip()
+    if stdout_excerpt:
+        return _bounded_text(stdout_excerpt, POST_TOOL_ROUTE_OUTPUT_CHARS)
+    return ""
+
+
+def _shell_stdout_line_count(store: EvidenceStore, record: EvidenceRecord) -> int | None:
+    try:
+        raw = store.load_raw(record.evidence_id)
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return None
+    stdout = _section_text(raw, "STDOUT:", "STDERR:")
+    source = stdout if stdout is not None else raw
+    stripped = source.strip()
+    if not stripped or stripped == "(empty)":
+        return 0
+    return len(stripped.splitlines())
 
 
 def _post_tool_route_card(record: EvidenceRecord) -> str:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -534,6 +534,104 @@ class EvidenceTests(unittest.TestCase):
             self.assertNotIn("web_search_results: true", context)
             self.assertNotIn("results: none", context)
 
+    def test_final_context_uses_shell_dual_view_for_previous_error_and_latest_ok(self) -> None:
+        previous_raw = "\n".join(
+            [
+                "shell_command_failed: true",
+                "exit_code: 127",
+                "STDOUT:",
+                "(empty)",
+                "STDERR:",
+                "command_that_does_not_exist_123: not found",
+            ]
+        )
+        latest_raw = "\n".join(
+            [
+                "STDOUT:",
+                *[f"line-{index}" for index in range(20)],
+                "STDERR:",
+                "(empty)",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add(
+                "exec_shell_full_command",
+                previous_raw,
+                metadata={"command": "command_that_does_not_exist_123"},
+            )
+            latest = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": "python3 -c 'for i in range(20): print(f\"line-{i}\")'"},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("shell_dual_view:", context)
+            self.assertIn("previous_failed_shell:", context)
+            self.assertIn('command="command_that_does_not_exist_123"', context)
+            self.assertIn("status=error", context)
+            self.assertIn("exit_code=127", context)
+            self.assertIn('error_summary="command_that_does_not_exist_123: not found"', context)
+            self.assertIn('stderr_excerpt="command_that_does_not_exist_123: not found"', context)
+            self.assertIn("latest_shell:", context)
+            self.assertIn("status=ok", context)
+            self.assertIn("output_lines=20", context)
+            self.assertIn("line-0", context)
+            self.assertIn("line-19", context)
+            self.assertNotIn(previous.final_card, context)
+            self.assertNotIn(latest.final_card, context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+            self.assertNotIn(previous.raw_ref, context)
+            self.assertNotIn(latest.raw_ref, context)
+
+    def test_final_context_keeps_legacy_view_for_two_successful_shell_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            first = store.add(
+                "exec_shell_full_command",
+                "STDOUT:\nalpha\nSTDERR:\n(empty)\n",
+                metadata={"command": "printf alpha"},
+            )
+            second = store.add(
+                "exec_shell_full_command",
+                "STDOUT:\nbeta\nSTDERR:\n(empty)\n",
+                metadata={"command": "printf beta"},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertNotIn("shell_dual_view:", context)
+            self.assertIn(first.final_card, context)
+            self.assertIn(second.final_card, context)
+
+    def test_final_context_keeps_legacy_view_when_latest_shell_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            first = store.add(
+                "exec_shell_full_command",
+                "STDOUT:\nalpha\nSTDERR:\n(empty)\n",
+                metadata={"command": "printf alpha"},
+            )
+            second = store.add(
+                "exec_shell_full_command",
+                "shell_command_failed: true\nexit_code: 2\nSTDOUT:\n(empty)\nSTDERR:\nboom\n",
+                metadata={"command": "broken"},
+            )
+
+            context = build_final_evidence_context(store)
+
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertNotIn("shell_dual_view:", context)
+            self.assertIn(first.final_card, context)
+            self.assertIn(second.final_card, context)
+
 
 def _store_with(record, content: str) -> EvidenceStore:
     store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -417,6 +417,103 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("...", final_rendered)
         self.assertFalse(any(message.get("role") == "tool" for message in final_messages))
 
+    def test_chat_final_retry_uses_shell_dual_view_for_previous_error_and_latest_ok(self) -> None:
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content="This is prose, not route JSON.",
+                    model="fake",
+                    finish_reason="length",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=128,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+                ChatResult(
+                    content="It failed because the command was not found.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=8,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+            ]
+        )
+        previous_raw = "\n".join(
+            [
+                "shell_command_failed: true",
+                "exit_code: 127",
+                "STDOUT:",
+                "(empty)",
+                "STDERR:",
+                "command_that_does_not_exist_123: not found",
+            ]
+        )
+        latest_raw = "\n".join(
+            [
+                "STDOUT:",
+                *[f"line-{index}" for index in range(20)],
+                "STDERR:",
+                "(empty)",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            previous = store.add(
+                "exec_shell_full_command",
+                previous_raw,
+                metadata={"command": "command_that_does_not_exist_123"},
+            )
+            latest = store.add(
+                "exec_shell_full_command",
+                latest_raw,
+                metadata={"command": "python3 -c 'for i in range(20): print(f\"line-{i}\")'"},
+            )
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "run missing command"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(previous),
+                    "evidence_id": previous.evidence_id,
+                },
+                {"role": "assistant", "content": "The command was not found."},
+                {"role": "user", "content": "run the line printer"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-2",
+                    "name": "exec_shell_full_command",
+                    "content": tool_evidence_ref(latest),
+                    "evidence_id": latest.evidence_id,
+                },
+                {"role": "assistant", "content": "It printed line-0 through line-19."},
+            ]
+
+            result = runtime.ask_auto(
+                "summarize the failed output",
+                temperature=0,
+                max_tokens=32,
+                workdir=Path(tmp),
+            )
+
+        self.assertEqual(result.content, "It failed because the command was not found.")
+        retry_rendered = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[1])
+        self.assertIn("shell_dual_view:", retry_rendered)
+        self.assertIn("previous_failed_shell:", retry_rendered)
+        self.assertIn("latest_shell:", retry_rendered)
+        self.assertIn("exit_code=127", retry_rendered)
+        self.assertIn("line-0", retry_rendered)
+        self.assertIn("line-19", retry_rendered)
+        self.assertNotIn(previous.final_card, retry_rendered)
+        self.assertNotIn(latest.final_card, retry_rendered)
+
     def test_post_tool_chat_final_keeps_short_previous_assistant_for_reference(self) -> None:
         raw = "exit_code: 0\nSTDOUT:\n./src/orbit/runtime/evidence.py\nSTDERR:\n(empty)"
         backend = SequenceBackend(


### PR DESCRIPTION
## Summary

This PR adds a dedicated final/retry prompt view for the specific case where the two most recent evidence records are:

1. a previous failed shell command
2. a latest successful shell command

Instead of rendering two full shell evidence cards plus raw excerpts, the runtime now emits a bounded `shell_dual_view` with:

- `previous_failed_shell`
- `latest_shell`

This keeps the two tool results structurally distinct while reducing duplicated prompt content.

## Motivation

Post-PR #96 validation showed that cumulative shell follow-ups were correct but expensive:

- `summarize the output`: ~853 final/retry tokens
- `summarize the failed output`: ~853 final/retry tokens

Earlier compression attempts reduced tokens but broke referential correctness. This PR uses a dedicated symmetric view instead of generic compression.

Observed results:

- `summarize the output`: ~853 -> 386 tokens, correct
- `summarize the failed output`: ~853 -> 326 tokens, correct

## Scope

Changed:
- final/retry evidence prompt view for previous failed shell + latest successful shell

Unchanged:
- route contract
- route messages
- tool behavior
- EvidenceStore storage
- sidecars
- final/audit metadata outside this operational prompt view
- web/grep/read paths
- MTP/KV/vendor

No recall mechanism, selector, hidden evidence index, route guard, or `evidence_request` is introduced.

## Validation

Tests:
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime tests.test_final_policy -q`
- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_evidence tests.test_tool_message tests.test_runtime tests.test_final_policy tests.test_native_mtp_experimental -q`
- `python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

MTP smoke:
- mmproj/multimodal detected
- `prewarm_succeeded=true`
- `prefix_token_count=694`
- `route_anchor_hit=true`
- `restore_used=true`
- clean shutdown
- no crash/SIGABRT/double-free

Regression smoke:
- failed command -> shell20 -> `summarize the output`: correct, focuses on latest shell output
- failed command -> shell20 -> `summarize the failed output`: correct, focuses on previous failed shell command
- web -> shell: real tools, no fake output
- pwd follow-up: no redundant tool call, matches known baseline behavior
- failed command -> what happened: error preserved
