### PR TITLE
Add user turn lineage to evidence records

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -130,6 +130,8 @@ class ChatRuntime:
     local_capabilities: LocalCapabilities = field(default_factory=discover_local_capabilities)
     diagnostic_session_id: str = "default"
     evidence_store: EvidenceStore | None = None
+    user_turn_counter: int = 0
+    current_user_turn_id: str | None = None
 
     def __post_init__(self) -> None:
         self.backend = instrument_backend(self.backend)
@@ -141,6 +143,11 @@ class ChatRuntime:
     def refresh_local_capabilities(self) -> LocalCapabilities:
         self.local_capabilities = discover_local_capabilities()
         return self.local_capabilities
+
+    def _begin_user_turn(self) -> str:
+        self.user_turn_counter += 1
+        self.current_user_turn_id = f"turn_{self.user_turn_counter}"
+        return self.current_user_turn_id
 
     @user_request
     def ask(
@@ -156,6 +163,7 @@ class ChatRuntime:
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
+        self._begin_user_turn()
         user_content = message_content(prompt, images or [], audios or [])
         result = self._pure_chat_environment().ask_user_content(
             user_content,
@@ -182,6 +190,7 @@ class ChatRuntime:
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
+        self._begin_user_turn()
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
         call_messages = with_chat_system_prompt([*self.messages, {"role": "user", "content": prompt}])
@@ -236,6 +245,7 @@ class ChatRuntime:
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
+        self._begin_user_turn()
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
         self.messages.append({"role": "user", "content": prompt})
@@ -279,6 +289,7 @@ class ChatRuntime:
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
         allowed_tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
+        self._begin_user_turn()
         self.last_memory_refresh = None
         self.refresh_memory_if_needed(temperature=temperature)
         resolution = self._file_input_environment(workdir).resolve(
@@ -713,6 +724,7 @@ class ChatRuntime:
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
             local_capabilities=self.local_capabilities,
+            user_turn_id=self.current_user_turn_id,
         )
     def _stream_tool_thinking_plan(
         self,

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -383,6 +383,7 @@ class ToolLoopEnvironment:
         tool_names: tuple[str, ...] | None,
         initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
         local_capabilities=None,
+        user_turn_id: str | None = None,
     ) -> ToolResultBundle:
         result = run_tool_loop(
             self.runtime,
@@ -399,6 +400,7 @@ class ToolLoopEnvironment:
             tool_names=tool_names,
             initial_tool_calls=initial_tool_calls,
             local_capabilities=local_capabilities,
+            user_turn_id=user_turn_id,
         )
         return ToolResultBundle(
             result=result,

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -94,6 +94,7 @@ def run_tool_loop(
     tool_names: tuple[str, ...] | None,
     initial_tool_calls: list[dict[str, object]] | dict[str, object] | None = None,
     local_capabilities: LocalCapabilities | None = None,
+    user_turn_id: str | None = None,
 ) -> ChatResult:
     allowed_tool_names = tool_names or default_tool_names()
     executor = HybridToolExecutor(
@@ -597,7 +598,12 @@ def run_tool_loop(
                         tool_call,
                         tool_result,
                         evidence_store=evidence_store,
-                        metadata=_tool_evidence_metadata(tool_call, source=execution.source),
+                        metadata=_tool_evidence_metadata(
+                            tool_call,
+                            source=execution.source,
+                            user_turn_id=user_turn_id,
+                            produced_by_phase="initial_tool_call",
+                        ),
                     )
                 )
                 if should_handoff_to_final_from_tool():
@@ -715,6 +721,7 @@ def run_tool_loop(
             on_final_delta=tool_delta_callback,
             on_progress=on_progress,
         )
+        produced_by_phase: str | None = "tool_call"
         last_result = result
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop_index, result=result, phase="tool_call" if result.tool_calls else None))
@@ -737,6 +744,7 @@ def run_tool_loop(
                 on_final_delta=suppress_tool_delta,
                 on_progress=on_progress,
             )
+            produced_by_phase = "tool_call_retry"
             last_result = result
             repair.contract_retry_pending = False
             if on_model_step:
@@ -778,11 +786,13 @@ def run_tool_loop(
         if result.finish_reason == "length" and not result.tool_calls:
             with model_call_context(phase="tool_call_retry", tools_mode="on"):
                 result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+            produced_by_phase = "tool_call_retry"
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=loop_index + 1, result=result, phase="tool_call_retry" if result.tool_calls else None))
         if not result.tool_calls and _is_empty_final_response(result):
             with model_call_context(phase="tool_call_retry", tools_mode="on"):
                 result = runtime.backend.chat(call_messages, temperature=temperature, max_tokens=tool_max_tokens, tools=tools)
+            produced_by_phase = "tool_call_retry"
             if on_model_step:
                 on_model_step(ModelStepMetrics.from_result(loop=loop_index + 1, result=result, phase="tool_call_retry" if result.tool_calls else None))
             if not result.tool_calls and _is_empty_final_response(result):
@@ -932,7 +942,12 @@ def run_tool_loop(
                     tool_call,
                     tool_result,
                     evidence_store=evidence_store,
-                    metadata=_tool_evidence_metadata(tool_call, source=execution.source),
+                    metadata=_tool_evidence_metadata(
+                        tool_call,
+                        source=execution.source,
+                        user_turn_id=user_turn_id,
+                        produced_by_phase=produced_by_phase,
+                    ),
                 )
             )
             if should_handoff_to_final_from_tool():
