### PR TITLE
Enable aligned final tool prefix reuse by default

### DIFF
--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -29,6 +29,12 @@ if str(SRC) not in sys.path:
 from orbit import __version__
 from orbit.backend.base import ChatResult
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
+from orbit.final_prefix_config import (
+    FINAL_PREFIX_EXPERIMENT_ENV,
+    FINAL_PREFIX_REUSE_ENV,
+    FINAL_PREFIX_TOKEN_COUNT,
+    resolve_final_prefix_reuse,
+)
 from orbit.runtime.chat import ChatRuntime
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import current_phase
@@ -559,7 +565,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-tokens", type=int, default=128)
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--repetitions", type=positive_int, default=1)
-    parser.add_argument("--final-prefix-mode", choices=("inherit", "off", "on"), default="inherit")
+    parser.add_argument(
+        "--final-prefix-mode",
+        choices=(
+            "inherit",
+            "off",
+            "on",
+            "legacy-off",
+            "legacy-on",
+            "stable-off-legacy-on",
+            "stable-on-legacy-off",
+            "stable-invalid",
+        ),
+        default="inherit",
+    )
     parser.add_argument("--manage-server", action="store_true", help="Start and stop a native server for this run.")
     parser.add_argument("--server-start-timeout", type=float, default=180.0)
     parser.add_argument("--model")
@@ -1155,6 +1174,7 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "server_command": server_command(args) if args.manage_server else "external",
         "client_command": " ".join(sys.argv),
         "final_prefix": final_prefix_props(props),
+        "final_prefix_config": final_prefix_config_metadata(args.final_prefix_mode, props),
         "block_id": args.block_id,
         "run_order": args.run_order,
         "cooling_seconds": args.cooling_seconds,
@@ -1181,6 +1201,29 @@ def final_prefix_props(props: dict[str, object]) -> dict[str, object]:
     return {name: props.get(source) for name, source in FINAL_PREFIX_PROP_KEYS.items()}
 
 
+def final_prefix_config_metadata(mode: str, props: dict[str, object]) -> dict[str, object]:
+    client = final_prefix_config_for_mode(mode)
+    server_known = "final_prefix_reuse_source" in props
+    server = {
+        "enabled": props.get("final_prefix_reuse_enabled"),
+        "source": props.get("final_prefix_reuse_source"),
+        "config_error": props.get("final_prefix_reuse_config_error"),
+        "legacy_detected": props.get("final_prefix_reuse_legacy_detected"),
+    }
+    client_metadata = {
+        "enabled": client.enabled,
+        "source": client.source,
+        "config_error": client.validation_error,
+        "legacy_detected": client.legacy_detected,
+    }
+    return {
+        "requested": mode,
+        "client": client_metadata,
+        "server": server,
+        "server_client_parity": server == client_metadata if server_known else None,
+    }
+
+
 def final_prefix_step_state(before: dict[str, object], after: dict[str, object]) -> dict[str, object]:
     state = final_prefix_props(after)
     for name in ("capture_count", "restore_count", "fallback_count"):
@@ -1199,13 +1242,14 @@ def final_prefix_validation_failure(
 ) -> str | None:
     state = final_prefix_props(props)
     eligible = [report for report in reports if "final_from_tool" in report.completion_kind]
-    if mode == "off":
+    expected_enabled = final_prefix_mode_enabled(mode)
+    if expected_enabled is False:
         if state.get("enabled") is not False:
             return "off_mode_enabled"
         if any((report.final_prefix.get("capture_count_delta") or 0) > 0 for report in eligible):
             return "off_mode_capture"
         return None
-    if mode != "on":
+    if expected_enabled is not True:
         return "explicit_mode_required"
     if state.get("enabled") is not True:
         return "on_mode_disabled"
