### PR TITLE
Enable post-tool final prose reuse by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,15 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - RC21 validation: focused canonical/healing/comparator/capability/harness PASS with 151 tests; full unit discovery PASS with 1,165 tests; MTP shim build PASS; `compileall` PASS; `git diff --check` PASS. Default final-prefix PASS with capture then `cached=64`; combined kill switches PASS with `cached=4` and zero prefix activity; strict MTP/mmproj PASS with usable MTP and zero final-prefix activity.
 - No semantic-healing, success-rate, or deterministic performance claim is made. Do not expand the repair whitelist or add a nudge retry without natural, repeatable malformed production-budget samples and separate safety evidence.
 
+## Post-Tool Final Prose Reuse
+
+- `ORBIT_POST_TOOL_FINAL_REUSE` is enabled by default. Setting it to `0` is the immediate kill switch; setting it to `1` explicitly enables it; invalid values disable the feature safely. Diagnostics report only the bounded effective state and source (`default` or `stable`).
+- The optimization applies only after a terminal `post_tool_route` result: the model stopped normally, no new tool call or retry is present, the terminal tool result is complete, no error or guardrail is pending, and the original prose is non-empty, complete, and free of tool markup, control markup, or technical JSON. Any uncertainty falls back to the normal `final_from_tool` call.
+- When eligible, runtime returns the exact original `ChatResult.content`; it does not construct, summarize, correct, or semantically reinterpret an answer. Tool selection, arguments, execution, evidence, finish reason, and correctness remain unchanged in the validated cases.
+- Process-isolated Gemma 4 12B validation recorded 50/50 comparable OFF cases and 50/50 correct, stop ON reuses, with 50 model calls avoided and zero false positives or skipped tools. The measured aggregate saving was 65,189 evaluated tokens; the median per reuse was 1,084 evaluated tokens and approximately 107.5 seconds of wall time in that workload.
+- Eligibility analysis overhead measured approximately 8.55 microseconds at p95. The wall-time result is workload-, output-, process-, and thermal-dependent; no deterministic speedup claim is made.
+- Read, system, web, error, synthesis, multi-tool, cancellation, timeout, and reset cases retain normal fallback when the structural eligibility conditions are not met. This feature does not change routing, tool selection, executor behavior, MTP, final-prefix reuse, or retry policy.
+
 ## MTP
 
 - MTP is optional and experimental.
@@ -185,6 +194,32 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - MTP gate: `simple_chat --mtp-required` with healthy `/props`.
 - Recovery gate: timeout/cancel with `shell20`, then a new `simple_chat --mtp-required`.
 - Never use a persistent store for RC evidence-lineage smokes.
+
+## Bounded Multi-Action Planning Shadow
+
+- Bounded multi-action planning is observational only. Production routing,
+  tool execution, and finalization remain unchanged.
+- `ORBIT_TOOL_PLAN_SHADOW` is OFF by default. The dedicated smoke-harness mode
+  performs one real planning inference, validates exactly two literal linear
+  steps, and never executes a tool or starts post-tool finalization.
+- The initial shadow allowlist is `system_info` and `list_directory`. Network,
+  mutation, and unrestricted shell actions are excluded, including shell calls
+  that appear read-only but can access external resources or paths.
+- The only alternate response is exact `{"type":"unsupported_plan"}`. Model
+  IDs, expectations, dependencies, branches, parallelism, and completion choice
+  are not part of the minimal schema.
+- Every proposed step reuses the canonical tool contract. The analyzer rejects
+  multiple plans, duplicate keys, dynamic step references, external text,
+  truncation, disabled tools, schema/policy/permission failures, and operational
+  limit failures.
+- Structural literal arguments do not prove semantic independence from prior
+  step output. This is the main technical stop before any opt-in execution.
+- Three compact prompt views were tested on nine scenarios each. The best view
+  reached 88.9% JSON compliance, 50% exact positive plans, 100% unsupported
+  accuracy, and an 11.1% wrong-plan rate. It failed the smoke gate, so five
+  repetitions were not run and no model-call reduction is credited.
+- See `docs/BOUNDED_TOOL_PLANNING.md` for the minimal schema, prompt comparison,
+  token/wall measurements, and closure decision.
 
 ## #124, Conversation Reuse Route Guidance
 

--- a/docs/BOUNDED_TOOL_PLANNING.md
+++ b/docs/BOUNDED_TOOL_PLANNING.md
@@ -1,0 +1,109 @@
+# Minimal Two-Step Tool Planning Shadow
+
+## Status
+
+The experiment is observational only. It requires both
+`ORBIT_TOOL_PLAN_SHADOW=1` and
+`scripts/orbit_smoke_harness.py --tool-plan-shadow`. The resolver is OFF by
+default; `0` and invalid values stop the benchmark before server startup.
+Production routing, canonical validation, healing, tool execution, MTP, final
+prefix reuse, and finalization are unchanged. No plan is executed.
+
+## Minimal Contract
+
+The model may return exactly one of two objects:
+
+```json
+{
+  "type": "tool_plan",
+  "steps": [
+    {"name": "system_info", "arguments": {}},
+    {"name": "list_directory", "arguments": {"path": ".", "max_entries": 20}}
+  ]
+}
+```
+
+```json
+{"type": "unsupported_plan"}
+```
+
+The plan has exactly two steps. The runtime assigns internal `step_1` and
+`step_2` IDs after parsing. The model does not choose IDs, expectations,
+dependencies, branching, completion behavior, or execution policy.
+
+Only `system_info` and `list_directory` are eligible. Both steps must have
+literal arguments known before execution and must independently pass the
+existing canonical contract. Optional arguments retain only defaults already
+declared by the canonical schema; the planning layer does not add values.
+
+`unsupported_plan` is required when any action needs another tool, mutation,
+network access, an intermediate result, or cannot be completed by exactly two
+eligible calls.
+
+## Prompt Views
+
+All views use the same schema, tool definitions, corpus, model configuration,
+and output budget.
+
+1. `contract`: minimal schemas and unsupported conditions.
+2. `json_only`: `contract` plus one instruction prohibiting prose and Markdown.
+3. `exactness`: `json_only` plus one instruction prohibiting substitution of an
+   unsupported requested action with an allowed tool.
+
+This isolates one prompt change between adjacent views.
+
+## Corpus
+
+The nine-case corpus contains:
+
+- two `system_info` plus `list_directory` plans in different orders;
+- two independent `list_directory` pairs with exact paths and bounds;
+- five unsupported tasks covering shell, mutation, output dependency, network,
+  and a missing file-read tool.
+
+Correctness is measured against exact tool order and exact argument values.
+Canonical validity alone is not semantic correctness. A valid plan returned for
+an unsupported task, or a plan with changed arguments, is `wrong_plan`.
+
+## Gemma 4 12B Result
+
+The one-repetition smoke used native Gemma 4 12B Q4_K_M, the production
+template, `ctx=8192`, six threads, temperature zero, and 160 output tokens.
+All 27 calls were evaluable with healthy cleanup. Tool executions and
+finalizations were zero.
+
+| View | JSON | Exact positive plans | Unsupported accuracy | Wrong-plan rate | Gate |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `contract` | 44.4% | 0% | 80% | 0% | FAIL |
+| `json_only` | 55.6% | 0% | 100% | 0% | FAIL |
+| `exactness` | 88.9% | 50% | 100% | 11.1% | FAIL |
+
+`exactness` produced two exact plans, one positive plan with the correct tool
+sequence but different arguments, and one positive response with prose
+leakage. The other views leaked prose for every positive plan. No invalid JSON
+object was observed after a candidate marker; one negative `contract` response
+contained no plan marker and was classified as prose/no-plan.
+
+Per-view cost for nine calls:
+
+| View | Prompt tokens | Evaluated tokens | Output tokens | Median wall | Total wall |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `contract` | 5,504 | 809 | 284 | 5.88 s | 174.18 s |
+| `json_only` | 5,621 | 714 | 239 | 5.48 s | 133.97 s |
+| `exactness` | 5,729 | 713 | 265 | 4.70 s | 141.45 s |
+
+No model-call reduction is credited. Two exact shadow plans imply only a
+structural possibility; they were not executed and the view failed the semantic
+gate. The five-repetition phase was not run because no view achieved at least
+90% JSON compliance, zero wrong plans, and complete positive/negative accuracy.
+
+## Decision
+
+Runtime parsing and validation remain feasible, but model adherence is not
+sufficient even for the minimal two-step contract. The experiment remains
+closed to execution.
+
+Do not add tolerant parsing, grammar, retries, semantic repair, tool
+substitution, or a larger schema from this result. Reopen only with new model or
+template evidence that can achieve zero wrong plans and exact arguments on the
+same minimal corpus.

