### PR TITLE
Reduce redundant evidence in conversation reuse prompts

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -47,6 +47,7 @@ from orbit.runtime.messages import (
     with_media_system_prompt,
     with_command_system_prompt,
     with_tool_call_system_prompt,
+    with_visible_chat_system_prompt,
 )
 
 from orbit.runtime.command_request import (
@@ -59,7 +60,7 @@ from orbit.runtime.command_request import (
     command_tool_call_from_tool_calls,
 )
 from orbit.runtime.results import error_result
-from orbit.runtime.session_memory import MemoryRefresh, maybe_refresh_memory
+from orbit.runtime.session_memory import MEMORY_PREFIX, MemoryRefresh, estimate_message_tokens, maybe_refresh_memory
 from orbit.runtime.shell_guardrails import is_metadata_only_shell_command
 from orbit.runtime.thinking_mode import (
     ThinkingMode,
@@ -132,6 +133,12 @@ class ChatRuntime:
     evidence_store: EvidenceStore | None = None
     user_turn_counter: int = 0
     current_user_turn_id: str | None = None
+    current_turn_evidence_sequence_start: int = 0
+    completed_evidence_ids: set[str] = field(default_factory=set, repr=False)
+    last_chat_projection_used: bool = False
+    last_chat_projection_fallback_reason: str | None = None
+    last_chat_projection_omitted_evidence_count: int = 0
+    last_chat_projection_estimated_tokens_saved: int = 0
 
     def __post_init__(self) -> None:
         self.backend = instrument_backend(self.backend)
@@ -147,6 +154,16 @@ class ChatRuntime:
     def _begin_user_turn(self) -> str:
         self.user_turn_counter += 1
         self.current_user_turn_id = f"turn_{self.user_turn_counter}"
+        sequences = (
+            [record.evidence_sequence for record in self.evidence_store.records.values()]
+            if self.evidence_store is not None
+            else []
+        )
+        self.current_turn_evidence_sequence_start = max(
+            (sequence for sequence in sequences if isinstance(sequence, int)),
+            default=0,
+        )
+        self._reset_chat_projection_diagnostics()
         return self.current_user_turn_id
 
     @user_request
@@ -620,6 +637,20 @@ class ChatRuntime:
 
     def _remember_visible_result(self, result: ChatResult) -> ChatResult:
         self.client_state.update_from_result(result, thinking=self._thinking())
+        turn_id = self.current_user_turn_id
+        if turn_id and self.evidence_store is not None:
+            produced_records = [
+                record
+                for record in self.evidence_store.records.values()
+                if record.user_turn_id == turn_id
+                and isinstance(record.evidence_sequence, int)
+                and record.evidence_sequence > self.current_turn_evidence_sequence_start
+            ]
+            produced_ids = {record.evidence_id for record in produced_records}
+            if produced_ids and result.finish_reason == "stop" and result.content.strip():
+                self.completed_evidence_ids.update(produced_ids)
+            elif produced_ids:
+                self.completed_evidence_ids.difference_update(produced_ids)
         return result
 
     def _ask_media_if_referenced(
@@ -861,6 +892,9 @@ class ChatRuntime:
         if self.evidence_store is not None:
             self.evidence_store.clear_memory()
         self.client_state.reset()
+        self.completed_evidence_ids.clear()
+        self.current_turn_evidence_sequence_start = 0
+        self._reset_chat_projection_diagnostics()
         self.last_memory_refresh = None
         self.last_memory_refresh_message_count = None
         self.last_memory_refresh_attempt = None
@@ -897,6 +931,9 @@ class ChatRuntime:
             count = 0
         del self.messages[count:]
         self.client_state.reset()
+        self.completed_evidence_ids.clear()
+        self.current_turn_evidence_sequence_start = 0
+        self._reset_chat_projection_diagnostics()
         self.last_memory_refresh = None
         if self.last_memory_refresh_message_count is not None and self.last_memory_refresh_message_count > len(self.messages):
             self.last_memory_refresh_message_count = None
@@ -1032,6 +1069,7 @@ class ChatRuntime:
 
     def _chat_final_messages(self) -> list[Message]:
         if self.evidence_store is None or not self.evidence_store.recent_records(1):
+            self.last_chat_projection_fallback_reason = "no_evidence"
             return self._with_final_evidence_context(with_chat_system_prompt(self.messages))
         messages: list[Message] = []
         assistant = _latest_operational_assistant_message(self.messages)
@@ -1040,18 +1078,91 @@ class ChatRuntime:
         latest_user = _latest_user_message(self.messages)
         if latest_user is not None:
             messages.append(latest_user)
+        visible_messages = self._covered_visible_chat_messages()
+        if visible_messages is not None:
+            candidate = with_visible_chat_system_prompt(visible_messages)
+            fallback = with_chat_system_prompt(messages)
+            context, _context_kind, _limit = self._chat_final_retry_evidence_context()
+            if context:
+                fallback.append({"role": "system", "content": context})
+            candidate_tokens = estimate_message_tokens(candidate)
+            fallback_tokens = estimate_message_tokens(fallback)
+            if candidate_tokens < fallback_tokens:
+                limit = 1 if self._should_compact_final_from_tool_window() else 2
+                self.last_chat_projection_used = True
+                self.last_chat_projection_fallback_reason = None
+                self.last_chat_projection_omitted_evidence_count = len(self.evidence_store.recent_records(limit))
+                self.last_chat_projection_estimated_tokens_saved = fallback_tokens - candidate_tokens
+                self._emit_evidence_lineage_context(
+                    context_kind="visible_covered",
+                    consumer_phase="chat_final",
+                    limit=limit,
+                )
+                return candidate
+            self.last_chat_projection_fallback_reason = "visible_projection_not_smaller"
         return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages), consumer_phase="chat_final")
 
+    def _covered_visible_chat_messages(self) -> list[Message] | None:
+        if self.last_visible_finish_reason != "stop":
+            self.last_chat_projection_fallback_reason = "previous_final_not_complete"
+            return None
+        if self.evidence_store is None:
+            self.last_chat_projection_fallback_reason = "evidence_store_unavailable"
+            return None
+        system_messages = [message for message in self.messages if message.get("role") == "system"]
+        if len(system_messages) > 1 or any(
+            isinstance(message.get("content"), str) and str(message["content"]).startswith(MEMORY_PREFIX)
+            for message in system_messages
+        ):
+            self.last_chat_projection_fallback_reason = "session_memory_or_system_context"
+            return None
+        records = self.evidence_store.recent_records(1 if self._should_compact_final_from_tool_window() else 2)
+        if not records:
+            self.last_chat_projection_fallback_reason = "no_recent_evidence"
+            return None
+        for record in records:
+            if record.evidence_id not in self.completed_evidence_ids:
+                self.last_chat_projection_fallback_reason = "evidence_completion_unproven"
+                return None
+            if not _evidence_has_visible_final(self.messages, record.evidence_id):
+                self.last_chat_projection_fallback_reason = "evidence_final_association_inconsistent"
+                return None
+        visible: list[Message] = []
+        for message in self.messages:
+            role = message.get("role")
+            if role == "user":
+                visible.append(dict(message))
+                continue
+            if role != "assistant" or message.get("tool_calls"):
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                visible.append({"role": "assistant", "content": content})
+        if not visible:
+            self.last_chat_projection_fallback_reason = "visible_history_empty"
+            return None
+        return visible
+
+    def _reset_chat_projection_diagnostics(self) -> None:
+        self.last_chat_projection_used = False
+        self.last_chat_projection_fallback_reason = None
+        self.last_chat_projection_omitted_evidence_count = 0
+        self.last_chat_projection_estimated_tokens_saved = 0
+
     def _with_chat_final_retry_evidence_context(self, messages: list[Message], *, consumer_phase: str) -> list[Message]:
-        if self._should_compact_final_from_tool_window():
-            context = build_compact_final_evidence_context(self.evidence_store)
-            self._emit_evidence_lineage_context(context_kind="compact_final", consumer_phase=consumer_phase, limit=1)
-        else:
-            context = build_final_evidence_context(self.evidence_store)
-            self._emit_evidence_lineage_context(context_kind="final", consumer_phase=consumer_phase, limit=2)
+        context, context_kind, limit = self._chat_final_retry_evidence_context()
+        self._emit_evidence_lineage_context(context_kind=context_kind, consumer_phase=consumer_phase, limit=limit)
         if not context:
             return messages
         return [*messages, {"role": "system", "content": context}]
+
+    def _chat_final_retry_evidence_context(self) -> tuple[str | None, str, int]:
+        if self._should_compact_final_from_tool_window():
+            context = build_compact_final_evidence_context(self.evidence_store)
+            return context, "compact_final", 1
+        else:
+            context = build_final_evidence_context(self.evidence_store)
+            return context, "final", 2
 
     def _emit_evidence_lineage_context(self, *, context_kind: str, consumer_phase: str, limit: int) -> None:
         if self.evidence_store is None:
@@ -1365,6 +1476,44 @@ def _latest_short_assistant_message(messages: list[Message], *, max_chars: int =
 
 def _latest_operational_assistant_message(messages: list[Message], *, max_chars: int = 160) -> Message | None:
     return _latest_assistant_excerpt_message(messages, max_chars=max_chars)
+
+
+def _evidence_has_visible_final(messages: list[Message], evidence_id: str) -> bool:
+    tool_index = next(
+        (
+            index
+            for index, message in enumerate(messages)
+            if message.get("role") == "tool" and message.get("evidence_id") == evidence_id
+        ),
+        None,
+    )
+    if tool_index is None:
+        return False
+    if not _tool_has_associated_user(messages[:tool_index]):
+        return False
+    for message in messages[tool_index + 1 :]:
+        role = message.get("role")
+        if role == "user":
+            return False
+        if role != "assistant" or message.get("tool_calls"):
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return True
+    return False
+
+
+def _tool_has_associated_user(messages: list[Message]) -> bool:
+    for message in reversed(messages):
+        role = message.get("role")
+        if role == "user":
+            return True
+        if role != "assistant" or message.get("tool_calls"):
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return False
+    return False
 
 
 def _latest_assistant_excerpt_message(messages: list[Message], *, max_chars: int = 140) -> Message | None:

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -27,10 +27,9 @@ def _detect_shell() -> str:
 
 CHAT_SYSTEM_PROMPT = "Answer normally for conversation, explanation, writing, opinion, and general knowledge."
 VISIBLE_CHAT_SYSTEM_PROMPT = (
-    "Treat visible assistant answers as the source for follow-up questions. "
-    "Answer the latest request directly and faithfully. "
-    "Preserve concrete facts, paths, counts, errors, filenames, and matched values. "
-    "If required information is absent, say so; do not invent details."
+    "Use visible assistant answers as the source for follow-ups. Answer the latest request directly. "
+    "Preserve facts, paths, counts, errors, filenames, and matched values. "
+    "If a detail is missing, say only that it is unavailable in the visible conversation. Never infer omitted context."
 )
 MEDIA_SYSTEM_PROMPT = "Answer using the attached image/audio."
 _COMMAND_SYSTEM_TEMPLATE = """Decide compactly whether the user request needs local tools.

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -26,6 +26,12 @@ def _detect_shell() -> str:
 
 
 CHAT_SYSTEM_PROMPT = "Answer normally for conversation, explanation, writing, opinion, and general knowledge."
+VISIBLE_CHAT_SYSTEM_PROMPT = (
+    "Treat visible assistant answers as the source for follow-up questions. "
+    "Answer the latest request directly and faithfully. "
+    "Preserve concrete facts, paths, counts, errors, filenames, and matched values. "
+    "If required information is absent, say so; do not invent details."
+)
 MEDIA_SYSTEM_PROMPT = "Answer using the attached image/audio."
 _COMMAND_SYSTEM_TEMPLATE = """Decide compactly whether the user request needs local tools.
 Tool tasks: files/read/edit/create/append/delete, system, URLs/web/search/fetch, execution, and analysis that needs local or fetched evidence.
@@ -144,6 +150,10 @@ def with_chat_system_prompt(messages: list[Message]) -> list[Message]:
         copied[0]["content"] = CHAT_SYSTEM_PROMPT
         return copied
     return [{"role": "system", "content": CHAT_SYSTEM_PROMPT}, *copied]
+
+
+def with_visible_chat_system_prompt(messages: list[Message]) -> list[Message]:
+    return [{"role": "system", "content": VISIBLE_CHAT_SYSTEM_PROMPT}, *[dict(message) for message in messages]]
 
 
 def with_tool_call_system_prompt(messages: list[Message]) -> list[Message]:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -29,8 +29,10 @@ class MessagePromptTests(unittest.TestCase):
         messages = with_visible_chat_system_prompt([{"role": "user", "content": "summarize that"}])
         self.assertEqual(messages[0]["content"], VISIBLE_CHAT_SYSTEM_PROMPT)
         self.assertIn("visible assistant answers", VISIBLE_CHAT_SYSTEM_PROMPT)
-        self.assertIn("Preserve concrete facts", VISIBLE_CHAT_SYSTEM_PROMPT)
-        self.assertIn("If required information is absent", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("Preserve facts", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("If a detail is missing", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("visible conversation", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("Never infer", VISIBLE_CHAT_SYSTEM_PROMPT)
 
     def test_route_policy_prefers_existing_context_for_recaps(self) -> None:
         self.assertIn("recap, repeat, summary, explanation, comparison, or continuation", ROUTE_SYSTEM_PROMPT)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -7,7 +7,9 @@ from orbit.runtime.messages import (
     FINAL_FROM_TOOL_SYSTEM_PROMPT,
     ROUTE_SYSTEM_PROMPT,
     TOOL_CALL_SYSTEM_PROMPT,
+    VISIBLE_CHAT_SYSTEM_PROMPT,
     with_chat_system_prompt,
+    with_visible_chat_system_prompt,
 )
 
 
@@ -22,6 +24,13 @@ class MessagePromptTests(unittest.TestCase):
             [{"role": "system", "content": ROUTE_SYSTEM_PROMPT}, {"role": "user", "content": "x"}]
         )
         self.assertEqual(messages[0]["content"], CHAT_SYSTEM_PROMPT)
+
+    def test_visible_chat_prompt_preserves_facts_and_rejects_missing_details(self) -> None:
+        messages = with_visible_chat_system_prompt([{"role": "user", "content": "summarize that"}])
+        self.assertEqual(messages[0]["content"], VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("visible assistant answers", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("Preserve concrete facts", VISIBLE_CHAT_SYSTEM_PROMPT)
+        self.assertIn("If required information is absent", VISIBLE_CHAT_SYSTEM_PROMPT)
 
     def test_route_policy_prefers_existing_context_for_recaps(self) -> None:
         self.assertIn("recap, repeat, summary, explanation, comparison, or continuation", ROUTE_SYSTEM_PROMPT)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -471,6 +471,379 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn(record.raw_ref, final_rendered)
         self.assertNotIn("tool_evidence_ref: true", final_rendered)
 
+    def test_post_tool_chat_final_uses_visible_history_when_evidence_is_covered(self) -> None:
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content='{"route":"CHAT"}', model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=None, completion_tokens=1, cached_tokens=None,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                ),
+                ChatResult(
+                    content="Alpha was first.", model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=None, completion_tokens=4, cached_tokens=None,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            first = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            second = store.add(
+                "exec_shell_full_command", "beta", metadata={"command": "printf beta", "user_turn_id": "turn_2"}
+            )
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "give the first result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(first), "evidence_id": first.evidence_id},
+                {"role": "assistant", "content": "The first result is alpha."},
+                {"role": "user", "content": "give the second result"},
+                {"role": "tool", "tool_call_id": "call-2", "name": "exec_shell_full_command", "content": tool_evidence_ref(second), "evidence_id": second.evidence_id},
+                {"role": "assistant", "content": "The second result is beta."},
+            ]
+            runtime.completed_evidence_ids.update({first.evidence_id, second.evidence_id})
+            runtime.last_visible_finish_reason = "stop"
+
+            runtime.ask_auto("summarize the first result", temperature=0, max_tokens=32, workdir=Path(tmp))
+
+        final_messages = backend.messages_by_call[1]
+        rendered = "\n".join(str(message.get("content", "")) for message in final_messages)
+        self.assertEqual(
+            [message.get("role") for message in final_messages],
+            ["system", "user", "assistant", "user", "assistant", "user"],
+        )
+        self.assertEqual(sum(message.get("content") == "summarize the first result" for message in final_messages), 1)
+        self.assertIn("The first result is alpha.", rendered)
+        self.assertIn("The second result is beta.", rendered)
+        self.assertIn("summarize the first result", rendered)
+        self.assertNotIn("evidence_context:", rendered)
+        self.assertFalse(any(message.get("role") == "tool" for message in final_messages))
+        self.assertEqual(len(store.records), 2)
+        self.assertTrue(runtime.last_chat_projection_used)
+        self.assertIsNone(runtime.last_chat_projection_fallback_reason)
+        self.assertEqual(runtime.last_chat_projection_omitted_evidence_count, 2)
+        self.assertGreater(runtime.last_chat_projection_estimated_tokens_saved, 0)
+
+    def test_multiple_tool_results_from_one_completed_flow_are_covered_together(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            error = store.add(
+                "exec_shell_full_command", "first command failed", metadata={"user_turn_id": "turn_1"}
+            )
+            success = store.add(
+                "exec_shell_full_command", "second command returned alpha", metadata={"user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "find the result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(error), "evidence_id": error.evidence_id},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "call-2", "function": {"name": "exec_shell_full_command", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "call-2", "name": "exec_shell_full_command", "content": tool_evidence_ref(success), "evidence_id": success.evidence_id},
+                {"role": "assistant", "content": "The retry found alpha."},
+                {"role": "user", "content": "summarize the result"},
+            ]
+            runtime.completed_evidence_ids.update({error.evidence_id, success.evidence_id})
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("The retry found alpha.", rendered)
+        self.assertNotIn("evidence_context:", rendered)
+        self.assertFalse(any(message.get("role") == "tool" for message in messages))
+
+    def test_newer_unrelated_final_does_not_cover_older_unfinished_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            older = store.add("exec_shell_full_command", "older raw detail", metadata={"user_turn_id": "turn_1"})
+            newer = store.add("exec_shell_full_command", "newer result", metadata={"user_turn_id": "turn_2"})
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "run the first task"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(older), "evidence_id": older.evidence_id},
+                {"role": "user", "content": "run the second task"},
+                {"role": "tool", "tool_call_id": "call-2", "name": "exec_shell_full_command", "content": tool_evidence_ref(newer), "evidence_id": newer.evidence_id},
+                {"role": "assistant", "content": "The second task returned newer result."},
+                {"role": "user", "content": "summarize the first result"},
+            ]
+            runtime.completed_evidence_ids.update({older.evidence_id, newer.evidence_id})
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        self.assertIn("evidence_context:", "\n".join(str(message.get("content", "")) for message in messages))
+
+    def test_post_tool_chat_final_keeps_evidence_when_not_covered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "user", "content": "summarize that"},
+            ]
+            runtime.completed_evidence_ids.add(record.evidence_id)
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("evidence_context:", rendered)
+        self.assertIn(record.raw_ref, rendered)
+        self.assertFalse(runtime.last_chat_projection_used)
+        self.assertEqual(runtime.last_chat_projection_fallback_reason, "evidence_final_association_inconsistent")
+
+    def test_tool_without_associated_user_does_not_cover_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The result is alpha."},
+                {"role": "user", "content": "summarize that"},
+            ]
+            runtime.completed_evidence_ids.add(record.evidence_id)
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        self.assertIn("evidence_context:", "\n".join(str(message.get("content", "")) for message in messages))
+
+    def test_incomplete_visible_final_does_not_cover_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The result starts with alpha"},
+                {"role": "user", "content": "summarize that"},
+            ]
+            runtime.completed_evidence_ids.add(record.evidence_id)
+            runtime.last_visible_finish_reason = "length"
+
+            messages = runtime._chat_final_messages()
+
+        self.assertIn("evidence_context:", "\n".join(str(message.get("content", "")) for message in messages))
+
+    def test_loaded_history_without_completion_state_keeps_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The result is alpha."},
+                {"role": "user", "content": "summarize that"},
+            ]
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        self.assertIn("evidence_context:", "\n".join(str(message.get("content", "")) for message in messages))
+
+    def test_only_completed_evidence_turn_is_recorded_as_covered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add("exec_shell_full_command", "alpha", metadata={"user_turn_id": "turn_1"})
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.current_user_turn_id = "turn_1"
+            stop = ChatResult(
+                content="The result is alpha.", model="fake", finish_reason="stop", tool_calls=[],
+                prompt_tokens=None, completion_tokens=4, cached_tokens=None,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+            length = ChatResult(
+                content="The result starts", model="fake", finish_reason="length", tool_calls=[],
+                prompt_tokens=None, completion_tokens=4, cached_tokens=None,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+
+            runtime._remember_visible_result(stop)
+            self.assertIn(record.evidence_id, runtime.completed_evidence_ids)
+            runtime._remember_visible_result(length)
+
+        self.assertNotIn(record.evidence_id, runtime.completed_evidence_ids)
+
+    def test_empty_and_length_results_do_not_cover_evidence_but_retry_stop_does(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add("exec_shell_full_command", "alpha", metadata={"user_turn_id": "turn_1"})
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.current_user_turn_id = "turn_1"
+
+            for content, finish_reason in (("", "stop"), ("partial", "length")):
+                runtime._remember_visible_result(
+                    ChatResult(
+                        content=content, model="fake", finish_reason=finish_reason, tool_calls=[],
+                        prompt_tokens=None, completion_tokens=1, cached_tokens=None,
+                        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                    )
+                )
+                self.assertNotIn(record.evidence_id, runtime.completed_evidence_ids)
+
+            runtime._remember_visible_result(
+                ChatResult(
+                    content="The complete result is alpha.", model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=None, completion_tokens=5, cached_tokens=None,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+            )
+
+        self.assertIn(record.evidence_id, runtime.completed_evidence_ids)
+
+    def test_cancelled_final_without_completed_result_keeps_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime._begin_user_turn()
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"user_turn_id": runtime.current_user_turn_id}
+            )
+            runtime.messages = [
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "user", "content": "summarize that"},
+            ]
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        self.assertIn("evidence_context:", "\n".join(str(message.get("content", "")) for message in messages))
+        self.assertEqual(runtime.last_chat_projection_fallback_reason, "evidence_completion_unproven")
+
+    def test_completed_continuation_can_cover_evidence_with_both_visible_parts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime._begin_user_turn()
+            record = store.add(
+                "exec_shell_full_command", "alpha beta", metadata={"user_turn_id": runtime.current_user_turn_id}
+            )
+            runtime.messages = [
+                {"role": "user", "content": "give both results"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The first result is alpha"},
+            ]
+            runtime._remember_visible_result(
+                ChatResult(
+                    content="The first result is alpha", model="fake", finish_reason="length", tool_calls=[],
+                    prompt_tokens=None, completion_tokens=5, cached_tokens=None,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+            )
+            runtime.messages.append({"role": "assistant", "content": "and the second result is beta."})
+            runtime._remember_visible_result(
+                ChatResult(
+                    content="and the second result is beta.", model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=None, completion_tokens=7, cached_tokens=None,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+            )
+            runtime.messages.append({"role": "user", "content": "summarize both"})
+
+            messages = runtime._chat_final_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("The first result is alpha", rendered)
+        self.assertIn("and the second result is beta.", rendered)
+        self.assertNotIn("evidence_context:", rendered)
+
+    def test_reset_and_history_rollback_clear_evidence_coverage(self) -> None:
+        runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None)
+        runtime.completed_evidence_ids.add("ev-reset")
+        runtime.last_chat_projection_used = True
+        runtime.last_chat_projection_omitted_evidence_count = 1
+
+        runtime.reset()
+        self.assertEqual(runtime.completed_evidence_ids, set())
+        self.assertFalse(runtime.last_chat_projection_used)
+        self.assertEqual(runtime.last_chat_projection_omitted_evidence_count, 0)
+        runtime.completed_evidence_ids.add("ev-rollback")
+        runtime.messages = [{"role": "user", "content": "hello"}]
+        runtime.restore_message_count(0)
+
+        self.assertEqual(runtime.completed_evidence_ids, set())
+
+    def test_reloaded_turn_id_does_not_cover_older_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            old = store.add("exec_shell_full_command", "old", metadata={"user_turn_id": "turn_1"})
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime._begin_user_turn()
+            new = store.add("exec_shell_full_command", "new", metadata={"user_turn_id": "turn_1"})
+            stop = ChatResult(
+                content="The new result.", model="fake", finish_reason="stop", tool_calls=[],
+                prompt_tokens=None, completion_tokens=4, cached_tokens=None,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+
+            runtime._remember_visible_result(stop)
+
+        self.assertNotIn(old.evidence_id, runtime.completed_evidence_ids)
+        self.assertIn(new.evidence_id, runtime.completed_evidence_ids)
+
+    def test_session_memory_disables_visible_history_projection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "system", "content": "Orbit session memory: visible context; use it for follow-ups.\nOlder result."},
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The result is alpha."},
+                {"role": "user", "content": "summarize our discussion"},
+            ]
+            runtime.completed_evidence_ids.add(record.evidence_id)
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("evidence_context:", rendered)
+
+    def test_visible_history_projection_must_reduce_estimated_prompt_size(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add(
+                "exec_shell_full_command", "alpha", metadata={"command": "printf alpha", "user_turn_id": "turn_1"}
+            )
+            runtime = ChatRuntime(backend=FakeBackend(), system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "give a result"},
+                {"role": "tool", "tool_call_id": "call-1", "name": "exec_shell_full_command", "content": tool_evidence_ref(record), "evidence_id": record.evidence_id},
+                {"role": "assistant", "content": "The result is alpha."},
+                {"role": "user", "content": "unrelated context " * 500},
+                {"role": "assistant", "content": "acknowledged"},
+                {"role": "user", "content": "repeat the result"},
+            ]
+            runtime.completed_evidence_ids.add(record.evidence_id)
+            runtime.last_visible_finish_reason = "stop"
+
+            messages = runtime._chat_final_messages()
+
+        rendered = "\n".join(str(message.get("content", "")) for message in messages)
+        self.assertIn("evidence_context:", rendered)
+        self.assertNotIn("unrelated context " * 20, rendered)
+        self.assertEqual(runtime.last_chat_projection_fallback_reason, "visible_projection_not_smaller")
+
     def test_route_without_evidence_keeps_existing_history_window(self) -> None:
         backend = SequenceBackend(
             [


### PR DESCRIPTION
- Omits hidden evidence from CHAT prompts only when a completed visible assistant final structurally covers it.
- Preserves all visible user/assistant history and stored evidence.
- Falls back conservatively when coverage is uncertain.
- Review hardened omitted-detail handling: missing details are reported only as unavailable in visible conversation, without claims about omitted tool evidence.
- Measured baseline system recap was 841 prompt / 837 evaluated tokens. The reviewed policy projects 279 prompt / 275 evaluated tokens, an exact 562-token reduction.
- No route, tool-loop, evidence-store, MTP, KV or budget changes.
- No deterministic wall-time claim.

Validation:
- messages/final-policy/completion-budget: 60 tests PASS
- runtime/evidence/tool-message: 213 tests PASS
- full discovery: 1,038 tests PASS
- native omitted serial/raw-error probes: PASS
- compileall PASS
- git diff --check PASS