### PR TITLE
Document discarded optimization experiment results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,30 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - Small `shell`, `grep_search`, and `unknown` finals remain at 96 tokens.
 - `/max-tokens` is user-facing; the runtime still applies internal per-phase budgets.
 
+## Discarded Optimization Experiments
+
+- The post-reuse model-call audit found no additional frequent model call that
+  could be removed without taking over a semantic decision. Exact final-input
+  replay remains unimplemented and stopped pending repeated real opportunities.
+- Additive structured `read_file`/`grep_search` schemas increased cold prefill
+  and regressed exact argument fidelity. Their schemas, harness branches, and
+  tests are not present in production.
+- Production tool-schema compaction changed tool selection or exact arguments;
+  generic output bounding lacked supporting oversized evidence. Both remain
+  technical stops.
+- Bounded planning failed its semantic smoke gate with Gemma 4 12B and remains
+  inactive. It requires a new model/template to pass exact-plan,
+  unsupported-plan, and zero-wrong-plan gates before reconsideration.
+- A 768-token tool-mode checkpoint was numerically exact but the
+  production-like opportunity sample observed no useful real restore. It also
+  retained about 252 MiB. Its runtime integration and
+  `ORBIT_TOOL_PREFIX_REUSE` flag were discarded after RC23.
+- Preserve only the measured audits in
+  `docs/POST_TOOL_MODEL_CALL_AUDIT.md`,
+  `docs/STRUCTURED_FILE_TOOLS_SHADOW.md`, and
+  `docs/TOOL_CALL_POST_ROUTE_KV_REUSE.md`. Do not restore their experimental
+  code without new production evidence and a separate review.
+
 ## Evidence Lineage
 
 - `user_turn_id` is useful for provenance, not relevance.

--- a/docs/POST_TOOL_MODEL_CALL_AUDIT.md
+++ b/docs/POST_TOOL_MODEL_CALL_AUDIT.md
@@ -1,0 +1,82 @@
+# Post-Tool Model-Call Audit
+
+## Scope
+
+This observational audit followed default post-tool final prose reuse. It did
+not change routing, tool selection, execution, finalization, retries, prompts,
+schemas, or backend behavior.
+
+The measured corpus combined 50 process-isolated post-tool reuse scenarios,
+five additional tool scenarios, and three route scenarios. In total, 58
+correct scenarios produced 121 correlated model calls. Diagnostics contained
+metadata only, without prompts, tool arguments, evidence, or complete outputs.
+
+## Measured Call Map
+
+| Category | Calls | Evaluated tokens | Output tokens | Wall seconds | Disposition |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `tool_call` | 55 | 12,566 | 1,395 | 1,436.7 | necessary |
+| `post_tool_route` | 50 | 14,639 | 749 | 1,455.3 | necessary; prose reused |
+| `initial_route` | 8 | 359 | 119 | 75.3 | necessary |
+| `final_from_tool` synthesis | 5 | 712 | 340 | 166.8 | necessary |
+| bounded confirmation | 2 | 284 | 26 | 30.0 | theoretical candidate only |
+| `chat_final` | 1 | 270 | 76 | 45.8 | necessary |
+
+All measured calls ended with `finish_reason=stop`. No retry, formatting
+repair, duplicate route decision, or uncorrelated backend call was observed.
+
+## Conclusions
+
+Tool selection, post-tool decisions that may select another tool, evidence
+interpretation, requested synthesis, and CHAT finalization remained necessary
+model work. No additional frequent inference was safely eliminable in the
+measured sample.
+
+The two bounded confirmation calls could not be removed safely: runtime had no
+prior prose to reuse and could not prove that raw tool output was a complete
+user-facing response without taking over a semantic decision.
+
+## Exact Replay
+
+An exact final-input replay counter was considered as a hypothesis for an
+observational follow-up. A safe design would require a hash over the complete
+rendered input and all model, tokenizer, template, backend, phase,
+temperature, token-budget, thinking, and runtime identities. It would also
+require session-local bounded state and lifecycle invalidation.
+
+No replay implementation was promoted or retained. Repeated opportunities and
+full equivalence were not established, so exact replay remains a technical
+stop rather than a production feature.
+
+## Other Technical Stops
+
+- Structured `read_file` and `grep_search` schemas increased cold prefill and
+  reduced argument fidelity in the measured candidate.
+- Production schema compaction changed tool selection, exact arguments, or
+  adversarial behavior in every useful compact variant.
+- Additional generic output bounding was not justified by observed downstream
+  evidence; existing shell/search bounds and final evidence compaction already
+  covered the sample.
+- Bounded multi-action planning failed its semantic smoke gate with Gemma 4
+  12B and is not active.
+
+No runtime implementation was retained for exact replay, structured file
+tools, schema compaction, generic output bounding, or tool-prefix reuse. The
+bounded planning analyzer, `ORBIT_TOOL_PLAN_SHADOW`, generation-only harness,
+and related tests remain as OFF-by-default observational infrastructure. They
+never execute a plan, and the planning technical stop remains in force.
+
+## Reopening Criteria
+
+- Exact replay requires repeated byte-identical final inputs in real sessions,
+  full compatibility identity, process-isolated equivalence, bounded storage,
+  lifecycle invalidation, and an OFF-by-default shadow phase before any reuse.
+- Structured file tools require a new model/template result with no tool or
+  argument regression and lower end-to-end evaluated-token and wall cost.
+- Schema compaction requires exact tool and payload invariance across complex
+  paths and adversarial negatives, not merely fewer prompt tokens.
+- Generic output bounding requires observed oversized downstream evidence with
+  material token cost and proof that all user-required content is preserved.
+- Bounded planning requires a materially different model/template to pass the
+  documented JSON, exact-plan, unsupported-plan, and zero-wrong-plan smoke
+  gates before repetitions or execution can be reconsidered.

