### PR TITLE
Report web search errors without answering from memory

### DIFF
--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -327,6 +327,13 @@ def build_web_final_evidence_context(store: EvidenceStore | None) -> str | None:
         f"sha256: {record.raw_sha256[:16]}",
         f"size: {record.raw_chars} chars, {record.raw_lines} lines",
     ]
+    if record.status == "error":
+        parts.extend(
+            [
+                "web_search_failed: true",
+                "final_instruction: The web search failed. Report this failure briefly; do not answer from general knowledge as if the search succeeded.",
+            ]
+        )
     for key in ("query", "result_count", "error_message", "top_domains", "top_titles"):
         value = record.metadata.get(key)
         if value in (None, "", [], {}):

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -644,6 +644,8 @@ class EvidenceTests(unittest.TestCase):
             self.assertIn("status: error", context)
             self.assertIn("query: location of Avola", context)
             self.assertIn("result_count: 0", context)
+            self.assertIn("web_search_failed: true", context)
+            self.assertIn("do not answer from general knowledge", context)
             self.assertIn("error_message: error: web search failed", context)
             self.assertIn(record.raw_ref, context)
             self.assertIn(record.raw_sha256[:16], context)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3066,8 +3066,13 @@ class ToolRuntimeTests(unittest.TestCase):
                         generation_tokens_per_second=None,
                     )
                 self.final_messages = messages
+                rendered = "\n".join(str(message.get("content", "")) for message in messages)
+                if "do not answer from general knowledge" not in rendered:
+                    content = "Avola is in Sicily."
+                else:
+                    content = "The web search failed because DNS resolution was unavailable."
                 return ChatResult(
-                    content="The web search failed because DNS resolution was unavailable.",
+                    content=content,
                     model="fake",
                     finish_reason="stop",
                     tool_calls=[],
@@ -3103,6 +3108,8 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn("web_search_evidence: true", rendered)
         self.assertIn("status: error", rendered)
         self.assertIn("query: location of Avola", rendered)
+        self.assertIn("web_search_failed: true", rendered)
+        self.assertIn("do not answer from general knowledge", rendered)
         self.assertIn("error_message: error: web search failed", rendered)
         self.assertNotIn("Decide compactly whether the user request needs local tools", rendered)
 


### PR DESCRIPTION
## Summary

Fixes compact `web_search` error final behavior so failed web searches are reported as failures instead of allowing the model to answer from general knowledge as if the search succeeded.

## Problem

After #128, `web_search` errors correctly use the compact web final view. However, a known-query error such as `location of Avola` could still lead the final model call to answer from memory instead of reporting that the web search failed.

## Solution

For `web_search` records with `status=error`, the compact web final context now includes:

- `web_search_failed: true`
- a narrow final instruction to report the web failure briefly and not answer from general knowledge as if the search succeeded

## Safety

- Scoped to `web_search` with `status=error`.
- Non-web errors are unchanged.
- `status=none` and successful web results are unchanged.
- Raw output is not reinjected.
- No route/tool-loop changes.
- No MTP/cache/KV/budget changes.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime -q`
- `PYTHONPATH=src python3 -m unittest tests.test_messages tests.test_final_policy tests.test_completion_budget -q`
- `python3 -m compileall -q src/orbit/runtime tests`
- `git diff --check`

Full unit discovery previously passed with 988 tests.