### PR TITLE
Use settled MTP props in smoke harness

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -173,15 +173,20 @@ def main(argv: list[str] | None = None) -> int:
                 temperature=args.temperature,
             )
         )
-    env = environment_summary(args=args, backend=backend, props=fresh_backend_props(args.base_url, args.timeout))
+    final_props = settled_backend_props(args.base_url, args.timeout)
+    env = environment_summary(args=args, backend=backend, props=final_props)
     write_jsonl(jsonl_path, env, reports)
     write_markdown(markdown_path, env, reports)
+    scenario_failure = scenario_failure_reason(reports)
     if args.mtp_required:
-        final_mtp = mtp_state_from_props(fresh_backend_props(args.base_url, args.timeout))
+        final_mtp = mtp_state_from_props(final_props)
         if not final_mtp["usable"]:
             reason = final_mtp["failure_reason"] or final_mtp["status"]
             print(f"error: --mtp-required set but backend MTP is not usable ({reason})", file=sys.stderr)
             return 2
+    if scenario_failure is not None:
+        print(f"error: scenario failed ({scenario_failure})", file=sys.stderr)
+        return 1
     print(f"jsonl={jsonl_path}")
     print(f"markdown={markdown_path}")
     return 0
@@ -457,11 +462,46 @@ def fresh_backend_props(base_url: str, timeout: float) -> dict[str, object]:
         return {}
 
 
+def settled_backend_props(base_url: str, timeout: float, *, settle_seconds: float = 2.0, poll_interval: float = 0.2) -> dict[str, object]:
+    props = fresh_backend_props(base_url, timeout)
+    if not props:
+        return {}
+    last_serialized = json.dumps(props, sort_keys=True, ensure_ascii=False)
+    deadline = time.monotonic() + max(0.0, settle_seconds)
+    while time.monotonic() < deadline:
+        state = mtp_state_from_props(props)
+        if state["usable"]:
+            return props
+        if state["failure_reason"] is None and not state["requested"]:
+            return props
+        time.sleep(poll_interval)
+        refreshed = fresh_backend_props(base_url, timeout)
+        if not refreshed:
+            return props
+        serialized = json.dumps(refreshed, sort_keys=True, ensure_ascii=False)
+        props = refreshed
+        if serialized == last_serialized and state["failure_reason"] != "cancelled":
+            return props
+        last_serialized = serialized
+    return props
+
+
 def safe_model_info(backend: LlamaServerBackend):
     try:
         return backend.model_info()
     except Exception:
         return None
+
+
+def scenario_failure_reason(reports: list[StepReport]) -> str | None:
+    for report in reports:
+        if report.notes != "exception":
+            continue
+        text = report.answer_excerpt.lower()
+        if "timed out" in text or "timeout" in text:
+            return "timeout"
+        return "error"
+    return None
 
 
 def git_head() -> str:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -21,6 +21,31 @@ SPEC.loader.exec_module(smoke_harness)
 
 
 class SmokeHarnessTests(unittest.TestCase):
+    def _step_report(self, *, notes: str = "", answer_excerpt: str = "", finish_reason: str = "stop") -> smoke_harness.StepReport:
+        return smoke_harness.StepReport(
+            case="simple_chat",
+            step=1,
+            prompt="hi",
+            prompt_kind="chat",
+            completion_kind="chat_final",
+            route_tokens=None,
+            final_tokens=12,
+            prompt_tokens=12,
+            cached_tokens=4,
+            evaluated_tokens=8,
+            finish_reason=finish_reason,
+            tool_calls=0,
+            tool_names=[],
+            wall_ms=10.0,
+            correctness_category="correct",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes=notes,
+            answer_excerpt=answer_excerpt,
+            model_steps=[],
+        )
+
     def test_parser_accepts_output_and_selection_options(self) -> None:
         args = smoke_harness.build_parser().parse_args(
             [
@@ -161,6 +186,104 @@ class SmokeHarnessTests(unittest.TestCase):
             rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
 
         self.assertEqual(rc, 0)
+
+    def test_main_mtp_required_uses_settled_final_props_over_stale_cancelled_state(self) -> None:
+        initial = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        stale = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": "cancelled",
+            "mtp_fallback_reason": "cancelled",
+        }
+        healthy = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": True,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        captured_env: list[dict[str, object]] = []
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=initial), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", side_effect=[stale, healthy, healthy]), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[]), \
+            mock.patch.object(smoke_harness, "write_jsonl", side_effect=lambda _p, env, _r: captured_env.append(env)), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(captured_env)
+        self.assertEqual(captured_env[0]["mtp"], "on")
+        self.assertTrue(captured_env[0]["mtp_usable"])
+
+    def test_main_timeout_with_healthy_final_props_fails_as_timeout_not_mtp(self) -> None:
+        initial = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        healthy = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": True,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        report = self._step_report(
+            notes="exception",
+            answer_excerpt="LlamaServerError: backend server request timed out after 60s",
+            finish_reason="error",
+        )
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=initial), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", return_value=healthy), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[report]), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "shell20", "--no-web", "--output-dir", tmp])
+
+        self.assertEqual(rc, 1)
+
+    def test_main_correct_scenario_with_failed_final_props_still_fails_mtp_required(self) -> None:
+        initial = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        failed = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": False,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": "failed to decode target prefill suffix",
+            "mtp_fallback_reason": "failed to decode target prefill suffix",
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=initial), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", return_value=failed), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[self._step_report()]), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
+
+        self.assertEqual(rc, 2)
 
     def test_jsonl_output_contains_environment_and_step_rows(self) -> None:
         report = smoke_harness.StepReport(


### PR DESCRIPTION
## Summary

This PR fixes false negatives in the smoke harness MTP gate.

The harness previously treated a single immediate post-scenario `/props` read as final truth. For interrupted or recently cancelled scenarios, that snapshot could briefly report a transient cancelled/failed MTP state even when the backend settled back to healthy immediately after.

The harness now:
- polls final `/props` briefly for a settled state
- uses settled final props in the environment row
- separates scenario status from MTP usability
- makes `--mtp-required` fail only when settled final props report MTP unusable

## Exit behavior

- `0`: scenario succeeded, and MTP is usable when `--mtp-required` is set
- `1`: scenario timeout/error while final MTP remains healthy
- `2`: final MTP is not usable under `--mtp-required`

## Validation

Tests:
- `PYTHONPATH=src python3 -m unittest tests.test_smoke_harness -q`
- targeted suite PASS
- `python3 -m unittest discover -s tests -q`
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

Smoke:
- `shell20 --timeout 120 --mtp-required`: exit 0, final `/props` healthy
- `shell20 --timeout 60` without `--mtp-required`: timeout, final `/props` healthy, not reported as MTP failed
- after timeout, `simple_chat --mtp-required`: exit 0, final `/props` healthy
- `shell_error --timeout 60 --mtp-required`: exit 0, final `/props` healthy

## Notes

This PR does not change runtime behavior, backend MTP algorithms, route/tool behavior, prompt policy, or vendor code.

`pwd_followup` remains unsuitable as the primary `--mtp-required` proof because it can resolve route-only.
