### PR TITLE
Improve route guidance for conversation reuse

### DIFF
--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -30,6 +30,8 @@ MEDIA_SYSTEM_PROMPT = "Answer using the attached image/audio."
 _COMMAND_SYSTEM_TEMPLATE = """Decide compactly whether the user request needs local tools.
 Tool tasks: files/read/edit/create/append/delete, system, URLs/web/search/fetch, execution, and analysis that needs local or fetched evidence.
 For tool tasks, return a tool decision; do not answer directly or return CHAT.
+If the latest request is only a recap, repeat, summary, explanation, comparison, or continuation of information already in this conversation, prefer {{"route":"CHAT"}} when the prior context is sufficient.
+Call tools for fresh/current data, verification, changed files/state, new information, or missing/stale/ambiguous/insufficient prior context.
 Web/search/latest/current/online and URL fetch/read/open/explain/summarize/analyze requests are tool tasks; return a compact tool decision, not a direct answer.
 Specific file read/explain/summarize/analyze requests require file content evidence; return a content-reading command decision, not a directory listing.
 If the target is a file path or filename, use a content-reading command; do not inspect it with list_directory.

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT, with_chat_system_prompt
+from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT, TOOL_CALL_SYSTEM_PROMPT, with_chat_system_prompt
 
 
 class MessagePromptTests(unittest.TestCase):
@@ -16,6 +16,28 @@ class MessagePromptTests(unittest.TestCase):
             [{"role": "system", "content": ROUTE_SYSTEM_PROMPT}, {"role": "user", "content": "x"}]
         )
         self.assertEqual(messages[0]["content"], CHAT_SYSTEM_PROMPT)
+
+    def test_route_policy_prefers_existing_context_for_recaps(self) -> None:
+        self.assertIn("recap, repeat, summary, explanation, comparison, or continuation", ROUTE_SYSTEM_PROMPT)
+        self.assertIn('prefer {"route":"CHAT"} when the prior context is sufficient', ROUTE_SYSTEM_PROMPT)
+
+    def test_route_policy_allows_refresh_and_verification_tools(self) -> None:
+        self.assertIn("fresh/current data", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("verification", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("changed files/state", ROUTE_SYSTEM_PROMPT)
+
+    def test_route_policy_allows_new_information_tools(self) -> None:
+        self.assertIn("new information", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("missing/stale/ambiguous/insufficient prior context", ROUTE_SYSTEM_PROMPT)
+
+    def test_route_policy_covers_prior_file_or_search_summaries_generally(self) -> None:
+        self.assertIn("information already in this conversation", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("summary", ROUTE_SYSTEM_PROMPT)
+        self.assertIn("prior context is sufficient", ROUTE_SYSTEM_PROMPT)
+
+    def test_tool_call_policy_still_requires_one_tool_after_route_decides_tool(self) -> None:
+        self.assertIn("Call exactly one available tool", TOOL_CALL_SYSTEM_PROMPT)
+        self.assertIn("Operate on the latest user request only", TOOL_CALL_SYSTEM_PROMPT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Improves route guidance for conversation reuse.

Problem: the router could call tools again for recaps, summaries, repetitions, or continuations of information already present in the conversation.

Solution: add a general, model-guided route prompt rule to prefer `CHAT` when the existing conversation context is sufficient.

Safety:
- fresh/current requests can still use tools
- verification/check requests can still use tools
- changed file/state requests can still use tools
- new information requests can still use tools
- missing, stale, ambiguous, or insufficient context can still use tools

No fast path, cache/TTL, tool-specific logic, runtime changes, or tool-loop changes are introduced.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_messages -q`
- `python3 -m compileall -q src/orbit/runtime tests`
- `git diff --check`