### PR TITLE
Add native backend compatibility observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,6 +373,16 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - Do not expand the healing whitelist or add a nudge retry without natural, repeatable malformed tool-call events observed at the production budget. Any expansion still requires zero false positives and unsafe acceptance in a sufficiently large real sample; replay-only evidence is insufficient.
 - A future tool-selection reliability investigation must be separate from formal healing. It may measure wrong-tool and unwanted-tool decisions, but must not add fuzzy matching, deterministic semantic routing, invented arguments, or tool substitution to this mechanism.
 
+## Native Backend Compatibility Observability
+
+- Native `/props` exposes a bounded `native_backend_capabilities` manifest for the `orbit-gemma4-native-v1` profile. It is observational and must not alter startup eligibility, inference, routing, tools, healing, MTP, or final-prefix behavior.
+- The manifest fingerprints the loaded `llama.cpp` build and library, the exact aligned final-prefix tokenizer boundary, and a versioned Gemma 4 renderer fixture suite. It contains hashes and bounded identifiers only; prompts, outputs, evidence, tool arguments, model paths, and environment values are excluded.
+- Renderer conformance covers tool declaration/generation, a complete tool round trip, nested and escaped argument shapes, and tool error responses. Golden fixture hashes are checked in explicitly; expectations must never be derived from the implementation under test.
+- `verified` means the reviewed backend commit, renderer fixtures, and tokenizer boundary all match. A new backend commit reports `backend_unverified` and remains usable so that its behavior can be measured. Renderer or tokenizer mismatch remains diagnostic and must not be silently treated as verified.
+- The generation-only benchmark records a versioned corpus hash, an actual tool-mode protocol hash covering the production system prompt and registered schemas, and a hash of the generation-affecting configuration. Raw corpus prompts and schemas are not copied into comparison output.
+- `scripts/compare_tool_call_generation.py` is an offline gate. It accepts an unverified backend revision only when corpus, sample set, protocol, configuration, renderer suite, and tokenizer identity remain comparable. It rejects semantic regressions, markup leakage, multiple candidates, tool execution, finalization, and extra model calls. Timing deltas are informational only.
+- Do not make the capability manifest a runtime startup gate without separate evidence and an explicit rollback path. Use it to identify drift, then run the versioned conformance corpus before accepting a new backend or template revision.
+
 ## Current Route Priority
 
 - Keep #142: structurally covered evidence omission is effective whenever a valid `CHAT` decision reaches the normal `chat_final` path, and its conservative lifecycle fallbacks remain required.
@@ -381,6 +391,7 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 
 ## Main Commits
 
