### PR TITLE
Document optional MTP model download

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Download model artifacts as needed:
 ```bash
 orbit download ggml-org/gemma-4-12B-it-GGUF
 orbit download ggml-org/gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-Q8_0.gguf
-orbit download unsloth/gemma-4-12b-it-GGUF/MTP/gemma-4-12b-it-Q8_0-MTP.gguf
 ```
 
 ## Quick Start
@@ -96,6 +95,12 @@ ORBIT_KV_DIAG=1 .venv/bin/orbit --workdir workdir --tools on --think off "hi"
 ### Optional MTP
 
 Native MTP is explicit:
+
+Only download the MTP draft model if you intentionally want to test native MTP:
+
+```bash
+orbit download unsloth/gemma-4-12b-it-GGUF/MTP/gemma-4-12b-it-Q8_0-MTP.gguf
+```
 
 ```bash
 PYTHONPATH=src .venv/bin/orbit server --mtp


### PR DESCRIPTION
## Summary

Moves the native MTP draft model download out of the base install flow.

The base install now downloads only the main Gemma model and multimodal projection model. The MTP draft model is documented under the optional native MTP section and should only be downloaded when intentionally testing native MTP.

## Validation

- `git diff --check`

## Notes

Documentation-only change.
No runtime, script, benchmark, routing, prompt, tool, MTP, or cache behavior changes.