### PR TITLE
Add diagnostic route output classification

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -53,6 +53,7 @@ from orbit.runtime.messages import (
 from orbit.runtime.command_request import (
     ToolRoute,
     command_stream_state,
+    classify_route_output,
     decision_tool_names,
     parse_command_decision,
     parse_command_decision_from_tool_calls,
@@ -451,6 +452,13 @@ class ChatRuntime:
                 if retry_decision is not None:
                     _emit_route_outcome_for_result(route_retry, decision=retry_decision, outcome=_route_parsed_outcome(retry_decision))
                     route_outcome_emitted = True
+                else:
+                    _emit_route_outcome_for_result(
+                        route_retry,
+                        decision=None,
+                        outcome="route_retry_invalid_output",
+                        retry_reason=retry_reason,
+                    )
                 if retry_decision is not None:
                     first = route_retry
                     command_content = route_retry.content
@@ -1415,6 +1423,17 @@ def _emit_route_outcome_for_result(
     retry_reason: str | None = None,
 ) -> None:
     decision_type = decision.route.value if decision is not None else None
+    parser_source = None
+    if decision is not None:
+        parser_source = "tool_calls" if parse_command_decision_from_tool_calls(result.tool_calls) is not None else "content"
+    diagnostic = classify_route_output(
+        result.content,
+        parsed_decision=decision,
+        parser_source=parser_source,
+        direct_prose=outcome == "route_direct_final_stop",
+        finish_reason=result.finish_reason,
+        output_tokens=result.completion_tokens,
+    )
     emit_route_outcome(
         outcome=outcome,
         finish_reason=result.finish_reason,
@@ -1422,6 +1441,10 @@ def _emit_route_outcome_for_result(
         output_chars=len(result.content),
         output_tokens=result.completion_tokens,
         retry_reason=retry_reason,
+        route_output_class=diagnostic.classification.value,
+        route_output_reason=diagnostic.reason,
+        route_output_canonical=diagnostic.canonical,
+        route_parser_accepted=diagnostic.parser_accepted,
     )
 
 

--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -32,6 +32,124 @@ class RouteDecision:
     tool_names: tuple[str, ...] = ()
 
 
+class RouteOutputClass(StrEnum):
+    CANONICAL = "canonical"
+    LEGACY_TOLERATED = "legacy_tolerated"
+    DIRECT_PROSE = "direct_prose"
+    MALFORMED = "malformed"
+    CONTROL_LOOP = "control_loop"
+
+
+@dataclass(frozen=True)
+class RouteOutputDiagnostic:
+    classification: RouteOutputClass
+    reason: str
+    canonical: bool
+    parser_accepted: bool
+
+
+_CONTROL_TOKEN_CYCLE = (100, 45518, 107, 101)
+_CONTROL_ONLY_RE = re.compile(r"(?:\s*<\|channel>thought\s*<channel\|>\s*)+")
+
+
+def classify_route_output(
+    content: str,
+    *,
+    parsed_decision: RouteDecision | None,
+    parser_source: str | None,
+    direct_prose: bool,
+    finish_reason: str | None,
+    output_tokens: int | None,
+    raw_token_ids: list[int] | tuple[int, ...] | None = None,
+) -> RouteOutputDiagnostic:
+    """Classify a completed route output without changing its interpretation."""
+
+    parser_accepted = parsed_decision is not None
+    if _has_control_token_cycle(raw_token_ids):
+        return RouteOutputDiagnostic(RouteOutputClass.CONTROL_LOOP, "repeated_control_token_cycle", False, parser_accepted)
+    text = content.strip()
+    if text and _CONTROL_ONLY_RE.fullmatch(text):
+        return RouteOutputDiagnostic(RouteOutputClass.CONTROL_LOOP, "control_only_text", False, parser_accepted)
+    if not text and finish_reason == "length" and isinstance(output_tokens, int) and output_tokens >= len(_CONTROL_TOKEN_CYCLE) * 2:
+        return RouteOutputDiagnostic(RouteOutputClass.CONTROL_LOOP, "empty_visible_control_output", False, parser_accepted)
+
+    canonical_reason = _canonical_route_reason(text)
+    if canonical_reason is not None and parser_accepted and parser_source == "content":
+        return RouteOutputDiagnostic(RouteOutputClass.CANONICAL, canonical_reason, True, True)
+    if parser_accepted:
+        reason = "normalized_backend_tool_calls" if parser_source == "tool_calls" else "parser_tolerated_noncanonical"
+        return RouteOutputDiagnostic(RouteOutputClass.LEGACY_TOLERATED, reason, False, True)
+    if direct_prose and text and not _looks_like_route_syntax(text):
+        return RouteOutputDiagnostic(RouteOutputClass.DIRECT_PROSE, "accepted_direct_answer", False, False)
+    reason = "empty_output" if not text else "unaccepted_route_syntax" if _looks_like_route_syntax(text) else "unaccepted_output"
+    return RouteOutputDiagnostic(RouteOutputClass.MALFORMED, reason, False, False)
+
+
+def _has_control_token_cycle(raw_token_ids: list[int] | tuple[int, ...] | None) -> bool:
+    if raw_token_ids is None or len(raw_token_ids) < len(_CONTROL_TOKEN_CYCLE) * 2:
+        return False
+    return all(token == _CONTROL_TOKEN_CYCLE[index % len(_CONTROL_TOKEN_CYCLE)] for index, token in enumerate(raw_token_ids))
+
+
+def _canonical_route_reason(text: str) -> str | None:
+    if not text:
+        return None
+    try:
+        value = json.loads(text, object_pairs_hook=_unique_json_object)
+    except (json.JSONDecodeError, _DuplicateJsonKey):
+        return None
+    if not isinstance(value, dict):
+        return None
+    keys = set(value)
+    if keys == {"route"} and value.get("route") == ToolRoute.CHAT.value:
+        return "canonical_chat"
+    if keys == {"command"} and _nonempty_string(value.get("command")):
+        return "canonical_command"
+    if keys == {"url"} and _nonempty_string(value.get("url")):
+        return "canonical_url"
+    if keys and keys <= set(LIST_DIRECTORY_KEYS) and _canonical_list_directory(value):
+        return "canonical_list_directory"
+    if keys and keys <= set(SYSTEM_INFO_KEYS) and all(isinstance(arg, bool) for arg in value.values()):
+        return "canonical_system_info"
+    return None
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateJsonKey(key)
+        value[key] = item
+    return value
+
+
+def _canonical_list_directory(value: dict[str, Any]) -> bool:
+    for key, item in value.items():
+        if key == "path" and not isinstance(item, str):
+            return False
+        if key in {"recursive", "include_hidden", "dirs_first", "files_only", "dirs_only"} and not isinstance(item, bool):
+            return False
+        if key == "max_depth" and item is not None and (isinstance(item, bool) or not isinstance(item, int)):
+            return False
+        if key == "max_entries" and (isinstance(item, bool) or not isinstance(item, int)):
+            return False
+    return True
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _looks_like_route_syntax(text: str) -> bool:
+    if text.startswith(("{", "[", "```", "<|tool_call>")):
+        return True
+    return any(marker in text for marker in ('{"route"', '{"command"', '{"url"', '{"path"', '{"include_'))
+
+
 def parse_tool_command(content: str) -> ToolRoute | None:
     decision = parse_command_decision(content)
     return decision.route if decision is not None else None

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -441,6 +441,10 @@ def emit_route_outcome(
     output_chars: int | None,
     output_tokens: int | None,
     retry_reason: str | None,
+    route_output_class: str | None = None,
+    route_output_reason: str | None = None,
+    route_output_canonical: bool | None = None,
+    route_parser_accepted: bool | None = None,
 ) -> None:
     if not enabled() or _LAST_MODEL_CALL is None:
         return
@@ -458,6 +462,12 @@ def emit_route_outcome(
             "decision_type": decision_type,
             "output_chars": output_chars,
             "output_tokens": output_tokens,
+            "route_output_tokens": output_tokens,
+            "route_finish_reason": finish_reason,
+            "route_output_class": route_output_class,
+            "route_output_reason": route_output_reason,
+            "route_output_canonical": route_output_canonical,
+            "route_parser_accepted": route_parser_accepted,
             "retry_reason": retry_reason,
             "outcome": outcome,
         }

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -12,7 +12,9 @@ if str(SRC) not in sys.path:
 
 from orbit.runtime.command_request import (
     CommandStreamFilter,
+    RouteOutputClass,
     ToolRoute,
+    classify_route_output,
     decision_tool_names,
     parse_command_decision,
     parse_command_decision_from_tool_calls,
@@ -25,6 +27,119 @@ from orbit.runtime.command_request import (
 
 
 class RouteRequestTests(unittest.TestCase):
+    def _classify(
+        self,
+        content: str,
+        *,
+        direct_prose: bool = False,
+        finish_reason: str = "stop",
+        output_tokens: int = 5,
+        raw_token_ids: list[int] | None = None,
+    ):
+        decision = parse_command_decision(content)
+        return classify_route_output(
+            content,
+            parsed_decision=decision,
+            parser_source="content" if decision is not None else None,
+            direct_prose=direct_prose,
+            finish_reason=finish_reason,
+            output_tokens=output_tokens,
+            raw_token_ids=raw_token_ids,
+        )
+
+    def test_route_output_classifier_accepts_only_canonical_json_shapes(self) -> None:
+        for content in (
+            '{"route":"CHAT"}',
+            '{"command":"ls -F"}',
+            '{"url":"https://example.com?a=1&b=2"}',
+            '{"path":".","recursive":false,"max_depth":null}',
+            '{"include_cpu":true,"include_memory":true}',
+        ):
+            with self.subTest(content=content):
+                diagnostic = self._classify(content)
+                self.assertEqual(diagnostic.classification, RouteOutputClass.CANONICAL)
+                self.assertTrue(diagnostic.canonical)
+                self.assertTrue(diagnostic.parser_accepted)
+
+    def test_route_output_classifier_marks_parser_compatibility_forms_as_legacy(self) -> None:
+        for content in (
+            '```json\n{"route":"CHAT"}\n```',
+            '{"route":"chat"}',
+            'prefix\n{"route":"CHAT"}\nsuffix',
+            '<|tool_call>call:exec_shell_full_command{"command":"pwd"}<tool_call|>',
+            '{"command":"pwd","timeout":5}',
+        ):
+            with self.subTest(content=content):
+                diagnostic = self._classify(content)
+                self.assertEqual(diagnostic.classification, RouteOutputClass.LEGACY_TOLERATED)
+                self.assertFalse(diagnostic.canonical)
+                self.assertTrue(diagnostic.parser_accepted)
+
+    def test_route_output_classifier_marks_backend_tool_calls_as_legacy(self) -> None:
+        decision = parse_command_decision_from_tool_calls(
+            [{"type": "function", "function": {"name": "system_info", "arguments": '{"include_cpu":true}'}}]
+        )
+        diagnostic = classify_route_output(
+            "",
+            parsed_decision=decision,
+            parser_source="tool_calls",
+            direct_prose=False,
+            finish_reason="stop",
+            output_tokens=5,
+        )
+
+        self.assertEqual(diagnostic.classification, RouteOutputClass.LEGACY_TOLERATED)
+        self.assertTrue(diagnostic.parser_accepted)
+
+    def test_route_output_classifier_preserves_direct_prose(self) -> None:
+        content = "The answer is four."
+
+        diagnostic = self._classify(content, direct_prose=True)
+
+        self.assertEqual(diagnostic.classification, RouteOutputClass.DIRECT_PROSE)
+        self.assertFalse(diagnostic.parser_accepted)
+        self.assertEqual(content, "The answer is four.")
+
+    def test_route_output_classifier_separates_malformed_forms(self) -> None:
+        for content in ("", '{"route":', '[{"route":"CHAT"}]', '{"route":"FILESYSTEM"}', '{"command":""}', '{"route":"CHAT"} trailing'):
+            with self.subTest(content=content):
+                diagnostic = self._classify(content, direct_prose=True)
+                self.assertEqual(diagnostic.classification, RouteOutputClass.MALFORMED)
+                self.assertFalse(diagnostic.parser_accepted)
+
+    def test_route_output_classifier_detects_control_only_generation(self) -> None:
+        cycle = [100, 45518, 107, 101] * 2
+        from_tokens = self._classify("", finish_reason="length", output_tokens=len(cycle), raw_token_ids=cycle)
+        from_text = self._classify("<|channel>thought\n<channel|>" * 2, finish_reason="length", output_tokens=8)
+        from_hidden_output = self._classify("", finish_reason="length", output_tokens=64)
+
+        self.assertEqual(from_tokens.classification, RouteOutputClass.CONTROL_LOOP)
+        self.assertEqual(from_text.classification, RouteOutputClass.CONTROL_LOOP)
+        self.assertEqual(from_hidden_output.classification, RouteOutputClass.CONTROL_LOOP)
+
+    def test_route_output_classifier_does_not_treat_other_empty_finishes_as_control_loops(self) -> None:
+        for finish_reason in ("stop", "error", "cancelled"):
+            with self.subTest(finish_reason=finish_reason):
+                diagnostic = self._classify("", finish_reason=finish_reason, output_tokens=64)
+                self.assertEqual(diagnostic.classification, RouteOutputClass.MALFORMED)
+                self.assertEqual(diagnostic.reason, "empty_output")
+
+    def test_route_output_classifier_does_not_change_parser_results(self) -> None:
+        cases = (
+            '{"route":"CHAT"}',
+            '{"command":"pwd"}',
+            '```json\n{"url":"https://example.com"}\n```',
+            '{"route":"CHAT","command":"pwd"}',
+            '{"route":"UNKNOWN"}',
+            'direct prose',
+        )
+        for content in cases:
+            with self.subTest(content=content):
+                before = parse_command_decision(content)
+                self._classify(content, direct_prose=True)
+                after = parse_command_decision(content)
+                self.assertEqual(before, after)
+
     def test_parse_command_decision_accepts_shell_command_json(self) -> None:
         decision = parse_command_decision('{"command":"ls -F"}')
 

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -503,6 +503,9 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(outcomes[0]["phase"], "route")
         self.assertEqual(outcomes[0]["finish_reason"], "stop")
         self.assertIsNone(outcomes[0]["decision_type"])
+        self.assertEqual(outcomes[0]["route_output_class"], "direct_prose")
+        self.assertFalse(outcomes[0]["route_output_canonical"])
+        self.assertFalse(outcomes[0]["route_parser_accepted"])
         self.assertNotIn("direct answer", json.dumps(outcomes))
 
     def test_route_no_decision_length_retry_is_observed_without_behavior_change(self) -> None:
@@ -535,8 +538,135 @@ class KVDiagTests(unittest.TestCase):
         self.assertEqual(outcomes[0]["outcome"], "route_no_decision_length_retry")
         self.assertEqual(outcomes[0]["retry_reason"], "length_without_decision")
         self.assertEqual(outcomes[0]["output_tokens"], 128)
+        self.assertEqual(outcomes[0]["route_output_class"], "malformed")
+        self.assertEqual(outcomes[0]["route_output_tokens"], 128)
+        self.assertEqual(outcomes[0]["route_finish_reason"], "length")
         self.assertNotIn("truncated route prose", json.dumps(outcomes))
         self.assertNotIn("final answer", json.dumps(outcomes))
+
+    def test_route_control_only_length_is_classified_without_behavior_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            backend = SequenceBackend(
+                [
+                    _result("", finish_reason="length", prompt_tokens=12, completion_tokens=64, cached_tokens=8),
+                    _result("final answer", finish_reason="stop", prompt_tokens=20, completion_tokens=3, cached_tokens=19),
+                ]
+            )
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=backend, system_prompt=None)
+                result = runtime.ask_auto(
+                    "hi, tell me something about yourself",
+                    temperature=0,
+                    max_tokens=32,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command", "fetch_url", "list_directory", "system_info"),
+                )
+
+            lines = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcome = next(line for line in lines if line["event"] == "kv_diag_route_outcome")
+
+        self.assertEqual(result.content, "final answer")
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(outcome["route_output_class"], "control_loop")
+        self.assertEqual(outcome["route_output_reason"], "empty_visible_control_output")
+        self.assertNotIn("final answer", json.dumps(outcome))
+
+    def test_invalid_route_retry_is_classified_without_changing_tool_fallback(self) -> None:
+        class RouteRetryBackend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls == 1:
+                    return _result("route prose", finish_reason="stop")
+                if self.calls == 2:
+                    return _result("retry prose", finish_reason="length", completion_tokens=64)
+                if self.calls == 3:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": '{"command":"printf route-diagnostic-result"}',
+                                },
+                            }
+                        ],
+                        prompt_tokens=10,
+                        completion_tokens=2,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=10.0,
+                        generation_tokens_per_second=3.0,
+                    )
+                return _result("route diagnostic result", finish_reason="stop")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            backend = RouteRetryBackend()
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=backend, system_prompt="route system")
+                result = runtime.ask_auto(
+                    "search online for route diagnostic information",
+                    temperature=0,
+                    max_tokens=32,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command",),
+                )
+
+            events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcomes = [event for event in events if event["event"] == "kv_diag_route_outcome"]
+
+        self.assertEqual(result.content, "route diagnostic result")
+        self.assertEqual(backend.calls, 5)
+        self.assertEqual(
+            [event["outcome"] for event in outcomes],
+            ["route_other_retry", "route_retry_invalid_output"],
+        )
+        self.assertEqual(outcomes[1]["route_output_class"], "malformed")
+        self.assertFalse(outcomes[1]["route_parser_accepted"])
+        self.assertNotIn("route prose", json.dumps(outcomes))
+        self.assertNotIn("retry prose", json.dumps(outcomes))
+
+    def test_valid_route_retry_is_classified_independently_and_keeps_tool_selection(self) -> None:
+        backend = SequenceBackend(
+            [
+                _result("route prose", finish_reason="stop"),
+                _result('{"command":"printf route-valid-retry"}', finish_reason="stop"),
+                _result("route valid retry", finish_reason="stop"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "diag.jsonl"
+            with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)}, clear=False):
+                runtime = ChatRuntime(backend=backend, system_prompt="route system")
+                result = runtime.ask_auto(
+                    "search online for route validation information",
+                    temperature=0,
+                    max_tokens=32,
+                    workdir=Path(tmp),
+                    allowed_tool_names=("exec_shell_full_command",),
+                )
+
+            events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            outcomes = [event for event in events if event["event"] == "kv_diag_route_outcome"]
+
+        self.assertEqual(result.content, "route valid retry")
+        self.assertEqual(backend.calls, 3)
+        self.assertEqual(
+            [(event["outcome"], event["route_output_class"]) for event in outcomes],
+            [("route_other_retry", "malformed"), ("route_parsed_tool", "canonical")],
+        )
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(tool_messages[-1]["name"], "exec_shell_full_command")
+        self.assertIn("route-valid-retry", tool_messages[-1]["content"])
+        self.assertNotIn("route prose", json.dumps(outcomes))
+        self.assertNotIn("route-valid-retry", json.dumps(outcomes))
 
     def test_route_outcome_event_is_metadata_only_for_required_classes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
- Adds diagnostic-only classification of route outputs: `canonical`, `legacy_tolerated`, `direct_prose`, `malformed`, and `control_loop`.
- Classification occurs after existing parser/direct-answer behavior and never affects routing or fallback.
- Emits bounded metadata-only diagnostics with no raw route content.
- Production empty-visible length classification is a conservative surrogate because raw token IDs are unavailable.
- Representative native sample: 8 canonical, 3 legacy, 2 direct prose, 2 malformed, and 3 control-loop/surrogate.
- No grammar, parser, route, tool-loop, MTP, KV, or budget changes.
- No release.