### PR TITLE
Fix smoke harness MTP required consistency

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -118,6 +118,33 @@ class ProbeBackend:
         return self._backend.continue_current(max_tokens=max_tokens, on_delta=on_delta, on_progress=on_progress)
 
 
+def mtp_state_from_props(props: dict[str, object]) -> dict[str, object]:
+    requested = bool(props.get("mtp_experimental_enabled"))
+    session_ready = bool(props.get("mtp_initialized"))
+    last_success = props.get("mtp_last_completion_success") is True
+    failure_reason = first_nonempty_str(props.get("mtp_failure_reason"), props.get("mtp_fallback_reason"))
+    attempted = last_success or failure_reason is not None
+    usable = bool(requested and session_ready and last_success and failure_reason is None)
+    if usable:
+        status = "on"
+    elif failure_reason is not None:
+        status = "failed"
+    elif requested and session_ready:
+        status = "ready"
+    elif requested:
+        status = "requested"
+    else:
+        status = "off"
+    return {
+        "requested": requested,
+        "session_ready": session_ready,
+        "attempted": attempted,
+        "usable": usable,
+        "status": status,
+        "failure_reason": failure_reason,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -129,9 +156,10 @@ def main(argv: list[str] | None = None) -> int:
     markdown_path = Path(args.markdown) if args.markdown else output_dir / f"orbit_smoke_{stamp}.md"
 
     backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
-    env = environment_summary(args=args, backend=backend)
-    if args.mtp_required and env.get("mtp") != "on":
-        print("error: --mtp-required set but backend does not report MTP enabled", file=sys.stderr)
+    initial_props = safe_backend_props(backend)
+    initial_mtp = mtp_state_from_props(initial_props)
+    if args.mtp_required and not (initial_mtp["requested"] or initial_mtp["usable"]):
+        print("error: --mtp-required set but backend does not report MTP requested/enabled", file=sys.stderr)
         return 2
 
     reports: list[StepReport] = []
@@ -145,8 +173,15 @@ def main(argv: list[str] | None = None) -> int:
                 temperature=args.temperature,
             )
         )
+    env = environment_summary(args=args, backend=backend, props=fresh_backend_props(args.base_url, args.timeout))
     write_jsonl(jsonl_path, env, reports)
     write_markdown(markdown_path, env, reports)
+    if args.mtp_required:
+        final_mtp = mtp_state_from_props(fresh_backend_props(args.base_url, args.timeout))
+        if not final_mtp["usable"]:
+            reason = final_mtp["failure_reason"] or final_mtp["status"]
+            print(f"error: --mtp-required set but backend MTP is not usable ({reason})", file=sys.stderr)
+            return 2
     print(f"jsonl={jsonl_path}")
     print(f"markdown={markdown_path}")
     return 0
@@ -381,10 +416,11 @@ def model_step_to_json(metric: ModelStepMetrics) -> dict[str, object]:
     }
 
 
-def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend) -> dict[str, object]:
-    props = safe_backend_props(backend)
+def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend, props: dict[str, object] | None = None) -> dict[str, object]:
+    props = props if props is not None else safe_backend_props(backend)
     info = safe_model_info(backend)
     host = collect_host_info()