@@ -1219,7 +1263,7 @@ def final_prefix_validation_failure(
         return None
     if state.get("fallback_count") not in {0, None}:
         return "fallback_observed"
-    if state.get("prefix_tokens") != 43:
+    if state.get("prefix_tokens") != FINAL_PREFIX_TOKEN_COUNT:
         return "unexpected_prefix_tokens"
     if (state.get("capture_count") or 0) < 1:
         return "capture_missing"
@@ -1316,18 +1360,49 @@ def tool_expectation_result(expected: tuple[str, ...] | None, actual: list[str])
 
 @contextmanager
 def final_prefix_environment(mode: str):
-    previous = os.environ.get("ORBIT_FINAL_PREFIX_EXPERIMENT")
-    if mode == "on":
-        os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"] = "1"
-    elif mode == "off":
-        os.environ.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
+    previous = {name: os.environ.get(name) for name in (FINAL_PREFIX_REUSE_ENV, FINAL_PREFIX_EXPERIMENT_ENV)}
+    apply_final_prefix_mode(os.environ, mode)
     try:
         yield
     finally:
-        if previous is None:
-            os.environ.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
-        else:
-            os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"] = previous
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+FINAL_PREFIX_MODE_VALUES = {
+    "off": {FINAL_PREFIX_REUSE_ENV: "0"},
+    "on": {FINAL_PREFIX_REUSE_ENV: "1"},
+    "legacy-off": {FINAL_PREFIX_EXPERIMENT_ENV: "0"},
+    "legacy-on": {FINAL_PREFIX_EXPERIMENT_ENV: "1"},
+    "stable-off-legacy-on": {FINAL_PREFIX_REUSE_ENV: "0", FINAL_PREFIX_EXPERIMENT_ENV: "1"},
+    "stable-on-legacy-off": {FINAL_PREFIX_REUSE_ENV: "1", FINAL_PREFIX_EXPERIMENT_ENV: "0"},
+    "stable-invalid": {FINAL_PREFIX_REUSE_ENV: "invalid", FINAL_PREFIX_EXPERIMENT_ENV: "1"},
+}
+
+
+def apply_final_prefix_mode(environ: dict[str, str], mode: str) -> None:
+    if mode == "inherit":
+        return
+    environ.pop(FINAL_PREFIX_REUSE_ENV, None)
+    environ.pop(FINAL_PREFIX_EXPERIMENT_ENV, None)
+    environ.update(FINAL_PREFIX_MODE_VALUES[mode])
+
+
+def final_prefix_mode_enabled(mode: str) -> bool | None:
+    if mode == "inherit":
+        return None
+    return final_prefix_config_for_mode(mode).enabled
+
+
+def final_prefix_config_for_mode(mode: str):
+    if mode == "inherit":
+        return resolve_final_prefix_reuse()
+    env: dict[str, str] = {}
+    apply_final_prefix_mode(env, mode)
+    return resolve_final_prefix_reuse(env)
 
 
 @contextmanager
@@ -1397,10 +1472,7 @@ def managed_server(args: argparse.Namespace):
         raise RuntimeError(f"managed server requires an unused base URL: {args.base_url}")
     env = os.environ.copy()
     env["ORBIT_TOOLS"] = args.tools
-    if args.final_prefix_mode == "on":
-        env["ORBIT_FINAL_PREFIX_EXPERIMENT"] = "1"
-    else:
-        env.pop("ORBIT_FINAL_PREFIX_EXPERIMENT", None)
+    apply_final_prefix_mode(env, args.final_prefix_mode)
     process = subprocess.Popen(
         server_command(args),
         cwd=ROOT,
@@ -1412,8 +1484,20 @@ def managed_server(args: argparse.Namespace):
     try:
         wait_for_server(args.base_url, process, args.server_start_timeout)
         props = fresh_backend_props(args.base_url, 2.0)
-        expected_enabled = args.final_prefix_mode == "on"
-        if props.get("final_prefix_experiment_enabled") is not expected_enabled:
+        expected = resolve_final_prefix_reuse(env)
+        actual = (
+            props.get("final_prefix_reuse_enabled"),
+            props.get("final_prefix_reuse_source"),
+            props.get("final_prefix_reuse_config_error"),
+            props.get("final_prefix_reuse_legacy_detected"),
+        )
+        expected_values = (
+            expected.enabled,
+            expected.source,
+            expected.validation_error,
+            expected.legacy_detected,
+        )
+        if actual != expected_values or props.get("final_prefix_experiment_enabled") is not expected.enabled:
             raise RuntimeError("managed server final-prefix mode does not match the requested mode")
         yield process
     finally:
@@ -1689,8 +1773,8 @@ def run_lifecycle_checks(
     jsonl_path: Path,
     markdown_path: Path,
 ) -> int:
-    if args.final_prefix_mode != "on" or not args.manage_server:
-        print("error: lifecycle checks require --manage-server --final-prefix-mode on", file=sys.stderr)
+    if final_prefix_mode_enabled(args.final_prefix_mode) is not True or not args.manage_server:
+        print("error: lifecycle checks require managed server with final-prefix reuse enabled", file=sys.stderr)
         return 2
     reports: list[StepReport] = []
     extra_rows: list[dict[str, object]] = []

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 from dataclasses import replace
 from typing import Any, Callable
@@ -11,6 +10,7 @@ from urllib.request import Request, urlopen
 from .base import ChatResult, Message, ModelInfo, StreamProgress
 from .model_names import resolve_model_display_name
 from .payloads import ChatPayloadOptions, build_chat_payload
+from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 
@@ -724,7 +724,7 @@ def _allow_mtp_experimental_requested(*, native_backend: bool) -> bool | None:
 
 
 def _final_prefix_experiment_requested(*, native_backend: bool) -> bool:
-    if not native_backend or os.environ.get("ORBIT_FINAL_PREFIX_EXPERIMENT") != "1":
+    if not native_backend or not resolve_final_prefix_reuse().enabled:
         return False
     phase = current_phase()
     return current_tools_mode() == "on" and phase is not None and phase.startswith("final_from_tool")

--- a/src/orbit/final_prefix_config.py
+++ b/src/orbit/final_prefix_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Literal, Mapping
+
+
+FINAL_PREFIX_REUSE_ENV = "ORBIT_FINAL_PREFIX_REUSE"
+FINAL_PREFIX_EXPERIMENT_ENV = "ORBIT_FINAL_PREFIX_EXPERIMENT"
+FINAL_PREFIX_TOKEN_COUNT = 64
+
+
+@dataclass(frozen=True)
+class FinalPrefixReuseConfig:
+    enabled: bool
+    source: Literal["stable", "legacy", "default"]
+    raw_value: str | None
+    validation_error: str | None
+    legacy_detected: bool
+
+
+def resolve_final_prefix_reuse(environ: Mapping[str, str] | None = None) -> FinalPrefixReuseConfig:
+    env = os.environ if environ is None else environ
+    legacy_detected = FINAL_PREFIX_EXPERIMENT_ENV in env
+    if FINAL_PREFIX_REUSE_ENV in env:
+        return _resolve_value(
+            env.get(FINAL_PREFIX_REUSE_ENV, ""),
+            source="stable",
+            error="invalid_stable_value",
+            legacy_detected=legacy_detected,
+        )
+    if legacy_detected:
+        return _resolve_value(
+            env.get(FINAL_PREFIX_EXPERIMENT_ENV, ""),
+            source="legacy",
+            error="invalid_legacy_value",
+            legacy_detected=True,
+        )
+    return FinalPrefixReuseConfig(
+        enabled=True,
+        source="default",
+        raw_value=None,
+        validation_error=None,
+        legacy_detected=False,
+    )
+
+
+def _resolve_value(
+    value: str,
+    *,
+    source: Literal["stable", "legacy"],
+    error: str,
+    legacy_detected: bool,
+) -> FinalPrefixReuseConfig:
+    valid = value in {"0", "1"}
+    return FinalPrefixReuseConfig(
+        enabled=value == "1" if valid else False,
+        source=source,
+        raw_value=_bounded_raw_value(value),
+        validation_error=None if valid else error,
+        legacy_detected=legacy_detected,
+    )
+
+
+def _bounded_raw_value(value: str) -> str | None:
+    if len(value) > 16 or not value.isascii() or not value.isprintable():
+        return None
+    return value

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 import threading
 
+from orbit.final_prefix_config import FINAL_PREFIX_TOKEN_COUNT
+
 from .bindings import (
     GgmlAbortCallback,
     GgmlLogCallback,
@@ -67,6 +69,9 @@ class NativeClientConfig:
     mtp_decode_probe_enabled: bool = False
     use_mtp_experimental: bool = False
     final_prefix_experiment_enabled: bool = False
+    final_prefix_reuse_source: str = "default"
+    final_prefix_reuse_config_error: str | None = None
+    final_prefix_reuse_legacy_detected: bool = False
 
 
 @dataclass
@@ -1499,10 +1504,14 @@ class NativeLlamaClient:
         if segments is None:
             return None
         stable_tokens = self.tokenize(segments.stable_prefix_text)
-        if len(prompt_tokens) <= 43 or len(stable_tokens) > 43:
+        if (
+            len(prompt_tokens) <= FINAL_PREFIX_TOKEN_COUNT
+            or len(stable_tokens) != FINAL_PREFIX_TOKEN_COUNT
+            or prompt_tokens[:FINAL_PREFIX_TOKEN_COUNT] != stable_tokens
+        ):
             self._record_final_prefix_fallback("prefix_token_count_mismatch")
             return None
-        prefix_tokens = prompt_tokens[:43]
+        prefix_tokens = stable_tokens
         if segments.full_prompt_text != prompt:
             self._record_final_prefix_fallback("prefix_identity_mismatch")
             return None
@@ -1593,7 +1602,7 @@ class NativeLlamaClient:
         )
         return {
             "model_id": str(self.paths.model),
-            "template_id": f"gemma4-final-prefix-v1:{config_id}",
+            "template_id": f"gemma4-final-prefix-v2:{config_id}",
             "tool_schema_hash": "none",
             "capability_summary_hash": "none",
             "runtime_policy_hash": segments.stable_prefix_hash,

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -12,6 +12,7 @@ import threading
 import time
 from typing import Any, Mapping
 
+from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
 from orbit.native_llama.client import (
     NativeClientConfig,
@@ -45,7 +46,6 @@ PREFIX_PREWARM_ENV = "ORBIT_KV_PREFIX_PREWARM"
 PREFIX_PREWARM_OFF = "off"
 PREFIX_PREWARM_STARTUP = "startup"
 TOOLS_ENV = "ORBIT_TOOLS"
-FINAL_PREFIX_EXPERIMENT_ENV = "ORBIT_FINAL_PREFIX_EXPERIMENT"
 
 
 class OrbitNativeServer:
@@ -230,6 +230,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_last_validate_equivalence = _mtp_last_validate_equivalence_payload(state.client)
             mtp_config = _mtp_config_payload(state.client)
             final_prefix = state.client.final_prefix_experiment_status()
+            final_prefix_config = _final_prefix_reuse_props(state.client)
             self._json(
                 {
                     "model_path": str(state.client.paths.model),
@@ -289,6 +290,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "final_prefix_experiment_failure_reason": final_prefix["failure_reason"],
                     "final_prefix_experiment_last_used": final_prefix["last_used"],
                     "final_prefix_experiment_checkpoint_size_bytes": final_prefix["checkpoint_size_bytes"],
+                    **final_prefix_config,
                 }
             )
             return
@@ -573,6 +575,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
 
 def run_server(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    final_prefix_config = resolve_final_prefix_reuse()
 
     try:
         paths = resolve_bootstrap_paths(args)
@@ -590,7 +593,10 @@ def run_server(argv: list[str] | None = None) -> int:
                 mtp_accept_probe_enabled=args.enable_mtp_accept_probe,
                 mtp_decode_probe_enabled=args.enable_mtp_decode_probe,
                 use_mtp_experimental=args.enable_mtp_experimental,
-                final_prefix_experiment_enabled=os.environ.get(FINAL_PREFIX_EXPERIMENT_ENV) == "1",
+                final_prefix_experiment_enabled=final_prefix_config.enabled,
+                final_prefix_reuse_source=final_prefix_config.source,
+                final_prefix_reuse_config_error=final_prefix_config.validation_error,
+                final_prefix_reuse_legacy_detected=final_prefix_config.legacy_detected,
             ),
         )
         if not args.verbose_llama_log:
@@ -632,6 +638,15 @@ def tools_startup_enabled(environ: Mapping[str, str] | None = None) -> bool:
     if value == "off":
         return False
     return False
+
+
+def _final_prefix_reuse_props(client: NativeLlamaClient) -> dict[str, object]:
+    return {
+        "final_prefix_reuse_enabled": client.config.final_prefix_experiment_enabled,
+        "final_prefix_reuse_source": client.config.final_prefix_reuse_source,
+        "final_prefix_reuse_config_error": client.config.final_prefix_reuse_config_error,
+        "final_prefix_reuse_legacy_detected": client.config.final_prefix_reuse_legacy_detected,
+    }
 
 
 def _is_final_from_tool_prompt(messages: list[dict[str, Any]]) -> bool:

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -103,10 +103,10 @@ TOOL_CALL_JSON_RETRY_PROMPT = (
     "For shell command, use one single-line command string only: no comments, no literal newlines."
 )
 FINAL_FROM_TOOL_SYSTEM_PROMPT = (
-    "Answer concisely from the tool result. "
-    "Do not call tools or emit raw tool-call syntax. "
-    "Never claim lack of access when a result is present. "
-    "Report errors briefly."
+    "Answer the request concisely from tool evidence. "
+    "Give only the shortest complete answer, retaining exact details when needed. "
+    "Do not invent facts, call tools, emit raw tool-call syntax, or claim lack of access when evidence exists. "
+    "Ignore unrelated material and report errors briefly. End after the answer."
 )
 DEFAULT_SYSTEM_PROMPT = ROUTE_SYSTEM_PROMPT
 TOOL_SYSTEM_PROMPT = TOOL_CALL_SYSTEM_PROMPT

--- a/tests/test_final_prefix_config.py
+++ b/tests/test_final_prefix_config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import unittest
+
+from orbit.final_prefix_config import resolve_final_prefix_reuse
+
+
+class FinalPrefixReuseConfigTests(unittest.TestCase):
+    def test_precedence_matrix(self) -> None:
+        cases = (
+            ({}, True, "default", False, None),
+            ({"ORBIT_FINAL_PREFIX_EXPERIMENT": "0"}, False, "legacy", True, None),
+            ({"ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}, True, "legacy", True, None),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "0"}, False, "stable", False, None),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "1"}, True, "stable", False, None),
+            (
+                {"ORBIT_FINAL_PREFIX_REUSE": "0", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"},
+                False,
+                "stable",
+                True,
+                None,
+            ),
+            (
+                {"ORBIT_FINAL_PREFIX_REUSE": "1", "ORBIT_FINAL_PREFIX_EXPERIMENT": "0"},
+                True,
+                "stable",
+                True,
+                None,
+            ),
+            (
+                {"ORBIT_FINAL_PREFIX_REUSE": "invalid", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"},
+                False,
+                "stable",
+                True,
+                "invalid_stable_value",
+            ),
+        )
+        for env, enabled, source, legacy_detected, error in cases:
+            with self.subTest(env=env):
+                result = resolve_final_prefix_reuse(env)
+                self.assertIs(result.enabled, enabled)
+                self.assertEqual(result.source, source)
+                self.assertIs(result.legacy_detected, legacy_detected)
+                self.assertEqual(result.validation_error, error)
+
+    def test_invalid_legacy_value_preserves_disabled_behavior_with_diagnostic(self) -> None:
+        result = resolve_final_prefix_reuse({"ORBIT_FINAL_PREFIX_EXPERIMENT": "old"})
+
+        self.assertFalse(result.enabled)
+        self.assertEqual(result.source, "legacy")
+        self.assertEqual(result.raw_value, "old")
+        self.assertEqual(result.validation_error, "invalid_legacy_value")
+
+    def test_unbounded_or_control_raw_values_are_not_returned(self) -> None:
+        for value in ("x" * 17, "bad\nvalue", "inv\N{SNOWMAN}lid"):
+            with self.subTest(value=value):
+                result = resolve_final_prefix_reuse({"ORBIT_FINAL_PREFIX_REUSE": value})
+                self.assertFalse(result.enabled)
+                self.assertIsNone(result.raw_value)
+                self.assertEqual(result.validation_error, "invalid_stable_value")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -20,6 +20,7 @@ from orbit.backend.llama_server import (
     _parse_chat_stream,
     _parse_model_info,
     _parse_native_stream,
+    _final_prefix_experiment_requested,
 )
 from orbit.backend.base import ChatResult
 from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
@@ -339,10 +340,44 @@ class LlamaServerBackendTests(unittest.TestCase):
                 backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
             with model_call_context(phase="final_from_tool", tools_mode="on"):
                 backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with mock.patch.dict(
+            os.environ,
+            {"ORBIT_FINAL_PREFIX_REUSE": "0", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"},
+            clear=True,
+        ):
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
+        with mock.patch.dict(os.environ, {"ORBIT_FINAL_PREFIX_REUSE": "1"}, clear=True):
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=16)
 
         self.assertNotIn("final_prefix_experiment", backend.payloads[0])
         self.assertNotIn("final_prefix_experiment", backend.payloads[1])
         self.assertTrue(backend.payloads[2]["final_prefix_experiment"])
+        self.assertNotIn("final_prefix_experiment", backend.payloads[3])
+        self.assertTrue(backend.payloads[4]["final_prefix_experiment"])
+
+    def test_final_prefix_stable_configuration_controls_native_payload_request(self) -> None:
+        cases = (
+            ({}, True),
+            ({"ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}, True),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "1"}, True),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "0", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}, False),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "1", "ORBIT_FINAL_PREFIX_EXPERIMENT": "0"}, True),
+            ({"ORBIT_FINAL_PREFIX_REUSE": "invalid", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}, False),
+        )
+        for env, expected in cases:
+            with self.subTest(env=env), mock.patch.dict(os.environ, env, clear=True), model_call_context(
+                phase="final_from_tool", tools_mode="on"
+            ):
+                self.assertIs(_final_prefix_experiment_requested(native_backend=True), expected)
+
+    def test_final_prefix_request_remains_ineligible_without_tools_or_native_backend(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_FINAL_PREFIX_REUSE": "1"}, clear=True):
+            with model_call_context(phase="final_from_tool", tools_mode="off"):
+                self.assertFalse(_final_prefix_experiment_requested(native_backend=True))
+            with model_call_context(phase="final_from_tool", tools_mode="on"):
+                self.assertFalse(_final_prefix_experiment_requested(native_backend=False))
 
     def test_native_kv_diag_payload_carries_phase_only_when_enabled(self) -> None:
         class Backend(LlamaServerBackend):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -57,11 +57,15 @@ class MessagePromptTests(unittest.TestCase):
         self.assertIn("Operate on the latest user request only", TOOL_CALL_SYSTEM_PROMPT)
 
     def test_final_tool_policy_preserves_safety_and_error_guidance(self) -> None:
-        self.assertIn("from the tool result", FINAL_FROM_TOOL_SYSTEM_PROMPT)
-        self.assertIn("Do not call tools", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("from tool evidence", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("shortest complete answer", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("retaining exact details when needed", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("Do not invent facts", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("call tools", FINAL_FROM_TOOL_SYSTEM_PROMPT)
         self.assertIn("raw tool-call syntax", FINAL_FROM_TOOL_SYSTEM_PROMPT)
-        self.assertIn("Never claim lack of access", FINAL_FROM_TOOL_SYSTEM_PROMPT)
-        self.assertIn("Report errors briefly", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("claim lack of access", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("report errors briefly", FINAL_FROM_TOOL_SYSTEM_PROMPT)
+        self.assertIn("End after the answer", FINAL_FROM_TOOL_SYSTEM_PROMPT)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -26,6 +26,7 @@ class _FakeNativeClient:
     instances: list["_FakeNativeClient"] = []
 
     def __init__(self, *_args, **_kwargs) -> None:
+        self.config = _args[1] if len(_args) > 1 else None
         self.loaded = False
         self.closed = False
         self.capture_calls = 0
@@ -389,6 +390,29 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(len(_FakeNativeClient.instances), 1)
         self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 0)
         self.assertIsNotNone(_FakeHTTPServer.instances[0].orbit_state)
+
+    @mock.patch.dict(
+        "os.environ",
+        {"ORBIT_FINAL_PREFIX_REUSE": "0", "ORBIT_FINAL_PREFIX_EXPERIMENT": "1"},
+        clear=True,
+    )
+    def test_run_server_uses_stable_final_prefix_precedence(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths", return_value=SimpleNamespace()),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        config = _FakeNativeClient.instances[0].config
+        self.assertFalse(config.final_prefix_experiment_enabled)
+        self.assertEqual(config.final_prefix_reuse_source, "stable")
+        self.assertTrue(config.final_prefix_reuse_legacy_detected)
+        self.assertIsNone(config.final_prefix_reuse_config_error)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 
 from orbit.native_server.protocol import (
     DEFAULT_SESSION_ID,
@@ -11,9 +12,30 @@ from orbit.native_server.protocol import (
     trim_at_stop,
     validate_session_id,
 )
+from orbit.native_server.app import _final_prefix_reuse_props
 
 
 class NativeServerProtocolTests(unittest.TestCase):
+    def test_final_prefix_reuse_props_are_bounded_configuration_metadata(self) -> None:
+        client = SimpleNamespace(
+            config=SimpleNamespace(
+                final_prefix_experiment_enabled=False,
+                final_prefix_reuse_source="stable",
+                final_prefix_reuse_config_error="invalid_stable_value",
+                final_prefix_reuse_legacy_detected=True,
+            )
+        )
+
+        self.assertEqual(
+            _final_prefix_reuse_props(client),
+            {
+                "final_prefix_reuse_enabled": False,
+                "final_prefix_reuse_source": "stable",
+                "final_prefix_reuse_config_error": "invalid_stable_value",
+                "final_prefix_reuse_legacy_detected": True,
+            },
+        )
+
     def test_parse_chat_request_defaults_to_default_session(self) -> None:
         request = parse_chat_request(
             {

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -158,9 +158,8 @@ def _prefill_hook_client(segments, *, lib=None) -> NativeLlamaClient:
 
 def _final_prefix_client(segments, *, lib=None) -> NativeLlamaClient:
     client = _prefill_hook_client(segments, lib=lib)
-    stable_tokens = list(range(1, 43))
-    prefix_tokens = stable_tokens + [43]
-    full_tokens = prefix_tokens + [44, 45]
+    stable_tokens = list(range(1, 65))
+    full_tokens = stable_tokens + [65, 66]
     client.tokenize = lambda text: {
         segments.stable_prefix_text: stable_tokens,
         segments.full_prompt_text: full_tokens,
@@ -175,7 +174,7 @@ class PrefixAnchorProbeTests(unittest.TestCase):
 
         self.assertFalse(client._final_prefix_experiment_eligible(True))
 
-    def test_final_prefix_capture_then_restore_reuses_exact_43_tokens(self) -> None:
+    def test_final_prefix_capture_then_restore_reuses_exact_64_tokens(self) -> None:
         segments = render_gemma4_route_prompt_segments(
             [
                 {"role": "system", "content": "final policy"},
@@ -192,9 +191,9 @@ class PrefixAnchorProbeTests(unittest.TestCase):
         first_start, first_reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
         second_start, second_reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
 
-        self.assertEqual((first_start, first_reused), (43, 0))
-        self.assertEqual((second_start, second_reused), (43, 43))
-        self.assertEqual(client.lib.lib.current_tokens, list(range(1, 44)))
+        self.assertEqual((first_start, first_reused), (64, 0))
+        self.assertEqual((second_start, second_reused), (64, 64))
+        self.assertEqual(client.lib.lib.current_tokens, list(range(1, 65)))
         self.assertEqual(client.final_prefix_experiment_status()["capture_count"], 1)
         self.assertEqual(client.final_prefix_experiment_status()["restore_count"], 1)
         self.assertTrue(client.final_prefix_experiment_status()["last_used"])
@@ -212,7 +211,7 @@ class PrefixAnchorProbeTests(unittest.TestCase):
         prompt_tokens = client.tokenize(segments.full_prompt_text)
         client._final_prefix_anchor_state = PrefixAnchorState(
             prefix_hash="different",
-            token_count=43,
+            token_count=64,
             valid=True,
             checkpoint_size=1,
             checkpoint_data=b"x",
@@ -228,6 +227,38 @@ class PrefixAnchorProbeTests(unittest.TestCase):
         normal_prefill.assert_called_once_with(prompt_tokens)
         self.assertEqual(client.final_prefix_experiment_status()["failure_reason"], "prefix_hash_changed")
         self.assertEqual(client.final_prefix_experiment_status()["fallback_count"], 1)
+
+    def test_stale_43_token_checkpoint_is_rejected_before_64_token_recapture(self) -> None:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": "final policy"},
+                {"role": "user", "content": "request"},
+                {"role": "system", "content": "evidence"},
+            ],
+            thinking=False,
+        )
+        client = _final_prefix_client(segments)
+        prompt_tokens = client.tokenize(segments.full_prompt_text)
+        client._final_prefix_anchor_state = PrefixAnchorState(
+            prefix_hash="stale-43-token-checkpoint",
+            token_count=43,
+            valid=True,
+            checkpoint_size=1,
+            checkpoint_data=b"x",
+        )
+        plan = client._final_prefix_plan(segments.full_prompt_text, prompt_tokens, segments)
+
+        with patch.object(client, "_prepare_memory_for_prompt", return_value=0) as normal_prefill:
+            start, reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+
+        self.assertEqual((start, reused), (0, 0))
+        normal_prefill.assert_called_once_with(prompt_tokens)
+        self.assertFalse(client.final_prefix_experiment_status()["initialized"])
+        self.assertEqual(client.final_prefix_experiment_status()["failure_reason"], "prefix_hash_changed")
+
+        start, reused = client._prepare_memory_with_final_prefix(plan, prompt_tokens)  # type: ignore[arg-type]
+        self.assertEqual((start, reused), (64, 0))
+        self.assertEqual(client.final_prefix_experiment_status()["prefix_tokens"], 64)
 
     def test_final_prefix_restore_failure_uses_normal_prefill(self) -> None:
         segments = render_gemma4_route_prompt_segments(

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -373,6 +373,10 @@ class SmokeHarnessTests(unittest.TestCase):
                 "ubatch_size": 128,
                 "final_prefix_experiment_enabled": True,
                 "final_prefix_experiment_restore_count": 2,
+                "final_prefix_reuse_enabled": True,
+                "final_prefix_reuse_source": "stable",
+                "final_prefix_reuse_config_error": None,
+                "final_prefix_reuse_legacy_detected": False,
             },
         )
 
@@ -380,6 +384,9 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(env["scenario"], ["final_prefix_local"])
         self.assertEqual(env["ctx"], 8192)
         self.assertEqual(env["final_prefix"]["restore_count"], 2)
+        self.assertEqual(env["final_prefix_config"]["requested"], "on")
+        self.assertTrue(env["final_prefix_config"]["server_client_parity"])
+        self.assertNotIn("raw_value", env["final_prefix_config"]["client"])
         self.assertEqual(env["timeout"], 30.0)
         self.assertEqual(env["block_id"], "abba-1-on-a")
         self.assertEqual(env["run_order"], "ON")
@@ -387,14 +394,41 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertIsInstance(env["cpu_affinity"], list)
 
     def test_final_prefix_environment_controls_client_flag_and_restores_it(self) -> None:
-        with mock.patch.dict("os.environ", {"ORBIT_FINAL_PREFIX_EXPERIMENT": "old"}, clear=False):
+        with mock.patch.dict(
+            "os.environ",
+            {"ORBIT_FINAL_PREFIX_REUSE": "old-stable", "ORBIT_FINAL_PREFIX_EXPERIMENT": "old-legacy"},
+            clear=False,
+        ):
             with smoke_harness.final_prefix_environment("on"):
-                self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "1")
-            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old")
+                self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_REUSE"], "1")
+                self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", smoke_harness.os.environ)
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_REUSE"], "old-stable")
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old-legacy")
 
             with smoke_harness.final_prefix_environment("off"):
+                self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_REUSE"], "0")
                 self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", smoke_harness.os.environ)
-            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old")
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_REUSE"], "old-stable")
+            self.assertEqual(smoke_harness.os.environ["ORBIT_FINAL_PREFIX_EXPERIMENT"], "old-legacy")
+
+    def test_final_prefix_harness_modes_cover_stable_legacy_conflict_and_invalid(self) -> None:
+        expected = {
+            "off": (False, "stable", None, False),
+            "on": (True, "stable", None, False),
+            "legacy-off": (False, "legacy", None, True),
+            "legacy-on": (True, "legacy", None, True),
+            "stable-off-legacy-on": (False, "stable", None, True),
+            "stable-on-legacy-off": (True, "stable", None, True),
+            "stable-invalid": (False, "stable", "invalid_stable_value", True),
+        }
+        for mode, values in expected.items():
+            with self.subTest(mode=mode), mock.patch.dict(smoke_harness.os.environ, {}, clear=True):
+                with smoke_harness.final_prefix_environment(mode):
+                    resolved = smoke_harness.resolve_final_prefix_reuse()
+                    self.assertEqual(
+                        (resolved.enabled, resolved.source, resolved.validation_error, resolved.legacy_detected),
+                        values,
+                    )
 
     def test_managed_server_passes_final_prefix_flag_only_when_on(self) -> None:
         args = smoke_harness.build_parser().parse_args(["--manage-server", "--final-prefix-mode", "on"])
@@ -406,11 +440,21 @@ class SmokeHarnessTests(unittest.TestCase):
             mock.patch.object(
                 smoke_harness,
                 "fresh_backend_props",
-                side_effect=[{}, {"final_prefix_experiment_enabled": True}],
+                side_effect=[
+                    {},
+                    {
+                        "final_prefix_experiment_enabled": True,
+                        "final_prefix_reuse_enabled": True,
+                        "final_prefix_reuse_source": "stable",
+                        "final_prefix_reuse_config_error": None,
+                        "final_prefix_reuse_legacy_detected": False,
+                    },
+                ],
             ):
             with smoke_harness.managed_server(args):
                 pass
-        self.assertEqual(popen.call_args.kwargs["env"]["ORBIT_FINAL_PREFIX_EXPERIMENT"], "1")
+        self.assertEqual(popen.call_args.kwargs["env"]["ORBIT_FINAL_PREFIX_REUSE"], "1")
+        self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", popen.call_args.kwargs["env"])
 
         args = smoke_harness.build_parser().parse_args(["--manage-server", "--final-prefix-mode", "off"])
         with mock.patch.dict(smoke_harness.os.environ, {"ORBIT_FINAL_PREFIX_EXPERIMENT": "1"}), \
@@ -419,10 +463,20 @@ class SmokeHarnessTests(unittest.TestCase):
             mock.patch.object(
                 smoke_harness,
                 "fresh_backend_props",
-                side_effect=[{}, {"final_prefix_experiment_enabled": False}],
+                side_effect=[
+                    {},
+                    {
+                        "final_prefix_experiment_enabled": False,
+                        "final_prefix_reuse_enabled": False,
+                        "final_prefix_reuse_source": "stable",
+                        "final_prefix_reuse_config_error": None,
+                        "final_prefix_reuse_legacy_detected": False,
+                    },
+                ],
             ):
             with smoke_harness.managed_server(args):
                 pass
+        self.assertEqual(popen.call_args.kwargs["env"]["ORBIT_FINAL_PREFIX_REUSE"], "0")
         self.assertNotIn("ORBIT_FINAL_PREFIX_EXPERIMENT", popen.call_args.kwargs["env"])
 
     def test_managed_server_rejects_an_already_used_base_url(self) -> None:
@@ -454,7 +508,16 @@ class SmokeHarnessTests(unittest.TestCase):
             mock.patch.object(
                 smoke_harness,
                 "fresh_backend_props",
-                side_effect=[{}, {"final_prefix_experiment_enabled": False}],
+                side_effect=[
+                    {},
+                    {
+                        "final_prefix_experiment_enabled": True,
+                        "final_prefix_reuse_enabled": True,
+                        "final_prefix_reuse_source": "default",
+                        "final_prefix_reuse_config_error": None,
+                        "final_prefix_reuse_legacy_detected": False,
+                    },
+                ],
             ):
             with smoke_harness.managed_server(args):
                 pass
@@ -477,7 +540,7 @@ class SmokeHarnessTests(unittest.TestCase):
         after = {
             "final_prefix_experiment_enabled": True,
             "final_prefix_experiment_initialized": True,
-            "final_prefix_experiment_prefix_tokens": 43,
+            "final_prefix_experiment_prefix_tokens": 64,
             "final_prefix_experiment_capture_count": 1,
             "final_prefix_experiment_restore_count": 4,
             "final_prefix_experiment_fallback_count": 0,
@@ -488,7 +551,7 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(state["capture_count_delta"], 0)
         self.assertEqual(state["restore_count_delta"], 1)
         self.assertEqual(state["fallback_count_delta"], 0)
-        self.assertEqual(state["prefix_tokens"], 43)
+        self.assertEqual(state["prefix_tokens"], 64)
 
     def test_final_prefix_validation_encodes_off_capture_and_on_restore_contract(self) -> None:
         final = smoke_harness.StepReport(
@@ -500,7 +563,7 @@ class SmokeHarnessTests(unittest.TestCase):
             route_tokens=800,
             final_tokens=100,
             prompt_tokens=100,
-            cached_tokens=43,
+            cached_tokens=64,
             evaluated_tokens=57,
             finish_reason="stop",
             tool_calls=1,
@@ -520,7 +583,7 @@ class SmokeHarnessTests(unittest.TestCase):
         }
         on_props = {
             "final_prefix_experiment_enabled": True,
-            "final_prefix_experiment_prefix_tokens": 43,
+            "final_prefix_experiment_prefix_tokens": 64,
             "final_prefix_experiment_capture_count": 1,
             "final_prefix_experiment_restore_count": 1,
             "final_prefix_experiment_fallback_count": 0,
@@ -1142,10 +1205,10 @@ class SmokeHarnessTests(unittest.TestCase):
         rows = []
         for cached, evaluated, wall, restore in (
             (4, 96, 20.0, 0),
-            (43, 57, 14.0, 1),
-            (43, 57, 15.0, 1),
-            (43, 57, 13.0, 1),
-            (43, 57, 16.0, 1),
+            (64, 36, 14.0, 1),
+            (64, 36, 15.0, 1),
+            (64, 36, 13.0, 1),
+            (64, 36, 16.0, 1),
         ):
             rows.append(
                 smoke_harness.StepReport(
@@ -1176,12 +1239,12 @@ class SmokeHarnessTests(unittest.TestCase):
 
         summary = smoke_harness.summarize_reports(rows)[0]
 
-        self.assertEqual(summary["cached_tokens"]["median"], 43.0)
-        self.assertEqual(summary["evaluated_tokens"]["median"], 57.0)
+        self.assertEqual(summary["cached_tokens"]["median"], 64.0)
+        self.assertEqual(summary["evaluated_tokens"]["median"], 36.0)
         self.assertEqual(summary["runs"], 5)
         self.assertEqual(summary["restore_delta"], 4)
         self.assertEqual(summary["restored"]["runs"], 4)
-        self.assertEqual(summary["restored"]["cached_tokens"]["min"], 43.0)
+        self.assertEqual(summary["restored"]["cached_tokens"]["min"], 64.0)
 
     def test_summary_aggregates_fifty_stability_calls(self) -> None:
         row = smoke_harness.StepReport(
@@ -1193,8 +1256,8 @@ class SmokeHarnessTests(unittest.TestCase):
             route_tokens=780,
             final_tokens=100,
             prompt_tokens=100,
-            cached_tokens=43,
-            evaluated_tokens=57,
+            cached_tokens=64,
+            evaluated_tokens=36,
             finish_reason="stop",
             tool_calls=1,
             tool_names=["exec_shell_full_command"],


### PR DESCRIPTION
- Replaces the experimental 43-token boundary with an exact meaningful 64-token final_from_tool prefix.
- Cold, segmented and restored paths are bit-exact across 11 final families.
- Eliminates the previous read truncation regression.
- Enables reuse by default for eligible finals.
- Adds ORBIT_FINAL_PREFIX_REUSE=0 as an immediate kill switch.
- Retains legacy flag compatibility and MTP/tools/thinking guards.
- Restored calls save 36 evaluated tokens versus current production, with break-even on the second eligible final.
- No deterministic wall-time guarantee.
- Tests: full suite 1,067 PASS.
- No release.
