### PR TITLE
Use compact final view for web search errors

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -967,7 +967,7 @@ class ChatRuntime:
         record = next(iter(self.evidence_store.recent_records(1)), None)
         if record is None or record.kind != "web_search":
             return False
-        if record.status == "none":
+        if record.status in {"none", "error"}:
             return True
         if use_tool_prompt:
             return False

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -313,7 +313,7 @@ def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
     if record is None or record.kind != "web_search":
         return None
     snippets = record.metadata.get("top_snippets")
-    if (not isinstance(snippets, list) or not snippets) and record.status != "none":
+    if (not isinstance(snippets, list) or not snippets) and record.status not in {"none", "error"}:
         return None
     parts = [
         "evidence_context:",
@@ -327,7 +327,7 @@ def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
         f"sha256: {record.raw_sha256[:16]}",
         f"size: {record.raw_chars} chars, {record.raw_lines} lines",
     ]
-    for key in ("query", "result_count", "top_domains", "top_titles"):
+    for key in ("query", "result_count", "error_message", "top_domains", "top_titles"):
         value = record.metadata.get(key)
         if value in (None, "", [], {}):
             continue
@@ -400,6 +400,8 @@ def _classify_kind(tool_name: str, content: str, metadata: dict[str, object]) ->
 
 def _status_for(kind: str, content: str, metadata: dict[str, object]) -> str:
     if kind == "web_search":
+        if content.lstrip().lower().startswith("error:"):
+            return "error"
         if "results: none" in content:
             return "none"
         if "web_search_results: true" in content:
@@ -428,9 +430,11 @@ def _web_metadata(content: str, metadata: dict[str, object]) -> dict[str, object
     urls = re.findall(r"^\s+url:\s*(.+)$", content, re.MULTILINE)
     snippets = re.findall(r"^\s+snippet:\s*(.+)$", content, re.MULTILINE)
     domains = [_domain(url) for url in urls]
+    error_message = content.strip() if content.lstrip().lower().startswith("error:") else ""
     return {
         "query": query or "",
         "result_count": len(titles),
+        "error_message": _bounded_text(error_message, 240) if error_message else "",
         "top_titles": titles[:3],
         "top_domains": [domain for domain in domains[:3] if domain],
         "top_snippets": snippets[:3],

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -624,6 +624,47 @@ class EvidenceTests(unittest.TestCase):
             self.assertNotIn("web_search_results: true", context)
             self.assertNotIn("results: none", context)
 
+    def test_web_final_context_handles_error_without_full_raw_output(self) -> None:
+        raw = "error: web search failed: " + ("dns resolution unavailable " * 40)
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": 'orbit-web-search "location of Avola"'},
+            )
+
+            context = build_web_final_evidence_context(store)
+
+            self.assertEqual(record.kind, "web_search")
+            self.assertEqual(record.status, "error")
+            self.assertIsNotNone(context)
+            assert context is not None
+            self.assertIn("web_search_evidence: true", context)
+            self.assertIn("status: error", context)
+            self.assertIn("query: location of Avola", context)
+            self.assertIn("result_count: 0", context)
+            self.assertIn("error_message: error: web search failed", context)
+            self.assertIn(record.raw_ref, context)
+            self.assertIn(record.raw_sha256[:16], context)
+            self.assertNotIn("bounded_raw_excerpt:", context)
+            self.assertNotIn("dns resolution unavailable " * 20, context)
+
+    def test_web_final_context_ignores_non_web_error_records(self) -> None:
+        raw = "error: command failed"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command",
+                raw,
+                metadata={"command": "false"},
+            )
+
+            context = build_web_final_evidence_context(store)
+
+            self.assertEqual(record.kind, "shell")
+            self.assertIsNone(context)
+
 
 def _store_with(record, content: str) -> EvidenceStore:
     store = EvidenceStore(Path("/tmp/orbit-test-unused-session.evidence"))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3043,6 +3043,69 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertNotIn("results: none", rendered)
         self.assertNotIn("Decide compactly whether the user request needs local tools", rendered)
 
+    def test_error_web_search_route_uses_brief_final_prompt(self) -> None:
+        class ErrorWebSearchBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.max_tokens_seen: list[int] = []
+                self.final_messages: list[Message] | None = None
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.max_tokens_seen.append(max_tokens)
+                if self.calls == 1:
+                    return ChatResult(
+                        content='{"command":"orbit-web-search \\"location of Avola\\""}',
+                        model="fake",
+                        finish_reason="stop",
+                        tool_calls=[],
+                        prompt_tokens=10,
+                        completion_tokens=8,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                self.final_messages = messages
+                return ChatResult(
+                    content="The web search failed because DNS resolution was unavailable.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=38,
+                    completion_tokens=10,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = ErrorWebSearchBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            with patch(
+                "orbit.runtime.shell_guardrails.search_web",
+                return_value="error: web search failed: <urlopen error [Errno -2] Name or service not known>",
+            ):
+                result = runtime.ask_auto(
+                    "search online for location of Avola",
+                    temperature=0,
+                    max_tokens=512,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command",),
+                )
+
+        self.assertEqual(result.content, "The web search failed because DNS resolution was unavailable.")
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(backend.max_tokens_seen, [64, 192])
+        self.assertIsNotNone(backend.final_messages)
+        self.assertEqual(backend.final_messages[0]["content"], FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.final_messages or [])
+        self.assertTrue(runtime._should_use_web_final_view(use_tool_prompt=True))
+        self.assertIn("web_search_evidence: true", rendered)
+        self.assertIn("status: error", rendered)
+        self.assertIn("query: location of Avola", rendered)
+        self.assertIn("error_message: error: web search failed", rendered)
+        self.assertNotIn("Decide compactly whether the user request needs local tools", rendered)
+
     def test_new_web_turn_uses_latest_tool_evidence_not_previous_local_result(self) -> None:
         class RoutedBackend:
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Routes web search errors through the compact web final view.

Previously, a failed web search could fall back to a larger `final_from_tool` prompt even though the model only needed to briefly report the error. This PR treats `web_search` evidence with `status=error` like other compact web final cases and includes bounded error metadata in the final context.

## Safety

- Scoped to `web_search` evidence.
- Non-web errors are unchanged.
- Full raw error/output is not reinjected into the compact final prompt.
- Long web-search errors are bounded in `error_message`.
- `status=none` and successful web search behavior remain covered.
- No routing/tool-loop changes.
- No MTP, cache/KV, or global budget changes.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime.ToolRuntimeTests.test_empty_web_search_route_uses_brief_final_prompt tests.test_runtime.ToolRuntimeTests.test_error_web_search_route_uses_brief_final_prompt -q`
- `PYTHONPATH=src python3 -m unittest tests.test_runtime tests.test_evidence tests.test_tool_message -q`
- `PYTHONPATH=src python3 -m unittest tests.test_messages tests.test_final_policy tests.test_completion_budget -q`
- `python3 -m compileall -q src/orbit/runtime tests`
- `git diff --check`

Full unit discovery previously passed: 988 tests.