+    mtp = mtp_state_from_props(props)
     return {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "command": " ".join(sys.argv),
@@ -392,7 +428,11 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "version": __version__,
         "model": getattr(info, "id", None) or props.get("model_id") or "unknown",
         "backend": props.get("backend") or "unknown",
-        "mtp": on_off(props.get("mtp_enabled")),
+        "mtp": mtp["status"],
+        "mtp_requested": mtp["requested"],
+        "mtp_session_ready": mtp["session_ready"],
+        "mtp_usable": mtp["usable"],
+        "mtp_failure_reason": mtp["failure_reason"],
         "mmproj": "loaded" if props.get("multimodal_available") is True else ("missing" if props else "unknown"),
         "cpu": host.cpu,
         "cores": {"physical": host.physical_cores, "logical": host.logical_cores},
@@ -406,6 +446,13 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
 def safe_backend_props(backend: LlamaServerBackend) -> dict[str, object]:
     try:
         return backend.backend_props()
+    except Exception:
+        return {}
+
+
+def fresh_backend_props(base_url: str, timeout: float) -> dict[str, object]:
+    try:
+        return LlamaServerBackend(base_url=base_url, timeout=timeout).backend_props()
     except Exception:
         return {}
 
@@ -442,6 +489,15 @@ def on_off(value: object) -> str:
     if value is False:
         return "off"
     return "unknown"
+
+
+def first_nonempty_str(*values: object) -> str | None:
+    for value in values:
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return text
+    return None
 
 
 def acceleration_mode(props: dict[str, object]) -> str:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from orbit.runtime.turn_trace import ModelStepMetrics
 
@@ -62,6 +63,104 @@ class SmokeHarnessTests(unittest.TestCase):
     def test_correctness_categorizer_detects_fake_shell20_without_tool_call(self) -> None:
         self.assertEqual(smoke_harness.check_shell20("line-19", []), "fake_tool_output")
         self.assertEqual(smoke_harness.check_shell20("line-19", ["exec_shell_full_command"]), "correct")
+
+    def test_mtp_state_marks_failed_props_as_not_usable(self) -> None:
+        state = smoke_harness.mtp_state_from_props(
+            {
+                "mtp_experimental_enabled": True,
+                "mtp_initialized": False,
+                "mtp_last_completion_success": False,
+                "mtp_failure_reason": "failed to decode target prefill suffix",
+            }
+        )
+
+        self.assertEqual(state["status"], "failed")
+        self.assertFalse(state["usable"])
+        self.assertEqual(state["failure_reason"], "failed to decode target prefill suffix")
+
+    def test_mtp_state_marks_session_ready_without_attempt_as_ready(self) -> None:
+        state = smoke_harness.mtp_state_from_props(
+            {
+                "mtp_experimental_enabled": True,
+                "mtp_initialized": True,
+                "mtp_last_completion_success": False,
+                "mtp_failure_reason": None,
+                "mtp_fallback_reason": None,
+            }
+        )
+
+        self.assertEqual(state["status"], "ready")
+        self.assertFalse(state["usable"])
+
+    def test_environment_summary_uses_mtp_state_fields(self) -> None:
+        class Backend:
+            def model_info(self):
+                return type("Info", (), {"id": "m"})()
+
+        args = smoke_harness.build_parser().parse_args([])
+        env = smoke_harness.environment_summary(
+            args=args,
+            backend=Backend(),
+            props={
+                "backend": "orbit-native",
+                "model_id": "m",
+                "multimodal_available": True,
+                "mtp_experimental_enabled": True,
+                "mtp_initialized": False,
+                "mtp_last_completion_success": False,
+                "mtp_failure_reason": "probe failed",
+            },
+        )
+
+        self.assertEqual(env["mtp"], "failed")
+        self.assertFalse(env["mtp_usable"])
+        self.assertEqual(env["mtp_failure_reason"], "probe failed")
+
+    def test_main_mtp_required_fails_when_post_run_props_not_usable(self) -> None:
+        initial = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        final = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": False,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": "failed to decode target prefill suffix",
+            "mtp_fallback_reason": "failed to decode target prefill suffix",
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=initial), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", return_value=final), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[]), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
+
+        self.assertEqual(rc, 2)
+
+    def test_main_mtp_required_passes_when_post_run_props_usable(self) -> None:
+        props = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": True,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=props), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", return_value=props), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[]), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
+
+        self.assertEqual(rc, 0)
 
     def test_jsonl_output_contains_environment_and_step_rows(self) -> None:
         report = smoke_harness.StepReport(


### PR DESCRIPTION
## Summary

This PR fixes a consistency bug in the external smoke harness MTP gate.

The harness no longer treats the initial `mtp_enabled` value as proof that MTP is actually usable. Instead it:
- distinguishes `mtp_requested`, `mtp_session_ready`, `mtp_usable`, and `mtp_failure_reason`
- re-reads `/props` after running the selected scenario
- fails `--mtp-required` if the backend degrades after the first request

## Root cause

On this setup, a native server started with `--mtp` can report an optimistic ready state before the first request:
- `mtp_enabled=true`
- `mtp_initialized=true`
- `mtp_failure_reason=null`

But the first real completion can still fail and degrade MTP to:
- `mtp_enabled=false`
- `mtp_initialized=false`
- `mtp_failure_reason=failed to decode target prefill suffix`

The harness previously checked only the initial state, so `--mtp-required` could pass once and fail immediately after.

## Scope

Changed:
- `scripts/orbit_smoke_harness.py`
- `tests/test_smoke_harness.py`

Unchanged:
- route behavior
- tool behavior
- prompt behavior
- backend MTP algorithm
- MTP/KV/vendor code

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_smoke_harness tests.test_native_mtp_experimental tests.test_runtime_status tests.test_cli tests.test_repl tests.test_commands -q`
- `python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

Observed behavior after the fix:
- if MTP is not truly usable, `--mtp-required` now fails consistently and clearly
- harness environment rows report final MTP state coherently (`requested` / `ready` / `failed` / `on`)

## Notes

This PR is diagnostic/gating only. It does not fix the underlying backend MTP failure on this setup (`failed to decode target prefill suffix`), which remains the RC12 blocker.
