### PR TITLE
Clarify CPU-first server and MTP guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,15 @@ orbit download unsloth/gemma-4-12b-it-GGUF/MTP/gemma-4-12b-it-Q8_0-MTP.gguf
 
 ## Quick Start
 
-Start the native server with MTP enabled:
+Start the native server:
 
 ```bash
-PYTHONPATH=src .venv/bin/orbit server --mtp
+PYTHONPATH=src .venv/bin/orbit server
 ```
 
 The current release gate expects:
 
 - native backend loaded
-- MTP initialized when `--mtp` is used
 - multimodal capability detected when `mmproj` is available
 - route-prefix KV prewarm completed
 - no duplicate `llama.cpp` runtime loaded
@@ -94,6 +93,18 @@ ORBIT_KV_DIAG=1 .venv/bin/orbit --workdir workdir --tools on --think off "hi"
 
 `ORBIT_KV_DIAG=1` is diagnostic only. It is not required for normal use.
 
+### Optional MTP
+
+Native MTP is explicit:
+
+```bash
+PYTHONPATH=src .venv/bin/orbit server --mtp
+```
+
+Use it for targeted validation or experiments, not as a default speed
+assumption. Current diagnostics show MTP can be stable while still being slower
+on some CPU-only workloads.
+
 ## Tools
 
 Tools are off by default. Tools-on mode exposes unrestricted local shell access
@@ -103,7 +114,7 @@ workdir.
 Keep tools disabled at server startup:
 
 ```bash
-ORBIT_TOOLS=off .venv/bin/orbit server --mtp
+ORBIT_TOOLS=off .venv/bin/orbit server
 ```
 
 Disable tools for a client/session:
@@ -147,13 +158,13 @@ also enabled by default for the tools-on route prefix.
 Disable only startup prewarm:
 
 ```bash
-ORBIT_KV_PREFIX_PREWARM=off .venv/bin/orbit server --mtp
+ORBIT_KV_PREFIX_PREWARM=off .venv/bin/orbit server
 ```
 
 Disable route-prefix anchor and prewarm:
 
 ```bash
-ORBIT_KV_PREFIX_ANCHOR=off .venv/bin/orbit server --mtp
+ORBIT_KV_PREFIX_ANCHOR=off .venv/bin/orbit server
 ```
 
 The prewarm cost is paid at startup. It does not remove CPU work; it shifts part
@@ -227,16 +238,27 @@ For post-tool issues, first check whether raw evidence is leaking into the
 prompt, whether a redundant tool call happened, and whether the final footer
 shows a large prompt or simply slow CPU prefill.
 
-Future work includes a Dynamic Completion Budget Policy: route, tool, final,
-and repair calls should get per-completion-kind output budgets so Orbit can
-avoid both truncation and overly long internal generations without changing
-prompt policy.
+Output budgets are per completion kind. `/max-tokens` is still the user-facing
+budget, but Orbit may use smaller internal budgets for route, tool, final, and
+repair phases to avoid excessive CPU work. If an answer is truncated, the footer
+shows `stop: length` and `/continue` is available.
+
+For CPU benchmarking, record the exact Orbit commit or tag, model artifact,
+backend mode, context size, thread settings, MTP state, tools mode, and whether
+startup prewarm was enabled. Single-run numbers are useful for triage, but not
+release-quality performance evidence.
 
 ## Compatibility
 
 The preferred runtime is native `orbit server`. Orbit can still talk to a local
 OpenAI-compatible HTTP backend through `--base-url`, but that is a compatibility
 or comparison path, not the primary product path.
+
+Native Orbit is CPU-first and currently configures `gpu_layers=0`. GPU tests
+should use an external OpenAI-compatible backend such as `llama-server` with
+GPU offload enabled, then point Orbit at it with `--base-url`. Treat those
+results as compatibility/backend comparisons, not native `orbit server`
+performance.
 
 ## Troubleshooting
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -28,6 +28,31 @@ parallel_slots=1
 
 These defaults favor stability on CPU-only systems. Change them only with comparable benchmarks.
 
+On Apple Silicon, thread count is not automatically "all cores". Local
+measurements have shown that using only performance cores can beat using
+performance plus efficiency cores for token-by-token generation. On thermally
+constrained Intel laptops, extra threads can also be erased by throttling.
+Treat thread changes as workload- and machine-specific.
+
+## GPU and compatibility backends
+
+Native `orbit server` is CPU-first and currently configures `gpu_layers=0`.
+It does not expose native GPU offload as a normal server option.
+
+GPU measurements should use a separate OpenAI-compatible backend, for example
+`llama-server` built with Metal/CUDA and started with GPU offload enabled. Point
+Orbit at that backend with:
+
+```bash
+orbit bench-core --base-url http://127.0.0.1:8080
+```
+
+Do not include `/v1` in the base URL; Orbit appends the OpenAI-compatible paths.
+
+Interpret GPU results as backend comparisons. They are useful, but they are not
+native `orbit server` results. MLX/Ollama results are even less directly
+comparable when quantization, context length, and tool-call behavior differ.
+
 ## MTP
 
 Native MTP is supported through:
@@ -97,6 +122,44 @@ Rules:
 - keep prompt, config, model, and backend mode identical
 - use fixed CPU affinity for serious CPU-only measurements
 - treat single-run differences as noise unless repeated
+- record the exact Orbit commit or tag with `git rev-parse HEAD`
+- record the model artifact, quantization, context size, threads,
+  `threads-batch`, MTP state, tools mode, and startup prewarm state
+- keep raw benchmark output or logs outside the repository workdir unless they
+  are intentionally sanitized fixtures
+
+Minimum metadata to attach to any benchmark note:
+
+```text
+orbit_commit=<git rev-parse HEAD>
+orbit_tag=<tag or none>
+backend=native|llama-server|other
+model=<repo/file or local path>
+quant=<for example Q4_K_M>
+ctx=8192
+threads=<n>
+threads_batch=<n>
+mtp=on|off
+tools=on|off
+prewarm=on|off
+platform=<OS/CPU/GPU>
+```
+
+## Exploratory hardware observations
+
+Local exploratory tests on Gemma 4 12B Q4_K_M are consistent with common
+llama.cpp behavior:
+
+- generation is often memory-bandwidth-bound, not pure compute-bound
+- prefill benefits more from GPU/offload and larger batch compute
+- laptop Intel CPUs can be dominated by thermal throttling
+- Apple Silicon CPU results depend strongly on performance-core thread counts
+- external GPU backends can greatly improve prefill, but they are separate from
+  native Orbit CPU behavior
+
+These observations are useful for choosing hardware and benchmark matrices.
+They should not be treated as release gates unless the exact commit, backend,
+model, configuration, and repeated raw results are recorded.
 
 ## Main bottlenecks observed
 


### PR DESCRIPTION
## Summary

This PR updates the README and performance documentation to clarify Orbit's CPU-first native server defaults and the optional nature of MTP.

Key changes:
- Quick Start now uses `orbit server` without implying MTP by default.
- MTP is documented as optional and not guaranteed to improve throughput.
- `/max-tokens` is clarified as a user-facing limit while Orbit still applies phase-specific runtime budgets.
- CPU benchmark guidance now recommends recording commit/tag, model, context size, threads, MTP state, tools, and prewarm.
- Native `orbit server` is documented as CPU-first with `gpu_layers=0`.
- GPU performance should be measured through compatible external backends, for example llama-server via `--base-url`.
- Exploratory performance notes are framed as observations, not guarantees.

## Validation

- `git diff --check`

## Notes

Documentation-only change.
No runtime, routing, prompt, tool loop, MTP, cache, or benchmark code changes.