### PR TITLE
Add experimental final tool prefix reuse

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import replace
 from typing import Any, Callable
@@ -48,6 +49,7 @@ class LlamaServerBackend:
                 tools=tools,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
+                final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
         )
         _attach_native_kv_diag_payload(payload, native_backend=native_backend)
@@ -85,6 +87,7 @@ class LlamaServerBackend:
                 stream=True,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
+                final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
         )
         _attach_native_kv_diag_payload(payload, native_backend=native_backend)
@@ -718,6 +721,13 @@ def _allow_mtp_experimental_requested(*, native_backend: bool) -> bool | None:
     if phase == "chat_final_retry" or phase.startswith("final_from_tool"):
         return False
     return None
+
+
+def _final_prefix_experiment_requested(*, native_backend: bool) -> bool:
+    if not native_backend or os.environ.get("ORBIT_FINAL_PREFIX_EXPERIMENT") != "1":
+        return False
+    phase = current_phase()
+    return current_tools_mode() == "on" and phase is not None and phase.startswith("final_from_tool")
 
 
 def _attach_native_kv_diag_payload(payload: dict[str, Any], *, native_backend: bool) -> None:

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -17,6 +17,7 @@ class ChatPayloadOptions:
     cache_prompt: bool = True
     route_prefix_anchor: bool = False
     allow_mtp_experimental: bool | None = None
+    final_prefix_experiment: bool = False
 
 
 def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
@@ -35,6 +36,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["route_prefix_anchor"] = True
     if options.allow_mtp_experimental is not None:
         payload["allow_mtp_experimental"] = options.allow_mtp_experimental
+    if options.final_prefix_experiment:
+        payload["final_prefix_experiment"] = True
     if options.tools:
         payload["tools"] = options.tools
         payload["tool_choice"] = "auto"

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -66,6 +66,18 @@ class NativeClientConfig:
     mtp_accept_probe_enabled: bool = False
     mtp_decode_probe_enabled: bool = False
     use_mtp_experimental: bool = False
+    final_prefix_experiment_enabled: bool = False
+
+
+@dataclass
+class FinalPrefixExperimentStatus:
+    initialized: bool = False
+    prefix_tokens: int = 0
+    capture_count: int = 0
+    restore_count: int = 0
+    fallback_count: int = 0
+    failure_reason: str | None = None
+    last_used: bool = False
 
 
 @dataclass(frozen=True)
@@ -146,11 +158,27 @@ class NativeLlamaClient:
         self._last_prompt_decode_batch_n_tokens = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
         self._route_prefix_prefill_lock = threading.Lock()
+        self._final_prefix_anchor_state = PrefixAnchorState()
+        self._final_prefix_status = FinalPrefixExperimentStatus()
 
     def session_snapshot(self, session_id: str = DEFAULT_NATIVE_SESSION_ID) -> NativeSessionSnapshot:
         if session_id != self._session.session_id:
             raise ValueError("only the default native session is supported in this experiment")
         return self._session.snapshot(backend_mode=self._current_backend_mode())
+
+    def final_prefix_experiment_status(self) -> dict[str, object]:
+        status = self._final_prefix_status
+        return {
+            "enabled": self.config.final_prefix_experiment_enabled,
+            "initialized": status.initialized,
+            "prefix_tokens": status.prefix_tokens,
+            "capture_count": status.capture_count,
+            "restore_count": status.restore_count,
+            "fallback_count": status.fallback_count,
+            "failure_reason": status.failure_reason,
+            "last_used": status.last_used,
+            "checkpoint_size_bytes": self._final_prefix_anchor_state.checkpoint_size,
+        }
 
     def _current_backend_mode(self) -> str:
         if not self.config.use_mtp_experimental:
@@ -189,6 +217,7 @@ class NativeLlamaClient:
         # corrupt teardown after mixed target-only/MTP client lifetimes.
 
     def cancel(self) -> None:
+        self._invalidate_final_prefix("cancelled")
         self._session.cancel_requested = True
         self._session.continuation_ready = False
         self.cancel_event.set()
