### PR TITLE
Add repeatable final prefix benchmark coverage

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 import os
 import queue
+import statistics
+import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -25,7 +28,9 @@ from orbit import __version__
 from orbit.backend.base import ChatResult
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.kv_diag import current_phase
 from orbit.runtime.messages import DEFAULT_SYSTEM_PROMPT
+from orbit.runtime.tools import TOOL_NAMES
 from orbit.runtime.turn_trace import ModelStepMetrics
 from orbit.terminal.runtime_status import collect_host_info
 
@@ -46,6 +51,8 @@ class SmokeScenario:
     steps: tuple[SmokeStep, ...]
     requires_web: bool = False
     optional: bool = False
+    allowed_tool_names: tuple[str, ...] = ("exec_shell_full_command",)
+    isolated_steps: bool = False
 
 
 @dataclass(frozen=True)
@@ -71,6 +78,14 @@ class StepReport:
     notes: str
     answer_excerpt: str
     model_steps: list[dict[str, object]]
+    output_tokens: int | None = None
+    final_prefix: dict[str, object] = field(default_factory=dict)
+    lifecycle: dict[str, object] = field(default_factory=dict)
+    phase_wall_ms: dict[str, float] = field(default_factory=dict)
+    prompt_tokens_per_second: float | None = None
+    generation_tokens_per_second: float | None = None
+    estimated_generation_ms: float | None = None
+    estimated_prefill_residual_ms: float | None = None
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -84,6 +99,7 @@ class StepReport:
             "prompt_tokens": self.prompt_tokens,
             "cached_tokens": self.cached_tokens,
             "evaluated_tokens": self.evaluated_tokens,
+            "output_tokens": self.output_tokens,
             "finish_reason": self.finish_reason,
             "tool_calls": self.tool_calls,
             "tool_names": self.tool_names,
@@ -95,31 +111,59 @@ class StepReport:
             "notes": self.notes,
             "answer_excerpt": self.answer_excerpt,
             "model_steps": self.model_steps,
+            "final_prefix": self.final_prefix,
+            "lifecycle": self.lifecycle,
+            "phase_wall_ms": self.phase_wall_ms,
+            "prompt_tokens_per_second": self.prompt_tokens_per_second,
+            "generation_tokens_per_second": self.generation_tokens_per_second,
+            "estimated_generation_ms": self.estimated_generation_ms,
+            "estimated_prefill_residual_ms": self.estimated_prefill_residual_ms,
         }
 
 
 class ProbeBackend:
     def __init__(self, backend: LlamaServerBackend) -> None:
         self._backend = backend
+        self._phase_timings: list[tuple[str, float]] = []
 
     def __getattr__(self, name: str):
         return getattr(self._backend, name)
 
     def chat(self, messages, *, temperature, max_tokens, tools=None):
-        return self._backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+        return self._timed(
+            lambda: self._backend.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+        )
 
     def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None):
-        return self._backend.chat_stream(
-            messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            tools=tools,
-            on_delta=on_delta or (lambda _text: None),
-            on_progress=on_progress,
+        return self._timed(
+            lambda: self._backend.chat_stream(
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                on_delta=on_delta or (lambda _text: None),
+                on_progress=on_progress,
+            )
         )
 
     def continue_current(self, *, max_tokens, on_delta=None, on_progress=None):
-        return self._backend.continue_current(max_tokens=max_tokens, on_delta=on_delta, on_progress=on_progress)
+        return self._timed(
+            lambda: self._backend.continue_current(max_tokens=max_tokens, on_delta=on_delta, on_progress=on_progress)
+        )
+
+    def _timed(self, call):
+        phase = current_phase() or "unknown"
+        started = time.perf_counter()
+        try:
+            return call()
+        finally:
+            self._phase_timings.append((phase, round((time.perf_counter() - started) * 1000, 1)))
+
+    def reset_phase_timings(self) -> None:
+        self._phase_timings.clear()
+
+    def phase_timings(self) -> list[tuple[str, float]]:
+        return list(self._phase_timings)
 
 
 def mtp_state_from_props(props: dict[str, object]) -> dict[str, object]:
@@ -159,29 +203,42 @@ def main(argv: list[str] | None = None) -> int:
     jsonl_path = Path(args.jsonl) if args.jsonl else output_dir / f"orbit_smoke_{stamp}.jsonl"
     markdown_path = Path(args.markdown) if args.markdown else output_dir / f"orbit_smoke_{stamp}.md"
 
-    backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
-    initial_props = safe_backend_props(backend)
-    initial_mtp = mtp_state_from_props(initial_props)
-    if args.mtp_required and not (initial_mtp["requested"] or initial_mtp["usable"]):
-        print("error: --mtp-required set but backend does not report MTP requested/enabled", file=sys.stderr)
-        return 2
+    with final_prefix_environment(args.final_prefix_mode), deterministic_web(args.deterministic_web), managed_server(args) as server_process:
+        backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
+        backend.thinking = args.server_thinking == "on"
+        rss_before_kib = process_rss_kib(server_process)
+        if args.cooling_seconds:
+            time.sleep(args.cooling_seconds)
+        initial_props = safe_backend_props(backend)
+        initial_mtp = mtp_state_from_props(initial_props)
+        if args.mtp_required and not (initial_mtp["requested"] or initial_mtp["usable"]):
+            print("error: --mtp-required set but backend does not report MTP requested/enabled", file=sys.stderr)
+            return 2
 
-    reports: list[StepReport] = []
-    for scenario in selected:
-        reports.extend(
-            run_scenario(
-                scenario,
-                backend=backend,
-                workdir=Path(args.workdir),
-                max_tokens=args.max_tokens,
-                temperature=args.temperature,
-                timeout=args.timeout,
-            )
-        )
-    final_props = settled_backend_props(args.base_url, args.timeout)
-    env = environment_summary(args=args, backend=backend, props=final_props)
+        reports: list[StepReport] = []
+        for scenario in selected:
+            for _repeat in range(args.repetitions):
+                reports.extend(
+                    run_scenario(
+                        scenario,
+                        backend=backend,
+                        workdir=Path(args.workdir),
+                        max_tokens=args.max_tokens,
+                        temperature=args.temperature,
+                        timeout=args.timeout,
+                    )
+                )
+        final_props = settled_backend_props(args.base_url, args.timeout)
+        env = environment_summary(args=args, backend=backend, props=final_props)
+        env["server_rss_before_kib"] = rss_before_kib
+        env["server_rss_after_kib"] = process_rss_kib(server_process)
     write_jsonl(jsonl_path, env, reports)
     write_markdown(markdown_path, env, reports)
+    if args.verify_final_prefix:
+        failure = final_prefix_validation_failure(args.final_prefix_mode, reports, final_props)
+        if failure is not None:
+            print(f"error: final-prefix validation failed ({failure})", file=sys.stderr)
+            return 1
     if args.mtp_required:
         final_mtp = mtp_state_from_props(final_props)
         if not final_mtp["usable"]:
@@ -211,6 +268,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument("--max-tokens", type=int, default=128)
     parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--repetitions", type=positive_int, default=1)
+    parser.add_argument("--final-prefix-mode", choices=("inherit", "off", "on"), default="inherit")
+    parser.add_argument("--manage-server", action="store_true", help="Start and stop a native server for this run.")
+    parser.add_argument("--server-start-timeout", type=float, default=180.0)
+    parser.add_argument("--model")
+    parser.add_argument("--mmproj")
+    parser.add_argument("--ctx", type=int, default=8192)
+    parser.add_argument("--threads", type=int, default=6)
+    parser.add_argument("--threads-batch", type=int, default=6)
+    parser.add_argument("--batch", type=int, default=256)
+    parser.add_argument("--ubatch", type=int, default=128)
+    parser.add_argument("--server-mtp", action="store_true", help="Start the managed server with experimental MTP enabled.")
+    parser.add_argument("--server-thinking", choices=("off", "on"), default="off")
+    parser.add_argument("--tools", choices=("off", "on"), default="on")
+    parser.add_argument("--block-id", default=None)
+    parser.add_argument("--run-order", default=None)
+    parser.add_argument("--cooling-seconds", type=float, default=0.0)
+    parser.add_argument("--deterministic-web", action="store_true", help="Use bounded local web fixtures for final-prefix smoke cases.")
+    parser.add_argument(
+        "--verify-final-prefix",
+        action="store_true",
+        help="Fail unless OFF/ON final-prefix counters match the requested experimental mode.",
+    )
     return parser
 
 
@@ -271,6 +351,70 @@ def scenarios() -> dict[str, SmokeScenario]:
             ),
             optional=True,
         ),
+        "final_prefix_local": SmokeScenario(
+            "final_prefix_local",
+            (
+                SmokeStep("run pwd", checker_name="path_like"),
+                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
+                SmokeStep("read text/summary.txt", checker_name="nonempty"),
+                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
+                SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
+                SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
+                SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
+            ),
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+        ),
+        "final_prefix_web": SmokeScenario(
+            "final_prefix_web",
+            (
+                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
+                SmokeStep("search online for orbit fixture none", checker_name="nonempty"),
+                SmokeStep("search online for where is Avola located?", checker_name="web_error"),
+                SmokeStep("search online for latest status of fictional endpoint xqz-orbit-404", checker_name="web_error"),
+            ),
+            requires_web=True,
+            optional=True,
+        ),
+        "final_prefix_mixed": SmokeScenario(
+            "final_prefix_mixed",
+            (
+                SmokeStep("run pwd", checker_name="path_like"),
+                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
+                SmokeStep("read text/summary.txt", checker_name="nonempty"),
+                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
+                SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
+                SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
+                SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
+                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
+                SmokeStep("search online for orbit fixture none", checker_name="nonempty"),
+                SmokeStep("search online for where is Avola located?", checker_name="web_error"),
+                SmokeStep("search online for latest status of fictional endpoint xqz-orbit-404", checker_name="web_error"),
+            ),
+            requires_web=True,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            isolated_steps=True,
+        ),
+        "final_prefix_paired": SmokeScenario(
+            "final_prefix_paired",
+            (
+                SmokeStep("run pwd", checker_name="path_like"),
+                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
+                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
+                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
+            ),
+            requires_web=True,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            isolated_steps=True,
+        ),
+        "final_prefix_web_short": SmokeScenario(
+            "final_prefix_web_short",
+            (SmokeStep("search online for orbit fixture success and answer in one short sentence", checker_name="nonempty"),),
+            requires_web=True,
+            optional=True,
+        ),
     }
 
 
