### PR TITLE
Add final prompt component token diagnostics

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -22,7 +22,7 @@ from .bindings import (
 )
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativeProgress, NativeTimings
-from .kv_diag import emit_prompt_cache_event, emit_route_prefix_anchor_event
+from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
@@ -582,6 +582,7 @@ class NativeLlamaClient:
             allow_mtp_experimental=allow_mtp,
             thinking=thinking,
             route_anchor_segments=route_anchor_segments,
+            kv_diag_messages=messages,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
@@ -934,6 +935,7 @@ class NativeLlamaClient:
         allow_mtp_experimental: bool = True,
         thinking: bool | None = None,
         route_anchor_segments: RoutePromptSegments | None = None,
+        kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -971,6 +973,7 @@ class NativeLlamaClient:
                 prompt,
                 max_tokens=max_tokens,
                 route_anchor_segments=route_anchor_segments,
+                kv_diag_messages=kv_diag_messages,
                 on_progress=on_progress,
                 on_token=on_token,
                 should_cancel=should_cancel,
@@ -1111,6 +1114,7 @@ class NativeLlamaClient:
         *,
         max_tokens: int = 16,
         route_anchor_segments: RoutePromptSegments | None = None,
+        kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -1159,6 +1163,13 @@ class NativeLlamaClient:
             on_token=on_token,
             should_cancel=should_cancel,
         )
+        component_tokens = None
+        if kv_diag_enabled() and kv_diag_messages is not None:
+            component_tokens = build_prompt_component_tokens(
+                messages=[dict(message) for message in kv_diag_messages],
+                prompt_tokens_total=n_prompt,
+                token_count=self._content_token_count,
+            )
         emit_prompt_cache_event(
             prompt_tokens=prompt_tokens,
             previous_prompt_tokens=previous_prompt_tokens,
@@ -1166,6 +1177,7 @@ class NativeLlamaClient:
             output_tokens=generated,
             cancelled=cancelled,
             slot_id=self._session.session_id,
+            component_tokens=component_tokens,
         )
         if anchor_metadata is not None:
             anchor_metadata["cached_tokens"] = reused
@@ -1540,9 +1552,16 @@ class NativeLlamaClient:
     def tokenize(self, prompt: str) -> list[int]:
         if not self._vocab:
             raise RuntimeError("native client not loaded")
+        return self._tokenize_text(prompt, add_special=not prompt.startswith("<bos>"))
+
+    def _content_token_count(self, text: str) -> int:
+        if not text:
+            return 0
+        return len(self._tokenize_text(text, add_special=False))
+
+    def _tokenize_text(self, text: str, *, add_special: bool) -> list[int]:
         lib = self.lib.lib
-        prompt_bytes = prompt.encode()
-        add_special = not prompt.startswith("<bos>")
+        prompt_bytes = text.encode()
         n_prompt = -lib.llama_tokenize(self._vocab, prompt_bytes, len(prompt_bytes), None, 0, add_special, True)
         if n_prompt <= 0:
             return []

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -8,7 +8,7 @@ import os
 import sys
 from dataclasses import dataclass
 from itertools import count
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 
 _REQUEST_IDS = count(1)
@@ -76,6 +76,7 @@ def emit_prompt_cache_event(
     output_tokens: int,
     cancelled: bool,
     slot_id: str,
+    component_tokens: dict[str, Any] | None = None,
 ) -> None:
     if not enabled():
         return
@@ -127,6 +128,115 @@ def emit_prompt_cache_event(
             common_tokens=common,
             reused_prompt_tokens=reused_prompt_tokens,
         ),