+- `b7207aa` Add canonical tool-call validation and deterministic healing (#149)
 - `73ec021` Add release notes for v0.0.1-rc20
 - `6330d85` Enable aligned final tool prefix reuse by default (#147)
 - `000fbfe` Record route and argument validation technical stops (#146)

--- a/docs/NATIVE_BACKEND_CAPABILITIES.md
+++ b/docs/NATIVE_BACKEND_CAPABILITIES.md
@@ -1,0 +1,55 @@
+# Native Backend Capability Manifest
+
+Orbit exposes a bounded, observational Gemma 4 compatibility manifest under
+`native_backend_capabilities` in the native server `/props` response.
+
+The manifest records:
+
+- the `llama.cpp` build number, commit, target, compiler, and runtime-library hash;
+- the Orbit Gemma 4 renderer profile and a versioned fixture suite covering
+  tool declarations, tool generation, structured argument rendering, and tool
+  responses;
+- the exact 64-token `final_from_tool` prefix hash and next dynamic token;
+- whether the current build, renderer, and tokenizer match the validated profile.
+
+The initial profile is `orbit-gemma4-native-v1`. A `verified` status requires
+the checked-in renderer fixtures, the production tokenizer probe, and an
+explicitly reviewed `llama.cpp` commit to match. New backend revisions remain
+usable but report `backend_unverified` until their conformance corpus is
+reviewed.
+
+`verified` is deliberately scoped to backend identity and prompt/tokenizer
+conformance. It is not a claim that every inference output is equivalent or
+that a backend revision is performance-positive.
+
+This manifest does not alter startup, inference, routing, tool execution,
+healing, MTP, or final-prefix eligibility. It is intended to make backend and
+template drift visible before a behavioral compatibility decision is made.
+
+The manifest contains hashes and bounded build metadata only. It does not
+include prompts, model output, evidence, tool arguments, environment values, or
+model paths.
+
+Renderer fixtures are golden hashes, not self-derived expectations. A drifted
+fixture identifies the affected rendering family while the aggregate suite
+hash provides one bounded compatibility identity. Fixture text and synthetic
+arguments are never exposed through `/props` or benchmark JSONL.
+
+The `--tool-call-generation-only` smoke-harness mode records this redacted
+identity together with a versioned corpus hash. This makes results comparable
+across backend and template revisions without copying corpus prompts into the
+JSONL output. The manifest is stored once in the environment and summary rows,
+not repeated for every generated sample.
+
+Use `scripts/compare_tool_call_generation.py BASELINE.jsonl CANDIDATE.jsonl`
+for an offline comparison. The comparison refuses different corpus or sample
+sets, tool-mode protocol fingerprints, or comparable runtime configurations.
+It reports backend/template identity changes and fails on new semantic
+tool-selection failures, markup leakage, multiple candidates, tool execution,
+finalization, or additional model calls. Timing deltas are reported but are not
+treated as deterministic correctness evidence.
+
+A new, unreviewed backend commit remains comparable: the behavioral corpus is
+the evidence needed to review it. A missing manifest or renderer/tokenizer
+mismatch is instead non-comparable because the generation-only corpus does not
+prove final-prefix or template conformance.

--- a/scripts/compare_tool_call_generation.py
+++ b/scripts/compare_tool_call_generation.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+
+
+METRICS = (
+    "completion_rate",
+    "valid_first_pass_rate",
+    "exact_tool_match_rate",
+    "model_unwanted_attempt_rate",
+    "detector_false_positive_rate",
+    "detector_false_negative_rate",
+    "multiple_candidate_rate",
+    "budget_truncation_rate",
+    "structural_truncation_rate",
+    "markup_leakage_rate",
+    "generation_wall_ms_median",
+    "generation_wall_ms_p95",
+    "healing_us_median",
+    "healing_us_p95",
+)
+
+NONCOMPARABLE_BLOCKERS = {
+    "baseline_capability_unavailable",
+    "baseline_renderer_or_tokenizer_mismatch",
+    "capability_contract_mismatch",
+    "candidate_capability_unavailable",
+    "candidate_renderer_or_tokenizer_mismatch",
+    "configuration_mismatch",
+    "corpus_mismatch",
+    "protocol_mismatch",
+    "sample_set_mismatch",
+}
+
+
+@dataclass(frozen=True)
+class GenerationRun:
+    environment: dict[str, object]
+    samples: dict[tuple[str, int], dict[str, object]]
+    summary: dict[str, object]
+
+
+class ComparisonInputError(ValueError):
+    pass
+
+
+def load_generation_run(path: Path) -> GenerationRun:
+    environments: list[dict[str, object]] = []
+    summaries: list[dict[str, object]] = []
+    samples: dict[tuple[str, int], dict[str, object]] = {}
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            for line in stream:
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise ComparisonInputError("row_not_object")
+                row_type = value.get("type")
+                if row_type == "environment":
+                    environments.append(value)
+                elif row_type == "tool_call_generation_summary":
+                    summaries.append(value)
+                elif row_type == "tool_call_generation":
+                    key = _sample_key(value)
+                    if key in samples:
+                        raise ComparisonInputError("duplicate_sample")
+                    samples[key] = value
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ComparisonInputError(f"unreadable_jsonl:{type(exc).__name__}") from exc
+    if len(environments) != 1 or environments[0].get("benchmark_mode") != "tool_call_generation_only":
+        raise ComparisonInputError("missing_generation_environment")
+    if len(summaries) != 1:
+        raise ComparisonInputError("missing_generation_summary")
+    if not samples:
+        raise ComparisonInputError("missing_generation_samples")
+    return GenerationRun(environments[0], samples, summaries[0])
+
+
+def compare_generation_runs(baseline: GenerationRun, candidate: GenerationRun) -> dict[str, object]:
+    blockers: list[str] = []
+    baseline_corpus = _corpus_identity(baseline.environment)
+    candidate_corpus = _corpus_identity(candidate.environment)
+    if baseline_corpus != candidate_corpus or None in baseline_corpus:
+        blockers.append("corpus_mismatch")
+
+    baseline_protocol = _versioned_hash_identity(baseline.environment, "protocol")
+    candidate_protocol = _versioned_hash_identity(candidate.environment, "protocol")
+    if baseline_protocol != candidate_protocol or None in baseline_protocol:
+        blockers.append("protocol_mismatch")
+
+    baseline_configuration = _versioned_hash_identity(baseline.environment, "configuration")
+    candidate_configuration = _versioned_hash_identity(candidate.environment, "configuration")
+    if baseline_configuration != candidate_configuration or None in baseline_configuration:
+        blockers.append("configuration_mismatch")
+
+    blockers.extend(_capability_blockers("baseline", baseline.environment.get("native_backend_capabilities")))
+    blockers.extend(_capability_blockers("candidate", candidate.environment.get("native_backend_capabilities")))
+    if _capability_contract_identity(baseline.environment) != _capability_contract_identity(candidate.environment):
+        blockers.append("capability_contract_mismatch")
+
+    baseline_keys = set(baseline.samples)
+    candidate_keys = set(candidate.samples)
+    if baseline_keys != candidate_keys:
+        blockers.append("sample_set_mismatch")
+
+    if not NONCOMPARABLE_BLOCKERS.intersection(blockers):
+        blockers.extend(_sample_regressions(baseline.samples, candidate.samples))
+
+    if _safe_count(candidate.summary.get("tools_executed")) != 0:
+        blockers.append("candidate_executed_tool")
+    if _safe_count(candidate.summary.get("finalizations_started")) != 0:
+        blockers.append("candidate_started_finalization")
+    if _safe_count(candidate.summary.get("model_calls")) != len(candidate.samples):
+        blockers.append("candidate_model_call_count")
+
+    deltas = {metric: _numeric_delta(baseline.summary.get(metric), candidate.summary.get(metric)) for metric in METRICS}
+    comparable = not NONCOMPARABLE_BLOCKERS.intersection(blockers)
+    return {
+        "type": "tool_call_generation_comparison",
+        "decision": "pass" if not blockers else "fail" if comparable else "incomparable",
+        "comparable": comparable,
+        "corpus": {"version": baseline_corpus[0], "hash": baseline_corpus[1]},
+        "protocol": {"version": baseline_protocol[0], "hash": baseline_protocol[1]},
+        "configuration": {"version": baseline_configuration[0], "hash": baseline_configuration[1]},
+        "baseline": _run_identity(baseline),
+        "candidate": _run_identity(candidate),
+        "identity_changes": _identity_changes(baseline.environment, candidate.environment),
+        "metric_deltas": deltas,
+        "blockers": sorted(set(blockers)),
+        "raw_content_included": False,
+    }
+
+
+def _sample_regressions(
+    baseline: dict[tuple[str, int], dict[str, object]],
+    candidate: dict[tuple[str, int], dict[str, object]],
+) -> list[str]:
+    blockers: list[str] = []
+    for key in sorted(baseline):
+        before = baseline[key]
+        after = candidate[key]
+        if before.get("expected_tool") != after.get("expected_tool"):
+            blockers.append("expected_tool_mismatch")
+        if before.get("template") != after.get("template"):
+            blockers.append("template_mismatch")
+        if before.get("evaluable") is True and after.get("evaluable") is not True:
+            blockers.append("completion_regression")
+        if before.get("semantic_outcome") == "expected_tool" and after.get("semantic_outcome") != "expected_tool":
+            blockers.append("tool_selection_regression")
+        if before.get("semantic_outcome") == "no_attempt" and after.get("semantic_outcome") != "no_attempt":
+            blockers.append("negative_false_positive_regression")
+        for field, blocker in (
+            ("multiple_candidates", "multiple_candidate_regression"),
+            ("markup_leakage", "markup_leakage_regression"),
+            ("tool_executed", "sample_tool_execution"),
+            ("finalization_started", "sample_finalization"),
+        ):
+            if before.get(field) is not True and after.get(field) is True:
+                blockers.append(blocker)
+        if _safe_count(after.get("model_calls")) != 1:
+            blockers.append("sample_model_call_count")
+    return blockers
+
+
+def _run_identity(run: GenerationRun) -> dict[str, object]:
+    capability = _capability_identity(run.environment.get("native_backend_capabilities"))
+    return {
+        "samples": len(run.samples),
+        "model": _safe_identifier(run.environment.get("model")),
+        "mtp": _safe_identifier(run.environment.get("mtp")),
+        "protocol": _versioned_hash_mapping(run.environment, "protocol"),
+        "configuration": _versioned_hash_mapping(run.environment, "configuration"),
+        "capability": capability,
+    }
+
+
+def _identity_changes(baseline: dict[str, object], candidate: dict[str, object]) -> dict[str, bool]:
+    before = _capability_identity(baseline.get("native_backend_capabilities"))
+    after = _capability_identity(candidate.get("native_backend_capabilities"))
+    return {
+        "profile": before.get("profile_id") != after.get("profile_id"),
+        "backend_commit": before.get("backend_commit") != after.get("backend_commit"),
+        "backend_library": before.get("backend_library_hash") != after.get("backend_library_hash"),
+        "tool_protocol": before.get("tool_protocol_text_hash") != after.get("tool_protocol_text_hash"),
+        "final_prefix": before.get("final_prefix_text_hash") != after.get("final_prefix_text_hash"),
+        "renderer_fixture_suite": before.get("renderer_fixture_suite_hash") != after.get("renderer_fixture_suite_hash"),
+        "tokenizer": before.get("tokenizer_prefix_hash") != after.get("tokenizer_prefix_hash"),
+    }
+
+
+def _capability_identity(value: object) -> dict[str, object]:
+    manifest = value if isinstance(value, dict) else {}
+    build_number = manifest.get("backend_build_number")
+    return {
+        "profile_id": _safe_identifier(manifest.get("profile_id")),
+        "status": _safe_identifier(manifest.get("status")),
+        "backend_build_number": build_number if isinstance(build_number, int) and not isinstance(build_number, bool) else None,
+        "backend_commit": _safe_identifier(manifest.get("backend_commit")),
+        "backend_library_hash": _safe_hash(manifest.get("backend_library_hash")),
+        "tool_protocol_text_hash": _safe_hash(manifest.get("tool_protocol_text_hash")),
+        "final_prefix_text_hash": _safe_hash(manifest.get("final_prefix_text_hash")),
+        "renderer_fixture_suite_hash": _safe_hash(manifest.get("renderer_fixture_suite_hash")),
+        "tokenizer_prefix_hash": _safe_hash(manifest.get("tokenizer_prefix_hash")),
+    }
+
+
+def _corpus_identity(environment: dict[str, object]) -> tuple[int | None, str | None]:
+    version = environment.get("corpus_version")
+    return (
+        version if isinstance(version, int) and not isinstance(version, bool) else None,
+        _safe_hash(environment.get("corpus_hash")),
+    )
+
+
+def _versioned_hash_identity(environment: dict[str, object], name: str) -> tuple[int | None, str | None]:
+    version = environment.get(f"{name}_version")
+    return (
+        version if isinstance(version, int) and not isinstance(version, bool) else None,
+        _safe_hash(environment.get(f"{name}_hash")),
+    )
+
+
+def _versioned_hash_mapping(environment: dict[str, object], name: str) -> dict[str, object]:
+    version, value_hash = _versioned_hash_identity(environment, name)
+    return {"version": version, "hash": value_hash}
+
+
+def _capability_blockers(label: str, value: object) -> list[str]:
+    capability = _capability_identity(value)
+    status = capability.get("status")
+    if capability.get("profile_id") is None or status is None:
+        return [f"{label}_capability_unavailable"]
+    if any(
+        capability.get(field) is None
+        for field in (
+            "tool_protocol_text_hash",
+            "final_prefix_text_hash",
+            "renderer_fixture_suite_hash",
+            "tokenizer_prefix_hash",
+        )
+    ):
+        return [f"{label}_capability_unavailable"]
+    if status not in {"verified", "backend_unverified"}:
+        return [f"{label}_renderer_or_tokenizer_mismatch"]
+    return []
+
+
+def _capability_contract_identity(environment: dict[str, object]) -> tuple[object, ...]:
+    capability = _capability_identity(environment.get("native_backend_capabilities"))
+    return (
+        capability.get("profile_id"),
+        capability.get("tool_protocol_text_hash"),
+        capability.get("final_prefix_text_hash"),
+        capability.get("renderer_fixture_suite_hash"),
+        capability.get("tokenizer_prefix_hash"),
+    )
+
+
+def _sample_key(row: dict[str, object]) -> tuple[str, int]:
+    scenario = _safe_identifier(row.get("scenario"))
+    repetition = row.get("repetition")
+    if scenario is None or not isinstance(repetition, int) or isinstance(repetition, bool) or repetition < 1:
+        raise ComparisonInputError("invalid_sample_identity")
+    return scenario, repetition
+
+
+def _safe_identifier(value: object, *, limit: int = 96) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > limit:
+        return None
+    if not all(character.isalnum() or character in {"_", "-", ".", ":"} for character in value):
+        return None
+    return value
+
+
+def _safe_hash(value: object) -> str | None:
+    if not isinstance(value, str) or len(value) != 64:
+        return None
+    return value if all(character in "0123456789abcdef" for character in value) else None
+
+
+def _numeric_delta(before: object, after: object) -> float | None:
+    if isinstance(before, bool) or isinstance(after, bool):
+        return None
+    if not isinstance(before, int | float) or not isinstance(after, int | float):
+        return None
+    return round(float(after) - float(before), 6)
+
+
+def _safe_count(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else -1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compare two redacted Orbit tool-call generation benchmark JSONL files.")
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = compare_generation_runs(load_generation_run(args.baseline), load_generation_run(args.candidate))
+    except ComparisonInputError as exc:
+        print(json.dumps({"type": "tool_call_generation_comparison", "decision": "invalid", "error": str(exc)}))
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["decision"] == "pass" else 2 if result["decision"] == "incomparable" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -43,7 +43,7 @@ from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import current_phase
 from orbit.runtime.kv_diag import model_call_context
-from orbit.runtime.messages import DEFAULT_SYSTEM_PROMPT, with_tool_call_system_prompt
+from orbit.runtime.messages import DEFAULT_SYSTEM_PROMPT, TOOL_CALL_SYSTEM_PROMPT, with_tool_call_system_prompt
 from orbit.runtime.tool_backends import HybridToolExecutor
 from orbit.runtime.tool_healing import analyze_tool_attempt, tool_call_healing_status
 from orbit.runtime.tools import TOOL_NAMES, tool_definitions
@@ -280,6 +280,9 @@ TOOL_CALL_GENERATION_CORPUS = (
         "Answer only: no tool is required.",
     ), 1)),
 )
+TOOL_CALL_GENERATION_CORPUS_VERSION = 1
+TOOL_CALL_GENERATION_PROTOCOL_VERSION = 1
+TOOL_CALL_GENERATION_CONFIGURATION_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -982,11 +985,28 @@ def run_tool_call_generation_benchmark(
                 "benchmark_mode": "tool_call_generation_only",
                 "server_pid": server_process.pid if server_process is not None else None,
                 "corpus_size": len(corpus),
+                "corpus_version": TOOL_CALL_GENERATION_CORPUS_VERSION,
+                "corpus_hash": tool_call_generation_corpus_hash(corpus),
+                "protocol_version": TOOL_CALL_GENERATION_PROTOCOL_VERSION,
+                "protocol_hash": tool_call_generation_protocol_hash(),
                 "repetitions": args.repetitions,
                 "mtp_tool_mode_eligible": False,
             }
         )
