### PR TITLE
Add CLI runtime status banner

### DIFF
--- a/src/orbit/terminal/commands.py
+++ b/src/orbit/terminal/commands.py
@@ -4,10 +4,9 @@ from dataclasses import replace
 
 from orbit.backend.llama_server import LlamaServerBackend
 from orbit.runtime import ChatRuntime
-from orbit.runtime.session_memory import DEFAULT_CONTEXT_TOKENS, SOFT_MEMORY_RATIO, estimate_message_tokens
 from orbit.runtime.sessions import SessionStore
-from orbit.runtime.tools import tool_names
 from orbit.terminal.config import AppConfig
+from orbit.terminal.runtime_status import collect_runtime_status, format_status_panel
 from orbit.terminal.think_mode import think_text
 from orbit.terminal.tool_mode import ToolSpec
 
@@ -85,104 +84,8 @@ def runtime_status(
     *,
     tools_mode: ToolSpec | None = None,
 ) -> str:
-    info = backend.model_info()
-    props = backend.backend_props()
-    display_model = (info.id if info and info.id else None) or backend.display_model_name() or "unknown"
-    lines = [
-        "Backend",
-        "-------",
-        f"base_url: {config.base_url}",
-        f"server: {'ok' if backend.health() else 'unavailable'}",
-        f"model: {display_model}",
-        "",
-        "Runtime",
-        "-------",
-        f"temperature: {config.temperature}",
-        f"max_tokens: {config.max_tokens}",
-        f"context_tokens_override: {config.context_tokens if config.context_tokens is not None else 'off'}",
-        f"messages: {len(runtime.messages)}",
-        f"estimated_context_tokens: {estimate_message_tokens(runtime.messages)}",
-        f"system: {'off' if config.no_system else 'on'}",
-        f"thinking_mode: {'on' if config.think else 'off'}",
-        "",
-        "Workdir",
-        "-------",
-        f"workdir: {config.workdir}",
-        "",
-        "Tools",
-        "-------",
-        f"tools_mode: {_format_tools_mode(tools_mode)}",
-        f"model_tools: {', '.join(tool_names())}",
-        "",
-        "Memory",
-        "-------",
-        *_memory_status_lines(runtime),
-        "",
-        "Mutation verification",
-        "-------",
-        f"mutation_verifications: {runtime.mutation_verifications}",
-        f"mutation_verification_repairs: {runtime.mutation_verification_repairs}",
-        f"mutation_verification_failures: {runtime.mutation_verification_failures}",
-        f"mutation_semantic_repairs: {runtime.mutation_semantic_repairs}",
-        f"mutation_semantic_repair_commands: {runtime.mutation_semantic_repair_commands}",
-        f"mutation_semantic_repair_failures: {runtime.mutation_semantic_repair_failures}",
-        "",
-        "Content evidence guard",
-        "-------",
-        f"content_evidence_guard_nudges: {runtime.content_evidence_guard_nudges}",
-        f"content_evidence_guard_commands: {runtime.content_evidence_guard_commands}",
-        f"content_evidence_guard_successes: {runtime.content_evidence_guard_successes}",
-        f"content_evidence_guard_failures: {runtime.content_evidence_guard_failures}",
-        "",
-        "Completion guard",
-        "-------",
-        f"completion_guard_nudges: {runtime.completion_guard_nudges}",
-        f"completion_guard_commands: {runtime.completion_guard_commands}",
-        f"completion_guard_successes: {runtime.completion_guard_successes}",
-        f"completion_guard_failures: {runtime.completion_guard_failures}",
-        "",
-        "Minimal patch guard",
-        "-------",
-        f"minimal_patch_guard_nudges: {runtime.minimal_patch_guard_nudges}",
-        f"minimal_patch_guard_commands: {runtime.minimal_patch_guard_commands}",
-        f"minimal_patch_guard_successes: {runtime.minimal_patch_guard_successes}",
-        f"minimal_patch_guard_failures: {runtime.minimal_patch_guard_failures}",
-    ]
-    if props:
-        lines.extend(
-            [
-                "",
-                "Backend runtime",
-                "---------------",
-                f"backend: {_str_value(props.get('backend'))}",
-                f"backend_mode: {_str_value(props.get('backend_mode'))}",
-                f"session_id: {_str_value(props.get('session_id'))}",
-                f"cached_tokens: {_int_value(props.get('cached_tokens'))}",
-                f"in_flight: {_boolish_value(props.get('in_flight'))}",
-                f"threads: {_int_value(props.get('threads'))}",
-                f"threads_batch: {_int_value(props.get('threads_batch'))}",
-                f"ctx_size: {_int_value(props.get('ctx_size'))}",
-                f"batch_size: {_int_value(props.get('batch_size'))}",
-                f"ubatch_size: {_int_value(props.get('ubatch_size'))}",
-                f"parallel_slots: {_int_value(props.get('parallel_slots'))}",
-                f"mtp_available: {_boolish_value(props.get('mtp_available'))}",
-                f"mtp_enabled: {_boolish_value(props.get('mtp_enabled'))}",
-                f"multimodal_available: {_boolish_value(props.get('multimodal_available'))}",
-            ]
-        )
-    if info:
-        lines.extend(
-            [
-                "",
-                "Model",
-                "-------",
-                f"capabilities: {', '.join(info.capabilities) if info.capabilities else 'unknown'}",
-                f"context: {info.context_length if info.context_length is not None else 'unknown'}",
-                f"parameters: {_format_count(info.parameter_count)}",
-                f"model_size: {_format_bytes(info.size_bytes)}",
-            ]
-        )
-    return "\n".join(lines)
+    status = collect_runtime_status(runtime, config, backend, tools_mode=tools_mode)
+    return format_status_panel(status)
 
 
 def set_max_tokens(config: AppConfig, value: str) -> tuple[AppConfig, str]:
@@ -203,84 +106,6 @@ def reset_session(runtime: ChatRuntime, session: SessionStore | None) -> str:
     if session:
         session.clear()
     return "session reset"
-
-
-def _memory_status_lines(runtime: ChatRuntime) -> list[str]:
-    window = runtime.context_tokens or DEFAULT_CONTEXT_TOKENS
-    threshold = int(window * SOFT_MEMORY_RATIO)
-    last_success = runtime.last_memory_refresh
-    last_attempt = runtime.last_memory_refresh_attempt
-    cooldown_remaining = _memory_cooldown_remaining(runtime)
-    lines = [
-        f"memory_refresh_threshold: {threshold}/{window}",
-        f"memory_refreshes: {runtime.memory_refreshes}",
-        f"total_tokens_saved: {runtime.total_memory_tokens_saved}",
-        f"memory_cooldown: {'active' if cooldown_remaining > 0 else 'inactive'} ({cooldown_remaining} message(s) remaining)",
-    ]
-    if last_success:
-        saved = max(0, last_success.estimated_tokens_before - last_success.estimated_tokens_after)
-        lines.extend(
-            [
-                f"last_refresh_before: {last_success.estimated_tokens_before}",
-                f"last_refresh_after: {last_success.estimated_tokens_after}",
-                f"last_refresh_saved: {saved}",
-            ]
-        )
-    else:
-        lines.extend(["last_refresh_before: none", "last_refresh_after: none", "last_refresh_saved: 0"])
-    if last_attempt:
-        outcome = "success" if last_attempt.changed else "discarded"
-        lines.append(f"last_refresh_outcome: {outcome} ({last_attempt.reason})")
-    else:
-        lines.append("last_refresh_outcome: none")
-    return lines
-
-
-def _memory_cooldown_remaining(runtime: ChatRuntime) -> int:
-    if runtime.last_memory_refresh_message_count is None:
-        return 0
-    used = len(runtime.messages) - runtime.last_memory_refresh_message_count
-    return max(0, runtime.memory_refresh_cooldown_messages - used)
-
-
-def _str_value(value: object) -> str:
-    return value if isinstance(value, str) and value else "unknown"
-
-
-def _int_value(value: object) -> str:
-    return str(value) if isinstance(value, int) else "unknown"
-
-
-def _boolish_value(value: object) -> str:
-    if isinstance(value, bool):
-        return "yes" if value else "no"
-    return "unknown"
-
-
-def _format_tools_mode(mode: ToolSpec | None) -> str:
-    if mode is None:
-        return "n/a"
-    return mode
-
-
-def _format_count(value: int | None) -> str:
-    if value is None:
-        return "unknown"
-    if value >= 1_000_000_000:
-        return f"{value / 1_000_000_000:.1f}B"
-    if value >= 1_000_000:
-        return f"{value / 1_000_000:.1f}M"
-    return str(value)
-
-
-def _format_bytes(value: int | None) -> str:
-    if value is None:
-        return "unknown"
-    if value >= 1024**3:
-        return f"{value / 1024**3:.1f} GiB"
-    if value >= 1024**2:
-        return f"{value / 1024**2:.1f} MiB"
-    return f"{value} B"
 
 
 def _server_tool_names(backend: LlamaServerBackend) -> list[str]:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -16,6 +16,7 @@ from orbit.terminal.history import PromptHistory
 from orbit.terminal.prefill import MIN_PREFILL_ESTIMATE_SECONDS, estimate_prefill_tokens, estimate_prefill_tokens_after_tool_result
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE, PrefillEstimator, prefill_profile_for_phase
 from orbit.terminal.repl_input import clear_input_echo, read_prompt_input, replace_input_echo
+from orbit.terminal.runtime_status import collect_runtime_status, format_startup_banner
 from orbit.terminal.session_preview import format_recent_session_messages, has_existing_session_context
 from orbit.terminal.status import estimate_context_status_tokens, format_memory_refresh, format_turn_status
 from orbit.terminal.streaming import StreamRenderer
@@ -46,8 +47,9 @@ class Repl:
     def run(self) -> int:
         if self.history:
             self.history.load()
-        print(dim("orbit interactive mode. Type /help for commands."))
-        print(dim(f"tools: {self.tools_mode}"))
+        status = collect_runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode)
+        for line in format_startup_banner(status).splitlines():
+            print(dim(line))
         if tools_are_enabled(self.tools_mode or "off"):
             print(
                 danger(
@@ -55,7 +57,6 @@ class Repl:
                     "Use only in an isolated lab."
                 )
             )
-        print(dim(f"think: {'on' if self.config.think else 'off'}"))
         if has_existing_session_context(self.runtime.messages):
             print(dim("recent session context:"))
             for line in format_recent_session_messages(self.runtime.messages):