@@ -319,6 +348,7 @@ class NativeLlamaClient:
         self._session.prompt_cache_mode = None
         self._session.continuation_ready = False
         self._session.last_metrics = None
+        self._invalidate_final_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
         try:
@@ -531,10 +561,12 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
+        final_prefix_experiment: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
     ) -> NativeTimings:
+        self._final_prefix_status.last_used = False
         thinking = self._thinking_enabled(thinking)
         prepared_multimodal = prepare_multimodal_messages(messages, media_marker=self._media_marker)
         mode = (
@@ -573,7 +605,15 @@ class NativeLlamaClient:
             thinking=thinking,
             prompt=prompt,
         ) if route_prefix_anchor else None
+        final_prefix_segments = self._final_prefix_segments_for_prompt(
+            messages,
+            tools=tools,
+            thinking=thinking,
+            prompt=prompt,
+        ) if self._final_prefix_experiment_eligible(final_prefix_experiment) else None
         allow_mtp = not tools and route_anchor_segments is None
+        if final_prefix_segments is not None:
+            allow_mtp = False
         if allow_mtp_experimental is False:
             allow_mtp = False
         return self.complete_prompt(
@@ -582,6 +622,7 @@ class NativeLlamaClient:
             allow_mtp_experimental=allow_mtp,
             thinking=thinking,
             route_anchor_segments=route_anchor_segments,
+            final_prefix_segments=final_prefix_segments,
             kv_diag_messages=messages,
             on_progress=on_progress,
             on_token=on_token,
@@ -598,6 +639,7 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
+        final_prefix_experiment: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -611,6 +653,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
+            final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
@@ -656,6 +699,7 @@ class NativeLlamaClient:
         thinking: bool,
         route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
+        final_prefix_experiment: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -722,6 +766,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
+            final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
             on_token=collect,
             should_cancel=should_cancel,
@@ -935,6 +980,7 @@ class NativeLlamaClient:
         allow_mtp_experimental: bool = True,
         thinking: bool | None = None,
         route_anchor_segments: RoutePromptSegments | None = None,
+        final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
@@ -973,6 +1019,7 @@ class NativeLlamaClient:
                 prompt,
                 max_tokens=max_tokens,
                 route_anchor_segments=route_anchor_segments,
+                final_prefix_segments=final_prefix_segments,
                 kv_diag_messages=kv_diag_messages,
                 on_progress=on_progress,
                 on_token=on_token,
@@ -980,7 +1027,13 @@ class NativeLlamaClient:
             )
             self._session.last_metrics = timings
             self._session.continuation_ready = _can_continue_from_timings(timings)
+            if final_prefix_segments is not None and timings.cancelled:
+                self._invalidate_final_prefix("cancelled")
             return timings
+        except Exception:
+            if final_prefix_segments is not None:
+                self._invalidate_final_prefix("completion_error")
+            raise
         finally:
             self._session.in_flight = False
 
@@ -1114,6 +1167,7 @@ class NativeLlamaClient:
         *,
         max_tokens: int = 16,
         route_anchor_segments: RoutePromptSegments | None = None,
+        final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
@@ -1131,9 +1185,12 @@ class NativeLlamaClient:
         previous_prompt_tokens = list(self._session.cached_prompt_tokens)
         pf_start = lib.llama_time_us()
         anchor_plan = self._route_anchor_plan(prompt, prompt_tokens, route_anchor_segments)
+        final_plan = self._final_prefix_plan(prompt, prompt_tokens, final_prefix_segments)
         anchor_metadata: dict[str, object] | None = None
         processed_start = 0
-        if anchor_plan is None:
+        if final_plan is not None:
+            processed_start, reused = self._prepare_memory_with_final_prefix(final_plan, prompt_tokens)
+        elif anchor_plan is None:
             reused = self._prepare_memory_for_prompt(prompt_tokens)
         else:
             processed_start, reused, anchor_metadata = self._prepare_memory_with_route_anchor(anchor_plan)
