### PR TITLE
Add evidence lineage diagnostics

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -37,7 +37,7 @@ from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
 )
 from orbit.runtime.file_input_resolver import FileInputResolver
-from orbit.runtime.kv_diag import emit_route_outcome, instrument_backend, model_call_context, user_request
+from orbit.runtime.kv_diag import emit_evidence_lineage, emit_route_outcome, instrument_backend, model_call_context, user_request
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
@@ -932,6 +932,7 @@ class ChatRuntime:
         if latest_user is not None:
             messages.append(latest_user)
         context = build_compact_final_evidence_context(self.evidence_store)
+        self._emit_evidence_lineage_context(context_kind="compact_final", consumer_phase="final_from_tool", limit=1)
         final_messages = with_final_tool_system_prompt(messages)
         if not context:
             return final_messages
@@ -1012,6 +1013,7 @@ class ChatRuntime:
 
     def _with_final_evidence_context(self, messages: list[Message]) -> list[Message]:
         context = build_final_evidence_context(self.evidence_store)
+        self._emit_evidence_lineage_context(context_kind="final", consumer_phase="final", limit=2)
         if not context:
             return messages
         return [*messages, {"role": "system", "content": context}]
@@ -1026,16 +1028,39 @@ class ChatRuntime:
         latest_user = _latest_user_message(self.messages)
         if latest_user is not None:
             messages.append(latest_user)
-        return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages))
+        return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages), consumer_phase="chat_final")
 
-    def _with_chat_final_retry_evidence_context(self, messages: list[Message]) -> list[Message]:
+    def _with_chat_final_retry_evidence_context(self, messages: list[Message], *, consumer_phase: str) -> list[Message]:
         if self._should_compact_final_from_tool_window():
             context = build_compact_final_evidence_context(self.evidence_store)
+            self._emit_evidence_lineage_context(context_kind="compact_final", consumer_phase=consumer_phase, limit=1)
         else:
             context = build_final_evidence_context(self.evidence_store)
+            self._emit_evidence_lineage_context(context_kind="final", consumer_phase=consumer_phase, limit=2)
         if not context:
             return messages
         return [*messages, {"role": "system", "content": context}]
+
+    def _emit_evidence_lineage_context(self, *, context_kind: str, consumer_phase: str, limit: int) -> None:
+        if self.evidence_store is None:
+            return
+        records = self.evidence_store.recent_records(limit)
+        for index, record in enumerate(records, start=1):
+            emit_evidence_lineage(
+                {
+                    "context_kind": context_kind,
+                    "phase": consumer_phase,
+                    "card_index": index,
+                    "evidence_id": record.evidence_id,
+                    "evidence_sequence": record.evidence_sequence,
+                    "tool_call_id": record.tool_call_id,
+                    "user_turn_id": record.user_turn_id,
+                    "producer_model_call_id": record.producer_model_call_id,
+                    "produced_by_phase": record.produced_by_phase,
+                    "kind": record.kind,
+                    "status": record.status,
+                }
+            )
 
     def _chat_final_retry_messages(self) -> list[Message]:
         messages: list[Message] = []
@@ -1048,7 +1073,7 @@ class ChatRuntime:
             messages.append(assistant)
         if latest_user is not None:
             messages.append(latest_user)
-        return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages))
+        return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages), consumer_phase="chat_final_retry")
 
     def chat_final_completion_repair_messages(self, repair_instruction: str) -> list[Message] | None:
         if self.evidence_store is None or not self.evidence_store.recent_records(1):

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -40,6 +40,11 @@ class EvidenceRecord:
     metadata: dict[str, object]
     route_card: str
     final_card: str
+    evidence_sequence: int | None = None
+    tool_call_id: str | None = None
+    user_turn_id: str | None = None
+    producer_model_call_id: str | None = None
+    produced_by_phase: str | None = None
 
 
 class EvidenceStore:
@@ -69,7 +74,12 @@ class EvidenceStore:
                 self.records[record.evidence_id] = record
 
     def add(self, tool_name: str, content: str, *, metadata: dict[str, object] | None = None) -> EvidenceRecord:
-        record = build_evidence_record(tool_name, content, metadata or {})
+        record = build_evidence_record(
+            tool_name,
+            content,
+            metadata or {},
+            evidence_sequence=self._next_sequence(),
+        )
         self.records[record.evidence_id] = record
         self.raw_cache[record.evidence_id] = content
         try:
@@ -104,6 +114,14 @@ class EvidenceStore:
             return []
         return list(self.records.values())[-limit:]
 