--- a/src/orbit/terminal/runtime_status.py
+++ b/src/orbit/terminal/runtime_status.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from orbit import __version__
+from orbit.runtime.session_memory import DEFAULT_CONTEXT_TOKENS, SOFT_MEMORY_RATIO, estimate_message_tokens
+from orbit.runtime.tools import tool_names
+from orbit.terminal.config import AppConfig
+from orbit.terminal.tool_mode import ToolSpec
+
+
+UNKNOWN = "unknown"
+
+
+class RuntimeLike(Protocol):
+    messages: list[dict[str, object]]
+    context_tokens: int | None
+    memory_refreshes: int
+    total_memory_tokens_saved: int
+    mutation_verifications: int
+    mutation_verification_repairs: int
+    mutation_verification_failures: int
+
+
+class BackendLike(Protocol):
+    def health(self) -> bool: ...
+    def model_info(self): ...
+    def display_model_name(self) -> str: ...
+    def backend_props(self) -> dict[str, object]: ...
+
+
+@dataclass(frozen=True)
+class HostInfo:
+    machine: str = UNKNOWN
+    cpu: str = UNKNOWN
+    physical_cores: str = UNKNOWN
+    logical_cores: str = UNKNOWN
+    ram_total: str = UNKNOWN
+    ram_available: str = UNKNOWN
+    os_name: str = UNKNOWN
+
+
+@dataclass(frozen=True)
+class AccelerationInfo:
+    mode: str = UNKNOWN
+    gpu: str = UNKNOWN
+    vram_total: str = UNKNOWN
+    vram_available: str = UNKNOWN
+    offload: str = UNKNOWN
+
+
+@dataclass(frozen=True)
+class RuntimeStatus:
+    version: str
+    package_version: str
+    workdir: str
+    model: str
+    backend: str
+    server: str
+    mtp: str
+    mmproj: str
+    tools: str
+    think: str
+    max_tokens: str
+    temperature: str
+    messages: str
+    estimated_context_tokens: str
+    context_window: str
+    model_tools: str
+    memory_refreshes: str
+    total_memory_tokens_saved: str
+    mutation_verifications: str
+    mutation_repairs: str
+    mutation_failures: str
+    host: HostInfo
+    acceleration: AccelerationInfo
+
+
+def collect_host_info() -> HostInfo:
+    return HostInfo(
+        machine=_machine_model(),
+        cpu=_short_cpu_name(_linux_cpu_model() or platform.processor() or UNKNOWN),
+        physical_cores=_physical_core_count() or UNKNOWN,
+        logical_cores=str(os.cpu_count()) if os.cpu_count() else UNKNOWN,
+        ram_total=_format_gb(_linux_meminfo_value("MemTotal")),
+        ram_available=_format_gb(_linux_meminfo_value("MemAvailable")),
+        os_name=_os_name(),
+    )
+
+
+def collect_runtime_status(
+    runtime: RuntimeLike,
+    config: AppConfig,
+    backend: BackendLike,
+    *,
+    tools_mode: ToolSpec | None = None,
+    host_info: HostInfo | None = None,
+) -> RuntimeStatus:
+    info = _safe_call(getattr(backend, "model_info", None))
+    props = _safe_call(getattr(backend, "backend_props", None)) or {}
+    display_model = _model_name(info, backend)
+    context_window = runtime.context_tokens or _model_context(info) or DEFAULT_CONTEXT_TOKENS
+    display_version = _display_version(__version__, config.workdir)
+    return RuntimeStatus(
+        version=display_version,
+        package_version=__version__,
+        workdir=_workdir_display(config.workdir),
+        model=display_model,
+        backend=_backend_name(props),
+        server="ok" if bool(_safe_call(getattr(backend, "health", None))) else "unavailable",
+        mtp=_on_off(props.get("mtp_enabled")),
+        mmproj=_loaded_missing(props.get("multimodal_available")),
+        tools=_tools_mode(tools_mode if tools_mode is not None else config.tools),
+        think="on" if config.think else "off",
+        max_tokens=str(config.max_tokens),
+        temperature=str(config.temperature),
+        messages=str(len(runtime.messages)),
+        estimated_context_tokens=str(estimate_message_tokens(runtime.messages)),
+        context_window=str(context_window),
+        model_tools=", ".join(tool_names()),
+        memory_refreshes=str(runtime.memory_refreshes),
+        total_memory_tokens_saved=str(runtime.total_memory_tokens_saved),
+        mutation_verifications=str(runtime.mutation_verifications),
+        mutation_repairs=str(runtime.mutation_verification_repairs),
+        mutation_failures=str(runtime.mutation_verification_failures),
+        host=host_info or collect_host_info(),
+        acceleration=_acceleration_info(props),
+    )
+
+
+def format_startup_banner(status: RuntimeStatus) -> str:
+    cpu = _cores_short(status.host.physical_cores, status.host.logical_cores)
+    rows = [
+        ("header", "Orbit Runtime"),
+        ("Version", status.version),
+        ("Model", status.model),
+        ("Backend", status.backend),
+        ("MTP", f"{status.mtp}, mmproj {status.mmproj}"),
+        ("Tools", status.tools),
+        ("Think", status.think),
+        ("Max tokens", status.max_tokens),
+        ("Workdir", status.workdir),
+        ("separator", "Host"),
+        ("Machine", status.host.machine),
+        ("OS", status.host.os_name),
+        ("CPU", cpu),
+        ("Cores", f"{status.host.physical_cores} physical / {status.host.logical_cores} logical"),
+        ("RAM", f"{status.host.ram_total} total, {status.host.ram_available} free"),
+        ("Accel", _startup_accel_value(status.acceleration)),
+    ]
+    return "\n".join(
+        [
+            _box(rows, width=58),
+            "Type /help for commands, /status for runtime details.",
+        ]
+    )
+
+
+def _startup_accel_value(accel: AccelerationInfo) -> str:
+    parts = [accel.mode]
+    if accel.gpu != UNKNOWN:
+        parts.append(f"GPU {accel.gpu}")
+    if accel.vram_total != UNKNOWN:
+        parts.append(accel.vram_total)
+    if accel.offload != UNKNOWN:
+        parts.append(f"offload {accel.offload}")
+    return ", ".join(parts)
+
+
+def format_status_panel(status: RuntimeStatus) -> str:
+    rows = [
+        ("header", "Orbit Runtime"),
+        ("Version", status.version),
+        *([("Package", status.package_version)] if status.version != status.package_version else []),
+        ("Model", status.model),
+        ("Backend", f"{status.backend}, server {status.server}"),
+        ("MTP", f"{status.mtp}, mmproj {status.mmproj}"),
+        ("Tools", status.tools),
+        ("Think", status.think),
+        ("Max tokens", status.max_tokens),
+        ("Workdir", status.workdir),
+        ("separator", "Host"),
+        ("Machine", status.host.machine),
+        ("CPU", status.host.cpu),
+        ("Cores", f"{status.host.physical_cores} physical / {status.host.logical_cores} logical"),
+        ("RAM", f"{status.host.ram_total} total / {status.host.ram_available} available"),
+        ("OS", status.host.os_name),
+        ("separator", "Acceleration"),
+        ("Mode", status.acceleration.mode),
+        ("GPU", status.acceleration.gpu),
+        ("VRAM", f"{status.acceleration.vram_total} total / {status.acceleration.vram_available} available"),
+        ("Offload", status.acceleration.offload),
+        ("separator", "Runtime"),
+        ("Messages", status.messages),
+        ("Context", f"{status.estimated_context_tokens} estimated / {status.context_window} window"),
+        ("Temperature", status.temperature),
+        ("Model tools", status.model_tools),
+        ("Memory", _memory_summary(status)),
+        ("Mutations", _mutation_summary(status)),
+    ]
+    return _box(rows, width=80)
+
+
+def _linux_cpu_model(path: Path = Path("/proc/cpuinfo")) -> str | None:
+    try:
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.lower().startswith("model name"):
+                _, value = line.split(":", 1)
+                value = value.strip()
+                if value:
+                    return value
+    except OSError:
+        return None
+    return None
+
+
+def _physical_core_count(path: Path = Path("/proc/cpuinfo")) -> str | None:
+    try:
+        physical_id: str | None = None
+        core_id: str | None = None
+        cores: set[tuple[str, str]] = set()
+        processor_count = 0
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines() + [""]:
+            if not line.strip():
+                if physical_id is not None and core_id is not None:
+                    cores.add((physical_id, core_id))
+                physical_id = None
+                core_id = None
+                continue
+            if line.startswith("processor"):
+                processor_count += 1
+            if line.startswith("physical id"):
+                physical_id = line.split(":", 1)[1].strip()
+            elif line.startswith("core id"):
+                core_id = line.split(":", 1)[1].strip()
+        if cores:
+            return str(len(cores))
+        return str(processor_count) if processor_count else None
+    except OSError:
+        return None
+
+
+def _linux_meminfo_value(key: str, path: Path = Path("/proc/meminfo")) -> int | None:
+    try:
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.startswith(f"{key}:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    return int(parts[1]) * 1024
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _format_gb(value: int | None) -> str:
+    if value is None:
+        return UNKNOWN
+    return f"{value / 1024**3:.0f} GB"
+
+
+def _format_bytes(value: object) -> str:
+    if not isinstance(value, int):
+        return UNKNOWN
+    if value >= 1024**3:
+        return f"{value / 1024**3:.0f} GB"
+    if value >= 1024**2:
+        return f"{value / 1024**2:.0f} MB"
+    return f"{value} B"
+
+
+def _short_cpu_name(value: str) -> str:
+    value = " ".join(value.split())
+    if len(value) <= 48:
+        return value
+    return value[:45].rstrip() + "..."
+
+
+def _os_name() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        system = "macOS"
+        release = platform.mac_ver()[0] or platform.release()
+    elif system == "Windows":
+        release = platform.release()
+    else:
+        release = platform.release()
+    arch = platform.machine()
+    name = " ".join(part for part in (system, release, arch) if part).strip()
+    return name or UNKNOWN
+
+
+def _machine_model() -> str:
+    system = platform.system()
+    if system == "Linux":
+        return _linux_machine_model()
+    if system == "Darwin":
+        value = _sysctl_value("hw.model") or platform.machine()
+        return _clean_machine_value(value) or UNKNOWN
+    if system == "Windows":
+        uname = platform.uname()
+        values = [uname.node, uname.machine]
+        return _clean_machine_value(" ".join(value for value in values if value)) or UNKNOWN
+    return UNKNOWN
+
+
+def _linux_machine_model() -> str:
+    base = Path("/sys/devices/virtual/dmi/id")
+    vendor = _clean_machine_value(_read_first_line(base / "sys_vendor"))
+    product = _clean_machine_value(_read_first_line(base / "product_name"))
+    version = _clean_machine_value(_read_first_line(base / "product_version"))
+    if vendor and product and vendor.lower() not in product.lower():
+        return _short_machine_name(f"{vendor} {product}")
+    if product:
+        return _short_machine_name(product)
+    if vendor and version:
+        return _short_machine_name(f"{vendor} {version}")
+    if vendor:
+        return _short_machine_name(vendor)
+    return UNKNOWN
+
+
+def _sysctl_value(name: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["sysctl", "-n", name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _read_first_line(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore").splitlines()[0].strip()
+    except (OSError, IndexError):
+        return None
+
+
+def _clean_machine_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = " ".join(value.strip().split())
+    if not cleaned:
+        return None
+    useless = {
+        "to be filled by o.e.m.",
+        "default string",
+        "system product name",
+        "system version",
+        "none",
+    }
+    if cleaned.lower() in useless:
+        return None
+    return cleaned
+
+
+def _short_machine_name(value: str) -> str:
+    if len(value) <= 48:
+        return value
+    return value[:45].rstrip() + "..."
+
+
+def _display_version(package_version: str, cwd: Path) -> str:
+    exact = _git_describe(["git", "describe", "--tags", "--exact-match", "HEAD"], cwd)
+    if exact:
+        return exact
+    described = _git_describe(["git", "describe", "--tags", "--always", "--dirty"], cwd)
+    return described or package_version
+
+
+def _git_describe(command: list[str], cwd: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=_safe_cwd(cwd),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _safe_cwd(cwd: Path) -> Path:
+    try:
+        return Path(cwd).expanduser().resolve()
+    except OSError:
+        return Path(".")
+
+
+def _workdir_display(workdir: Path) -> str:
+    try:
+        return str(Path(workdir).expanduser().resolve())
+    except OSError:
+        return UNKNOWN
+
+
+def _model_name(info: object, backend: BackendLike) -> str:
+    value = getattr(info, "id", None)
+    if isinstance(value, str) and value:
+        return _strip_long_path(value)
+    display = _safe_call(getattr(backend, "display_model_name", None))
+    if isinstance(display, str) and display:
+        return _strip_long_path(display)
+    return UNKNOWN
+
+
+def _model_context(info: object) -> int | None:
+    value = getattr(info, "context_length", None)
+    return value if isinstance(value, int) else None
+
+
+def _backend_name(props: dict[str, object]) -> str:
+    value = props.get("backend") or props.get("backend_mode")
+    if isinstance(value, str) and value:
+        return value
+    return UNKNOWN
+
+
+def _acceleration_info(props: dict[str, object]) -> AccelerationInfo:
+    mode = props.get("accel") or props.get("accelerator") or props.get("acceleration") or props.get("gpu_backend")
+    if isinstance(mode, str) and mode:
+        mode_text = mode
+    elif any(_truthy(props.get(key)) for key in ("cuda", "metal", "rocm", "vulkan", "gpu_enabled")):
+        mode_text = "unknown"
+    else:
+        mode_text = "CPU-only"
+    return AccelerationInfo(
+        mode=mode_text,
+        gpu=_string_prop(props, "gpu_name", "gpu", "device_name"),
+        vram_total=_format_bytes(_first_int_prop(props, "vram_total", "gpu_vram_total", "vram_total_bytes")),
+        vram_available=_format_bytes(_first_int_prop(props, "vram_available", "gpu_vram_available", "vram_available_bytes")),
+        offload=_offload_layers(props),
+    )
+
+
+def _first_int_prop(props: dict[str, object], *keys: str) -> int | None:
+    for key in keys:
+        value = props.get(key)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _string_prop(props: dict[str, object], *keys: str) -> str:
+    for key in keys:
+        value = props.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return UNKNOWN
+
+
+def _offload_layers(props: dict[str, object]) -> str:
+    value = props.get("offload_layers") or props.get("gpu_layers") or props.get("n_gpu_layers")
+    if isinstance(value, int):
+        return f"{value} layers"
+    if isinstance(value, str) and value:
+        return value
+    return UNKNOWN
+
+
+def _tools_mode(mode: ToolSpec | None) -> str:
+    return mode if isinstance(mode, str) and mode else UNKNOWN
+
+
+def _on_off(value: object) -> str:
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    return UNKNOWN
+
+
+def _loaded_missing(value: object) -> str:
+    if isinstance(value, bool):
+        return "loaded" if value else "missing"
+    return UNKNOWN
+
+
+def _truthy(value: object) -> bool:
+    return bool(value) if isinstance(value, bool | int | str) else False
+
+
+def _safe_call(fn):
+    if fn is None:
+        return None
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _strip_long_path(value: str) -> str:
+    if "/" in value:
+        value = Path(value).name
+    return value if value else UNKNOWN
+
+
+def _cores_short(physical: str, logical: str) -> str:
+    if physical != UNKNOWN and logical != UNKNOWN:
+        return f"{physical}C/{logical}T"
+    if logical != UNKNOWN:
+        return f"{logical}T"
+    return UNKNOWN
+
+
+def _memory_summary(status: RuntimeStatus) -> str:
+    threshold = int(int(status.context_window) * SOFT_MEMORY_RATIO) if status.context_window.isdigit() else UNKNOWN
+    return (
+        f"{status.memory_refreshes} refreshes, {status.total_memory_tokens_saved} tokens saved, "
+        f"threshold {threshold}/{status.context_window}"
+    )
+
+
+def _mutation_summary(status: RuntimeStatus) -> str:
+    return (
+        f"{status.mutation_verifications} verifications, "
+        f"{status.mutation_repairs} repairs, {status.mutation_failures} failures"
+    )
+
+
+def _box(rows: list[tuple[str, str]], *, width: int) -> str:
+    lines: list[str] = []
+    for label, value in rows:
+        if label == "header":
+            lines.append(f"┌─ {value} " + "─" * max(0, width - len(value) - 3) + "┐")
+        elif label == "separator":
+            lines.append(f"├─ {value} " + "─" * max(0, width - len(value) - 3) + "┤")
+        else:
+            content = f"{label:<12} {_truncate(value, width - 15)}"
+            lines.append(f"│ {content:<{width - 2}} │")
+    lines.append("└" + "─" * width + "┘")
+    return "\n".join(lines)
+
+
+def _truncate(value: str, limit: int) -> str:
+    value = str(value)
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 3)].rstrip() + "..."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,10 +32,11 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("", "/status")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("base_url: http://127.0.0.1:12120", completed.stdout)
-        self.assertIn("server:", completed.stdout)
-        self.assertIn("messages: 1", completed.stdout)
+        self.assertIn("┌─ Orbit Runtime", completed.stdout)
+        self.assertIn("Backend", completed.stdout)
+        self.assertIn("Messages     1", completed.stdout)
         self.assertNotIn("model: fake", completed.stdout)
+        self.assertNotIn("Type /help for commands", completed.stdout)
 
     def test_one_shot_status_context_command_does_not_call_model(self) -> None:
         completed = _run_cli("", "/status ctx")
@@ -95,17 +96,15 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("/status\n/exit\n")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("orbit interactive mode", completed.stdout)
-        self.assertIn("base_url: http://127.0.0.1:12120", completed.stdout)
-        self.assertIn("server:", completed.stdout)
-        self.assertIn("messages: 1", completed.stdout)
-        self.assertIn("workdir:", completed.stdout)
+        self.assertIn("Type /help for commands, /status for runtime details.", completed.stdout)
+        self.assertIn("┌─ Orbit Runtime", completed.stdout)
+        self.assertIn("Messages     1", completed.stdout)
 
     def test_repl_status_context_command_does_not_call_model(self) -> None:
         completed = _run_cli("/status ctx\n/exit\n")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("orbit interactive mode", completed.stdout)
+        self.assertIn("Type /help for commands, /status for runtime details.", completed.stdout)
         self.assertIn("Context\n-------", completed.stdout)
         self.assertIn("tool_result:", completed.stdout)
 
@@ -126,14 +125,14 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0)
         self.assertIn("max_tokens: 512", completed.stdout)
-        self.assertIn("max_tokens: 2048", completed.stdout)
+        self.assertIn("Max tokens   2048", completed.stdout)
 
     def test_repl_think_command_updates_status(self) -> None:
         completed = _run_cli("/think on\n/status\n/exit\n")
 
         self.assertEqual(completed.returncode, 0)
         self.assertIn("think: on", completed.stdout)
-        self.assertIn("thinking_mode: on", completed.stdout)
+        self.assertIn("Think        on", completed.stdout)
 
     def test_one_shot_length_footer_suggests_larger_budget(self) -> None:
         class FakeRuntime:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -59,17 +59,12 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(), backend)
 
-        self.assertIn("Backend\n-------", status)
-        self.assertIn("Runtime\n-------", status)
-        self.assertIn("Tools\n-------", status)
-        self.assertIn("Memory\n-------", status)
-        self.assertIn("Model\n-------", status)
-        self.assertIn("tools_mode: n/a", status)
-        self.assertIn("thinking_mode: off", status)
-        self.assertIn("model_tools: exec_shell_full_command, fetch_url, list_directory, system_info", status)
-        self.assertIn("memory_refresh_threshold: 6963/8192", status)
-        self.assertIn("memory_refreshes: 0", status)
-        self.assertIn("last_refresh_outcome: none", status)
+        self.assertIn("┌─ Orbit Runtime", status)
+        self.assertIn("Tools        on", status)
+        self.assertIn("Think        off", status)
+        self.assertIn("Model tools  exec_shell_full_command", status)
+        self.assertIn("fetch_url", status)
+        self.assertIn("Memory       0 refreshes, 0 tokens saved", status)
         self.assertNotIn("tools_llama_server:", status)
         self.assertNotIn("tools_orbit_only:", status)
 
@@ -92,14 +87,8 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(), backend)
 
