### PR TITLE
Increase system info final budget

### DIFF
--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -13,6 +13,7 @@ CHAT_MAX_TOKENS = 256
 
 FINAL_SMALL_MAX_TOKENS = 96
 FINAL_SHELL_ERROR_MAX_TOKENS = 128
+FINAL_SYSTEM_INFO_MAX_TOKENS = 160
 FINAL_MEDIUM_MAX_TOKENS = 192
 FINAL_WEB_SEARCH_MAX_TOKENS = 192
 FINAL_READ_MAX_TOKENS = 256
@@ -81,6 +82,8 @@ def _final_from_tool_tokens(requested: int | None, evidence_kind: str, evidence_
         return _floor_and_cap(requested, FINAL_READ_MAX_TOKENS, FINAL_READ_MAX_TOKENS)
     if evidence_kind == "shell_error":
         return _floor_and_cap(requested, FINAL_SHELL_ERROR_MAX_TOKENS, FINAL_SHELL_ERROR_MAX_TOKENS)
+    if evidence_kind == "system_info":
+        return _floor_and_cap(requested, FINAL_SYSTEM_INFO_MAX_TOKENS, FINAL_SYSTEM_INFO_MAX_TOKENS)
     if evidence_kind in {"shell", "unknown", "grep_search"} and evidence_chars is not None and evidence_chars <= 500:
         return _floor_and_cap(requested, FINAL_SMALL_MAX_TOKENS, FINAL_SMALL_MAX_TOKENS)
     if evidence_kind in {"shell", "unknown", "grep_search"}:

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -672,6 +672,8 @@ class FinalFromToolEnvironment:
         record = next(iter(store.recent_records(1)), None)
         if record is None:
             return None, None
+        if record.tool_name == "system_info":
+            return "system_info", record.raw_chars
         if record.kind in {"shell", "unknown"} and record.status == "error":
             return "shell_error", record.raw_chars
         return record.kind, record.raw_chars

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -18,6 +18,7 @@ PDF_FINAL_MAX_TOKENS = 128
 PDF_BRIEF_FINAL_MAX_TOKENS = 72
 LIST_FINAL_MAX_TOKENS = 96
 OPERATIONAL_STATUS_FINAL_MAX_TOKENS = 96
+SYSTEM_INFO_FINAL_MAX_TOKENS = 160
 LONG_SHELL_ANALYSIS_FINAL_MAX_TOKENS = 96
 BRIEF_SHELL_FINAL_MAX_TOKENS = 96
 COMPACT_FINAL_RETRY_MAX_TOKENS = 160
@@ -100,6 +101,7 @@ def build_final_tool_policy(
     pdf_text_result = has_pdf_text_tool_result(call_messages)
     list_like_result = has_list_like_tool_result(call_messages) and is_compact_list_request(prompt)
     shell_full_result = has_tool_result(call_messages, "exec_shell_full_command")
+    system_info_result = has_tool_result(call_messages, "system_info")
     operational_status_result = shell_full_result and is_operational_status_request(prompt)
     brief_request = is_brief_final_request(prompt)
     brief_shell_result = shell_full_result and brief_request and not (
@@ -240,6 +242,7 @@ def build_final_tool_policy(
             pdf_text_result=pdf_text_result,
             list_like_result=list_like_result,
             operational_status_result=operational_status_result,
+            system_info_result=system_info_result,
             compact_shell_analysis_result=compact_shell_analysis_result,
             brief_shell_result=brief_shell_result,
             brief_request=brief_request,
@@ -263,6 +266,7 @@ def final_tool_max_tokens(
     pdf_text_result: bool,
     list_like_result: bool,
     operational_status_result: bool = False,
+    system_info_result: bool = False,
     compact_shell_analysis_result: bool = False,
     brief_shell_result: bool = False,
     brief_request: bool = False,
@@ -289,6 +293,8 @@ def final_tool_max_tokens(
         )
     if list_like_result:
         return min(max_tokens, LIST_FINAL_MAX_TOKENS)
+    if system_info_result:
+        return min(max_tokens, SYSTEM_INFO_FINAL_MAX_TOKENS)
     if operational_status_result:
         return min(max_tokens, OPERATIONAL_STATUS_FINAL_MAX_TOKENS)
     if compact_shell_analysis_result:

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -31,6 +31,7 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=80), 96)
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="unknown", evidence_chars=80), 96)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell_error", evidence_chars=120), 128)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="system_info", evidence_chars=300), 160)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=1200), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="web_search", evidence_chars=1200), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="read", evidence_chars=8000), 256)

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -505,6 +505,27 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("Ignore older tool results", policy.messages[-1]["content"])
         self.assertIn("Do not summarize file or page content", policy.messages[-1]["content"])
 
+    def test_system_info_policy_uses_larger_small_final_budget(self) -> None:
+        messages = [
+            {"role": "user", "content": "tell me specs about this computer"},
+            {
+                "role": "tool",
+                "name": "system_info",
+                "content": (
+                    "system_info:\n"
+                    "OS: Linux 6.17.0-35-generic x86_64\n"
+                    "CPU: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz\n"
+                    "RAM: 62.5 GiB total (47.8 GiB available)\n"
+                    "Disk:\n- /: 915.3 GiB total, 164.1 GiB available\n"
+                    "Python: 3.12.3"
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=512, streamed=False)
+
+        self.assertEqual(policy.max_tokens, 160)
+
     def test_operational_status_policy_preserves_remove_confirmation(self) -> None:
         messages = [
             {"role": "user", "content": "remove index.html"},


### PR DESCRIPTION
## Summary

This PR adds a dedicated final-from-tool output budget for `system_info`.

Previously, small final-from-tool responses were capped at 96 tokens. This caused `system_info` answers such as “tell me specs about this computer” to stop with `finish_reason=length` and require `/continue`.

The new dedicated budget gives `system_info` 160 tokens while keeping existing small shell/grep/unknown budgets unchanged.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_completion_budget tests.test_final_policy -q`
- `python3 -m compileall -q src/orbit/runtime tests`
- `git diff --check`

Manual smoke:

- prompt: `tell me specs about this computer`
- tools on
- max tokens 512

Before:
- `tks 287->96`
- `stop: length`
- `/continue` required

After:
- `tks 289->147`
- `stop: stop`
- no `/continue`

## Notes / Risks

- Uses structural tool metadata, not user-text keywords.
- Does not change routing, tool execution, prompts, MTP, or global max token behavior.
- Small shell/grep/unknown final budgets remain unchanged.