--- a/docs/STRUCTURED_FILE_TOOLS_SHADOW.md
+++ b/docs/STRUCTURED_FILE_TOOLS_SHADOW.md
@@ -1,0 +1,37 @@
+# Structured File Tools Shadow: Technical Stop
+
+## Scope
+
+Orbit production represents file reads and content searches through the
+existing shell tool. An additive benchmark candidate introduced strict
+`read_file` and `grep_search` schemas only for generation-only observation; it
+never added those names to production tools or executed either candidate.
+
+The comparison retained all production tools and added the two schemas, so it
+did not credit an unrealistically smaller tool set. It covered path integrity,
+including spaces, apostrophes, and non-ASCII characters, along with exact tool
+and argument agreement.
+
+## Measured Results
+
+- the larger schema increased cold prompt and evaluated-token cost;
+- cold wall time did not improve;
+- exact argument fidelity regressed in relevant path and search cases;
+- schema safety alone did not offset the model-adherence regression.
+
+## Conclusion
+
+The benchmark-specific schemas, runtime module, harness switches, and tests
+were intentionally discarded after RC23. No structured file tool is active or
+available to routing.
+
+## Reopening Criteria
+
+Reconsider this work only with a new model or template and a process-isolated
+additive-schema comparison that demonstrates all of the following:
+
+- exact tool and argument fidelity on ordinary and complex paths;
+- no increase in unwanted tool attempts or truncation;
+- lower total prompt/evaluated-token cost;
+- lower or neutral cold and warm wall time;
+- no routing, lifecycle, canonical-contract, or safety regression.

