### PR TITLE
Slim compact final evidence metadata

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -251,7 +251,7 @@ def build_compact_final_evidence_context(store: EvidenceStore | None, *, limit: 
     parts = ["evidence_context:"]
     for index, record in enumerate(records, start=1):
         parts.append(f"- evidence {index}:")
-        parts.append(_compact_final_card(record))
+        parts.append(_compact_final_prompt_card(record))
         if _compact_final_context_needs_raw_excerpt(record):
             parts.append("bounded_raw_excerpt:")
             parts.append(
@@ -456,6 +456,39 @@ def _compact_final_card(record: EvidenceRecord) -> str:
     ]
     lines.extend(_card_metadata_lines(record, compact=True))
     return "\n".join(lines)
+
+
+def _compact_final_prompt_card(record: EvidenceRecord) -> str:
+    if not _should_use_small_final_prompt_card(record):
+        return _compact_final_card(record)
+    lines = [
+        "tool_evidence_card: true",
+        f"kind: {record.kind}",
+        f"status: {record.status}",
+        f"raw_ref: {record.raw_ref}",
+    ]
+    for key in _small_final_prompt_metadata_keys(record):
+        value = record.metadata.get(key)
+        if value in (None, "", [], {}):
+            continue
+        if isinstance(value, list):
+            joined = "; ".join(str(item) for item in value[:2])
+            lines.append(f"{key}: {joined}")
+        else:
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+def _should_use_small_final_prompt_card(record: EvidenceRecord) -> bool:
+    if record.raw_chars > COMPACT_FINAL_RAW_EXCERPT_CHARS:
+        return False
+    return record.kind in {"shell", "grep_search", "unknown"}
+
+
+def _small_final_prompt_metadata_keys(record: EvidenceRecord) -> tuple[str, ...]:
+    if record.kind == "grep_search":
+        return ("query", "exit_code", "match_count", "files_count", "file_paths", "first_matches")
+    return ("exit_code", "stdout_excerpt", "stderr_excerpt", "sidecar_status")
 
 
 def _final_context_needs_raw_excerpt(record: EvidenceRecord) -> bool:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -160,6 +160,22 @@ class EvidenceTests(unittest.TestCase):
         self.assertNotIn("hash=", context)
         self.assertNotIn("sha256", context)
 
+    def test_compact_final_context_uses_small_card_for_small_shell_output(self) -> None:
+        content = "/home/example/project\n"
+        record = build_evidence_record("exec_shell_full_command", content, {"command": "pwd"})
+        context = build_compact_final_evidence_context(_store_with(record, content)) or ""
+
+        self.assertIn("evidence_context:", context)
+        self.assertIn("tool_evidence_card: true", context)
+        self.assertIn("kind: shell", context)
+        self.assertIn("status: ok", context)
+        self.assertIn(record.raw_ref, context)
+        self.assertIn("stdout_excerpt: /home/example/project", context)
+        self.assertNotIn("command: pwd", context)
+        self.assertNotIn("sha256:", context)
+        self.assertNotIn("size:", context)
+        self.assertNotIn("stdout_chars:", context)
+
     def test_post_tool_route_omits_command_for_medium_shell_output(self) -> None:
         content = "\n".join(f"line-{index}" for index in range(120))
         record = build_evidence_record("exec_shell_full_command", content, {"command": "python3 print-lines.py"})


### PR DESCRIPTION
## Summary

This PR reduces prompt tokens in compact final evidence by using a smaller prompt-facing evidence card for small final outputs.

The compact final prompt card keeps the fields needed for answer generation, such as:

- evidence kind
- status
- exit code when relevant
- raw reference
- summary/excerpt

It avoids carrying audit/debug metadata into the final prompt when that metadata is not needed for generation.

Storage/sidecar data remains unchanged.

## Why

Cross-phase KV diagnostics showed that final/retry calls often reuse only 4 cached tokens because route and final prompt views diverge immediately.

Since cache reuse is not available for these final views, reducing evaluated final tokens is the safer performance path.

Measured before/after:

- `pwd_followup final_from_tool`
  - prompt `210 -> 152`
  - evaluated `206 -> 148`
  - evidence `136 -> 78`

- `shell_error final_from_tool`
  - prompt `319 -> 244`
  - evaluated `315 -> 240`
  - evidence `233 -> 158`

`chat_final` multi-evidence remains intentionally unchanged.

## Validation

- `python3 -m compileall -q src/orbit/runtime src/orbit/native_llama tests`
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_kv_diag -q`
- `git diff --check`

Manual smoke:

- `pwd_followup`: PASS
- `shell_error`: PASS
- final component token diagnostics confirm reduced evidence metadata
- correctness remains `correct`

## Notes / Risks

- This is a conservative prompt-size reduction.
- It does not change routing, tool execution, cache behavior, or final answer generation policy.
- It does not touch dual shell evidence.
- It does not change multi-evidence `chat_final` handling.
- Audit/debug metadata remains available outside the prompt.
