### PR TITLE
Document bench core metadata and profile guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ backend mode, context size, thread settings, MTP state, tools mode, and whether
 startup prewarm was enabled. Single-run numbers are useful for triage, but not
 release-quality performance evidence.
 
+For local performance checks, use `orbit bench-core`. For a conservative
+starting point on server thread and batch settings, see
+`scripts/suggest-server-profile.sh`. Benchmark and tuning notes are in
+[docs/PERFORMANCE.md](docs/PERFORMANCE.md).
+
 ## Compatibility
 
 The preferred runtime is native `orbit server`. Orbit can still talk to a local

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -28,6 +28,17 @@ parallel_slots=1
 
 These defaults favor stability on CPU-only systems. Change them only with comparable benchmarks.
 
+For a conservative machine-local starting point, run:
+
+```bash
+scripts/suggest-server-profile.sh
+```
+
+The script prints suggested `THREADS`, `BATCH_SIZE`, `UBATCH_SIZE`, and
+`CACHE_RAM` exports for `orbit server`. Treat them as starting values, not
+guaranteed optimal settings; validate changes with comparable `bench-core`
+runs.
+
 On Apple Silicon, thread count is not automatically "all cores". Local
 measurements have shown that using only performance cores can beat using
 performance plus efficiency cores for token-by-token generation. On thermally
@@ -115,6 +126,11 @@ Public regression benchmark:
 ```bash
 orbit bench-core --base-url http://127.0.0.1:12120
 ```
+
+`bench-core` prints a metadata header by default so shared results include the
+Orbit commit/tag, local benchmark options, selected environment variables, and
+best-effort backend `/props` fields. Use `--no-metadata` only when the old
+minimal output is required.
 
 Rules:
 

--- a/scripts/suggest-server-profile.sh
+++ b/scripts/suggest-server-profile.sh
@@ -166,7 +166,8 @@ cat <<EOF
 # These values are suggestions for orbit server. Review them before exporting.
 # Typical use:
 #   export THREADS=$THREADS BATCH_SIZE=$BATCH_SIZE UBATCH_SIZE=$UBATCH_SIZE CACHE_RAM=$CACHE_RAM
-#   orbit server --port 12120 --mtp
+#   orbit server --port 12120
+# Add --mtp only when intentionally testing native MTP.
 
 export THREADS=$THREADS
 export BATCH_SIZE=$BATCH_SIZE


### PR DESCRIPTION
## Summary

Updates documentation and profiling guidance after the bench-core metadata work.

Key changes:
- README now points users to `orbit bench-core`, `scripts/suggest-server-profile.sh`, and `docs/PERFORMANCE.md`.
- Performance docs describe `suggest-server-profile.sh` as a conservative starting point, not a guarantee of optimal tuning.
- Performance docs clarify that `orbit bench-core` prints a metadata header by default.
- `--no-metadata` is documented as the way to restore minimal benchmark output.
- `scripts/suggest-server-profile.sh` no longer suggests `--mtp` in the default server command.
- MTP is now explicitly shown only as an intentional native MTP test option.

## Validation

- `git diff --check`

## Notes

Documentation/script guidance only.
No runtime, benchmark logic, routing, prompt, tool, MTP, cache, or release changes.