--- a/scripts/compare_post_tool_final_reuse.py
+++ b/scripts/compare_post_tool_final_reuse.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+class ComparisonInputError(ValueError):
+    pass
+
+
+def load_run(path: Path) -> tuple[dict[str, object], dict[tuple[str, int, int], dict[str, object]]]:
+    environments: list[dict[str, object]] = []
+    steps: dict[tuple[str, int, int], dict[str, object]] = {}
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            for line in stream:
+                if not line.strip():
+                    continue
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise ComparisonInputError("row_not_object")
+                if row.get("type") == "environment":
+                    environments.append(row)
+                elif row.get("type") == "step":
+                    key = _step_key(row)
+                    if key in steps:
+                        raise ComparisonInputError("duplicate_step")
+                    steps[key] = row
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ComparisonInputError(f"unreadable_jsonl:{type(exc).__name__}") from exc
+    if len(environments) != 1 or not steps:
+        raise ComparisonInputError("missing_environment_or_steps")
+    return environments[0], steps
+
+
+def compare_runs(
+    baseline: tuple[dict[str, object], dict[tuple[str, int, int], dict[str, object]]],
+    candidate: tuple[dict[str, object], dict[tuple[str, int, int], dict[str, object]]],
+) -> dict[str, object]:
+    baseline_env, baseline_steps = baseline
+    candidate_env, candidate_steps = candidate
+    blockers: list[str] = []
+    fingerprint = baseline_env.get("post_tool_final_reuse_comparison_fingerprint")
+    if not isinstance(fingerprint, str) or fingerprint != candidate_env.get(
+        "post_tool_final_reuse_comparison_fingerprint"
+    ):
+        blockers.append("fingerprint_mismatch")
+    if baseline_env.get("server_pid") == candidate_env.get("server_pid"):
+        blockers.append("process_not_isolated")
+    if set(baseline_steps) != set(candidate_steps):
+        blockers.append("step_set_mismatch")
+    if _reuse_enabled(baseline_env) is not False or _reuse_enabled(candidate_env) is not True:
+        blockers.append("mode_mismatch")
+
+    rows: list[dict[str, object]] = []
+    if not blockers:
+        for key in sorted(baseline_steps):
+            before = baseline_steps[key]
+            after = candidate_steps[key]
+            row_blockers: list[str] = []
+            if before.get("tool_names") != after.get("tool_names"):
+                row_blockers.append("tool_mismatch")
+            if before.get("correctness_category") != after.get("correctness_category"):
+                row_blockers.append("correctness_mismatch")
+            if before.get("finish_reason") != after.get("finish_reason"):
+                row_blockers.append("finish_reason_mismatch")
+            reused = _reuse_delta(after) > 0
+            before_calls = len(_model_steps(before))
+            after_calls = len(_model_steps(after))
+            if reused and before_calls - after_calls != 1:
+                row_blockers.append("unexpected_model_call_delta")
+            blockers.extend(row_blockers)
+            rows.append(
+                {
+                    "case": key[0],
+                    "step": key[1],
+                    "repetition": key[2],
+                    "reused": reused,
+                    "model_calls_saved": before_calls - after_calls,
+                    "evaluated_tokens_saved": _evaluated_tokens(before) - _evaluated_tokens(after),
+                    "wall_ms_saved": _number(before.get("wall_ms")) - _number(after.get("wall_ms")),
+                    "correctness_unchanged": before.get("correctness_category") == after.get("correctness_category"),
+                    "finish_reason_unchanged": before.get("finish_reason") == after.get("finish_reason"),
+                    "tool_unchanged": before.get("tool_names") == after.get("tool_names"),
+                    "blockers": row_blockers,
+                }
+            )
+    reused_rows = [row for row in rows if row["reused"]]
+    return {
+        "type": "post_tool_final_reuse_comparison",
+        "decision": "pass" if not blockers and reused_rows else "fail",
+        "fingerprint": fingerprint if isinstance(fingerprint, str) else None,
+        "process_isolated": baseline_env.get("server_pid") != candidate_env.get("server_pid"),
+        "steps": len(rows),
+        "reused_steps": len(reused_rows),
+        "model_calls_saved": sum(int(row["model_calls_saved"]) for row in reused_rows),
+        "evaluated_tokens_saved": sum(int(row["evaluated_tokens_saved"]) for row in reused_rows),
+        "wall_ms_saved": round(sum(float(row["wall_ms_saved"]) for row in reused_rows), 1),
+        "rows": rows,
+        "blockers": sorted(set(blockers or (["no_reused_step"] if not reused_rows else []))),
+        "raw_content_included": False,
+    }
+
+
+def _step_key(row: dict[str, object]) -> tuple[str, int, int]:
+    case = row.get("case")
+    step = row.get("step")
+    repetition = row.get("repetition")
+    if not isinstance(case, str) or not isinstance(step, int):
+        raise ComparisonInputError("invalid_step_identity")
+    return case, step, repetition if isinstance(repetition, int) else 1
+
+
+def _reuse_enabled(environment: dict[str, object]) -> bool | None:
+    value = environment.get("post_tool_final_reuse")
+    return value.get("enabled") if isinstance(value, dict) and isinstance(value.get("enabled"), bool) else None
+
+
+def _reuse_delta(row: dict[str, object]) -> int:
+    value = row.get("post_tool_final_reuse")
+    delta = value.get("reused_count_delta") if isinstance(value, dict) else None
+    return delta if isinstance(delta, int) else 0
+
+
+def _model_steps(row: dict[str, object]) -> list[object]:
+    value = row.get("model_steps")
+    return value if isinstance(value, list) else []
+
+
+def _evaluated_tokens(row: dict[str, object]) -> int:
+    return sum(
+        int(step.get("evaluated_tokens") or 0)
+        for step in _model_steps(row)
+        if isinstance(step, dict)
+    )
+
+
+def _number(value: object) -> float:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0.0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare process-isolated post-tool final reuse smoke runs.")
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        result = compare_runs(load_run(args.baseline), load_run(args.candidate))
+    except ComparisonInputError as exc:
+        print(json.dumps({"type": "post_tool_final_reuse_comparison", "decision": "invalid", "error": str(exc)}))
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["decision"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orbit_smoke_harness.py
+++ b/scripts/orbit_smoke_harness.py
@@ -38,19 +38,27 @@ from orbit.final_prefix_config import (
     FINAL_PREFIX_TOKEN_COUNT,
     resolve_final_prefix_reuse,
 )
+from orbit.inference_audit_config import resolve_inference_audit_shadow
+from orbit.post_tool_final_reuse_config import (
+    POST_TOOL_FINAL_REUSE_ENV,
+    resolve_post_tool_final_reuse,
+)
 from orbit.runtime.chat import ChatRuntime
 from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import current_phase
 from orbit.runtime.kv_diag import model_call_context
+from orbit.runtime.inference_audit import audit_model_calls, summarize_inference_audits
 from orbit.runtime.messages import DEFAULT_SYSTEM_PROMPT, TOOL_CALL_SYSTEM_PROMPT, with_tool_call_system_prompt
 from orbit.runtime.tool_backends import HybridToolExecutor
 from orbit.runtime.tool_healing import analyze_tool_attempt, tool_call_healing_status
+from orbit.runtime.tool_plan_shadow import analyze_tool_plan_shadow
 from orbit.runtime.tools import TOOL_NAMES, tool_definitions
-from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 from orbit.terminal.runtime_status import collect_host_info
 from orbit.tool_contract_config import TOOL_CALL_CANONICAL_GATE_ENV, resolve_tool_call_canonical_gate
 from orbit.tool_healing_config import TOOL_CALL_HEALING_ENV, resolve_tool_call_healing
+from orbit.tool_plan_config import resolve_tool_plan_shadow
 
 
 CorrectnessChecker = Callable[[str, list[str]], str]
@@ -64,16 +72,17 @@ class SmokeStep:
     expected_route: str | None = None
     expected_tool_names: tuple[str, ...] | None = None
     expected_active_outcome: str | None = None
+    inference_audit_expectation: str = "unknown"
 
 
 FINAL_PREFIX_LOCAL_STEPS = (
-    SmokeStep("run pwd", checker_name="path_like"),
-    SmokeStep("tell me specs about this computer", checker_name="nonempty"),
-    SmokeStep("read text/summary.txt", checker_name="nonempty"),
-    SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty"),
-    SmokeStep("list files and directories in this workdir", checker_name="nonempty"),
-    SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty"),
-    SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error"),
+    SmokeStep("run pwd", checker_name="path_like", inference_audit_expectation="bounded_confirmation"),
+    SmokeStep("tell me specs about this computer", checker_name="nonempty", inference_audit_expectation="synthesis_required"),
+    SmokeStep("read text/summary.txt", checker_name="nonempty", inference_audit_expectation="synthesis_required"),
+    SmokeStep('search inside local text files for "Orbit"', checker_name="nonempty", inference_audit_expectation="synthesis_required"),
+    SmokeStep("list files and directories in this workdir", checker_name="nonempty", inference_audit_expectation="synthesis_required"),
+    SmokeStep("run printf 'orbit-final-prefix-ok\\n'", checker_name="nonempty", inference_audit_expectation="bounded_confirmation"),
+    SmokeStep("run command_that_does_not_exist_123", checker_name="shell_error", inference_audit_expectation="structured_error"),
 )
 
 FINAL_PREFIX_WEB_STEPS = (
@@ -192,15 +201,15 @@ ROUTE_CLASS_WEB_ERROR_STEPS = (
 )
 
 TOOL_HEALING_STEPS = (
-    SmokeStep("show the computer specifications", mode="tool", checker_name="nonempty", expected_tool_names=("system_info",), expected_active_outcome="executed"),
-    SmokeStep("list this directory", mode="tool", checker_name="nonempty", expected_tool_names=("list_directory",), expected_active_outcome="executed"),
-    SmokeStep("read route_fixture.txt", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed"),
-    SmokeStep('search route_fixture.txt for "route-fixture-match"', mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed"),
-    SmokeStep("run printf 'healing-ok\\n'", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed"),
+    SmokeStep("show the computer specifications", mode="tool", checker_name="nonempty", expected_tool_names=("system_info",), expected_active_outcome="executed", inference_audit_expectation="synthesis_required"),
+    SmokeStep("list this directory", mode="tool", checker_name="nonempty", expected_tool_names=("list_directory",), expected_active_outcome="executed", inference_audit_expectation="synthesis_required"),
+    SmokeStep("read route_fixture.txt", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed", inference_audit_expectation="synthesis_required"),
+    SmokeStep('search route_fixture.txt for "route-fixture-match"', mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed", inference_audit_expectation="synthesis_required"),
+    SmokeStep("run printf 'healing-ok\\n'", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed", inference_audit_expectation="bounded_confirmation"),
     SmokeStep("without changing files, delete route_fixture.txt", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="rejected_policy"),
-    SmokeStep("fetch http://127.0.0.1:9/orbit-healing", mode="tool", checker_name="nonempty", expected_tool_names=("fetch_url",), expected_active_outcome="runtime_error"),
-    SmokeStep("fetch file:///etc/passwd", mode="tool", checker_name="nonempty", expected_tool_names=("fetch_url",), expected_active_outcome="runtime_error"),
-    SmokeStep("run pwd and answer briefly", mode="tool", checker_name="path_like", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed"),
+    SmokeStep("fetch http://127.0.0.1:9/orbit-healing", mode="tool", checker_name="nonempty", expected_tool_names=("fetch_url",), expected_active_outcome="runtime_error", inference_audit_expectation="structured_error"),
+    SmokeStep("fetch file:///etc/passwd", mode="tool", checker_name="nonempty", expected_tool_names=("fetch_url",), expected_active_outcome="runtime_error", inference_audit_expectation="structured_error"),
+    SmokeStep("run pwd and answer briefly", mode="tool", checker_name="path_like", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed", inference_audit_expectation="bounded_confirmation"),
     SmokeStep("run printf 'near-limit-%080d\\n' 1", mode="tool", checker_name="nonempty", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="executed"),
     SmokeStep("Explain in one sentence that system_info is a tool name; do not call tools.", mode="tool", checker_name="nonempty", expected_tool_names=(), expected_active_outcome="executed"),
     SmokeStep('Show this JSON example literally: {"name":"system_info","arguments":{}}. Do not call it.', mode="tool", checker_name="nonempty", expected_tool_names=(), expected_active_outcome="executed"),
@@ -213,13 +222,62 @@ TOOL_HEALING_QUICK_STEPS = (
     TOOL_HEALING_STEPS[11],
     TOOL_HEALING_STEPS[12],
 )
+
+INFERENCE_AUDIT_SINGLE_STEPS = (
+    SmokeStep(
+        "run printf 'audit-confirmation-ok\\n'",
+        checker_name="nonempty",
+        inference_audit_expectation="bounded_confirmation",
+    ),
+    SmokeStep(
+        "run command_that_does_not_exist_123",
+        checker_name="shell_error",
+        inference_audit_expectation="structured_error",
+    ),
+    SmokeStep(
+        "tell me specs about this computer",
+        checker_name="nonempty",
+        inference_audit_expectation="synthesis_required",
+    ),
+    SmokeStep(
+        "read text/summary.txt and explain its contents briefly",
+        checker_name="nonempty",
+        inference_audit_expectation="synthesis_required",
+    ),
+    SmokeStep(
+        "search online for orbit fixture success and summarize the result",
+        checker_name="nonempty",
+        inference_audit_expectation="synthesis_required",
+    ),
+)
+
+INFERENCE_AUDIT_TWO_TOOL_STEPS = (
+    SmokeStep(
+        "Run printf 'audit-first\\n', then run printf 'audit-second\\n', and report both results.",
+        checker_name="nonempty",
+        inference_audit_expectation="next_tool_required",
+    ),
+)
+
+INFERENCE_AUDIT_SYNTHESIS_STEPS = (
+    SmokeStep(
+        "run python3 -c 'for i in range(20): print(f\"audit-line-{i}\")'",
+        checker_name="nonempty",
+        inference_audit_expectation="synthesis_required",
+    ),
+    SmokeStep(
+        "compare the first five and last five lines and explain the pattern",
+        checker_name="nonempty",
+        inference_audit_expectation="synthesis_required",
+    ),
+)
 CANONICAL_GATE_REAL_STEPS = (
     TOOL_HEALING_STEPS[0],
     TOOL_HEALING_STEPS[1],
     TOOL_HEALING_STEPS[2],
     TOOL_HEALING_STEPS[3],
     TOOL_HEALING_STEPS[4],
-    SmokeStep("run command_that_does_not_exist_123", mode="tool", checker_name="shell_error", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="runtime_error"),
+    SmokeStep("run command_that_does_not_exist_123", mode="tool", checker_name="shell_error", expected_tool_names=("exec_shell_full_command",), expected_active_outcome="runtime_error", inference_audit_expectation="structured_error"),
     TOOL_HEALING_STEPS[6],
     TOOL_HEALING_STEPS[11],
 )
@@ -284,6 +342,55 @@ TOOL_CALL_GENERATION_CORPUS_VERSION = 1
 TOOL_CALL_GENERATION_PROTOCOL_VERSION = 1
 TOOL_CALL_GENERATION_CONFIGURATION_VERSION = 1
 
+_TOOL_PLAN_BASE_PROMPT = """Choose exactly one response schema. Supported task: exactly two independent calls using only system_info or list_directory, with all arguments known now. Plan schema: {\"type\":\"tool_plan\",\"steps\":[{\"name\":\"<exact tool>\",\"arguments\":{}},{\"name\":\"<exact tool>\",\"arguments\":{}}]}. Unsupported schema: {\"type\":\"unsupported_plan\"}. Use unsupported_plan if any requested action needs another tool, mutation, network access, an intermediate result, or cannot be completed by exactly two supported calls."""
+TOOL_PLAN_SHADOW_PROMPT_VIEWS = {
+    "contract": _TOOL_PLAN_BASE_PROMPT,
+    "json_only": _TOOL_PLAN_BASE_PROMPT + " Output only the JSON object, with no prose or Markdown fences.",
+    "exactness": _TOOL_PLAN_BASE_PROMPT + " Output only the JSON object, with no prose or Markdown fences. Do not replace an unsupported requested action with a supported tool.",
+}
+
+TOOL_PLAN_SHADOW_CORPUS = (
+    (
+        "mixed_specs_list",
+        "positive_mixed",
+        "First collect computer specifications, then list '.' with at most 20 entries.",
+        "plan",
+        (("system_info", {}), ("list_directory", {"path": ".", "max_entries": 20})),
+    ),
+    (
+        "mixed_list_specs",
+        "positive_mixed",
+        "First list 'docs' with at most 10 entries, then collect computer specifications.",
+        "plan",
+        (("list_directory", {"path": "docs", "max_entries": 10}), ("system_info", {})),
+    ),
+    (
+        "two_lists_alpha_beta",
+        "positive_two_lists",
+        "List 'alpha' with at most 5 entries and independently list 'beta' with at most 7 entries, in that order.",
+        "plan",
+        (("list_directory", {"path": "alpha", "max_entries": 5}), ("list_directory", {"path": "beta", "max_entries": 7})),
+    ),
+    (
+        "two_lists_src_tests",
+        "positive_two_lists",
+        "List 'src' with at most 12 entries and independently list 'tests' with at most 15 entries, in that order.",
+        "plan",
+        (("list_directory", {"path": "src", "max_entries": 12}), ("list_directory", {"path": "tests", "max_entries": 15})),
+    ),
+    ("unsupported_shell", "negative", "Run pwd and uname -s as two shell commands.", "unsupported", None),
+    ("unsupported_mutation", "negative", "Create synthetic.txt and then list the current directory.", "unsupported", None),
+    (
+        "unsupported_dependency",
+        "negative",
+        "List the current directory and then read the first filename returned by that listing.",
+        "unsupported",
+        None,
+    ),
+    ("unsupported_network", "negative", "Fetch https://synthetic.invalid and then show system specifications.", "unsupported", None),
+    ("unsupported_missing_tool", "negative", "Read known.txt and list the docs directory.", "unsupported", None),
+)
+
 
 @dataclass(frozen=True)
 class SmokeScenario:
@@ -342,12 +449,17 @@ class StepReport:
     route_fallback_used: bool = False
     tool_healing_diagnostics_enabled: bool = False
     tool_healing_attempts: list[dict[str, object]] = field(default_factory=list)
+    model_phase_starts: list[dict[str, object]] = field(default_factory=list)
+    phase_timing_sequence: list[dict[str, object]] = field(default_factory=list)
+    inference_audit_enabled: bool = False
+    inference_audit: dict[str, object] = field(default_factory=dict)
+    post_tool_final_reuse: dict[str, object] = field(default_factory=dict)
 
     def to_json(self) -> dict[str, object]:
         return {
             "case": self.case,
             "step": self.step,
-            "prompt": "<redacted>" if self.tool_healing_diagnostics_enabled else self.prompt,
+            "prompt": "<redacted>" if self.tool_healing_diagnostics_enabled or self.inference_audit_enabled else self.prompt,
             "prompt_kind": self.prompt_kind,
             "completion_kind": self.completion_kind,
             "route_tokens": self.route_tokens,
@@ -365,7 +477,7 @@ class StepReport:
             "fake_output": self.fake_output,
             "loop": self.loop,
             "notes": self.notes,
-            "answer_excerpt": "<redacted>" if self.tool_healing_diagnostics_enabled else self.answer_excerpt,
+            "answer_excerpt": "<redacted>" if self.tool_healing_diagnostics_enabled or self.inference_audit_enabled else self.answer_excerpt,
             "model_steps": self.model_steps,
             "final_prefix": self.final_prefix,
             "lifecycle": self.lifecycle,
@@ -389,6 +501,11 @@ class StepReport:
             "route_fallback_used": self.route_fallback_used,
             "tool_healing_diagnostics_enabled": self.tool_healing_diagnostics_enabled,
             "tool_healing_attempts": self.tool_healing_attempts,
+            "model_phase_starts": self.model_phase_starts,
+            "phase_timing_sequence": self.phase_timing_sequence,
+            "inference_audit_enabled": self.inference_audit_enabled,
+            "inference_audit": self.inference_audit,
+            "post_tool_final_reuse": self.post_tool_final_reuse,
         }
 
 
@@ -762,20 +879,35 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.lifecycle_check:
         return run_lifecycle_checks(args, jsonl_path=jsonl_path, markdown_path=markdown_path)
+    if args.tool_plan_shadow:
+        plan_config = resolve_tool_plan_shadow()
+        if not plan_config.enabled:
+            reason = plan_config.validation_error or "disabled"
+            print(f"error: bounded tool-plan shadow is not enabled ({reason})", file=sys.stderr)
+            return 2
+        return run_tool_plan_shadow_benchmark(args, jsonl_path=jsonl_path, markdown_path=markdown_path)
     if args.tool_call_generation_only:
         return run_tool_call_generation_benchmark(args, jsonl_path=jsonl_path, markdown_path=markdown_path)
 
+    inference_audit_config = resolve_inference_audit_shadow()
+    if args.inference_audit_shadow and not inference_audit_config.enabled:
+        reason = inference_audit_config.validation_error or "disabled"
+        print(f"error: inference audit shadow is not enabled ({reason})", file=sys.stderr)
+        return 2
+    inference_audit_enabled = args.inference_audit_shadow and inference_audit_config.enabled
+
     with (
         final_prefix_environment(args.final_prefix_mode),
+        post_tool_final_reuse_environment(args.post_tool_final_reuse_mode),
         canonical_gate_environment(args.canonical_gate),
         tool_healing_environment(args.tool_healing_mode),
         deterministic_web(args.deterministic_web),
         managed_server(args) as server_process,
         route_diagnostic_environment(
-            args.route_output_diagnostics or args.tool_healing_diagnostics,
+            args.route_output_diagnostics or args.tool_healing_diagnostics or inference_audit_enabled,
             store_mode=args.route_diagnostic_store,
             tool_healing=args.tool_healing_diagnostics,
-            route_output=args.route_output_diagnostics,
+            route_output=args.route_output_diagnostics or inference_audit_enabled,
         ) as route_collector,
     ):
         backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
@@ -808,6 +940,7 @@ def main(argv: list[str] | None = None) -> int:
                         block_id=args.block_id or f"run-{run_order_index:04d}",
                         run_order=args.run_order or str(run_order_index),
                         repetition=repeat,
+                        inference_audit_enabled=inference_audit_enabled,
                     )
                 )
         final_props = settled_backend_props(args.base_url, args.timeout)
@@ -815,6 +948,9 @@ def main(argv: list[str] | None = None) -> int:
         env["server_pid"] = server_process.pid if server_process is not None else None
         env["server_rss_before_kib"] = rss_before_kib
         env["server_rss_after_kib"] = process_rss_kib(server_process)
+        env["post_tool_final_reuse_comparison_fingerprint"] = (
+            post_tool_final_reuse_comparison_fingerprint(env)
+        )
     replay_rows = run_tool_healing_replay(Path(args.workdir)) if args.tool_healing_replay else []
     if replay_rows:
         write_jsonl(jsonl_path, env, reports, extra_rows=replay_rows)
@@ -855,6 +991,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument("--max-tokens", type=int, default=128)
     parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument(
+        "--post-tool-final-reuse-mode",
+        choices=("inherit", "off", "on"),
+        default="inherit",
+        help="Control post-tool prose final reuse for this benchmark only.",
+    )
     parser.add_argument(
         "--canonical-gate",
         choices=("inherit", "off", "on"),
@@ -922,6 +1064,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--tool-call-generation-smoke",
         action="store_true",
         help="Use one prompt per tool family plus two negatives instead of the full 40-prompt corpus.",
+    )
+    parser.add_argument(
+        "--tool-plan-shadow",
+        action="store_true",
+        help="Generate and validate one bounded tool plan per benchmark case without executing tools.",
+    )
+    parser.add_argument(
+        "--tool-plan-shadow-smoke",
+        action="store_true",
+        help="Use a four-case subset of the bounded tool-plan shadow corpus.",
+    )
+    parser.add_argument(
+        "--inference-audit-shadow",
+        action="store_true",
+        help="Classify model calls and theoretical savings without changing runtime behavior.",
+    )
+    parser.add_argument(
+        "--tool-plan-prompt-view",
+        choices=("all", *TOOL_PLAN_SHADOW_PROMPT_VIEWS),
+        default="all",
+        help="Select one bounded tool-plan prompt view or compare all views.",
     )
     parser.add_argument(
         "--route-diagnostic-store",
@@ -1012,6 +1175,347 @@ def run_tool_call_generation_benchmark(
     print(f"jsonl={jsonl_path}")
     print(f"markdown={markdown_path}")
     return 1 if any(row.get("cleanup_healthy") is False for row in rows) else 0
+
+
+def run_tool_plan_shadow_benchmark(
+    args: argparse.Namespace,
+    *,
+    jsonl_path: Path,
+    markdown_path: Path,
+) -> int:
+    with managed_server(args) as server_process:
+        backend = LlamaServerBackend(base_url=args.base_url, timeout=args.timeout)
+        backend.thinking = args.server_thinking == "on"
+        corpus = tool_plan_shadow_corpus(smoke=args.tool_plan_shadow_smoke)
+        prompt_views = (
+            TOOL_PLAN_SHADOW_PROMPT_VIEWS
+            if args.tool_plan_prompt_view == "all"
+            else {args.tool_plan_prompt_view: TOOL_PLAN_SHADOW_PROMPT_VIEWS[args.tool_plan_prompt_view]}
+        )
+        rows: list[dict[str, object]] = []
+        workdir = Path(args.workdir)
+        for prompt_view, system_prompt in prompt_views.items():
+            for repetition in range(1, args.repetitions + 1):
+                for scenario, group, prompt, expected_kind, expected_steps in corpus:
+                    rows.append(
+                        run_tool_plan_shadow_sample(
+                            backend,
+                            base_url=args.base_url,
+                            timeout=args.timeout,
+                            workdir=workdir,
+                            scenario=scenario,
+                            group=group,
+                            prompt=prompt,
+                            prompt_view=prompt_view,
+                            system_prompt=system_prompt,
+                            expected_kind=expected_kind,
+                            expected_steps=expected_steps,
+                            repetition=repetition,
+                            temperature=args.temperature,
+                            max_tokens=args.max_tokens,
+                        )
+                    )
+        final_props = settled_backend_props(args.base_url, args.timeout)
+        env = environment_summary(args=args, backend=backend, props=final_props)
+        env.update(
+            {
+                "type": "environment",
+                "benchmark_mode": "tool_plan_shadow",
+                "server_pid": server_process.pid if server_process is not None else None,
+                "corpus_size": len(corpus),
+                "corpus_version": 1,
+                "corpus_hash": _hash_bounded_tool_plan_corpus(corpus),
+                "tool_plan_shadow": {
+                    "enabled": resolve_tool_plan_shadow().enabled,
+                    "source": resolve_tool_plan_shadow().source,
+                    "validation_error": resolve_tool_plan_shadow().validation_error,
+                    "active_execution": False,
+                    "model_tools_mode": "off",
+                    "schemas_in_prompt": True,
+                    "step_count": 2,
+                    "prompt_views": list(prompt_views),
+                },
+            }
+        )
+    summary = summarize_tool_plan_shadow(rows)
+    write_tool_plan_shadow_jsonl(jsonl_path, env, rows, summary)
+    write_tool_plan_shadow_markdown(markdown_path, env, summary)
+    print(f"jsonl={jsonl_path}")
+    print(f"markdown={markdown_path}")
+    return 1 if any(row.get("cleanup_healthy") is False for row in rows) else 0
+
+
+def tool_plan_shadow_corpus(
+    *,
+    smoke: bool,
+) -> tuple[tuple[str, str, str, str, tuple[tuple[str, dict[str, object]], ...] | None], ...]:
+    if not smoke:
+        return TOOL_PLAN_SHADOW_CORPUS
+    selected = {"mixed_specs_list", "two_lists_alpha_beta", "unsupported_shell", "unsupported_dependency"}
+    return tuple(item for item in TOOL_PLAN_SHADOW_CORPUS if item[0] in selected)
+
+
+def run_tool_plan_shadow_sample(
+    backend: LlamaServerBackend,
+    *,
+    base_url: str,
+    timeout: float,
+    workdir: Path,
+    scenario: str,
+    group: str,
+    prompt: str,
+    prompt_view: str,
+    system_prompt: str,
+    expected_kind: str,
+    expected_steps: tuple[tuple[str, dict[str, object]], ...] | None,
+    repetition: int,
+    temperature: float,
+    max_tokens: int,
+) -> dict[str, object]:
+    runtime = ChatRuntime(backend=ProbeBackend(backend), system_prompt=None)
+    plan_tools = tool_definitions(tuple(sorted({"list_directory", "system_info"})))
+    schema_text = json.dumps(plan_tools, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    messages = [
+        {"role": "system", "content": f"{system_prompt}\nCanonical tool schemas: {schema_text}"},
+        {"role": "user", "content": prompt},
+    ]
+    result_queue: queue.Queue[ChatResult | BaseException] = queue.Queue(maxsize=1)
+
+    def generate() -> None:
+        try:
+            with model_call_context(phase="tool_plan_shadow", tools_mode="off"):
+                result_queue.put(
+                    runtime._chat_once(
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        on_final_delta=None,
+                        on_progress=None,
+                    )
+                )
+        except BaseException as exc:
+            result_queue.put(exc)
+
+    worker = threading.Thread(target=generate, daemon=True)
+    started = time.perf_counter()
+    worker.start()
+    worker.join(timeout)
+    timed_out = worker.is_alive()
+    cancel_requested = False
+    cleanup_started = time.perf_counter()
+    if timed_out:
+        cancel_requested = request_backend_cancel(base_url, timeout=min(5.0, max(1.0, timeout)))
+    props = wait_for_backend_idle(base_url, timeout=min(10.0, max(2.0, timeout / 5.0)))
+    worker.join(min(2.0, max(0.5, timeout / 10.0)))
+    cleanup_ms = round((time.perf_counter() - cleanup_started) * 1000, 1)
+    wall_ms = round((time.perf_counter() - started) * 1000, 1)
+    value = result_queue.get_nowait() if not result_queue.empty() else None
+    result = value if isinstance(value, ChatResult) else None
+    error = value if isinstance(value, BaseException) else None
+    cancelled = bool(result and result.finish_reason == "cancelled")
+    evaluable = result is not None and not timed_out and not cancelled and error is None
+    validation_us: float | None = None
+    report = None
+    if result is not None:
+        validation_started = time.perf_counter_ns()
+        report = analyze_tool_plan_shadow(
+            result.content,
+            finish_reason=result.finish_reason,
+            tool_definitions=tool_definitions(TOOL_NAMES),
+            allowed_tool_names=TOOL_NAMES,
+            workdir=workdir,
+            user_prompt=prompt,
+        )
+        validation_us = round((time.perf_counter_ns() - validation_started) / 1000, 1)
+    diagnostic = report.diagnostic() if report is not None else {}
+    if result is not None and result.tool_calls:
+        diagnostic.update(
+            {
+                "valid": False,
+                "rejection_code": "unexpected_backend_tool_call",
+                "response_kind": None,
+            }
+        )
+    if validation_us is not None:
+        diagnostic["validation_us"] = validation_us
+    prompt_tokens = result.prompt_tokens if result else None
+    cached_tokens = result.cached_tokens if result else None
+    actual_steps = _normalized_plan_steps(report.plan) if report is not None and report.plan is not None else None
+    exact_tool_sequence = _tool_sequence(actual_steps) == _tool_sequence(expected_steps) if expected_steps else None
+    exact_arguments = actual_steps == expected_steps if expected_steps else None
+    scenario_outcome = _tool_plan_scenario_outcome(
+        evaluable=evaluable,
+        report_valid=diagnostic.get("valid") is True,
+        response_kind=diagnostic.get("response_kind"),
+        expected_kind=expected_kind,
+        exact_arguments=exact_arguments,
+    )
+    exact_plan = scenario_outcome == "exact_plan"
+    correct_unsupported = scenario_outcome == "correct_unsupported"
+    return {
+        "type": "tool_plan_shadow",
+        "scenario": scenario,
+        "group": group,
+        "prompt_view": prompt_view,
+        "repetition": repetition,
+        "expected_kind": expected_kind,
+        "scenario_outcome": scenario_outcome,
+        "exact_tool_sequence": exact_tool_sequence,
+        "exact_arguments": exact_arguments,
+        "exact_plan": exact_plan,
+        "correct_unsupported": correct_unsupported,
+        "wrong_plan": scenario_outcome == "wrong_plan",
+        "evaluable": evaluable,
+        "model_calls": 1,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "evaluated_tokens": (
+            prompt_tokens - cached_tokens
+            if isinstance(prompt_tokens, int) and isinstance(cached_tokens, int)
+            else None
+        ),
+        "output_tokens": result.completion_tokens if result else None,
+        "finish_reason": result.finish_reason if result else "timeout" if timed_out else "error",
+        "generation_wall_ms": wall_ms,
+        "timeout": timed_out,
+        "cancel_requested": cancel_requested,
+        "cancelled": cancelled,
+        "cleanup_ms": cleanup_ms,
+        "cleanup_healthy": props.get("in_flight") is False and not worker.is_alive(),
+        "unexpected_backend_tool_calls": bool(result and result.tool_calls),
+        "error_type": type(error).__name__ if error is not None else None,
+        "potential_model_call_reduction": 2 if exact_plan else 0,
+        "realized_model_call_reduction": 0,
+        **diagnostic,
+    }
+
+
+def summarize_tool_plan_shadow(rows: list[dict[str, object]]) -> dict[str, object]:
+    evaluable = [row for row in rows if row.get("evaluable") is True]
+    latencies = [float(row["validation_us"]) for row in evaluable if isinstance(row.get("validation_us"), int | float)]
+    generation = [float(row["generation_wall_ms"]) for row in evaluable if isinstance(row.get("generation_wall_ms"), int | float)]
+    views = {
+        view: _summarize_tool_plan_view([row for row in rows if row.get("prompt_view") == view])
+        for view in TOOL_PLAN_SHADOW_PROMPT_VIEWS
+        if any(row.get("prompt_view") == view for row in rows)
+    }
+    return {
+        "type": "tool_plan_shadow_summary",
+        "samples": len(rows),
+        "evaluable": len(evaluable),
+        "json_compliant": sum(row.get("json_compliant") is True for row in evaluable),
+        "exact_plans": sum(row.get("exact_plan") is True for row in evaluable),
+        "correct_unsupported": sum(row.get("correct_unsupported") is True for row in evaluable),
+        "wrong_plans": sum(row.get("wrong_plan") is True for row in evaluable),
+        "prose_leakage": sum(row.get("prose_leakage") is True for row in evaluable),
+        "invalid_json": sum(row.get("invalid_json") is True for row in evaluable),
+        "model_calls": sum(int(row.get("model_calls") or 0) for row in rows),
+        "potential_model_call_reduction": sum(int(row.get("potential_model_call_reduction") or 0) for row in rows),
+        "realized_model_call_reduction": 0,
+        "tool_executions": 0,
+        "finalizations_started": 0,
+        "validation_us_median": round(statistics.median(latencies), 1) if latencies else None,
+        "validation_us_p95": percentile(latencies, 0.95),
+        "generation_wall_ms_median": round(statistics.median(generation), 1) if generation else None,
+        "prompt_tokens_total": sum(int(row.get("prompt_tokens") or 0) for row in evaluable),
+        "evaluated_tokens_total": sum(int(row.get("evaluated_tokens") or 0) for row in evaluable),
+        "output_tokens_total": sum(int(row.get("output_tokens") or 0) for row in evaluable),
+        "views": views,
+        "raw_content_included": False,
+    }
+
+
+def write_tool_plan_shadow_jsonl(
+    path: Path,
+    env: dict[str, object],
+    rows: list[dict[str, object]],
+    summary: dict[str, object],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as stream:
+        for row in (env, *rows, summary):
+            stream.write(json.dumps(row, ensure_ascii=True, sort_keys=True) + "\n")
+
+
+def write_tool_plan_shadow_markdown(path: Path, env: dict[str, object], summary: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "# Orbit Bounded Tool-Plan Shadow Benchmark\n\n"
+        f"- Model: `{env.get('model')}`\n"
+        f"- Samples: `{summary.get('samples')}`\n"
+        f"- Evaluable: `{summary.get('evaluable')}`\n"
+        f"- JSON compliant: `{summary.get('json_compliant')}`\n"
+        f"- Exact plans: `{summary.get('exact_plans')}`\n"
+        f"- Correct unsupported: `{summary.get('correct_unsupported')}`\n"
+        f"- Wrong plans: `{summary.get('wrong_plans')}`\n"
+        f"- Tool executions: `{summary.get('tool_executions')}`\n"
+        f"- Finalizations: `{summary.get('finalizations_started')}`\n"
+        f"- Realized model-call reduction: `{summary.get('realized_model_call_reduction')}`\n",
+        encoding="utf-8",
+    )
+
+
+def _normalized_plan_steps(plan) -> tuple[tuple[str, dict[str, object]], ...]:
+    return tuple((step.name, step.arguments) for step in plan.steps)
+
+
+def _tool_sequence(steps: tuple[tuple[str, dict[str, object]], ...] | None) -> tuple[str, ...] | None:
+    return tuple(name for name, _arguments in steps) if steps is not None else None
+
+
+def _tool_plan_scenario_outcome(
+    *,
+    evaluable: bool,
+    report_valid: bool,
+    response_kind: object,
+    expected_kind: str,
+    exact_arguments: bool | None,
+) -> str:
+    if not evaluable:
+        return "non_evaluable"
+    if not report_valid:
+        return "invalid_response"
+    if expected_kind == "unsupported":
+        return "correct_unsupported" if response_kind == "unsupported" else "wrong_plan"
+    if response_kind != "plan":
+        return "missed_plan"
+    return "exact_plan" if exact_arguments is True else "wrong_plan"
+
+
+def _summarize_tool_plan_view(rows: list[dict[str, object]]) -> dict[str, object]:
+    evaluable = [row for row in rows if row.get("evaluable") is True]
+    positives = [row for row in evaluable if row.get("expected_kind") == "plan"]
+    negatives = [row for row in evaluable if row.get("expected_kind") == "unsupported"]
+    json_count = sum(row.get("json_compliant") is True for row in evaluable)
+    exact_count = sum(row.get("exact_plan") is True for row in positives)
+    unsupported_count = sum(row.get("correct_unsupported") is True for row in negatives)
+    wrong_count = sum(row.get("wrong_plan") is True for row in evaluable)
+    return {
+        "samples": len(rows),
+        "evaluable": len(evaluable),
+        "json_compliance_rate": round(json_count / len(evaluable), 6) if evaluable else None,
+        "exact_plan_rate": round(exact_count / len(positives), 6) if positives else None,
+        "unsupported_accuracy": round(unsupported_count / len(negatives), 6) if negatives else None,
+        "wrong_plan_rate": round(wrong_count / len(evaluable), 6) if evaluable else None,
+        "prose_leakage": sum(row.get("prose_leakage") is True for row in evaluable),
+        "invalid_json": sum(row.get("invalid_json") is True for row in evaluable),
+        "prompt_tokens_total": sum(int(row.get("prompt_tokens") or 0) for row in evaluable),
+        "evaluated_tokens_total": sum(int(row.get("evaluated_tokens") or 0) for row in evaluable),
+        "output_tokens_total": sum(int(row.get("output_tokens") or 0) for row in evaluable),
+        "generation_wall_ms_total": round(sum(float(row.get("generation_wall_ms") or 0) for row in evaluable), 1),
+        "smoke_gate_pass": bool(
+            evaluable
+            and json_count / len(evaluable) >= 0.9
+            and wrong_count == 0
+            and exact_count == len(positives)
+            and unsupported_count == len(negatives)
+        ),
+    }
+
+
+def _hash_bounded_tool_plan_corpus(corpus: tuple[object, ...]) -> str:
+    payload = json.dumps(corpus, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def tool_call_generation_corpus(*, smoke: bool) -> tuple[tuple[str, str | None, str], ...]:
@@ -1539,6 +2043,29 @@ def scenarios() -> dict[str, SmokeScenario]:
         "canonical_gate_shell_error": SmokeScenario("canonical_gate_shell_error", (CANONICAL_GATE_REAL_STEPS[5],), optional=True, allowed_tool_names=TOOL_NAMES, family="canonical_gate"),
         "canonical_gate_fetch_error": SmokeScenario("canonical_gate_fetch_error", (CANONICAL_GATE_REAL_STEPS[6],), optional=True, allowed_tool_names=TOOL_NAMES, family="canonical_gate"),
         "canonical_gate_negative": SmokeScenario("canonical_gate_negative", (CANONICAL_GATE_REAL_STEPS[7],), optional=True, allowed_tool_names=TOOL_NAMES, family="canonical_gate"),
+        "inference_audit_single": SmokeScenario(
+            "inference_audit_single",
+            INFERENCE_AUDIT_SINGLE_STEPS,
+            optional=True,
+            requires_web=True,
+            allowed_tool_names=TOOL_NAMES,
+            isolated_steps=True,
+            family="inference_audit",
+        ),
+        "inference_audit_two_tool": SmokeScenario(
+            "inference_audit_two_tool",
+            INFERENCE_AUDIT_TWO_TOOL_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="inference_audit",
+        ),
+        "inference_audit_synthesis": SmokeScenario(
+            "inference_audit_synthesis",
+            INFERENCE_AUDIT_SYNTHESIS_STEPS,
+            optional=True,
+            allowed_tool_names=TOOL_NAMES,
+            family="inference_audit",
+        ),
     }
 
 
@@ -1574,6 +2101,7 @@ def run_scenario(
     block_id: str | None = None,
     run_order: str | None = None,
     repetition: int | None = None,
+    inference_audit_enabled: bool = False,
 ) -> list[StepReport]:
     runtime = new_runtime(backend, workdir, route_collector=route_collector)
     reports: list[StepReport] = []
@@ -1597,6 +2125,7 @@ def run_scenario(
             block_id=block_id,
             run_order=run_order,
             repetition=repetition,
+            inference_audit_enabled=inference_audit_enabled,
         )
         reports.append(report)
         if report.finish_reason in {"timeout", "error"}:
@@ -1640,6 +2169,7 @@ def run_step(
     block_id: str | None = None,
     run_order: str | None = None,
     repetition: int | None = None,
+    inference_audit_enabled: bool = False,
 ) -> StepReport:
     props_before = fresh_backend_props(base_url, min(timeout, 5.0))
     diagnostic_offset = route_collector.mark() if route_collector is not None else 0
@@ -1656,6 +2186,7 @@ def run_step(
                 max_tokens=max_tokens,
                 temperature=temperature,
                 allowed_tool_names=allowed_tool_names,
+                inference_audit_enabled=inference_audit_enabled,
             )
         ),
         daemon=True,
@@ -1706,6 +2237,7 @@ def run_step(
                 "cleanup_healthy": props_after.get("in_flight") is False,
             },
             phase_wall_ms={},
+            inference_audit_enabled=inference_audit_enabled,
         )
         report = enrich_step_route_diagnostics(
             report,
@@ -1718,12 +2250,13 @@ def run_step(
             run_order=run_order,
             repetition=repetition,
         )
-        return enrich_step_tool_healing(
+        report = enrich_step_tool_healing(
             report,
             route_collector.tool_healing_events_since(diagnostic_offset) if route_collector is not None else [],
             step=step,
             enabled=bool(route_collector and route_collector.tool_healing),
         )
+        return enrich_step_inference_audit(report, step=step, enabled=inference_audit_enabled)
     report = result_queue.get()
     props_after = fresh_backend_props(base_url, min(timeout, 5.0))
     report = replace_step_final_prefix(report, final_prefix_step_state(props_before, props_after))
@@ -1738,12 +2271,13 @@ def run_step(
         run_order=run_order,
         repetition=repetition,
     )
-    return enrich_step_tool_healing(
+    report = enrich_step_tool_healing(
         report,
         route_collector.tool_healing_events_since(diagnostic_offset) if route_collector is not None else [],
         step=step,
         enabled=bool(route_collector and route_collector.tool_healing),
     )
+    return enrich_step_inference_audit(report, step=step, enabled=inference_audit_enabled)
 
 
 def _run_step_inner(
@@ -1756,9 +2290,12 @@ def _run_step_inner(
     max_tokens: int,
     temperature: float,
     allowed_tool_names: tuple[str, ...],
+    inference_audit_enabled: bool = False,
 ) -> StepReport:
     model_steps: list[ModelStepMetrics] = []
+    phase_starts: list[ModelPhaseStart] = []
     tool_names: list[str] = []
+    reuse_before = post_tool_final_reuse_runtime_state(runtime)
     started = time.perf_counter()
     probe = probe_backend(runtime.backend)
     if probe is not None:
@@ -1771,6 +2308,7 @@ def _run_step_inner(
                 temperature=temperature,
                 max_tokens=max_tokens,
                 on_model_step=model_steps.append,
+                on_phase_start=phase_starts.append if inference_audit_enabled else None,
             )
         elif step.mode == "tool":
             result = runtime.ask_with_tools(
@@ -1780,6 +2318,7 @@ def _run_step_inner(
                 workdir=workdir,
                 tool_names=allowed_tool_names,
                 on_model_step=model_steps.append,
+                on_phase_start=phase_starts.append if inference_audit_enabled else None,
                 on_tool_call=lambda name, _args: tool_names.append(name),
             )
         else:
@@ -1790,6 +2329,7 @@ def _run_step_inner(
                 workdir=workdir,
                 allowed_tool_names=allowed_tool_names,
                 on_model_step=model_steps.append,
+                on_phase_start=phase_starts.append if inference_audit_enabled else None,
                 on_tool_call=lambda name, _args: tool_names.append(name),
             )
     except Exception as exc:
@@ -1806,7 +2346,8 @@ def _run_step_inner(
         )
         notes = "exception"
     wall_ms = round((time.perf_counter() - started) * 1000, 1)
-    phase_timings = phase_timing_summary(probe.phase_timings() if probe is not None else [], wall_ms)
+    raw_phase_timings = probe.phase_timings() if probe is not None else []
+    phase_timings = phase_timing_summary(raw_phase_timings, wall_ms)
     final_wall_ms = phase_duration(phase_timings, "final_from_tool")
     generation_ms = estimated_generation_ms(result.completion_tokens, result.generation_tokens_per_second)
     residual_ms = (
@@ -1851,6 +2392,13 @@ def _run_step_inner(
         final_prefix={},
         lifecycle={},
         phase_wall_ms=phase_timings,
+        model_phase_starts=[model_phase_start_to_json(item) for item in phase_starts],
+        phase_timing_sequence=[{"phase": phase, "wall_ms": duration} for phase, duration in raw_phase_timings],
+        inference_audit_enabled=inference_audit_enabled,
+        post_tool_final_reuse=post_tool_final_reuse_step_state(
+            reuse_before,
+            post_tool_final_reuse_runtime_state(runtime),
+        ),
         prompt_tokens_per_second=result.prompt_tokens_per_second,
         generation_tokens_per_second=result.generation_tokens_per_second,
         estimated_generation_ms=generation_ms,
@@ -1905,12 +2453,27 @@ def model_step_to_json(metric: ModelStepMetrics) -> dict[str, object]:
     }
 
 
+def model_phase_start_to_json(start: ModelPhaseStart) -> dict[str, object]:
+    return {
+        "phase": start.phase,
+        "streamed": start.streamed,
+        "attempt": start.attempt,
+        "reason": bounded_identifier(start.reason),
+    }
+
+
 def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend, props: dict[str, object] | None = None) -> dict[str, object]:
     props = props if props is not None else safe_backend_props(backend)
     info = safe_model_info(backend)
     host = collect_host_info()
     mtp = mtp_state_from_props(props)
-    redact = args.tool_healing_diagnostics or args.tool_call_generation_only
+    inference_audit = resolve_inference_audit_shadow()
+    redact = (
+        args.tool_healing_diagnostics
+        or args.tool_call_generation_only
+        or args.tool_plan_shadow
+        or args.inference_audit_shadow
+    )
     return {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "command": "<redacted>" if redact else " ".join(sys.argv),
@@ -1947,6 +2510,7 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "client_command": "<redacted>" if redact else " ".join(sys.argv),
         "final_prefix": final_prefix_props(props),
         "final_prefix_config": final_prefix_config_metadata(args.final_prefix_mode, props),
+        "post_tool_final_reuse": post_tool_final_reuse_metadata(args.post_tool_final_reuse_mode),
         "native_backend_capabilities": native_backend_capability_metadata(props),
         "block_id": args.block_id,
         "run_order": args.run_order,
@@ -1957,6 +2521,12 @@ def environment_summary(*, args: argparse.Namespace, backend: LlamaServerBackend
         "tool_healing": tool_healing_metadata(args.tool_healing_mode),
         "canonical_gate": canonical_gate_metadata(args.canonical_gate),
         "route_diagnostic_store": args.route_diagnostic_store,
+        "inference_audit_shadow": {
+            "requested": args.inference_audit_shadow,
+            "enabled": inference_audit.enabled and args.inference_audit_shadow,
+            "source": inference_audit.source,
+            "config_error": inference_audit.validation_error,
+        },
     }
 
 
@@ -2215,6 +2785,29 @@ def enrich_step_tool_healing(
     return StepReport(**values)
 
 
+def enrich_step_inference_audit(
+    report: StepReport,
+    *,
+    step: SmokeStep,
+    enabled: bool,
+) -> StepReport:
+    values = report.__dict__.copy()
+    values["inference_audit_enabled"] = enabled
+    if enabled:
+        values["inference_audit"] = audit_model_calls(
+            model_steps=report.model_steps,
+            phase_starts=report.model_phase_starts,
+            phase_timings=report.phase_timing_sequence,
+            route_outputs=report.route_outputs,
+            tool_names=report.tool_names,
+            expectation=step.inference_audit_expectation,
+            correctness=report.correctness_category,
+        )
+    else:
+        values["inference_audit"] = {}
+    return StepReport(**values)
+
+
 def route_expectation_result(
     expected_route: str | None,
     final_route: object,
@@ -2249,6 +2842,108 @@ def final_prefix_environment(mode: str):
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
+
+
+@contextmanager
+def post_tool_final_reuse_environment(mode: str):
+    previous = os.environ.get(POST_TOOL_FINAL_REUSE_ENV)
+    if mode != "inherit":
+        os.environ[POST_TOOL_FINAL_REUSE_ENV] = "1" if mode == "on" else "0"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(POST_TOOL_FINAL_REUSE_ENV, None)
+        else:
+            os.environ[POST_TOOL_FINAL_REUSE_ENV] = previous
+
+
+def post_tool_final_reuse_metadata(mode: str) -> dict[str, object]:
+    config = (
+        resolve_post_tool_final_reuse()
+        if mode == "inherit"
+        else resolve_post_tool_final_reuse(
+            {POST_TOOL_FINAL_REUSE_ENV: "1" if mode == "on" else "0"}
+        )
+    )
+    return {
+        "requested_mode": mode,
+        "enabled": config.enabled,
+        "source": config.source,
+        "validation_error": config.validation_error,
+    }
+
+
+def post_tool_final_reuse_runtime_state(runtime: ChatRuntime) -> dict[str, object]:
+    return {
+        "eligible_count": getattr(runtime, "post_tool_final_reuse_eligible_count", 0),
+        "reused_count": getattr(runtime, "post_tool_final_reuse_reused_count", 0),
+        "fallback_count": getattr(runtime, "post_tool_final_reuse_fallback_count", 0),
+        "avoided_model_calls": getattr(runtime, "post_tool_final_reuse_avoided_model_calls", 0),
+        "last_reason": bounded_identifier(getattr(runtime, "post_tool_final_reuse_last_reason", None)),
+    }
+
+
+def post_tool_final_reuse_step_state(
+    before: dict[str, object],
+    after: dict[str, object],
+) -> dict[str, object]:
+    config = resolve_post_tool_final_reuse()
+    state: dict[str, object] = {
+        "enabled": config.enabled,
+        "source": config.source,
+        "validation_error": config.validation_error,
+        "last_reason": after.get("last_reason"),
+        "saved_evaluated_tokens": None,
+        "saved_wall_ms": None,
+        "savings_measurement": "process_isolated_off_on_required",
+    }
+    for name in ("eligible_count", "reused_count", "fallback_count", "avoided_model_calls"):
+        old = before.get(name)
+        new = after.get(name)
+        state[name] = new
+        state[f"{name}_delta"] = new - old if isinstance(old, int) and isinstance(new, int) else None
+    state["eligible"] = bool(state.get("eligible_count_delta"))
+    state["reused"] = bool(state.get("reused_count_delta"))
+    state["fallback_reason"] = (
+        after.get("last_reason") if state.get("fallback_count_delta") else None
+    )
+    return state
+
+
+def post_tool_final_reuse_comparison_fingerprint(environment: dict[str, object]) -> str:
+    comparable = {
+        name: environment.get(name)
+        for name in (
+            "git_head",
+            "version",
+            "model",
+            "backend",
+            "thinking",
+            "mtp",
+            "mmproj",
+            "cpu",
+            "cores",
+            "accel",
+            "ctx",
+            "threads",
+            "threads_batch",
+            "batch",
+            "ubatch",
+            "tools",
+            "max_tokens",
+            "temperature",
+            "cpu_affinity",
+            "scenario",
+            "final_prefix_mode",
+            "final_prefix_config",
+            "native_backend_capabilities",
+            "canonical_gate",
+            "tool_healing",
+        )
+    }
+    payload = json.dumps(comparable, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 @contextmanager
@@ -2918,6 +3613,11 @@ def write_jsonl(
         healing_summary = summarize_tool_healing(reports)
         if healing_summary is not None:
             handle.write(json.dumps(healing_summary, ensure_ascii=False, sort_keys=True) + "\n")
+        audit_rows = [report.inference_audit for report in reports if report.inference_audit_enabled]
+        if audit_rows:
+            handle.write(
+                json.dumps(summarize_inference_audits(audit_rows), ensure_ascii=False, sort_keys=True) + "\n"
+            )
         for row in extra_rows or []:
             handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
@@ -2977,6 +3677,21 @@ def write_markdown(path: Path, env: dict[str, object], reports: list[StepReport]
                 f"{format_range(summary['cached_tokens'])} | {format_range(summary['evaluated_tokens'])} | "
                 f"{format_range(summary['wall_ms'])} |"
             )
+    audit_rows = [report.inference_audit for report in reports if report.inference_audit_enabled]
+    if audit_rows:
+        audit = summarize_inference_audits(audit_rows)
+        lines.extend(
+            [
+                "",
+                "## Inference Audit Shadow",
+                "",
+                f"- Model calls observed: `{audit['model_calls']}`",
+                f"- Theoretical candidates: `{audit['theoretical_model_calls']}`",
+                f"- Theoretical evaluated tokens: `{audit['theoretical_evaluated_tokens']}`",
+                f"- Theoretical model wall ms: `{audit['theoretical_wall_ms']}`",
+                "- Active behavior changed: `false`",
+            ]
+        )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/src/orbit/inference_audit_config.py
+++ b/src/orbit/inference_audit_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Mapping
+
+
+INFERENCE_AUDIT_SHADOW_ENV = "ORBIT_INFERENCE_AUDIT_SHADOW"
+
+
+@dataclass(frozen=True)
+class InferenceAuditShadowConfig:
+    enabled: bool
+    source: str
+    validation_error: str | None = None
+
+
+def resolve_inference_audit_shadow(
+    environ: Mapping[str, str] | None = None,
+) -> InferenceAuditShadowConfig:
+    env = os.environ if environ is None else environ
+    if INFERENCE_AUDIT_SHADOW_ENV not in env:
+        return InferenceAuditShadowConfig(False, "default")
+    value = env.get(INFERENCE_AUDIT_SHADOW_ENV, "")
+    if value == "1":
+        return InferenceAuditShadowConfig(True, "stable")
+    if value == "0":
+        return InferenceAuditShadowConfig(False, "stable")
+    return InferenceAuditShadowConfig(False, "stable", "invalid_boolean")

--- a/src/orbit/post_tool_final_reuse_config.py
+++ b/src/orbit/post_tool_final_reuse_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Mapping
+
+
+POST_TOOL_FINAL_REUSE_ENV = "ORBIT_POST_TOOL_FINAL_REUSE"
+
+
+@dataclass(frozen=True)
+class PostToolFinalReuseConfig:
+    enabled: bool
+    source: str
+    validation_error: str | None = None
+
+
+def resolve_post_tool_final_reuse(
+    environ: Mapping[str, str] | None = None,
+) -> PostToolFinalReuseConfig:
+    env = os.environ if environ is None else environ
+    if POST_TOOL_FINAL_REUSE_ENV not in env:
+        return PostToolFinalReuseConfig(True, "default")
+    value = env.get(POST_TOOL_FINAL_REUSE_ENV, "")
+    if value == "1":
+        return PostToolFinalReuseConfig(True, "stable")
+    if value == "0":
+        return PostToolFinalReuseConfig(False, "stable")
+    return PostToolFinalReuseConfig(False, "stable", "invalid_boolean")

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -140,6 +140,11 @@ class ChatRuntime:
     last_chat_projection_fallback_reason: str | None = None
     last_chat_projection_omitted_evidence_count: int = 0
     last_chat_projection_estimated_tokens_saved: int = 0
+    post_tool_final_reuse_eligible_count: int = 0
+    post_tool_final_reuse_reused_count: int = 0
+    post_tool_final_reuse_fallback_count: int = 0
+    post_tool_final_reuse_avoided_model_calls: int = 0
+    post_tool_final_reuse_last_reason: str | None = None
 
     def __post_init__(self) -> None:
         self.backend = instrument_backend(self.backend)
@@ -903,6 +908,11 @@ class ChatRuntime:
         self.completed_evidence_ids.clear()
         self.current_turn_evidence_sequence_start = 0
         self._reset_chat_projection_diagnostics()
+        self.post_tool_final_reuse_eligible_count = 0
+        self.post_tool_final_reuse_reused_count = 0
+        self.post_tool_final_reuse_fallback_count = 0
+        self.post_tool_final_reuse_avoided_model_calls = 0
+        self.post_tool_final_reuse_last_reason = None
         self.last_memory_refresh = None
         self.last_memory_refresh_message_count = None
         self.last_memory_refresh_attempt = None

--- a/src/orbit/runtime/inference_audit.py
+++ b/src/orbit/runtime/inference_audit.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable, Mapping, Sequence
+
+
+CALL_CATEGORIES = {
+    "initial_route",
+    "tool_call",
+    "post_tool_route",
+    "retry",
+    "final_from_tool",
+    "chat_final",
+    "formatting_only",
+    "confirmation_only",
+    "error_recovery",
+}
+
+DISPOSITIONS = {
+    "necessary",
+    "avoidable",
+    "duplicate",
+    "formatting_only",
+    "deterministic_completion_candidate",
+    "retry_caused",
+}
+
+AUDIT_EXPECTATIONS = {
+    "unknown",
+    "bounded_confirmation",
+    "structured_error",
+    "synthesis_required",
+    "next_tool_required",
+}
+
+_RETRY_PHASES = {
+    "route_retry",
+    "tool_call_retry",
+    "tool_call_json_retry",
+    "chat_final_retry",
+    "final_from_tool_retry",
+    "chat_continue_native",
+}
+_FORMATTING_PHASES = {
+    "chat_final_completion_repair",
+    "final_from_tool_completion_repair",
+    "final_from_tool_compact_retry",
+}
+_ERROR_REASONS = {
+    "empty_or_invalid",
+    "empty_response",
+    "length",
+    "length_retry",
+    "tool_contract_retry",
+}
+
+
+def audit_model_calls(
+    *,
+    model_steps: Sequence[Mapping[str, object]],
+    phase_starts: Sequence[Mapping[str, object]] = (),
+    phase_timings: Sequence[Mapping[str, object]] = (),
+    route_outputs: Sequence[Mapping[str, object]] = (),
+    tool_names: Sequence[str] = (),
+    expectation: str = "unknown",
+    correctness: str = "not_evaluated",
+) -> dict[str, object]:
+    """Classify completed calls without changing or interpreting runtime behavior."""
+    if expectation not in AUDIT_EXPECTATIONS:
+        expectation = "unknown"
+    occurrences = _correlate_occurrences(model_steps, phase_timings)
+    starts = _phase_start_queues(phase_starts)
+    route_queues = _route_output_queues(route_outputs)
+    calls: list[dict[str, object]] = []
+    allocated_tools = 0
+
+    for index, occurrence in enumerate(occurrences):
+        metric = occurrence.get("metric")
+        metric = metric if isinstance(metric, Mapping) else {}
+        timing_phase = _identifier(occurrence.get("phase")) or "unknown"
+        metric_phase = _identifier(metric.get("phase"))
+        phase = metric_phase or timing_phase
+        start = _take_phase_start(starts, timing_phase, phase)
+        reason = _identifier(start.get("reason")) if start else None
+        next_occurrence = occurrences[index + 1] if index + 1 < len(occurrences) else None
+        next_phase = _occurrence_phase(next_occurrence)
+        tool_call_count = _integer(metric.get("tool_calls")) or 0
+        category = _call_category(
+            phase=phase,
+            timing_phase=timing_phase,
+            loop=_integer(metric.get("loop")),
+            tool_call_count=tool_call_count,
+            tools_executed=bool(tool_names),
+            expectation=expectation,
+            reason=reason or _identifier(metric.get("retry_reason")),
+        )
+        route_event = _take_route_output(route_queues, timing_phase, phase)
+        decision = _decision_kind(category, tool_call_count, route_event)
+        executed_tool = None
+        if tool_call_count > 0 and allocated_tools < len(tool_names):
+            executed_tool = tool_names[allocated_tools]
+            allocated_tools += 1
+        elif category == "initial_route" and route_event:
+            selected = route_event.get("selected_tool")
+            executed_tool = selected if isinstance(selected, str) else None
+        disposition = _disposition(
+            category=category,
+            expectation=expectation,
+            correctness=correctness,
+            finish_reason=_identifier(metric.get("finish_reason")),
+            tool_count=len(tool_names),
+            tool_call_count=tool_call_count,
+            next_phase=next_phase,
+        )
+        evaluated_tokens = _integer(metric.get("evaluated_tokens"))
+        if evaluated_tokens is None:
+            prompt_tokens = _integer(metric.get("prompt_tokens"))
+            cached_tokens = _integer(metric.get("cached_tokens"))
+            if prompt_tokens is not None and cached_tokens is not None:
+                evaluated_tokens = prompt_tokens - cached_tokens
+        counted = disposition in {"avoidable", "duplicate", "deterministic_completion_candidate"}
+        calls.append(
+            {
+                "call_id": f"call_{index + 1:03d}",
+                "category": category,
+                "phase": phase,
+                "timing_phase": timing_phase,
+                "entry_reason": reason or _default_entry_reason(category),
+                "prompt_view": _prompt_view(phase, timing_phase),
+                "prompt_tokens": _integer(metric.get("prompt_tokens")),
+                "cached_tokens": _integer(metric.get("cached_tokens")),
+                "evaluated_tokens": evaluated_tokens,
+                "output_tokens": _integer(metric.get("completion_tokens")),
+                "wall_ms": _number(occurrence.get("wall_ms")),
+                "finish_reason": _identifier(metric.get("finish_reason")),
+                "decision": decision,
+                "tool_executed": executed_tool,
+                "output_changes_next_step": _changes_next_step(category, decision),
+                "repeats_determined_decision": _repeats_determined_decision(category, expectation),
+                "disposition": disposition,
+                "counted_as_theoretical_saving": counted,
+                "potential_evaluated_tokens": evaluated_tokens if counted else 0,
+                "potential_wall_ms": _number(occurrence.get("wall_ms")) if counted else 0.0,
+                "information_loss_if_removed": _information_loss(category, disposition),
+                "required_invariant": _required_invariant(category, disposition),
+                "metrics_correlated": bool(metric),
+            }
+        )
+
+    category_counts = Counter(str(call["category"]) for call in calls)
+    disposition_counts = Counter(str(call["disposition"]) for call in calls)
+    return {
+        "calls": calls,
+        "summary": {
+            "model_calls": len(calls),
+            "reported_model_steps": len(model_steps),
+            "timed_backend_calls": len(phase_timings),
+            "uncorrelated_backend_calls": sum(not call["metrics_correlated"] for call in calls),
+            "categories": dict(sorted(category_counts.items())),
+            "dispositions": dict(sorted(disposition_counts.items())),
+            "theoretical_model_calls": sum(bool(call["counted_as_theoretical_saving"]) for call in calls),
+            "theoretical_evaluated_tokens": sum(int(call["potential_evaluated_tokens"] or 0) for call in calls),
+            "theoretical_wall_ms": round(sum(float(call["potential_wall_ms"] or 0.0) for call in calls), 1),
+            "expectation": expectation,
+            "correctness": correctness,
+        },
+    }
+
+
+def summarize_inference_audits(audits: Iterable[Mapping[str, object]]) -> dict[str, object]:
+    category_counts: Counter[str] = Counter()
+    disposition_counts: Counter[str] = Counter()
+    calls = 0
+    theoretical_calls = 0
+    theoretical_tokens = 0
+    theoretical_wall_ms = 0.0
+    scenarios = 0
+    for audit in audits:
+        summary = audit.get("summary")
+        if not isinstance(summary, Mapping):
+            continue
+        scenarios += 1
+        calls += _integer(summary.get("model_calls")) or 0
+        theoretical_calls += _integer(summary.get("theoretical_model_calls")) or 0
+        theoretical_tokens += _integer(summary.get("theoretical_evaluated_tokens")) or 0
+        theoretical_wall_ms += _number(summary.get("theoretical_wall_ms")) or 0.0
+        _update_counter(category_counts, summary.get("categories"))
+        _update_counter(disposition_counts, summary.get("dispositions"))
+    return {
+        "type": "inference_audit_summary",
+        "scenarios": scenarios,
+        "model_calls": calls,
+        "categories": dict(sorted(category_counts.items())),
+        "dispositions": dict(sorted(disposition_counts.items())),
+        "theoretical_model_calls": theoretical_calls,
+        "theoretical_evaluated_tokens": theoretical_tokens,
+        "theoretical_wall_ms": round(theoretical_wall_ms, 1),
+        "active_behavior_changed": False,
+    }
+
+
+def _correlate_occurrences(
+    model_steps: Sequence[Mapping[str, object]],
+    phase_timings: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    if not phase_timings:
+        return [
+            {"phase": _identifier(metric.get("phase")) or "unknown", "wall_ms": None, "metric": metric}
+            for metric in model_steps
+        ]
+    if len(phase_timings) <= len(model_steps):
+        occurrences = [
+            {
+                "phase": _identifier(metric.get("phase")) or "unknown",
+                "wall_ms": None,
+                "metric": metric,
+            }
+            for metric in model_steps
+        ]
+        available = set(range(len(occurrences)))
+        extra_timings: list[dict[str, object]] = []
+        for timing in phase_timings:
+            timing_phase = _identifier(timing.get("phase")) or "unknown"
+            match = next(
+                (
+                    index
+                    for index in sorted(available)
+                    if _phases_compatible(timing_phase, str(occurrences[index]["phase"]))
+                ),
+                None,
+            )
+            if match is None:
+                extra_timings.append(
+                    {"phase": timing_phase, "wall_ms": _number(timing.get("wall_ms")), "metric": None}
+                )
+                continue
+            occurrences[match]["phase"] = timing_phase
+            occurrences[match]["wall_ms"] = _number(timing.get("wall_ms"))
+            available.remove(match)
+        occurrences.extend(extra_timings)
+        return occurrences
+    occurrences = [
+        {
+            "phase": _identifier(item.get("phase")) or "unknown",
+            "wall_ms": _number(item.get("wall_ms")),
+            "metric": None,
+        }
+        for item in phase_timings
+    ]
+    available = set(range(len(occurrences)))
+    for metric in reversed(model_steps):
+        metric_phase = _identifier(metric.get("phase")) or "unknown"
+        match = next(
+            (
+                index
+                for index in sorted(available, reverse=True)
+                if _phases_compatible(str(occurrences[index]["phase"]), metric_phase)
+            ),
+            None,
+        )
+        if match is None:
+            continue
+        occurrences[match]["metric"] = metric
+        available.remove(match)
+    unmatched_metrics = [metric for metric in model_steps if all(item.get("metric") is not metric for item in occurrences)]
+    occurrences.extend(
+        {"phase": _identifier(metric.get("phase")) or "unknown", "wall_ms": None, "metric": metric}
+        for metric in unmatched_metrics
+    )
+    return occurrences
+
+
+def _phases_compatible(timing_phase: str, metric_phase: str) -> bool:
+    if timing_phase == metric_phase:
+        return True
+    if metric_phase == "post_tool_route" and timing_phase == "tool_call":
+        return True
+    return metric_phase == "final" and timing_phase in {"tool_call", "tool_call_retry", "tool_call_json_retry"}
+
+
+def _call_category(
+    *,
+    phase: str,
+    timing_phase: str,
+    loop: int | None,
+    tool_call_count: int,
+    tools_executed: bool,
+    expectation: str,
+    reason: str | None,
+) -> str:
+    if phase in _FORMATTING_PHASES:
+        return "formatting_only"
+    if phase in _RETRY_PHASES or timing_phase in _RETRY_PHASES:
+        return "error_recovery" if reason in _ERROR_REASONS else "retry"
+    if phase == "route":
+        return "initial_route"
+    if phase == "post_tool_route":
+        return "post_tool_route"
+    if phase == "final" and tools_executed:
+        return "post_tool_route"
+    if phase == "tool_call" or timing_phase == "tool_call":
+        if tools_executed and (loop or 0) > 1 and tool_call_count == 0:
+            return "post_tool_route"
+        return "tool_call"
+    if phase == "final_from_tool":
+        if expectation in {"bounded_confirmation", "structured_error"}:
+            return "confirmation_only"
+        return "final_from_tool"
+    if phase == "chat_final" or phase.startswith("chat_continue"):
+        return "chat_final"
+    return "chat_final"
+
+
+def _disposition(
+    *,
+    category: str,
+    expectation: str,
+    correctness: str,
+    finish_reason: str | None,
+    tool_count: int,
+    tool_call_count: int,
+    next_phase: str | None,
+) -> str:
+    if category in {"retry", "error_recovery"}:
+        return "retry_caused"
+    if category == "formatting_only":
+        return "formatting_only"
+    bounded = expectation in {"bounded_confirmation", "structured_error"}
+    complete = correctness == "correct" and finish_reason == "stop"
+    if category == "post_tool_route" and bounded and tool_count == 1 and tool_call_count == 0:
+        if next_phase == "final_from_tool":
+            return "deterministic_completion_candidate"
+    if category == "confirmation_only" and bounded and complete and tool_count == 1:
+        return "deterministic_completion_candidate"
+    return "necessary"
+
+
+def _decision_kind(category: str, tool_call_count: int, route_event: Mapping[str, object] | None) -> str:
+    if route_event is not None and isinstance(route_event.get("parsed_route"), str):
+        return str(route_event["parsed_route"])
+    if tool_call_count:
+        return "tool_call"
+    if category == "post_tool_route":
+        return "stop_tools"
+    if category in {"final_from_tool", "confirmation_only", "chat_final", "formatting_only"}:
+        return "final_answer"
+    if category in {"retry", "error_recovery"}:
+        return "replacement_output"
+    return "unknown"
+
+
+def _changes_next_step(category: str, decision: str) -> bool | None:
+    if category in {"initial_route", "tool_call", "post_tool_route", "retry", "error_recovery"}:
+        return True
+    if decision == "final_answer":
+        return False
+    return None
+
+
+def _repeats_determined_decision(category: str, expectation: str) -> bool | None:
+    if category == "confirmation_only" and expectation in {"bounded_confirmation", "structured_error"}:
+        return True
+    return None
+
+
+def _prompt_view(phase: str, timing_phase: str) -> str:
+    effective = timing_phase if timing_phase != "unknown" else phase
+    if effective == "route":
+        return "route"
+    if effective == "route_retry":
+        return "route_retry"
+    if effective.startswith("tool_call"):
+        return effective
+    if effective.startswith("final_from_tool"):
+        return "final_from_tool_family"
+    if effective.startswith("chat_final"):
+        return "chat_final_family"
+    return effective
+
+
+def _default_entry_reason(category: str) -> str:
+    return {
+        "initial_route": "tool_decision",
+        "tool_call": "tool_selection",
+        "post_tool_route": "post_tool_decision",
+        "retry": "retry",
+        "final_from_tool": "tool_evidence_finalization",
+        "chat_final": "chat_response",
+        "formatting_only": "completion_format_repair",
+        "confirmation_only": "bounded_tool_result_finalization",
+        "error_recovery": "error_recovery",
+    }[category]
+
+
+def _information_loss(category: str, disposition: str) -> str:
+    if disposition == "deterministic_completion_candidate":
+        if category == "post_tool_route":
+            return "model_decision_to_stop_or_select_another_tool"
+        return "model_wording_and_evidence_interpretation"
+    if disposition == "formatting_only":
+        return "clean_final_answer_when_first_output_is_incomplete"
+    if disposition == "retry_caused":
+        return "recovery_from_an_invalid_or_incomplete_prior_output"
+    return "semantic_decision_or_user_facing_synthesis"
+
+
+def _required_invariant(category: str, disposition: str) -> str:
+    if disposition == "deterministic_completion_candidate":
+        if category == "post_tool_route":
+            return "single_terminal_tool_result_and_no_possible_follow_up_tool_needed"
+        return "bounded_structured_result_fully_satisfies_an_explicit_response_contract"
+    if disposition == "formatting_only":
+        return "first_pass_completion_is_already_valid_and_complete"
+    if disposition == "retry_caused":
+        return "first_pass_format_and_budget_reliability"
+    return "model_output_remains_required"
+
+
+def _phase_start_queues(phase_starts: Sequence[Mapping[str, object]]) -> dict[str, list[Mapping[str, object]]]:
+    result: dict[str, list[Mapping[str, object]]] = {}
+    for item in phase_starts:
+        phase = _identifier(item.get("phase"))
+        if phase:
+            result.setdefault(phase, []).append(item)
+    return result
+
+
+def _take_phase_start(
+    queues: dict[str, list[Mapping[str, object]]],
+    timing_phase: str,
+    metric_phase: str,
+) -> Mapping[str, object] | None:
+    for phase in (timing_phase, metric_phase):
+        values = queues.get(phase)
+        if values:
+            return values.pop(0)
+    return None
+
+
+def _route_output_queues(
+    route_outputs: Sequence[Mapping[str, object]],
+) -> dict[str, list[Mapping[str, object]]]:
+    result = {"route": [], "route_retry": []}
+    for item in route_outputs:
+        key = "route_retry" if item.get("route_call") == "retry" else "route"
+        result[key].append(item)
+    return result
+
+
+def _take_route_output(
+    queues: dict[str, list[Mapping[str, object]]],
+    timing_phase: str,
+    metric_phase: str,
+) -> Mapping[str, object] | None:
+    for phase in (timing_phase, metric_phase):
+        values = queues.get(phase)
+        if values:
+            return values.pop(0)
+    return None
+
+
+def _occurrence_phase(occurrence: Mapping[str, object] | None) -> str | None:
+    if occurrence is None:
+        return None
+    metric = occurrence.get("metric")
+    if isinstance(metric, Mapping):
+        phase = _identifier(metric.get("phase"))
+        if phase:
+            return phase
+    return _identifier(occurrence.get("phase"))
+
+
+def _update_counter(counter: Counter[str], value: object) -> None:
+    if not isinstance(value, Mapping):
+        return
+    for key, count in value.items():
+        if isinstance(key, str) and isinstance(count, int):
+            counter[key] += count
+
+
+def _identifier(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or len(value) > 80:
+        return None
+    return value
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _number(value: object) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None

--- a/src/orbit/runtime/post_tool_final_reuse.py
+++ b/src/orbit/runtime/post_tool_final_reuse.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Mapping, Sequence
+
+from orbit.backend.base import Message
+from orbit.runtime.final_policy import classify_final_answer_completeness, contains_raw_tool_call
+from orbit.runtime.thinking_mode import contains_control_channel_markup
+
+
+_TECHNICAL_TAG_RE = re.compile(r"</?(?:tool_call|function|arguments?)\b", re.IGNORECASE)
+_JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*[{[]", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class PostToolFinalReuseDecision:
+    eligible: bool
+    reason: str
+
+
+def evaluate_post_tool_final_reuse(
+    *,
+    content: str,
+    finish_reason: str | None,
+    tool_calls: Sequence[Mapping[str, object]],
+    phase: str | None,
+    messages: Sequence[Message],
+    tool_rounds: int,
+    output_was_suppressed: bool,
+    pending_internal_request: bool,
+    executed_internal_tool_prompt: bool,
+    shell_error_pending: bool,
+    shadow_attempt_detected: bool,
+) -> PostToolFinalReuseDecision:
+    """Apply structural eligibility only; never interpret or rewrite model prose."""
+    if phase != "post_tool_route":
+        return PostToolFinalReuseDecision(False, "not_post_tool_route")
+    if finish_reason != "stop":
+        return PostToolFinalReuseDecision(False, "finish_reason")
+    if tool_calls:
+        return PostToolFinalReuseDecision(False, "tool_call_present")
+    if tool_rounds < 1 or not _latest_message_is_tool(messages):
+        return PostToolFinalReuseDecision(False, "no_terminal_tool_result")
+    if not output_was_suppressed:
+        return PostToolFinalReuseDecision(False, "output_not_suppressed")
+    if pending_internal_request:
+        return PostToolFinalReuseDecision(False, "pending_internal_request")
+    if executed_internal_tool_prompt:
+        return PostToolFinalReuseDecision(False, "internal_guard_result")
+    if shell_error_pending:
+        return PostToolFinalReuseDecision(False, "tool_error_pending")
+    stripped = content.strip()
+    if not stripped:
+        return PostToolFinalReuseDecision(False, "empty_prose")
+    if shadow_attempt_detected:
+        return PostToolFinalReuseDecision(False, "tool_attempt_detected")
+    if contains_raw_tool_call(content) or contains_control_channel_markup(content):
+        return PostToolFinalReuseDecision(False, "technical_markup")
+    if "<|" in content or "|>" in content:
+        return PostToolFinalReuseDecision(False, "technical_markup")
+    if _TECHNICAL_TAG_RE.search(content) or _looks_like_technical_json(stripped):
+        return PostToolFinalReuseDecision(False, "technical_payload")
+    completeness = classify_final_answer_completeness(content, messages=list(messages))
+    if not completeness.is_complete:
+        return PostToolFinalReuseDecision(False, f"incomplete_{completeness.status}")
+    return PostToolFinalReuseDecision(True, "complete_post_tool_prose")
+
+
+def _latest_message_is_tool(messages: Sequence[Message]) -> bool:
+    return bool(messages) and messages[-1].get("role") == "tool"
+
+
+def _looks_like_technical_json(content: str) -> bool:
+    if "{" in content or "}" in content:
+        return True
+    return bool(content.startswith("[") or _JSON_FENCE_RE.match(content))

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -8,12 +8,14 @@ from typing import Callable
 
 from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
+from orbit.post_tool_final_reuse_config import resolve_post_tool_final_reuse
 from orbit.runtime.capabilities import LocalCapabilities
 from orbit.runtime.command_request import command_like_tool_call, command_tool_call_from_tool_calls
 from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.messages import with_chat_system_prompt, with_tool_call_system_prompt
+from orbit.runtime.post_tool_final_reuse import evaluate_post_tool_final_reuse
 from orbit.runtime.session_memory import should_refresh_for_append
 from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
@@ -122,6 +124,7 @@ def run_tool_loop(
     tools = executor.tool_definitions()
     canonical_gate_enabled = resolve_tool_call_canonical_gate().enabled
     healing_enabled = canonical_gate_enabled and resolve_tool_call_healing().enabled
+    post_tool_final_reuse_enabled = resolve_post_tool_final_reuse().enabled
     last_result: ChatResult | None = None
     state = ToolLoopState(allowed_tool_names)
     user_prompt = _last_user_text(runtime.messages)
@@ -153,6 +156,12 @@ def run_tool_loop(
             phase=phase,
             attempt_id=attempt_id,
         )
+
+    def record_post_tool_final_reuse_fallback(reason: str) -> None:
+        if not post_tool_final_reuse_enabled:
+            return
+        runtime.post_tool_final_reuse_fallback_count += 1
+        runtime.post_tool_final_reuse_last_reason = reason
 
     def record_terminal(
         *,
@@ -784,7 +793,10 @@ def run_tool_loop(
         executing_mutation_verification_repair = repair.mutation_verification_repair_pending
         executing_mutation_semantic_repair = repair.mutation_semantic_repair_pending
         executing_read_only_mutation_retry = repair.read_only_mutation_retry_pending
+        executing_shell_repair = repair.shell_repair_prompt_pending is not None
+        executing_shell_empty_result_check = repair.shell_empty_result_check_pending
         executing_content_evidence_guard = turn.pending_content_evidence_guard
+        executing_analysis_completion_guard = turn.pending_analysis_completion_guard
         executing_file_recovery_guard = turn.pending_file_recovery_guard
         executing_url_recovery_guard = turn.pending_url_recovery_guard
         executing_completion_guard = turn.pending_completion_guard
@@ -852,7 +864,17 @@ def run_tool_loop(
         produced_by_phase: str | None = "tool_call"
         last_result = result
         if on_model_step:
-            on_model_step(ModelStepMetrics.from_result(loop=loop_index, result=result, phase="tool_call" if result.tool_calls else None))
+            on_model_step(
+                ModelStepMetrics.from_result(
+                    loop=loop_index,
+                    result=result,
+                    phase=(
+                        "tool_call"
+                        if result.tool_calls
+                        else "post_tool_route" if state.tool_rounds > 0 else None
+                    ),
+                )
+            )
         if repair.contract_retry_pending and not result.tool_calls:
             record_terminal(
                 attempt_id=attempt_id,
@@ -919,6 +941,7 @@ def run_tool_loop(
             request_minimal_patch_guard()
             continue
         if result.finish_reason == "length" and not result.tool_calls and state.tool_rounds > 0:
+            record_post_tool_final_reuse_fallback("finish_reason")
             record_terminal(
                 attempt_id=attempt_id,
                 report=shadow_report,
@@ -1089,7 +1112,10 @@ def run_tool_loop(
                 or executing_mutation_verification_repair
                 or executing_mutation_semantic_repair
                 or executing_read_only_mutation_retry
+                or executing_shell_repair
+                or executing_shell_empty_result_check
                 or executing_content_evidence_guard
+                or executing_analysis_completion_guard
                 or executing_file_recovery_guard
                 or executing_url_recovery_guard
                 or executing_completion_guard
@@ -1161,6 +1187,36 @@ def run_tool_loop(
                     phase=produced_by_phase or "tool_call",
                 )
                 turn.mark_finalizable()
+                if post_tool_final_reuse_enabled:
+                    reuse_decision = evaluate_post_tool_final_reuse(
+                        content=result.content,
+                        finish_reason=result.finish_reason,
+                        tool_calls=result.tool_calls,
+                        phase=(
+                            "post_tool_route"
+                            if produced_by_phase == "tool_call" and state.tool_rounds > 0
+                            else produced_by_phase
+                        ),
+                        messages=runtime.messages,
+                        tool_rounds=state.tool_rounds,
+                        output_was_suppressed=tool_delta_callback is suppress_tool_delta,
+                        pending_internal_request=has_pending_internal_request(),
+                        executed_internal_tool_prompt=executed_internal_tool_prompt,
+                        shell_error_pending=repair.shell_error_final_pending,
+                        shadow_attempt_detected=bool(
+                            shadow_report is not None and shadow_report.attempt_detected
+                        ),
+                    )
+                    runtime.post_tool_final_reuse_last_reason = reuse_decision.reason
+                    if reuse_decision.eligible:
+                        runtime.post_tool_final_reuse_eligible_count += 1
+                        runtime.post_tool_final_reuse_reused_count += 1
+                        runtime.post_tool_final_reuse_avoided_model_calls += 1
+                        runtime.messages.append({"role": "assistant", "content": result.content})
+                        if on_final_delta is not None and result.content:
+                            on_final_delta(result.content)
+                        return result
+                    runtime.post_tool_final_reuse_fallback_count += 1
                 return runtime._answer_from_tool_results(
                     temperature=temperature,
                     max_tokens=max_tokens,

--- a/src/orbit/runtime/tool_plan_shadow.py
+++ b/src/orbit/runtime/tool_plan_shadow.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterable
+
+from orbit.runtime.tool_contract import CanonicalToolDecision, validate_canonical_tool_call
+
+
+TOOL_PLAN_SCHEMA_VERSION = 2
+TOOL_PLAN_STEP_COUNT = 2
+TOOL_PLAN_INITIAL_TOOLS = frozenset({"list_directory", "system_info"})
+_PLAN_MARKER = re.compile(r'"type"\s*:\s*"(?:tool_plan|unsupported_plan)"')
+_PLAN_REFERENCE = re.compile(r"(?:\$\{?|\{\{)[^}]{0,80}(?:step|output|result)", re.IGNORECASE)
+
+
+class DuplicatePlanKey(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ToolPlanStep:
+    id: str
+    name: str
+    arguments: dict[str, Any]
+    canonical_decision: CanonicalToolDecision
+
+
+@dataclass(frozen=True)
+class ToolPlan:
+    steps: tuple[ToolPlanStep, ToolPlanStep]
+
+
+@dataclass(frozen=True)
+class ToolPlanShadowReport:
+    detected: bool
+    candidate_count: int
+    json_compliant: bool
+    valid: bool
+    response_kind: str | None
+    rejection_code: str | None
+    plan: ToolPlan | None
+    payload_hash: str | None
+
+    def diagnostic(self) -> dict[str, object]:
+        steps = self.plan.steps if self.plan is not None else ()
+        return {
+            "schema_version": TOOL_PLAN_SCHEMA_VERSION,
+            "detected": self.detected,
+            "candidate_count": self.candidate_count,
+            "json_compliant": self.json_compliant,
+            "valid": self.valid,
+            "response_kind": self.response_kind,
+            "rejection_code": self.rejection_code,
+            "step_count": len(steps),
+            "step_ids": [step.id for step in steps],
+            "tool_hashes": [_hash_text(step.name) for step in steps],
+            "argument_hashes": [_hash_json(step.arguments) for step in steps],
+            "payload_hash": self.payload_hash,
+            "prose_leakage": self.rejection_code in {"external_text", "no_plan"},
+            "invalid_json": self.rejection_code in {"invalid_json", "duplicate_key"},
+            "raw_content_included": False,
+            "tool_executed": False,
+            "finalization_started": False,
+        }
+
+
+def analyze_tool_plan_shadow(
+    text: str,
+    *,
+    finish_reason: str | None,
+    tool_definitions: list[dict[str, Any]],
+    allowed_tool_names: Iterable[str],
+    workdir: Path,
+    user_prompt: str | None,
+) -> ToolPlanShadowReport:
+    markers = len(_PLAN_MARKER.findall(text))
+    if markers == 0:
+        return _report(False, 0, False, False, None, "no_plan", None, text)
+    if markers != 1:
+        return _report(True, markers, False, False, None, "multiple_candidates", None, text)
+    if finish_reason in {"length", "cancelled", "timeout"}:
+        return _report(True, 1, False, False, None, f"nonrecoverable_{finish_reason}", None, text)
+    if finish_reason not in {None, "stop"}:
+        return _report(True, 1, False, False, None, "nonrecoverable_finish_reason", None, text)
+    stripped = text.strip()
+    if not stripped.startswith("{"):
+        return _report(True, 1, False, False, None, "external_text", None, text)
+    try:
+        payload = json.loads(stripped, object_pairs_hook=_unique_object)
+    except DuplicatePlanKey:
+        return _report(True, 1, False, False, None, "duplicate_key", None, stripped)
+    except json.JSONDecodeError:
+        if _has_complete_json_prefix(stripped):
+            return _report(True, 1, False, False, None, "external_text", None, stripped)
+        return _report(True, 1, False, False, None, "invalid_json", None, stripped)
+    plan, kind, rejection = validate_tool_plan_payload(
+        payload,
+        tool_definitions=tool_definitions,
+        allowed_tool_names=allowed_tool_names,
+        workdir=workdir,
+        user_prompt=user_prompt,
+    )
+    return _report(True, 1, True, rejection is None, kind, rejection, plan, stripped)
+
+
+def validate_tool_plan_payload(
+    payload: object,
+    *,
+    tool_definitions: list[dict[str, Any]],
+    allowed_tool_names: Iterable[str],
+    workdir: Path,
+    user_prompt: str | None,
+) -> tuple[ToolPlan | None, str | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, None, "invalid_response_shape"
+    response_type = payload.get("type")
+    if response_type == "unsupported_plan":
+        if set(payload) != {"type"}:
+            return None, "unsupported", "invalid_unsupported_shape"
+        return None, "unsupported", None
+    if response_type != "tool_plan" or set(payload) != {"type", "steps"}:
+        return None, None, "invalid_plan_shape"
+    raw_steps = payload.get("steps")
+    if not isinstance(raw_steps, list) or len(raw_steps) != TOOL_PLAN_STEP_COUNT:
+        return None, "plan", "invalid_step_count"
+    allowed = tuple(allowed_tool_names)
+    steps: list[ToolPlanStep] = []
+    for index, raw_step in enumerate(raw_steps, start=1):
+        if not isinstance(raw_step, dict) or set(raw_step) != {"name", "arguments"}:
+            return None, "plan", "invalid_step_shape"
+        name = raw_step.get("name")
+        arguments = raw_step.get("arguments")
+        if not isinstance(name, str) or not name:
+            return None, "plan", "invalid_tool_name"
+        if name not in TOOL_PLAN_INITIAL_TOOLS:
+            return None, "plan", "tool_not_plan_eligible"
+        if not isinstance(arguments, dict):
+            return None, "plan", "arguments_not_object"
+        if _contains_dynamic_reference(arguments):
+            return None, "plan", "dynamic_dependency"
+        decision = validate_canonical_tool_call(
+            name,
+            arguments,
+            tool_definitions=tool_definitions,
+            allowed_tool_names=allowed,
+            workdir=workdir,
+            user_prompt=user_prompt,
+        )
+        if not decision.accepted:
+            return None, "plan", f"canonical_{decision.rejection_code or decision.terminal_decision}"
+        steps.append(ToolPlanStep(f"step_{index}", name, arguments, decision))
+    assert len(steps) == TOOL_PLAN_STEP_COUNT
+    return ToolPlan((steps[0], steps[1])), "plan", None
+
+
+def _report(
+    detected: bool,
+    candidate_count: int,
+    json_compliant: bool,
+    valid: bool,
+    response_kind: str | None,
+    rejection_code: str | None,
+    plan: ToolPlan | None,
+    hashed_text: str,
+) -> ToolPlanShadowReport:
+    return ToolPlanShadowReport(
+        detected,
+        candidate_count,
+        json_compliant,
+        valid,
+        response_kind,
+        rejection_code,
+        plan,
+        _hash_text(hashed_text),
+    )
+
+
+def _contains_dynamic_reference(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(_PLAN_REFERENCE.search(value))
+    if isinstance(value, dict):
+        return any(_contains_dynamic_reference(key) or _contains_dynamic_reference(item) for key, item in value.items())
+    if isinstance(value, list):
+        return any(_contains_dynamic_reference(item) for item in value)
+    return False
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicatePlanKey(key)
+        result[key] = value
+    return result
+
+
+def _has_complete_json_prefix(text: str) -> bool:
+    try:
+        _value, end = json.JSONDecoder().raw_decode(text)
+    except json.JSONDecodeError:
+        return False
+    return bool(text[end:].strip())
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _hash_json(value: object) -> str:
+    encoded = json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return _hash_text(encoded)

--- a/src/orbit/tool_plan_config.py
+++ b/src/orbit/tool_plan_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Mapping
+
+
+TOOL_PLAN_SHADOW_ENV = "ORBIT_TOOL_PLAN_SHADOW"
+
+
+@dataclass(frozen=True)
+class ToolPlanShadowConfig:
+    enabled: bool
+    source: str
+    validation_error: str | None = None
+
+
+def resolve_tool_plan_shadow(env: Mapping[str, str] | None = None) -> ToolPlanShadowConfig:
+    values = os.environ if env is None else env
+    if TOOL_PLAN_SHADOW_ENV not in values:
+        return ToolPlanShadowConfig(False, "default")
+    raw = values.get(TOOL_PLAN_SHADOW_ENV, "")
+    if raw == "1":
+        return ToolPlanShadowConfig(True, "stable")
+    if raw == "0":
+        return ToolPlanShadowConfig(False, "stable")
+    return ToolPlanShadowConfig(False, "stable", "invalid_boolean")

--- a/tests/test_inference_audit.py
+++ b/tests/test_inference_audit.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import unittest
+
+from orbit.inference_audit_config import resolve_inference_audit_shadow
+from orbit.runtime.inference_audit import audit_model_calls, summarize_inference_audits
+
+
+def metric(
+    phase: str,
+    *,
+    loop: int,
+    prompt: int,
+    cached: int,
+    output: int,
+    tool_calls: int = 0,
+    finish: str = "stop",
+    retry_reason: str | None = None,
+) -> dict[str, object]:
+    return {
+        "phase": phase,
+        "loop": loop,
+        "prompt_tokens": prompt,
+        "cached_tokens": cached,
+        "evaluated_tokens": prompt - cached,
+        "completion_tokens": output,
+        "tool_calls": tool_calls,
+        "finish_reason": finish,
+        "retry_reason": retry_reason,
+    }
+
+
+class InferenceAuditConfigTests(unittest.TestCase):
+    def test_default_is_off_and_invalid_value_disables(self) -> None:
+        self.assertEqual(resolve_inference_audit_shadow({}).enabled, False)
+        self.assertEqual(resolve_inference_audit_shadow({}).source, "default")
+        self.assertEqual(resolve_inference_audit_shadow({"ORBIT_INFERENCE_AUDIT_SHADOW": "1"}).enabled, True)
+        self.assertEqual(resolve_inference_audit_shadow({"ORBIT_INFERENCE_AUDIT_SHADOW": "0"}).enabled, False)
+        invalid = resolve_inference_audit_shadow({"ORBIT_INFERENCE_AUDIT_SHADOW": "yes"})
+        self.assertFalse(invalid.enabled)
+        self.assertEqual(invalid.validation_error, "invalid_boolean")
+
+
+class InferenceAuditTests(unittest.TestCase):
+    def test_bounded_single_tool_graph_marks_only_post_tool_and_final_as_candidates(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[
+                metric("tool_call", loop=1, prompt=900, cached=4, output=15, tool_calls=1),
+                metric("final", loop=2, prompt=400, cached=300, output=3),
+                metric("final_from_tool", loop=3, prompt=120, cached=64, output=3),
+            ],
+            phase_starts=[
+                {"phase": "tool_call", "reason": "tool_selection"},
+                {"phase": "final_from_tool", "reason": "tool_evidence"},
+            ],
+            phase_timings=[
+                {"phase": "tool_call", "wall_ms": 1000.0},
+                {"phase": "tool_call", "wall_ms": 200.0},
+                {"phase": "final_from_tool", "wall_ms": 100.0},
+            ],
+            tool_names=["exec_shell_full_command"],
+            expectation="bounded_confirmation",
+            correctness="correct",
+        )
+        calls = audit["calls"]
+        self.assertEqual([call["category"] for call in calls], ["tool_call", "post_tool_route", "confirmation_only"])
+        self.assertEqual(
+            [call["disposition"] for call in calls],
+            ["necessary", "deterministic_completion_candidate", "deterministic_completion_candidate"],
+        )
+        self.assertEqual(audit["summary"]["theoretical_model_calls"], 2)
+        self.assertEqual(audit["summary"]["theoretical_evaluated_tokens"], 156)
+        self.assertEqual(audit["summary"]["theoretical_wall_ms"], 300.0)
+
+    def test_synthesis_keeps_post_tool_route_and_final_necessary(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[
+                metric("tool_call", loop=1, prompt=900, cached=4, output=15, tool_calls=1),
+                metric("final", loop=2, prompt=400, cached=300, output=12),
+                metric("final_from_tool", loop=3, prompt=500, cached=64, output=40),
+            ],
+            tool_names=["system_info"],
+            expectation="synthesis_required",
+            correctness="correct",
+        )
+        self.assertTrue(all(call["disposition"] == "necessary" for call in audit["calls"]))
+        self.assertEqual(audit["summary"]["theoretical_model_calls"], 0)
+
+    def test_route_and_chat_final_preserve_route_decision(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[
+                metric("route", loop=1, prompt=700, cached=600, output=5),
+                metric("chat_final", loop=2, prompt=300, cached=4, output=20),
+            ],
+            route_outputs=[{"route_call": "initial", "parsed_route": "CHAT"}],
+            expectation="synthesis_required",
+            correctness="correct",
+        )
+        self.assertEqual([call["category"] for call in audit["calls"]], ["initial_route", "chat_final"])
+        self.assertEqual(audit["calls"][0]["decision"], "CHAT")
+        self.assertEqual(audit["summary"]["theoretical_model_calls"], 0)
+
+    def test_retry_and_completion_repair_are_not_counted_as_safe_savings(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[
+                metric("route_retry", loop=2, prompt=700, cached=600, output=8, retry_reason="length"),
+                metric("final_from_tool_completion_repair", loop=4, prompt=200, cached=64, output=20),
+            ],
+            expectation="bounded_confirmation",
+            correctness="correct",
+        )
+        self.assertEqual([call["category"] for call in audit["calls"]], ["error_recovery", "formatting_only"])
+        self.assertEqual([call["disposition"] for call in audit["calls"]], ["retry_caused", "formatting_only"])
+        self.assertEqual(audit["summary"]["theoretical_model_calls"], 0)
+
+    def test_unreported_backend_retry_remains_visible_and_uncorrelated(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[metric("tool_call", loop=1, prompt=100, cached=0, output=4, tool_calls=1)],
+            phase_timings=[
+                {"phase": "tool_call", "wall_ms": 20.0},
+                {"phase": "tool_call_json_retry", "wall_ms": 30.0},
+            ],
+            tool_names=["system_info"],
+        )
+        self.assertEqual(audit["summary"]["model_calls"], 2)
+        self.assertEqual(audit["summary"]["uncorrelated_backend_calls"], 1)
+        self.assertIn("retry", {call["category"] for call in audit["calls"]})
+
+    def test_records_are_content_free_and_deterministic(self) -> None:
+        kwargs = {
+            "model_steps": [metric("final_from_tool", loop=2, prompt=120, cached=64, output=3)],
+            "tool_names": ["system_info"],
+            "expectation": "bounded_confirmation",
+            "correctness": "correct",
+        }
+        first = audit_model_calls(**kwargs)
+        second = audit_model_calls(**kwargs)
+        self.assertEqual(first, second)
+        rendered = repr(first)
+        for forbidden in ("sensitive request", "raw arguments", "secret evidence", "https://secret", "/tmp/private"):
+            self.assertNotIn(forbidden, rendered)
+
+    def test_summary_aggregates_only_observational_data(self) -> None:
+        audit = audit_model_calls(
+            model_steps=[metric("chat_final", loop=1, prompt=50, cached=4, output=5)],
+            expectation="synthesis_required",
+            correctness="correct",
+        )
+        summary = summarize_inference_audits([audit, audit])
+        self.assertEqual(summary["model_calls"], 2)
+        self.assertEqual(summary["categories"], {"chat_final": 2})
+        self.assertFalse(summary["active_behavior_changed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -102,6 +102,12 @@ class KVDiagTests(unittest.TestCase):
     def setUp(self) -> None:
         reset_diagnostics_for_tests()
         reset_native_diagnostics_for_tests()
+        self._post_tool_final_reuse_env = mock.patch.dict(
+            os.environ,
+            {"ORBIT_POST_TOOL_FINAL_REUSE": "0"},
+        )
+        self._post_tool_final_reuse_env.start()
+        self.addCleanup(self._post_tool_final_reuse_env.stop)
 
     def test_diag_default_off_does_not_write_log(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_post_tool_final_reuse.py
+++ b/tests/test_post_tool_final_reuse.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from orbit.backend.base import ChatResult, Message
+from orbit.post_tool_final_reuse_config import resolve_post_tool_final_reuse
+from orbit.runtime import ChatRuntime
+from orbit.runtime.post_tool_final_reuse import evaluate_post_tool_final_reuse
+
+
+def _result(
+    content: str,
+    *,
+    finish_reason: str = "stop",
+    tool_calls: list[dict[str, object]] | None = None,
+) -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=tool_calls or [],
+        prompt_tokens=20,
+        completion_tokens=4,
+        cached_tokens=4,
+        prompt_tokens_per_second=100.0,
+        generation_tokens_per_second=10.0,
+    )
+
+
+def _tool_call(call_id: str, command: str) -> dict[str, object]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": "exec_shell_full_command",
+            "arguments": f'{{"command":"{command}"}}',
+        },
+    }
+
+
+def _named_tool_call(call_id: str, name: str, arguments: dict[str, object]) -> dict[str, object]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(arguments, separators=(",", ":"))},
+    }
+
+
+class SequenceBackend:
+    def __init__(self, results: list[ChatResult | BaseException]) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+        self.calls += 1
+        if not self.results:
+            raise AssertionError("unexpected model call")
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def chat_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools=None,
+        on_delta=None,
+        on_progress=None,
+    ) -> ChatResult:
+        result = self.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+        if on_delta is not None and result.content:
+            on_delta(result.content)
+        return result
+
+
+class PostToolFinalReuseConfigTests(unittest.TestCase):
+    def test_resolver_is_on_by_default_and_invalid_values_disable(self) -> None:
+        default = resolve_post_tool_final_reuse({})
+        self.assertEqual((default.enabled, default.source), (True, "default"))
+        self.assertEqual(resolve_post_tool_final_reuse({"ORBIT_POST_TOOL_FINAL_REUSE": "1"}).enabled, True)
+        disabled = resolve_post_tool_final_reuse({"ORBIT_POST_TOOL_FINAL_REUSE": "0"})
+        self.assertEqual((disabled.enabled, disabled.source), (False, "stable"))
+        invalid = resolve_post_tool_final_reuse({"ORBIT_POST_TOOL_FINAL_REUSE": "yes"})
+        self.assertEqual((invalid.enabled, invalid.validation_error), (False, "invalid_boolean"))
+
+
+class PostToolFinalReuseEligibilityTests(unittest.TestCase):
+    def _decision(self, content: str = "The operation completed successfully.", **overrides):
+        values = {
+            "content": content,
+            "finish_reason": "stop",
+            "tool_calls": [],
+            "phase": "post_tool_route",
+            "messages": [{"role": "tool", "content": "ok", "name": "exec_shell_full_command"}],
+            "tool_rounds": 1,
+            "output_was_suppressed": True,
+            "pending_internal_request": False,
+            "executed_internal_tool_prompt": False,
+            "shell_error_pending": False,
+            "shadow_attempt_detected": False,
+        }
+        values.update(overrides)
+        return evaluate_post_tool_final_reuse(**values)
+
+    def test_accepts_only_complete_suppressed_first_pass_prose(self) -> None:
+        self.assertTrue(self._decision().eligible)
+        cases = {
+            "retry": {"phase": "tool_call_retry"},
+            "length": {"finish_reason": "length"},
+            "tool": {"tool_calls": [_tool_call("call-2", "pwd")]},
+            "empty": {"content": ""},
+            "streamed": {"output_was_suppressed": False},
+            "pending": {"pending_internal_request": True},
+            "guard": {"executed_internal_tool_prompt": True},
+            "error": {"shell_error_pending": True},
+            "attempt": {"shadow_attempt_detected": True},
+            "no_result": {"messages": [{"role": "user", "content": "run it"}]},
+        }
+        for name, overrides in cases.items():
+            with self.subTest(name=name):
+                self.assertFalse(self._decision(**overrides).eligible)
+
+    def test_rejects_technical_or_incomplete_content(self) -> None:
+        contents = (
+            '<|tool_call>{"name":"system_info","arguments":{}}<tool_call|>',
+            '<tool_call>{"name":"system_info"}</tool_call>',
+            '{"name":"system_info","arguments":{}}',
+            '```json\n{"name":"system_info","arguments":{}}\n```',
+            'For example: {"name":"system_info","arguments":{}}',
+            "Result:",
+            "<|channel>thought<channel|>",
+        )
+        for content in contents:
+            with self.subTest(content=content):
+                self.assertFalse(self._decision(content).eligible)
+
+
+class PostToolFinalReuseRuntimeTests(unittest.TestCase):
+    def _run(
+        self,
+        env_value: str | None,
+        results: list[ChatResult],
+        *,
+        on_final_delta=None,
+        prompt: str = "list files",
+        tool_names: tuple[str, ...] = ("exec_shell_full_command",),
+    ):
+        backend = SequenceBackend(results)
+        with tempfile.TemporaryDirectory() as tmp, patch.dict("os.environ", {}, clear=False) as environ:
+            if env_value is None:
+                environ.pop("ORBIT_POST_TOOL_FINAL_REUSE", None)
+            else:
+                environ["ORBIT_POST_TOOL_FINAL_REUSE"] = env_value
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_with_tools(
+                prompt,
+                temperature=0,
+                max_tokens=64,
+                workdir=Path(tmp),
+                tool_names=tool_names,
+                on_final_delta=on_final_delta,
+            )
+        return backend, runtime, result
+
+    def test_enabled_reuses_exact_model_prose_and_avoids_one_call(self) -> None:
+        prose = "The directory listing completed successfully."
+        emitted: list[str] = []
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                _result(prose),
+            ],
+            on_final_delta=emitted.append,
+        )
+        self.assertEqual((backend.calls, result.content), (2, prose))
+        self.assertEqual(runtime.messages[-1], {"role": "assistant", "content": prose})
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 1)
+        self.assertEqual(runtime.post_tool_final_reuse_avoided_model_calls, 1)
+        self.assertEqual(emitted, [prose])
+
+    def test_disabled_and_invalid_configuration_keep_existing_three_call_path(self) -> None:
+        for value in ("0", "invalid"):
+            with self.subTest(value=value):
+                backend, runtime, result = self._run(
+                    value,
+                    [
+                        _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                        _result("Post-tool prose."),
+                        _result("Final answer."),
+                    ],
+                )
+                self.assertEqual((backend.calls, result.content), (3, "Final answer."))
+                self.assertEqual(runtime.post_tool_final_reuse_reused_count, 0)
+
+    def test_incomplete_prose_falls_back_to_existing_final(self) -> None:
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                _result("Result:"),
+                _result("The final result is complete."),
+            ],
+        )
+        self.assertEqual((backend.calls, result.content), (3, "The final result is complete."))
+        self.assertEqual(runtime.post_tool_final_reuse_fallback_count, 1)
+        self.assertTrue(runtime.post_tool_final_reuse_last_reason.startswith("incomplete_"))
+
+    def test_post_tool_length_records_fallback_and_uses_existing_final(self) -> None:
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                _result("An unfinished response", finish_reason="length"),
+                _result("The final response is complete."),
+            ],
+        )
+        self.assertEqual((backend.calls, result.content), (3, "The final response is complete."))
+        self.assertEqual(runtime.post_tool_final_reuse_fallback_count, 1)
+        self.assertEqual(runtime.post_tool_final_reuse_last_reason, "finish_reason")
+
+    def test_cancelled_post_tool_result_is_not_reused(self) -> None:
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                _result("Cancelled partial response.", finish_reason="cancelled"),
+                _result("The final response is complete."),
+            ],
+        )
+        self.assertEqual((backend.calls, result.content), (3, "The final response is complete."))
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 0)
+        self.assertEqual(runtime.post_tool_final_reuse_last_reason, "finish_reason")
+
+    def test_timeout_during_post_tool_route_never_reuses(self) -> None:
+        backend = SequenceBackend(
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                TimeoutError("synthetic timeout"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            "os.environ", {"ORBIT_POST_TOOL_FINAL_REUSE": "1"}, clear=False
+        ):
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            with self.assertRaises(TimeoutError):
+                runtime.ask_with_tools(
+                    "list files",
+                    temperature=0,
+                    max_tokens=64,
+                    workdir=Path(tmp),
+                    tool_names=("exec_shell_full_command",),
+                )
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 0)
+        self.assertEqual(runtime.post_tool_final_reuse_fallback_count, 0)
+
+    def test_shell_error_uses_existing_direct_final_without_reuse(self) -> None:
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "false")]),
+                _result("The command failed."),
+            ],
+        )
+        self.assertEqual((backend.calls, result.content), (2, "The command failed."))
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 0)
+        self.assertEqual(runtime.post_tool_final_reuse_fallback_count, 0)
+
+    def test_second_tool_is_not_skipped(self) -> None:
+        backend, runtime, result = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "printf first")]),
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-2", "printf second")]),
+                _result("Both commands completed successfully."),
+            ],
+        )
+        self.assertEqual((backend.calls, result.content), (3, "Both commands completed successfully."))
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 1)
+        tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 2)
+
+    def test_native_system_and_directory_families_can_reuse_complete_prose(self) -> None:
+        cases = (
+            (
+                "system_info",
+                {},
+                "Show the computer specifications.",
+                "The requested computer specifications are shown above.",
+            ),
+            (
+                "list_directory",
+                {"path": "."},
+                "List this directory.",
+                "The directory listing is complete.",
+            ),
+        )
+        for name, arguments, prompt, prose in cases:
+            with self.subTest(name=name):
+                backend, runtime, result = self._run(
+                    "1",
+                    [
+                        _result(
+                            "",
+                            finish_reason="tool_calls",
+                            tool_calls=[_named_tool_call("call-1", name, arguments)],
+                        ),
+                        _result(prose),
+                    ],
+                    prompt=prompt,
+                    tool_names=("exec_shell_full_command", name),
+                )
+                self.assertEqual((backend.calls, result.content), (2, prose))
+                self.assertEqual(runtime.post_tool_final_reuse_reused_count, 1)
+
+    def test_reset_clears_reuse_diagnostics(self) -> None:
+        _, runtime, _ = self._run(
+            "1",
+            [
+                _result("", finish_reason="tool_calls", tool_calls=[_tool_call("call-1", "ls -F")]),
+                _result("The directory listing completed successfully."),
+            ],
+        )
+        runtime.reset()
+        self.assertEqual(runtime.post_tool_final_reuse_reused_count, 0)
+        self.assertIsNone(runtime.post_tool_final_reuse_last_reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_post_tool_final_reuse_comparator.py
+++ b/tests/test_post_tool_final_reuse_comparator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "scripts" / "compare_post_tool_final_reuse.py"
+SPEC = importlib.util.spec_from_file_location("compare_post_tool_final_reuse", PATH)
+assert SPEC is not None and SPEC.loader is not None
+comparator = importlib.util.module_from_spec(SPEC)
+sys.modules["compare_post_tool_final_reuse"] = comparator
+SPEC.loader.exec_module(comparator)
+
+
+def _run(*, enabled: bool, pid: int, calls: int, reused: int):
+    environment = {
+        "post_tool_final_reuse_comparison_fingerprint": "a" * 64,
+        "post_tool_final_reuse": {"enabled": enabled},
+        "server_pid": pid,
+    }
+    step = {
+        "case": "fixture",
+        "step": 1,
+        "repetition": 1,
+        "tool_names": ["exec_shell_full_command"],
+        "correctness_category": "correct",
+        "finish_reason": "stop",
+        "wall_ms": float(calls * 100),
+        "model_steps": [{"evaluated_tokens": 10} for _ in range(calls)],
+        "post_tool_final_reuse": {"reused_count_delta": reused},
+    }
+    return environment, {("fixture", 1, 1): step}
+
+
+class PostToolFinalReuseComparatorTests(unittest.TestCase):
+    def test_process_isolated_pair_reports_bounded_savings(self) -> None:
+        result = comparator.compare_runs(
+            _run(enabled=False, pid=10, calls=3, reused=0),
+            _run(enabled=True, pid=11, calls=2, reused=1),
+        )
+        self.assertEqual(result["decision"], "pass")
+        self.assertEqual(result["model_calls_saved"], 1)
+        self.assertEqual(result["evaluated_tokens_saved"], 10)
+        self.assertFalse(result["raw_content_included"])
+
+    def test_rejects_same_process_or_fingerprint_mismatch(self) -> None:
+        baseline = _run(enabled=False, pid=10, calls=3, reused=0)
+        candidate = _run(enabled=True, pid=10, calls=2, reused=1)
+        self.assertEqual(comparator.compare_runs(baseline, candidate)["decision"], "fail")
+        candidate[0]["server_pid"] = 11
+        candidate[0]["post_tool_final_reuse_comparison_fingerprint"] = "b" * 64
+        self.assertEqual(comparator.compare_runs(baseline, candidate)["decision"], "fail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import unittest
 import tempfile
+import os
 from pathlib import Path
 from shutil import copyfile
 import sys
@@ -2448,6 +2449,16 @@ def _last_tool_message(runtime: ChatRuntime) -> Message:
 
 
 class ToolRuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Keep legacy-path fixtures explicit; default-on behavior is covered by
+        # the dedicated post-tool final reuse tests and live matrix.
+        self._post_tool_final_reuse_env = patch.dict(
+            os.environ,
+            {"ORBIT_POST_TOOL_FINAL_REUSE": "0"},
+        )
+        self._post_tool_final_reuse_env.start()
+        self.addCleanup(self._post_tool_final_reuse_env.stop)
+
     def test_ask_with_tools_disables_backend_thinking_for_tool_plan_and_final_answer(self) -> None:
         class ThinkingAwareBackend:
             def __init__(self) -> None:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -53,6 +53,166 @@ def route_step_report(**overrides: object):
 
 
 class SmokeHarnessTests(unittest.TestCase):
+    def test_post_tool_final_reuse_mode_and_bounded_step_diagnostics(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(smoke_harness.post_tool_final_reuse_metadata("inherit")["enabled"])
+            with smoke_harness.post_tool_final_reuse_environment("on"):
+                self.assertTrue(smoke_harness.post_tool_final_reuse_metadata("inherit")["enabled"])
+            self.assertNotIn("ORBIT_POST_TOOL_FINAL_REUSE", os.environ)
+
+        before = {
+            "eligible_count": 2,
+            "reused_count": 1,
+            "fallback_count": 1,
+            "avoided_model_calls": 1,
+            "last_reason": "old",
+        }
+        after = {
+            "eligible_count": 3,
+            "reused_count": 2,
+            "fallback_count": 1,
+            "avoided_model_calls": 2,
+            "last_reason": "complete_post_tool_prose",
+        }
+        with mock.patch.dict(os.environ, {"ORBIT_POST_TOOL_FINAL_REUSE": "1"}, clear=True):
+            state = smoke_harness.post_tool_final_reuse_step_state(before, after)
+        self.assertEqual(state["reused_count_delta"], 1)
+        self.assertEqual(state["avoided_model_calls_delta"], 1)
+        self.assertIsNone(state["saved_evaluated_tokens"])
+        self.assertEqual(state["savings_measurement"], "process_isolated_off_on_required")
+
+    def test_post_tool_final_reuse_fingerprint_ignores_only_run_identity_and_mode(self) -> None:
+        base = {
+            "git_head": "abc123",
+            "model": "gemma4-test",
+            "ctx": 8192,
+            "threads": 6,
+            "scenario": ["fixture"],
+            "post_tool_final_reuse": {"enabled": False},
+            "server_pid": 10,
+            "timestamp": "first",
+        }
+        candidate = {
+            **base,
+            "post_tool_final_reuse": {"enabled": True},
+            "server_pid": 11,
+            "timestamp": "second",
+        }
+        self.assertEqual(
+            smoke_harness.post_tool_final_reuse_comparison_fingerprint(base),
+            smoke_harness.post_tool_final_reuse_comparison_fingerprint(candidate),
+        )
+        self.assertNotEqual(
+            smoke_harness.post_tool_final_reuse_comparison_fingerprint(base),
+            smoke_harness.post_tool_final_reuse_comparison_fingerprint({**candidate, "threads": 4}),
+        )
+
+    def test_inference_audit_shadow_requires_explicit_enabled_resolver(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {}, clear=True):
+            result = smoke_harness.main(
+                [
+                    "--inference-audit-shadow",
+                    "--output-dir",
+                    tmp,
+                    "--scenario",
+                    "simple_chat",
+                ]
+            )
+        self.assertEqual(result, 2)
+
+    def test_inference_audit_enrichment_is_off_by_default_and_redacted_when_enabled(self) -> None:
+        report = route_step_report(
+            prompt="sensitive request",
+            answer_excerpt="sensitive answer",
+            model_steps=[
+                {
+                    "phase": "final_from_tool",
+                    "loop": 2,
+                    "prompt_tokens": 120,
+                    "cached_tokens": 64,
+                    "evaluated_tokens": 56,
+                    "completion_tokens": 3,
+                    "tool_calls": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            tool_names=["system_info"],
+            correctness_category="correct",
+        )
+        step = smoke_harness.SmokeStep(
+            "fixture",
+            inference_audit_expectation="bounded_confirmation",
+        )
+        disabled = smoke_harness.enrich_step_inference_audit(report, step=step, enabled=False)
+        self.assertEqual(disabled.inference_audit, {})
+        self.assertEqual(disabled.to_json()["prompt"], "sensitive request")
+
+        enabled = smoke_harness.enrich_step_inference_audit(report, step=step, enabled=True)
+        self.assertEqual(enabled.inference_audit["summary"]["theoretical_model_calls"], 1)
+        self.assertEqual(enabled.to_json()["prompt"], "<redacted>")
+        self.assertEqual(enabled.to_json()["answer_excerpt"], "<redacted>")
+
+    def test_inference_audit_off_on_preserves_result_and_model_call_count(self) -> None:
+        class Runtime:
+            backend = object()
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def ask_chat(self, _prompt, **kwargs):
+                self.calls += 1
+                result = smoke_harness.ChatResult(
+                    content="bounded answer",
+                    model="fixture",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=20,
+                    completion_tokens=3,
+                    cached_tokens=4,
+                    prompt_tokens_per_second=10.0,
+                    generation_tokens_per_second=5.0,
+                )
+                phase_start = kwargs.get("on_phase_start")
+                if phase_start is not None:
+                    phase_start(smoke_harness.ModelPhaseStart("chat_final", attempt=1, reason="chat_response"))
+                kwargs["on_model_step"](
+                    smoke_harness.ModelStepMetrics.from_result(loop=1, result=result, phase="chat_final")
+                )
+                return result
+
+        step = smoke_harness.SmokeStep("fixture", mode="chat", checker_name="nonempty")
+        disabled_runtime = Runtime()
+        enabled_runtime = Runtime()
+        disabled = smoke_harness._run_step_inner(
+            disabled_runtime,
+            scenario="fixture",
+            step_index=1,
+            step=step,
+            workdir=Path("."),
+            max_tokens=16,
+            temperature=0.0,
+            allowed_tool_names=(),
+            inference_audit_enabled=False,
+        )
+        enabled = smoke_harness._run_step_inner(
+            enabled_runtime,
+            scenario="fixture",
+            step_index=1,
+            step=step,
+            workdir=Path("."),
+            max_tokens=16,
+            temperature=0.0,
+            allowed_tool_names=(),
+            inference_audit_enabled=True,
+        )
+        self.assertEqual(disabled_runtime.calls, enabled_runtime.calls)
+        self.assertEqual(disabled.answer_excerpt, enabled.answer_excerpt)
+        self.assertEqual(disabled.finish_reason, enabled.finish_reason)
+        self.assertEqual(disabled.model_steps, enabled.model_steps)
+        self.assertEqual(disabled.tool_names, enabled.tool_names)
+        self.assertEqual(disabled.model_phase_starts, [])
+        self.assertEqual(len(enabled.model_phase_starts), 1)
+
     def test_tool_call_generation_corpus_identity_is_stable(self) -> None:
         self.assertEqual(smoke_harness.TOOL_CALL_GENERATION_CORPUS_VERSION, 1)
         self.assertEqual(len(smoke_harness.TOOL_CALL_GENERATION_CORPUS), 40)

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -18,6 +18,14 @@ from orbit.tool_contract_config import resolve_tool_call_canonical_gate
 
 
 class CanonicalToolContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._post_tool_final_reuse_env = mock.patch.dict(
+            os.environ,
+            {"ORBIT_POST_TOOL_FINAL_REUSE": "0"},
+        )
+        self._post_tool_final_reuse_env.start()
+        self.addCleanup(self._post_tool_final_reuse_env.stop)
+
     def _decision(
         self,
         name: object,

--- a/tests/test_tool_healing.py
+++ b/tests/test_tool_healing.py
@@ -26,6 +26,14 @@ from orbit.tool_healing_config import resolve_tool_call_healing, resolve_tool_ca
 
 
 class ToolHealingShadowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._post_tool_final_reuse_env = mock.patch.dict(
+            os.environ,
+            {"ORBIT_POST_TOOL_FINAL_REUSE": "0"},
+        )
+        self._post_tool_final_reuse_env.start()
+        self.addCleanup(self._post_tool_final_reuse_env.stop)
+
     def _analyze(
         self,
         text: str,

--- a/tests/test_tool_plan_harness.py
+++ b/tests/test_tool_plan_harness.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = ROOT / "scripts" / "orbit_smoke_harness.py"
+SPEC = importlib.util.spec_from_file_location("orbit_tool_plan_smoke_harness", HARNESS_PATH)
+assert SPEC is not None and SPEC.loader is not None
+harness = importlib.util.module_from_spec(SPEC)
+sys.modules["orbit_tool_plan_smoke_harness"] = harness
+SPEC.loader.exec_module(harness)
+
+
+EXPECTED_STEPS = (
+    ("system_info", {}),
+    ("list_directory", {"path": ".", "max_entries": 20}),
+)
+
+
+def _valid_plan() -> str:
+    return json.dumps(
+        {
+            "type": "tool_plan",
+            "steps": [
+                {"name": name, "arguments": arguments}
+                for name, arguments in EXPECTED_STEPS
+            ],
+        }
+    )
+
+
+class ToolPlanHarnessTests(unittest.TestCase):
+    def test_cli_shadow_requires_centralized_opt_in(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=True), \
+            mock.patch.object(harness, "run_tool_plan_shadow_benchmark") as run:
+            self.assertEqual(harness.main(["--tool-plan-shadow"]), 2)
+        run.assert_not_called()
+
+        with mock.patch.dict("os.environ", {"ORBIT_TOOL_PLAN_SHADOW": "invalid"}, clear=True), \
+            mock.patch.object(harness, "run_tool_plan_shadow_benchmark") as run:
+            self.assertEqual(harness.main(["--tool-plan-shadow"]), 2)
+        run.assert_not_called()
+
+        with mock.patch.dict("os.environ", {"ORBIT_TOOL_PLAN_SHADOW": "1"}, clear=True), \
+            mock.patch.object(harness, "run_tool_plan_shadow_benchmark", return_value=0) as run:
+            self.assertEqual(harness.main(["--tool-plan-shadow"]), 0)
+        run.assert_called_once()
+
+    def test_exact_plan_uses_one_model_call_without_tool_or_finalization(self) -> None:
+        class Backend:
+            base_url = "http://127.0.0.1:9"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                self.calls += 1
+                self.tools = tools
+                return harness.ChatResult(
+                    content=_valid_plan(),
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=100,
+                    completion_tokens=40,
+                    cached_tokens=4,
+                    prompt_tokens_per_second=100.0,
+                    generation_tokens_per_second=10.0,
+                )
+
+        backend = Backend()
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(harness, "wait_for_backend_idle", return_value={"in_flight": False}), \
+            mock.patch("orbit.runtime.tool_calls.execute_tool_call") as execute, \
+            mock.patch.object(harness.ChatRuntime, "_answer_from_tool_results") as finalize:
+            row = harness.run_tool_plan_shadow_sample(
+                backend,
+                base_url=backend.base_url,
+                timeout=1.0,
+                workdir=Path(tmp),
+                scenario="fixture",
+                group="positive_mixed",
+                prompt="sensitive synthetic request",
+                prompt_view="contract",
+                system_prompt=harness.TOOL_PLAN_SHADOW_PROMPT_VIEWS["contract"],
+                expected_kind="plan",
+                expected_steps=EXPECTED_STEPS,
+                repetition=1,
+                temperature=0,
+                max_tokens=128,
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIsNone(backend.tools)
+        self.assertEqual(row["model_calls"], 1)
+        self.assertTrue(row["exact_plan"])
+        self.assertTrue(row["exact_tool_sequence"])
+        self.assertTrue(row["exact_arguments"])
+        self.assertEqual(row["scenario_outcome"], "exact_plan")
+        self.assertEqual(row["potential_model_call_reduction"], 2)
+        self.assertEqual(row["realized_model_call_reduction"], 0)
+        self.assertFalse(row["tool_executed"])
+        self.assertFalse(row["finalization_started"])
+        execute.assert_not_called()
+        finalize.assert_not_called()
+
+    def test_unsupported_response_is_scored_separately(self) -> None:
+        class Backend:
+            base_url = "http://127.0.0.1:9"
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                return harness.ChatResult(
+                    content='{"type":"unsupported_plan"}',
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=80,
+                    completion_tokens=7,
+                    cached_tokens=4,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(harness, "wait_for_backend_idle", return_value={"in_flight": False}):
+            row = harness.run_tool_plan_shadow_sample(
+                Backend(),
+                base_url="http://127.0.0.1:9",
+                timeout=1.0,
+                workdir=Path(tmp),
+                scenario="unsupported",
+                group="negative",
+                prompt="fixture",
+                prompt_view="contract",
+                system_prompt=harness.TOOL_PLAN_SHADOW_PROMPT_VIEWS["contract"],
+                expected_kind="unsupported",
+                expected_steps=None,
+                repetition=1,
+                temperature=0,
+                max_tokens=128,
+            )
+
+        self.assertTrue(row["correct_unsupported"])
+        self.assertEqual(row["scenario_outcome"], "correct_unsupported")
+        self.assertFalse(row["wrong_plan"])
+
+    def test_timeout_cancels_and_never_executes(self) -> None:
+        release = threading.Event()
+
+        class Backend:
+            base_url = "http://127.0.0.1:9"
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                release.wait(1.0)
+                return harness.ChatResult(
+                    content="",
+                    model="fake",
+                    finish_reason="cancelled",
+                    tool_calls=[],
+                    prompt_tokens=1,
+                    completion_tokens=0,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        def cancel(*_args, **_kwargs):
+            release.set()
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(harness, "request_backend_cancel", side_effect=cancel), \
+            mock.patch.object(harness, "wait_for_backend_idle", return_value={"in_flight": False}), \
+            mock.patch("orbit.runtime.tool_calls.execute_tool_call") as execute:
+            row = harness.run_tool_plan_shadow_sample(
+                Backend(),
+                base_url="http://127.0.0.1:9",
+                timeout=0.01,
+                workdir=Path(tmp),
+                scenario="timeout",
+                group="negative",
+                prompt="fixture",
+                prompt_view="contract",
+                system_prompt=harness.TOOL_PLAN_SHADOW_PROMPT_VIEWS["contract"],
+                expected_kind="unsupported",
+                expected_steps=None,
+                repetition=1,
+                temperature=0,
+                max_tokens=128,
+            )
+
+        self.assertTrue(row["timeout"])
+        self.assertTrue(row["cancel_requested"])
+        self.assertTrue(row["cleanup_healthy"])
+        self.assertFalse(row["evaluable"])
+        execute.assert_not_called()
+
+    def test_native_backend_tool_call_is_rejected(self) -> None:
+        class Backend:
+            base_url = "http://127.0.0.1:9"
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                return harness.ChatResult(
+                    content=_valid_plan(),
+                    model="fake",
+                    finish_reason="tool_call",
+                    tool_calls=[{"function": {"name": "system_info", "arguments": {}}}],
+                    prompt_tokens=100,
+                    completion_tokens=40,
+                    cached_tokens=4,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp, \
+            mock.patch.object(harness, "wait_for_backend_idle", return_value={"in_flight": False}), \
+            mock.patch("orbit.runtime.tool_calls.execute_tool_call") as execute:
+            row = harness.run_tool_plan_shadow_sample(
+                Backend(),
+                base_url="http://127.0.0.1:9",
+                timeout=1.0,
+                workdir=Path(tmp),
+                scenario="native-call",
+                group="positive_mixed",
+                prompt="fixture",
+                prompt_view="contract",
+                system_prompt=harness.TOOL_PLAN_SHADOW_PROMPT_VIEWS["contract"],
+                expected_kind="plan",
+                expected_steps=EXPECTED_STEPS,
+                repetition=1,
+                temperature=0,
+                max_tokens=128,
+            )
+
+        self.assertFalse(row["valid"])
+        self.assertEqual(row["rejection_code"], "unexpected_backend_tool_call")
+        self.assertTrue(row["unexpected_backend_tool_calls"])
+        execute.assert_not_called()
+
+    def test_view_metrics_and_wrong_plan_credit(self) -> None:
+        exact = {
+            "prompt_view": "contract", "evaluable": True, "expected_kind": "plan",
+            "json_compliant": True, "exact_plan": True, "correct_unsupported": False,
+            "wrong_plan": False, "prose_leakage": False, "invalid_json": False,
+            "model_calls": 1, "potential_model_call_reduction": 2,
+        }
+        unsupported = {
+            "prompt_view": "contract", "evaluable": True, "expected_kind": "unsupported",
+            "json_compliant": True, "exact_plan": False, "correct_unsupported": True,
+            "wrong_plan": False, "prose_leakage": False, "invalid_json": False,
+            "model_calls": 1, "potential_model_call_reduction": 0,
+        }
+        wrong = {
+            "prompt_view": "json_only", "evaluable": True, "expected_kind": "unsupported",
+            "json_compliant": True, "exact_plan": False, "correct_unsupported": False,
+            "wrong_plan": True, "prose_leakage": False, "invalid_json": False,
+            "model_calls": 1, "potential_model_call_reduction": 0,
+        }
+        summary = harness.summarize_tool_plan_shadow([exact, unsupported, wrong])
+
+        self.assertEqual(summary["exact_plans"], 1)
+        self.assertEqual(summary["correct_unsupported"], 1)
+        self.assertEqual(summary["wrong_plans"], 1)
+        self.assertEqual(summary["potential_model_call_reduction"], 2)
+        self.assertEqual(summary["realized_model_call_reduction"], 0)
+        self.assertTrue(summary["views"]["contract"]["smoke_gate_pass"])
+        self.assertFalse(summary["views"]["json_only"]["smoke_gate_pass"])
+
+    def test_jsonl_is_bounded_and_content_free(self) -> None:
+        row = {
+            "type": "tool_plan_shadow", "scenario": "safe-id", "prompt_view": "contract",
+            "evaluable": True, "expected_kind": "unsupported", "json_compliant": True,
+            "exact_plan": False, "correct_unsupported": True, "wrong_plan": False,
+            "prose_leakage": False, "invalid_json": False, "model_calls": 1,
+            "tool_executed": False, "finalization_started": False,
+        }
+        summary = harness.summarize_tool_plan_shadow([row])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "plan.jsonl"
+            harness.write_tool_plan_shadow_jsonl(
+                path, {"type": "environment", "workdir": "<redacted>"}, [row], summary
+            )
+            text = path.read_text(encoding="utf-8")
+
+        self.assertNotIn('"prompt":', text)
+        self.assertNotIn('"arguments":', text)
+        self.assertNotIn('"raw_content":', text)
+
+    def test_corpus_has_three_groups_and_three_incremental_views(self) -> None:
+        groups = {item[1] for item in harness.TOOL_PLAN_SHADOW_CORPUS}
+        self.assertEqual(groups, {"positive_mixed", "positive_two_lists", "negative"})
+        self.assertEqual(tuple(harness.TOOL_PLAN_SHADOW_PROMPT_VIEWS), ("contract", "json_only", "exactness"))
+        self.assertGreaterEqual(len(harness.TOOL_PLAN_SHADOW_CORPUS), 9)
+        self.assertEqual(len(harness.tool_plan_shadow_corpus(smoke=True)), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_plan_shadow.py
+++ b/tests/test_tool_plan_shadow.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from orbit.runtime.tool_plan_shadow import analyze_tool_plan_shadow
+from orbit.runtime.tools import TOOL_NAMES, tool_definitions
+from orbit.tool_plan_config import resolve_tool_plan_shadow
+
+
+def _step(name: str, arguments: dict[str, object]) -> dict[str, object]:
+    return {"name": name, "arguments": arguments}
+
+
+def _plan(*steps: dict[str, object]) -> dict[str, object]:
+    return {"type": "tool_plan", "steps": list(steps)}
+
+
+class ToolPlanShadowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.tmp.name)
+        self.definitions = tool_definitions(TOOL_NAMES)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def analyze(self, payload: object, *, finish_reason: str = "stop"):
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        return analyze_tool_plan_shadow(
+            text,
+            finish_reason=finish_reason,
+            tool_definitions=self.definitions,
+            allowed_tool_names=TOOL_NAMES,
+            workdir=self.workdir,
+            user_prompt="inspect synthetic local state",
+        )
+
+    def test_config_is_off_by_default_and_invalid_values_disable(self) -> None:
+        self.assertFalse(resolve_tool_plan_shadow({}).enabled)
+        self.assertTrue(resolve_tool_plan_shadow({"ORBIT_TOOL_PLAN_SHADOW": "1"}).enabled)
+        self.assertFalse(resolve_tool_plan_shadow({"ORBIT_TOOL_PLAN_SHADOW": "0"}).enabled)
+        invalid = resolve_tool_plan_shadow({"ORBIT_TOOL_PLAN_SHADOW": "yes"})
+        self.assertFalse(invalid.enabled)
+        self.assertEqual(invalid.validation_error, "invalid_boolean")
+
+    def test_exact_two_step_plan_passes_and_runtime_ids_are_internal(self) -> None:
+        report = self.analyze(
+            _plan(
+                _step("system_info", {}),
+                _step("list_directory", {"path": ".", "max_entries": 20}),
+            )
+        )
+
+        self.assertTrue(report.valid)
+        self.assertEqual(report.response_kind, "plan")
+        self.assertEqual([step.id for step in report.plan.steps], ["step_1", "step_2"])  # type: ignore[union-attr]
+        diagnostic = report.diagnostic()
+        self.assertEqual(diagnostic["step_count"], 2)
+        self.assertFalse(diagnostic["raw_content_included"])
+        self.assertNotIn("arguments", diagnostic)
+
+    def test_exact_unsupported_response_passes(self) -> None:
+        report = self.analyze({"type": "unsupported_plan"})
+
+        self.assertTrue(report.valid)
+        self.assertEqual(report.response_kind, "unsupported")
+        self.assertIsNone(report.plan)
+
+    def test_only_exact_two_step_shape_is_accepted(self) -> None:
+        one = _plan(_step("system_info", {}))
+        three = _plan(_step("system_info", {}), _step("system_info", {}), _step("system_info", {}))
+        old_shape = {
+            "type": "tool_plan",
+            "steps": [
+                {"id": "step_1", "tool": "system_info", "arguments": {}, "expect": None},
+                {"id": "step_2", "tool": "system_info", "arguments": {}, "expect": None},
+            ],
+            "completion": "none",
+        }
+
+        self.assertEqual(self.analyze(one).rejection_code, "invalid_step_count")
+        self.assertEqual(self.analyze(three).rejection_code, "invalid_step_count")
+        self.assertEqual(self.analyze(old_shape).rejection_code, "invalid_plan_shape")
+
+    def test_unsupported_shape_is_exact(self) -> None:
+        report = self.analyze({"type": "unsupported_plan", "reason": "shell"})
+        self.assertEqual(report.rejection_code, "invalid_unsupported_shape")
+
+    def test_shell_network_and_unknown_tools_are_not_eligible(self) -> None:
+        for name, arguments in (
+            ("exec_shell_full_command", {"command": "pwd"}),
+            ("fetch_url", {"url": "https://synthetic.invalid"}),
+            ("missing_tool", {}),
+        ):
+            with self.subTest(name=name):
+                report = self.analyze(_plan(_step(name, arguments), _step("system_info", {})))
+                self.assertEqual(report.rejection_code, "tool_not_plan_eligible")
+
+    def test_dynamic_arguments_fail_closed(self) -> None:
+        report = self.analyze(
+            _plan(
+                _step("list_directory", {"path": "."}),
+                _step("list_directory", {"path": "${step_1.output}"}),
+            )
+        )
+        self.assertEqual(report.rejection_code, "dynamic_dependency")
+
+    def test_canonical_schema_permission_and_limits_are_authoritative(self) -> None:
+        cases = (
+            ({"path": ".", "extra": True}, "canonical_additional_property"),
+            ({"path": 7}, "canonical_type_mismatch"),
+            ({"path": ".", "max_entries": 100000}, "canonical_limit_out_of_range"),
+        )
+        for arguments, reason in cases:
+            with self.subTest(reason=reason):
+                report = self.analyze(
+                    _plan(_step("list_directory", arguments), _step("system_info", {}))
+                )
+                self.assertEqual(report.rejection_code, reason)
+        disabled = analyze_tool_plan_shadow(
+            json.dumps(_plan(_step("system_info", {}), _step("system_info", {}))),
+            finish_reason="stop",
+            tool_definitions=self.definitions,
+            allowed_tool_names=("list_directory",),
+            workdir=self.workdir,
+            user_prompt="inspect",
+        )
+        self.assertEqual(disabled.rejection_code, "canonical_tool_not_enabled")
+
+    def test_duplicate_multiple_prose_invalid_and_finish_fail_closed(self) -> None:
+        duplicate = (
+            '{"type":"tool_plan","steps":[{"name":"system_info","arguments":{},"arguments":{}},'
+            '{"name":"system_info","arguments":{}}]}'
+        )
+        multiple = json.dumps({"type": "unsupported_plan"}) + json.dumps({"type": "unsupported_plan"})
+        prose = "Result: " + json.dumps({"type": "unsupported_plan"})
+        invalid = '{"type":"unsupported_plan"'
+        plan = _plan(_step("system_info", {}), _step("system_info", {}))
+
+        self.assertEqual(self.analyze(duplicate).rejection_code, "duplicate_key")
+        self.assertEqual(self.analyze(multiple).rejection_code, "multiple_candidates")
+        self.assertEqual(self.analyze(prose).rejection_code, "external_text")
+        self.assertEqual(self.analyze(invalid).rejection_code, "invalid_json")
+        self.assertEqual(self.analyze(plan, finish_reason="length").rejection_code, "nonrecoverable_length")
+        self.assertEqual(self.analyze(plan, finish_reason="cancelled").rejection_code, "nonrecoverable_cancelled")
+
+    def test_normal_text_is_not_a_plan(self) -> None:
+        report = self.analyze("Explain system_info and list_directory.")
+        self.assertFalse(report.detected)
+        self.assertEqual(report.candidate_count, 0)
+        self.assertEqual(report.rejection_code, "no_plan")
+        self.assertTrue(report.diagnostic()["prose_leakage"])
+
+    def test_analysis_cannot_execute_a_tool(self) -> None:
+        with mock.patch("orbit.runtime.tool_backends.HybridToolExecutor.execute") as execute:
+            report = self.analyze(
+                _plan(_step("system_info", {}), _step("list_directory", {"path": "."}))
+            )
+        self.assertTrue(report.valid)
+        execute.assert_not_called()
+
+    def test_validation_is_deterministic_for_many_literal_plans(self) -> None:
+        for index in range(100):
+            payload = _plan(
+                _step("list_directory", {"path": f"alpha-{index}", "max_entries": 5}),
+                _step("list_directory", {"path": f"beta-{index}", "max_entries": 7}),
+            )
+            first = self.analyze(payload)
+            second = self.analyze(payload)
+            self.assertTrue(first.valid)
+            self.assertEqual(first.diagnostic(), second.diagnostic())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Enable `ORBIT_POST_TOOL_FINAL_REUSE` by default with an immediate `=0` kill switch.
- Reuse only the exact original `ChatResult.content` after strict structural eligibility checks.
- Preserve normal `final_from_tool` fallback for uncertainty and non-eligible results.

## Validation
- 50/50 process-isolated OFF/ON cases correct and stopped.
- 50 model calls avoided and 65,189 evaluated tokens saved in the measured workload.
- Zero false positives, skipped tools, or argument/tool changes.
- Full suite: 1,213 tests PASS.
- Comparator, MTP shim build, compileall, and diff check PASS.

No deterministic wall-time improvement is claimed. No merge, tag, or release.