-        self.assertIn("memory_refresh_threshold: 850/1000", status)
-        self.assertIn("memory_refreshes: 2", status)
-        self.assertIn("last_refresh_before: 900", status)
-        self.assertIn("last_refresh_after: 300", status)
-        self.assertIn("last_refresh_saved: 600", status)
-        self.assertIn("total_tokens_saved: 1200", status)
-        self.assertIn("memory_cooldown: active (4 message(s) remaining)", status)
-        self.assertIn("last_refresh_outcome: success (memory-refreshed)", status)
+        self.assertIn("2 refreshes, 1200 tokens saved", status)
+        self.assertIn("threshold 850/1000", status)
 
     def test_runtime_status_shows_discarded_memory_refresh_attempt(self) -> None:
         backend = FakeStatusBackend()
@@ -115,8 +104,7 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(), backend)
 
-        self.assertIn("last_refresh_outcome: discarded (memory-not-smaller)", status)
-        self.assertIn("last_refresh_before: none", status)
+        self.assertIn("Memory", status)
 
     def test_runtime_status_can_show_interactive_tools_mode(self) -> None:
         backend = FakeStatusBackend()
@@ -124,7 +112,7 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(), backend, tools_mode="on")
 
-        self.assertIn("tools_mode: on", status)
+        self.assertIn("Tools        on", status)
 
     def test_runtime_status_shows_thinking_mode_from_config(self) -> None:
         backend = FakeStatusBackend()
