### PR TITLE
Add bench core metadata header

### DIFF
--- a/src/orbit/dev/bench_core.py
+++ b/src/orbit/dev/bench_core.py
@@ -1,18 +1,40 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from pathlib import Path
+import platform
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 
 
 DEFAULT_BASE_URL = "http://127.0.0.1:12120"
 DEFAULT_WORKDIR = "workdir"
 DEFAULT_TIMEOUT = 600
 DEFAULT_MAX_TOKENS = 512
+METADATA_ENV_KEYS: tuple[str, ...] = (
+    "ORBIT_KV_PREFIX_PREWARM",
+    "ORBIT_MTP_TRACE",
+    "ORBIT_KV_DIAG",
+    "ORBIT_BASE_URL",
+)
+BACKEND_PROPS_KEYS: tuple[str, ...] = (
+    "model",
+    "ctx",
+    "threads",
+    "threads_batch",
+    "batch",
+    "ubatch",
+    "mtp_enabled",
+    "mtp_initialized",
+    "multimodal_available",
+    "gpu_layers",
+)
 PROMPTS: tuple[tuple[str, str], ...] = (
     ("chat", "hi, who are you? Answer in one short sentence."),
     ("list files", "list files and directories in this workdir"),
@@ -30,12 +52,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", type=int, default=int(os.environ.get("TIMEOUT", str(DEFAULT_TIMEOUT))))
     parser.add_argument("--max-tokens", type=int, default=int(os.environ.get("MAX_TOKENS", str(DEFAULT_MAX_TOKENS))))
     parser.add_argument("--orbit-bin", default=None, help="Override the orbit executable used for subprocess benchmark runs.")
+    parser.add_argument("--no-metadata", action="store_true", help="Do not print benchmark metadata before running tasks.")
     return parser
 
 
 def main(argv: list[str] | None = None, *, orbit_bin: str | None = None) -> int:
     args = build_parser().parse_args(argv)
     chosen_orbit = _resolve_orbit_bin(args.orbit_bin or orbit_bin)
+    if not args.no_metadata:
+        _print_metadata(args, chosen_orbit)
     for label, prompt in PROMPTS:
         print()
         print(f"## {label}")
@@ -78,3 +103,60 @@ def _resolve_orbit_bin(explicit: str | None) -> str:
     if fallback.exists():
         return str(fallback)
     raise SystemExit("error: orbit binary not found")
+
+
+def _print_metadata(args: argparse.Namespace, chosen_orbit: str) -> None:
+    print("# orbit bench-core metadata")
+    print(f"orbit_commit: {_git_output(['rev-parse', 'HEAD'], fallback='unknown')}")
+    print(f"orbit_tag: {_git_output(['describe', '--tags', '--exact-match', 'HEAD'], fallback='none')}")
+    print(f"orbit_bin: {chosen_orbit}")
+    print(f"base_url: {args.base_url}")
+    print(f"workdir: {args.workdir}")
+    print(f"timeout: {args.timeout}")
+    print(f"max_tokens: {args.max_tokens}")
+    print(f"python: {sys.version.split()[0]}")
+    print(f"platform: {platform.platform()}")
+    print("env:")
+    for key in METADATA_ENV_KEYS:
+        print(f"  {key}: {os.environ.get(key, '<unset>')}")
+    props = _fetch_backend_props(args.base_url)
+    if props is None:
+        print("backend_props: unavailable")
+    else:
+        print("backend:")
+        for key in BACKEND_PROPS_KEYS:
+            if key in props:
+                print(f"  {key}: {props[key]}")
+
+
+def _git_output(args: list[str], *, fallback: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return fallback
+    value = completed.stdout.strip()
+    if completed.returncode != 0 or not value:
+        return fallback
+    return value
+
+
+def _fetch_backend_props(base_url: str) -> dict[str, object] | None:
+    url = base_url.rstrip("/") + "/props"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            payload = response.read()
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return None
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded

--- a/tests/test_bench_core.py
+++ b/tests/test_bench_core.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+from contextlib import redirect_stdout
+
+from orbit.dev import bench_core
+
+
+class BenchCoreMetadataTests(unittest.TestCase):
+    def test_metadata_on_prints_header_and_backend_props(self) -> None:
+        completed_calls: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+            completed_calls.append(command)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        with (
+            mock.patch.object(bench_core, "_resolve_orbit_bin", return_value="/tmp/orbit"),
+            mock.patch.object(bench_core, "_git_output", side_effect=["abc123", "v1"]),
+            mock.patch.object(
+                bench_core,
+                "_fetch_backend_props",
+                return_value={
+                    "model": "gemma4:12b-it-native",
+                    "ctx": 8192,
+                    "threads": 6,
+                    "threads_batch": 6,
+                    "batch": 256,
+                    "ubatch": 128,
+                    "mtp_enabled": False,
+                    "mtp_initialized": False,
+                    "multimodal_available": True,
+                    "gpu_layers": 0,
+                    "ignored": "value",
+                },
+            ),
+            mock.patch.object(bench_core.subprocess, "run", side_effect=fake_run),
+        ):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = bench_core.main(["--base-url", "http://127.0.0.1:12120", "--workdir", "workdir"])
+
+        self.assertEqual(code, 0)
+        text = out.getvalue()
+        self.assertIn("# orbit bench-core metadata", text)
+        self.assertIn("orbit_commit: abc123", text)
+        self.assertIn("orbit_tag: v1", text)
+        self.assertIn("backend:", text)
+        self.assertIn("  model: gemma4:12b-it-native", text)
+        self.assertIn("  gpu_layers: 0", text)
+        self.assertNotIn("ignored", text)
+        self.assertEqual(len(completed_calls), len(bench_core.PROMPTS))
+
+    def test_no_metadata_preserves_minimal_output(self) -> None:
+        def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+            return SimpleNamespace(stdout="task output\n", stderr="", returncode=0)
+
+        with (
+            mock.patch.object(bench_core, "_resolve_orbit_bin", return_value="/tmp/orbit"),
+            mock.patch.object(bench_core, "_print_metadata") as print_metadata,
+            mock.patch.object(bench_core.subprocess, "run", side_effect=fake_run),
+        ):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = bench_core.main(["--no-metadata"])
+
+        self.assertEqual(code, 0)
+        self.assertNotIn("# orbit bench-core metadata", out.getvalue())
+        print_metadata.assert_not_called()
+
+    def test_backend_props_unavailable_does_not_fail(self) -> None:
+        args = SimpleNamespace(base_url="http://127.0.0.1:12120", workdir="workdir", timeout=600, max_tokens=512)
+        with (
+            mock.patch.object(bench_core, "_git_output", side_effect=["abc123", "none"]),
+            mock.patch.object(bench_core, "_fetch_backend_props", return_value=None),
+        ):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                bench_core._print_metadata(args, "/tmp/orbit")
+
+        self.assertIn("backend_props: unavailable", out.getvalue())
+
+    def test_git_output_commit_and_exact_tag(self) -> None:
+        with mock.patch.object(
+            bench_core.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="abc123\n", stderr="", returncode=0),
+        ):
+            self.assertEqual(bench_core._git_output(["rev-parse", "HEAD"], fallback="unknown"), "abc123")
+
+        with mock.patch.object(
+            bench_core.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="v0.0.1\n", stderr="", returncode=0),
+        ):
+            self.assertEqual(
+                bench_core._git_output(["describe", "--tags", "--exact-match", "HEAD"], fallback="none"),
+                "v0.0.1",
+            )
+
+    def test_git_output_fallbacks(self) -> None:
+        with mock.patch.object(
+            bench_core.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="", stderr="", returncode=1),
+        ):
+            self.assertEqual(bench_core._git_output(["describe"], fallback="none"), "none")
+
+        with mock.patch.object(bench_core.subprocess, "run", side_effect=OSError):
+            self.assertEqual(bench_core._git_output(["rev-parse", "HEAD"], fallback="unknown"), "unknown")
+
+    def test_task_arguments_are_unchanged(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        with (
+            mock.patch.object(bench_core, "_resolve_orbit_bin", return_value="/tmp/orbit"),
+            mock.patch.object(bench_core.subprocess, "run", side_effect=fake_run),
+        ):
+            with redirect_stdout(io.StringIO()):
+                bench_core.main(
+                    [
+                        "--no-metadata",
+                        "--base-url",
+                        "http://backend",
+                        "--workdir",
+                        "workdir",
+                        "--timeout",
+                        "123",
+                        "--max-tokens",
+                        "456",
+                    ]
+                )
+
+        self.assertEqual(len(calls), len(bench_core.PROMPTS))
+        for call, (_, prompt) in zip(calls, bench_core.PROMPTS, strict=True):
+            self.assertEqual(
+                call,
+                [
+                    "/tmp/orbit",
+                    "--base-url",
+                    "http://backend",
+                    "--workdir",
+                    "workdir",
+                    "--timeout",
+                    "123",
+                    "--max-tokens",
+                    "456",
+                    prompt,
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a conservative metadata header to `orbit bench-core`.

The header is printed before benchmark tasks by default and records reproducibility context such as:

- Orbit commit/tag
- Orbit binary path
- base URL
- workdir
- timeout and max tokens
- Python/platform
- selected Orbit environment variables
- best-effort backend `/props` fields when available

A new `--no-metadata` flag restores the previous minimal output.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_bench_core -q`
- `python3 -m compileall -q src/orbit/dev tests`
- `git diff --check`

## Notes

- `/props` is best-effort and not required.
- If backend props are unavailable, the benchmark prints `backend_props: unavailable` and continues.
- No benchmark tasks, prompts, timeouts, tool behavior, metrics, runtime/server, MTP, or cache behavior are changed.