@@ -1142,7 +1199,7 @@ class NativeLlamaClient:
                 processed_start = reused
         processed = 0
         step = max(1, min(self.config.progress_step, self.config.batch_size))
-        processed = processed_start if anchor_plan is not None and anchor_metadata is not None else reused
+        processed = processed_start if final_plan is not None or (anchor_plan is not None and anchor_metadata is not None) else reused
         if on_progress:
             on_progress(NativeProgress("prefill", processed, n_prompt))
         token_array = (llama_token * n_prompt)(*prompt_tokens)
@@ -1407,6 +1464,158 @@ class NativeLlamaClient:
             )
             return None
         return segments
+
+    def _final_prefix_segments_for_prompt(
+        self,
+        messages: list[NativeMessage],
+        *,
+        tools: list[dict] | None,
+        thinking: bool,
+        prompt: str,
+    ) -> RoutePromptSegments | None:
+        roles = [message.get("role") for message in messages]
+        if tools or thinking or roles != ["system", "user", "system"]:
+            self._record_final_prefix_fallback("ineligible_prompt_family")
+            return None
+        try:
+            segments = render_gemma4_route_prompt_segments(messages, thinking=False)
+        except Exception:
+            self._record_final_prefix_fallback("prompt_render_failed")
+            return None
+        if segments.full_prompt_text != prompt:
+            self._record_final_prefix_fallback("prompt_render_mismatch")
+            return None
+        return segments
+
+    def _final_prefix_experiment_eligible(self, requested: bool) -> bool:
+        return requested and self.config.final_prefix_experiment_enabled and not self.config.use_mtp_experimental
+
+    def _final_prefix_plan(
+        self,
+        prompt: str,
+        prompt_tokens: list[int],
+        segments: RoutePromptSegments | None,
+    ) -> _RouteAnchorRuntimePlan | None:
+        if segments is None:
+            return None
+        stable_tokens = self.tokenize(segments.stable_prefix_text)
+        if len(prompt_tokens) <= 43 or len(stable_tokens) > 43:
+            self._record_final_prefix_fallback("prefix_token_count_mismatch")
+            return None
+        prefix_tokens = prompt_tokens[:43]
+        if segments.full_prompt_text != prompt:
+            self._record_final_prefix_fallback("prefix_identity_mismatch")
+            return None
+        token_hash = _stable_tokens_hash_hex(prefix_tokens)
+        prefix_hash = compute_prefix_anchor_key(
+            **self._final_prefix_state_kwargs(segments, token_hash=token_hash)
+        )
+        return _RouteAnchorRuntimePlan(
+            segments=segments,
+            prefix_tokens=prefix_tokens,
+            prefix_hash=prefix_hash,
+            metadata={"prefix_token_count": len(prefix_tokens), "prefix_token_hash": token_hash},
+        )
+
+    def _prepare_memory_with_final_prefix(self, plan: _RouteAnchorRuntimePlan, prompt_tokens: list[int]) -> tuple[int, int]:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        token_hash = _stable_tokens_hash_hex(plan.prefix_tokens)
+        state_kwargs = self._final_prefix_state_kwargs(plan.segments, token_hash=token_hash)
+        if self._final_prefix_anchor_state.valid:
+            self._clear_target_memory()
+            ok, restored, metadata = restore_prefix_anchor(
+                self._final_prefix_anchor_state,
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **state_kwargs,
+            )
+            self._final_prefix_anchor_state = restored
+            if ok:
+                self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+                self._final_prefix_status.initialized = True
+                self._final_prefix_status.prefix_tokens = len(plan.prefix_tokens)
+                self._final_prefix_status.restore_count += 1
+                self._final_prefix_status.failure_reason = None
+                self._final_prefix_status.last_used = True
+                return len(plan.prefix_tokens), len(plan.prefix_tokens)
+            self._final_prefix_status.initialized = False
+            self._final_prefix_status.prefix_tokens = 0
+            self._record_final_prefix_fallback(str(metadata.get("fallback_reason") or "restore_failed"))
+            self._clear_target_memory()
+            return 0, self._prepare_memory_for_prompt(prompt_tokens)
+
+        self._clear_target_memory()
+        token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
+        try:
+            self._decode_prompt_range(
+                token_array,
+                processed=0,
+                end=len(plan.prefix_tokens),
+                step=min(self.config.progress_step, self.config.batch_size),
+                total=len(plan.prefix_tokens),
+            )
+            state, metadata = capture_prefix_anchor(
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **state_kwargs,
+            )
+        except Exception:
+            self._record_final_prefix_fallback("capture_exception")
+            self._clear_target_memory()
+            return 0, self._prepare_memory_for_prompt(prompt_tokens)
+        self._final_prefix_anchor_state = state
+        if not state.valid:
+            self._final_prefix_status.initialized = False
+            self._final_prefix_status.prefix_tokens = 0
+            self._record_final_prefix_fallback(str(metadata.get("fallback_reason") or "capture_failed"))
+            self._clear_target_memory()
+            return 0, self._prepare_memory_for_prompt(prompt_tokens)
+        self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+        self._final_prefix_status.initialized = True
+        self._final_prefix_status.prefix_tokens = len(plan.prefix_tokens)
+        self._final_prefix_status.capture_count += 1
+        self._final_prefix_status.failure_reason = None
+        self._final_prefix_status.last_used = True
+        return len(plan.prefix_tokens), 0
+
+    def _final_prefix_state_kwargs(self, segments: RoutePromptSegments, *, token_hash: str) -> dict[str, str]:
+        config_id = (
+            f"ctx={self.config.context_tokens}:batch={self.config.batch_size}:"
+            f"ubatch={self.config.ubatch_size}:threads={self.config.threads}:"
+            f"threads_batch={self.config.threads_batch}"
+        )
+        return {
+            "model_id": str(self.paths.model),
+            "template_id": f"gemma4-final-prefix-v1:{config_id}",
+            "tool_schema_hash": "none",
+            "capability_summary_hash": "none",
+            "runtime_policy_hash": segments.stable_prefix_hash,
+            "route_contract_hash": token_hash,
+            "backend_version": "orbit-native",
+            "native_version": runtime_library_filename("llama"),
+            "tools_mode": "final_from_tool:thinking=off",
+        }
+
+    def _record_final_prefix_fallback(self, reason: str) -> None:
+        self._final_prefix_status.fallback_count += 1
+        self._final_prefix_status.failure_reason = reason
+        self._final_prefix_status.last_used = False
+
+    def _invalidate_final_prefix(self, reason: str) -> None:
+        if not hasattr(self, "_final_prefix_anchor_state"):
+            return
+        self._final_prefix_anchor_state = PrefixAnchorState()
+        self._final_prefix_status.initialized = False
+        self._final_prefix_status.prefix_tokens = 0
+        self._final_prefix_status.failure_reason = reason
+        self._final_prefix_status.last_used = False
 
     def _continue_generation_from_current_context(
         self,

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -35,7 +35,7 @@ from orbit.native_server.protocol import (
     trim_at_stop,
     validate_session_id,
 )
-from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 
 
 DEFAULT_HOST = "127.0.0.1"
@@ -45,6 +45,7 @@ PREFIX_PREWARM_ENV = "ORBIT_KV_PREFIX_PREWARM"
 PREFIX_PREWARM_OFF = "off"
 PREFIX_PREWARM_STARTUP = "startup"
 TOOLS_ENV = "ORBIT_TOOLS"
+FINAL_PREFIX_EXPERIMENT_ENV = "ORBIT_FINAL_PREFIX_EXPERIMENT"
 
 
 class OrbitNativeServer:
@@ -68,6 +69,7 @@ class OrbitNativeServer:
 
         with self.lock:
             thinking = self.client.config.thinking if request.thinking is None else request.thinking
+            final_prefix_experiment = request.final_prefix_experiment and _is_final_from_tool_prompt(request.messages)
             completion = self.client.complete_chat_text(
                 request.messages,
                 max_tokens=request.max_tokens,
@@ -76,6 +78,7 @@ class OrbitNativeServer:
                 thinking=thinking,
                 route_prefix_anchor=request.route_prefix_anchor,
                 allow_mtp_experimental=request.allow_mtp_experimental,
+                final_prefix_experiment=final_prefix_experiment,
                 on_progress=on_progress,
                 on_token=collect,
                 should_cancel=should_cancel,
@@ -226,6 +229,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_last_validate_efficiency = _mtp_last_validate_efficiency_payload(state.client)
             mtp_last_validate_equivalence = _mtp_last_validate_equivalence_payload(state.client)
             mtp_config = _mtp_config_payload(state.client)
+            final_prefix = state.client.final_prefix_experiment_status()
             self._json(
                 {
                     "model_path": str(state.client.paths.model),
@@ -276,6 +280,15 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "batch_size": runtime["batch_size"],
                     "ubatch_size": runtime["ubatch_size"],
                     "parallel_slots": runtime["parallel_slots"],
+                    "final_prefix_experiment_enabled": final_prefix["enabled"],
+                    "final_prefix_experiment_initialized": final_prefix["initialized"],
+                    "final_prefix_experiment_prefix_tokens": final_prefix["prefix_tokens"],
+                    "final_prefix_experiment_capture_count": final_prefix["capture_count"],
+                    "final_prefix_experiment_restore_count": final_prefix["restore_count"],
+                    "final_prefix_experiment_fallback_count": final_prefix["fallback_count"],
+                    "final_prefix_experiment_failure_reason": final_prefix["failure_reason"],
+                    "final_prefix_experiment_last_used": final_prefix["last_used"],
+                    "final_prefix_experiment_checkpoint_size_bytes": final_prefix["checkpoint_size_bytes"],
                 }
             )
             return
@@ -577,6 +590,7 @@ def run_server(argv: list[str] | None = None) -> int:
                 mtp_accept_probe_enabled=args.enable_mtp_accept_probe,
                 mtp_decode_probe_enabled=args.enable_mtp_decode_probe,
                 use_mtp_experimental=args.enable_mtp_experimental,
+                final_prefix_experiment_enabled=os.environ.get(FINAL_PREFIX_EXPERIMENT_ENV) == "1",
             ),
         )
         if not args.verbose_llama_log:
