### PR TITLE
Expose MTP validate equivalence diagnostics

### DIFF
--- a/src/orbit/native_llama/mtp_completion.py
+++ b/src/orbit/native_llama/mtp_completion.py
@@ -53,6 +53,7 @@ class MtpCompletionResult:
     timing_json: str | None = None
     validate_trace_json: str | None = None
     target_decode_trace_json: str | None = None
+    validate_equivalence_json: str | None = None
     output_token_hashes_json: str | None = None
     first_sample_trace_json: str | None = None
 

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -167,6 +167,9 @@ class PersistentMtpLibrary:
         if hasattr(lib, "orbit_mtp_session_last_first_sample_trace_json"):
             lib.orbit_mtp_session_last_first_sample_trace_json.argtypes = [c_void_p]
             lib.orbit_mtp_session_last_first_sample_trace_json.restype = c_char_p
+        if hasattr(lib, "orbit_mtp_session_last_validate_equivalence_json"):
+            lib.orbit_mtp_session_last_validate_equivalence_json.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_validate_equivalence_json.restype = c_char_p
 
 
 def build_persistent_mtp_shim(
@@ -416,6 +419,7 @@ def run_persistent_mtp_completion(
         timing_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_timing_json", runtime.handle) if trace_enabled else None,
         validate_trace_json=None,
         target_decode_trace_json=None,
+        validate_equivalence_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_validate_equivalence_json", runtime.handle) if trace_enabled else None,
         output_token_hashes_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_output_token_hashes_json", runtime.handle) if trace_enabled else None,
         first_sample_trace_json=_optional_trace_text(library.lib, "orbit_mtp_session_last_first_sample_trace_json", runtime.handle) if trace_enabled else None,
     )

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -54,6 +54,11 @@ static bool validate_debug_enabled() {
     return value && value[0] && std::strcmp(value, "0") != 0;
 }
 
+static bool mtp_trace_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_TRACE");
+    return value && value[0] && std::strcmp(value, "0") != 0;
+}
+
 static bool boundary_split_enabled() {
     const char * value = std::getenv("ORBIT_MTP_BOUNDARY_SPLIT");
     if (!value || !value[0]) {
@@ -221,6 +226,7 @@ struct orbit_mtp_session {
     std::string last_timing_json;
     std::string last_validate_trace_json;
     std::string last_target_decode_trace_json;
+    std::string last_validate_equivalence_json;
     std::vector<uint64_t> last_output_token_hashes;
     std::string last_output_token_hashes_json;
     std::string last_first_sample_trace_json;
@@ -518,6 +524,110 @@ static std::string trace_step_json(const llama_vocab * vocab, const orbit_trace_
             << ",\"prefill_count\":" << step.prefill_count;
     }
     out << "}";
+    return out.str();
+}
+
+static std::string validate_equivalence_json(
+    const std::vector<orbit_trace_step> & steps,
+    int rows_requested_total,
+    int rows_consumed_estimated_total,
+    int rows_wasted_estimated_total
+) {
+    static constexpr size_t max_step_sample = 64;
+    int hist_0 = 0;
+    int hist_1 = 0;
+    int hist_2 = 0;
+    int hist_3 = 0;
+    int hist_ge4 = 0;
+    bool all_steps_have_frontier = !steps.empty();
+    bool all_steps_have_sampler_hash = !steps.empty();
+    for (const auto & step : steps) {
+        if (step.accepted_draft <= 0) {
+            hist_0++;
+        } else if (step.accepted_draft == 1) {
+            hist_1++;
+        } else if (step.accepted_draft == 2) {
+            hist_2++;
+        } else if (step.accepted_draft == 3) {
+            hist_3++;
+        } else {
+            hist_ge4++;
+        }
+        all_steps_have_frontier = all_steps_have_frontier &&
+            step.kv_tgt_before_min >= 0 &&
+            step.kv_tgt_before_max >= step.kv_tgt_before_min &&
+            step.kv_tgt_after_min >= 0 &&
+            step.kv_tgt_after_max >= step.kv_tgt_after_min;
+        all_steps_have_sampler_hash = all_steps_have_sampler_hash &&
+            step.sampler_state_hash_before != 0 &&
+            step.sampler_state_hash_after != 0;
+    }
+    const double rows_wasted_estimated_ratio = rows_requested_total > 0
+        ? (double) rows_wasted_estimated_total / (double) rows_requested_total
+        : 0.0;
+
+    std::ostringstream out;
+    out
+        << "{"
+        << "\"steps\":" << steps.size()
+        << ",\"steps_recorded\":" << std::min(steps.size(), max_step_sample)
+        << ",\"rows_requested_total\":" << rows_requested_total
+        << ",\"rows_consumed_estimated_total\":" << rows_consumed_estimated_total
+        << ",\"rows_wasted_estimated_total\":" << rows_wasted_estimated_total
+        << ",\"rows_wasted_estimated_ratio\":" << rows_wasted_estimated_ratio
+        << ",\"accepted_draft_histogram\":{"
+        << "\"0\":" << hist_0
+        << ",\"1\":" << hist_1
+        << ",\"2\":" << hist_2
+        << ",\"3\":" << hist_3
+        << ",\"ge4\":" << hist_ge4
+        << "}"
+        << ",\"all_steps_have_frontier\":" << (steps.empty() ? "null" : (all_steps_have_frontier ? "true" : "false"))
+        << ",\"all_steps_have_sampler_hash\":" << (steps.empty() ? "null" : (all_steps_have_sampler_hash ? "true" : "false"))
+        << ",\"step_sample\":[";
+    const size_t n_sample = std::min(steps.size(), max_step_sample);
+    for (size_t i = 0; i < n_sample; ++i) {
+        const auto & step = steps[i];
+        const int draft_size = (int) step.draft.size();
+        const int rows_requested = draft_size + 1;
+        const bool full_accept = step.resolution == "full_accept";
+        const int rows_consumed_estimated = full_accept ? rows_requested : std::min(rows_requested, step.accepted_draft + 1);
+        const int rows_wasted_estimated = std::max(0, rows_requested - rows_consumed_estimated);
+        if (i > 0) {
+            out << ",";
+        }
+        out
+            << "{"
+            << "\"step\":" << step.index
+            << ",\"draft_size\":" << draft_size
+            << ",\"accepted_draft\":" << step.accepted_draft
+            << ",\"resolution\":\"" << json_escape(step.resolution) << "\""
+            << ",\"rows_requested\":" << rows_requested
+            << ",\"rows_consumed_estimated\":" << rows_consumed_estimated
+            << ",\"rows_wasted_estimated\":" << rows_wasted_estimated
+            << ",\"sampler_before_hash\":" << (step.sampler_state_hash_before ? std::to_string(step.sampler_state_hash_before) : "null")
+            << ",\"sampler_after_hash\":" << (step.sampler_state_hash_after ? std::to_string(step.sampler_state_hash_after) : "null");
+        if (step.kv_tgt_before_min >= 0 && step.kv_tgt_before_max >= step.kv_tgt_before_min) {
+            out
+                << ",\"frontier_before\":{\"min\":" << step.kv_tgt_before_min
+                << ",\"max\":" << step.kv_tgt_before_max
+                << ",\"hash\":" << stable_hash_frontier(step.kv_tgt_before_min, step.kv_tgt_before_max)
+                << "}";
+        } else {
+            out << ",\"frontier_before\":null";
+        }
+        if (step.kv_tgt_after_min >= 0 && step.kv_tgt_after_max >= step.kv_tgt_after_min) {
+            out
+                << ",\"frontier_after\":{\"min\":" << step.kv_tgt_after_min
+                << ",\"max\":" << step.kv_tgt_after_max
+                << ",\"hash\":" << stable_hash_frontier(step.kv_tgt_after_min, step.kv_tgt_after_max)
+                << "}";
+        } else {
+            out << ",\"frontier_after\":null";
+        }
+        out << "}";
+    }
+    out << "]}";
     return out.str();
 }
 
@@ -1653,6 +1763,7 @@ extern "C" bool orbit_mtp_session_complete(
     session->last_timing_json = "{}";
     session->last_validate_trace_json = "[]";
     session->last_target_decode_trace_json = "[]";
+    session->last_validate_equivalence_json = "{}";
     session->last_output_token_hashes.clear();
     session->last_output_token_hashes_json = "[]";
     session->last_first_sample_trace_json = "{}";
@@ -2592,6 +2703,13 @@ done:
     }
     session->last_validate_trace_json = validate_trace_json(validate_traces);
     session->last_target_decode_trace_json = target_decode_trace_json(vocab_tgt, target_decode_traces);
+    if (mtp_trace_enabled()) {
+        session->last_validate_equivalence_json = validate_equivalence_json(
+            trace_steps,
+            session->last_rows_requested_total,
+            session->last_rows_consumed_estimated_total,
+            session->last_rows_wasted_estimated_total);
+    }
     session->last_output_token_hashes_json = uint64_vec_json(session->last_output_token_hashes);
     {
         const double suffix_target_prefill_ms = session->phase_suffix_decode_target.total_ms;
@@ -2850,6 +2968,11 @@ extern "C" const char * orbit_mtp_session_last_validate_trace_json(void * handle
 extern "C" const char * orbit_mtp_session_last_target_decode_trace_json(void * handle) {
     auto * session = static_cast<orbit_mtp_session *>(handle);
     return session ? session->last_target_decode_trace_json.c_str() : "[]";
+}
+
+extern "C" const char * orbit_mtp_session_last_validate_equivalence_json(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_validate_equivalence_json.c_str() : "{}";
 }
 
 extern "C" const char * orbit_mtp_session_last_output_token_hashes_json(void * handle) {

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -224,6 +224,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_last_completion = _mtp_last_completion_payload(state.client)
             mtp_last_timing = _mtp_last_timing_payload(state.client)
             mtp_last_validate_efficiency = _mtp_last_validate_efficiency_payload(state.client)
+            mtp_last_validate_equivalence = _mtp_last_validate_equivalence_payload(state.client)
             mtp_config = _mtp_config_payload(state.client)
             self._json(
                 {
@@ -256,6 +257,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "mtp_last_completion": mtp_last_completion,
                     "mtp_last_timing": mtp_last_timing,
                     "mtp_last_validate_efficiency": mtp_last_validate_efficiency,
+                    "mtp_last_validate_equivalence": mtp_last_validate_equivalence,
                     "mtp_config": mtp_config,
                     "mtp_fallback_reason": state.client.mtp_fallback_reason,
                     "mtp_enabled": session["mtp_enabled"],
@@ -934,6 +936,55 @@ def _mtp_last_validate_efficiency_payload(client: NativeLlamaClient) -> dict[str
         },
         "full_accept_steps": completion.full_accept_steps,
         "partial_accept_steps": completion.partial_accept_steps,
+    }
+
+
+def _mtp_last_validate_equivalence_payload(client: NativeLlamaClient) -> dict[str, object] | None:
+    completion = client.last_mtp_completion
+    if not completion.enabled or not completion.validate_equivalence_json:
+        return None
+    try:
+        payload = json.loads(completion.validate_equivalence_json)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, Mapping) or not payload:
+        return None
+
+    def _number(name: str) -> float | int | None:
+        value = payload.get(name)
+        if isinstance(value, (int, float)):
+            return value
+        return None
+
+    histogram = payload.get("accepted_draft_histogram")
+    if not isinstance(histogram, Mapping):
+        histogram_payload: dict[str, object] | None = None
+    else:
+        histogram_payload = {
+            "0": histogram.get("0") if isinstance(histogram.get("0"), int) else None,
+            "1": histogram.get("1") if isinstance(histogram.get("1"), int) else None,
+            "2": histogram.get("2") if isinstance(histogram.get("2"), int) else None,
+            "3": histogram.get("3") if isinstance(histogram.get("3"), int) else None,
+            "ge4": histogram.get("ge4") if isinstance(histogram.get("ge4"), int) else None,
+        }
+
+    step_sample = payload.get("step_sample")
+    if not isinstance(step_sample, list):
+        step_sample_payload: list[object] | None = None
+    else:
+        step_sample_payload = step_sample[:64]
+
+    return {
+        "steps": _number("steps"),
+        "steps_recorded": _number("steps_recorded"),
+        "rows_requested_total": _number("rows_requested_total"),
+        "rows_consumed_estimated_total": _number("rows_consumed_estimated_total"),
+        "rows_wasted_estimated_total": _number("rows_wasted_estimated_total"),
+        "rows_wasted_estimated_ratio": _number("rows_wasted_estimated_ratio"),
+        "accepted_draft_histogram": histogram_payload,
+        "all_steps_have_frontier": payload.get("all_steps_have_frontier") if isinstance(payload.get("all_steps_have_frontier"), bool) else None,
+        "all_steps_have_sampler_hash": payload.get("all_steps_have_sampler_hash") if isinstance(payload.get("all_steps_have_sampler_hash"), bool) else None,
+        "step_sample": step_sample_payload,
     }
 
 

--- a/tests/test_bench_mtp_throughput.py
+++ b/tests/test_bench_mtp_throughput.py
@@ -12,6 +12,7 @@ from orbit.native_server.app import (
     _mtp_config_payload,
     _mtp_last_completion_payload,
     _mtp_last_timing_payload,
+    _mtp_last_validate_equivalence_payload,
     _mtp_last_validate_efficiency_payload,
 )
 from orbit.native_llama.mtp_completion import MtpCompletionResult
@@ -250,6 +251,66 @@ class NativeServerMtpPropsTests(unittest.TestCase):
         self.assertEqual(payload["accepted_draft_histogram"], {"0": 1, "1": 2, "2": 0, "3": 1, "ge4": 1})
         self.assertEqual(payload["full_accept_steps"], 2)
         self.assertEqual(payload["partial_accept_steps"], 3)
+
+    def test_mtp_last_validate_equivalence_payload_is_none_when_absent(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                validate_equivalence_json=None,
+            )
+        )
+
+        self.assertIsNone(_mtp_last_validate_equivalence_payload(client))
+
+    def test_mtp_last_validate_equivalence_payload_is_none_when_malformed(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                validate_equivalence_json="{",
+            )
+        )
+
+        self.assertIsNone(_mtp_last_validate_equivalence_payload(client))
+
+    def test_mtp_last_validate_equivalence_payload_preserves_zero_and_bounds_sample(self) -> None:
+        client = SimpleNamespace(
+            last_mtp_completion=MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                validate_equivalence_json=json.dumps(
+                    {
+                        "steps": 0,
+                        "steps_recorded": 0,
+                        "rows_requested_total": 0,
+                        "rows_consumed_estimated_total": 0,
+                        "rows_wasted_estimated_total": 0,
+                        "rows_wasted_estimated_ratio": 0.0,
+                        "accepted_draft_histogram": {"0": 0, "1": 0, "2": 0, "3": 0, "ge4": 0},
+                        "all_steps_have_frontier": False,
+                        "all_steps_have_sampler_hash": True,
+                        "step_sample": [{"step": index} for index in range(70)],
+                    }
+                ),
+            )
+        )
+
+        payload = _mtp_last_validate_equivalence_payload(client)
+
+        assert payload is not None
+        self.assertEqual(payload["steps"], 0)
+        self.assertEqual(payload["rows_requested_total"], 0)
+        self.assertEqual(payload["rows_wasted_estimated_ratio"], 0.0)
+        self.assertEqual(payload["accepted_draft_histogram"], {"0": 0, "1": 0, "2": 0, "3": 0, "ge4": 0})
+        self.assertFalse(payload["all_steps_have_frontier"])
+        self.assertTrue(payload["all_steps_have_sampler_hash"])
+        step_sample = payload["step_sample"]
+        assert isinstance(step_sample, list)
+        self.assertEqual(len(step_sample), 64)
 
 
 class BenchMtpThroughputMarkdownTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR adds read-only, env-gated MTP validate equivalence diagnostics.

When `ORBIT_MTP_TRACE=1` is enabled, `/props` can expose `mtp_last_validate_equivalence`, a bounded per-step diagnostic summary for the validate path.

The payload reports:

- validate step count
- requested / consumed-estimated / wasted-estimated rows
- accepted-draft histogram
- bounded step sample
- sampler hash availability
- frontier availability

This is intended to support future validate-path experiments. It does not change MTP behavior.

## Validation

- `PYTHONPATH=src python3 -m orbit.native_llama.build_cli --with-mtp-shim`
- `python3 -m compileall -q src/orbit/native_llama src/orbit/native_server tests`
- `PYTHONPATH=src python3 -m unittest tests.test_bench_mtp_throughput tests.test_native_mtp_experimental -q`
- `git diff --check`

Manual smoke with `ORBIT_MTP_TRACE=1`:

- `orbit server --mtp`
- one direct `medium_chat` completion
- `/props.mtp_last_validate_equivalence` present
- `mtp_failure_reason=null`
- `in_flight=false`

Observed sample:

- `steps=55`
- `rows_requested_total=224`
- `rows_consumed_estimated_total=116`
- `rows_wasted_estimated_total=108`
- `rows_wasted_estimated_ratio=0.482143`
- accepted-draft histogram: `0=23`, `1=16`, `2=6`, `3=10`, `ge4=0`
- `all_steps_have_frontier=true`
- `all_steps_have_sampler_hash=true`

## Notes / Risks

- Diagnostic only.
- Exposed only when trace data is available.
- Step sample is bounded.
- Raw trace payloads are not exposed.
- This does not reduce logits, alter sampler behavior, or change acceptance semantics.
- Future two-pass validate work remains correctness-sensitive.