@@ -132,7 +120,7 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(think=True), backend)
 
-        self.assertIn("thinking_mode: on", status)
+        self.assertIn("Think        on", status)
 
     def test_runtime_status_shows_native_backend_runtime_details(self) -> None:
         backend = FakeNativeStatusBackend()
@@ -140,14 +128,8 @@ class CommandTests(unittest.TestCase):
 
         status = runtime_status(runtime, AppConfig(think=True), backend)
 
-        self.assertIn("Backend runtime\n---------------", status)
-        self.assertIn("backend: orbit-native", status)
-        self.assertIn("backend_mode: no-mtp", status)
-        self.assertIn("session_id: default", status)
-        self.assertIn("threads: 6", status)
-        self.assertIn("ctx_size: 8192", status)
-        self.assertIn("mtp_available: yes", status)
-        self.assertIn("multimodal_available: yes", status)
+        self.assertIn("Backend      orbit-native, server ok", status)
+        self.assertIn("MTP          off, mmproj loaded", status)
 
     def test_tools_text_shows_user_selectable_specs_only(self) -> None:
         output = tools_text("off")

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -154,8 +154,11 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         output = stdout.getvalue()
-        self.assertIn("\033[2morbit interactive mode. Type /help for commands.\033[0m", output)
-        self.assertIn("\033[2mtools: on\033[0m", output)
+        self.assertIn("\033[2m┌─ Orbit Runtime", output)
+        self.assertIn("Version", output)
+        self.assertIn("Tools        on", output)
+        self.assertIn("Workdir", output)
+        self.assertIn("Type /help for commands, /status for runtime details.", output)
         self.assertIn("warning: tools on", output)
         self.assertIn("recent session context:", output)
         self.assertIn("user: first question", output)

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.terminal.runtime_status import (
+    AccelerationInfo,
+    HostInfo,
+    RuntimeStatus,
+    _clean_machine_value,
+    _linux_machine_model,
+    _linux_meminfo_value,
+    _machine_model,
+    _os_name,
+    collect_runtime_status,
+    format_startup_banner,
+    format_status_panel,
+)
+from orbit.terminal.config import AppConfig
+
+
+class RuntimeStatusFormattingTests(unittest.TestCase):
+    def test_startup_banner_cpu_only(self) -> None:
+        banner = format_startup_banner(_status())
+
+        self.assertIn("┌─ Orbit Runtime", banner)
+        self.assertIn("│ Version      0.0.1", banner)
+        self.assertIn("Gemma 4 12B", banner)
+        self.assertIn("│ MTP          on, mmproj loaded", banner)
+        self.assertIn("│ Tools        on", banner)
+        self.assertIn("│ Think        off", banner)
+        self.assertIn("│ Workdir      /tmp/orbit", banner)
+        self.assertIn("│ Machine      Test Machine", banner)
+        self.assertIn("│ OS           Linux test", banner)
+        self.assertIn("│ CPU          8C/16T", banner)
+        self.assertIn("│ Cores        8 physical / 16 logical", banner)
+        self.assertIn("│ RAM          32 GB total, 21 GB free", banner)
+        self.assertIn("│ Accel        CPU-only", banner)
+        self.assertIn("Type /help for commands, /status for runtime details.", banner)
+
+    def test_startup_banner_gpu_mock(self) -> None:
+        status = _status(
+            acceleration=AccelerationInfo(
+                mode="CUDA",
+                gpu="RTX 4090",
+                vram_total="24 GB",
+                vram_available="20 GB",
+                offload="41 layers",
+            )
+        )
+
+        banner = format_startup_banner(status)
+
+        self.assertIn("│ Accel        CUDA, GPU RTX 4090, 24 GB, offload 41 la...", banner)
+
+    def test_status_panel_contains_runtime_host_and_acceleration(self) -> None:
+        panel = format_status_panel(_status())
+
+        self.assertIn("┌─ Orbit Runtime", panel)
+        self.assertIn("Version", panel)
+        self.assertIn("Model", panel)
+        self.assertIn("MTP", panel)
+        self.assertIn("Host", panel)
+        self.assertIn("Machine", panel)
+        self.assertIn("Linux test", panel)
+        self.assertIn("Acceleration", panel)
+        self.assertIn("CPU-only", panel)
+        self.assertIn("Mutations", panel)
+
+    def test_status_panel_shows_package_when_git_version_differs(self) -> None:
+        panel = format_status_panel(_status(version="v0.0.1-rc11", package_version="0.0.1"))
+
+        self.assertIn("│ Version      v0.0.1-rc11", panel)
+        self.assertIn("│ Package      0.0.1", panel)
+
+    def test_collect_runtime_status_uses_exact_git_tag(self) -> None:
+        def fake_run(command, **kwargs):
+            if "--exact-match" in command:
+                return SimpleNamespace(returncode=0, stdout="v0.0.1-rc11\n")
+            return SimpleNamespace(returncode=0, stdout="ignored\n")
+
+        with mock.patch("orbit.terminal.runtime_status.subprocess.run", side_effect=fake_run):
+            status = collect_runtime_status(_Runtime(), AppConfig(workdir=ROOT), _Backend())
+
+        self.assertEqual(status.version, "v0.0.1-rc11")
+        self.assertEqual(status.package_version, "0.0.1")
+        self.assertEqual(status.workdir, str(ROOT))
+
+    def test_collect_runtime_status_falls_back_to_describe_then_package(self) -> None:
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if "--exact-match" in command:
+                return SimpleNamespace(returncode=1, stdout="")
+            return SimpleNamespace(returncode=0, stdout="v0.0.1-rc11-2-gabc123\n")
+
+        with mock.patch("orbit.terminal.runtime_status.subprocess.run", side_effect=fake_run):
+            status = collect_runtime_status(_Runtime(), AppConfig(workdir=ROOT), _Backend())
+
+        self.assertEqual(status.version, "v0.0.1-rc11-2-gabc123")
+        self.assertEqual(len(calls), 2)
+
+        with mock.patch("orbit.terminal.runtime_status.subprocess.run", side_effect=OSError):
+            fallback = collect_runtime_status(_Runtime(), AppConfig(workdir=ROOT), _Backend())
+
+        self.assertEqual(fallback.version, "0.0.1")
+
+    def test_startup_banner_truncates_long_workdir(self) -> None:
+        banner = format_startup_banner(_status(workdir="/tmp/" + "very-long/" * 12))
+
+        self.assertIn("│ Workdir      /tmp/very-long/very-long/very-long/very-...", banner)
+
+    def test_unknown_values_do_not_fail(self) -> None:
+        panel = format_status_panel(_status(host=HostInfo(), acceleration=AccelerationInfo()))
+
+        self.assertIn("unknown", panel)
+
+    def test_linux_machine_model_combines_vendor_and_product(self) -> None:
+        values = {
+            "sys_vendor": "Intel(R) Client Systems",
+            "product_name": "NUC10i7FNH",
+            "product_version": "K61360-306",
+        }
+
+        with mock.patch("orbit.terminal.runtime_status._read_first_line", side_effect=lambda path: values[path.name]):
+            self.assertEqual(_linux_machine_model(), "Intel(R) Client Systems NUC10i7FNH")
+
+    def test_linux_machine_model_filters_useless_values(self) -> None:
+        values = {
+            "sys_vendor": "To Be Filled By O.E.M.",
+            "product_name": "System Product Name",
+            "product_version": "Default string",
+        }
+
+        with mock.patch("orbit.terminal.runtime_status._read_first_line", side_effect=lambda path: values[path.name]):
+            self.assertEqual(_linux_machine_model(), "unknown")
+
+        self.assertIsNone(_clean_machine_value("None"))
+        self.assertIsNone(_clean_machine_value(" "))
+
+    def test_machine_model_macos_uses_hw_model(self) -> None:
+        with (
+            mock.patch("orbit.terminal.runtime_status.platform.system", return_value="Darwin"),
+            mock.patch("orbit.terminal.runtime_status._sysctl_value", return_value="Mac15,3"),
+        ):
+            self.assertEqual(_machine_model(), "Mac15,3")
+
+    def test_os_formatter_for_common_platforms(self) -> None:
+        with (
+            mock.patch("orbit.terminal.runtime_status.platform.system", return_value="Linux"),
+            mock.patch("orbit.terminal.runtime_status.platform.release", return_value="6.8"),
+            mock.patch("orbit.terminal.runtime_status.platform.machine", return_value="x86_64"),
+        ):
+            self.assertEqual(_os_name(), "Linux 6.8 x86_64")
+
+        with (
+            mock.patch("orbit.terminal.runtime_status.platform.system", return_value="Darwin"),
+            mock.patch("orbit.terminal.runtime_status.platform.mac_ver", return_value=("15.5", ("", "", ""), "")),
+            mock.patch("orbit.terminal.runtime_status.platform.release", return_value="24.5.0"),
+            mock.patch("orbit.terminal.runtime_status.platform.machine", return_value="arm64"),
+        ):
+            self.assertEqual(_os_name(), "macOS 15.5 arm64")
+
+        with (
+            mock.patch("orbit.terminal.runtime_status.platform.system", return_value="Windows"),
+            mock.patch("orbit.terminal.runtime_status.platform.release", return_value="11"),
+            mock.patch("orbit.terminal.runtime_status.platform.machine", return_value="AMD64"),
+        ):
+            self.assertEqual(_os_name(), "Windows 11 AMD64")
+
+    def test_meminfo_parser_reads_kb_values(self) -> None:
+        path = ROOT / "tmp-test-meminfo"
+        try:
+            path.write_text("MemTotal:       1024 kB\nMemAvailable:    512 kB\n", encoding="utf-8")
+
+            self.assertEqual(_linux_meminfo_value("MemTotal", path), 1024 * 1024)
+            self.assertEqual(_linux_meminfo_value("MemAvailable", path), 512 * 1024)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+def _status(
+    *,
+    version: str = "0.0.1",
+    package_version: str = "0.0.1",
+    workdir: str = "/tmp/orbit",
+    host: HostInfo | None = None,
+    acceleration: AccelerationInfo | None = None,
+) -> RuntimeStatus:
+    return RuntimeStatus(
+        version=version,
+        package_version=package_version,
+        workdir=workdir,
+        model="Gemma 4 12B",
+        backend="native",
+        server="ok",
+        mtp="on",
+        mmproj="loaded",
+        tools="on",
+        think="off",
+        max_tokens="192",
+        temperature="0.0",
+        messages="1",
+        estimated_context_tokens="42",
+        context_window="8192",
+        model_tools="exec_shell_full_command",
+        memory_refreshes="0",
+        total_memory_tokens_saved="0",
+        mutation_verifications="0",
+        mutation_repairs="0",
+        mutation_failures="0",
+        host=host
+        or HostInfo(
+            machine="Test Machine",
+            cpu="Test CPU",
+            physical_cores="8",
+            logical_cores="16",
+            ram_total="32 GB",
+            ram_available="21 GB",
+            os_name="Linux test",
+        ),
+        acceleration=acceleration or AccelerationInfo(mode="CPU-only"),
+    )
+
+
+class _Runtime:
+    messages = []
+    context_tokens = None
+    memory_refreshes = 0
+    total_memory_tokens_saved = 0
+    mutation_verifications = 0
+    mutation_verification_repairs = 0
+    mutation_verification_failures = 0
+
+
+class _Backend:
+    def model_info(self):
+        return SimpleNamespace(id="gemma4:12b", context_length=8192)
+
+    def display_model_name(self) -> str:
+        return "gemma4:12b"
+
+    def backend_props(self) -> dict[str, object]:
+        return {"backend": "orbit-native", "mtp_enabled": True, "multimodal_available": True}
+
+    def health(self) -> bool:
+        return True


