### PR TITLE
Bound smoke harness step timeouts

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import queue
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -171,17 +175,23 @@ def main(argv: list[str] | None = None) -> int:
                 workdir=Path(args.workdir),
                 max_tokens=args.max_tokens,
                 temperature=args.temperature,
+                timeout=args.timeout,
             )
         )
-    env = environment_summary(args=args, backend=backend, props=fresh_backend_props(args.base_url, args.timeout))
+    final_props = settled_backend_props(args.base_url, args.timeout)
+    env = environment_summary(args=args, backend=backend, props=final_props)
     write_jsonl(jsonl_path, env, reports)
     write_markdown(markdown_path, env, reports)
     if args.mtp_required:
-        final_mtp = mtp_state_from_props(fresh_backend_props(args.base_url, args.timeout))
+        final_mtp = mtp_state_from_props(final_props)
         if not final_mtp["usable"]:
             reason = final_mtp["failure_reason"] or final_mtp["status"]
             print(f"error: --mtp-required set but backend MTP is not usable ({reason})", file=sys.stderr)
             return 2
+    scenario_failure = scenario_failure_reason(reports)
+    if scenario_failure is not None:
+        print(f"error: scenario failed ({scenario_failure})", file=sys.stderr)
+        return 1
     print(f"jsonl={jsonl_path}")
     print(f"markdown={markdown_path}")
     return 0