@@ -1043,8 +1058,18 @@ def _shell_raw_arguments_from_tool_call(tool_call: dict[str, object]) -> str | N
     return arguments if isinstance(arguments, str) and arguments.strip() else None
 
 
-def _tool_evidence_metadata(tool_call: dict[str, object], *, source: str) -> dict[str, object]:
+def _tool_evidence_metadata(
+    tool_call: dict[str, object],
+    *,
+    source: str,
+    user_turn_id: str | None = None,
+    produced_by_phase: str | None = None,
+) -> dict[str, object]:
     metadata: dict[str, object] = {"source": source}
+    if user_turn_id is not None:
+        metadata["user_turn_id"] = user_turn_id
+    if produced_by_phase is not None:
+        metadata["produced_by_phase"] = produced_by_phase
     command = _shell_command_from_tool_call(tool_call)
     if command:
         metadata["command"] = command

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -54,12 +54,22 @@ class EvidenceTests(unittest.TestCase):
             first = store.add(
                 "exec_shell_full_command",
                 "first",
-                metadata={"command": "printf first", "tool_call_id": "call_1"},
+                metadata={
+                    "command": "printf first",
+                    "tool_call_id": "call_1",
+                    "user_turn_id": "turn_1",
+                    "produced_by_phase": "tool_call",
+                },
             )
             second = store.add(
                 "exec_shell_full_command",
                 "second",
-                metadata={"command": "printf second", "tool_call_id": "call_2"},
+                metadata={
+                    "command": "printf second",
+                    "tool_call_id": "call_2",
+                    "user_turn_id": "turn_2",
+                    "produced_by_phase": "tool_call_retry",
+                },
             )
 
             reloaded = EvidenceStore(store.root)
@@ -68,6 +78,9 @@ class EvidenceTests(unittest.TestCase):
 
             self.assertEqual([record.evidence_sequence for record in loaded], [1, 2])
             self.assertEqual([record.tool_call_id for record in loaded], ["call_1", "call_2"])
+            self.assertEqual([record.user_turn_id for record in loaded], ["turn_1", "turn_2"])
+            self.assertEqual([record.produced_by_phase for record in loaded], ["tool_call", "tool_call_retry"])
+            self.assertEqual([record.producer_model_call_id for record in loaded], [None, None])
             self.assertEqual(first.evidence_sequence, 1)
             self.assertEqual(second.evidence_sequence, 2)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -6737,6 +6737,11 @@ EOF"""
         self.assertEqual(backend.calls, 3)
         tool_message = _last_tool_message(runtime)
         self.assertIn("file.txt", tool_message["content"])
+        self.assertIsNotNone(runtime.evidence_store)
+        record = runtime.evidence_store.recent_records(1)[0]
+        self.assertEqual(record.user_turn_id, "turn_1")
+        self.assertEqual(record.produced_by_phase, "tool_call")
+        self.assertIsNone(record.producer_model_call_id)
 
     def test_ask_with_tools_retries_empty_length_final_after_tool_result(self) -> None:
         class EmptyLengthFinalBackend:

--- a/tests/test_tool_message.py
+++ b/tests/test_tool_message.py
@@ -70,7 +70,12 @@ class ToolMessageTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             store = EvidenceStore(Path(tmp) / "session.evidence")
-            message = tool_result_message(tool_call, result, evidence_store=store)
+            message = tool_result_message(
+                tool_call,
+                result,
+                evidence_store=store,
+                metadata={"user_turn_id": "turn_1", "produced_by_phase": "tool_call"},
+            )
 
             self.assertEqual(message["role"], "tool")
             self.assertEqual(message["tool_call_id"], "call-1")
@@ -84,6 +89,9 @@ class ToolMessageTests(unittest.TestCase):
             self.assertEqual(store.load_raw(message["evidence_id"]), raw)
             record = store.recent_records(1)[0]
             self.assertEqual(record.tool_call_id, "call-1")
+            self.assertEqual(record.user_turn_id, "turn_1")
+            self.assertEqual(record.produced_by_phase, "tool_call")
+            self.assertIsNone(record.producer_model_call_id)
             self.assertEqual(record.evidence_sequence, 1)
 
 


### PR DESCRIPTION
## Summary

This PR adds runtime-local user turn lineage to evidence records.

It introduces:

- `user_turn_id`, generated by `ChatRuntime` as a runtime-local monotonic id such as `turn_1`
- propagation of `user_turn_id` through the tool loop into evidence metadata
- `produced_by_phase` for known producer paths:
  - `initial_tool_call`
  - `tool_call`
  - `tool_call_retry`

`producer_model_call_id` remains `null` for now.

## Why

Evidence lineage is needed before any safe relevance selection or multi-card reduction can be attempted.

Today, `recent_records(limit=2)` is insertion-order based. This PR does not change that behavior. It only adds structural lineage needed for future work.

## Validation

- `python3 -m compileall -q src/orbit/runtime src/orbit/native_llama tests`
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_tool_message tests.test_kv_diag -q`
- `PYTHONPATH=src python3 -m unittest tests.test_runtime.ToolRuntimeTests.test_ask_with_tools_reinjects_tool_result -q`
- `git diff --check`

Manual smoke:

- `shell_error`: PASS, correctness `correct`
- `dual_shell`: PASS, correctness `correct`

## Notes / Risks

- Diagnostic/structural only.
- No evidence selection, compaction, rendering, routing, tool loop, prompt, or cache behavior changes.
- `user_turn_id` is runtime-local, not globally stable across processes or sessions.
- `tool_call_id` and `user_turn_id` are lineage metadata, not relevance selectors by themselves.
