### PR TITLE
Add cross-phase KV LCP diagnostics

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -11,7 +11,7 @@ from .base import ChatResult, Message, ModelInfo, StreamProgress
 from .model_names import resolve_model_display_name
 from .payloads import ChatPayloadOptions, build_chat_payload
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
-from orbit.runtime.kv_diag import current_phase, current_tools_mode
+from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 
 
 class LlamaServerError(RuntimeError):
@@ -50,6 +50,7 @@ class LlamaServerBackend:
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
             )
         )
+        _attach_native_kv_diag_payload(payload, native_backend=native_backend)
         if native_backend:
             return self._with_display_model(
                 self._post_native_stream(
@@ -86,6 +87,7 @@ class LlamaServerBackend:
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
             )
         )
+        _attach_native_kv_diag_payload(payload, native_backend=native_backend)
         if native_backend:
             return self._with_display_model(
                 self._post_native_stream(
@@ -716,3 +718,14 @@ def _allow_mtp_experimental_requested(*, native_backend: bool) -> bool | None:
     if phase == "chat_final_retry" or phase.startswith("final_from_tool"):
         return False
     return None
+
+
+def _attach_native_kv_diag_payload(payload: dict[str, Any], *, native_backend: bool) -> None:
+    if not native_backend or not kv_diag_enabled():
+        return
+    phase = current_phase()
+    tools_mode = current_tools_mode()
+    if phase is not None:
+        payload["_orbit_kv_phase"] = phase
+    if tools_mode is not None:
+        payload["_orbit_kv_tools_mode"] = tools_mode

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -24,6 +24,8 @@ class NativeDiagRequest:
     endpoint: str | None
     stream: bool | None
     cache_prompt: bool | None
+    phase: str | None
+    tools_mode: str | None
     session_id_hash: str | None
     tools_parameter_present: bool
     tool_count: int
@@ -51,6 +53,8 @@ def request_context(*, endpoint: str | None, payload: dict[str, Any]) -> Iterato
         endpoint=endpoint,
         stream=payload.get("stream") is True,
         cache_prompt=payload.get("cache_prompt") if isinstance(payload.get("cache_prompt"), bool) else None,
+        phase=_safe_str(payload.get("_orbit_kv_phase")),
+        tools_mode=_safe_str(payload.get("_orbit_kv_tools_mode")),
         session_id_hash=_hash(str(payload.get("session_id") or "default")),
         tools_parameter_present=isinstance(payload.get("tools"), list) and bool(payload.get("tools")),
         tool_count=len(payload.get("tools")) if isinstance(payload.get("tools"), list) else 0,
@@ -80,12 +84,17 @@ def emit_prompt_cache_event(
     prompt_count = len(prompt_tokens)
     previous_count = len(previous_prompt_tokens)
     first_mismatch_token = common if common < min(prompt_count, previous_count) else None
+    previous_token_at_mismatch = (
+        previous_prompt_tokens[common] if first_mismatch_token is not None and common < previous_count else None
+    )
+    current_token_at_mismatch = prompt_tokens[common] if first_mismatch_token is not None and common < prompt_count else None
     evaluated = max(0, prompt_count - reused_prompt_tokens)
     event = {
         "event": "kv_diag_native_cache",
         "backend_request_id": request.backend_request_id if request else None,
         "model_call_id": None,
-        "phase": None,
+        "phase": request.phase if request else None,
+        "tools_mode": request.tools_mode if request else None,
         "endpoint": request.endpoint if request else None,
         "stream": request.stream if request else None,
         "cache_prompt": request.cache_prompt if request else None,
@@ -98,11 +107,16 @@ def emit_prompt_cache_event(
         "tool_count": request.tool_count if request else 0,
         "prompt_tokens": prompt_count,
         "previous_prompt_tokens": previous_count,
+        "current_tokenized_prompt_hash": _hash_tokens(prompt_tokens),
+        "previous_tokenized_prompt_hash": _hash_tokens(previous_prompt_tokens) if previous_prompt_tokens else None,
         "tokenized_prompt_hash": _hash_tokens(prompt_tokens),
         "tokenized_prefix_hash": _hash_tokens(prompt_tokens[:common]) if common else None,
         "tokenized_prefix_length": common,
         "longest_common_prefix_tokens": common,
+        "first_mismatch_index": first_mismatch_token,
         "first_mismatch_token": first_mismatch_token,
+        "previous_token_at_mismatch": previous_token_at_mismatch,
+        "current_token_at_mismatch": current_token_at_mismatch,
         "cached_tokens": reused_prompt_tokens,
         "evaluated_tokens": evaluated,
         "output_tokens": output_tokens,

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -593,6 +593,8 @@ class KVDiagTests(unittest.TestCase):
             payload = {
                 "cache_prompt": True,
                 "stream": True,
+                "_orbit_kv_phase": "final_from_tool",
+                "_orbit_kv_tools_mode": "on",
                 "session_id": "session-key-placeholder",
                 "messages": [
                     {"role": "system", "content": "runtime policy placeholder"},
@@ -619,12 +621,20 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(event["endpoint"], "/chat/stream")
         self.assertTrue(event["stream"])
         self.assertTrue(event["cache_prompt"])
+        self.assertEqual(event["phase"], "final_from_tool")
+        self.assertEqual(event["tools_mode"], "on")
         self.assertEqual(event["slot_id"], "default")
         self.assertEqual(event["prompt_tokens"], 4)
         self.assertEqual(event["previous_prompt_tokens"], 3)
+        self.assertIsNotNone(event["previous_tokenized_prompt_hash"])
+        self.assertNotEqual(event["previous_tokenized_prompt_hash"], event["current_tokenized_prompt_hash"])
+        self.assertEqual(event["current_tokenized_prompt_hash"], event["tokenized_prompt_hash"])
         self.assertEqual(event["tokenized_prefix_length"], 2)
         self.assertEqual(event["longest_common_prefix_tokens"], 2)
+        self.assertEqual(event["first_mismatch_index"], 2)
         self.assertEqual(event["first_mismatch_token"], 2)
+        self.assertEqual(event["previous_token_at_mismatch"], 99)
+        self.assertEqual(event["current_token_at_mismatch"], 33)
         self.assertEqual(event["cached_tokens"], 2)
         self.assertEqual(event["evaluated_tokens"], 2)
         self.assertEqual(event["output_tokens"], 3)
@@ -657,7 +667,10 @@ class KVDiagTests(unittest.TestCase):
 
         self.assertEqual(event["cache_miss_reason"], "prefix_mismatch_at_token_0")
         self.assertEqual(event["longest_common_prefix_tokens"], 0)
+        self.assertEqual(event["first_mismatch_index"], 0)
         self.assertEqual(event["first_mismatch_token"], 0)
+        self.assertEqual(event["previous_token_at_mismatch"], 1)
+        self.assertEqual(event["current_token_at_mismatch"], 5)
 
     def test_native_route_prefix_anchor_diagnostics_are_metadata_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -308,6 +308,41 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertNotIn("route_prefix_anchor", backend.payloads[2])
         self.assertNotIn("route_prefix_anchor", backend.payloads[3])
 
+    def test_native_kv_diag_payload_carries_phase_only_when_enabled(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payloads: list[dict[str, object]] = []
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "orbit-native"}
+
+            def _post_native_stream(self, _path: str, payload: dict[str, object], *, on_delta, on_progress) -> ChatResult:
+                self.payloads.append(payload)
+                return ChatResult(
+                    content="ok",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = Backend()
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "0"}, clear=False):
+            with model_call_context(phase="route", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1"}, clear=False):
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertNotIn("_orbit_kv_phase", backend.payloads[0])
+        self.assertEqual(backend.payloads[1]["_orbit_kv_phase"], "final_from_tool")
+        self.assertEqual(backend.payloads[1]["_orbit_kv_tools_mode"], "on")
+
     def test_allow_mtp_false_payload_is_limited_to_native_tools_final_fallbacks(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary

This PR adds cross-phase KV cache diagnostics for native model calls when `ORBIT_KV_DIAG=1` is enabled.

The diagnostic output now includes:

- model-call phase
- tools mode
- tokenized current/previous prompt hashes
- tokenized longest common prefix
- first mismatch index
- token ids at the mismatch
- role sequence

No raw prompt text is exposed.

## Why

This explains why some final/retry calls report `cached=4` while route calls can reuse a much larger prefix.

In the observed `pwd_followup` smoke:

- route reused about 694 cached tokens
- `final_from_tool` reused only 4 cached tokens
- `chat_final` reused only 4 cached tokens
- the native tokenized LCP from route to final was 4
- the first mismatch happened immediately in the system prompt

So `cached=4` is caused by prompt-view divergence, not by cache/session failure.

## Validation

- `python3 -m compileall -q src/orbit/native_llama src/orbit/runtime tests`
- `PYTHONPATH=src python3 -m unittest tests.test_kv_diag tests.test_llama_server_backend -q`
- `git diff --check`

Manual smoke:

- native server with `ORBIT_KV_DIAG=1`
- `scripts/orbit_smoke_harness.py --scenario pwd_followup`
- route → final LCP confirmed as 4
- no raw prompt text emitted

## Notes / Risks

- Diagnostic only.
- Enabled only with `ORBIT_KV_DIAG=1`.
- Token ids and hashes are low-level metadata, not raw prompt text.
- No prompt, routing, tool, evidence, or cache behavior changes.
