### PR TITLE
Reduce final from tool prompt tokens

### DIFF
--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -98,11 +98,10 @@ TOOL_CALL_JSON_RETRY_PROMPT = (
     "For shell command, use one single-line command string only: no comments, no literal newlines."
 )
 FINAL_FROM_TOOL_SYSTEM_PROMPT = (
-    "Answer concisely from the available tool result. "
-    "Do not call tools. "
-    "Do not emit raw tool-call syntax. "
-    "If a tool result is present, do not claim lack of access. "
-    "If the tool result is an error, report the error briefly."
+    "Answer concisely from the tool result. "
+    "Do not call tools or emit raw tool-call syntax. "
+    "Never claim lack of access when a result is present. "
+    "Report errors briefly."
 )
 DEFAULT_SYSTEM_PROMPT = ROUTE_SYSTEM_PROMPT
 TOOL_SYSTEM_PROMPT = TOOL_CALL_SYSTEM_PROMPT

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import unittest
 
-from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT, TOOL_CALL_SYSTEM_PROMPT, with_chat_system_prompt
+from orbit.runtime.messages import (
+    CHAT_SYSTEM_PROMPT,
+    FINAL_FROM_TOOL_SYSTEM_PROMPT,
+    ROUTE_SYSTEM_PROMPT,
+    TOOL_CALL_SYSTEM_PROMPT,
+    with_chat_system_prompt,
+)
 
 
 class MessagePromptTests(unittest.TestCase):
@@ -38,6 +44,13 @@ class MessagePromptTests(unittest.TestCase):
     def test_tool_call_policy_still_requires_one_tool_after_route_decides_tool(self) -> None:
         self.assertIn("Call exactly one available tool", TOOL_CALL_SYSTEM_PROMPT)
         self.assertIn("Operate on the latest user request only", TOOL_CALL_SYSTEM_PROMPT)
+
+    def test_final_tool_policy_preserves_safety_and_error_guidance(self) -> None:
+        self.assertIn("from the tool result", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("Do not call tools", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("raw tool-call syntax", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("Never claim lack of access", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("Report errors briefly", FINAL_FROM_TOOL_SYSTEM_PROMPT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reduces the token cost of the `final_from_tool` system instruction while preserving its complete behavioral contract.

## Problem

Every `final_from_tool` call evaluated a correct but unnecessarily verbose system instruction.

## Solution

The instruction now uses compact equivalent wording while retaining all requirements:

- answer concisely from tool evidence
- do not call tools
- do not expose raw tool-call syntax
- do not falsely claim lack of access
- report tool errors briefly

## Measured Result

The production tokenizer reports the system component reduced from 49 to 34 tokens, saving exactly 15 evaluated tokens per `final_from_tool` call.

Observed total prompt/evaluated reductions varied by approximately 15-17 tokens because evidence-reference tokenization varies. No deterministic wall-time improvement is claimed because CPU timings were noisy.

## Safety

- No route or tool-loop changes
- No evidence selection changes
- No MTP changes
- No cache/KV changes
- No completion budget changes

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_messages tests.test_final_policy tests.test_completion_budget -q`
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime -q`
- `python3 -m compileall -q src/orbit/runtime tests`
- `git diff --check`
- Full suite previously passed: 989 tests