+    }
+    _emit(event)
+    if component_tokens is not None and _is_final_or_retry_phase(request.phase if request else None):
+        _emit_prompt_component_tokens_event(
+            request=request,
+            component_tokens=component_tokens,
+            prompt_tokens=prompt_count,
+            cached_tokens=reused_prompt_tokens,
+            evaluated_tokens=evaluated,
+        )
+
+
+def build_prompt_component_tokens(
+    *,
+    messages: list[dict[str, Any]],
+    prompt_tokens_total: int,
+    token_count: Callable[[str], int],
+) -> dict[str, Any]:
+    components = {
+        "system_prompt_tokens": 0,
+        "conversation_window_tokens": 0,
+        "assistant_history_tokens": 0,
+        "user_message_tokens": 0,
+        "evidence_total_tokens": 0,
+        "evidence_wrapper_tokens": 0,
+        "evidence_metadata_tokens": 0,
+        "evidence_raw_excerpt_tokens": 0,
+        "evidence_summary_tokens": 0,
+        "tool_result_tokens": 0,
+        "other_message_tokens": 0,
+        "template_overhead_tokens": 0,
+        "unknown_tokens": 0,
+    }
+    evidence_kinds: list[str] = []
+    evidence_card_count = 0
+    content_total = 0
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = _content_text(message.get("content"))
+        tokens = token_count(content) if content else 0
+        if role == "system" and index == 0:
+            components["system_prompt_tokens"] += tokens
+            content_total += tokens
+            continue
+        if role == "system" and _looks_like_evidence_context(content):
+            evidence = _evidence_component_tokens(content, token_count=token_count)
+            for key in (
+                "evidence_wrapper_tokens",
+                "evidence_metadata_tokens",
+                "evidence_raw_excerpt_tokens",
+                "evidence_summary_tokens",
+            ):
+                components[key] += evidence[key]
+            components["evidence_total_tokens"] += tokens
+            content_total += tokens
+            evidence_card_count += evidence["evidence_card_count"]
+            for kind in evidence["evidence_kinds"]:
+                if kind not in evidence_kinds:
+                    evidence_kinds.append(kind)
+            continue
+        if role == "assistant":
+            components["assistant_history_tokens"] += tokens
+            components["conversation_window_tokens"] += tokens
+        elif role == "user":
+            components["user_message_tokens"] += tokens
+            components["conversation_window_tokens"] += tokens
+        elif role == "tool":
+            components["tool_result_tokens"] += tokens
+            components["conversation_window_tokens"] += tokens
+        else:
+            components["other_message_tokens"] += tokens
+        content_total += tokens
+    remainder = prompt_tokens_total - content_total
+    if remainder >= 0:
+        components["template_overhead_tokens"] = remainder
+    else:
+        components["unknown_tokens"] = -remainder
+    return {
+        "components": components,
+        "evidence_card_count": evidence_card_count,
+        "evidence_kinds": evidence_kinds,
+        "content_tokens_total": content_total,
+    }
+
+
+def _emit_prompt_component_tokens_event(
+    *,
+    request: NativeDiagRequest | None,
+    component_tokens: dict[str, Any],
+    prompt_tokens: int,
+    cached_tokens: int,
+    evaluated_tokens: int,
+) -> None:
+    event = {
+        "event": "kv_diag_prompt_component_tokens",
+        "backend_request_id": request.backend_request_id if request else None,
+        "model_call_id": None,
+        "phase": request.phase if request else None,
+        "tools_mode": request.tools_mode if request else None,
+        "prompt_tokens_total": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "evaluated_tokens": evaluated_tokens,
+        "role_sequence": request.role_sequence if request else [],
+        "components": component_tokens.get("components", {}),
+        "evidence_card_count": _safe_int(component_tokens.get("evidence_card_count")) or 0,
+        "evidence_kinds": component_tokens.get("evidence_kinds") if isinstance(component_tokens.get("evidence_kinds"), list) else [],
+        "content_tokens_total": _safe_int(component_tokens.get("content_tokens_total")),
     }
     _emit(event)
 
@@ -193,6 +303,85 @@ def emit_route_prefix_prewarm_event(metadata: dict[str, Any]) -> None:
         "restore_ready": bool(metadata.get("restore_ready")),
     }
     _emit(event)