@@ -289,6 +299,7 @@ def run_scenario(
     workdir: Path,
     max_tokens: int,
     temperature: float,
+    timeout: float,
 ) -> list[StepReport]:
     runtime = ChatRuntime(
         backend=ProbeBackend(backend),
@@ -297,21 +308,92 @@ def run_scenario(
     )
     reports: list[StepReport] = []
     for index, step in enumerate(scenario.steps, start=1):
-        reports.append(
-            run_step(
+        report = run_step(
+            runtime,
+            scenario=scenario.name,
+            step_index=index,
+            step=step,
+            workdir=workdir,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            base_url=backend.base_url,
+            timeout=timeout,
+        )
+        reports.append(report)
+        if report.finish_reason in {"timeout", "error"}:
+            break
+    return reports
+
+
+def run_step(
+    runtime: ChatRuntime,
+    *,
+    scenario: str,
+    step_index: int,
+    step: SmokeStep,
+    workdir: Path,
+    max_tokens: int,
+    temperature: float,
+    base_url: str,
+    timeout: float,
+) -> StepReport:
+    result_queue: queue.Queue[StepReport] = queue.Queue(maxsize=1)
+
+    worker = threading.Thread(
+        target=lambda: result_queue.put(
+            _run_step_inner(
                 runtime,
-                scenario=scenario.name,
-                step_index=index,
+                scenario=scenario,
+                step_index=step_index,
                 step=step,
                 workdir=workdir,
                 max_tokens=max_tokens,
                 temperature=temperature,
             )
+        ),
+        daemon=True,
+    )
+    started = time.perf_counter()
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        cancel_requested = request_backend_cancel(base_url, timeout=min(5.0, max(1.0, timeout)))
+        props_after = wait_for_backend_idle(base_url, timeout=min(5.0, max(1.0, timeout)))
+        worker.join(min(2.0, max(0.5, timeout / 10.0)))
+        notes = "timeout"
+        if cancel_requested:
+            notes += ",cancel_requested"
+        if props_after.get("in_flight") is False:
+            notes += ",cleanup_ok"
+        elif props_after:
+            notes += ",cleanup_pending"
+        return StepReport(
+            case=scenario,
+            step=step_index,
+            prompt=step.prompt,
+            prompt_kind=step.mode,
+            completion_kind="timeout",
+            route_tokens=None,
+            final_tokens=None,
+            prompt_tokens=None,
+            cached_tokens=None,
+            evaluated_tokens=None,
+            finish_reason="timeout",
+            tool_calls=0,
+            tool_names=[],
+            wall_ms=round((time.perf_counter() - started) * 1000, 1),
+            correctness_category="not_evaluated",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes=notes,
+            answer_excerpt="timeout",
+            model_steps=[],
         )
-    return reports
+    return result_queue.get()
 
 
-def run_step(
+def _run_step_inner(
     runtime: ChatRuntime,
     *,
     scenario: str,
@@ -457,11 +539,71 @@ def fresh_backend_props(base_url: str, timeout: float) -> dict[str, object]:
         return {}
 
 
+def request_backend_cancel(base_url: str, timeout: float) -> bool:
+    request = Request(
+        f"{base_url.rstrip('/')}/cancel",
+        data=json.dumps({"session_id": "default"}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8", errors="replace"))
+    except (OSError, URLError, TimeoutError, json.JSONDecodeError):
+        return False
+    return payload.get("status") == "cancel_requested"
+
+
+def wait_for_backend_idle(base_url: str, timeout: float, *, poll_interval: float = 0.2) -> dict[str, object]:
+    deadline = time.monotonic() + max(0.0, timeout)
+    latest: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        latest = fresh_backend_props(base_url, timeout=min(2.0, max(0.5, timeout)))
+        if latest and latest.get("in_flight") is False:
+            return latest
+        time.sleep(poll_interval)
+    return latest
+
+
+def settled_backend_props(base_url: str, timeout: float, *, settle_seconds: float = 3.0, poll_interval: float = 0.2) -> dict[str, object]:
+    props = fresh_backend_props(base_url, timeout)
+    if not props:
+        return {}
+    deadline = time.monotonic() + max(0.0, settle_seconds)
+    last_serialized = json.dumps(props, sort_keys=True, ensure_ascii=False)
+    while time.monotonic() < deadline:
+        if props.get("in_flight") is False:
+            failure_reason = first_nonempty_str(props.get("mtp_failure_reason"), props.get("mtp_fallback_reason"))
+            if failure_reason not in {"cancelled", "timeout"}:
+                return props
+        time.sleep(poll_interval)
+        refreshed = fresh_backend_props(base_url, timeout=min(2.0, max(0.5, timeout)))
+        if not refreshed:
+            return props
+        serialized = json.dumps(refreshed, sort_keys=True, ensure_ascii=False)
+        props = refreshed
+        if serialized == last_serialized and props.get("in_flight") is False:
+            return props
+        last_serialized = serialized
+    return props
+
+
 def safe_model_info(backend: LlamaServerBackend):
     try:
         return backend.model_info()
     except Exception:
         return None
+
+
+def scenario_failure_reason(reports: list[StepReport]) -> str | None:
+    for report in reports:
+        if report.finish_reason == "timeout" or "timeout" in report.notes:
+            return "timeout"
+        if report.notes == "exception":
+            return "error"
+        if report.finish_reason == "error":
+            return "error"
+    return None
 
 
 def git_head() -> str:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -244,6 +245,169 @@ class SmokeHarnessTests(unittest.TestCase):
         )
 
         self.assertEqual(row["evaluated_tokens"], 60)
+
+    def test_run_step_timeout_requests_cancel_and_returns_timeout_report(self) -> None:
+        runtime = mock.Mock()
+
+        def slow_ask_chat(*args, **kwargs):
+            time.sleep(0.2)
+            raise AssertionError("worker should have been abandoned after timeout")
+
+        runtime.ask_chat.side_effect = slow_ask_chat
+        with mock.patch.object(smoke_harness, "request_backend_cancel", return_value=True) as mocked_cancel, \
+            mock.patch.object(smoke_harness, "wait_for_backend_idle", return_value={"in_flight": False}):
+            report = smoke_harness.run_step(
+                runtime,
+                scenario="simple_chat",
+                step_index=1,
+                step=smoke_harness.SmokeStep("hi", mode="chat", checker_name="nonempty"),
+                workdir=Path("workdir"),
+                max_tokens=16,
+                temperature=0.0,
+                base_url="http://127.0.0.1:12120",
+                timeout=0.01,
+            )
+
+        mocked_cancel.assert_called_once()
+        self.assertEqual(report.finish_reason, "timeout")
+        self.assertEqual(report.completion_kind, "timeout")
+        self.assertIn("cancel_requested", report.notes)
+        self.assertIn("cleanup_ok", report.notes)
+
+    def test_main_returns_timeout_failure_when_report_times_out(self) -> None:
+        timeout_report = smoke_harness.StepReport(
+            case="shell20",
+            step=1,
+            prompt="run python3 -c 'for i in range(20): print(f\"line-{i}\")'",
+            prompt_kind="auto",
+            completion_kind="timeout",
+            route_tokens=None,
+            final_tokens=None,
+            prompt_tokens=None,
+            cached_tokens=None,
+            evaluated_tokens=None,
+            finish_reason="timeout",
+            tool_calls=0,
+            tool_names=[],
+            wall_ms=60001.0,
+            correctness_category="not_evaluated",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes="timeout,cancel_requested,cleanup_ok",
+            answer_excerpt="timeout",
+            model_steps=[],
+        )
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value={}), \
+            mock.patch.object(smoke_harness, "fresh_backend_props", return_value={}), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[timeout_report]), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "shell20", "--no-web", "--output-dir", tmp, "--timeout", "60"])
+
+        self.assertEqual(rc, 1)
+
+    def test_wait_for_backend_idle_returns_when_inflight_clears(self) -> None:
+        with mock.patch.object(
+            smoke_harness,
+            "fresh_backend_props",
+            side_effect=[{"in_flight": True}, {"in_flight": False, "mtp_enabled": True}],
+        ):
+            props = smoke_harness.wait_for_backend_idle("http://127.0.0.1:12120", 1.0, poll_interval=0.0)
+
+        self.assertEqual(props.get("in_flight"), False)
+
+    def test_settled_backend_props_waits_past_cancelled_snapshot(self) -> None:
+        with mock.patch.object(
+            smoke_harness,
+            "fresh_backend_props",
+            side_effect=[
+                {"in_flight": False, "mtp_fallback_reason": "cancelled", "mtp_failure_reason": None},
+                {"in_flight": False, "mtp_fallback_reason": None, "mtp_failure_reason": None, "mtp_initialized": True},
+            ],
+        ):
+            props = smoke_harness.settled_backend_props("http://127.0.0.1:12120", 1.0, settle_seconds=0.5, poll_interval=0.0)
+
+        self.assertIsNone(props.get("mtp_fallback_reason"))
+        self.assertTrue(props.get("mtp_initialized"))
+
+    def test_run_scenario_stops_after_timeout_report(self) -> None:
+        scenario = smoke_harness.SmokeScenario(
+            "shell20",
+            (
+                smoke_harness.SmokeStep("first"),
+                smoke_harness.SmokeStep("second"),
+            ),
+        )
+        timeout_report = smoke_harness.StepReport(
+            case="shell20",
+            step=1,
+            prompt="first",
+            prompt_kind="auto",
+            completion_kind="timeout",
+            route_tokens=None,
+            final_tokens=None,
+            prompt_tokens=None,
+            cached_tokens=None,
+            evaluated_tokens=None,
+            finish_reason="timeout",
+            tool_calls=0,
+            tool_names=[],
+            wall_ms=60000.0,
+            correctness_category="not_evaluated",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes="timeout",
+            answer_excerpt="timeout",
+            model_steps=[],
+        )
+        with mock.patch.object(smoke_harness, "run_step", return_value=timeout_report) as mocked_run_step, \
+            mock.patch.object(smoke_harness, "ChatRuntime"):
+            reports = smoke_harness.run_scenario(
+                scenario,
+                backend=mock.Mock(base_url="http://127.0.0.1:12120"),
+                workdir=Path("workdir"),
+                max_tokens=128,
+                temperature=0.0,
+                timeout=60.0,
+            )
+
+        self.assertEqual(len(reports), 1)
+        mocked_run_step.assert_called_once()
+
+    def test_main_uses_settled_props_for_environment_row(self) -> None:
+        initial = {
+            "backend": "orbit-native",
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": False,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        settled = {
+            "backend": "orbit-native",
+            "model_id": "m",
+            "multimodal_available": True,
+            "mtp_experimental_enabled": True,
+            "mtp_initialized": True,
+            "mtp_last_completion_success": True,
+            "mtp_failure_reason": None,
+            "mtp_fallback_reason": None,
+        }
+        captured_env: list[dict[str, object]] = []
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value=initial), \
+            mock.patch.object(smoke_harness, "settled_backend_props", return_value=settled), \
+            mock.patch.object(smoke_harness, "run_scenario", return_value=[]), \
+            mock.patch.object(smoke_harness, "write_jsonl", side_effect=lambda _p, env, _r: captured_env.append(env)), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(["--scenario", "simple_chat", "--no-web", "--output-dir", tmp, "--mtp-required"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured_env[0]["mtp"], "on")
+        self.assertTrue(captured_env[0]["mtp_usable"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n\nThis PR makes smoke harness timeouts wall-clock bounded.\n\nPreviously the harness relied on backend HTTP/socket timeouts. Long streamed completions could keep the socket alive with periodic stream/progress traffic, so  did not reliably bound total step runtime.\n\nThe harness now:\n- enforces per-step wall-clock timeouts\n- sends  when a step times out\n- waits briefly for cleanup via \n- stops a scenario after the first timeout/error\n- reports timeout as a scenario failure, not as MTP failure when the backend returns healthy\n- uses settled  for final environment reporting\n\n## Validation\n\nTests:\n- jsonl=/tmp/tmpna8j_moa/orbit_smoke_20260706T182747Z.jsonl
markdown=/tmp/tmpna8j_moa/orbit_smoke_20260706T182747Z.md
jsonl=/tmp/tmp6chh8n04/orbit_smoke_20260706T182750Z.jsonl
markdown=/tmp/tmp6chh8n04/orbit_smoke_20260706T182750Z.md\n- ==> checking toolchain
session reset
jsonl=/tmp/tmphtu4bjzj/orbit_smoke_20260706T182805Z.jsonl
markdown=/tmp/tmphtu4bjzj/orbit_smoke_20260706T182805Z.md
jsonl=/tmp/tmpdo8b_4_5/orbit_smoke_20260706T182808Z.jsonl
markdown=/tmp/tmpdo8b_4_5/orbit_smoke_20260706T182808Z.md
[2m◐ Working (0s - Ctrl+C to interrupt)[0m                                           [2m◐ Working (0s - Ctrl+C to interrupt)[0m                                           [2m◓ Working (1s - Ctrl+C to interrupt)[0m                                           [2m◓ Working [generation] (1s, 1/128 tk (0%) - Ctrl+C to interrupt)[0m               [2m◓ Working (1s - Ctrl+C to interrupt)[0m                                           [2m◑ Working (2s - Ctrl+C to interrupt)[0m                                           [2m◑ Working [generation] (2s, 1/128 tk (0%) - Ctrl+C to interrupt)[0m               [2m◑ Working (2s - Ctrl+C to interrupt)[0m                                           [2m◒ Working (3s - Ctrl+C to interrupt)[0m                                           [2m◒ Working [generation] (3s, 1/128 tk (0%) - Ctrl+C to interrupt)[0m               [2m◒ Working (3s - Ctrl+C to interrupt)[0m                                           [2m◐ Working (4s - Ctrl+C to interrupt)[0m                                           [2m◐ Working [generation] (4s, 1/128 tk (0%) - Ctrl+C to interrupt)[0m               [2m◐ Working (4s - Ctrl+C to interrupt)[0m                                           \n- \n- \n\nSmoke:\n- fresh  server\n-  exits bounded with RC=1\n- report includes , , , \n- final  remains healthy:\n  - \n  - \n  - \n  - \n-  remains healthy after 5s and 15s\n- same server recovery:  exits 0\n\n## Scope\n\nThis is harness-only.\n\nUnchanged:\n- runtime behavior\n- backend/MTP algorithm\n- route/tool behavior\n- prompt policy\n- vendor code