--- a/docs/TOOL_CALL_POST_ROUTE_KV_REUSE.md
+++ b/docs/TOOL_CALL_POST_ROUTE_KV_REUSE.md
@@ -1,0 +1,84 @@
+# Tool-Call and Post-Tool KV Reuse Audit
+
+## Scope
+
+This audit measured native Gemma 4 12B prompt reuse across `tool_call` and
+`post_tool_route`. It did not change prompts, model-call count, tool behavior,
+or active checkpoint selection.
+
+The measured CPU-only profile used context 8192, six threads, batch 256,
+ubatch 128, thinking off, tools on, fixed affinity, and temperature zero. The
+sample covered 23 workflows across shell, system information, directory list,
+file read, and content search families.
+
+The boundary and restore measurements below are deterministic probes. A later
+production-like opportunity sample observed no useful real restore
+opportunity. Probe savings therefore establish mechanism feasibility, not
+production utility.
+
+## Prompt Layout
+
+The native backend already reused the exact longest common prefix. Adjacent
+tool/post-tool prompts diverged before generated tokens because runtime placed
+`capability_context` after the current conversation on each loop. The first
+tool prompt had roles `system,user,system`; the next prompt had roles
+`system,user,assistant,tool,system`. Moving the capability block after the
+assistant call and tool result changed the prefix. This was prompt layout, not
+checkpoint invalidation or a backend LCP defect.
+
+## Boundary Probe
+
+The production tokenizer measured these candidate boundaries:
+
+| Boundary | Meaning | Cold/segmented max logits difference | Decision |
+| ---: | --- | ---: | --- |
+| 766 | existing route prewarm | 2.8360815 | reject |
+| 824 | stable tool system/schema end | 2.8860884 | reject |
+| 838 | before capability context | 2.9907508 | reject |
+| 768 | production 64-token batch boundary | 0.0 | numerically viable |
+
+The 768-token boundary used meaningful production content with no padding,
+prompt rewrite, or extra prefill. Cold full prefill, segmentation at 768, and
+checkpoint restore produced identical token positions, logits hashes, next
+tokens, ordered top candidates, tool calls, arguments, outputs, and finish
+reasons across the measured system, list, read, grep, and shell families.
+
+| Family | Cold evaluated | Restore evaluated | Cold prefill | Restored suffix |
+| --- | ---: | ---: | ---: | ---: |
+| system info | 926 | 158 | 69.29 s | 13.00 s |
+| list directory | 925 | 157 | 69.36 s | 12.87 s |
+| read file | 928 | 160 | 69.54 s | 13.15 s |
+| grep search | 934 | 166 | 70.06 s | 13.67 s |
+| shell success | 931 | 163 | 69.98 s | 13.38 s |
+
+The exact saving was 768 evaluated tokens for an eligible cold tool call. A
+12-output process-isolated comparison retained identical output and tool-call
+hashes and measured about 55.5-56.5 seconds less prefill on that machine. This
+was workload-specific and is not a deterministic performance guarantee.
+
+The checkpoint measured 264,260,776 bytes. Peak process RSS was roughly 499
+MiB above cold because capture and restore temporarily copied the buffer. RSS
+remained flat across ten restores, and invalidation removed the retained blob
+and released approximately 252 MiB.
+
+## Conclusion
+
+The optimization only helped cold tool calls with no useful normal LCP. MTP
+remained authoritative and incompatible with the candidate path. No useful
+real restore opportunity was observed in the production-like sample, while
+the checkpoint retained about 252 MiB. The measured utility did not justify
+retaining an unpromoted runtime feature after RC23.
+
+All tool-prefix runtime integration, configuration, payload fields,
+checkpoint state, diagnostics, and tests were discarded. The audit remains as
+numerical evidence only; tool-prefix reuse is not active in production.
+
+## Reopening Criteria
+
+Do not restore the implementation unless a new production-like sample shows a
+repeatable rate of cold calls with zero useful normal LCP and enough successful
+restore opportunities to justify the resident checkpoint. Any new proposal
+must also reproduce exact token, logits, tool, argument, output, and finish
+reason equivalence; pass process-isolated timing; bound RSS and temporary
+copies; preserve MTP authority; and pass cancel, timeout, reset, restart,
+identity-mismatch, and restore-failure lifecycle gates.


### PR DESCRIPTION
## Summary
- records the post-tool model-call audit and its remaining semantic boundaries
- documents structured file tools, schema compaction, output bounding, bounded planning, and tool-prefix reuse as technical stops
- defines measurable criteria required before any experiment can be reopened

## Scope
- documentation only
- no runtime, backend, script, test, prompt, schema, or configuration changes
- no production feature is activated

## Validation
- English-only and forbidden-reference checks PASS
- local documentation links and heading structure PASS
- git diff --check PASS
- full discovery remains unchanged; the immediately preceding run passed 1,223 tests