+
+
+def _content_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return " ".join(parts)
+    return ""
+
+
+def _looks_like_evidence_context(content: str) -> bool:
+    return content.startswith("evidence_context:")
+
+
+def _is_final_or_retry_phase(phase: str | None) -> bool:
+    if phase is None:
+        return False
+    return phase == "chat_final" or phase == "chat_final_retry" or phase.startswith("final_from_tool")
+
+
+def _evidence_component_tokens(content: str, *, token_count: Callable[[str], int]) -> dict[str, Any]:
+    wrapper_lines: list[str] = []
+    metadata_lines: list[str] = []
+    raw_lines: list[str] = []
+    summary_lines: list[str] = []
+    evidence_kinds: list[str] = []
+    in_raw_excerpt = False
+    evidence_card_count = 0
+    summary_prefixes = (
+        "stdout_excerpt:",
+        "stderr_excerpt:",
+        "first_matches:",
+        "top_snippets:",
+        "compat_excerpt:",
+    )
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "bounded_raw_excerpt:":
+            wrapper_lines.append(line)
+            in_raw_excerpt = True
+            continue
+        if stripped.startswith("- evidence "):
+            wrapper_lines.append(line)
+            evidence_card_count += 1
+            in_raw_excerpt = False
+            continue
+        if stripped == "evidence_context:":
+            wrapper_lines.append(line)
+            in_raw_excerpt = False
+            continue
+        if in_raw_excerpt:
+            raw_lines.append(line)
+            continue
+        if stripped.startswith("kind:"):
+            kind = stripped.split(":", 1)[1].strip()
+            if kind and kind not in evidence_kinds:
+                evidence_kinds.append(kind)
+        if stripped.startswith(summary_prefixes):
+            summary_lines.append(line)
+            continue
+        metadata_lines.append(line)
+    return {
+        "evidence_wrapper_tokens": _joined_token_count(wrapper_lines, token_count=token_count),
+        "evidence_metadata_tokens": _joined_token_count(metadata_lines, token_count=token_count),
+        "evidence_raw_excerpt_tokens": _joined_token_count(raw_lines, token_count=token_count),
+        "evidence_summary_tokens": _joined_token_count(summary_lines, token_count=token_count),
+        "evidence_card_count": evidence_card_count,
+        "evidence_kinds": evidence_kinds,
+    }
+
+
+def _joined_token_count(lines: list[str], *, token_count: Callable[[str], int]) -> int:
+    if not lines:
+        return 0
+    return token_count("\n".join(lines))
 
 
 def _cache_miss_reason(

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -18,6 +18,7 @@ from orbit.runtime.kv_diag import (
     reset_diagnostics_for_tests,
 )
 from orbit.native_llama.kv_diag import (
+    build_prompt_component_tokens,
     emit_prompt_cache_event as emit_native_prompt_cache_event,
     emit_route_prefix_anchor_event as emit_native_route_prefix_anchor_event,
     request_context as native_request_context,
@@ -671,6 +672,92 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(event["first_mismatch_token"], 0)
         self.assertEqual(event["previous_token_at_mismatch"], 1)
         self.assertEqual(event["current_token_at_mismatch"], 5)
+
+    def test_native_prompt_component_tokens_are_metadata_only(self) -> None:
+        def token_count(text: str) -> int:
+            return len([part for part in text.replace("\n", " ").split(" ") if part])
+
+        messages = [
+            {"role": "system", "content": "system policy"},
+            {"role": "assistant", "content": "prior answer"},
+            {"role": "user", "content": "placeholder component payload"},
+            {
+                "role": "system",
+                "content": "\n".join(
+                    [
+                        "evidence_context:",
+                        "- evidence 1:",
+                        "tool_evidence_card: true",
+                        "kind: shell",
+                        "stdout_excerpt: concise summary",
+                        "bounded_raw_excerpt:",
+                        "raw detail line",
+                    ]
+                ),
+            },
+        ]
+        component_tokens = build_prompt_component_tokens(
+            messages=messages,
+            prompt_tokens_total=64,
+            token_count=token_count,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            payload = {
+                "cache_prompt": True,
+                "stream": True,
+                "_orbit_kv_phase": "chat_final",
+                "_orbit_kv_tools_mode": "on",
+                "messages": messages,
+            }
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with native_request_context(endpoint="/chat/stream", payload=payload):
+                    emit_native_prompt_cache_event(
+                        prompt_tokens=list(range(64)),
+                        previous_prompt_tokens=[0, 1, 99],
+                        reused_prompt_tokens=2,
+                        output_tokens=1,
+                        cancelled=False,
+                        slot_id="default",
+                        component_tokens=component_tokens,
+                    )
+
+            events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            event = next(item for item in events if item["event"] == "kv_diag_prompt_component_tokens")
+            raw_log = json.dumps(event)
+
+        components = event["components"]
+        self.assertEqual(event["phase"], "chat_final")
+        self.assertEqual(event["prompt_tokens_total"], 64)
+        self.assertEqual(event["cached_tokens"], 2)
+        self.assertEqual(event["evaluated_tokens"], 62)
+        self.assertEqual(event["role_sequence"], ["system", "assistant", "user", "system"])
+        self.assertEqual(event["evidence_card_count"], 1)
+        self.assertEqual(event["evidence_kinds"], ["shell"])
+        self.assertEqual(components["system_prompt_tokens"], 2)
+        self.assertEqual(components["assistant_history_tokens"], 2)
+        self.assertEqual(components["user_message_tokens"], 3)
+        self.assertEqual(components["conversation_window_tokens"], 5)
+        self.assertGreater(components["evidence_total_tokens"], 0)
+        self.assertGreater(components["evidence_raw_excerpt_tokens"], 0)
+        self.assertGreater(components["evidence_summary_tokens"], 0)
+        self.assertGreaterEqual(components["template_overhead_tokens"], 0)
+        self.assertEqual(components["unknown_tokens"], 0)
+        self.assertNotIn("placeholder component payload", raw_log)
+        self.assertNotIn("raw detail line", raw_log)
+        self.assertNotIn("system policy", raw_log)
+
+    def test_prompt_component_tokens_preserve_zero_values(self) -> None:
+        component_tokens = build_prompt_component_tokens(
+            messages=[],
+            prompt_tokens_total=0,
+            token_count=lambda text: len(text.split()),
+        )
+
+        self.assertEqual(component_tokens["evidence_card_count"], 0)
+        self.assertEqual(component_tokens["evidence_kinds"], [])
+        for value in component_tokens["components"].values():
+            self.assertEqual(value, 0)
 
     def test_native_route_prefix_anchor_diagnostics_are_metadata_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

This PR adds final/retry prompt component token diagnostics when `ORBIT_KV_DIAG=1` is enabled.

A new `kv_diag_prompt_component_tokens` event reports exact token counts for final/retry prompt components, including:

- system prompt
- conversation/window
- evidence total
- evidence metadata
- evidence raw excerpt
- evidence summary
- evidence wrapper
- template overhead
- unknown residual

No raw prompt text is emitted.

## Why

Cross-phase KV diagnostics showed that final/retry calls often reuse only 4 cached tokens because route and final prompt views diverge immediately at the system prompt.

This diagnostic helps target evaluated-token reduction directly.

Observed smoke results:

- `pwd_followup final_from_tool`: prompt 210, evidence 136, unknown 0
- `shell_error final_from_tool`: prompt 319, evidence 233, unknown 0
- `shell_error chat_final`: prompt 539, evidence 466, unknown 0

Evidence metadata and repeated evidence cards are the largest contributors, not raw excerpt alone.

## Validation

- `python3 -m compileall -q src/orbit/native_llama src/orbit/runtime tests`
- `PYTHONPATH=src python3 -m unittest tests.test_kv_diag -q`
- `git diff --check`

Manual smoke:

- native server with `ORBIT_KV_DIAG=1`
- `pwd_followup`: PASS
- `shell_error`: PASS
- exact component breakdown emitted
- no raw prompt text emitted

## Notes / Risks

- Diagnostic only.
- Enabled only with `ORBIT_KV_DIAG=1`.
- No prompt, routing, tool, evidence, or cache behavior changes.
- Token counts are low-level diagnostics and should be used only for performance analysis.