@@ -301,13 +445,11 @@ def run_scenario(
     temperature: float,
     timeout: float,
 ) -> list[StepReport]:
-    runtime = ChatRuntime(
-        backend=ProbeBackend(backend),
-        system_prompt=DEFAULT_SYSTEM_PROMPT,
-        diagnostic_session_id=str(workdir),
-    )
+    runtime = new_runtime(backend, workdir)
     reports: list[StepReport] = []
     for index, step in enumerate(scenario.steps, start=1):
+        if scenario.isolated_steps and index > 1:
+            runtime = new_runtime(backend, workdir)
         report = run_step(
             runtime,
             scenario=scenario.name,
@@ -318,11 +460,20 @@ def run_scenario(
             temperature=temperature,
             base_url=backend.base_url,
             timeout=timeout,
+            allowed_tool_names=scenario.allowed_tool_names,
         )
         reports.append(report)
         if report.finish_reason in {"timeout", "error"}:
             break
     return reports
+
+
+def new_runtime(backend: LlamaServerBackend, workdir: Path) -> ChatRuntime:
+    return ChatRuntime(
+        backend=ProbeBackend(backend),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        diagnostic_session_id=str(workdir),
+    )
 
 
 def run_step(
@@ -336,7 +487,9 @@ def run_step(
     temperature: float,
     base_url: str,
     timeout: float,
+    allowed_tool_names: tuple[str, ...] = ("exec_shell_full_command",),
 ) -> StepReport:
+    props_before = fresh_backend_props(base_url, min(timeout, 5.0))
     result_queue: queue.Queue[StepReport] = queue.Queue(maxsize=1)
 
     worker = threading.Thread(
@@ -349,6 +502,7 @@ def run_step(
                 workdir=workdir,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                allowed_tool_names=allowed_tool_names,
             )
         ),
         daemon=True,
@@ -378,6 +532,7 @@ def run_step(
             prompt_tokens=None,
             cached_tokens=None,
             evaluated_tokens=None,
+            output_tokens=None,
             finish_reason="timeout",
             tool_calls=0,
             tool_names=[],
@@ -389,8 +544,19 @@ def run_step(
             notes=notes,
             answer_excerpt="timeout",
             model_steps=[],
+            final_prefix=final_prefix_step_state(props_before, props_after),
+            lifecycle={
+                "event": "timeout",
+                "timeout_observed": True,
+                "automatic_cancel": False,
+                "explicit_cancel_used": cancel_requested,
+                "cleanup_healthy": props_after.get("in_flight") is False,
+            },
+            phase_wall_ms={},
         )
-    return result_queue.get()
+    report = result_queue.get()
+    props_after = fresh_backend_props(base_url, min(timeout, 5.0))
+    return replace_step_final_prefix(report, final_prefix_step_state(props_before, props_after))
 
 
 def _run_step_inner(
@@ -402,10 +568,14 @@ def _run_step_inner(
     workdir: Path,
     max_tokens: int,
     temperature: float,
+    allowed_tool_names: tuple[str, ...],
 ) -> StepReport:
     model_steps: list[ModelStepMetrics] = []
     tool_names: list[str] = []
     started = time.perf_counter()
+    probe = runtime.backend if isinstance(runtime.backend, ProbeBackend) else None
+    if probe is not None:
+        probe.reset_phase_timings()
     notes = ""
     try:
         if step.mode == "chat":
@@ -421,7 +591,7 @@ def _run_step_inner(
                 temperature=temperature,
                 max_tokens=max_tokens,
                 workdir=workdir,
-                allowed_tool_names=("exec_shell_full_command",),
+                allowed_tool_names=allowed_tool_names,
                 on_model_step=model_steps.append,
                 on_tool_call=lambda name, _args: tool_names.append(name),
             )
@@ -439,6 +609,14 @@ def _run_step_inner(
         )
         notes = "exception"
     wall_ms = round((time.perf_counter() - started) * 1000, 1)
+    phase_timings = phase_timing_summary(probe.phase_timings() if probe is not None else [], wall_ms)
+    final_wall_ms = phase_duration(phase_timings, "final_from_tool")
+    generation_ms = estimated_generation_ms(result.completion_tokens, result.generation_tokens_per_second)
+    residual_ms = (
+        round(max(0.0, final_wall_ms - generation_ms), 1)
+        if final_wall_ms is not None and generation_ms is not None
+        else None
+    )
     completion_kind = ",".join(metric.phase for metric in model_steps) or "error"
     route_tokens = first_prompt_tokens(model_steps, route=True)
     final_tokens = first_prompt_tokens(model_steps, route=False, last=True)
@@ -461,6 +639,7 @@ def _run_step_inner(
         prompt_tokens=result.prompt_tokens,
         cached_tokens=result.cached_tokens,
         evaluated_tokens=evaluated,
+        output_tokens=result.completion_tokens,
         finish_reason=result.finish_reason,
         tool_calls=len(tool_names),
         tool_names=tool_names,
@@ -472,7 +651,29 @@ def _run_step_inner(
         notes=notes,
         answer_excerpt=excerpt(result.content),
         model_steps=[model_step_to_json(metric) for metric in model_steps],
+        final_prefix={},
+        lifecycle={},
+        phase_wall_ms=phase_timings,
+        prompt_tokens_per_second=result.prompt_tokens_per_second,
+        generation_tokens_per_second=result.generation_tokens_per_second,
+        estimated_generation_ms=generation_ms,
+        estimated_prefill_residual_ms=residual_ms,
     )
+
+
+def phase_timing_summary(timings: list[tuple[str, float]], total_wall_ms: float) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for phase, duration in timings:
+        result[phase] = round(result.get(phase, 0.0) + duration, 1)
+    model_wall = sum(result.values())
+    result["non_model_wall_ms"] = round(max(0.0, total_wall_ms - model_wall), 1)
+    return result
+
+
+def estimated_generation_ms(output_tokens: int | None, tokens_per_second: float | None) -> float | None:
+    if not isinstance(output_tokens, int) or not isinstance(tokens_per_second, int | float) or tokens_per_second <= 0:
+        return None
+    return round(output_tokens / float(tokens_per_second) * 1000, 1)
 
 
 def first_prompt_tokens(metrics: list[ModelStepMetrics], *, route: bool, last: bool = False) -> int | None:
@@ -495,6 +696,8 @@ def model_step_to_json(metric: ModelStepMetrics) -> dict[str, object]:
         "evaluated_tokens": evaluated,
         "tool_calls": metric.tool_calls,
         "retry_reason": metric.retry_reason,
+        "prompt_tokens_per_second": metric.prompt_tokens_per_second,
+        "generation_tokens_per_second": metric.generation_tokens_per_second,
     }
 
 
@@ -522,7 +725,236 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "accel": acceleration_mode(props),
         "base_url": args.base_url,
         "workdir": str(Path(args.workdir)),
+        "scenario": list(args.scenario or ["all"]),
+        "final_prefix_mode": args.final_prefix_mode,
+        "tools": args.tools,
+        "prewarm": os.environ.get("ORBIT_KV_PREFIX_PREWARM", "startup"),
+        "timeout": args.timeout,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "ctx": props.get("ctx_size", args.ctx),
+        "threads": props.get("threads", args.threads),
+        "threads_batch": props.get("threads_batch", args.threads_batch),
+        "batch": props.get("batch_size", args.batch),
+        "ubatch": props.get("ubatch_size", args.ubatch),
+        "server_command": server_command(args) if args.manage_server else "external",
+        "client_command": " ".join(sys.argv),
+        "final_prefix": final_prefix_props(props),
+        "block_id": args.block_id,
+        "run_order": args.run_order,
+        "cooling_seconds": args.cooling_seconds,
+        "cpu_affinity": sorted(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None,
     }
+
+
+FINAL_PREFIX_PROP_KEYS = {
+    "enabled": "final_prefix_experiment_enabled",
+    "initialized": "final_prefix_experiment_initialized",
+    "prefix_tokens": "final_prefix_experiment_prefix_tokens",
+    "capture_count": "final_prefix_experiment_capture_count",
+    "restore_count": "final_prefix_experiment_restore_count",
+    "fallback_count": "final_prefix_experiment_fallback_count",
+    "failure_reason": "final_prefix_experiment_failure_reason",
+    "last_used": "final_prefix_experiment_last_used",
+    "checkpoint_size": "final_prefix_experiment_checkpoint_size_bytes",
+}
+
+
+def final_prefix_props(props: dict[str, object]) -> dict[str, object]:
+    return {name: props.get(source) for name, source in FINAL_PREFIX_PROP_KEYS.items()}
+
+
+def final_prefix_step_state(before: dict[str, object], after: dict[str, object]) -> dict[str, object]:
+    state = final_prefix_props(after)
+    for name in ("capture_count", "restore_count", "fallback_count"):
+        old = final_prefix_props(before).get(name)
+        new = state.get(name)
+        state[f"{name}_delta"] = new - old if isinstance(old, int) and isinstance(new, int) else None
+    return state
+
+
+def final_prefix_validation_failure(
+    mode: str,
+    reports: list[StepReport],
+    props: dict[str, object],
+) -> str | None:
+    state = final_prefix_props(props)
+    eligible = [report for report in reports if "final_from_tool" in report.completion_kind]
+    if mode == "off":
+        if state.get("enabled") is not False:
+            return "off_mode_enabled"
+        if any((report.final_prefix.get("capture_count_delta") or 0) > 0 for report in eligible):
+            return "off_mode_capture"
+        return None
+    if mode != "on":
+        return "explicit_mode_required"
+    if state.get("enabled") is not True:
+        return "on_mode_disabled"
+    if props.get("mtp_experimental_enabled") is True:
+        if (state.get("capture_count") or 0) != 0 or (state.get("restore_count") or 0) != 0:
+            return "mtp_guard_failed"
+        return None
+    if state.get("fallback_count") not in {0, None}:
+        return "fallback_observed"
+    if state.get("prefix_tokens") != 43:
+        return "unexpected_prefix_tokens"
+    if (state.get("capture_count") or 0) < 1:
+        return "capture_missing"
+    if len(eligible) >= 2 and (state.get("restore_count") or 0) < 1:
+        return "restore_missing"
+    return None
+
+
+def replace_step_final_prefix(report: StepReport, state: dict[str, object]) -> StepReport:
+    values = report.__dict__.copy()
+    values["final_prefix"] = state
+    return StepReport(**values)
+
+
+@contextmanager
+def final_prefix_environment(mode: str):
+    previous = os.environ.get("ORBIT_FINAL_PREFIX_EXPERIMENT")
+    if mode == "on":
+        os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"] = "1"
+    elif mode == "off":
+        os.environ.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
+        else:
+            os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"] = previous
+
+
+@contextmanager
+def deterministic_web(enabled: bool):
+    if not enabled:
+        yield
+        return
+    from orbit.runtime import shell_guardrails
+
+    original = shell_guardrails.search_web
+
+    def fixture(query: str, *, max_results: int = 5) -> str:
+        del max_results
+        lower = query.lower()
+        if "fixture success" in lower:
+            return "\n".join(
+                [
+                    "web_search_results: true",
+                    f"query: {query}",
+                    "results:",
+                    "1. title: Orbit deterministic fixture",
+                    "   url: https://example.invalid/orbit-fixture",
+                    "   snippet: Orbit fixture result for bounded web final validation.",
+                ]
+            )
+        if "fixture none" in lower:
+            return "web_search_results: true\nresults: none"
+        return "error: web search failed: deterministic DNS fixture"
+
+    shell_guardrails.search_web = fixture
+    try:
+        yield
+    finally:
+        shell_guardrails.search_web = original
+
+
+def server_command(args: argparse.Namespace) -> list[str]:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(args.base_url)
+    command = [
+        sys.executable, "-m", "orbit.terminal.cli", "server",
+        "--host", parsed.hostname or "127.0.0.1",
+        "--port", str(parsed.port or 12120),
+        "--ctx", str(args.ctx),
+        "--threads", str(args.threads),
+        "--threads-batch", str(args.threads_batch),
+        "--batch", str(args.batch),
+        "--ubatch", str(args.ubatch),
+        "--think", args.server_thinking,
+    ]
+    if args.model:
+        command.extend(("--model", args.model))
+    if args.mmproj:
+        command.extend(("--mmproj", args.mmproj))
+    if args.server_mtp:
+        command.append("--mtp")
+    return command
+
+
+@contextmanager
+def managed_server(args: argparse.Namespace):
+    if not args.manage_server:
+        yield None
+        return
+    if fresh_backend_props(args.base_url, 1.0):
+        raise RuntimeError(f"managed server requires an unused base URL: {args.base_url}")
+    env = os.environ.copy()
+    env["ORBIT_TOOLS"] = args.tools
+    if args.final_prefix_mode == "on":
+        env["ORBIT_FINAL_PREFIX_EXPERIMENT"] = "1"
+    else:
+        env.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
+    process = subprocess.Popen(
+        server_command(args),
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        wait_for_server(args.base_url, process, args.server_start_timeout)
+        props = fresh_backend_props(args.base_url, 2.0)
+        expected_enabled = args.final_prefix_mode == "on"
+        if props.get("final_prefix_experiment_enabled") is not expected_enabled:
+            raise RuntimeError("managed server final-prefix mode does not match the requested mode")
+        yield process
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def wait_for_server(base_url: str, process: subprocess.Popen[str], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = process.stdout.read() if process.stdout is not None else ""
+            raise RuntimeError(f"managed server exited during startup: {excerpt(output, 500)}")
+        if fresh_backend_props(base_url, 2.0):
+            time.sleep(0.1)
+            if process.poll() is None:
+                return
+        time.sleep(0.25)
+    raise TimeoutError(f"managed server did not become ready within {timeout:.0f}s")
+
+
+def process_rss_kib(process: subprocess.Popen[str] | None) -> int | None:
+    if process is None:
+        return None
+    try:
+        text = Path(f"/proc/{process.pid}/status").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.startswith("VmRSS:"):
+            fields = line.split()
+            return int(fields[1]) if len(fields) >= 2 and fields[1].isdigit() else None
+    return None
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
 
 
 def safe_backend_props(backend: LlamaServerBackend) -> dict[str, object]:
@@ -656,6 +1088,8 @@ def write_jsonl(path: Path, env: dict[str, object], reports: list[StepReport]) -
         handle.write(json.dumps({"type": "environment", **env}, ensure_ascii=False, sort_keys=True) + "\n")
         for report in reports:
             handle.write(json.dumps({"type": "step", **report.to_json()}, ensure_ascii=False, sort_keys=True) + "\n")
+        for summary in summarize_reports(reports):
+            handle.write(json.dumps({"type": "summary", **summary}, ensure_ascii=False, sort_keys=True) + "\n")
 
 
 def write_markdown(path: Path, env: dict[str, object], reports: list[StepReport]) -> None:
@@ -696,7 +1130,96 @@ def write_markdown(path: Path, env: dict[str, object], reports: list[StepReport]
                 notes=report.notes or "-",
             )
         )
+    summaries = summarize_reports(reports)
+    if summaries:
+        lines.extend(
+            [
+                "",
+                "## Repetition Summary",
+                "",
+                "| Case | Step | Runs | Correct | Cached min/median/max | Eval min/median/max | Wall ms min/median/max |",
+                "| --- | ---: | ---: | ---: | --- | --- | --- |",
+            ]
+        )
+        for summary in summaries:
+            lines.append(
+                f"| {summary['case']} | {summary['step']} | {summary['runs']} | {summary['correct']} | "
+                f"{format_range(summary['cached_tokens'])} | {format_range(summary['evaluated_tokens'])} | "
+                f"{format_range(summary['wall_ms'])} |"
+            )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def summarize_reports(reports: list[StepReport]) -> list[dict[str, object]]:
+    grouped: dict[tuple[str, int], list[StepReport]] = {}
+    for report in reports:
+        grouped.setdefault((report.case, report.step), []).append(report)
+    result: list[dict[str, object]] = []
+    for (case, step), rows in grouped.items():
+        result.append(
+            {
+                "case": case,
+                "step": step,
+                "runs": len(rows),
+                "correct": sum(row.correctness_category == "correct" for row in rows),
+                "cached_tokens": numeric_range(row.cached_tokens for row in rows),
+                "evaluated_tokens": numeric_range(row.evaluated_tokens for row in rows),
+                "output_tokens": numeric_range(row.output_tokens for row in rows),
+                "wall_ms": numeric_range(row.wall_ms for row in rows),
+                "route_wall_ms": numeric_range(row.phase_wall_ms.get("route") for row in rows),
+                "final_wall_ms": numeric_range(
+                    phase_duration(row.phase_wall_ms, "final_from_tool")
+                    for row in rows
+                ),
+                "non_model_wall_ms": numeric_range(row.phase_wall_ms.get("non_model_wall_ms") for row in rows),
+                "prompt_tokens_per_second": numeric_range(row.prompt_tokens_per_second for row in rows),
+                "generation_tokens_per_second": numeric_range(row.generation_tokens_per_second for row in rows),
+                "estimated_generation_ms": numeric_range(row.estimated_generation_ms for row in rows),
+                "estimated_prefill_residual_ms": numeric_range(row.estimated_prefill_residual_ms for row in rows),
+                "capture_delta": sum(int(row.final_prefix.get("capture_count_delta") or 0) for row in rows),
+                "restore_delta": sum(int(row.final_prefix.get("restore_count_delta") or 0) for row in rows),
+                "fallback_delta": sum(int(row.final_prefix.get("fallback_count_delta") or 0) for row in rows),
+                "restored": summarize_restored_rows(rows),
+            }
+        )
+    return result
+
+
+def summarize_restored_rows(rows: list[StepReport]) -> dict[str, object]:
+    restored = [row for row in rows if (row.final_prefix.get("restore_count_delta") or 0) > 0]
+    return {
+        "runs": len(restored),
+        "cached_tokens": numeric_range(row.cached_tokens for row in restored),
+        "evaluated_tokens": numeric_range(row.evaluated_tokens for row in restored),
+        "output_tokens": numeric_range(row.output_tokens for row in restored),
+        "wall_ms": numeric_range(row.wall_ms for row in restored),
+        "final_wall_ms": numeric_range(
+            phase_duration(row.phase_wall_ms, "final_from_tool")
+            for row in restored
+        ),
+    }
+
+
+def phase_duration(timings: dict[str, float], prefix: str) -> float | None:
+    values = [value for phase, value in timings.items() if phase.startswith(prefix)]
+    return round(sum(values), 1) if values else None
+
+
+def numeric_range(values) -> dict[str, float] | None:
+    present = [float(item) for item in values if isinstance(item, int | float)]
+    if not present:
+        return None
+    return {
+        "min": round(min(present), 1),
+        "median": round(statistics.median(present), 1),
+        "max": round(max(present), 1),
+    }
+
+
+def format_range(value: object) -> str:
+    if not isinstance(value, dict):
+        return "-"
+    return f"{value.get('min')}/{value.get('median')}/{value.get('max')}"
 
 
 def value(item: object) -> object:
@@ -777,6 +1300,13 @@ def check_read_excerpt(text: str, _tools: list[str]) -> str:
     return "correct" if "EvidenceStore" in text or "from __future__" in text else "partial_baseline"
 
 
+def check_web_error(text: str, _tools: list[str]) -> str:
+    lower = text.lower()
+    reports_failure = "fail" in lower or "error" in lower or "could not" in lower or "unable" in lower
+    answers_from_memory = "avola is" in lower or "avola, sicily" in lower or "province of syracuse" in lower
+    return "correct" if reports_failure and not answers_from_memory else "wrong"
+
+
 CHECKERS: dict[str, CorrectnessChecker] = {
     "not_evaluated": check_not_evaluated,
     "nonempty": check_nonempty,
@@ -788,6 +1318,7 @@ CHECKERS: dict[str, CorrectnessChecker] = {
     "line5": check_line5,
     "grep_evidence": check_grep_evidence,
     "read_excerpt": check_read_excerpt,
+    "web_error": check_web_error,
 }
 
 

--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -45,6 +45,31 @@ class SmokeStep:
     checker_name: str = "not_evaluated"
 
 
+FINAL_PREFIX_LOCAL_STEPS = (
+    SmokeStep("run pwd", checker_name="path_like"),
+    SmokeStep("tell me specs about this computer", checker_name="nonempty"),
+    SmokeStep("read text/summary.txt", checker_name="nonempty"),
+    SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
+    SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
+    SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
+    SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
+)
+
+FINAL_PREFIX_WEB_STEPS = (
+    SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
+    SmokeStep("search online for orbit fixture none", checker_name="nonempty"),
+    SmokeStep("search online for where is Avola located?", checker_name="web_error"),
+    SmokeStep("search online for latest status of fictional endpoint xqz-orbit-404", checker_name="web_error"),
+)
+
+FINAL_PREFIX_PAIRED_STEPS = (
+    FINAL_PREFIX_LOCAL_STEPS[0],
+    FINAL_PREFIX_LOCAL_STEPS[1],
+    FINAL_PREFIX_LOCAL_STEPS[3],
+    FINAL_PREFIX_WEB_STEPS[0],
+)
+
+
 @dataclass(frozen=True)
 class SmokeScenario:
     name: str
@@ -119,6 +144,18 @@ class StepReport:
             "estimated_generation_ms": self.estimated_generation_ms,
             "estimated_prefill_residual_ms": self.estimated_prefill_residual_ms,
         }
+
+
+@dataclass(frozen=True)
+class LifecycleBlock:
+    block_id: str
+    server_pid: int
+    ctx: int
+    thinking: str
+    initial_props: dict[str, object]
+    final_props: dict[str, object]
+    reports: list[StepReport]
+    rss_samples: list[dict[str, object]]
 
 
 class ProbeBackend:
@@ -203,6 +240,9 @@ def main(argv: list[str] | None = None) -> int:
     jsonl_path = Path(args.jsonl) if args.jsonl else output_dir / f"orbit_smoke_{stamp}.jsonl"
     markdown_path = Path(args.markdown) if args.markdown else output_dir / f"orbit_smoke_{stamp}.md"
 
+    if args.lifecycle_check:
+        return run_lifecycle_checks(args, jsonl_path=jsonl_path, markdown_path=markdown_path)
+
     with final_prefix_environment(args.final_prefix_mode), deterministic_web(args.deterministic_web), managed_server(args) as server_process:
         backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
         backend.thinking = args.server_thinking == "on"
@@ -226,16 +266,18 @@ def main(argv: list[str] | None = None) -> int:
                         max_tokens=args.max_tokens,
                         temperature=args.temperature,
                         timeout=args.timeout,
+                        tools_mode=args.tools,
                     )
                 )
         final_props = settled_backend_props(args.base_url, args.timeout)
         env = environment_summary(args=args, backend=backend, props=final_props)
+        env["server_pid"] = server_process.pid if server_process is not None else None
         env["server_rss_before_kib"] = rss_before_kib
         env["server_rss_after_kib"] = process_rss_kib(server_process)
     write_jsonl(jsonl_path, env, reports)
     write_markdown(markdown_path, env, reports)
     if args.verify_final_prefix:
-        failure = final_prefix_validation_failure(args.final_prefix_mode, reports, final_props)
+        failure = final_prefix_validation_failure(args.final_prefix_mode, reports, final_props, tools_mode=args.tools)
         if failure is not None:
             print(f"error: final-prefix validation failed ({failure})", file=sys.stderr)
             return 1
@@ -286,6 +328,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--run-order", default=None)
     parser.add_argument("--cooling-seconds", type=float, default=0.0)
     parser.add_argument("--deterministic-web", action="store_true", help="Use bounded local web fixtures for final-prefix smoke cases.")
+    parser.add_argument(
+        "--lifecycle-check",
+        action="append",
+        choices=("restart", "ctx-change", "thinking", "rss"),
+        help="Run a managed final-prefix lifecycle check; repeatable.",
+    )
+    parser.add_argument("--ctx-change-to", type=positive_int, default=4096)
     parser.add_argument(
         "--verify-final-prefix",
         action="store_true",
@@ -353,44 +402,26 @@ def scenarios() -> dict[str, SmokeScenario]:
         ),
         "final_prefix_local": SmokeScenario(
             "final_prefix_local",
-            (
-                SmokeStep("run pwd", checker_name="path_like"),
-                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
-                SmokeStep("read text/summary.txt", checker_name="nonempty"),
-                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
-                SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
-                SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
-                SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
-            ),
+            FINAL_PREFIX_LOCAL_STEPS,
             optional=True,
             allowed_tool_names=TOOL_NAMES,
         ),
+        "final_prefix_pwd": SmokeScenario(
+            "final_prefix_pwd",
+            (FINAL_PREFIX_LOCAL_STEPS[0], FINAL_PREFIX_LOCAL_STEPS[0]),
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            isolated_steps=True,
+        ),
         "final_prefix_web": SmokeScenario(
             "final_prefix_web",
-            (
-                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
-                SmokeStep("search online for orbit fixture none", checker_name="nonempty"),
-                SmokeStep("search online for where is Avola located?", checker_name="web_error"),
-                SmokeStep("search online for latest status of fictional endpoint xqz-orbit-404", checker_name="web_error"),
-            ),
+            FINAL_PREFIX_WEB_STEPS,
             requires_web=True,
             optional=True,
         ),
         "final_prefix_mixed": SmokeScenario(
             "final_prefix_mixed",
-            (
-                SmokeStep("run pwd", checker_name="path_like"),
-                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
-                SmokeStep("read text/summary.txt", checker_name="nonempty"),
-                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
-                SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
-                SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
-                SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
-                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
-                SmokeStep("search online for orbit fixture none", checker_name="nonempty"),
-                SmokeStep("search online for where is Avola located?", checker_name="web_error"),
-                SmokeStep("search online for latest status of fictional endpoint xqz-orbit-404", checker_name="web_error"),
-            ),
+            FINAL_PREFIX_LOCAL_STEPS + FINAL_PREFIX_WEB_STEPS,
             requires_web=True,
             optional=True,
             allowed_tool_names=TOOL_NAMES,
@@ -398,12 +429,7 @@ def scenarios() -> dict[str, SmokeScenario]:
         ),
         "final_prefix_paired": SmokeScenario(
             "final_prefix_paired",
-            (
-                SmokeStep("run pwd", checker_name="path_like"),
-                SmokeStep("tell me specs about this computer", checker_name="nonempty"),
-                SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
-                SmokeStep("search online for orbit fixture success", checker_name="nonempty"),
-            ),
+            FINAL_PREFIX_PAIRED_STEPS,
             requires_web=True,
             optional=True,
             allowed_tool_names=TOOL_NAMES,
@@ -444,6 +470,7 @@ def run_scenario(
     max_tokens: int,
     temperature: float,
     timeout: float,
+    tools_mode: str = "on",
 ) -> list[StepReport]:
     runtime = new_runtime(backend, workdir)
     reports: list[StepReport] = []
@@ -460,12 +487,16 @@ def run_scenario(
             temperature=temperature,
             base_url=backend.base_url,
             timeout=timeout,
-            allowed_tool_names=scenario.allowed_tool_names,
+            allowed_tool_names=effective_allowed_tool_names(scenario, tools_mode),
         )
         reports.append(report)
         if report.finish_reason in {"timeout", "error"}:
             break
     return reports
+
+
+def effective_allowed_tool_names(scenario: SmokeScenario, tools_mode: str) -> tuple[str, ...]:
+    return scenario.allowed_tool_names if tools_mode == "on" else ()
 
 
 def new_runtime(backend: LlamaServerBackend, workdir: Path) -> ChatRuntime:
@@ -777,6 +808,8 @@ def final_prefix_validation_failure(
     mode: str,
     reports: list[StepReport],
     props: dict[str, object],
+    *,
+    tools_mode: str = "on",
 ) -> str | None:
     state = final_prefix_props(props)
     eligible = [report for report in reports if "final_from_tool" in report.completion_kind]
@@ -790,6 +823,10 @@ def final_prefix_validation_failure(
         return "explicit_mode_required"
     if state.get("enabled") is not True:
         return "on_mode_disabled"
+    if tools_mode == "off":
+        if (state.get("capture_count") or 0) != 0 or (state.get("restore_count") or 0) != 0:
+            return "tools_off_guard_failed"
+        return None
     if props.get("mtp_experimental_enabled") is True:
         if (state.get("capture_count") or 0) != 0 or (state.get("restore_count") or 0) != 0:
             return "mtp_guard_failed"
@@ -950,6 +987,290 @@ def process_rss_kib(process: subprocess.Popen[str] | None) -> int | None:
     return None
 
 
+def rss_sample(
+    process: subprocess.Popen[str],
+    *,
+    label: str,
+    block_id: str,
+    sequence: int,
+    props: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "type": "rss_sample",
+        "label": label,
+        "sequence": sequence,
+        "server_pid": process.pid,
+        "block_id": block_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "rss_kib": process_rss_kib(process),
+        "final_prefix": final_prefix_props(props or {}),
+    }
+
+
+def summarize_rss_samples(samples: list[dict[str, object]], *, block_id: str) -> dict[str, object]:
+    by_label = {str(sample.get("label")): sample.get("rss_kib") for sample in samples}
+
+    def delta(start: str, end: str) -> int | None:
+        before = by_label.get(start)
+        after = by_label.get(end)
+        return after - before if isinstance(before, int) and isinstance(after, int) else None
+
+    restore_values = [by_label.get(label) for label in ("after_restore_10", "after_restore_25", "after_restore_50")]
+    complete = all(isinstance(value, int) for value in restore_values)
+    linear_growth = None
+    if complete:
+        first, middle, last = (int(value) for value in restore_values)
+        linear_growth = first < middle < last and (last - first) >= 1024
+    required_labels = (
+        "startup",
+        "after_capture",
+        "after_restore_10",
+        "after_restore_25",
+        "after_restore_50",
+        "after_invalidation",
+        "after_recapture",
+    )
+    complete = all(label in by_label and isinstance(by_label[label], int) for label in required_labels)
+    invalidation = next((sample for sample in samples if sample.get("label") == "after_invalidation"), {})
+    recapture = next((sample for sample in samples if sample.get("label") == "after_recapture"), {})
+    invalidation_state = invalidation.get("final_prefix") if isinstance(invalidation.get("final_prefix"), dict) else {}
+    recapture_state = recapture.get("final_prefix") if isinstance(recapture.get("final_prefix"), dict) else {}
+    lifecycle_healthy = (
+        invalidation_state.get("initialized") is False
+        and invalidation_state.get("prefix_tokens") == 0
+        and recapture_state.get("initialized") is True
+        and (recapture_state.get("capture_count") or 0) >= 2
+    )
+    return {
+        "type": "lifecycle_summary",
+        "operation": "rss",
+        "block_id": block_id,
+        "server_pid": samples[0].get("server_pid") if samples else None,
+        "sample_labels": [sample.get("label") for sample in samples],
+        "startup_to_capture_delta_kib": delta("startup", "after_capture"),
+        "capture_to_restore50_delta_kib": delta("after_capture", "after_restore_50"),
+        "restore50_to_invalidation_delta_kib": delta("after_restore_50", "after_invalidation"),
+        "invalidation_to_recapture_delta_kib": delta("after_invalidation", "after_recapture"),
+        "linear_growth_suspected": linear_growth,
+        "invalidation_initialized": invalidation_state.get("initialized"),
+        "recapture_initialized": recapture_state.get("initialized"),
+        "complete": complete,
+        "passed": complete and lifecycle_healthy,
+    }
+
+
+def namespace_with(args: argparse.Namespace, **overrides: object) -> argparse.Namespace:
+    values = vars(args).copy()
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def lifecycle_pwd_scenario(name: str = "final_prefix_lifecycle") -> SmokeScenario:
+    return SmokeScenario(
+        name,
+        (FINAL_PREFIX_LOCAL_STEPS[0],),
+        optional=True,
+        allowed_tool_names=TOOL_NAMES,
+        isolated_steps=True,
+    )
+
+
+def run_lifecycle_block(
+    args: argparse.Namespace,
+    *,
+    block_id: str,
+    calls: int,
+    rss_series: bool = False,
+) -> LifecycleBlock:
+    block_args = namespace_with(args, block_id=block_id, manage_server=True)
+    samples: list[dict[str, object]] = []
+    reports: list[StepReport] = []
+    with final_prefix_environment(block_args.final_prefix_mode), deterministic_web(False), managed_server(block_args) as process:
+        if process is None:
+            raise RuntimeError("lifecycle checks require a managed server")
+        backend = LlamaServerBackend(base_url=block_args.base_url, timeout=block_args.timeout)
+        backend.thinking = block_args.server_thinking == "on"
+        initial_props = fresh_backend_props(block_args.base_url, 5.0)
+        samples.append(rss_sample(process, label="startup", block_id=block_id, sequence=0, props=initial_props))
+        restore_milestones = {10, 25, 50}
+        sampled_restore_milestones: set[int] = set()
+        capture_sampled = False
+        for call_index in range(calls):
+            batch = run_scenario(
+                lifecycle_pwd_scenario(),
+                backend=backend,
+                workdir=Path(block_args.workdir),
+                max_tokens=block_args.max_tokens,
+                temperature=block_args.temperature,
+                timeout=block_args.timeout,
+                tools_mode=block_args.tools,
+            )
+            reports.extend(batch)
+            state = batch[-1].final_prefix if batch else {}
+            if not capture_sampled and (state.get("capture_count_delta") or 0) > 0:
+                samples.append(
+                    rss_sample(
+                        process,
+                        label="after_capture",
+                        block_id=block_id,
+                        sequence=len(samples),
+                        props=fresh_backend_props(block_args.base_url, 5.0),
+                    )
+                )
+                capture_sampled = True
+            props = fresh_backend_props(block_args.base_url, 5.0)
+            restore_count = props.get("final_prefix_experiment_restore_count")
+            if isinstance(restore_count, int):
+                for milestone in sorted(restore_milestones - sampled_restore_milestones):
+                    if restore_count >= milestone:
+                        samples.append(
+                            rss_sample(
+                                process,
+                                label=f"after_restore_{milestone}",
+                                block_id=block_id,
+                                sequence=len(samples),
+                                props=props,
+                            )
+                        )
+                        sampled_restore_milestones.add(milestone)
+            if batch and batch[-1].finish_reason in {"timeout", "error"}:
+                break
+        if rss_series:
+            request_backend_cancel(block_args.base_url, timeout=5.0)
+            invalidated_props = wait_for_backend_idle(block_args.base_url, 10.0)
+            samples.append(
+                rss_sample(
+                    process,
+                    label="after_invalidation",
+                    block_id=block_id,
+                    sequence=len(samples),
+                    props=invalidated_props,
+                )
+            )
+            recapture = run_scenario(
+                lifecycle_pwd_scenario(),
+                backend=backend,
+                workdir=Path(block_args.workdir),
+                max_tokens=block_args.max_tokens,
+                temperature=block_args.temperature,
+                timeout=block_args.timeout,
+                tools_mode=block_args.tools,
+            )
+            reports.extend(recapture)
+            samples.append(
+                rss_sample(
+                    process,
+                    label="after_recapture",
+                    block_id=block_id,
+                    sequence=len(samples),
+                    props=fresh_backend_props(block_args.base_url, 5.0),
+                )
+            )
+        final_props = settled_backend_props(block_args.base_url, block_args.timeout)
+        return LifecycleBlock(
+            block_id=block_id,
+            server_pid=process.pid,
+            ctx=block_args.ctx,
+            thinking=block_args.server_thinking,
+            initial_props=initial_props,
+            final_props=final_props,
+            reports=reports,
+            rss_samples=samples,
+        )
+
+
+def lifecycle_transition_row(operation: str, blocks: list[LifecycleBlock]) -> dict[str, object]:
+    transitions = []
+    passed = True
+    for block in blocks:
+        state = final_prefix_props(block.final_props)
+        initial_state = final_prefix_props(block.initial_props)
+        capture_count = state.get("capture_count") if isinstance(state.get("capture_count"), int) else 0
+        restore_count = state.get("restore_count") if isinstance(state.get("restore_count"), int) else 0
+        eligible = block.thinking == "off"
+        block_passed = (
+            initial_state.get("initialized") is False and capture_count >= 1 and restore_count >= 1
+            if eligible
+            else initial_state.get("initialized") is False and capture_count == 0 and restore_count == 0
+        )
+        passed = passed and block_passed
+        transitions.append(
+            {
+                "block_id": block.block_id,
+                "server_pid": block.server_pid,
+                "ctx": block.ctx,
+                "thinking": block.thinking,
+                "initial_initialized": initial_state.get("initialized"),
+                "capture_count": capture_count,
+                "restore_count": restore_count,
+                "fallback_count": state.get("fallback_count"),
+                "eligibility": "eligible" if eligible else "ineligible_thinking",
+                "passed": block_passed,
+            }
+        )
+    return {
+        "type": "lifecycle_summary",
+        "operation": operation,
+        "passed": passed,
+        "process_ids": [block.server_pid for block in blocks],
+        "transitions": transitions,
+    }
+
+
+def run_lifecycle_checks(
+    args: argparse.Namespace,
+    *,
+    jsonl_path: Path,
+    markdown_path: Path,
+) -> int:
+    if args.final_prefix_mode != "on" or not args.manage_server:
+        print("error: lifecycle checks require --manage-server --final-prefix-mode on", file=sys.stderr)
+        return 2
+    reports: list[StepReport] = []
+    extra_rows: list[dict[str, object]] = []
+    blocks: list[LifecycleBlock] = []
+    for operation in args.lifecycle_check:
+        if operation == "restart":
+            current = [
+                run_lifecycle_block(args, block_id="restart-before", calls=2),
+                run_lifecycle_block(args, block_id="restart-after", calls=2),
+            ]
+        elif operation == "ctx-change":
+            current = [
+                run_lifecycle_block(args, block_id=f"ctx-{args.ctx}", calls=2),
+                run_lifecycle_block(
+                    namespace_with(args, ctx=args.ctx_change_to),
+                    block_id=f"ctx-{args.ctx_change_to}",
+                    calls=2,
+                ),
+            ]
+        elif operation == "thinking":
+            current = [
+                run_lifecycle_block(namespace_with(args, server_thinking="off"), block_id="thinking-off", calls=2),
+                run_lifecycle_block(namespace_with(args, server_thinking="on"), block_id="thinking-on", calls=0),
+            ]
+        else:
+            current = [run_lifecycle_block(args, block_id="rss-50", calls=51, rss_series=True)]
+            extra_rows.extend(current[0].rss_samples)
+            extra_rows.append(summarize_rss_samples(current[0].rss_samples, block_id=current[0].block_id))
+        blocks.extend(current)
+        extra_rows.append(lifecycle_transition_row(operation, current))
+        reports.extend(report for block in current for report in block.reports)
+    last = blocks[-1]
+    backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
+    env = environment_summary(args=args, backend=backend, props=last.final_props)
+    env["server_pid"] = last.server_pid
+    env["lifecycle_checks"] = list(args.lifecycle_check)
+    write_jsonl(jsonl_path, env, reports, extra_rows=extra_rows)
+    write_markdown(markdown_path, env, reports)
+    failed = any(row.get("type") == "lifecycle_summary" and row.get("passed") is False for row in extra_rows)
+    if failed or scenario_failure_reason(reports) is not None:
+        return 1
+    print(f"jsonl={jsonl_path}")
+    print(f"markdown={markdown_path}")
+    return 0
+
+
 def positive_int(value: str) -> int:
     parsed = int(value)
     if parsed < 1:
@@ -1082,7 +1403,13 @@ def acceleration_mode(props: dict[str, object]) -> str:
     return "unknown"
 
 
-def write_jsonl(path: Path, env: dict[str, object], reports: list[StepReport]) -> None:
+def write_jsonl(
+    path: Path,
+    env: dict[str, object],
+    reports: list[StepReport],
+    *,
+    extra_rows: list[dict[str, object]] | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:
         handle.write(json.dumps({"type": "environment", **env}, ensure_ascii=False, sort_keys=True) + "\n")
@@ -1090,6 +1417,8 @@ def write_jsonl(path: Path, env: dict[str, object], reports: list[StepReport]) -
             handle.write(json.dumps({"type": "step", **report.to_json()}, ensure_ascii=False, sort_keys=True) + "\n")
         for summary in summarize_reports(reports):
             handle.write(json.dumps({"type": "summary", **summary}, ensure_ascii=False, sort_keys=True) + "\n")
+        for row in extra_rows or []:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
 
 def write_markdown(path: Path, env: dict[str, object], reports: list[StepReport]) -> None:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -51,6 +51,24 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(args.final_prefix_mode, "on")
         self.assertEqual(args.repetitions, 5)
 
+    def test_parser_accepts_first_class_lifecycle_checks(self) -> None:
+        args = smoke_harness.build_parser().parse_args(
+            [
+                "--manage-server",
+                "--final-prefix-mode",
+                "on",
+                "--lifecycle-check",
+                "restart",
+                "--lifecycle-check",
+                "ctx-change",
+                "--ctx-change-to",
+                "4096",
+            ]
+        )
+
+        self.assertEqual(args.lifecycle_check, ["restart", "ctx-change"])
+        self.assertEqual(args.ctx_change_to, 4096)
+
     def test_select_scenarios_defaults_to_all_without_optional_or_web_when_disabled(self) -> None:
         selected = smoke_harness.select_scenarios(None, no_web=True, include_optional=False)
         names = [scenario.name for scenario in selected]
@@ -71,6 +89,39 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(len(scenario.steps), 11)
         self.assertTrue(scenario.isolated_steps)
         self.assertIn("system_info", scenario.allowed_tool_names)
+
+    def test_final_prefix_groups_share_canonical_case_definitions(self) -> None:
+        registry = smoke_harness.scenarios()
+
+        self.assertEqual(registry["final_prefix_local"].steps, smoke_harness.FINAL_PREFIX_LOCAL_STEPS)
+        self.assertEqual(registry["final_prefix_web"].steps, smoke_harness.FINAL_PREFIX_WEB_STEPS)
+        self.assertEqual(
+            registry["final_prefix_mixed"].steps,
+            smoke_harness.FINAL_PREFIX_LOCAL_STEPS + smoke_harness.FINAL_PREFIX_WEB_STEPS,
+        )
+        self.assertEqual(registry["final_prefix_paired"].steps, smoke_harness.FINAL_PREFIX_PAIRED_STEPS)
+
+    def test_tools_off_removes_runtime_tool_names(self) -> None:
+        scenario = smoke_harness.scenarios()["final_prefix_local"]
+
+        self.assertEqual(smoke_harness.effective_allowed_tool_names(scenario, "off"), ())
+        self.assertEqual(smoke_harness.effective_allowed_tool_names(scenario, "on"), scenario.allowed_tool_names)
+
+    def test_run_scenario_passes_no_tools_when_tools_mode_is_off(self) -> None:
+        report = mock.Mock(finish_reason="stop")
+        with mock.patch.object(smoke_harness, "run_step", return_value=report) as run_step, \
+            mock.patch.object(smoke_harness, "ChatRuntime"):
+            smoke_harness.run_scenario(
+                smoke_harness.SmokeScenario("chat", (smoke_harness.SmokeStep("hi"),)),
+                backend=mock.Mock(base_url="http://127.0.0.1:12120"),
+                workdir=Path("workdir"),
+                max_tokens=32,
+                temperature=0.0,
+                timeout=30.0,
+                tools_mode="off",
+            )
+
+        self.assertEqual(run_step.call_args.kwargs["allowed_tool_names"], ())
 
     def test_correctness_categorizer_detects_shell_error_and_mixed_output(self) -> None:
         self.assertEqual(smoke_harness.check_shell_error("exit_code=127 command not found", []), "correct")
@@ -348,6 +399,208 @@ class SmokeHarnessTests(unittest.TestCase):
                 },
             )
         )
+        self.assertIsNone(
+            smoke_harness.final_prefix_validation_failure(
+                "on",
+                [],
+                {
+                    "final_prefix_experiment_enabled": True,
+                    "final_prefix_experiment_capture_count": 0,
+                    "final_prefix_experiment_restore_count": 0,
+                },
+                tools_mode="off",
+            )
+        )
+        self.assertEqual(
+            smoke_harness.final_prefix_validation_failure(
+                "on",
+                [],
+                {
+                    "final_prefix_experiment_enabled": True,
+                    "final_prefix_experiment_capture_count": 1,
+                    "final_prefix_experiment_restore_count": 0,
+                },
+                tools_mode="off",
+            ),
+            "tools_off_guard_failed",
+        )
+
+    def test_lifecycle_transition_reports_restart_and_thinking_state(self) -> None:
+        eligible_props = {
+            "final_prefix_experiment_initialized": True,
+            "final_prefix_experiment_capture_count": 1,
+            "final_prefix_experiment_restore_count": 1,
+            "final_prefix_experiment_fallback_count": 0,
+        }
+        blocks = [
+            smoke_harness.LifecycleBlock(
+                block_id="before",
+                server_pid=101,
+                ctx=8192,
+                thinking="off",
+                initial_props={"final_prefix_experiment_initialized": False},
+                final_props=eligible_props,
+                reports=[],
+                rss_samples=[],
+            ),
+            smoke_harness.LifecycleBlock(
+                block_id="after",
+                server_pid=202,
+                ctx=4096,
+                thinking="off",
+                initial_props={"final_prefix_experiment_initialized": False},
+                final_props=eligible_props,
+                reports=[],
+                rss_samples=[],
+            ),
+        ]
+
+        restart = smoke_harness.lifecycle_transition_row("restart", blocks)
+        thinking = smoke_harness.lifecycle_transition_row(
+            "thinking",
+            [
+                smoke_harness.LifecycleBlock(
+                    block_id="thinking-on",
+                    server_pid=303,
+                    ctx=8192,
+                    thinking="on",
+                    initial_props={"final_prefix_experiment_initialized": False},
+                    final_props={
+                        "final_prefix_experiment_capture_count": 0,
+                        "final_prefix_experiment_restore_count": 0,
+                    },
+                    reports=[],
+                    rss_samples=[],
+                )
+            ],
+        )
+
+        self.assertTrue(restart["passed"])
+        self.assertEqual(restart["process_ids"], [101, 202])
+        self.assertFalse(restart["transitions"][1]["initial_initialized"])
+        self.assertTrue(thinking["passed"])
+        self.assertEqual(thinking["transitions"][0]["eligibility"], "ineligible_thinking")
+
+    def test_rss_samples_preserve_pid_order_and_compute_neutral_deltas(self) -> None:
+        process = mock.Mock(pid=4242)
+        values = iter((1000, 1200, 1210, 1220, 1230, 1240, 1250))
+        labels = (
+            "startup",
+            "after_capture",
+            "after_restore_10",
+            "after_restore_25",
+            "after_restore_50",
+            "after_invalidation",
+            "after_recapture",
+        )
+        with mock.patch.object(smoke_harness, "process_rss_kib", side_effect=lambda _process: next(values)):
+            samples = []
+            for index, label in enumerate(labels):
+                props = {}
+                if label == "after_invalidation":
+                    props = {
+                        "final_prefix_experiment_initialized": False,
+                        "final_prefix_experiment_prefix_tokens": 0,
+                    }
+                elif label == "after_recapture":
+                    props = {
+                        "final_prefix_experiment_initialized": True,
+                        "final_prefix_experiment_capture_count": 2,
+                    }
+                samples.append(
+                    smoke_harness.rss_sample(
+                        process,
+                        label=label,
+                        block_id="rss",
+                        sequence=index,
+                        props=props,
+                    )
+                )
+
+        summary = smoke_harness.summarize_rss_samples(samples, block_id="rss")
+
+        self.assertEqual(summary["sample_labels"], list(labels))
+        self.assertEqual(summary["server_pid"], 4242)
+        self.assertEqual(summary["startup_to_capture_delta_kib"], 200)
+        self.assertEqual(summary["capture_to_restore50_delta_kib"], 30)
+        self.assertFalse(summary["linear_growth_suspected"])
+        self.assertTrue(summary["complete"])
+        self.assertTrue(summary["passed"])
+
+    def test_rss_summary_handles_missing_samples_without_inference(self) -> None:
+        summary = smoke_harness.summarize_rss_samples(
+            [{"label": "startup", "rss_kib": None, "server_pid": 7}],
+            block_id="rss",
+        )
+
+        self.assertIsNone(summary["startup_to_capture_delta_kib"])
+        self.assertIsNone(summary["linear_growth_suspected"])
+        self.assertFalse(summary["complete"])
+
+    def test_lifecycle_runner_exercises_restart_ctx_and_thinking_transitions(self) -> None:
+        recorded: list[tuple[str, int, str]] = []
+
+        def fake_block(args, *, block_id, calls: int, rss_series=False):
+            del calls, rss_series
+            test_args = args
+            eligible = test_args.server_thinking == "off"
+            calls_state = 1 if eligible else 0
+            recorded.append((block_id, test_args.ctx, test_args.server_thinking))
+            return smoke_harness.LifecycleBlock(
+                block_id=block_id,
+                server_pid=100 + len(recorded),
+                ctx=test_args.ctx,
+                thinking=test_args.server_thinking,
+                initial_props={"final_prefix_experiment_initialized": False},
+                final_props={
+                    "backend": "orbit-native",
+                    "final_prefix_experiment_capture_count": calls_state,
+                    "final_prefix_experiment_restore_count": calls_state,
+                    "final_prefix_experiment_fallback_count": 0,
+                },
+                reports=[],
+                rss_samples=[],
+            )
+
+        args = smoke_harness.build_parser().parse_args(
+            [
+                "--manage-server",
+                "--final-prefix-mode",
+                "on",
+                "--lifecycle-check",
+                "restart",
+                "--lifecycle-check",
+                "ctx-change",
+                "--lifecycle-check",
+                "thinking",
+                "--ctx",
+                "8192",
+                "--ctx-change-to",
+                "4096",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "run_lifecycle_block", side_effect=fake_block), \
+            mock.patch.object(smoke_harness, "write_jsonl"), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.run_lifecycle_checks(
+                args,
+                jsonl_path=Path(tmp) / "out.jsonl",
+                markdown_path=Path(tmp) / "out.md",
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            recorded,
+            [
+                ("restart-before", 8192, "off"),
+                ("restart-after", 8192, "off"),
+                ("ctx-8192", 8192, "off"),
+                ("ctx-4096", 4096, "off"),
+                ("thinking-off", 8192, "off"),
+                ("thinking-on", 8192, "on"),
+            ],
+        )
 
     def test_main_mtp_required_fails_when_post_run_props_not_usable(self) -> None:
         initial = {
@@ -421,7 +674,12 @@ class SmokeHarnessTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "report.jsonl"
-            smoke_harness.write_jsonl(path, {"version": "0.0.1", "git_head": "abc"}, [report])
+            smoke_harness.write_jsonl(
+                path,
+                {"version": "0.0.1", "git_head": "abc"},
+                [report],
+                extra_rows=[{"type": "lifecycle_summary", "operation": "restart", "passed": True}],
+            )
             rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
 
         self.assertEqual(rows[0]["type"], "environment")
@@ -430,6 +688,29 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertIn("output_tokens", rows[1])
         self.assertIn("phase_wall_ms", rows[1])
         self.assertEqual(rows[2]["type"], "summary")
+        self.assertEqual(rows[3]["type"], "lifecycle_summary")
+
+    def test_main_tools_off_metadata_matches_runtime_mode(self) -> None:
+        captured_env: list[dict[str, object]] = []
+        captured_modes: list[str] = []
+
+        def fake_run_scenario(*_args, **kwargs):
+            captured_modes.append(kwargs["tools_mode"])
+            return []
+
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(smoke_harness, "safe_backend_props", return_value={}), \
+            mock.patch.object(smoke_harness, "settled_backend_props", return_value={}), \
+            mock.patch.object(smoke_harness, "run_scenario", side_effect=fake_run_scenario), \
+            mock.patch.object(smoke_harness, "write_jsonl", side_effect=lambda _p, env, _r: captured_env.append(env)), \
+            mock.patch.object(smoke_harness, "write_markdown"):
+            rc = smoke_harness.main(
+                ["--scenario", "simple_chat", "--no-web", "--tools", "off", "--output-dir", tmp]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured_modes, ["off"])
+        self.assertEqual(captured_env[0]["tools"], "off")
 
     def test_markdown_summary_contains_expected_columns(self) -> None:
         report = smoke_harness.StepReport(

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -42,6 +42,15 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(args.jsonl, "/tmp/out.jsonl")
         self.assertEqual(args.markdown, "/tmp/out.md")
 
+    def test_parser_accepts_managed_final_prefix_options(self) -> None:
+        args = smoke_harness.build_parser().parse_args(
+            ["--manage-server", "--final-prefix-mode", "on", "--repetitions", "5"]
+        )
+
+        self.assertTrue(args.manage_server)
+        self.assertEqual(args.final_prefix_mode, "on")
+        self.assertEqual(args.repetitions, 5)
+
     def test_select_scenarios_defaults_to_all_without_optional_or_web_when_disabled(self) -> None:
         selected = smoke_harness.select_scenarios(None, no_web=True, include_optional=False)
         names = [scenario.name for scenario in selected]
@@ -56,6 +65,13 @@ class SmokeHarnessTests(unittest.TestCase):
 
         self.assertEqual([scenario.name for scenario in selected], ["pwd_followup"])
 
+    def test_final_prefix_mixed_has_eleven_isolated_eligible_cases(self) -> None:
+        scenario = smoke_harness.scenarios()["final_prefix_mixed"]
+
+        self.assertEqual(len(scenario.steps), 11)
+        self.assertTrue(scenario.isolated_steps)
+        self.assertIn("system_info", scenario.allowed_tool_names)
+
     def test_correctness_categorizer_detects_shell_error_and_mixed_output(self) -> None:
         self.assertEqual(smoke_harness.check_shell_error("exit_code=127 command not found", []), "correct")
         self.assertEqual(smoke_harness.check_shell_error_focus("failed with 127", []), "correct")
@@ -64,6 +80,23 @@ class SmokeHarnessTests(unittest.TestCase):
     def test_correctness_categorizer_detects_fake_shell20_without_tool_call(self) -> None:
         self.assertEqual(smoke_harness.check_shell20("line-19", []), "fake_tool_output")
         self.assertEqual(smoke_harness.check_shell20("line-19", ["exec_shell_full_command"]), "correct")
+
+    def test_web_error_checker_rejects_answer_from_memory(self) -> None:
+        self.assertEqual(smoke_harness.check_web_error("The web search failed.", []), "correct")
+        self.assertEqual(
+            smoke_harness.check_web_error("The search failed, but Avola is in Sicily.", []),
+            "wrong",
+        )
+
+    def test_deterministic_web_fixture_covers_success_none_and_error(self) -> None:
+        from orbit.runtime import shell_guardrails
+
+        original = shell_guardrails.search_web
+        with smoke_harness.deterministic_web(True):
+            self.assertIn("Orbit deterministic fixture", shell_guardrails.search_web("orbit fixture success"))
+            self.assertIn("results: none", shell_guardrails.search_web("orbit fixture none"))
+            self.assertIn("error:", shell_guardrails.search_web("where is Avola located?"))
+        self.assertIs(shell_guardrails.search_web, original)
 
     def test_mtp_state_marks_failed_props_as_not_usable(self) -> None:
         state = smoke_harness.mtp_state_from_props(
@@ -116,6 +149,205 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(env["mtp"], "failed")
         self.assertFalse(env["mtp_usable"])
         self.assertEqual(env["mtp_failure_reason"], "probe failed")
+
+    def test_environment_summary_records_final_prefix_and_runtime_metadata(self) -> None:
+        class Backend:
+            def model_info(self):
+                return type("Info", (), {"id": "m"})()
+
+        args = smoke_harness.build_parser().parse_args(
+            [
+                "--scenario", "final_prefix_local", "--final-prefix-mode", "on", "--timeout", "30",
+                "--block-id", "abba-1-on-a", "--run-order", "ON", "--cooling-seconds", "15",
+            ]
+        )
+        env = smoke_harness.environment_summary(
+            args=args,
+            backend=Backend(),
+            props={
+                "backend": "orbit-native",
+                "ctx_size": 8192,
+                "threads": 6,
+                "threads_batch": 6,
+                "batch_size": 256,
+                "ubatch_size": 128,
+                "final_prefix_experiment_enabled": True,
+                "final_prefix_experiment_restore_count": 2,
+            },
+        )
+
+        self.assertEqual(env["final_prefix_mode"], "on")
+        self.assertEqual(env["scenario"], ["final_prefix_local"])
+        self.assertEqual(env["ctx"], 8192)
+        self.assertEqual(env["final_prefix"]["restore_count"], 2)
+        self.assertEqual(env["timeout"], 30.0)
+        self.assertEqual(env["block_id"], "abba-1-on-a")
+        self.assertEqual(env["run_order"], "ON")
+        self.assertEqual(env["cooling_seconds"], 15.0)
+        self.assertIsInstance(env["cpu_affinity"], list)
+
+    def test_final_prefix_environment_controls_client_flag_and_restores_it(self) -> None:
+        with mock.patch.dict("os.environ", {"ORBIT_FINAL_PREFIX_EXPERIMENT": "old"}, clear=False):
+            with smoke_harness.final_prefix_environment("on"):
+                self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "1")
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old")
+
+            with smoke_harness.final_prefix_environment("off"):
+                self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", smoke_harness.os.environ)
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old")
+
+    def test_managed_server_passes_final_prefix_flag_only_when_on(self) -> None:
+        args = smoke_harness.build_parser().parse_args(["--manage-server", "--final-prefix-mode", "on"])
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.return_value = 0
+        with mock.patch.object(smoke_harness.subprocess, "Popen", return_value=process) as popen, \
+            mock.patch.object(smoke_harness, "wait_for_server"), \
+            mock.patch.object(
+                smoke_harness,
+                "fresh_backend_props",
+                side_effect=[{}, {"final_prefix_experiment_enabled": True}],
+            ):
+            with smoke_harness.managed_server(args):
+                pass
+        self.assertEqual(popen.call_args.kwargs["env"]["ORBIT_FINAL_PREFIX_EXPERIMENT"], "1")
+
+        args = smoke_harness.build_parser().parse_args(["--manage-server", "--final-prefix-mode", "off"])
+        with mock.patch.dict(smoke_harness.os.environ, {"ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}), \
+            mock.patch.object(smoke_harness.subprocess, "Popen", return_value=process) as popen, \
+            mock.patch.object(smoke_harness, "wait_for_server"), \
+            mock.patch.object(
+                smoke_harness,
+                "fresh_backend_props",
+                side_effect=[{}, {"final_prefix_experiment_enabled": False}],
+            ):
+            with smoke_harness.managed_server(args):
+                pass
+        self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", popen.call_args.kwargs["env"])
+
+    def test_managed_server_rejects_an_already_used_base_url(self) -> None:
+        args = smoke_harness.build_parser().parse_args(["--manage-server", "--final-prefix-mode", "off"])
+        with mock.patch.object(smoke_harness, "fresh_backend_props", return_value={"backend": "orbit-native"}), \
+            self.assertRaisesRegex(RuntimeError, "unused base URL"):
+            with smoke_harness.managed_server(args):
+                pass
+
+    def test_server_command_can_enable_mtp_without_changing_final_prefix_mode(self) -> None:
+        args = smoke_harness.build_parser().parse_args(
+            ["--manage-server", "--final-prefix-mode", "on", "--server-mtp"]
+        )
+
+        command = smoke_harness.server_command(args)
+
+        self.assertIn("--mtp", command)
+        self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT=1", command)
+
+    def test_server_command_records_thinking_and_managed_tools_mode(self) -> None:
+        args = smoke_harness.build_parser().parse_args(
+            ["--manage-server", "--server-thinking", "on", "--tools", "off"]
+        )
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.return_value = 0
+        with mock.patch.object(smoke_harness.subprocess, "Popen", return_value=process) as popen, \
+            mock.patch.object(smoke_harness, "wait_for_server"), \
+            mock.patch.object(
+                smoke_harness,
+                "fresh_backend_props",
+                side_effect=[{}, {"final_prefix_experiment_enabled": False}],
+            ):
+            with smoke_harness.managed_server(args):
+                pass
+
+        command = popen.call_args.args[0]
+        self.assertEqual(command[command.index("--think") + 1], "on")
+        self.assertEqual(popen.call_args.kwargs["env"]["ORBIT_TOOLS"], "off")
+
+    def test_process_rss_reads_linux_status(self) -> None:
+        process = mock.Mock(pid=123)
+        with mock.patch.object(smoke_harness.Path, "read_text", return_value="Name:\torbit\nVmRSS:\t2048 kB\n"):
+            self.assertEqual(smoke_harness.process_rss_kib(process), 2048)
+
+    def test_final_prefix_step_state_reports_counter_deltas(self) -> None:
+        before = {
+            "final_prefix_experiment_capture_count": 1,
+            "final_prefix_experiment_restore_count": 3,
+            "final_prefix_experiment_fallback_count": 0,
+        }
+        after = {
+            "final_prefix_experiment_enabled": True,
+            "final_prefix_experiment_initialized": True,
+            "final_prefix_experiment_prefix_tokens": 43,
+            "final_prefix_experiment_capture_count": 1,
+            "final_prefix_experiment_restore_count": 4,
+            "final_prefix_experiment_fallback_count": 0,
+        }
+
+        state = smoke_harness.final_prefix_step_state(before, after)
+
+        self.assertEqual(state["capture_count_delta"], 0)
+        self.assertEqual(state["restore_count_delta"], 1)
+        self.assertEqual(state["fallback_count_delta"], 0)
+        self.assertEqual(state["prefix_tokens"], 43)
+
+    def test_final_prefix_validation_encodes_off_capture_and_on_restore_contract(self) -> None:
+        final = smoke_harness.StepReport(
+            case="pwd_followup",
+            step=1,
+            prompt="run pwd",
+            prompt_kind="auto",
+            completion_kind="route,final_from_tool",
+            route_tokens=800,
+            final_tokens=100,
+            prompt_tokens=100,
+            cached_tokens=43,
+            evaluated_tokens=57,
+            finish_reason="stop",
+            tool_calls=1,
+            tool_names=["exec_shell_full_command"],
+            wall_ms=100.0,
+            correctness_category="correct",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes="",
+            answer_excerpt="/tmp",
+            model_steps=[],
+        )
+        off_props = {
+            "final_prefix_experiment_enabled": False,
+            "final_prefix_experiment_capture_count": 0,
+        }
+        on_props = {
+            "final_prefix_experiment_enabled": True,
+            "final_prefix_experiment_prefix_tokens": 43,
+            "final_prefix_experiment_capture_count": 1,
+            "final_prefix_experiment_restore_count": 1,
+            "final_prefix_experiment_fallback_count": 0,
+        }
+
+        self.assertIsNone(smoke_harness.final_prefix_validation_failure("off", [final], off_props))
+        self.assertIsNone(smoke_harness.final_prefix_validation_failure("on", [final, final], on_props))
+        self.assertEqual(
+            smoke_harness.final_prefix_validation_failure(
+                "on",
+                [final, final],
+                {**on_props, "final_prefix_experiment_restore_count": 0},
+            ),
+            "restore_missing",
+        )
+        self.assertIsNone(
+            smoke_harness.final_prefix_validation_failure(
+                "on",
+                [final],
+                {
+                    "mtp_experimental_enabled": True,
+                    "final_prefix_experiment_enabled": True,
+                    "final_prefix_experiment_capture_count": 0,
+                    "final_prefix_experiment_restore_count": 0,
+                },
+            )
+        )
 
     def test_main_mtp_required_fails_when_post_run_props_not_usable(self) -> None:
         initial = {
@@ -195,6 +427,9 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(rows[0]["type"], "environment")
         self.assertEqual(rows[1]["type"], "step")
         self.assertEqual(rows[1]["case"], "simple_chat")
+        self.assertIn("output_tokens", rows[1])
+        self.assertIn("phase_wall_ms", rows[1])
+        self.assertEqual(rows[2]["type"], "summary")
 
     def test_markdown_summary_contains_expected_columns(self) -> None:
         report = smoke_harness.StepReport(
@@ -228,6 +463,96 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertIn("| Case | Step | Kind | Route | Final |", text)
         self.assertIn("pwd_followup", text)
         self.assertIn("partial_baseline", text)
+        self.assertIn("## Repetition Summary", text)
+
+    def test_summary_reports_median_and_final_prefix_counter_deltas(self) -> None:
+        rows = []
+        for cached, evaluated, wall, restore in (
+            (4, 96, 20.0, 0),
+            (43, 57, 14.0, 1),
+            (43, 57, 15.0, 1),
+            (43, 57, 13.0, 1),
+            (43, 57, 16.0, 1),
+        ):
+            rows.append(
+                smoke_harness.StepReport(
+                    case="pwd",
+                    step=1,
+                    prompt="run pwd",
+                    prompt_kind="auto",
+                    completion_kind="route,final_from_tool",
+                    route_tokens=800,
+                    final_tokens=100,
+                    prompt_tokens=100,
+                    cached_tokens=cached,
+                    evaluated_tokens=evaluated,
+                    finish_reason="stop",
+                    tool_calls=1,
+                    tool_names=["exec_shell_full_command"],
+                    wall_ms=wall,
+                    correctness_category="correct",
+                    raw_leak=False,
+                    fake_output=False,
+                    loop=False,
+                    notes="",
+                    answer_excerpt="/tmp",
+                    model_steps=[],
+                    final_prefix={"restore_count_delta": restore},
+                )
+            )
+
+        summary = smoke_harness.summarize_reports(rows)[0]
+
+        self.assertEqual(summary["cached_tokens"]["median"], 43.0)
+        self.assertEqual(summary["evaluated_tokens"]["median"], 57.0)
+        self.assertEqual(summary["runs"], 5)
+        self.assertEqual(summary["restore_delta"], 4)
+        self.assertEqual(summary["restored"]["runs"], 4)
+        self.assertEqual(summary["restored"]["cached_tokens"]["min"], 43.0)
+
+    def test_summary_aggregates_fifty_stability_calls(self) -> None:
+        row = smoke_harness.StepReport(
+            case="final_prefix_mixed",
+            step=1,
+            prompt="run pwd",
+            prompt_kind="auto",
+            completion_kind="route,final_from_tool",
+            route_tokens=780,
+            final_tokens=100,
+            prompt_tokens=100,
+            cached_tokens=43,
+            evaluated_tokens=57,
+            finish_reason="stop",
+            tool_calls=1,
+            tool_names=["exec_shell_full_command"],
+            wall_ms=12.0,
+            correctness_category="correct",
+            raw_leak=False,
+            fake_output=False,
+            loop=False,
+            notes="",
+            answer_excerpt="/tmp",
+            model_steps=[],
+            final_prefix={"restore_count_delta": 1, "fallback_count_delta": 0},
+        )
+
+        summary = smoke_harness.summarize_reports([row] * 50)[0]
+
+        self.assertEqual(summary["runs"], 50)
+        self.assertEqual(summary["correct"], 50)
+        self.assertEqual(summary["restore_delta"], 50)
+        self.assertEqual(summary["fallback_delta"], 0)
+
+    def test_phase_timing_summary_separates_model_and_non_model_wall(self) -> None:
+        timing = smoke_harness.phase_timing_summary(
+            [("route", 10.0), ("final_from_tool", 20.0), ("final_from_tool", 5.0)],
+            40.0,
+        )
+
+        self.assertEqual(timing["route"], 10.0)
+        self.assertEqual(timing["final_from_tool"], 25.0)
+        self.assertEqual(timing["non_model_wall_ms"], 5.0)
+        self.assertEqual(smoke_harness.estimated_generation_ms(10, 5.0), 2000.0)
 
     def test_model_step_to_json_includes_evaluated_tokens(self) -> None:
         row = smoke_harness.model_step_to_json(
@@ -273,6 +598,10 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(report.completion_kind, "timeout")
         self.assertIn("cancel_requested", report.notes)
         self.assertIn("cleanup_ok", report.notes)
+        self.assertTrue(report.lifecycle["timeout_observed"])
+        self.assertFalse(report.lifecycle["automatic_cancel"])
+        self.assertTrue(report.lifecycle["explicit_cancel_used"])
+        self.assertTrue(report.lifecycle["cleanup_healthy"])
 
     def test_main_returns_timeout_failure_when_report_times_out(self) -> None:
         timeout_report = smoke_harness.StepReport(


### PR DESCRIPTION
- Adds managed OFF/ON smoke coverage for the experimental final_from_tool prefix reuse.
- Propagates the flag to server and client without manual exports.
- Makes --tools off effective in both managed server and runtime tool availability.
- Records capture/restore/fallback, cached/evaluated tokens, output length, timing blocks, managed PID and RSS.
- Adds first-class restart, context-change, thinking-eligibility and 50-restore RSS lifecycle checks.
- Adds deterministic web fixtures, timeout/cancel classification and MTP guard validation.
- Controlled checks confirm cached 4 -> 43 and exactly 39 fewer evaluated tokens.
- RSS reporting is measurement-only and does not claim a leak.
- No deterministic performance guarantee is claimed.
- Harness only. Experiment remains OFF by default.
- No release.