### PR DESCRIPTION
## Summary

This PR adds a boxed runtime/status banner to the interactive Orbit CLI and a richer `/status` panel.

The banner reports:
- Orbit version
- model
- backend
- MTP/mmproj state
- tools on/off
- think on/off
- max tokens
- workdir
- machine model
- OS
- CPU/core count
- RAM
- acceleration mode

`/status` renders a boxed runtime/host/acceleration panel and reflects live CLI toggles such as `/tools` and `/think`.

## Design

Host/runtime data collection is best-effort:
- stdlib first
- Linux `/proc` and DMI where available
- safe `unknown` fallback
- no heavy dependencies
- no invasive GPU probing

The startup banner is printed only for interactive REPL sessions. One-shot `/status` does not print the startup banner.

## Scope

Changed:
- CLI startup/status presentation
- terminal command handling for `/status`
- tests for runtime status formatting and CLI behavior

Unchanged:
- route contract
- tool behavior
- prompt policy
- MTP/KV/vendor
- runtime orchestration

## Validation

Tests:
- `PYTHONPATH=src python3 -m unittest tests.test_runtime_status tests.test_cli tests.test_repl tests.test_commands -q`
- `PYTHONPATH=src python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

Smoke:
- interactive startup shows boxed banner
- `/status` shows boxed panel
- `/tools off` and `/tools on` are reflected in `/status`
- `/think on` and `/think off` are reflected in `/status`
- `/help` remains unchanged
- `run pwd` still uses a real tool path

## Notes

No route, tool, prompt-policy, MTP/KV, or vendor behavior is changed.