+        env["configuration_version"] = TOOL_CALL_GENERATION_CONFIGURATION_VERSION
+        env["configuration_hash"] = tool_call_generation_configuration_hash(env)
     summary = summarize_tool_call_generation(rows, mtp=env.get("mtp"))
+    summary.update(
+        {
+            "corpus_version": env.get("corpus_version"),
+            "corpus_hash": env.get("corpus_hash"),
+            "protocol_version": env.get("protocol_version"),
+            "protocol_hash": env.get("protocol_hash"),
+            "configuration_version": env.get("configuration_version"),
+            "configuration_hash": env.get("configuration_hash"),
+            "native_backend_capabilities": env.get("native_backend_capabilities"),
+        }
+    )
     write_tool_call_generation_jsonl(jsonl_path, env, rows, summary)
     write_tool_call_generation_markdown(markdown_path, env, summary)
     print(f"jsonl={jsonl_path}")
@@ -1002,6 +1022,50 @@ def tool_call_generation_corpus(*, smoke: bool) -> tuple[tuple[str, str | None, 
         "fetch_url_1", "exec_shell_1", "negative_1", "negative_6",
     }
     return tuple(item for item in TOOL_CALL_GENERATION_CORPUS if item[0] in selected)
+
+
+def tool_call_generation_corpus_hash(corpus: tuple[tuple[str, str | None, str], ...]) -> str:
+    payload = json.dumps(corpus, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def tool_call_generation_protocol_hash() -> str:
+    payload = {
+        "version": TOOL_CALL_GENERATION_PROTOCOL_VERSION,
+        "template": "production_tool_call_system_prompt",
+        "system_prompt": TOOL_CALL_SYSTEM_PROMPT,
+        "tools": tool_definitions(TOOL_NAMES),
+    }
+    serialized = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def tool_call_generation_configuration_hash(environment: dict[str, object]) -> str:
+    payload = {
+        "version": TOOL_CALL_GENERATION_CONFIGURATION_VERSION,
+        "model": environment.get("model"),
+        "backend": environment.get("backend"),
+        "thinking": environment.get("thinking"),
+        "mtp": environment.get("mtp"),
+        "mtp_requested": environment.get("mtp_requested"),
+        "mtp_session_ready": environment.get("mtp_session_ready"),
+        "mtp_usable": environment.get("mtp_usable"),
+        "mmproj": environment.get("mmproj"),
+        "tools": environment.get("tools"),
+        "timeout": environment.get("timeout"),
+        "max_tokens": environment.get("max_tokens"),
+        "temperature": environment.get("temperature"),
+        "ctx": environment.get("ctx"),
+        "threads": environment.get("threads"),
+        "threads_batch": environment.get("threads_batch"),
+        "batch": environment.get("batch"),
+        "ubatch": environment.get("ubatch"),
+        "cpu_affinity": environment.get("cpu_affinity"),
+        "cooling_seconds": environment.get("cooling_seconds"),
+        "repetitions": environment.get("repetitions"),
+    }
+    serialized = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def run_tool_call_generation_sample(
@@ -1261,6 +1325,11 @@ def write_tool_call_generation_markdown(
         "# Orbit Tool-Call Generation Benchmark\n\n"
         f"- Model: `{env.get('model')}`\n"
         f"- MTP: `{env.get('mtp')}`\n"
+        f"- Capability profile: `{(env.get('native_backend_capabilities') or {}).get('profile_id')}`\n"
+        f"- Capability status: `{(env.get('native_backend_capabilities') or {}).get('status')}`\n"
+        f"- Corpus: `v{env.get('corpus_version')} {env.get('corpus_hash')}`\n"
+        f"- Tool protocol: `v{env.get('protocol_version')} {env.get('protocol_hash')}`\n"
+        f"- Comparable configuration: `v{env.get('configuration_version')} {env.get('configuration_hash')}`\n"
         f"- Samples: `{summary.get('samples')}`\n"
         f"- Evaluable: `{summary.get('evaluable')}`\n"
         f"- Completion rate: `{summary.get('completion_rate')}`\n",
@@ -1849,6 +1918,7 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "version": __version__,
         "model": getattr(info, "id", None) or props.get("model_id") or "unknown",
         "backend": props.get("backend") or "unknown",
+        "thinking": bounded_identifier(props.get("thinking_mode")) or args.server_thinking,
         "mtp": mtp["status"],
         "mtp_requested": mtp["requested"],
         "mtp_session_ready": mtp["session_ready"],
@@ -1877,6 +1947,7 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "client_command": "<redacted>" if redact else " ".join(sys.argv),
         "final_prefix": final_prefix_props(props),
         "final_prefix_config": final_prefix_config_metadata(args.final_prefix_mode, props),
+        "native_backend_capabilities": native_backend_capability_metadata(props),
         "block_id": args.block_id,
         "run_order": args.run_order,
         "cooling_seconds": args.cooling_seconds,
@@ -1886,6 +1957,41 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "tool_healing": tool_healing_metadata(args.tool_healing_mode),
         "canonical_gate": canonical_gate_metadata(args.canonical_gate),
         "route_diagnostic_store": args.route_diagnostic_store,
+    }
+
+
+def native_backend_capability_metadata(props: dict[str, object]) -> dict[str, object]:
+    manifest = props.get("native_backend_capabilities")
+    if not isinstance(manifest, dict):
+        return {
+            "profile_id": None,
+            "status": "unavailable",
+            "schema_version": None,
+        }
+    backend = manifest.get("backend") if isinstance(manifest.get("backend"), dict) else {}
+    renderer = manifest.get("renderer") if isinstance(manifest.get("renderer"), dict) else {}
+    tokenizer = manifest.get("tokenizer") if isinstance(manifest.get("tokenizer"), dict) else {}
+    return {
+        "schema_version": manifest.get("schema_version") if isinstance(manifest.get("schema_version"), int) else None,
+        "profile_id": bounded_identifier(manifest.get("profile_id")),
+        "status": bounded_identifier(manifest.get("status")),
+        "verification_scope": bounded_identifier(manifest.get("verification_scope")),
+        "behavior_enforced": manifest.get("behavior_enforced") is True,
+        "backend_build_number": backend.get("build_number") if isinstance(backend.get("build_number"), int) else None,
+        "backend_commit": bounded_identifier(backend.get("commit"), limit=64),
+        "backend_library_hash": bounded_hex(backend.get("library_hash"), length=64),
+        "backend_verified_commit": backend.get("verified_commit") is True,
+        "tool_protocol_text_hash": bounded_hex(renderer.get("tool_protocol_text_hash"), length=64),
+        "final_prefix_text_hash": bounded_hex(renderer.get("final_prefix_text_hash"), length=64),
+        "renderer_fixture_suite_version": (
+            renderer.get("fixture_suite_version") if isinstance(renderer.get("fixture_suite_version"), int) else None
+        ),
+        "renderer_fixture_suite_hash": bounded_hex(renderer.get("fixture_suite_hash"), length=64),
+        "tokenizer_prefix_tokens": tokenizer.get("prefix_tokens") if isinstance(tokenizer.get("prefix_tokens"), int) else None,
+        "tokenizer_prefix_hash": bounded_hex(tokenizer.get("prefix_token_hash"), length=64),
+        "tokenizer_next_dynamic_token": (
+            tokenizer.get("next_dynamic_token") if isinstance(tokenizer.get("next_dynamic_token"), int) else None
+        ),
     }
 
 

--- a/src/orbit/native_llama/capabilities.py
+++ b/src/orbit/native_llama/capabilities.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from ctypes import c_char_p, c_int
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import struct
+from typing import Any, Protocol
+
+from .bindings import load_native_cdll, native_cdll_flags
+from .chat_template import render_gemma4_chat, render_gemma4_route_prompt_segments
+from .native_names import runtime_library_filename
+
+
+CAPABILITY_SCHEMA_VERSION = 1
+GEMMA4_PROFILE_ID = "orbit-gemma4-native-v1"
+GEMMA4_RENDERER_FIXTURE_SUITE_VERSION = 1
+GEMMA4_TOOL_PROTOCOL_TEXT_HASH = "ab72a1f741975b8b541ae3f3842a2ac0593dec6477dd41f1ea105410077eee1c"
+GEMMA4_RENDERER_FIXTURE_HASHES = {
+    "argument_shapes": "743b4db5d3fe5b509362ab324abd8f32c1e113fd5ebc9a2031465071ac6cdbca",
+    "tool_error_response": "01dbff3f4bcaea4a8db60b3dc116394985e8ab3675e3619dc1a3238476818bcf",
+    "tool_generation": "b56234bba876637765951d69f6d757306a49cab7fbb3e2760dd0b593bbcd8d34",
+    "tool_round_trip": GEMMA4_TOOL_PROTOCOL_TEXT_HASH,
+}
+GEMMA4_RENDERER_FIXTURE_SUITE_HASH = "b5148f35dd93d584e439dfefc38674824d4e645b42b84988c70964ef00023146"
+GEMMA4_FINAL_PREFIX_TEXT_HASH = "c3b8e45ac695a87e60146bb8017a98f1b41fc13a708565b58160cce6d419c6f3"
+GEMMA4_FINAL_PREFIX_TOKEN_HASH = "398338fd38a9c80d54b269e09ae70077ab7323ec1a47920879a24896928cdfc5"
+GEMMA4_FINAL_PREFIX_TOKEN_COUNT = 64
+GEMMA4_NEXT_DYNAMIC_TOKEN = 105
+VERIFIED_LLAMA_CPP_COMMITS = frozenset({"6f79e02"})
+
+
+class _TokenizingClient(Protocol):
+    paths: object
+
+    def tokenize(self, prompt: str) -> list[int]: ...
+
+
+@dataclass(frozen=True)
+class LlamaCppBuildInfo:
+    build_number: int | None
+    commit: str | None
+    target: str | None
+    compiler: str | None
+    library_hash: str | None
+    source: str
+    error: str | None = None
+
+
+def safe_gemma4_capability_manifest(client: _TokenizingClient, *, final_system_prompt: str) -> dict[str, object]:
+    try:
+        return build_gemma4_capability_manifest(client, final_system_prompt=final_system_prompt)
+    except Exception as exc:
+        return {
+            "schema_version": CAPABILITY_SCHEMA_VERSION,
+            "profile_id": GEMMA4_PROFILE_ID,
+            "status": "manifest_unavailable",
+            "verification_scope": "backend_identity_and_prompt_conformance",
+            "behavior_enforced": False,
+            "error": f"manifest_failed:{type(exc).__name__}",
+        }
+
+
+def build_gemma4_capability_manifest(client: _TokenizingClient, *, final_system_prompt: str) -> dict[str, object]:
+    """Return bounded, observational native-backend compatibility metadata."""
+
+    build_bin = _client_build_bin(client)
+    build = read_llama_cpp_build_info(build_bin) if build_bin is not None else _unavailable_build("build_bin_unavailable")
+    renderer_fixture_hashes = {
+        name: _sha256_text(rendered)
+        for name, rendered in _render_renderer_fixtures().items()
+    }
+    renderer_suite_hash = _hash_named_hashes(renderer_fixture_hashes)
+    tool_protocol_hash = renderer_fixture_hashes["tool_round_trip"]
+    renderer_conformant = (
+        renderer_fixture_hashes == GEMMA4_RENDERER_FIXTURE_HASHES
+        and renderer_suite_hash == GEMMA4_RENDERER_FIXTURE_SUITE_HASH
+    )
+
+    segments = render_gemma4_route_prompt_segments(
+        [
+            {"role": "system", "content": final_system_prompt},
+            {"role": "user", "content": "capability request"},
+            {"role": "system", "content": "bounded capability evidence"},
+        ],
+        thinking=False,
+    )
+    prefix_text_hash = _sha256_text(segments.stable_prefix_text)
+    tokenizer = _tokenizer_conformance(client, segments.stable_prefix_text, segments.full_prompt_text)
+    build_verified = build.commit in VERIFIED_LLAMA_CPP_COMMITS
+
+    if not renderer_conformant or prefix_text_hash != GEMMA4_FINAL_PREFIX_TEXT_HASH:
+        status = "renderer_mismatch"
+    elif tokenizer["status"] == "mismatch":
+        status = "tokenizer_mismatch"
+    elif tokenizer["status"] == "unavailable":
+        status = "tokenizer_unavailable"
+    elif not build_verified:
+        status = "backend_unverified"
+    else:
+        status = "verified"
+
+    return {
+        "schema_version": CAPABILITY_SCHEMA_VERSION,
+        "profile_id": GEMMA4_PROFILE_ID,
+        "status": status,
+        "verification_scope": "backend_identity_and_prompt_conformance",
+        "behavior_enforced": False,
+        "backend": {
+            "engine": "llama.cpp",
+            "build_number": build.build_number,
+            "commit": build.commit,
+            "target": build.target,
+            "compiler": build.compiler,
+            "library_hash": build.library_hash,
+            "source": build.source,
+            "error": build.error,
+            "verified_commit": build_verified,
+        },
+        "renderer": {
+            "implementation": "orbit-gemma4",
+            "fixture_suite_version": GEMMA4_RENDERER_FIXTURE_SUITE_VERSION,
+            "fixture_hashes": renderer_fixture_hashes,
+            "expected_fixture_hashes": GEMMA4_RENDERER_FIXTURE_HASHES,
+            "fixture_suite_hash": renderer_suite_hash,
+            "expected_fixture_suite_hash": GEMMA4_RENDERER_FIXTURE_SUITE_HASH,
+            "tool_protocol_text_hash": tool_protocol_hash,
+            "expected_tool_protocol_text_hash": GEMMA4_TOOL_PROTOCOL_TEXT_HASH,
+            "final_prefix_text_hash": prefix_text_hash,
+            "expected_final_prefix_text_hash": GEMMA4_FINAL_PREFIX_TEXT_HASH,
+            "conformant": renderer_conformant and prefix_text_hash == GEMMA4_FINAL_PREFIX_TEXT_HASH,
+        },
+        "tokenizer": tokenizer,
+        "requirements": {
+            "bos_token": 2,
+            "turn_token": GEMMA4_NEXT_DYNAMIC_TOKEN,
+            "stable_prefix_tokens": GEMMA4_FINAL_PREFIX_TOKEN_COUNT,
+            "production_prefill_alignment": 64,
+        },
+    }
+
+
+def read_llama_cpp_build_info(build_bin: Path) -> LlamaCppBuildInfo:
+    common_path = build_bin / runtime_library_filename("llama-common")
+    llama_path = build_bin / runtime_library_filename("llama")
+    if not common_path.is_file():
+        return _unavailable_build("llama_common_unavailable")
+    try:
+        common = load_native_cdll(common_path, mode=native_cdll_flags())
+        return LlamaCppBuildInfo(
+            build_number=_read_int_symbol(common, "LLAMA_BUILD_NUMBER"),
+            commit=_read_text_symbol(common, "LLAMA_COMMIT", limit=64),
+            target=_read_text_symbol(common, "LLAMA_BUILD_TARGET", limit=128),
+            compiler=_read_text_symbol(common, "LLAMA_COMPILER", limit=128),
+            library_hash=_sha256_file(llama_path) if llama_path.is_file() else None,
+            source="runtime_symbols",
+        )
+    except (AttributeError, OSError, TypeError, ValueError) as exc:
+        return _unavailable_build(f"build_info_unavailable:{type(exc).__name__}")
+
+
+def _render_tool_protocol_fixture() -> str:
+    tools = [_renderer_fixture_tool()]
+    messages = [
+        {"role": "system", "content": "Use one available tool when required."},
+        {"role": "user", "content": "Read the synthetic fixture."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": {"path": "fixture.txt"}},
+                }
+            ],
+        },
+        {"role": "tool", "name": "read_file", "content": "alpha=1"},
+    ]
+    return render_gemma4_chat(messages, tools=tools, thinking=False)
+
+
+def _render_renderer_fixtures() -> dict[str, str]:
+    tool = _renderer_fixture_tool()
+    return {
+        "argument_shapes": render_gemma4_chat(
+            [
+                {"role": "system", "content": "Use the provided tool."},
+                {"role": "user", "content": "Use structured arguments."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "synthetic_tool",
+                                "arguments": {
+                                    "enabled": True,
+                                    "items": ["a", "quoted \"value\""],
+                                    "nested": {"count": 2, "empty": None},
+                                },
+                            },
+                        }
+                    ],
+                },
+            ],
+            thinking=False,
+        ),
+        "tool_error_response": render_gemma4_chat(
+            [
+                {"role": "system", "content": "Answer from tool evidence."},
+                {"role": "user", "content": "Run the synthetic operation."},
+                {"role": "tool", "name": "synthetic_tool", "content": "error: denied\ncode=7"},
+            ],
+            thinking=False,
+        ),
+        "tool_generation": render_gemma4_chat(
+            [
+                {"role": "system", "content": "Use one available tool when required."},
+                {"role": "user", "content": "Read the synthetic fixture."},
+            ],
+            tools=[tool],
+            thinking=False,
+        ),
+        "tool_round_trip": _render_tool_protocol_fixture(),
+    }
+
+
+def _renderer_fixture_tool() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string", "description": "File path."}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _hash_named_hashes(values: dict[str, str]) -> str:
+    payload = json.dumps(values, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return _sha256_text(payload)
+
+
+def _tokenizer_conformance(client: _TokenizingClient, stable_prefix: str, full_prompt: str) -> dict[str, object]:
+    try:
+        prefix_tokens = client.tokenize(stable_prefix)
+        full_tokens = client.tokenize(full_prompt)
+        if not _valid_token_ids(prefix_tokens) or not _valid_token_ids(full_tokens):
+            return _unavailable_tokenizer("invalid_token_ids")
+        next_dynamic_token = full_tokens[len(prefix_tokens)] if len(full_tokens) > len(prefix_tokens) else None
+        token_hash = _hash_token_ids(prefix_tokens)
+    except (AttributeError, OverflowError, RuntimeError, struct.error, TypeError, ValueError):
+        return _unavailable_tokenizer("tokenizer_probe_unavailable")
+
+    conformant = (
+        len(prefix_tokens) == GEMMA4_FINAL_PREFIX_TOKEN_COUNT
+        and token_hash == GEMMA4_FINAL_PREFIX_TOKEN_HASH
+        and next_dynamic_token == GEMMA4_NEXT_DYNAMIC_TOKEN
+    )
+    return {
+        "status": "verified" if conformant else "mismatch",
+        "prefix_tokens": len(prefix_tokens),
+        "prefix_token_hash": token_hash,
+        "expected_prefix_token_hash": GEMMA4_FINAL_PREFIX_TOKEN_HASH,
+        "next_dynamic_token": next_dynamic_token,
+        "expected_next_dynamic_token": GEMMA4_NEXT_DYNAMIC_TOKEN,
+        "conformant": conformant,
+        "error": None,
+    }
+
+
+def _unavailable_tokenizer(error: str) -> dict[str, object]:
+    return {
+        "status": "unavailable",
+        "prefix_tokens": None,
+        "prefix_token_hash": None,
+        "expected_prefix_token_hash": GEMMA4_FINAL_PREFIX_TOKEN_HASH,
+        "next_dynamic_token": None,
+        "expected_next_dynamic_token": GEMMA4_NEXT_DYNAMIC_TOKEN,
+        "conformant": False,
+        "error": error,
+    }
+
+
+def _client_build_bin(client: _TokenizingClient) -> Path | None:
+    paths = getattr(client, "paths", None)
+    value = getattr(paths, "build_bin", None)
+    return value if isinstance(value, Path) else None
+
+
+def _unavailable_build(error: str) -> LlamaCppBuildInfo:
+    return LlamaCppBuildInfo(None, None, None, None, None, "unavailable", error)
+
+
+def _read_int_symbol(library: object, name: str) -> int:
+    return int(c_int.in_dll(library, name).value)
+
+
+def _read_text_symbol(library: object, name: str, *, limit: int) -> str | None:
+    raw = c_char_p.in_dll(library, name).value
+    if raw is None:
+        return None
+    value = raw.decode("utf-8", errors="replace")
+    if not value.isprintable():
+        return None
+    return value[:limit]
+
+
+def _hash_token_ids(tokens: list[int]) -> str:
+    payload = b"".join(struct.pack("<i", token) for token in tokens)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _valid_token_ids(tokens: object) -> bool:
+    return isinstance(tokens, list) and all(isinstance(token, int) and -(2**31) <= token < 2**31 for token in tokens)
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -13,6 +13,7 @@ import time
 from typing import Any, Mapping
 
 from orbit.final_prefix_config import resolve_final_prefix_reuse
+from orbit.native_llama.capabilities import safe_gemma4_capability_manifest
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
 from orbit.native_llama.client import (
     NativeClientConfig,
@@ -54,6 +55,10 @@ class OrbitNativeServer:
         self.client = client
         self.model_alias = model_alias
         self.lock = threading.Lock()
+        self.native_backend_capabilities = safe_gemma4_capability_manifest(
+            client,
+            final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
+        )
 
     def chat(self, payload: dict[str, Any], *, on_token=None, on_progress=None, should_cancel=None) -> dict[str, Any]:
         request = parse_chat_request(payload)
@@ -271,6 +276,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "mtp_failure_reason": session["mtp_failure_reason"],
                     "model_id": state.client.paths.model_id,
                     "backend": "orbit-native",
+                    "native_backend_capabilities": state.native_backend_capabilities,
                     "backend_mode": session["backend_mode"],
                     "thinking_mode": runtime["thinking_mode"],
                     "session_id": session["id"],

--- a/tests/test_native_capabilities.py
+++ b/tests/test_native_capabilities.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.capabilities import (
+    GEMMA4_FINAL_PREFIX_TEXT_HASH,
+    GEMMA4_FINAL_PREFIX_TOKEN_HASH,
+    GEMMA4_RENDERER_FIXTURE_HASHES,
+    GEMMA4_RENDERER_FIXTURE_SUITE_HASH,
+    GEMMA4_TOOL_PROTOCOL_TEXT_HASH,
+    LlamaCppBuildInfo,
+    _hash_token_ids,
+    _hash_named_hashes,
+    _render_renderer_fixtures,
+    _render_tool_protocol_fixture,
+    build_gemma4_capability_manifest,
+    read_llama_cpp_build_info,
+    safe_gemma4_capability_manifest,
+)
+from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
+from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT
+
+
+FINAL_PREFIX_TOKENS = [
+    2, 105, 9731, 107, 7925, 506, 2864, 214219, 699, 5904, 4914, 236761, 23097, 1186, 506, 48037,
+    4133, 3890, 236764, 44257, 4453, 4889, 1056, 4354, 236761, 3574, 711, 10149, 10797, 236764,
+    2246, 6436, 236764, 29910, 10445, 5904, 236772, 6639, 33413, 236764, 653, 3539, 6220, 529,
+    2802, 1056, 4914, 7519, 236761, 98936, 56124, 2561, 532, 2072, 9825, 21485, 236761, 8006,
+    1308, 506, 3890, 236761, 106, 107,
+]
+
+
+class _ConformantClient:
+    paths = SimpleNamespace(build_bin=Path("/native/lib"))
+
+    def tokenize(self, prompt: str) -> list[int]:
+        segments = render_gemma4_route_prompt_segments(
+            [
+                {"role": "system", "content": FINAL_FROM_TOOL_SYSTEM_PROMPT},
+                {"role": "user", "content": "capability request"},
+                {"role": "system", "content": "bounded capability evidence"},
+            ],
+            thinking=False,
+        )
+        if prompt == segments.stable_prefix_text:
+            return list(FINAL_PREFIX_TOKENS)
+        if prompt == segments.full_prompt_text:
+            return [*FINAL_PREFIX_TOKENS, 105, 999]
+        raise AssertionError("unexpected capability prompt")
+
+
+class NativeCapabilityTests(unittest.TestCase):
+    def test_tool_protocol_fixture_hash_is_stable(self) -> None:
+        import hashlib
+
+        actual = hashlib.sha256(_render_tool_protocol_fixture().encode("utf-8")).hexdigest()
+
+        self.assertEqual(actual, GEMMA4_TOOL_PROTOCOL_TEXT_HASH)
+
+    def test_renderer_fixture_suite_hashes_are_stable(self) -> None:
+        import hashlib
+
+        actual = {
+            name: hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+            for name, rendered in _render_renderer_fixtures().items()
+        }
+
+        self.assertEqual(actual, GEMMA4_RENDERER_FIXTURE_HASHES)
+        self.assertEqual(_hash_named_hashes(actual), GEMMA4_RENDERER_FIXTURE_SUITE_HASH)
+
+    def test_final_prefix_token_serialization_matches_production_probe(self) -> None:
+        self.assertEqual(len(FINAL_PREFIX_TOKENS), 64)
+        self.assertEqual(_hash_token_ids(FINAL_PREFIX_TOKENS), GEMMA4_FINAL_PREFIX_TOKEN_HASH)
+
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_manifest_is_verified_only_when_build_renderer_and_tokenizer_match(self, build_info) -> None:
+        build_info.return_value = LlamaCppBuildInfo(
+            build_number=278,
+            commit="6f79e02",
+            target="Linux x86_64",
+            compiler="GNU 13",
+            library_hash="a" * 64,
+            source="runtime_symbols",
+        )
+
+        manifest = build_gemma4_capability_manifest(
+            _ConformantClient(),
+            final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
+        )
+
+        self.assertEqual(manifest["status"], "verified")
+        self.assertEqual(manifest["verification_scope"], "backend_identity_and_prompt_conformance")
+        self.assertFalse(manifest["behavior_enforced"])
+        self.assertTrue(manifest["renderer"]["conformant"])
+        self.assertEqual(manifest["renderer"]["fixture_hashes"], GEMMA4_RENDERER_FIXTURE_HASHES)
+        self.assertEqual(manifest["renderer"]["fixture_suite_hash"], GEMMA4_RENDERER_FIXTURE_SUITE_HASH)
+        self.assertEqual(manifest["renderer"]["final_prefix_text_hash"], GEMMA4_FINAL_PREFIX_TEXT_HASH)
+        self.assertTrue(manifest["tokenizer"]["conformant"])
+        self.assertEqual(manifest["tokenizer"]["prefix_tokens"], 64)
+        self.assertEqual(manifest["tokenizer"]["next_dynamic_token"], 105)
+        self.assertTrue(manifest["backend"]["verified_commit"])
+
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_tokenizer_mismatch_is_reported_without_enforcement(self, build_info) -> None:
+        build_info.return_value = LlamaCppBuildInfo(278, "6f79e02", None, None, None, "runtime_symbols")
+        client = _ConformantClient()
+        client.tokenize = lambda _prompt: [2, 105]  # type: ignore[method-assign]
+
+        manifest = build_gemma4_capability_manifest(client, final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT)
+
+        self.assertEqual(manifest["status"], "tokenizer_mismatch")
+        self.assertFalse(manifest["tokenizer"]["conformant"])
+        self.assertFalse(manifest["behavior_enforced"])
+
+    @mock.patch("orbit.native_llama.capabilities._render_renderer_fixtures")
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_renderer_fixture_drift_is_reported_without_enforcement(self, build_info, render_fixtures) -> None:
+        build_info.return_value = LlamaCppBuildInfo(278, "6f79e02", None, None, None, "runtime_symbols")
+        render_fixtures.return_value = {
+            **_render_renderer_fixtures(),
+            "tool_generation": "drifted renderer output",
+        }
+
+        manifest = build_gemma4_capability_manifest(
+            _ConformantClient(),
+            final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
+        )
+
+        self.assertEqual(manifest["status"], "renderer_mismatch")
+        self.assertFalse(manifest["renderer"]["conformant"])
+        self.assertFalse(manifest["behavior_enforced"])
+
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_unavailable_tokenizer_cannot_break_manifest_generation(self, build_info) -> None:
+        build_info.return_value = LlamaCppBuildInfo(278, "6f79e02", None, None, None, "runtime_symbols")
+        client = _ConformantClient()
+        client.tokenize = lambda _prompt: (_ for _ in ()).throw(RuntimeError("not loaded"))  # type: ignore[method-assign]
+
+        manifest = build_gemma4_capability_manifest(client, final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT)
+
+        self.assertEqual(manifest["status"], "tokenizer_unavailable")
+        self.assertEqual(manifest["tokenizer"]["error"], "tokenizer_probe_unavailable")
+        self.assertFalse(manifest["behavior_enforced"])
+
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_unknown_backend_commit_is_observational_not_a_runtime_failure(self, build_info) -> None:
+        build_info.return_value = LlamaCppBuildInfo(279, "unknown-new", None, None, None, "runtime_symbols")
+
+        manifest = build_gemma4_capability_manifest(
+            _ConformantClient(),
+            final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
+        )
+
+        self.assertEqual(manifest["status"], "backend_unverified")
+        self.assertFalse(manifest["backend"]["verified_commit"])
+        self.assertFalse(manifest["behavior_enforced"])
+
+    @mock.patch("orbit.native_llama.capabilities._sha256_file", return_value="b" * 64)
+    @mock.patch("orbit.native_llama.capabilities._read_text_symbol")
+    @mock.patch("orbit.native_llama.capabilities._read_int_symbol", return_value=278)
+    @mock.patch("orbit.native_llama.capabilities.load_native_cdll", return_value=object())
+    def test_reads_bounded_runtime_build_symbols(self, _load, _number, text_symbol, _file_hash) -> None:
+        text_symbol.side_effect = ["6f79e02", "Linux x86_64", "GNU 13"]
+        with mock.patch.object(Path, "is_file", return_value=True):
+            info = read_llama_cpp_build_info(Path("/native/lib"))
+
+        self.assertEqual(info.build_number, 278)
+        self.assertEqual(info.commit, "6f79e02")
+        self.assertEqual(info.target, "Linux x86_64")
+        self.assertEqual(info.compiler, "GNU 13")
+        self.assertEqual(info.library_hash, "b" * 64)
+        self.assertEqual(info.source, "runtime_symbols")
+
+    def test_missing_runtime_library_reports_bounded_unavailable_state(self) -> None:
+        with mock.patch.object(Path, "is_file", return_value=False):
+            info = read_llama_cpp_build_info(Path("/missing"))
+
+        self.assertEqual(info.source, "unavailable")
+        self.assertEqual(info.error, "llama_common_unavailable")
+        self.assertIsNone(info.commit)
+
+    @mock.patch("orbit.native_llama.capabilities.build_gemma4_capability_manifest", side_effect=RuntimeError("diagnostic failure"))
+    def test_safe_manifest_cannot_break_server_startup(self, _build_manifest) -> None:
+        manifest = safe_gemma4_capability_manifest(
+            _ConformantClient(),
+            final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
+        )
+
+        self.assertEqual(manifest["status"], "manifest_unavailable")
+        self.assertEqual(manifest["error"], "manifest_failed:RuntimeError")
+        self.assertFalse(manifest["behavior_enforced"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_runtime_props.py
+++ b/tests/test_native_runtime_props.py
@@ -61,6 +61,22 @@ class NativeRuntimePropsTests(unittest.TestCase):
         self.assertTrue(server.client.supports_vision)
         self.assertTrue(server.client.supports_audio)
 
+    @mock.patch("orbit.native_server.app.safe_gemma4_capability_manifest")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_server_caches_bounded_native_capability_manifest(self, _mocked_lib, build_manifest) -> None:
+        build_manifest.return_value = {
+            "schema_version": 1,
+            "profile_id": "orbit-gemma4-native-v1",
+            "status": "verified",
+            "behavior_enforced": False,
+        }
+        client = NativeLlamaClient(self._paths(), NativeClientConfig())
+
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        self.assertEqual(server.native_backend_capabilities["status"], "verified")
+        build_manifest.assert_called_once_with(client, final_system_prompt=mock.ANY)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -53,6 +53,97 @@ def route_step_report(**overrides: object):
 
 
 class SmokeHarnessTests(unittest.TestCase):
+    def test_tool_call_generation_corpus_identity_is_stable(self) -> None:
+        self.assertEqual(smoke_harness.TOOL_CALL_GENERATION_CORPUS_VERSION, 1)
+        self.assertEqual(len(smoke_harness.TOOL_CALL_GENERATION_CORPUS), 40)
+        self.assertEqual(
+            smoke_harness.tool_call_generation_corpus_hash(smoke_harness.TOOL_CALL_GENERATION_CORPUS),
+            "f5db2bc1802ec6535ca25b1bb42d5ff288dbbf1dd71868b1bbc33a2092394585",
+        )
+        self.assertEqual(smoke_harness.TOOL_CALL_GENERATION_PROTOCOL_VERSION, 1)
+        self.assertEqual(
+            smoke_harness.tool_call_generation_protocol_hash(),
+            "1407e2a5f7444446ebd2bd0d6cbdb3c81c155f814c587e203515de9babe55301",
+        )
+
+    def test_tool_call_generation_configuration_hash_uses_comparable_fields_only(self) -> None:
+        environment = {
+            "model": "gemma4-test",
+            "backend": "orbit-native",
+            "thinking": "off",
+            "mtp": "disabled",
+            "timeout": 60.0,
+            "max_tokens": 128,
+            "temperature": 0.0,
+            "ctx": 8192,
+            "threads": 6,
+            "threads_batch": 6,
+            "batch": 256,
+            "ubatch": 128,
+            "repetitions": 5,
+            "canonical_gate": {"enabled": True, "repair_count": 999},
+            "tool_healing": {"enabled": True, "repair_count": 123},
+            "timestamp": "ignored",
+            "git_head": "ignored",
+        }
+        baseline = smoke_harness.tool_call_generation_configuration_hash(environment)
+
+        environment["timestamp"] = "still-ignored"
+        environment["git_head"] = "still-ignored"
+        environment["canonical_gate"]["repair_count"] = 1000
+        environment["canonical_gate"]["enabled"] = False
+        environment["tool_healing"]["enabled"] = False
+        self.assertEqual(smoke_harness.tool_call_generation_configuration_hash(environment), baseline)
+
+        environment["threads"] = 4
+        self.assertNotEqual(smoke_harness.tool_call_generation_configuration_hash(environment), baseline)
+
+        environment["threads"] = 6
+        environment["thinking"] = "on"
+        self.assertNotEqual(smoke_harness.tool_call_generation_configuration_hash(environment), baseline)
+
+    def test_native_capability_metadata_is_bounded_and_content_free(self) -> None:
+        metadata = smoke_harness.native_backend_capability_metadata(
+            {
+                "native_backend_capabilities": {
+                    "schema_version": 1,
+                    "profile_id": "orbit-gemma4-native-v1",
+                    "status": "verified",
+                    "verification_scope": "backend_identity_and_prompt_conformance",
+                    "behavior_enforced": False,
+                    "backend": {
+                        "build_number": 278,
+                        "commit": "6f79e02",
+                        "library_hash": "a" * 64,
+                        "verified_commit": True,
+                        "compiler": "must-not-be-copied",
+                    },
+                    "renderer": {
+                        "tool_protocol_text_hash": "b" * 64,
+                        "final_prefix_text_hash": "c" * 64,
+                        "fixture_suite_version": 1,
+                        "fixture_suite_hash": "e" * 64,
+                    },
+                    "tokenizer": {
+                        "prefix_tokens": 64,
+                        "prefix_token_hash": "d" * 64,
+                        "next_dynamic_token": 105,
+                    },
+                    "prompt": "must-not-be-copied",
+                    "arguments": {"secret": "must-not-be-copied"},
+                }
+            }
+        )
+
+        self.assertEqual(metadata["profile_id"], "orbit-gemma4-native-v1")
+        self.assertEqual(metadata["backend_commit"], "6f79e02")
+        self.assertEqual(metadata["tokenizer_prefix_tokens"], 64)
+        self.assertEqual(metadata["renderer_fixture_suite_hash"], "e" * 64)
+        self.assertNotIn("prompt", metadata)
+        self.assertNotIn("arguments", metadata)
+        self.assertNotIn("compiler", metadata)
+        self.assertNotIn("must-not-be-copied", json.dumps(metadata))
+
     def test_tool_call_generation_only_uses_one_model_call_without_execution_or_finalization(self) -> None:
         class Backend:
             base_url = "http://127.0.0.1:9"

--- a/tests/test_tool_call_generation_compare.py
+++ b/tests/test_tool_call_generation_compare.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "compare_tool_call_generation.py"
+SPEC = importlib.util.spec_from_file_location("compare_tool_call_generation", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+comparison = importlib.util.module_from_spec(SPEC)
+sys.modules["compare_tool_call_generation"] = comparison
+SPEC.loader.exec_module(comparison)
+
+
+def _environment(*, corpus_hash: str = "a" * 64, commit: str = "base") -> dict[str, object]:
+    return {
+        "type": "environment",
+        "benchmark_mode": "tool_call_generation_only",
+        "corpus_version": 1,
+        "corpus_hash": corpus_hash,
+        "protocol_version": 1,
+        "protocol_hash": "1" * 64,
+        "configuration_version": 1,
+        "configuration_hash": "2" * 64,
+        "model": "gemma4-test",
+        "mtp": "off",
+        "native_backend_capabilities": {
+            "profile_id": "orbit-gemma4-native-v1",
+            "status": "verified",
+            "backend_build_number": 278,
+            "backend_commit": commit,
+            "backend_library_hash": "b" * 64,
+            "tool_protocol_text_hash": "c" * 64,
+            "final_prefix_text_hash": "e" * 64,
+            "renderer_fixture_suite_hash": "f" * 64,
+            "tokenizer_prefix_hash": "d" * 64,
+        },
+    }
+
+
+def _sample(*, scenario: str = "system_info_1", outcome: str = "expected_tool") -> dict[str, object]:
+    return {
+        "type": "tool_call_generation",
+        "scenario": scenario,
+        "repetition": 1,
+        "expected_tool": "system_info" if outcome != "no_attempt" else None,
+        "template": "production_tool_call_system_prompt",
+        "evaluable": True,
+        "semantic_outcome": outcome,
+        "multiple_candidates": False,
+        "markup_leakage": False,
+        "tool_executed": False,
+        "finalization_started": False,
+        "model_calls": 1,
+    }
+
+
+def _summary() -> dict[str, object]:
+    return {
+        "type": "tool_call_generation_summary",
+        "samples": 1,
+        "completion_rate": 1.0,
+        "valid_first_pass_rate": 1.0,
+        "exact_tool_match_rate": 1.0,
+        "model_unwanted_attempt_rate": 0.0,
+        "detector_false_positive_rate": 0.0,
+        "detector_false_negative_rate": 0.0,
+        "multiple_candidate_rate": 0.0,
+        "budget_truncation_rate": 0.0,
+        "structural_truncation_rate": 0.0,
+        "markup_leakage_rate": 0.0,
+        "generation_wall_ms_median": 10.0,
+        "generation_wall_ms_p95": 12.0,
+        "healing_us_median": 50.0,
+        "healing_us_p95": 60.0,
+        "model_calls": 1,
+        "tools_executed": 0,
+        "finalizations_started": 0,
+    }
+
+
+def _write(path: Path, environment: dict[str, object], sample: dict[str, object], summary: dict[str, object]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row) for row in (environment, sample, summary)) + "\n",
+        encoding="utf-8",
+    )
+
+
+class ToolCallGenerationComparisonTests(unittest.TestCase):
+    def _run_cli(self, baseline: Path, candidate: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), str(baseline), str(candidate)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_equivalent_runs_pass_and_report_backend_identity_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(commit="old"), _sample(), _summary())
+            _write(candidate_path, _environment(commit="new"), _sample(), _summary())
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "pass")
+        self.assertTrue(result["identity_changes"]["backend_commit"])
+        self.assertEqual(result["blockers"], [])
+        self.assertFalse(result["raw_content_included"])
+
+    def test_corpus_mismatch_is_incomparable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(corpus_hash="e" * 64), _sample(), _summary())
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "incomparable")
+        self.assertIn("corpus_mismatch", result["blockers"])
+
+    def test_protocol_or_configuration_mismatch_is_incomparable(self) -> None:
+        candidate_environment = _environment()
+        candidate_environment["configuration_hash"] = "3" * 64
+        candidate_environment["protocol_hash"] = "4" * 64
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, candidate_environment, _sample(), _summary())
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "incomparable")
+        self.assertIn("configuration_mismatch", result["blockers"])
+        self.assertIn("protocol_mismatch", result["blockers"])
+
+    def test_backend_unverified_is_comparable_but_tokenizer_mismatch_is_not(self) -> None:
+        unverified_environment = _environment(commit="new")
+        unverified_environment["native_backend_capabilities"]["status"] = "backend_unverified"
+        mismatch_environment = _environment(commit="new")
+        mismatch_environment["native_backend_capabilities"]["status"] = "tokenizer_mismatch"
+        unknown_environment = _environment(commit="new")
+        unknown_environment["native_backend_capabilities"]["status"] = "future_status"
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            unverified_path = Path(tmp) / "unverified.jsonl"
+            mismatch_path = Path(tmp) / "mismatch.jsonl"
+            unknown_path = Path(tmp) / "unknown.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(unverified_path, unverified_environment, _sample(), _summary())
+            _write(mismatch_path, mismatch_environment, _sample(), _summary())
+            _write(unknown_path, unknown_environment, _sample(), _summary())
+            baseline = comparison.load_generation_run(baseline_path)
+
+            unverified = comparison.compare_generation_runs(baseline, comparison.load_generation_run(unverified_path))
+            mismatch = comparison.compare_generation_runs(baseline, comparison.load_generation_run(mismatch_path))
+            unknown = comparison.compare_generation_runs(baseline, comparison.load_generation_run(unknown_path))
+
+        self.assertEqual(unverified["decision"], "pass")
+        self.assertEqual(mismatch["decision"], "incomparable")
+        self.assertIn("candidate_renderer_or_tokenizer_mismatch", mismatch["blockers"])
+        self.assertEqual(unknown["decision"], "incomparable")
+
+    def test_declared_verified_capability_contract_drift_is_incomparable(self) -> None:
+        candidate_environment = _environment()
+        candidate_environment["native_backend_capabilities"]["tokenizer_prefix_hash"] = "f" * 64
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, candidate_environment, _sample(), _summary())
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "incomparable")
+        self.assertIn("capability_contract_mismatch", result["blockers"])
+
+    def test_semantic_and_markup_regressions_fail(self) -> None:
+        candidate_sample = _sample(outcome="wrong_tool")
+        candidate_sample["markup_leakage"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(), candidate_sample, _summary())
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "fail")
+        self.assertIn("tool_selection_regression", result["blockers"])
+        self.assertIn("markup_leakage_regression", result["blockers"])
+
+    def test_tool_execution_or_extra_model_call_fail(self) -> None:
+        candidate_sample = _sample()
+        candidate_sample["tool_executed"] = True
+        candidate_sample["model_calls"] = 2
+        candidate_summary = _summary()
+        candidate_summary["tools_executed"] = 1
+        candidate_summary["model_calls"] = 2
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(), candidate_sample, candidate_summary)
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "fail")
+        self.assertIn("candidate_executed_tool", result["blockers"])
+        self.assertIn("candidate_model_call_count", result["blockers"])
+        self.assertIn("sample_model_call_count", result["blockers"])
+
+    def test_loader_rejects_duplicate_samples_without_echoing_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "duplicate.jsonl"
+            path.write_text(
+                "\n".join(json.dumps(row) for row in (_environment(), _sample(), _sample(), _summary())) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(comparison.ComparisonInputError, "duplicate_sample"):
+                comparison.load_generation_run(path)
+
+    def test_malformed_candidate_counts_fail_closed(self) -> None:
+        candidate_summary = _summary()
+        candidate_summary["model_calls"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(), _sample(), candidate_summary)
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertEqual(result["decision"], "fail")
+        self.assertIn("candidate_model_call_count", result["blockers"])
+
+    def test_boolean_metrics_are_not_reported_as_numeric_deltas(self) -> None:
+        candidate_summary = _summary()
+        candidate_summary["completion_rate"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(), _sample(), candidate_summary)
+
+            result = comparison.compare_generation_runs(
+                comparison.load_generation_run(baseline_path),
+                comparison.load_generation_run(candidate_path),
+            )
+
+        self.assertIsNone(result["metric_deltas"]["completion_rate"])
+
+    def test_cli_exit_codes_distinguish_pass_fail_and_incomparable(self) -> None:
+        wrong_tool = _sample(outcome="wrong_tool")
+        mismatched_environment = _environment()
+        mismatched_environment["configuration_hash"] = "9" * 64
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            passing_path = Path(tmp) / "passing.jsonl"
+            failing_path = Path(tmp) / "failing.jsonl"
+            incomparable_path = Path(tmp) / "incomparable.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(passing_path, _environment(commit="new"), _sample(), _summary())
+            _write(failing_path, _environment(), wrong_tool, _summary())
+            _write(incomparable_path, mismatched_environment, _sample(), _summary())
+
+            passing = self._run_cli(baseline_path, passing_path)
+            failing = self._run_cli(baseline_path, failing_path)
+            incomparable = self._run_cli(baseline_path, incomparable_path)
+
+        self.assertEqual(passing.returncode, 0)
+        self.assertEqual(passing.stderr, "")
+        self.assertEqual(json.loads(passing.stdout)["decision"], "pass")
+        self.assertEqual(failing.returncode, 1)
+        self.assertEqual(failing.stderr, "")
+        self.assertEqual(json.loads(failing.stdout)["decision"], "fail")
+        self.assertEqual(incomparable.returncode, 2)
+        self.assertEqual(incomparable.stderr, "")
+        self.assertEqual(json.loads(incomparable.stdout)["decision"], "incomparable")
+
+    def test_cli_invalid_input_is_bounded_and_content_free(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            invalid_path = Path(tmp) / "invalid.jsonl"
+            valid_path = Path(tmp) / "valid.jsonl"
+            invalid_path.write_text('{"secret":"must-not-leak"', encoding="utf-8")
+            _write(valid_path, _environment(), _sample(), _summary())
+
+            result = self._run_cli(invalid_path, valid_path)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stderr, "")
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["decision"], "invalid")
+        self.assertNotIn("must-not-leak", result.stdout)
+
+    def test_cli_failure_does_not_echo_unrecognized_sensitive_fields(self) -> None:
+        candidate_sample = _sample(outcome="wrong_tool")
+        candidate_sample.update(
+            {
+                "raw_output": "secret-output",
+                "arguments": {"path": "/private/example", "token": "secret-token"},
+                "evidence": "secret-evidence",
+                "url": "https://secret.invalid/query",
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_path = Path(tmp) / "baseline.jsonl"
+            candidate_path = Path(tmp) / "candidate.jsonl"
+            _write(baseline_path, _environment(), _sample(), _summary())
+            _write(candidate_path, _environment(), candidate_sample, _summary())
+
+            result = self._run_cli(baseline_path, candidate_path)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, "")
+        for sensitive in ("secret-output", "/private/example", "secret-token", "secret-evidence", "secret.invalid"):
+            self.assertNotIn(sensitive, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose a bounded, observational Gemma 4 native capability manifest
- add versioned renderer, tokenizer, tool-protocol, corpus, and configuration fingerprints
- add an offline generation-only baseline comparator with redacted output and stable exit codes
- document the compatibility workflow and technical limits

## Validation
- focused compatibility, CLI, native props, and harness tests: 97 PASS
- full unit discovery: 1,165 PASS
- two process-isolated real generation-only smokes: 8/8 evaluable in each, 8 model calls, zero tool executions, zero finalizations
- baseline/candidate comparison: PASS with identical model, thinking mode, affinity, protocol, renderer, tokenizer, and configuration fingerprints
- compileall: PASS
- git diff --check: PASS

The observed exact-tool, unwanted-attempt, and budget-truncation rates remain visible and unchanged. Timing deltas are informational only; no speedup is claimed. No runtime enforcement, routing, executor, MTP, final-prefix, healing rule, or retry behavior is changed.