+    def _next_sequence(self) -> int:
+        sequences = [
+            record.evidence_sequence
+            for record in self.records.values()
+            if isinstance(record.evidence_sequence, int)
+        ]
+        return (max(sequences) if sequences else 0) + 1
+
     def raw_excerpt(self, record: EvidenceRecord, *, max_chars: int = RAW_EXCERPT_CHARS) -> str:
         try:
             raw = self.load_raw(record.evidence_id)
@@ -122,8 +140,26 @@ class EvidenceStore:
         return data if isinstance(data, dict) else {}
 
 
-def build_evidence_record(tool_name: str, content: str, metadata: dict[str, object] | None = None) -> EvidenceRecord:
+def build_evidence_record(
+    tool_name: str,
+    content: str,
+    metadata: dict[str, object] | None = None,
+    *,
+    evidence_sequence: int | None = None,
+    tool_call_id: str | None = None,
+    user_turn_id: str | None = None,
+    producer_model_call_id: str | None = None,
+    produced_by_phase: str | None = None,
+) -> EvidenceRecord:
     metadata = dict(metadata or {})
+    tool_call_id = _optional_str(tool_call_id if tool_call_id is not None else metadata.get("tool_call_id"))
+    user_turn_id = _optional_str(user_turn_id if user_turn_id is not None else metadata.get("user_turn_id"))
+    producer_model_call_id = _optional_str(
+        producer_model_call_id if producer_model_call_id is not None else metadata.get("producer_model_call_id")
+    )
+    produced_by_phase = _optional_str(
+        produced_by_phase if produced_by_phase is not None else metadata.get("produced_by_phase")
+    )
     digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
     evidence_id = f"ev_{uuid.uuid4().hex[:12]}_{digest[:16]}"
     kind = _classify_kind(tool_name, content, metadata)
@@ -143,6 +179,11 @@ def build_evidence_record(tool_name: str, content: str, metadata: dict[str, obje
         metadata=enriched,
         route_card="",
         final_card="",
+        evidence_sequence=evidence_sequence,
+        tool_call_id=tool_call_id,
+        user_turn_id=user_turn_id,
+        producer_model_call_id=producer_model_call_id,
+        produced_by_phase=produced_by_phase,
     )
     return EvidenceRecord(
         **{**asdict(base), "route_card": route_card(base), "final_card": final_card(base)}
@@ -164,6 +205,11 @@ def _record_from_index(value: dict[str, object]) -> EvidenceRecord | None:
             metadata=dict(metadata) if isinstance(metadata, dict) else {},
             route_card="",
             final_card="",
+            evidence_sequence=_optional_int(value.get("evidence_sequence")),
+            tool_call_id=_optional_str(value.get("tool_call_id")),
+            user_turn_id=_optional_str(value.get("user_turn_id")),
+            producer_model_call_id=_optional_str(value.get("producer_model_call_id")),
+            produced_by_phase=_optional_str(value.get("produced_by_phase")),
         )
     except (KeyError, TypeError, ValueError):
         return None
@@ -311,8 +357,28 @@ def _record_with_sidecar_status(record: EvidenceRecord, status: str) -> Evidence
         metadata=metadata,
         route_card="",
         final_card="",
+        evidence_sequence=record.evidence_sequence,
+        tool_call_id=record.tool_call_id,
+        user_turn_id=record.user_turn_id,
+        producer_model_call_id=record.producer_model_call_id,
+        produced_by_phase=record.produced_by_phase,
     )
     return EvidenceRecord(**{**asdict(updated), "route_card": route_card(updated), "final_card": final_card(updated)})
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _classify_kind(tool_name: str, content: str, metadata: dict[str, object]) -> str:

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -464,6 +464,33 @@ def emit_route_outcome(
     )
 
 
+def emit_evidence_lineage(metadata: dict[str, Any]) -> None:
+    if not enabled():
+        return
+    evidence_id = metadata.get("evidence_id")
+    tool_call_id = metadata.get("tool_call_id")
+    active_phase = _PHASE.get()
+    event = {
+        "event": "kv_diag_evidence_lineage",
+        "session_id_hash": _current_session_id_hash(),
+        "request_id": _current_request_id(),
+        "model_call_id": _LAST_MODEL_CALL.get("model_call_id") if active_phase and _LAST_MODEL_CALL else None,
+        "phase": _safe_str(metadata.get("phase")) or active_phase,
+        "tools_mode": _TOOLS_MODE.get() if active_phase else None,
+        "context_kind": _safe_str(metadata.get("context_kind")),
+        "card_index": _safe_int(metadata.get("card_index")),
+        "evidence_id_hash": _hash(evidence_id) if isinstance(evidence_id, str) and evidence_id else None,
+        "evidence_sequence": _safe_int(metadata.get("evidence_sequence")),
+        "tool_call_id_hash": _hash(tool_call_id) if isinstance(tool_call_id, str) and tool_call_id else None,
+        "user_turn_id": _safe_str(metadata.get("user_turn_id")),
+        "producer_model_call_id": _safe_str(metadata.get("producer_model_call_id")),
+        "produced_by_phase": _safe_str(metadata.get("produced_by_phase")),
+        "kind": _safe_str(metadata.get("kind")),
+        "status": _safe_str(metadata.get("status")),
+    }
+    _emit(event)
+
+
 def _next_call_context(phase: str, tools_mode: str | None) -> dict[str, Any]:
     request = _REQUEST.get()
     call_id = next(_CALL_IDS)
