### PR TITLE
Expose MTP config diagnostics in props

### DIFF
--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -222,6 +222,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             session = state.session_info()
             runtime = state.runtime_info()
             mtp_last_completion = _mtp_last_completion_payload(state.client)
+            mtp_config = _mtp_config_payload(state.client)
             self._json(
                 {
                     "model_path": str(state.client.paths.model),
@@ -251,6 +252,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "mtp_experimental_enabled": state.client.config.use_mtp_experimental,
                     "mtp_last_completion_success": state.client.last_mtp_completion.success,
                     "mtp_last_completion": mtp_last_completion,
+                    "mtp_config": mtp_config,
                     "mtp_fallback_reason": state.client.mtp_fallback_reason,
                     "mtp_enabled": session["mtp_enabled"],
                     "mtp_initialized": session["mtp_initialized"],
@@ -828,6 +830,20 @@ def _mtp_last_completion_payload(client: NativeLlamaClient) -> dict[str, object]
         "rollback_tokens_total": completion.rollback_tokens_total,
         "checkpoint_count": completion.checkpoint_count,
         "restore_count": completion.restore_count,
+    }
+
+
+def _mtp_config_payload(client: NativeLlamaClient) -> dict[str, object] | None:
+    if not client.config.use_mtp_experimental:
+        return None
+    return {
+        # Keep this in sync with the hardcoded Orbit native MTP shim config.
+        "n_max": 3,
+        "n_min": None,
+        "p_min": None,
+        "backend_sampling": None,
+        "ctx_tgt": client._session.ctx_tgt is not None,
+        "ctx_dft": client._session.ctx_dft is not None,
     }
 
 

--- a/tests/test_bench_mtp_throughput.py
+++ b/tests/test_bench_mtp_throughput.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from orbit.native_server.app import _mtp_last_completion_payload
+from orbit.native_server.app import _mtp_config_payload, _mtp_last_completion_payload
 from orbit.native_llama.mtp_completion import MtpCompletionResult
 
 
@@ -22,6 +22,30 @@ SPEC.loader.exec_module(bench_mtp)
 
 
 class NativeServerMtpPropsTests(unittest.TestCase):
+    def test_mtp_config_payload_is_none_when_mtp_experimental_is_disabled(self) -> None:
+        client = SimpleNamespace(
+            config=SimpleNamespace(use_mtp_experimental=False),
+            _session=SimpleNamespace(ctx_tgt=None, ctx_dft=None),
+        )
+
+        self.assertIsNone(_mtp_config_payload(client))
+
+    def test_mtp_config_payload_exposes_available_effective_values(self) -> None:
+        client = SimpleNamespace(
+            config=SimpleNamespace(use_mtp_experimental=True),
+            _session=SimpleNamespace(ctx_tgt=object(), ctx_dft=None),
+        )
+
+        payload = _mtp_config_payload(client)
+
+        assert payload is not None
+        self.assertEqual(payload["n_max"], 3)
+        self.assertIsNone(payload["n_min"])
+        self.assertIsNone(payload["p_min"])
+        self.assertIsNone(payload["backend_sampling"])
+        self.assertTrue(payload["ctx_tgt"])
+        self.assertFalse(payload["ctx_dft"])
+
     def test_mtp_last_completion_payload_is_none_when_completion_is_disabled(self) -> None:
         client = SimpleNamespace(
             last_mtp_completion=MtpCompletionResult(


### PR DESCRIPTION
## Summary

This PR exposes a small read-only `mtp_config` block through `/props`.

It reports the MTP configuration values currently available from the Python/runtime side:

- `n_max`
- `ctx_tgt`
- `ctx_dft`

Values that are not currently available without extending the native shim are reported as `null`:

- `n_min`
- `p_min`
- `backend_sampling`

This is diagnostic only. It does not make `n_max` configurable and does not change MTP behavior.

## Validation

- `python3 -m compileall -q src/orbit/native_server tests`
- `PYTHONPATH=src python3 -m unittest tests.test_bench_mtp_throughput -q`
- `git diff --cached --check`

Manual smoke:

- started `orbit server --mtp`
- checked `/props` after startup
- ran one minimal chat completion
- checked `/props` after completion

Observed:

```json
{
  "mtp_config": {
    "n_max": 3,
    "n_min": null,
    "p_min": null,
    "backend_sampling": null,
    "ctx_tgt": true,
    "ctx_dft": true
  },
  "mtp_enabled": true,
  "mtp_initialized": true,
  "mtp_failure_reason": null,
  "in_flight": false
}
```
