### PR TITLE
Add route output classification benchmark coverage

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -6,9 +6,11 @@ from contextlib import contextmanager
 import json
 import os
 import queue
+import shutil
 import statistics
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
@@ -28,6 +30,7 @@ from orbit import __version__
 from orbit.backend.base import ChatResult
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import current_phase
 from orbit.runtime.messages import DEFAULT_SYSTEM_PROMPT
 from orbit.runtime.tools import TOOL_NAMES
@@ -43,6 +46,8 @@ class SmokeStep:
     prompt: str
     mode: str = "auto"
     checker_name: str = "not_evaluated"
+    expected_route: str | None = None
+    expected_tool_names: tuple[str, ...] | None = None
 
 
 FINAL_PREFIX_LOCAL_STEPS = (
@@ -69,6 +74,107 @@ FINAL_PREFIX_PAIRED_STEPS = (
     FINAL_PREFIX_WEB_STEPS[0],
 )
 
+ROUTE_PWD_STEP = SmokeStep(
+    "run pwd", checker_name="path_like", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+ROUTE_SYSTEM_INFO_STEP = SmokeStep(
+    "tell me specs about this computer", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("system_info",)
+)
+ROUTE_READ_STEP = SmokeStep(
+    "read route_fixture.txt", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+ROUTE_REFRESH_STEP = SmokeStep(
+    "refresh the current computer specs", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("system_info",)
+)
+ROUTE_VERIFY_STEP = SmokeStep(
+    "verify whether route_fixture.txt changed", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+ROUTE_SHELL_ERROR_STEP = SmokeStep(
+    "run command_that_does_not_exist_123", checker_name="shell_error", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+ROUTE_RECOVERY_SUCCESS_STEP = SmokeStep(
+    "run printf 'route-recovery-success\\n'", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+ROUTE_ERROR_SUCCESS_COMPARE_STEP = SmokeStep(
+    "compare the failed command with the successful command", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()
+)
+ROUTE_WEB_ERROR_STEP = SmokeStep(
+    "search online for where is Avola located?", checker_name="web_error", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)
+)
+
+ROUTE_CLASS_RECAP_STEPS = (
+    ROUTE_PWD_STEP,
+    ROUTE_SYSTEM_INFO_STEP,
+    SmokeStep("summarize the specs you gave me", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+)
+
+ROUTE_CLASS_CHAT_STEPS = (
+    SmokeStep("explain CPU versus GPU in one short sentence", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    *ROUTE_CLASS_RECAP_STEPS,
+    SmokeStep("summarize our whole discussion", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    SmokeStep("explain why local context can matter", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    SmokeStep("summarize that", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    SmokeStep("compare the directory and computer specifications", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    SmokeStep("run printf 'route-third-result\\n'", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    SmokeStep("compare the first and third tool results", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+)
+
+ROUTE_CLASS_LOCAL_TOOL_STEPS = (
+    ROUTE_PWD_STEP,
+    ROUTE_SYSTEM_INFO_STEP,
+    ROUTE_READ_STEP,
+    SmokeStep('search route_fixture.txt for "route-fixture-match"', checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    SmokeStep("list files and directories in this workdir", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("list_directory",)),
+    SmokeStep("run printf 'route-shell-success\\n'", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    ROUTE_SHELL_ERROR_STEP,
+    ROUTE_REFRESH_STEP,
+    ROUTE_VERIFY_STEP,
+)
+
+ROUTE_CLASS_WEB_STEPS = (
+    SmokeStep("search online for orbit fixture success", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    SmokeStep("search online for orbit fixture none", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    ROUTE_WEB_ERROR_STEP,
+    SmokeStep("fetch https://example.com", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("fetch_url",)),
+    SmokeStep("search online for new information about orbit fixture success", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+)
+
+ROUTE_CLASS_EVIDENCE_STEPS = (
+    ROUTE_SHELL_ERROR_STEP,
+    ROUTE_RECOVERY_SUCCESS_STEP,
+    ROUTE_ERROR_SUCCESS_COMPARE_STEP,
+    SmokeStep("run python3 -c 'for i in range(40): print(f\"route-long-summary-{i}\")'", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    SmokeStep("summarize that output", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+    SmokeStep("read route_long_excerpt.txt", checker_name="nonempty", expected_route="FILESYSTEM", expected_tool_names=("exec_shell_full_command",)),
+    SmokeStep("explain the excerpt", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+)
+
+ROUTE_CLASS_AMBIGUOUS_STEPS = (
+    ROUTE_PWD_STEP,
+    ROUTE_SYSTEM_INFO_STEP,
+    SmokeStep("summarize that", checker_name="nonempty", expected_route="CHAT", expected_tool_names=()),
+)
+
+ROUTE_CLASS_REFRESH_STEPS = (
+    ROUTE_SYSTEM_INFO_STEP,
+    ROUTE_REFRESH_STEP,
+)
+
+ROUTE_CLASS_VERIFY_STEPS = (
+    ROUTE_READ_STEP,
+    ROUTE_VERIFY_STEP,
+)
+
+ROUTE_CLASS_ERROR_SUCCESS_STEPS = (
+    ROUTE_SHELL_ERROR_STEP,
+    ROUTE_RECOVERY_SUCCESS_STEP,
+    ROUTE_ERROR_SUCCESS_COMPARE_STEP,
+)
+
+ROUTE_CLASS_WEB_ERROR_STEPS = (
+    ROUTE_WEB_ERROR_STEP,
+)
+
 
 @dataclass(frozen=True)
 class SmokeScenario:
@@ -78,6 +184,7 @@ class SmokeScenario:
     optional: bool = False
     allowed_tool_names: tuple[str, ...] = ("exec_shell_full_command",)
     isolated_steps: bool = False
+    family: str = "general"
 
 
 @dataclass(frozen=True)
@@ -111,6 +218,19 @@ class StepReport:
     generation_tokens_per_second: float | None = None
     estimated_generation_ms: float | None = None
     estimated_prefill_residual_ms: float | None = None
+    scenario_family: str = "general"
+    process_id: int | None = None
+    block_id: str | None = None
+    run_order: str | None = None
+    repetition: int | None = None
+    route_diagnostics_enabled: bool = False
+    route_outputs: list[dict[str, object]] = field(default_factory=list)
+    final_parsed_route: str | None = None
+    route_correct: bool | None = None
+    tool_correct: bool | None = None
+    downstream_final_correct: bool | None = None
+    retry_required: bool = False
+    route_fallback_used: bool = False
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -143,6 +263,19 @@ class StepReport:
             "generation_tokens_per_second": self.generation_tokens_per_second,
             "estimated_generation_ms": self.estimated_generation_ms,
             "estimated_prefill_residual_ms": self.estimated_prefill_residual_ms,
+            "scenario_family": self.scenario_family,
+            "process_id": self.process_id,
+            "block_id": self.block_id,
+            "run_order": self.run_order,
+            "repetition": self.repetition,
+            "route_diagnostics_enabled": self.route_diagnostics_enabled,
+            "route_outputs": self.route_outputs,
+            "final_parsed_route": self.final_parsed_route,
+            "route_correct": self.route_correct,
+            "tool_correct": self.tool_correct,
+            "downstream_final_correct": self.downstream_final_correct,
+            "retry_required": self.retry_required,
+            "route_fallback_used": self.route_fallback_used,
         }
 
 
@@ -203,6 +336,106 @@ class ProbeBackend:
         return list(self._phase_timings)
 
 
+ROUTE_OUTPUT_CLASSES = ("canonical", "legacy_tolerated", "direct_prose", "malformed", "control_loop")
+ROUTE_FALLBACK_OUTCOMES = {"route_invalid_output", "route_no_decision_length_retry", "route_retry_invalid_output"}
+
+
+class RouteDiagnosticCollector:
+    def __init__(self, root: Path, *, store_mode: str) -> None:
+        self.path = root / "route-kv-diag.jsonl"
+        self.store_root = root / "evidence"
+        self.store_mode = store_mode
+        self._store_index = 0
+
+    def mark(self) -> int:
+        try:
+            return self.path.stat().st_size
+        except OSError:
+            return 0
+
+    def events_since(self, offset: int) -> list[dict[str, object]]:
+        try:
+            with self.path.open("rb") as handle:
+                handle.seek(offset)
+                lines = [line.decode("utf-8", errors="replace") for line in handle.readlines()]
+        except OSError:
+            return []
+        return parse_route_diagnostic_lines(lines)
+
+    def new_evidence_store(self, workdir: Path) -> EvidenceStore:
+        self._store_index += 1
+        destination = self.store_root / f"store-{self._store_index:04d}"
+        if self.store_mode == "existing-snapshot":
+            source = EvidenceStore.for_workdir(workdir).root
+            if source.is_dir():
+                shutil.copytree(source, destination)
+        store = EvidenceStore(destination)
+        store.load_index()
+        return store
+
+
+def parse_route_diagnostic_lines(lines: list[str]) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in lines:
+        try:
+            value = json.loads(line)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(value, dict) or value.get("event") != "kv_diag_route_outcome":
+            continue
+        route_class = value.get("route_output_class")
+        if route_class not in ROUTE_OUTPUT_CLASSES:
+            route_class = None
+        phase = value.get("phase")
+        events.append(
+            {
+                "route_call": "retry" if phase == "route_retry" else "initial",
+                "route_output_class": route_class,
+                "route_output_reason": bounded_identifier(value.get("route_output_reason")),
+                "parser_accepted": value.get("route_parser_accepted") if isinstance(value.get("route_parser_accepted"), bool) else None,
+                "finish_reason": bounded_identifier(value.get("route_finish_reason")),
+                "output_tokens": value.get("route_output_tokens") if isinstance(value.get("route_output_tokens"), int) else None,
+                "parsed_route": bounded_identifier(value.get("decision_type")),
+                "outcome": bounded_identifier(value.get("outcome")),
+                "retry_reason": bounded_identifier(value.get("retry_reason")),
+                "control_loop_surrogate": value.get("route_output_reason") == "empty_visible_control_output",
+            }
+        )
+    return events
+
+
+def bounded_identifier(value: object, *, limit: int = 80) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > limit:
+        return None
+    if not all(character.isalnum() or character in {"_", "-"} for character in value):
+        return None
+    return value
+
+
+@contextmanager
+def route_diagnostic_environment(enabled: bool, *, store_mode: str):
+    if not enabled:
+        yield None
+        return
+    previous_enabled = os.environ.get("ORBIT_KV_DIAG")
+    previous_path = os.environ.get("ORBIT_KV_DIAG_FILE")
+    with tempfile.TemporaryDirectory(prefix="orbit-route-diag-") as tmp:
+        collector = RouteDiagnosticCollector(Path(tmp), store_mode=store_mode)
+        os.environ["ORBIT_KV_DIAG"] = "1"
+        os.environ["ORBIT_KV_DIAG_FILE"] = str(collector.path)
+        try:
+            yield collector
+        finally:
+            if previous_enabled is None:
+                os.environ.pop("ORBIT_KV_DIAG", None)
+            else:
+                os.environ["ORBIT_KV_DIAG"] = previous_enabled
+            if previous_path is None:
+                os.environ.pop("ORBIT_KV_DIAG_FILE", None)
+            else:
+                os.environ["ORBIT_KV_DIAG_FILE"] = previous_path
+
+
 def mtp_state_from_props(props: dict[str, object]) -> dict[str, object]:
     requested = bool(props.get("mtp_experimental_enabled"))
     session_ready = bool(props.get("mtp_initialized"))
@@ -243,7 +476,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.lifecycle_check:
         return run_lifecycle_checks(args, jsonl_path=jsonl_path, markdown_path=markdown_path)
 
-    with final_prefix_environment(args.final_prefix_mode), deterministic_web(args.deterministic_web), managed_server(args) as server_process:
+    with (
+        final_prefix_environment(args.final_prefix_mode),
+        deterministic_web(args.deterministic_web),
+        managed_server(args) as server_process,
+        route_diagnostic_environment(
+            args.route_output_diagnostics,
+            store_mode=args.route_diagnostic_store,
+        ) as route_collector,
+    ):
         backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
         backend.thinking = args.server_thinking == "on"
         rss_before_kib = process_rss_kib(server_process)
@@ -256,8 +497,10 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
         reports: list[StepReport] = []
+        run_order_index = 0
         for scenario in selected:
-            for _repeat in range(args.repetitions):
+            for repeat in range(1, args.repetitions + 1):
+                run_order_index += 1
                 reports.extend(
                     run_scenario(
                         scenario,
@@ -267,6 +510,11 @@ def main(argv: list[str] | None = None) -> int:
                         temperature=args.temperature,
                         timeout=args.timeout,
                         tools_mode=args.tools,
+                        route_collector=route_collector,
+                        process_id=server_process.pid if server_process is not None else None,
+                        block_id=args.block_id or f"run-{run_order_index:04d}",
+                        run_order=args.run_order or str(run_order_index),
+                        repetition=repeat,
                     )
                 )
         final_props = settled_backend_props(args.base_url, args.timeout)
@@ -328,6 +576,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--run-order", default=None)
     parser.add_argument("--cooling-seconds", type=float, default=0.0)
     parser.add_argument("--deterministic-web", action="store_true", help="Use bounded local web fixtures for final-prefix smoke cases.")
+    parser.add_argument(
+        "--route-output-diagnostics",
+        action="store_true",
+        help="Collect bounded route-output classifications from existing KV diagnostic events.",
+    )
+    parser.add_argument(
+        "--route-diagnostic-store",
+        choices=("clean", "existing-snapshot"),
+        default="clean",
+        help="Use a clean temporary evidence store or a read-only snapshot of the selected workdir store.",
+    )
     parser.add_argument(
         "--lifecycle-check",
         action="append",
@@ -441,6 +700,78 @@ def scenarios() -> dict[str, SmokeScenario]:
             requires_web=True,
             optional=True,
         ),
+        "route_classification_recap": SmokeScenario(
+            "route_classification_recap",
+            ROUTE_CLASS_RECAP_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="chat_recap",
+        ),
+        "route_classification_chat": SmokeScenario(
+            "route_classification_chat",
+            ROUTE_CLASS_CHAT_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="chat",
+        ),
+        "route_classification_local": SmokeScenario(
+            "route_classification_local",
+            ROUTE_CLASS_LOCAL_TOOL_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="local_tool",
+        ),
+        "route_classification_web": SmokeScenario(
+            "route_classification_web",
+            ROUTE_CLASS_WEB_STEPS,
+            requires_web=True,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="web",
+        ),
+        "route_classification_evidence": SmokeScenario(
+            "route_classification_evidence",
+            ROUTE_CLASS_EVIDENCE_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="evidence_shape",
+        ),
+        "route_classification_ambiguous": SmokeScenario(
+            "route_classification_ambiguous",
+            ROUTE_CLASS_AMBIGUOUS_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="fragile_ambiguous",
+        ),
+        "route_classification_refresh": SmokeScenario(
+            "route_classification_refresh",
+            ROUTE_CLASS_REFRESH_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="fragile_refresh",
+        ),
+        "route_classification_verify": SmokeScenario(
+            "route_classification_verify",
+            ROUTE_CLASS_VERIFY_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="fragile_verify",
+        ),
+        "route_classification_error_success": SmokeScenario(
+            "route_classification_error_success",
+            ROUTE_CLASS_ERROR_SUCCESS_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="fragile_error_success",
+        ),
+        "route_classification_web_error": SmokeScenario(
+            "route_classification_web_error",
+            ROUTE_CLASS_WEB_ERROR_STEPS,
+            requires_web=True,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="fragile_web_error",
+        ),
     }
 
 
@@ -471,12 +802,17 @@ def run_scenario(
     temperature: float,
     timeout: float,
     tools_mode: str = "on",
+    route_collector: RouteDiagnosticCollector | None = None,
+    process_id: int | None = None,
+    block_id: str | None = None,
+    run_order: str | None = None,
+    repetition: int | None = None,
 ) -> list[StepReport]:
-    runtime = new_runtime(backend, workdir)
+    runtime = new_runtime(backend, workdir, route_collector=route_collector)
     reports: list[StepReport] = []
     for index, step in enumerate(scenario.steps, start=1):
         if scenario.isolated_steps and index > 1:
-            runtime = new_runtime(backend, workdir)
+            runtime = new_runtime(backend, workdir, route_collector=route_collector)
         report = run_step(
             runtime,
             scenario=scenario.name,
@@ -488,6 +824,12 @@ def run_scenario(
             base_url=backend.base_url,
             timeout=timeout,
             allowed_tool_names=effective_allowed_tool_names(scenario, tools_mode),
+            route_collector=route_collector,
+            scenario_family=scenario.family,
+            process_id=process_id,
+            block_id=block_id,
+            run_order=run_order,
+            repetition=repetition,
         )
         reports.append(report)
         if report.finish_reason in {"timeout", "error"}:
@@ -499,11 +841,17 @@ def effective_allowed_tool_names(scenario: SmokeScenario, tools_mode: str) -> tu
     return scenario.allowed_tool_names if tools_mode == "on" else ()
 
 
-def new_runtime(backend: LlamaServerBackend, workdir: Path) -> ChatRuntime:
+def new_runtime(
+    backend: LlamaServerBackend,
+    workdir: Path,
+    *,
+    route_collector: RouteDiagnosticCollector | None = None,
+) -> ChatRuntime:
     return ChatRuntime(
         backend=ProbeBackend(backend),
         system_prompt=DEFAULT_SYSTEM_PROMPT,
         diagnostic_session_id=str(workdir),
+        evidence_store=route_collector.new_evidence_store(workdir) if route_collector is not None else None,
     )
 
 
@@ -519,8 +867,15 @@ def run_step(
     base_url: str,
     timeout: float,
     allowed_tool_names: tuple[str, ...] = ("exec_shell_full_command",),
+    route_collector: RouteDiagnosticCollector | None = None,
+    scenario_family: str = "general",
+    process_id: int | None = None,
+    block_id: str | None = None,
+    run_order: str | None = None,
+    repetition: int | None = None,
 ) -> StepReport:
     props_before = fresh_backend_props(base_url, min(timeout, 5.0))
+    diagnostic_offset = route_collector.mark() if route_collector is not None else 0
     result_queue: queue.Queue[StepReport] = queue.Queue(maxsize=1)
 
     worker = threading.Thread(
@@ -552,7 +907,7 @@ def run_step(
             notes += ",cleanup_ok"
         elif props_after:
             notes += ",cleanup_pending"
-        return StepReport(
+        report = StepReport(
             case=scenario,
             step=step_index,
             prompt=step.prompt,
@@ -585,9 +940,31 @@ def run_step(
             },
             phase_wall_ms={},
         )
+        return enrich_step_route_diagnostics(
+            report,
+            route_collector.events_since(diagnostic_offset) if route_collector is not None else [],
+            step=step,
+            enabled=route_collector is not None,
+            scenario_family=scenario_family,
+            process_id=process_id,
+            block_id=block_id,
+            run_order=run_order,
+            repetition=repetition,
+        )
     report = result_queue.get()
     props_after = fresh_backend_props(base_url, min(timeout, 5.0))
-    return replace_step_final_prefix(report, final_prefix_step_state(props_before, props_after))
+    report = replace_step_final_prefix(report, final_prefix_step_state(props_before, props_after))
+    return enrich_step_route_diagnostics(
+        report,
+        route_collector.events_since(diagnostic_offset) if route_collector is not None else [],
+        step=step,
+        enabled=route_collector is not None,
+        scenario_family=scenario_family,
+        process_id=process_id,
+        block_id=block_id,
+        run_order=run_order,
+        repetition=repetition,
+    )
 
 
 def _run_step_inner(
@@ -604,7 +981,7 @@ def _run_step_inner(
     model_steps: list[ModelStepMetrics] = []
     tool_names: list[str] = []
     started = time.perf_counter()
-    probe = runtime.backend if isinstance(runtime.backend, ProbeBackend) else None
+    probe = probe_backend(runtime.backend)
     if probe is not None:
         probe.reset_phase_timings()
     notes = ""
@@ -701,6 +1078,13 @@ def phase_timing_summary(timings: list[tuple[str, float]], total_wall_ms: float)
     return result
 
 
+def probe_backend(backend: object) -> ProbeBackend | None:
+    if isinstance(backend, ProbeBackend):
+        return backend
+    wrapped = getattr(backend, "_backend", None)
+    return wrapped if isinstance(wrapped, ProbeBackend) else None
+
+
 def estimated_generation_ms(output_tokens: int | None, tokens_per_second: float | None) -> float | None:
     if not isinstance(output_tokens, int) or not isinstance(tokens_per_second, int | float) or tokens_per_second <= 0:
         return None
@@ -775,6 +1159,8 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "run_order": args.run_order,
         "cooling_seconds": args.cooling_seconds,
         "cpu_affinity": sorted(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None,
+        "route_output_diagnostics": args.route_output_diagnostics,
+        "route_diagnostic_store": args.route_diagnostic_store,
     }
 
 
@@ -846,6 +1232,86 @@ def replace_step_final_prefix(report: StepReport, state: dict[str, object]) -> S
     values = report.__dict__.copy()
     values["final_prefix"] = state
     return StepReport(**values)
+
+
+def enrich_step_route_diagnostics(
+    report: StepReport,
+    events: list[dict[str, object]],
+    *,
+    step: SmokeStep,
+    enabled: bool,
+    scenario_family: str,
+    process_id: int | None,
+    block_id: str | None,
+    run_order: str | None,
+    repetition: int | None,
+) -> StepReport:
+    final_route = next(
+        (event.get("parsed_route") for event in reversed(events) if isinstance(event.get("parsed_route"), str)),
+        None,
+    )
+    retry_required = any(event.get("route_call") == "retry" for event in events) or any(
+        "retry" in str(metric.get("phase") or "") for metric in report.model_steps
+    )
+    route_correct = route_expectation_result(step.expected_route, final_route, events, report.tool_names)
+    tool_correct = tool_expectation_result(step.expected_tool_names, report.tool_names) if events else None
+    downstream_correct = report.correctness_category == "correct"
+    fallback_used = any(event.get("outcome") in ROUTE_FALLBACK_OUTCOMES for event in events)
+    selected_tool = report.tool_names[0] if report.tool_names else None
+    correlated = [
+        {
+            **event,
+            "final_parsed_route": final_route,
+            "selected_tool": selected_tool,
+            "route_correct": route_correct,
+            "tool_correct": tool_correct,
+            "downstream_final_correct": downstream_correct,
+            "retry_required": retry_required,
+            "fallback_used": fallback_used,
+        }
+        for event in events
+    ]
+    values = report.__dict__.copy()
+    values.update(
+        {
+            "scenario_family": scenario_family,
+            "process_id": process_id,
+            "block_id": block_id,
+            "run_order": run_order,
+            "repetition": repetition,
+            "route_diagnostics_enabled": enabled,
+            "route_outputs": correlated,
+            "final_parsed_route": final_route,
+            "route_correct": route_correct,
+            "tool_correct": tool_correct,
+            "downstream_final_correct": downstream_correct,
+            "retry_required": retry_required,
+            "route_fallback_used": fallback_used,
+        }
+    )
+    return StepReport(**values)
+
+
+def route_expectation_result(
+    expected_route: str | None,
+    final_route: object,
+    events: list[dict[str, object]],
+    tool_names: list[str],
+) -> bool | None:
+    if expected_route is None or not events:
+        return None
+    if expected_route == "CHAT":
+        direct = any(event.get("route_output_class") == "direct_prose" for event in events)
+        return (final_route == "CHAT" or direct) and not tool_names
+    return final_route == expected_route
+
+
+def tool_expectation_result(expected: tuple[str, ...] | None, actual: list[str]) -> bool | None:
+    if expected is None:
+        return None
+    if not expected:
+        return not actual
+    return bool(actual) and set(actual).issubset(set(expected))
 
 
 @contextmanager
@@ -1417,6 +1883,9 @@ def write_jsonl(
             handle.write(json.dumps({"type": "step", **report.to_json()}, ensure_ascii=False, sort_keys=True) + "\n")
         for summary in summarize_reports(reports):
             handle.write(json.dumps({"type": "summary", **summary}, ensure_ascii=False, sort_keys=True) + "\n")
+        route_summary = summarize_route_classifications(reports)
+        if route_summary is not None:
+            handle.write(json.dumps(route_summary, ensure_ascii=False, sort_keys=True) + "\n")
         for row in extra_rows or []:
             handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
@@ -1512,6 +1981,94 @@ def summarize_reports(reports: list[StepReport]) -> list[dict[str, object]]:
             }
         )
     return result
+
+
+def summarize_route_classifications(reports: list[StepReport]) -> dict[str, object] | None:
+    diagnostic_reports = [report for report in reports if report.route_diagnostics_enabled]
+    if not diagnostic_reports:
+        return None
+    class_counts = empty_route_class_counts()
+    initial_counts = empty_route_class_counts()
+    retry_counts = empty_route_class_counts()
+    by_family: dict[str, dict[str, int]] = {}
+    correctness = {
+        route_class: {
+            "calls": 0,
+            "route_correct": 0,
+            "route_wrong": 0,
+            "tool_correct": 0,
+            "tool_wrong": 0,
+            "downstream_correct": 0,
+            "downstream_wrong": 0,
+            "retry_required": 0,
+        }
+        for route_class in ROUTE_OUTPUT_CLASSES
+    }
+    malformed_to_retry = 0
+    control_loop_to_retry = 0
+    final_successful_decisions = 0
+    fallback_count = 0
+    surrogate_count = 0
+    for report in diagnostic_reports:
+        family_counts = by_family.setdefault(report.scenario_family, empty_route_class_counts())
+        if report.final_parsed_route is not None:
+            final_successful_decisions += 1
+        if report.route_fallback_used:
+            fallback_count += 1
+        initial_classes = {
+            event.get("route_output_class")
+            for event in report.route_outputs
+            if event.get("route_call") == "initial"
+        }
+        if report.retry_required and "malformed" in initial_classes:
+            malformed_to_retry += 1
+        if report.retry_required and "control_loop" in initial_classes:
+            control_loop_to_retry += 1
+        for event in report.route_outputs:
+            route_class = event.get("route_output_class")
+            if route_class not in ROUTE_OUTPUT_CLASSES:
+                continue
+            class_counts[route_class] += 1
+            family_counts[route_class] += 1
+            target = retry_counts if event.get("route_call") == "retry" else initial_counts
+            target[route_class] += 1
+            correlation = correctness[route_class]
+            correlation["calls"] += 1
+            _increment_boolean_counts(correlation, "route", event.get("route_correct"))
+            _increment_boolean_counts(correlation, "tool", event.get("tool_correct"))
+            _increment_boolean_counts(correlation, "downstream", event.get("downstream_final_correct"))
+            if event.get("retry_required") is True:
+                correlation["retry_required"] += 1
+            if event.get("control_loop_surrogate") is True:
+                surrogate_count += 1
+    return {
+        "type": "route_classification_summary",
+        "class_counts": class_counts,
+        "initial_class_counts": initial_counts,
+        "retry_class_counts": retry_counts,
+        "malformed_to_retry_transitions": malformed_to_retry,
+        "control_loop_to_retry_transitions": control_loop_to_retry,
+        "final_successful_decision_count": final_successful_decisions,
+        "fallback_count": fallback_count,
+        "class_distribution_by_scenario_family": by_family,
+        "correctness_by_class": correctness,
+        "diagnostic_steps": len(diagnostic_reports),
+        "steps_with_route_events": sum(bool(report.route_outputs) for report in diagnostic_reports),
+        "missing_route_diagnostic_steps": sum(not report.route_outputs for report in diagnostic_reports),
+        "empty_visible_control_output_surrogate_count": surrogate_count,
+        "control_loop_surrogate_note": "empty visible output at length with at least 8 output tokens is diagnostic evidence, not exact token-cycle proof",
+    }
+
+
+def empty_route_class_counts() -> dict[str, int]:
+    return {route_class: 0 for route_class in ROUTE_OUTPUT_CLASSES}
+
+
+def _increment_boolean_counts(target: dict[str, int], prefix: str, value: object) -> None:
+    if value is True:
+        target[f"{prefix}_correct"] += 1
+    elif value is False:
+        target[f"{prefix}_wrong"] += 1
 
 
 def summarize_restored_rows(rows: list[StepReport]) -> dict[str, object]:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import sys
@@ -19,6 +20,34 @@ assert SPEC is not None and SPEC.loader is not None
 smoke_harness = importlib.util.module_from_spec(SPEC)
 sys.modules["orbit_smoke_harness"] = smoke_harness
 SPEC.loader.exec_module(smoke_harness)
+
+
+def route_step_report(**overrides: object):
+    values = {
+        "case": "route",
+        "step": 1,
+        "prompt": "fixture",
+        "prompt_kind": "auto",
+        "completion_kind": "route",
+        "route_tokens": 10,
+        "final_tokens": 10,
+        "prompt_tokens": 10,
+        "cached_tokens": 0,
+        "evaluated_tokens": 10,
+        "finish_reason": "stop",
+        "tool_calls": 0,
+        "tool_names": [],
+        "wall_ms": 1.0,
+        "correctness_category": "correct",
+        "raw_leak": False,
+        "fake_output": False,
+        "loop": False,
+        "notes": "",
+        "answer_excerpt": "answer",
+        "model_steps": [],
+    }
+    values.update(overrides)
+    return smoke_harness.StepReport(**values)
 
 
 class SmokeHarnessTests(unittest.TestCase):
@@ -69,6 +98,18 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(args.lifecycle_check, ["restart", "ctx-change"])
         self.assertEqual(args.ctx_change_to, 4096)
 
+    def test_parser_accepts_opt_in_route_output_diagnostics(self) -> None:
+        args = smoke_harness.build_parser().parse_args(
+            ["--route-output-diagnostics", "--route-diagnostic-store", "existing-snapshot"]
+        )
+
+        self.assertTrue(args.route_output_diagnostics)
+        self.assertEqual(args.route_diagnostic_store, "existing-snapshot")
+
+        defaults = smoke_harness.build_parser().parse_args([])
+        self.assertFalse(defaults.route_output_diagnostics)
+        self.assertEqual(defaults.route_diagnostic_store, "clean")
+
     def test_select_scenarios_defaults_to_all_without_optional_or_web_when_disabled(self) -> None:
         selected = smoke_harness.select_scenarios(None, no_web=True, include_optional=False)
         names = [scenario.name for scenario in selected]
@@ -100,6 +141,114 @@ class SmokeHarnessTests(unittest.TestCase):
             smoke_harness.FINAL_PREFIX_LOCAL_STEPS + smoke_harness.FINAL_PREFIX_WEB_STEPS,
         )
         self.assertEqual(registry["final_prefix_paired"].steps, smoke_harness.FINAL_PREFIX_PAIRED_STEPS)
+
+    def test_route_classification_matrix_is_declarative_and_optional(self) -> None:
+        registry = smoke_harness.scenarios()
+        names = (
+            "route_classification_recap",
+            "route_classification_chat",
+            "route_classification_local",
+            "route_classification_web",
+            "route_classification_evidence",
+            "route_classification_ambiguous",
+            "route_classification_refresh",
+            "route_classification_verify",
+            "route_classification_error_success",
+            "route_classification_web_error",
+        )
+
+        self.assertTrue(all(registry[name].optional for name in names))
+        self.assertEqual(registry["route_classification_recap"].steps, smoke_harness.ROUTE_CLASS_RECAP_STEPS)
+        self.assertEqual(registry["route_classification_web"].family, "web")
+        self.assertEqual(registry["route_classification_ambiguous"].steps, smoke_harness.ROUTE_CLASS_AMBIGUOUS_STEPS)
+        self.assertEqual(registry["route_classification_refresh"].steps, smoke_harness.ROUTE_CLASS_REFRESH_STEPS)
+        self.assertEqual(registry["route_classification_verify"].steps, smoke_harness.ROUTE_CLASS_VERIFY_STEPS)
+        self.assertEqual(registry["route_classification_error_success"].steps, smoke_harness.ROUTE_CLASS_ERROR_SUCCESS_STEPS)
+        self.assertEqual(registry["route_classification_web_error"].steps, smoke_harness.ROUTE_CLASS_WEB_ERROR_STEPS)
+        self.assertTrue(
+            all(step.expected_route is not None for name in names for step in registry[name].steps)
+        )
+
+    def test_route_diagnostic_lines_are_sanitized_and_missing_fields_are_safe(self) -> None:
+        lines = [
+            *(
+                json.dumps(
+                    {
+                        "event": "kv_diag_route_outcome",
+                        "phase": "route",
+                        "route_output_class": route_class,
+                        "route_output_reason": f"fixture_{route_class}",
+                        "route_parser_accepted": route_class in {"canonical", "legacy_tolerated"},
+                    }
+                )
+                for route_class in smoke_harness.ROUTE_OUTPUT_CLASSES
+            ),
+            json.dumps(
+                {
+                    "event": "kv_diag_route_outcome",
+                    "phase": "route",
+                    "route_output_class": "malformed",
+                    "route_output_reason": "unaccepted_output",
+                    "route_parser_accepted": False,
+                    "route_finish_reason": "length",
+                    "route_output_tokens": 64,
+                    "decision_type": None,
+                    "outcome": "route_no_decision_length_retry",
+                    "retry_reason": "length_without_decision",
+                    "raw_route_text": "route-secret",
+                    "user_request": "request-secret",
+                    "evidence": "evidence-secret",
+                }
+            ),
+            json.dumps({"event": "kv_diag_route_outcome", "phase": "route_retry"}),
+            "not-json",
+        ]
+
+        events = smoke_harness.parse_route_diagnostic_lines(lines)
+        serialized = json.dumps(events)
+
+        self.assertEqual(len(events), 7)
+        self.assertEqual(
+            [event["route_output_class"] for event in events[:5]],
+            list(smoke_harness.ROUTE_OUTPUT_CLASSES),
+        )
+        self.assertEqual(events[0]["route_call"], "initial")
+        self.assertEqual(events[-1]["route_call"], "retry")
+        self.assertIsNone(events[-1]["route_output_class"])
+        self.assertNotIn("route-secret", serialized)
+        self.assertNotIn("request-secret", serialized)
+        self.assertNotIn("evidence-secret", serialized)
+
+    def test_route_diagnostic_snapshot_does_not_modify_source_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = smoke_harness.EvidenceStore(root / "source")
+            source.add("system_info", "source evidence")
+            source_hash_before = hashlib.sha256(
+                b"".join(
+                    path.relative_to(source.root).as_posix().encode() + b"\0" + path.read_bytes() + b"\0"
+                    for path in sorted(source.root.rglob("*"))
+                    if path.is_file()
+                )
+            ).hexdigest()
+            collector = smoke_harness.RouteDiagnosticCollector(root / "collector", store_mode="existing-snapshot")
+            with mock.patch.object(smoke_harness.EvidenceStore, "for_workdir", return_value=source):
+                snapshot = collector.new_evidence_store(Path("workdir"))
+            snapshot.add("exec_shell_full_command", "snapshot evidence")
+            source_hash_after = hashlib.sha256(
+                b"".join(
+                    path.relative_to(source.root).as_posix().encode() + b"\0" + path.read_bytes() + b"\0"
+                    for path in sorted(source.root.rglob("*"))
+                    if path.is_file()
+                )
+            ).hexdigest()
+
+            reloaded_source = smoke_harness.EvidenceStore(source.root)
+            reloaded_source.load_index()
+
+        self.assertEqual(len(reloaded_source.records), 1)
+        self.assertEqual(len(snapshot.records), 2)
+        self.assertEqual(source_hash_after, source_hash_before)
 
     def test_tools_off_removes_runtime_tool_names(self) -> None:
         scenario = smoke_harness.scenarios()["final_prefix_local"]
@@ -689,6 +838,249 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertIn("phase_wall_ms", rows[1])
         self.assertEqual(rows[2]["type"], "summary")
         self.assertEqual(rows[3]["type"], "lifecycle_summary")
+
+    def test_route_diagnostics_keep_initial_retry_and_tool_correlation_separate(self) -> None:
+        report = route_step_report(
+            prompt="fixture request",
+            completion_kind="route,route_retry,final_from_tool",
+            route_tokens=100,
+            final_tokens=50,
+            prompt_tokens=50,
+            cached_tokens=4,
+            evaluated_tokens=46,
+            tool_calls=1,
+            tool_names=["exec_shell_full_command"],
+            wall_ms=10.0,
+            answer_excerpt="fixture answer",
+            model_steps=[{"phase": "route_retry"}],
+        )
+        events = [
+            {
+                "route_call": "initial",
+                "route_output_class": "malformed",
+                "route_output_reason": "unaccepted_output",
+                "parser_accepted": False,
+                "finish_reason": "stop",
+                "output_tokens": 10,
+                "parsed_route": None,
+                "outcome": "route_other_retry",
+                "retry_reason": "explicit_web_search",
+                "control_loop_surrogate": False,
+            },
+            {
+                "route_call": "retry",
+                "route_output_class": "canonical",
+                "route_output_reason": "canonical_command",
+                "parser_accepted": True,
+                "finish_reason": "stop",
+                "output_tokens": 5,
+                "parsed_route": "FILESYSTEM",
+                "outcome": "route_parsed_tool",
+                "retry_reason": None,
+                "control_loop_surrogate": False,
+            },
+        ]
+
+        enriched = smoke_harness.enrich_step_route_diagnostics(
+            report,
+            events,
+            step=smoke_harness.SmokeStep(
+                "fixture request",
+                expected_route="FILESYSTEM",
+                expected_tool_names=("exec_shell_full_command",),
+            ),
+            enabled=True,
+            scenario_family="web",
+            process_id=4321,
+            block_id="block-a",
+            run_order="2",
+            repetition=1,
+        )
+
+        self.assertEqual([event["route_call"] for event in enriched.route_outputs], ["initial", "retry"])
+        self.assertEqual(enriched.final_parsed_route, "FILESYSTEM")
+        self.assertTrue(enriched.route_correct)
+        self.assertTrue(enriched.tool_correct)
+        self.assertTrue(enriched.retry_required)
+        self.assertFalse(enriched.route_fallback_used)
+        self.assertEqual(enriched.process_id, 4321)
+        self.assertEqual(enriched.block_id, "block-a")
+
+    def test_route_classification_summary_counts_transitions_and_correlations(self) -> None:
+        def report_with(events, *, family, final_route, fallback, retry, downstream=True):
+            return route_step_report(
+                case=family,
+                correctness_category="correct" if downstream else "length_failure",
+                scenario_family=family,
+                route_diagnostics_enabled=True,
+                route_outputs=events,
+                final_parsed_route=final_route,
+                route_correct=True,
+                tool_correct=True,
+                downstream_final_correct=downstream,
+                retry_required=retry,
+                route_fallback_used=fallback,
+            )
+
+        malformed = {
+            "route_call": "initial", "route_output_class": "malformed", "route_correct": True,
+            "tool_correct": True, "downstream_final_correct": True, "retry_required": True,
+            "control_loop_surrogate": False,
+        }
+        canonical_retry = {
+            "route_call": "retry", "route_output_class": "canonical", "route_correct": True,
+            "tool_correct": True, "downstream_final_correct": True, "retry_required": True,
+            "control_loop_surrogate": False,
+        }
+        control = {
+            "route_call": "initial", "route_output_class": "control_loop", "route_correct": False,
+            "tool_correct": False, "downstream_final_correct": True, "retry_required": True,
+            "control_loop_surrogate": True,
+        }
+        legacy = {
+            "route_call": "initial", "route_output_class": "legacy_tolerated", "route_correct": True,
+            "tool_correct": True, "downstream_final_correct": True, "retry_required": False,
+            "control_loop_surrogate": False,
+        }
+        direct = {
+            "route_call": "initial", "route_output_class": "direct_prose", "route_correct": True,
+            "tool_correct": True, "downstream_final_correct": True, "retry_required": False,
+            "control_loop_surrogate": False,
+        }
+        malformed_failure = {
+            "route_call": "initial", "route_output_class": "malformed", "route_correct": False,
+            "tool_correct": True, "downstream_final_correct": False, "retry_required": True,
+            "control_loop_surrogate": False,
+        }
+        malformed_retry = {**malformed_failure, "route_call": "retry"}
+        reports = [
+            report_with([malformed, canonical_retry], family="web", final_route="FILESYSTEM", fallback=False, retry=True),
+            report_with([control], family="chat", final_route=None, fallback=True, retry=True),
+            report_with([legacy], family="local", final_route="FILESYSTEM", fallback=False, retry=False),
+            report_with([direct], family="chat", final_route=None, fallback=False, retry=False),
+            report_with(
+                [malformed_failure, malformed_retry],
+                family="evidence",
+                final_route=None,
+                fallback=True,
+                retry=True,
+                downstream=False,
+            ),
+        ]
+
+        summary = smoke_harness.summarize_route_classifications(reports)
+
+        self.assertEqual(summary["class_counts"]["canonical"], 1)
+        self.assertEqual(summary["class_counts"]["legacy_tolerated"], 1)
+        self.assertEqual(summary["class_counts"]["direct_prose"], 1)
+        self.assertEqual(summary["initial_class_counts"]["malformed"], 2)
+        self.assertEqual(summary["retry_class_counts"]["canonical"], 1)
+        self.assertEqual(summary["retry_class_counts"]["malformed"], 1)
+        self.assertEqual(summary["malformed_to_retry_transitions"], 2)
+        self.assertEqual(summary["control_loop_to_retry_transitions"], 1)
+        self.assertEqual(summary["final_successful_decision_count"], 2)
+        self.assertEqual(summary["fallback_count"], 2)
+        self.assertEqual(summary["class_distribution_by_scenario_family"]["web"]["canonical"], 1)
+        self.assertEqual(summary["class_distribution_by_scenario_family"]["evidence"]["malformed"], 2)
+        self.assertEqual(summary["correctness_by_class"]["malformed"]["downstream_wrong"], 2)
+        self.assertEqual(summary["empty_visible_control_output_surrogate_count"], 1)
+        self.assertIn("not exact token-cycle proof", summary["control_loop_surrogate_note"])
+
+    def test_route_classification_summary_aggregates_five_repetitions(self) -> None:
+        reports = []
+        for repetition in range(1, 6):
+            reports.append(
+                route_step_report(
+                    case="fragile",
+                    completion_kind="route,chat_final",
+                    scenario_family="fragile_ambiguous",
+                    repetition=repetition,
+                    route_diagnostics_enabled=True,
+                    route_outputs=[
+                        {
+                            "route_call": "initial",
+                            "route_output_class": "canonical",
+                            "route_correct": True,
+                            "tool_correct": True,
+                            "downstream_final_correct": True,
+                            "retry_required": False,
+                            "control_loop_surrogate": False,
+                        }
+                    ],
+                    final_parsed_route="CHAT",
+                    route_correct=True,
+                    tool_correct=True,
+                    downstream_final_correct=True,
+                )
+            )
+
+        summary = smoke_harness.summarize_route_classifications(reports)
+
+        self.assertEqual(summary["diagnostic_steps"], 5)
+        self.assertEqual(summary["class_counts"]["canonical"], 5)
+        self.assertEqual(summary["final_successful_decision_count"], 5)
+        self.assertEqual(summary["class_distribution_by_scenario_family"]["fragile_ambiguous"]["canonical"], 5)
+        self.assertEqual(summary["correctness_by_class"]["canonical"]["downstream_correct"], 5)
+
+    def test_route_jsonl_rows_are_additive_and_do_not_copy_raw_diagnostic_content(self) -> None:
+        report = route_step_report(
+            prompt="existing step prompt",
+            answer_excerpt="existing answer excerpt",
+            route_diagnostics_enabled=True,
+            route_outputs=[
+                {
+                    "route_call": "initial",
+                    "route_output_class": "canonical",
+                    "route_output_reason": "canonical_chat",
+                    "parser_accepted": True,
+                    "finish_reason": "stop",
+                    "output_tokens": 5,
+                    "parsed_route": "CHAT",
+                }
+            ],
+            final_parsed_route="CHAT",
+            route_correct=True,
+            tool_correct=True,
+            downstream_final_correct=True,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "report.jsonl"
+            smoke_harness.write_jsonl(path, {"version": "test"}, [report])
+            text = path.read_text(encoding="utf-8")
+            rows = [json.loads(line) for line in text.splitlines()]
+
+        self.assertEqual([row["type"] for row in rows], ["environment", "step", "summary", "route_classification_summary"])
+        self.assertEqual(rows[1]["prompt"], "existing step prompt")
+        route_metadata = json.dumps(rows[1]["route_outputs"])
+        self.assertNotIn("existing step prompt", route_metadata)
+        self.assertNotIn("existing answer excerpt", route_metadata)
+        self.assertNotIn("raw_route_text", text)
+        self.assertNotIn("route-secret", text)
+
+    def test_missing_route_diagnostics_do_not_add_summary_or_change_old_rows(self) -> None:
+        report = route_step_report(
+            case="simple_chat",
+            prompt="hi",
+            prompt_kind="chat",
+            completion_kind="final",
+            route_tokens=None,
+            final_tokens=2,
+            prompt_tokens=2,
+            evaluated_tokens=2,
+            answer_excerpt="hello",
+        )
+
+        self.assertIsNone(smoke_harness.summarize_route_classifications([report]))
+
+        values = report.__dict__.copy()
+        values["route_diagnostics_enabled"] = True
+        partial = smoke_harness.StepReport(**values)
+        summary = smoke_harness.summarize_route_classifications([partial])
+
+        self.assertEqual(summary["diagnostic_steps"], 1)
+        self.assertEqual(summary["steps_with_route_events"], 0)
+        self.assertEqual(summary["missing_route_diagnostic_steps"], 1)
+        self.assertEqual(summary["class_counts"], smoke_harness.empty_route_class_counts())
 
     def test_main_tools_off_metadata_matches_runtime_mode(self) -> None:
         captured_env: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary

- Aggregates diagnostic route-output classes in the smoke harness.
- Records `canonical`, `legacy_tolerated`, `direct_prose`, `malformed`, and `control_loop` classifications.
- Keeps initial and retry route events separate.
- Adds correctness, fallback, and scenario-family correlations.
- Uses additive JSONL fields and summary rows.
- Stores no raw route, request, or evidence content in new diagnostics.

Representative run:
- 74 canonical
- 7 legacy tolerated
- 3 direct prose
- 9 malformed
- 1 control-loop surrogate

The control-loop value is a conservative diagnostic surrogate, not proof of the exact raw token cycle. Classification remains observational only and does not alter runtime, parser, routing, fallback, direct-answer, or tool behavior.

## Validation

- `tests.test_bench_core`: PASS, 6 tests
- `tests.test_smoke_harness`: PASS, 53 tests
- full discovery: PASS, 1,058 tests
- `compileall`: PASS
- `git diff --check`: PASS

Harness only. No release.