### PR TITLE
Expose MTP timing diagnostics in props

### DIFF
--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -222,6 +222,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             session = state.session_info()
             runtime = state.runtime_info()
             mtp_last_completion = _mtp_last_completion_payload(state.client)
+            mtp_last_timing = _mtp_last_timing_payload(state.client)
             mtp_config = _mtp_config_payload(state.client)
             self._json(
                 {
@@ -252,6 +253,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "mtp_experimental_enabled": state.client.config.use_mtp_experimental,
                     "mtp_last_completion_success": state.client.last_mtp_completion.success,
                     "mtp_last_completion": mtp_last_completion,
+                    "mtp_last_timing": mtp_last_timing,
                     "mtp_config": mtp_config,
                     "mtp_fallback_reason": state.client.mtp_fallback_reason,
                     "mtp_enabled": session["mtp_enabled"],
@@ -830,6 +832,67 @@ def _mtp_last_completion_payload(client: NativeLlamaClient) -> dict[str, object]
         "rollback_tokens_total": completion.rollback_tokens_total,
         "checkpoint_count": completion.checkpoint_count,
         "restore_count": completion.restore_count,
+    }
+
+
+def _mtp_last_timing_payload(client: NativeLlamaClient) -> dict[str, object] | None:
+    completion = client.last_mtp_completion
+    if not completion.enabled or not completion.timing_json:
+        return None
+    try:
+        payload = json.loads(completion.timing_json)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        return None
+
+    def _number(name: str) -> float | int | None:
+        value = summary.get(name)
+        if isinstance(value, (int, float)):
+            return value
+        return None
+
+    total_ms = _number("total_wall_ms")
+    suffix_target_prefill_ms = _number("suffix_target_prefill_ms")
+    speculative_loop_ms = _number("speculative_loop_ms")
+    speculative_loop_including_suffix_ms = _number("speculative_loop_including_suffix_ms")
+    target_validate_ms = _number("target_validate_ms")
+    draft_generation_ms = _number("draft_generation_ms")
+    checkpoint_restore_ms = _number("checkpoint_restore_ms")
+    sampler_ms = _number("sampler_ms")
+    seq_rm_ms = _number("seq_rm_ms")
+    non_loop_overhead_ms = _number("non_loop_overhead_ms")
+
+    other_ms = None
+    if isinstance(total_ms, (int, float)):
+        known_components = [
+            suffix_target_prefill_ms,
+            speculative_loop_ms,
+            target_validate_ms,
+            draft_generation_ms,
+            checkpoint_restore_ms,
+            sampler_ms,
+            seq_rm_ms,
+            non_loop_overhead_ms,
+        ]
+        known_total = sum(float(value) for value in known_components if isinstance(value, (int, float)))
+        other_ms = max(0.0, float(total_ms) - known_total)
+
+    return {
+        "total_ms": total_ms,
+        "suffix_target_prefill_ms": suffix_target_prefill_ms,
+        "speculative_loop_ms": speculative_loop_ms,
+        "speculative_loop_including_suffix_ms": speculative_loop_including_suffix_ms,
+        "target_validate_ms": target_validate_ms,
+        "draft_generation_ms": draft_generation_ms,
+        "checkpoint_restore_ms": checkpoint_restore_ms,
+        "sampler_ms": sampler_ms,
+        "seq_rm_ms": seq_rm_ms,
+        "non_loop_overhead_ms": non_loop_overhead_ms,
+        "other_ms": other_ms,
     }
 
 

--- a/tests/test_bench_mtp_throughput.py
+++ b/tests/test_bench_mtp_throughput.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from orbit.native_server.app import _mtp_config_payload, _mtp_last_completion_payload
+from orbit.native_server.app import _mtp_config_payload, _mtp_last_completion_payload, _mtp_last_timing_payload
 from orbit.native_llama.mtp_completion import MtpCompletionResult
 
 
@@ -101,6 +101,75 @@ class NativeServerMtpPropsTests(unittest.TestCase):
         self.assertEqual(payload["rollback_tokens_total"], 0)
         self.assertEqual(payload["checkpoint_count"], 0)
         self.assertEqual(payload["restore_count"], 0)
+
+    def test_mtp_last_timing_payload_is_none_when_completion_is_disabled(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=False,
+                success=False,
+                error=None,
+            )
+        )
+
+        self.assertIsNone(_mtp_last_timing_payload(client))
+
+    def test_mtp_last_timing_payload_is_none_when_timing_json_is_absent(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                timing_json=None,
+            )
+        )
+
+        self.assertIsNone(_mtp_last_timing_payload(client))
+
+    def test_mtp_last_timing_payload_is_none_when_timing_json_is_malformed(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                timing_json="{",
+            )
+        )
+
+        self.assertIsNone(_mtp_last_timing_payload(client))
+
+    def test_mtp_last_timing_payload_extracts_summary_and_preserves_zero(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                timing_json=json.dumps(
+                    {
+                        "summary": {
+                            "total_wall_ms": 10.0,
+                            "suffix_target_prefill_ms": 0.0,
+                            "speculative_loop_ms": 6.0,
+                            "speculative_loop_including_suffix_ms": 6.5,
+                            "target_validate_ms": 2.0,
+                            "draft_generation_ms": 1.5,
+                            "checkpoint_restore_ms": 0.0,
+                            "sampler_ms": 0.5,
+                            "seq_rm_ms": 0.0,
+                            "non_loop_overhead_ms": 1.0,
+                        }
+                    }
+                ),
+            )
+        )
+
+        payload = _mtp_last_timing_payload(client)
+
+        assert payload is not None
+        self.assertEqual(payload["total_ms"], 10.0)
+        self.assertEqual(payload["suffix_target_prefill_ms"], 0.0)
+        self.assertEqual(payload["checkpoint_restore_ms"], 0.0)
+        self.assertEqual(payload["seq_rm_ms"], 0.0)
+        self.assertEqual(payload["other_ms"], 0.0)
 
 
 class BenchMtpThroughputMarkdownTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR adds a small read-only `mtp_last_timing` block to `/props`.

The payload is derived from `client.last_mtp_completion.timing_json.summary` when MTP trace timing is available.

It exposes aggregated timing only:

- `total_ms`
- `suffix_target_prefill_ms`
- `speculative_loop_ms`
- `speculative_loop_including_suffix_ms`
- `target_validate_ms`
- `draft_generation_ms`
- `checkpoint_restore_ms`
- `sampler_ms`
- `seq_rm_ms`
- `non_loop_overhead_ms`
- `other_ms`

Raw traces are intentionally not exposed.

## Validation

- `python3 -m compileall -q src/orbit/native_server tests`
- `PYTHONPATH=src python3 -m unittest tests.test_bench_mtp_throughput -q`
- `git diff --check`

Manual smoke with `ORBIT_MTP_TRACE=1`:

- started `orbit server --mtp`
- ran one direct `medium_chat` completion
- checked `/props`
- `mtp_failure_reason=null`
- `in_flight=false`
- `mtp_last_timing` present

Observed timing sample:

- `total_ms=48173.7`
- `target_validate_ms=37915.4`
- `draft_generation_ms=4589.93`
- `checkpoint_restore_ms=376.191`
- `seq_rm_ms=1.57806`

## Notes / Risks

- Diagnostic only. No MTP behavior change.
- `mtp_last_timing` is present only when timing_json exists.
- Malformed or absent timing JSON returns `null`.
- Raw `trace_json`, `validate_trace_json`, and `target_decode_trace_json` are not exposed.
- The timing sample confirms target validation dominates this workload.