@@ -488,6 +515,20 @@ def _next_call_context(phase: str, tools_mode: str | None) -> dict[str, Any]:
         "phase": phase,
         "tools_mode": tools_mode,
     }
+
+
+def _current_session_id_hash() -> str | None:
+    request = _REQUEST.get()
+    if request is not None:
+        return request.session_id_hash
+    return _LAST_MODEL_CALL.get("session_id_hash") if _LAST_MODEL_CALL else None
+
+
+def _current_request_id() -> str | None:
+    request = _REQUEST.get()
+    if request is not None:
+        return request.request_id
+    return _LAST_MODEL_CALL.get("request_id") if _LAST_MODEL_CALL else None
 
 
 def _record_model_call(event: dict[str, Any]) -> None:
@@ -550,6 +591,16 @@ def _sum_optional(values: Iterator[Any]) -> int | None:
             total += int(value)
             seen = True
     return total if seen else None
+
+
+def _safe_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _safe_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
 
 
 def _component_changes(request_id: str | None, phase: str, tools_mode: str | None, fingerprint: PromptFingerprint) -> list[str]:

--- a/src/orbit/runtime/tool_message.py
+++ b/src/orbit/runtime/tool_message.py
@@ -26,7 +26,9 @@ def tool_result_message(
     content = tool_result.content
     evidence_id = None
     if evidence_store is not None and tool_result.content:
-        record = evidence_store.add(tool_result.name, tool_result.content, metadata=metadata or _tool_call_metadata(tool_call))
+        evidence_metadata = dict(metadata or _tool_call_metadata(tool_call))
+        evidence_metadata.setdefault("tool_call_id", tool_call_id(tool_call))
+        record = evidence_store.add(tool_result.name, tool_result.content, metadata=evidence_metadata)
         content = tool_evidence_ref(record)
         evidence_id = record.evidence_id
     return {

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -42,6 +43,66 @@ class EvidenceTests(unittest.TestCase):
             self.assertEqual(store.load_raw(record.evidence_id), "raw content")
             self.assertTrue((store.root / "index.json").exists())
             self.assertTrue((store.root / f"{record.evidence_id}.txt").exists())
+            self.assertEqual(record.evidence_sequence, 1)
+            self.assertIsNone(record.user_turn_id)
+            self.assertIsNone(record.producer_model_call_id)
+            self.assertIsNone(record.produced_by_phase)
+
+    def test_lineage_fields_roundtrip_and_sequence_increments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            first = store.add(
+                "exec_shell_full_command",
+                "first",
+                metadata={"command": "printf first", "tool_call_id": "call_1"},
+            )
+            second = store.add(
+                "exec_shell_full_command",
+                "second",
+                metadata={"command": "printf second", "tool_call_id": "call_2"},
+            )
+
+            reloaded = EvidenceStore(store.root)
+            reloaded.load_index()
+            loaded = reloaded.recent_records(2)
+
+            self.assertEqual([record.evidence_sequence for record in loaded], [1, 2])
+            self.assertEqual([record.tool_call_id for record in loaded], ["call_1", "call_2"])
+            self.assertEqual(first.evidence_sequence, 1)
+            self.assertEqual(second.evidence_sequence, 2)
+
+    def test_old_index_without_lineage_loads_with_null_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = build_evidence_record("exec_shell_full_command", "legacy", {"command": "pwd"})
+            store.root.mkdir(parents=True)
+            (store.root / f"{record.evidence_id}.txt").write_text("legacy", encoding="utf-8")
+            legacy = {
+                record.evidence_id: {
+                    "evidence_id": record.evidence_id,
+                    "tool_name": record.tool_name,
+                    "kind": record.kind,
+                    "raw_ref": record.raw_ref,
+                    "raw_sha256": record.raw_sha256,
+                    "raw_chars": record.raw_chars,
+                    "raw_lines": record.raw_lines,
+                    "status": record.status,
+                    "metadata": record.metadata,
+                    "route_card": record.route_card,
+                    "final_card": record.final_card,
+                }
+            }
+            (store.root / "index.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+            reloaded = EvidenceStore(store.root)
+            reloaded.load_index()
+            loaded = reloaded.recent_records(1)[0]
+
+            self.assertIsNone(loaded.evidence_sequence)
+            self.assertIsNone(loaded.tool_call_id)
+            self.assertIsNone(loaded.user_turn_id)
+            self.assertIsNone(loaded.producer_model_call_id)
+            self.assertIsNone(loaded.produced_by_phase)
 
     def test_for_workdir_reloads_index_and_lazy_raw(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -10,6 +10,7 @@ from unittest import mock
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
 from orbit.runtime.kv_diag import (
+    emit_evidence_lineage,
     emit_route_outcome,
     fingerprint_prompt,
     instrument_backend,
@@ -826,6 +827,46 @@ class KVDiagTests(unittest.TestCase):
         self.assertNotIn("/secret/path.txt", raw_log)
         self.assertNotIn("raw detail line", raw_log)
         self.assertNotIn("evidence:secret-raw-ref", raw_log)
+
+    def test_runtime_evidence_lineage_is_metadata_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                with request_context(session_id="session-a"):
+                    with model_call_context(phase="chat_final", tools_mode="on"):
+                        emit_evidence_lineage(
+                            {
+                                "context_kind": "final",
+                                "card_index": 1,
+                                "evidence_id": "ev_secret_raw",
+                                "evidence_sequence": 0,
+                                "tool_call_id": "call_secret",
+                                "user_turn_id": None,
+                                "producer_model_call_id": None,
+                                "produced_by_phase": None,
+                                "kind": "shell",
+                                "status": "error",
+                            }
+                        )
+
+            events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            event = next(item for item in events if item["event"] == "kv_diag_evidence_lineage")
+            raw_log = json.dumps(event)
+
+        self.assertEqual(event["phase"], "chat_final")
+        self.assertEqual(event["tools_mode"], "on")
+        self.assertEqual(event["context_kind"], "final")
+        self.assertEqual(event["card_index"], 1)
+        self.assertEqual(event["evidence_sequence"], 0)
+        self.assertIsNotNone(event["evidence_id_hash"])
+        self.assertIsNotNone(event["tool_call_id_hash"])
+        self.assertIsNone(event["user_turn_id"])
+        self.assertIsNone(event["producer_model_call_id"])
+        self.assertIsNone(event["produced_by_phase"])
+        self.assertEqual(event["kind"], "shell")
+        self.assertEqual(event["status"], "error")
+        self.assertNotIn("ev_secret_raw", raw_log)
+        self.assertNotIn("call_secret", raw_log)
 
     def test_prompt_component_tokens_preserve_zero_values(self) -> None:
         component_tokens = build_prompt_component_tokens(

--- a/tests/test_tool_message.py
+++ b/tests/test_tool_message.py
@@ -82,6 +82,9 @@ class ToolMessageTests(unittest.TestCase):
             self.assertLess(len(str(message["content"])), len(raw))
             self.assertNotIn(raw, message["content"])
             self.assertEqual(store.load_raw(message["evidence_id"]), raw)
+            record = store.recent_records(1)[0]
+            self.assertEqual(record.tool_call_id, "call-1")
+            self.assertEqual(record.evidence_sequence, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds structural lineage fields to `EvidenceRecord` and exposes evidence lineage diagnostics when `ORBIT_KV_DIAG=1` is enabled.

New lineage fields:

- `evidence_sequence`
- `tool_call_id`
- `user_turn_id`
- `producer_model_call_id`
- `produced_by_phase`

Fields that are not available yet remain `null`.

A new diagnostic event, `kv_diag_evidence_lineage`, reports safe lineage metadata such as:

- evidence id hash
- tool call id hash
- evidence sequence
- phase
- context kind
- card index
- kind/status

No raw content, command, path, or prompt text is emitted.

## Why

Multi-card `chat_final` evidence is costly, but reducing it safely requires structural lineage first.

Today `recent_records(limit=2)` is insertion-order based and does not encode relevance, user turn, producer phase, or parent/child relation. This PR adds the first safe building block for future evidence selection work.

## Validation

- `python3 -m compileall -q src/orbit/runtime src/orbit/native_llama tests`
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_kv_diag tests.test_tool_message -q`
- `git diff --check`

Manual smoke:

- `shell_error`: PASS
- `dual_shell`: PASS
- correctness remains `correct`
- no evidence compaction or selection behavior changed

## Notes / Risks

- Diagnostic/structural only.
- No prompt, routing, tool loop, cache, final policy, or evidence rendering behavior changes.
- `tool_call_id` alone is not sufficient for relevance selection.
- `user_turn_id` and `produced_by_phase` remain future work where not yet available.