@@ -618,6 +632,14 @@ def tools_startup_enabled(environ: Mapping[str, str] | None = None) -> bool:
     if value == "off":
         return False
     return False
+
+
+def _is_final_from_tool_prompt(messages: list[dict[str, Any]]) -> bool:
+    return (
+        len(messages) == 3
+        and [message.get("role") for message in messages] == ["system", "user", "system"]
+        and messages[0].get("content") == FINAL_FROM_TOOL_SYSTEM_PROMPT
+    )
 
 
 def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefixPrefillResult:

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -20,6 +20,7 @@ class ChatRequest:
     tools: list[dict[str, Any]]
     route_prefix_anchor: bool
     allow_mtp_experimental: bool | None
+    final_prefix_experiment: bool
 
 
 @dataclass(frozen=True)
@@ -42,6 +43,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         tools=_tools_from_payload(payload.get("tools")),
         route_prefix_anchor=payload.get("route_prefix_anchor") is True,
         allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
+        final_prefix_experiment=payload.get("final_prefix_experiment") is True,
     )
 
 

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -308,6 +308,42 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertNotIn("route_prefix_anchor", backend.payloads[2])
         self.assertNotIn("route_prefix_anchor", backend.payloads[3])
 
+    def test_final_prefix_experiment_payload_is_limited_to_native_final_tool_phase(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payloads: list[dict[str, object]] = []
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {"backend": "orbit-native"}
+
+            def _post_native_stream(self, _path: str, payload: dict[str, object], *, on_delta, on_progress) -> ChatResult:
+                self.payloads.append(payload)
+                return ChatResult(
+                    content="ok",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=1,
+                    completion_tokens=1,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = Backend()
+        with mock.patch.dict(os.environ, {"ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}, clear=False):
+            with model_call_context(phase="route", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+            with model_call_context(phase="final_from_tool", tools_mode="off"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+
+        self.assertNotIn("final_prefix_experiment", backend.payloads[0])
+        self.assertNotIn("final_prefix_experiment", backend.payloads[1])
+        self.assertTrue(backend.payloads[2]["final_prefix_experiment"])
+
     def test_native_kv_diag_payload_carries_phase_only_when_enabled(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -32,6 +32,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(request.tools, [])
         self.assertFalse(request.route_prefix_anchor)
         self.assertIsNone(request.allow_mtp_experimental)
+        self.assertFalse(request.final_prefix_experiment)
 
     def test_parse_chat_request_accepts_thinking_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "thinking": True})
@@ -78,6 +79,13 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertFalse(disabled.allow_mtp_experimental)
         self.assertTrue(enabled.allow_mtp_experimental)
         self.assertIsNone(ignored.allow_mtp_experimental)
+
+    def test_parse_chat_request_accepts_final_prefix_experiment_flag(self) -> None:
+        enabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "final_prefix_experiment": True})
+        ignored = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "final_prefix_experiment": "true"})
+
+        self.assertTrue(enabled.final_prefix_experiment)
+        self.assertFalse(ignored.final_prefix_experiment)
 
     def test_parse_chat_request_rejects_malformed_payloads(self) -> None:
         bad_payloads = [

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 
 from orbit.native_server.app import OrbitNativeHandler, OrbitNativeServer, _DisconnectWatcher
 from orbit.native_server.protocol import openai_chat_response, parse_chat_request
+from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT
 
 
 @dataclass
@@ -38,6 +39,7 @@ class _FakeClient:
         self.last_mtp_completion = type("Probe", (), {"success": False})()
         self.mtp_fallback_reason = None
         self.allow_mtp_calls: list[bool | None] = []
+        self.final_prefix_calls: list[bool] = []
 
     def complete_chat_text(
         self,
@@ -49,12 +51,14 @@ class _FakeClient:
         thinking,
         route_prefix_anchor=False,
         allow_mtp_experimental=None,
+        final_prefix_experiment=False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
     ):
         self.calls.append(thinking)
         self.allow_mtp_calls.append(allow_mtp_experimental)
+        self.final_prefix_calls.append(final_prefix_experiment)
         return _FakeCompletion()
 
     def session_snapshot(self, session_id: str):
@@ -75,6 +79,25 @@ class _FakeClient:
 
 
 class NativeServerThinkTests(unittest.TestCase):
+    def test_final_prefix_experiment_requires_exact_final_prompt_family(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="fake")
+        final_messages = [
+            {"role": "system", "content": FINAL_FROM_TOOL_SYSTEM_PROMPT},
+            {"role": "user", "content": "request"},
+            {"role": "system", "content": "evidence"},
+        ]
+        unknown_messages = [
+            {"role": "system", "content": "different prompt"},
+            {"role": "user", "content": "request"},
+            {"role": "system", "content": "evidence"},
+        ]
+
+        server.complete(parse_chat_request({"messages": final_messages, "final_prefix_experiment": True}))
+        server.complete(parse_chat_request({"messages": unknown_messages, "final_prefix_experiment": True}))
+
+        self.assertEqual(client.final_prefix_calls, [True, False])
+
     def test_disconnect_watcher_disarm_skips_cancel_callback(self) -> None:
         called: list[str] = []
         watcher = _DisconnectWatcher(None, lambda: called.append("cancel"))  # type: ignore[arg-type]

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -97,5 +97,22 @@ class PayloadTests(unittest.TestCase):
         self.assertNotIn("allow_mtp_experimental", baseline)
         self.assertFalse(disabled["allow_mtp_experimental"])
 
+    def test_build_chat_payload_includes_final_prefix_experiment_only_when_requested(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(model="m", messages=[{"role": "user", "content": "hello"}], temperature=0, max_tokens=32)
+        )
+        experimental = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+                final_prefix_experiment=True,
+            )
+        )
+
+        self.assertNotIn("final_prefix_experiment", baseline)
+        self.assertTrue(experimental["final_prefix_experiment"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -8,7 +8,12 @@ import threading
 import unittest
 from unittest.mock import patch
 
-from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, NativeRoutePrefixPrefillResult
+from orbit.native_llama.client import (
+    FinalPrefixExperimentStatus,
+    NativeClientConfig,
+    NativeLlamaClient,
+    NativeRoutePrefixPrefillResult,
+)
 from orbit.native_llama.prefix_anchor_probe import (
     PrefixPrefillOnlyProbeResult,
     PrefixAnchorProbeResult,
@@ -140,6 +145,8 @@ def _prefill_hook_client(segments, *, lib=None) -> NativeLlamaClient:
         cancel_requested=False,
     )
     client._route_prefix_anchor_state = PrefixAnchorState()
+    client._final_prefix_anchor_state = PrefixAnchorState()
+    client._final_prefix_status = FinalPrefixExperimentStatus()
     client._route_prefix_prefill_lock = threading.Lock()
     mapping = {
         segments.stable_prefix_text: [1, 2, 3, 4],
@@ -149,7 +156,104 @@ def _prefill_hook_client(segments, *, lib=None) -> NativeLlamaClient:
     return client
 
 
+def _final_prefix_client(segments, *, lib=None) -> NativeLlamaClient:
+    client = _prefill_hook_client(segments, lib=lib)
+    stable_tokens = list(range(1, 43))
+    prefix_tokens = stable_tokens + [43]
+    full_tokens = prefix_tokens + [44, 45]
+    client.tokenize = lambda text: {
+        segments.stable_prefix_text: stable_tokens,
+        segments.full_prompt_text: full_tokens,
+    }[text]
+    return client
+
+
 class PrefixAnchorProbeTests(unittest.TestCase):
+    def test_final_prefix_experiment_is_ineligible_when_native_mtp_is_enabled(self) -> None:
+        client = NativeLlamaClient.__new__(NativeLlamaClient)
+        client.config = NativeClientConfig(final_prefix_experiment_enabled=True, use_mtp_experimental=True)
+
+        self.assertFalse(client._final_prefix_experiment_eligible(True))
+
+    def test_final_prefix_capture_then_restore_reuses_exact_43_tokens(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "final policy"},
+                {"role": "user", "content": "request"},
+                {"role": "system", "content": "evidence"},
+            ],
+            thinking=False,
+        )
+        client = _final_prefix_client(segments)
+        prompt_tokens = client.tokenize(segments.full_prompt_text)
+        plan = client._final_prefix_plan(segments.full_prompt_text, prompt_tokens, segments)
+
+        self.assertIsNotNone(plan)
+        first_start, first_reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+        second_start, second_reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+
+        self.assertEqual((first_start, first_reused), (43, 0))
+        self.assertEqual((second_start, second_reused), (43, 43))
+        self.assertEqual(client.lib.lib.current_tokens, list(range(1, 44)))
+        self.assertEqual(client.final_prefix_experiment_status()["capture_count"], 1)
+        self.assertEqual(client.final_prefix_experiment_status()["restore_count"], 1)
+        self.assertTrue(client.final_prefix_experiment_status()["last_used"])
+
+    def test_final_prefix_identity_mismatch_falls_back_before_restore(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "final policy"},
+                {"role": "user", "content": "request"},
+                {"role": "system", "content": "evidence"},
+            ],
+            thinking=False,
+        )
+        client = _final_prefix_client(segments)
+        prompt_tokens = client.tokenize(segments.full_prompt_text)
+        client._final_prefix_anchor_state = PrefixAnchorState(
+            prefix_hash="different",
+            token_count=43,
+            valid=True,
+            checkpoint_size=1,
+            checkpoint_data=b"x",
+        )
+
+        plan = client._final_prefix_plan(segments.full_prompt_text, prompt_tokens, segments)
+
+        self.assertIsNotNone(plan)
+        with patch.object(client, "_prepare_memory_for_prompt", return_value=0) as normal_prefill:
+            start, reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+
+        self.assertEqual((start, reused), (0, 0))
+        normal_prefill.assert_called_once_with(prompt_tokens)
+        self.assertEqual(client.final_prefix_experiment_status()["failure_reason"], "prefix_hash_changed")
+        self.assertEqual(client.final_prefix_experiment_status()["fallback_count"], 1)
+
+    def test_final_prefix_restore_failure_uses_normal_prefill(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "final policy"},
+                {"role": "user", "content": "request"},
+                {"role": "system", "content": "evidence"},
+            ],
+            thinking=False,
+        )
+        client = _final_prefix_client(segments, lib=_FailingRestoreLib())
+        prompt_tokens = client.tokenize(segments.full_prompt_text)
+        plan = client._final_prefix_plan(segments.full_prompt_text, prompt_tokens, segments)
+        client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+
+        with patch.object(client, "_prepare_memory_for_prompt", return_value=0) as normal_prefill:
+            start, reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+
+        self.assertEqual((start, reused), (0, 0))
+        normal_prefill.assert_called_once_with(prompt_tokens)
+        self.assertFalse(client.final_prefix_experiment_status()["initialized"])
+        self.assertEqual(client.final_prefix_experiment_status()["fallback_count"], 1)
+        self.assertEqual(
+            client.final_prefix_experiment_status()["failure_reason"],
+            "checkpoint_restore_size_mismatch",
+        )
     def test_route_boundary_token_probe_reports_valid_token_prefix(self) -> None:
         segments = render_gemma4_route_prompt_segments(
             [


### PR DESCRIPTION
## Summary

Adds an off-by-default `final_from_tool` prefix checkpoint experiment.

Enable it with:

```text
ORBIT_FINAL_PREFIX_EXPERIMENT=1
```

Eligible native final calls reuse 43 prefix tokens instead of the normal `cached=4`, for a net reduction of 39 evaluated tokens versus current route-to-final behavior. Default OFF behavior remains unchanged.

The experiment includes:
- exact `FINAL_FROM_TOOL_SYSTEM_PROMPT`, role-family, and 43-token prefix validation
- lazy checkpoint capture and restore
- normal-prefill fallback on identity mismatch or restore failure
- cancel/reset/completion-error invalidation
- bounded `/props` diagnostics
- explicit isolation from native MTP

## Validation

- OFF/ON matrix: 11 scenarios, 3 repetitions per mode, 66 finals total
- All 66 finals completed with `finish_reason=stop`
- No repeated correctness, routing, tool, or web-error regression
- 50-call mixed stability run: no fallback, stale state, contamination, or meaningful RSS growth
- `PYTHONPATH=src python3 -m unittest tests.test_messages tests.test_final_policy tests.test_completion_budget -q`
- `PYTHONPATH=src python3 -m unittest tests.test_evidence tests.test_runtime tests.test_tool_message -q`
- `PYTHONPATH=src python3 -m unittest tests.test_llama_server_backend tests.test_native_server_protocol tests.test_native_server_think tests.test_payloads tests.test_prefix_anchor_probe -q`
- Full suite: PASS, 997 tests
- `python3 -m compileall -q src tests scripts`
- `git diff --check`

## Warnings

- Logits differ from cold full prefill because the 43-token boundary changes prefill segmentation; checkpoint restore is bit-exact against an identically segmented baseline.
- No deterministic wall-time improvement is claimed.
- Non-stream HTTP timeout alone does not reliably trigger cancellation; explicit `/cancel` is required for reliable cleanup.
- Experimental only and OFF by default.

No release is created by this PR.
