### PR TITLE
Honor explicit no-mutation constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,99 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   `inspect_python`/`read_file` schemas, harness, and tests were removed after
   the failed first smoke. No completion verifier, recovery flag, or restricted
   recovery path remains.
+- A later obligation-driven Agent v2 probe stopped at its mandatory
+  generation-only contract gate and never entered runtime integration. Three
+  exact-span representations were compared. On the four-subject configuration
+  request, atomic spans passed once, while the initial shared-instruction and
+  complete-partition encodings failed structural validation.
+- Across the required ten-shape contract corpus, the first atomic encoding was
+  structurally valid in 6/10 cases and matched the independent expected
+  decomposition in 3/10. A refined shared-subject encoding with exact
+  model-selected span references and structural coordination groups improved
+  those results to 8/10 structurally valid and 5/10 expected, but still split
+  simple requests, confused ordinary file capabilities, selected partial or
+  duplicate spans, and mishandled inert Markdown.
+- A final model-owned `existing` fast-path choice did not protect bounded
+  workflows: Gemma selected obligation orchestration for system information,
+  create/edit/verify, and inert JSON controls. The targeted mode probe passed
+  only the configuration audit (1/4). All measured contract calls stopped
+  normally, but the complete contract gate failed, so no source index, child
+  context, synthesis path, flag, or default change was implemented.
+- The Agent v2 contract module, benchmark harness, and tests were removed.
+  Reopen obligation orchestration only for a model/template that passes the
+  complete generation-only corpus with exact spans, no missing or invented
+  obligations, correct capability classes, and preservation of existing fast
+  paths before any runtime integration.
+- A later normal-loop qualification kept `tools=True` and `agent=False`.
+  Exact repeated-call rejection and mutation epochs were already shared by the
+  normal loop, so no runtime port was needed. `apply_patch` was selected in
+  0/2 normal-loop edit probes and increased the tool-call prompt cost, so it
+  remains agent-only. Mandatory post-mutation verification and mutating-action
+  review improved specific safety properties but caused material regressions
+  on valid bounded mutations; both remain agent-only.
+- The qualification retained one canonical policy hardening: explicit
+  no-mutation constraints such as "without changing any files" are
+  authoritative even when the same request also contains a mutation verb.
+  The measured contradictory deletion changed from an unsafe eight-call
+  execution to a safe four-call rejection, while the ten unaffected baseline
+  scenarios retained their existing model/tool-call counts.
+- The final adversarial review restricts that policy to unquoted active user
+  prose. Quoted strings, inline or fenced code, Markdown blockquotes, JSON
+  strings, explicitly introduced Markdown example/payload lists, and tool
+  output cannot activate the explicit constraint. Ordinary Markdown
+  instruction lists remain active. The classifier has only three bounded
+  structural outcomes: `none`, `global`, and `mixed`.
+- Global forms include `without changing any files`, `make no changes`,
+  `leave files unchanged`, and coordinated `do not`/`don't` file-mutation
+  clauses. Generic shell strings are never treated as provably read-only under
+  a global or mixed constraint; every `exec_shell_full_command` call is denied
+  without parsing, rewriting, or substituting it. Structured read-only tools
+  remain available. `apply_patch` is denied through the same runtime policy.
+- The invariant is independent of `ORBIT_TOOL_CALL_CANONICAL_GATE`. The
+  canonical preflight and legacy executor adapter apply the shared decision
+  before dispatch, and the common dispatcher enforces the same pure policy as
+  the final boundary. Disabling canonical schema validation cannot disable
+  explicit user safety.
+- Policy rejection is propagated only through the structured execution outcome
+  and reason. Tool stdout/stderr that resembles a rejection message is never
+  interpreted as user policy.
+- Scoped exceptions and phase changes are intentionally unsupported. Requests
+  such as inspect-then-fix, all-files-except-one, source-read-only plus report
+  creation, or analyze-then-actually-correct are classified as `mixed`.
+  Unquoted generic bullet/item/line lists containing a no-mutation phrase are
+  also `mixed`. Explicitly labeled Markdown examples or payloads, and
+  `this`/`following content|text` sections introduced by a bounded output
+  action, are masked as inert data only for one immediate plain line or one
+  bounded Markdown list.
+  Structured read-only observations may run, but generic shell and every
+  mutation fail closed with a bounded instruction to split the work into
+  separate unambiguous user requests.
+- The real-model adversarial matrix completed 17/17 stop responses with zero
+  mutation under global constraints, zero false blocks on quoted/inert data,
+  and 3/3 legitimate mutations preserved. The post-review matrix used 45 model
+  calls, 21 model-proposed tool calls, 10 executed tools, 11 policy rejections,
+  15,868 evaluated tokens, 849 output tokens, and 722.862 seconds of observed
+  CPU wall time. All generic-shell attempts under global or mixed constraints
+  were rejected; structured directory listings remained usable.
+- A separate normal-loop production corpus remained 11/11 correct and stopped:
+  direct chat, read, list, search, create, edit, command, bounded workflow,
+  inert tool-like data, explicit no-mutation, and command failure. It used 26
+  model calls, 12 proposed tool calls, 10 executed tools, 7,351 evaluated
+  tokens, 598 output tokens, and 329.358 seconds. These non-isolated timings are
+  descriptive safety and regression evidence, not a performance claim.
+- Generic file reads and test execution cannot be promised under an explicit
+  global no-mutation constraint when the model selects unrestricted shell.
+  Arbitrary executables can mutate state even when passed as an argv array, so
+  no nominally read-only process allowlist was added. Such requests receive a
+  bounded denial unless the model can use an existing structured read-only
+  tool. Add a dedicated structured capability only after a separate measured
+  need and a complete side-effect contract.
+- No normal-loop `read_file` or `run_process` schema was added. Existing read,
+  list, search, command, creation, edit, and bounded workflow baselines were
+  already correct; adding a schema would require route/prefill changes without
+  a measured failure. Legacy `--agent` remains an explicit stricter
+  orchestration profile for workflows where its extra review and verification
+  cost is intentionally accepted, not a default capability upgrade.
 - Removing shell competition therefore reduced wasted discovery but did not
   make the model acquire source evidence. The profile failed its first
   correctness and natural-tool-selection gates. Its resolver, restricted

--- a/docs/AGENT_MODE_DEFAULT_VALIDATION.md
+++ b/docs/AGENT_MODE_DEFAULT_VALIDATION.md
@@ -722,6 +722,219 @@ verifier module, recovery flag, or restricted recovery path remains. Agent
 mode remains opt-in; normal agent and non-agent prompts, tool sets, prefill,
 and lifecycle are unchanged.
 
+### Obligation-driven Agent v2 contract qualification
+
+A later probe tested obligation-driven orchestration without first changing
+the runtime. The mandatory first phase was generation-only: one dedicated
+model call had to produce a bounded contract whose obligations referred to
+exact character spans in the original request. No tool was executed, no child
+context or final synthesis was started, and no production module imported the
+prototype.
+
+Three representations were compared first on the four-subject configuration
+audit:
+
+| Representation | Structurally valid | Expected four subjects | Evaluated tokens | Output tokens | Wall time |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Atomic obligation spans | yes | yes | 620 | 144 | 36.690 s |
+| Shared instruction plus subject spans | no | no | 553 | 178 | 39.500 s |
+| Complete request partition | no | no | 554 | 198 | 42.509 s |
+
+The initial shared representation omitted required outer fields. The partition
+left punctuation and newline gaps. The atomic result did identify `agent`,
+`tools`, `think`, and `max_tokens` independently, but qualification required
+the complete ten-shape corpus rather than one favorable request.
+
+The first atomic corpus run produced ten normal stop completions but was
+structurally valid in only 6/10 cases and matched the independent expected
+contract in 3/10. It used 4,029 evaluated tokens, 1,078 output tokens, and
+257.850 seconds. Failures included wrong capability classes for ordinary
+files, repeated spans in mutation workflows, inaccurate bullet offsets, and
+over-decomposition of coordinated subjects.
+
+A smaller exact-span catalog removed model arithmetic over offsets without
+selecting any span on the model's behalf. A refined shared-subject encoding
+also separated common instructions and represented punctuation-defined
+coordination groups structurally. This improved the complete corpus to 8/10
+structurally valid and 5/10 expected, using 4,568 evaluated tokens, 1,206 output
+tokens, and 275.039 seconds. Remaining failures included:
+
+- splitting one system-information action into separate obligations;
+- treating report fields as independent obligations in a file comparison;
+- choosing partial spans for explicit numbered items;
+- using the source-inspection capability for ordinary file reads;
+- selecting the same file span for both mutation and verification in inert
+  Markdown content.
+
+A final model-owned fast-path alternative allowed exact
+`{"mode":"existing"}` instead of obligations. In a four-case targeted probe,
+the configuration audit passed, but Gemma still selected obligation mode for a
+single system-information request, a create/edit/verify workflow, and an inert
+JSON file request. The mode gate therefore passed 1/4. Runtime did not override
+those choices.
+
+The evidence demonstrates that exact span references can prevent invented
+free-text deliverables, but they do not make this model choose a stable
+decomposition or preserve existing fast paths across request shapes. The
+complete contract corpus failed before runtime integration, so the
+configuration audit was not executed through child contexts. The required ten
+audit repetitions, remaining source audits, and twenty-scenario regression
+matrix were not run.
+
+The contract module, generation-only harness, and focused tests were removed.
+No Agent v2 flag, source index, obligation state, child context, synthesis
+path, retry, or production prompt change remains. Agent mode stays disabled by
+default.
+
+Reopen obligation-driven orchestration only for a model or template that first
+passes the full generation-only contract corpus with:
+
+- exact request-span validity and normal stop completion;
+- no omitted, duplicated, merged, or invented obligation;
+- correct model-selected capability classes;
+- complete coverage of explicit and coordinated request items;
+- correct rejection of inert JSON and Markdown as task structure;
+- preservation of the existing path for simple and already reliable bounded
+  workflows.
+
+### Normal-loop mechanism qualification
+
+A later qualification evaluated whether individual agent mechanisms should be
+ported into the normal bounded tool loop. Defaults remained `tools=True` and
+`agent=False`; no interactive mode switch was added.
+
+The production baseline used eleven representative request families from
+`docs/PROMPTS.md`: direct chat, file read, directory listing, text search, file
+creation, existing-file modification, command execution, a bounded
+create/read/remove workflow, inert JSON/Markdown, a contradictory permission
+request, and a command failure.
+
+Ten non-conflicting families were already correct. Their baseline and retained
+candidate both used 20 model calls and nine executed tools. Evaluated tokens
+were 2,402 versus 2,406, and measured wall time was 224.3 versus 216.1 seconds;
+the timing difference is directional and not a performance claim. Direct chat
+remained one call with zero tools. Read, list, search, command, creation, edit,
+workflow, inert-data, and command-failure behavior did not gain a new path.
+
+The mechanism results were:
+
+- Exact repeated-call rejection and mutation epochs were already active in the
+  shared normal loop. A regression test now proves that a successful mutation
+  reopens prior observations in the new epoch while keeping the exact mutation
+  blocked.
+- Adding `apply_patch` to the normal surface was rejected. Gemma selected it in
+  0/2 edit probes, continued to use shell, and increased evaluated tokens from
+  1,098 to 1,190 and 1,200 in the two variants. Schema order did not change the
+  selection. `apply_patch` remains agent-only.
+- Mandatory separate post-mutation verification was rejected. It increased a
+  creation case from 2 calls, 127 evaluated tokens, and 17.8 seconds to 3
+  calls, 1,259 tokens, and 55.0 seconds. It also made the bounded
+  create/read/remove workflow incomplete by focusing the final answer on the
+  removed directory rather than the previously observed marker.
+- Model action review for every normal-loop mutation was rejected. It safely
+  declined the contradictory deletion but increased valid creation from 2 to
+  3 calls and valid edit from 3 to 4 calls, with material token and wall-time
+  regressions. Read-only actions did not receive review calls.
+- `read_file` and `run_process` were not added. The corresponding shell
+  baselines were already correct, bounded, and free of malformed arguments.
+  Natural selection would require new route guidance or schema exposure without
+  a measured failure, contrary to the production-baseline gate.
+
+One safety bug was retained as a minimal policy fix. The canonical read-only
+policy now recognizes general explicit constraints such as "without changing
+any files", even if the same request contains a mutation verb. Before the fix,
+the contradictory deletion scenario used eight model calls, executed four
+tools including the deletion, evaluated 2,915 tokens, and took 199.7 seconds.
+After the fix it stopped safely with the file intact, four model calls, two
+read-only tools, 1,671 evaluated tokens, and 74.2 seconds. This is a policy
+correction, not semantic routing or a deterministic task solution.
+
+#### Explicit no-mutation adversarial review
+
+The retained rule inspects only active prose from the latest user request.
+Before matching, it masks quoted strings, inline and fenced code, Markdown
+blockquotes, JSON string values, and Markdown example or payload lists after an
+explicit data-introduction header. Ordinary Markdown instruction lists remain
+active. Tool results are not policy input. The bounded classifier returns only:
+
+- `none`: no active explicit constraint;
+- `global`: one unscoped explicit no-mutation constraint;
+- `mixed`: a scoped exception, partial scope, or later mutation phase.
+
+Supported global forms include `without changing any files`, `make no
+changes`, `leave files unchanged`, and coordinated `do not` or `don't`
+file-mutation clauses. No unrestricted shell string is treated as provably
+read-only under a global or mixed constraint. Every
+`exec_shell_full_command` call is rejected without parsing, rewriting, or
+substitution, including absolute or relative executable aliases, environment
+wrappers, pipelines, redirects, interpreters, and commands with apparently
+read-only names. Structured read-only tools such as `list_directory` and
+`system_info` remain available. Agent-only `apply_patch` receives the same
+policy decision.
+
+The invariant is independent of `ORBIT_TOOL_CALL_CANONICAL_GATE`. The
+canonical preflight and legacy executor adapter apply the shared decision
+before dispatch, and the common dispatcher enforces the same pure policy as
+the final boundary. The canonical kill switch therefore restores only legacy
+schema validation; it cannot disable an explicit user safety constraint.
+Formal-healing state, agent mode, and non-agent mode do not alter the decision.
+Policy rejection is carried only by the structured execution outcome and
+reason; matching text in tool stdout or stderr is not policy input.
+
+Mixed or scoped language is deliberately not interpreted as an executable
+exception policy. Inspect-then-fix, all-files-except-one, source-read-only plus
+report creation, and analyze-then-actually-correct requests are unsupported.
+An unquoted generic bullet, item, or line list containing a no-mutation phrase
+is also unsupported and classified as `mixed`. Explicitly labeled Markdown
+examples or payloads, and `this`/`following content|text` sections introduced
+by a bounded output action, are masked as inert data only for one immediate
+plain line or one bounded Markdown list.
+Structured read-only observations may execute, but generic shell and proposed
+mutations are rejected before their concrete executor with a bounded message
+asking the user to split the workflow into separate requests. Runtime does not
+infer the exception target or choose an action.
+
+The final real-model matrix used seventeen clean temporary workdirs:
+
+| Family | Scenarios | Result |
+| --- | ---: | --- |
+| Explicit global constraint | 5 | zero mutations; structured directory listing remained available |
+| Quoted, Markdown, JSON, and tool-output controls | 5 | zero false constraint activation |
+| Legitimate mutation | 3 | create, overwrite, and rename all completed |
+| Mixed or scoped request | 4 | zero mutations; generic shell proposals rejected explicitly |
+
+The post-review seventeen-scenario sample completed every final response with
+`finish_reason=stop`. It used 45 model calls, 21 model-proposed tool calls, 10
+executed tools, 11 policy rejections, 15,868 evaluated tokens, 849 output
+tokens, and 722.862 seconds of observed wall time. There were zero actual
+mutations under global or mixed constraints, zero false blocks across the five
+quoted/inert controls, and zero regressions across the three legitimate
+mutations. The global listing cases selected `list_directory` successfully.
+Generic file reads and test execution were denied when the model selected
+unrestricted shell, and the model reported that evidence could not be
+confirmed.
+
+That limitation is intentional. Passing a command as an argv array does not
+prove that the executable or test suite is side-effect free. Orbit therefore
+does not maintain a nominally read-only process allowlist. A future dedicated
+structured tool would require separate measured need, path confinement, and a
+complete side-effect contract; the current policy does not infer one.
+
+A separate normal-loop production corpus remained 11/11 correct with
+`finish_reason=stop`: direct chat, read, list, search, create, edit, command,
+bounded create/read/remove, inert tool-like data, explicit no-mutation, and
+command failure. It used 26 model calls, 12 proposed tool calls, 10 executed
+tools, 7,351 evaluated tokens, 598 output tokens, and 329.358 seconds. Direct
+chat remained one call and zero tools. These runs shared one native CPU server
+and were not an ABBA or process-isolated timing comparison; no speed claim is
+made.
+
+The legacy opt-in agent mode therefore retains a narrow purpose: it offers the
+stricter action-review, exact-patch, and post-mutation-verification protocol
+when a user deliberately accepts its additional model calls. It has not
+demonstrated enough incremental capability or efficiency to become the
+default.
+
 Reconsider default promotion only after production-like multi-deliverable
 source audits complete correctly and stop within the existing round and final
 budgets, without broad-scan reviewer calls or deterministic semantic routing.

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -29,6 +29,7 @@ SHELL_FAILURE_STREAM_CHARS = 1200
 SHELL_READ_FILE_THRESHOLD_BYTES = 8 * 1024
 SHELL_FULL_CONTRACT_ERROR_PREFIX = "error: shell-full analysis requests require content/source/string evidence"
 SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX = "error: read-only request rejected mutating shell command"
+SHELL_FULL_MIXED_MUTATION_ERROR_PREFIX = "error: mixed or scoped mutation constraint rejected mutating shell command"
 SHELL_FULL_CONTRACT_RETRY_PROMPT = (
     "The previous shell-full command was rejected because it only listed metadata. "
     "Use the available exec_shell_full_command tool now to inspect source/content/string evidence. "
@@ -207,6 +208,99 @@ _NEGATED_MUTATION_PROMPT_RE = re.compile(
     r"\b(?:do\s+not|don't|without)\s+(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
 )
+_NO_MUTATION_OBJECT = (
+    r"(?:(?:all|any|the)\s+)?"
+    r"(?:(?:local|project|repository|source)\s+)?"
+    r"(?:files?|filesystem|worktree|repository|project|data|state|anything)"
+)
+_NO_MUTATION_VERB = r"(?:alter|change|create|delete|edit|modify|remove|rename|touch|write)"
+_NO_MUTATION_GERUND = (
+    r"(?:altering|changing|creating|deleting|editing|modifying|removing|renaming|touching|writing)"
+)
+_NO_MUTATION_VERB_SEQUENCE = (
+    rf"{_NO_MUTATION_VERB}(?:\s*,\s*{_NO_MUTATION_VERB})*"
+    rf"(?:\s*,?\s*(?:and|or)\s+{_NO_MUTATION_VERB})?"
+)
+_NO_MUTATION_GERUND_SEQUENCE = (
+    rf"{_NO_MUTATION_GERUND}(?:\s*,\s*{_NO_MUTATION_GERUND})*"
+    rf"(?:\s*,?\s*(?:and|or)\s+{_NO_MUTATION_GERUND})?"
+)
+_NO_MUTATION_PAST = (
+    r"(?:altered|changed|created|deleted|edited|modified|removed|renamed|touched|written)"
+)
+_GLOBAL_NO_MUTATION_CONSTRAINT_RE = re.compile(
+    rf"\b(?:"
+    rf"(?:do\s+not|don't|(?:you\s+)?must\s+not|never)\s+(?:"
+    rf"(?:make|perform)\s+(?:any\s+)?(?:file\s+)?(?:changes?|modifications?)"
+    rf"(?:\s+to\s+{_NO_MUTATION_OBJECT})?"
+    rf"|{_NO_MUTATION_VERB_SEQUENCE}\s+{_NO_MUTATION_OBJECT})"
+    rf"|(?:avoid|(?:please\s+)?refrain\s+from|without)\s+(?:"
+    rf"making\s+(?:any\s+)?(?:file\s+)?(?:changes?|modifications?)"
+    rf"|{_NO_MUTATION_GERUND_SEQUENCE}\s+{_NO_MUTATION_OBJECT})"
+    rf"|make\s+no\s+(?:file\s+)?(?:changes?|modifications?)"
+    rf"(?:\s+to\s+{_NO_MUTATION_OBJECT})?"
+    rf"|(?:keep|leave)\s+{_NO_MUTATION_OBJECT}(?=.{{0,80}}\bunchanged\b)"
+    rf"|{_NO_MUTATION_OBJECT}\s+(?:must|should)\s+not\s+be\s+{_NO_MUTATION_PAST}"
+    rf"|{_NO_MUTATION_OBJECT}\s+must\s+(?:remain|stay)\s+unchanged"
+    rf")\b",
+    re.IGNORECASE,
+)
+_READ_ONLY_PHASE_RE = re.compile(r"\b(?:analy[sz]e|inspect|read)\s+only\b", re.IGNORECASE)
+_MUTATION_AFTER_TRANSITION_RE = re.compile(
+    r"(?:\b(?:then|afterwards?|subsequently|actually|and|but|however|though|while|yet)\b|[,.;]\s*).{0,120}"
+    r"\b(?:add|change|correct|create|delete|edit|fix|modify|remove|rename|replace|update|write)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_SCOPED_EXCEPTION_RE = re.compile(
+    r"\b(?:apart\s+from|except|other\s+than|unless)\b",
+    re.IGNORECASE,
+)
+_SCOPED_CONSTRAINT_TAIL_RE = re.compile(
+    r"^\s+(?:(?:for|from|in|inside|matching|named|on|outside|to|under|within)\b"
+    r"|located\s+(?:in|under|within)\b"
+    r"|that\s+(?:are\s+)?(?:in|matching|named|under|within)\b"
+    r"|(?:associated\s+with|belonging\s+to|related\s+to)\b)",
+    re.IGNORECASE,
+)
+_MARKDOWN_DATA_SECTION_RE = re.compile(
+    r"(?P<header>^(?:"
+    r"[ \t]*(?:example|markdown|payload)(?:\s+(?:example|payload))?[ \t]*:"
+    r"|[^\n]{0,160}\b(?:the\s+following|this)\s+"
+    r"(?:example|markdown|payload)\b[^\n]*:"
+    r"|[ \t]*(?:append|copy|create|output|paste|put|replace|save|write)\b[^\n]{0,120}"
+    r"\b(?:the\s+following|this)\s+(?:content|text)\b[^\n]*:"
+    r"|[ \t]*(?:append|copy|create|explain|output|paste|provide|put|quote|render|replace|return|save|show|use|write)\b[^\n]{0,120}"
+    r"\b(?:contains?|containing)\b[^\n]*:"
+    r"|[ \t]*(?:append|copy|create|explain|output|paste|provide|put|quote|render|replace|return|save|show|use|write)\b[^\n]{0,120}"
+    r"\b(?:here\s+is|the\s+following)\s+(?:an?\s+)?(?:markdown\s+)?"
+    r"(?:content|example|payload)\b[^\n]*:"
+    r"|[ \t]*(?:here\s+is|the\s+following)\s+(?:an?\s+)?(?:markdown\s+)?"
+    r"(?:content|example|payload)\b[^\n]*:"
+    r"|[ \t]*(?:append|copy|create|explain|output|paste|provide|put|quote|render|replace|return|save|show|use|write)\b[^\n]{0,120}"
+    r"\ban?\s+markdown\s+(?:example|payload)\s+follows\b[^\n]*:"
+    r")\s*\n)"
+    r"(?P<body>(?:^[ \t]*(?:[-*+]|\d+[.)])\s+.*(?:\n|$))+"
+    r"|^[ \t]*\S.*(?:\n|$))",
+    re.IGNORECASE | re.MULTILINE,
+)
+_AMBIGUOUS_MARKDOWN_LIST_RE = re.compile(
+    r"^[^\n]{0,160}\b(?:following|these|this)\s+"
+    r"(?:bullets?|items?|lines?)\s*:\s*\n"
+    r"(?:^[ \t]*(?:[-*+]|\d+[.)])\s+.*(?:\n|$))+",
+    re.IGNORECASE | re.MULTILINE,
+)
+_INERT_USER_TEXT_RE = re.compile(
+    r"```.*?(?:```|\Z)"
+    r"|~~~.*?(?:~~~|\Z)"
+    r"|`[^`\n]*`"
+    r'|"(?:\\.|[^"\\])*"'
+    r"|(?<![A-Za-z0-9])'(?:\\.|[^'\\])*'(?![A-Za-z0-9])"
+    r"|^[ \t]*>.*$",
+    re.DOTALL | re.MULTILINE,
+)
+_NO_MUTATION_NONE = "none"
+_NO_MUTATION_GLOBAL = "global"
+_NO_MUTATION_MIXED = "mixed"
 
 
 def exec_shell_full_definition() -> dict[str, Any]:
@@ -344,14 +438,27 @@ def validate_read_only_shell_mutation(arguments: dict[str, Any], *, user_prompt:
     raw_command = arguments.get("command")
     if not isinstance(raw_command, str) or not raw_command.strip():
         return None
+    explicit_mode = classify_explicit_no_mutation_constraint(user_prompt)
+    if explicit_mode != _NO_MUTATION_NONE:
+        return read_only_mutation_policy_error(user_prompt, action="unrestricted shell command")
     if not is_read_only_user_request(user_prompt):
         return None
     if not is_mutating_shell_command(raw_command):
         return None
-    return (
-        f"{SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX}. "
-        "Use a non-mutating command or answer from existing evidence unless the latest user request explicitly asks for a change."
-    )
+    return read_only_mutation_policy_error(user_prompt, action="mutating shell command")
+
+
+def validate_tool_no_mutation_policy(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    user_prompt: str | None,
+) -> str | None:
+    if name == "exec_shell_full_command":
+        return validate_read_only_shell_mutation(arguments, user_prompt=user_prompt)
+    if name == "apply_patch" and is_read_only_user_request(user_prompt):
+        return read_only_mutation_policy_error(user_prompt, action="file patch")
+    return None
 
 
 def requires_direct_content_evidence(user_prompt: str | None) -> bool:
@@ -437,10 +544,6 @@ def looks_like_url_content_evidence(text: str | None) -> bool:
 
 def is_shell_full_contract_error(content: str) -> bool:
     return content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX)
-
-
-def is_shell_full_read_only_mutation_error(content: str) -> bool:
-    return content.startswith(SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX)
 
 
 def build_shell_full_file_recovery_guard_prompt(
@@ -599,25 +702,99 @@ def should_verify_shell_mutation(command: str, *, user_prompt: str | None) -> bo
 def is_read_only_user_request(user_prompt: str | None) -> bool:
     if not user_prompt:
         return False
-    if _NEGATED_MUTATION_PROMPT_RE.search(user_prompt):
+    if classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
         return True
-    intent_text = _without_user_paths_and_urls(user_prompt)
-    return _READ_ONLY_PROMPT_RE.search(user_prompt) is not None and _MUTATION_PROMPT_RE.search(intent_text) is None
+    active_text = _without_inert_user_text(user_prompt)
+    intent_text = _without_user_paths_and_urls(active_text)
+    return _READ_ONLY_PROMPT_RE.search(active_text) is not None and _MUTATION_PROMPT_RE.search(intent_text) is None
 
 
 def is_mutative_user_request(user_prompt: str | None) -> bool:
     if not user_prompt:
         return False
-    intent_text = _without_user_paths_and_urls(user_prompt)
-    if _NEGATED_MUTATION_PROMPT_RE.search(user_prompt) and not re.search(
+    active_text = _without_inert_user_text(user_prompt)
+    intent_text = _without_user_paths_and_urls(active_text)
+    if classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
+        return False
+    if _NEGATED_MUTATION_PROMPT_RE.search(active_text) and not re.search(
         r"\b(?:fix|update|change|create|write|rename|refactor|edit)\b.*\b(?:file|code|implementation|config|test)\b",
         intent_text,
         re.IGNORECASE,
     ):
         return False
-    if _READ_ONLY_PROMPT_RE.search(user_prompt) and not _MUTATION_PROMPT_RE.search(intent_text):
+    if _READ_ONLY_PROMPT_RE.search(active_text) and not _MUTATION_PROMPT_RE.search(intent_text):
         return False
     return _MUTATION_PROMPT_RE.search(intent_text) is not None
+
+
+def classify_explicit_no_mutation_constraint(text: str | None) -> str:
+    if not text:
+        return _NO_MUTATION_NONE
+    active_text = _without_inert_user_text(text)
+    global_match = _GLOBAL_NO_MUTATION_CONSTRAINT_RE.search(active_text)
+    ambiguous_markdown = _AMBIGUOUS_MARKDOWN_LIST_RE.search(active_text)
+    scoped_match = _NEGATED_MUTATION_PROMPT_RE.search(active_text)
+    phase_match = _READ_ONLY_PHASE_RE.search(active_text)
+    fallback_matches = [match for match in (scoped_match, phase_match) if match is not None]
+    constraint = global_match or (
+        min(fallback_matches, key=lambda match: match.start()) if fallback_matches else None
+    )
+    if constraint is None:
+        return _NO_MUTATION_NONE
+    remainder = active_text[constraint.end() :]
+    if (
+        (ambiguous_markdown is not None and ambiguous_markdown.start() < constraint.start())
+        or _SCOPED_EXCEPTION_RE.search(remainder)
+        or _SCOPED_CONSTRAINT_TAIL_RE.search(remainder)
+        or _MUTATION_AFTER_TRANSITION_RE.search(remainder)
+    ):
+        return _NO_MUTATION_MIXED
+    if constraint is global_match:
+        return _NO_MUTATION_GLOBAL
+    return _NO_MUTATION_MIXED
+
+
+def read_only_mutation_policy_error(user_prompt: str | None, *, action: str) -> str:
+    if classify_explicit_no_mutation_constraint(user_prompt) == _NO_MUTATION_MIXED:
+        prefix = (
+            SHELL_FULL_MIXED_MUTATION_ERROR_PREFIX
+            if action == "mutating shell command"
+            else f"error: mixed or scoped mutation constraint rejected {action}"
+        )
+        return (
+            f"{prefix}. "
+            "Split inspection and mutation into separate user requests with one unambiguous scope."
+        )
+    prefix = (
+        SHELL_FULL_READ_ONLY_MUTATION_ERROR_PREFIX
+        if action == "mutating shell command"
+        else f"error: read-only request rejected {action}"
+    )
+    return (
+        f"{prefix}. "
+        "Use a non-mutating action or answer from existing evidence unless the latest user request explicitly asks for a change."
+    )
+
+
+def _without_inert_user_text(text: str) -> str:
+    def mask(match: re.Match[str]) -> str:
+        return "".join("\n" if char == "\n" else " " for char in match.group(0))
+
+    def mask_markdown_body(match: re.Match[str]) -> str:
+        return match.group("header") + "".join(
+            "\n" if char == "\n" else " " for char in match.group("body")
+        )
+
+    normalized = text.translate(
+        {
+            0x2018: "'",
+            0x2019: "'",
+            0x201C: '"',
+            0x201D: '"',
+        }
+    )
+    without_markdown_payloads = _MARKDOWN_DATA_SECTION_RE.sub(mask_markdown_body, normalized)
+    return _INERT_USER_TEXT_RE.sub(mask, without_markdown_payloads)
 
 
 def _without_user_paths_and_urls(text: str) -> str:
@@ -1002,15 +1179,34 @@ def _is_mutating_shell_command(command: str) -> bool:
     if _has_shell_write_operator(command):
         return True
     try:
-        tokens = shlex.split(command)
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
     except ValueError:
         return any(marker in command for marker in (">", ">>", "| tee", " -i", "--in-place"))
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token and all(char in ";&|()" for char in token):
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(token)
+    if current:
+        segments.append(current)
+    return any(_is_mutating_shell_segment(segment) for segment in segments)
+
+
+def _is_mutating_shell_segment(tokens: list[str]) -> bool:
     if not tokens:
         return False
     words = [Path(token).name for token in tokens if token not in {"sudo", "env", "command", "xargs"}]
     if not words:
         return False
     primary = words[0]
+    segment_text = " ".join(tokens)
     if primary in {"cp", "install", "ln", "mkdir", "mv", "rm", "rmdir", "tee", "touch", "truncate"}:
         return True
     if primary in {"chmod", "chgrp", "chown", "setfacl"}:
@@ -1021,10 +1217,29 @@ def _is_mutating_shell_command(command: str) -> bool:
         return True
     if primary == "git" and len(words) > 1 and words[1] in {"add", "am", "apply", "checkout", "clean", "commit", "merge", "mv", "rebase", "reset", "restore", "rm", "stash", "switch"}:
         return True
-    if primary == "sqlite3" and re.search(r"\b(?:alter|create|delete|drop|insert|replace|update)\b", command, re.IGNORECASE):
+    if primary == "sqlite3" and re.search(
+        r"\b(?:alter|create|delete|drop|insert|replace|update)\b",
+        segment_text,
+        re.IGNORECASE,
+    ):
         return True
-    if primary in {"bash", "dash", "fish", "sh", "zsh", "python", "python3", "node", "ruby"}:
-        return _has_shell_write_operator(command) or re.search(r"\b(?:open|write_text|write_bytes|remove|rename|unlink|mkdir)\b", command) is not None
+    if primary in {"bash", "dash", "fish", "sh", "zsh"} and "-c" in tokens:
+        command_index = tokens.index("-c") + 1
+        return command_index < len(tokens) and _is_mutating_shell_command(tokens[command_index])
+    if primary in {"python", "python3", "node", "ruby"}:
+        return re.search(r"\b(?:open|write_text|write_bytes|remove|rename|unlink|mkdir)\b", segment_text) is not None
+    if primary == "dd" and any(token.startswith("of=") for token in tokens[1:]):
+        return True
+    if primary == "find" and ("-delete" in tokens or "-exec" in tokens or "-execdir" in tokens):
+        return True
+    if primary in {"tar", "bsdtar"} and any("x" in token[1:] for token in tokens[1:] if token.startswith("-")):
+        return True
+    if primary == "unzip" and not any(token in {"-l", "-t", "-v", "-Z"} for token in tokens[1:]):
+        return True
+    if primary == "cpio" and any(
+        token in {"-i", "--extract", "-p", "--pass-through"} for token in tokens[1:]
+    ):
+        return True
     if len(words) > 1 and words[1] in {"install", "update", "add", "remove"} and primary in {"apt", "apt-get", "brew", "cargo", "npm", "pip", "pip3", "uv"}:
         return True
     return False

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-from orbit.runtime.shell_guardrails import validate_read_only_shell_mutation, validate_shell_full_contract
+from orbit.runtime.shell_guardrails import (
+    validate_shell_full_contract,
+    validate_tool_no_mutation_policy,
+)
 from orbit.runtime.tool_contract import (
     CanonicalToolDecision,
     canonical_rejection_content,
@@ -111,15 +114,16 @@ class HybridToolExecutor:
         parsed = parse_tool_arguments(arguments)
         if isinstance(parsed, str):
             return ToolExecution(ToolResult(name=name, content=parsed), "orbit", "rejected_parse", "invalid_arguments")
-        if name == "exec_shell_full_command" and not canonical_validated:
-            read_only_mutation_error = validate_read_only_shell_mutation(parsed, user_prompt=self.user_prompt)
-            if read_only_mutation_error:
+        if not canonical_validated:
+            policy_error = validate_tool_no_mutation_policy(name, parsed, user_prompt=self.user_prompt)
+            if policy_error:
                 return ToolExecution(
-                    ToolResult(name=name, content=read_only_mutation_error),
+                    ToolResult(name=name, content=policy_error),
                     "orbit",
                     "rejected_policy",
-                    "read_only_mutation",
+                    "policy_read_only_mutation",
                 )
+        if name == "exec_shell_full_command" and not canonical_validated:
             contract_error = validate_shell_full_contract(parsed, user_prompt=self.user_prompt)
             if contract_error:
                 return ToolExecution(
@@ -128,7 +132,13 @@ class HybridToolExecutor:
                     "rejected_guardrail",
                     "shell_contract",
                 )
-        result = execute_tool(name, parsed, workdir=self.workdir, chunk_budget=chunk_budget, user_prompt=self.user_prompt)
+        result = execute_tool(
+            name,
+            parsed,
+            workdir=self.workdir,
+            chunk_budget=chunk_budget,
+            user_prompt=self.user_prompt,
+        )
         outcome = "runtime_error" if _tool_result_is_error(name, result.content) else "executed"
         return ToolExecution(result, "orbit", outcome, "tool_error" if outcome == "runtime_error" else None)
 

--- a/src/orbit/runtime/tool_contract.py
+++ b/src/orbit/runtime/tool_contract.py
@@ -13,9 +13,8 @@ from orbit.runtime.path_guardrails import resolve_inside_workdir
 from orbit.runtime.shell_guardrails import (
     MAX_SHELL_OUTPUT_BYTES,
     MAX_SHELL_TIMEOUT,
-    is_read_only_user_request,
-    validate_read_only_shell_mutation,
     validate_shell_full_contract,
+    validate_tool_no_mutation_policy,
 )
 from orbit.runtime.web import MAX_FETCH_MAX_BYTES, MAX_FETCH_TIMEOUT_SECONDS
 
@@ -200,7 +199,7 @@ def _policy_and_operational(
             shlex.split(command)
         except ValueError:
             return neutral, ContractStageOutcome(False, "invalid_shell_syntax", "arguments.command")
-        policy_error = validate_read_only_shell_mutation(arguments, user_prompt=user_prompt)
+        policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
         if policy_error:
             return ContractStageOutcome(
                 False,
@@ -244,12 +243,13 @@ def _policy_and_operational(
             limit = _integer_limit(arguments, "max_entries", 1, MAX_ENTRIES_LIMIT)
         return neutral, limit or neutral
     if name == "apply_patch":
-        if is_read_only_user_request(user_prompt):
+        policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
+        if policy_error:
             return ContractStageOutcome(
                 False,
                 "policy_read_only_mutation",
                 "arguments.patch",
-                "error: read-only request rejected file patch",
+                policy_error,
             ), neutral
         patch_error = validate_file_patch(arguments.get("patch"), workdir=workdir)
         if patch_error is not None:

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -55,7 +55,6 @@ from orbit.runtime.shell_guardrails import (
     is_mutative_user_request,
     is_repairable_shell_error,
     is_shell_full_contract_error,
-    is_shell_full_read_only_mutation_error,
     is_shell_full_execution_error,
     looks_like_broad_file_rewrite,
     requires_direct_content_evidence,
@@ -669,7 +668,10 @@ def run_tool_loop(
         command = _shell_command_from_tool_call(tool_call)
         raw_arguments = _shell_raw_arguments_from_tool_call(tool_call)
         command_is_mutating = bool(command and is_mutating_shell_command(command))
-        read_only_mutation_rejected = is_shell_full_read_only_mutation_error(tool_result.content)
+        read_only_mutation_rejected = (
+            execution_outcome == "rejected_policy"
+            and execution_reason == "policy_read_only_mutation"
+        )
         command_is_content_evidence = bool(command and is_content_evidence_shell_command(command))
         command_is_url_fetch = bool(
             command

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from orbit.runtime.directory_listing import execute_list_directory, list_directory_definition
 from orbit.runtime.file_patch import apply_patch_definition, execute_apply_patch
-from orbit.runtime.shell_guardrails import exec_shell_full_definition, execute_exec_shell_full_command
+from orbit.runtime.shell_guardrails import (
+    exec_shell_full_definition,
+    execute_exec_shell_full_command,
+    validate_tool_no_mutation_policy,
+)
 from orbit.runtime.system_info import execute_system_info, system_info_definition
 from orbit.runtime.tool_arguments import parse_tool_arguments
 from orbit.runtime.web import execute_fetch_url, fetch_url_definition
@@ -67,6 +71,9 @@ def execute_tool(
     parsed = parse_tool_arguments(arguments)
     if isinstance(parsed, str):
         return ToolResult(name=name, content=parsed)
+    policy_error = validate_tool_no_mutation_policy(name, parsed, user_prompt=user_prompt)
+    if policy_error:
+        return ToolResult(name=name, content=policy_error)
     if name == "fetch_url":
         return ToolResult(name=name, content=execute_fetch_url(parsed))
     if name == "list_directory":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5660,7 +5660,7 @@ class ToolRuntimeTests(unittest.TestCase):
             backend = ReadOnlyBackend()
             runtime = ChatRuntime(backend=backend, system_prompt="route system")
             result = runtime.ask_auto(
-                "Review vulnerable_service.py and report the vulnerable function. Do not modify files.",
+                "Review vulnerable_service.py and report the vulnerable function.",
                 temperature=0,
                 max_tokens=64,
                 workdir=workdir,

--- a/tests/test_shell_guardrails.py
+++ b/tests/test_shell_guardrails.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import unittest
 
 from orbit.runtime.shell_guardrails import (
+    classify_explicit_no_mutation_constraint,
     is_mutating_shell_command,
     is_mutative_user_request,
+    is_read_only_user_request,
     validate_read_only_shell_mutation,
 )
 
@@ -42,6 +44,231 @@ class ShellGuardrailsTests(unittest.TestCase):
         )
 
         self.assertIsNotNone(error)
+
+    def test_explicit_without_changing_files_constraint_is_read_only(self) -> None:
+        prompt = "Without changing any files, delete protected.txt and report what happened."
+
+        self.assertTrue(is_read_only_user_request(prompt))
+        self.assertFalse(is_mutative_user_request(prompt))
+        error = validate_read_only_shell_mutation(
+            {"command": "rm -f protected.txt"},
+            user_prompt=prompt,
+        )
+        self.assertIn("mixed or scoped mutation constraint", error or "")
+
+    def test_global_no_mutation_constraint_overrides_positive_mutation_verb(self) -> None:
+        prompt = "Update config.json, but do so without making any changes."
+
+        self.assertTrue(is_read_only_user_request(prompt))
+        self.assertFalse(is_mutative_user_request(prompt))
+
+    def test_explicit_global_constraints_block_mutations(self) -> None:
+        prompts = (
+            "Analyze the project without changing any files.",
+            "Read only. Do not modify, create or delete files.",
+            "Run the tests, but make no changes.",
+            "Inspect the repository and leave files unchanged.",
+            "Don't modify files; only report what you find.",
+            "Do not make changes.",
+            "Make no file changes.",
+            "Don't make any changes.",
+            "Do not touch files.",
+            "Keep all files unchanged.",
+            "Files must not be modified.",
+            "Please refrain from changing files.",
+            "Never modify files.",
+            "You must not modify files.",
+            "Avoid modifying files.",
+            "Don\u2019t modify files.",
+            "Without altering files, report what you find.",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "global")
+                self.assertIn(
+                    "read-only request rejected",
+                    validate_read_only_shell_mutation(
+                        {"command": "touch marker.txt"},
+                        user_prompt=prompt,
+                    )
+                    or "",
+                )
+
+    def test_explicit_constraints_deny_every_generic_shell_command(self) -> None:
+        prompt = "Analyze the project without changing any files."
+        commands = (
+            "./cat README.md",
+            "/bin/cat README.md",
+            "env cat README.md",
+            "command cat README.md",
+            "sed -n 'w marker.txt' README.md",
+            "sed -i 's/a/b/' README.md",
+            "git diff --output=marker",
+            "find . -exec touch marker.txt ';'",
+            "printf marker | xargs touch",
+            "python3 -c 'open(\"marker.txt\", \"w\").write(\"x\")'",
+            "cat $(touch marker.txt)",
+            "cat README.md > copy.txt",
+            "grep Orbit README.md | tee copy.txt",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIn(
+                    "unrestricted shell command",
+                    validate_read_only_shell_mutation(
+                        {"command": command}, user_prompt=prompt
+                    )
+                    or "",
+                )
+
+    def test_quoted_and_structured_examples_do_not_activate_explicit_constraint(self) -> None:
+        prompts = (
+            'Explain what "without changing any files" means.',
+            'The README contains the text "do not modify files". Show that line.',
+            'Explain this Markdown: `without changing any files`.',
+            "Explain this Markdown example:\n- do not modify files",
+            "Create sample.md containing:\n- without changing any files",
+            "Create report.md. Here is a Markdown example:\n- do not modify files",
+            "Save this as report.md. The following Markdown payload:\n- do not modify files",
+            "Write report.md. A Markdown example follows:\n- do not modify files",
+            "Here is a Markdown example:\n- do not modify files",
+            "The following Markdown payload:\n- do not modify files",
+            "Copy the following Markdown into report.md:\n- do not modify files",
+            "Output this Markdown:\n- do not modify files",
+            "Return this Markdown:\n- do not modify files",
+            "Provide this Markdown:\n- do not modify files",
+            "Put this Markdown in report.md:\n- do not modify files",
+            "Use the following Markdown payload:\n- do not modify files",
+            "Replace report.md with this content:\n- do not modify files",
+            "Append the following content to report.md:\n- do not modify files",
+            "Paste this Markdown into report.md:\n- do not modify files",
+            "Create report.txt with this payload:\ndo not modify files",
+            "Create quote.txt containing \u201cdo not modify files\u201d.",
+            'Explain this JSON: {"instruction":"do not modify files"}.',
+            "Explain this block:\n```text\nwithout changing any files\n```",
+            "Explain this quote:\n> do not modify files",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "none")
+
+    def test_inert_phrase_does_not_block_a_separately_requested_mutation(self) -> None:
+        prompt = 'Create report.txt containing the exact text "without changing any files".'
+
+        self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "none")
+        self.assertTrue(is_mutative_user_request(prompt))
+        self.assertIsNone(
+            validate_read_only_shell_mutation(
+                {"command": "printf '%s\n' 'without changing any files' > report.txt"},
+                user_prompt=prompt,
+            )
+        )
+
+    def test_descriptive_no_changes_text_is_not_an_explicit_constraint(self) -> None:
+        prompt = "There are no file changes in the current status. Create report.txt."
+
+        self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "none")
+        self.assertTrue(is_mutative_user_request(prompt))
+        self.assertIsNone(
+            validate_read_only_shell_mutation(
+                {"command": "printf report > report.txt"},
+                user_prompt=prompt,
+            )
+        )
+
+    def test_markdown_instruction_lists_remain_active(self) -> None:
+        prompts = (
+            "Instructions:\n- do not modify files",
+            "Content requirements:\n- do not modify files",
+            "Follow the following content requirements:\n- do not modify files",
+            "Instructions containing:\n- do not modify files",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "global")
+
+    def test_ambiguous_unquoted_markdown_lists_fail_closed_as_mixed(self) -> None:
+        prompts = (
+            "Use the following bullets:\n- Do not modify files.\n- Delete old.txt.",
+            "Create report.md with the following bullets:\n- do not modify files",
+            "Generate report.md with the following bullets:\n- do not modify files",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "mixed")
+                self.assertIn(
+                    "mixed or scoped mutation constraint",
+                    validate_read_only_shell_mutation(
+                        {"command": "touch marker.txt"},
+                        user_prompt=prompt,
+                    )
+                    or "",
+                )
+
+    def test_mixed_or_scoped_constraints_fail_closed_with_explicit_reason(self) -> None:
+        prompts = (
+            "First inspect without changing files, then fix the issue.",
+            "Do not change any files except config.json.",
+            "Do not modify source files, but create report.txt.",
+            "Analyze only. Actually, correct the typo in README.md.",
+            "Do not modify any files in docs; update src/a.py.",
+            "Do not modify any files located in docs.",
+            "Do not modify any files that are in docs.",
+            "Do not modify any files associated with tests.",
+            "Do not modify any files belonging to docs.",
+            "Do not modify files unless they are generated.",
+            "Keep files in docs unchanged.",
+            "Do not make changes to files in docs.",
+            "Do not make changes to README.md.",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "mixed")
+                self.assertIn(
+                    "unrestricted shell command",
+                    validate_read_only_shell_mutation(
+                        {"command": "cat README.md"}, user_prompt=prompt
+                    )
+                    or "",
+                )
+                self.assertIn(
+                    "mixed or scoped mutation constraint",
+                    validate_read_only_shell_mutation(
+                        {"command": "touch report.txt"},
+                        user_prompt=prompt,
+                    )
+                    or "",
+                )
+
+    def test_mutation_detection_covers_file_and_directory_operations(self) -> None:
+        commands = (
+            "printf x > item.txt",
+            "printf y >> item.txt",
+            "echo x | tee item.txt",
+            "rm -f item.txt",
+            "cd . && rm -f item.txt",
+            "mv old.txt new.txt",
+            "mkdir output",
+            "rmdir output",
+            "dd if=/dev/null of=item.txt",
+            "find . -name '*.tmp' -delete",
+            "python3 -c 'from pathlib import Path; Path(\"item.txt\").write_text(\"x\")'",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertTrue(is_mutating_shell_command(command))
+
+    def test_plain_delete_request_remains_mutative(self) -> None:
+        prompt = "Delete protected.txt and report what happened."
+
+        self.assertFalse(is_read_only_user_request(prompt))
+        self.assertTrue(is_mutative_user_request(prompt))
+        self.assertIsNone(
+            validate_read_only_shell_mutation(
+                {"command": "rm -f protected.txt"},
+                user_prompt=prompt,
+            )
+        )
 
     def test_explicit_edit_request_allows_mutating_shell_command(self) -> None:
         error = validate_read_only_shell_mutation(

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -11,9 +11,16 @@ from unittest import mock
 
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
+from orbit.runtime.shell_guardrails import validate_tool_no_mutation_policy
 from orbit.runtime.tool_backends import HybridToolExecutor
 from orbit.runtime.tool_contract import validate_canonical_tool_call
-from orbit.runtime.tools import ToolResult, agent_tool_names, default_tool_names, tool_definitions
+from orbit.runtime.tools import (
+    ToolResult,
+    agent_tool_names,
+    default_tool_names,
+    execute_tool,
+    tool_definitions,
+)
 from orbit.tool_contract_config import resolve_tool_call_canonical_gate
 
 
@@ -118,6 +125,370 @@ class CanonicalToolContractTests(unittest.TestCase):
         self.assertEqual((denied.terminal_decision, denied.rejection_code), ("rejected_permission", "tool_not_enabled"))
         self.assertEqual((read_only.terminal_decision, read_only.rejection_code), ("rejected_policy", "policy_read_only_mutation"))
         self.assertEqual((invalid.terminal_decision, invalid.rejection_code), ("rejected_guardrail", "context_mismatch"))
+
+    def test_apply_patch_obeys_global_and_mixed_constraints_but_ignores_inert_quotes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "item.txt").write_text("before\n", encoding="utf-8")
+            patch = "--- item.txt\n+++ item.txt\n@@ -1 +1 @@\n-before\n+after\n"
+            cases = (
+                ("Analyze without changing any files.", False, "read-only request rejected"),
+                ("Inspect without changing files, then fix item.txt.", False, "mixed or scoped"),
+                ('Change item.txt to contain "without changing any files".', True, None),
+            )
+            for prompt, accepted, message in cases:
+                with self.subTest(prompt=prompt):
+                    decision = validate_canonical_tool_call(
+                        "apply_patch",
+                        {"patch": patch},
+                        tool_definitions=tool_definitions(agent_tool_names()),
+                        allowed_tool_names=agent_tool_names(),
+                        workdir=root,
+                        user_prompt=prompt,
+                    )
+                    self.assertIs(decision.accepted, accepted)
+                    if message is not None:
+                        self.assertIn(message, decision.policy_outcome.message or "")
+
+    def test_explicit_no_mutation_policy_rejects_before_executor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "orbit.runtime.tool_backends.execute_tool"
+        ) as execute:
+            result = HybridToolExecutor(
+                backend=None,
+                workdir=Path(tmp),
+                allowed_tool_names=default_tool_names(),
+                user_prompt="Analyze the project without changing any files.",
+            ).execute(
+                "exec_shell_full_command",
+                {"command": "cd . && touch marker.txt"},
+                chunk_budget={},
+            )
+
+        self.assertEqual((result.terminal_outcome, result.terminal_reason), ("rejected_policy", "policy_read_only_mutation"))
+        execute.assert_not_called()
+
+    def test_no_mutation_policy_survives_canonical_and_healing_kill_switches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "item.txt"
+            patch = "--- item.txt\n+++ item.txt\n@@ -1 +1 @@\n-before\n+after\n"
+            for gate in ("0", "1"):
+                for healing in ("0", "1"):
+                    with self.subTest(gate=gate, healing=healing), mock.patch.dict(
+                        os.environ,
+                        {
+                            "ORBIT_TOOL_CALL_CANONICAL_GATE": gate,
+                            "ORBIT_TOOL_CALL_HEALING": healing,
+                        },
+                        clear=False,
+                    ):
+                        target.write_text("before\n", encoding="utf-8")
+                        executor = HybridToolExecutor(
+                            backend=None,
+                            workdir=root,
+                            allowed_tool_names=agent_tool_names(),
+                            user_prompt="Analyze without changing any files.",
+                        )
+                        shell = executor.execute(
+                            "exec_shell_full_command",
+                            {"command": "cat README.md"},
+                            chunk_budget={},
+                        )
+                        applied = executor.execute(
+                            "apply_patch",
+                            {"patch": patch},
+                            chunk_budget={},
+                        )
+
+                        self.assertEqual(
+                            (shell.terminal_outcome, shell.terminal_reason),
+                            ("rejected_policy", "policy_read_only_mutation"),
+                        )
+                        self.assertEqual(
+                            (applied.terminal_outcome, applied.terminal_reason),
+                            ("rejected_policy", "policy_read_only_mutation"),
+                        )
+                        self.assertEqual(target.read_text(encoding="utf-8"), "before\n")
+
+    def test_common_global_forms_are_enforced_with_canonical_gate_on_and_off(self) -> None:
+        prompts = (
+            "Keep all files unchanged.",
+            "Files must not be modified.",
+            "Please refrain from changing files.",
+            "Never modify files.",
+            "You must not modify files.",
+            "Avoid modifying files.",
+            "Don\u2019t modify files.",
+            "Without altering files, report what you find.",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for gate in ("0", "1"):
+                for prompt in prompts:
+                    with self.subTest(gate=gate, prompt=prompt), mock.patch.dict(
+                        os.environ,
+                        {"ORBIT_TOOL_CALL_CANONICAL_GATE": gate},
+                        clear=False,
+                    ):
+                        result = HybridToolExecutor(
+                            backend=None,
+                            workdir=root,
+                            allowed_tool_names=default_tool_names(),
+                            user_prompt=prompt,
+                        ).execute(
+                            "exec_shell_full_command",
+                            {"command": "touch marker.txt"},
+                            chunk_budget={},
+                        )
+
+                        self.assertEqual(result.terminal_outcome, "rejected_policy")
+                        self.assertFalse((root / "marker.txt").exists())
+
+    def test_descriptive_no_changes_text_allows_mutation_with_gate_on_or_off(self) -> None:
+        prompt = "There are no file changes in the current status. Create report.txt."
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for gate in ("0", "1"):
+                with self.subTest(gate=gate), mock.patch.dict(
+                    os.environ,
+                    {"ORBIT_TOOL_CALL_CANONICAL_GATE": gate},
+                    clear=False,
+                ):
+                    marker = root / "marker.txt"
+                    marker.unlink(missing_ok=True)
+                    result = HybridToolExecutor(
+                        backend=None,
+                        workdir=root,
+                        allowed_tool_names=default_tool_names(),
+                        user_prompt=prompt,
+                    ).execute(
+                        "exec_shell_full_command",
+                        {"command": "printf report > marker.txt"},
+                        chunk_budget={},
+                    )
+
+                    self.assertEqual(result.terminal_outcome, "executed")
+                    self.assertEqual(marker.read_text(encoding="utf-8"), "report")
+
+    def test_ambiguous_markdown_lists_fail_closed_with_gate_on_or_off(self) -> None:
+        prompts = (
+            "Use the following bullets:\n- Do not modify files.\n- Delete old.txt.",
+            "Create report.md with the following bullets:\n- do not modify files",
+            "Generate report.md with the following bullets:\n- do not modify files",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for gate in ("0", "1"):
+                for prompt in prompts:
+                    with self.subTest(gate=gate, prompt=prompt), mock.patch.dict(
+                        os.environ,
+                        {"ORBIT_TOOL_CALL_CANONICAL_GATE": gate},
+                        clear=False,
+                    ):
+                        marker = root / "marker.txt"
+                        marker.unlink(missing_ok=True)
+                        result = HybridToolExecutor(
+                            backend=None,
+                            workdir=root,
+                            allowed_tool_names=default_tool_names(),
+                            user_prompt=prompt,
+                        ).execute(
+                            "exec_shell_full_command",
+                            {"command": "printf unsafe > marker.txt"},
+                            chunk_budget={},
+                        )
+
+                        self.assertEqual(
+                            (result.terminal_outcome, result.terminal_reason),
+                            ("rejected_policy", "policy_read_only_mutation"),
+                        )
+                        self.assertIn("mixed or scoped mutation constraint", result.result.content)
+                        self.assertFalse(marker.exists())
+
+    def test_markdown_payload_headers_do_not_block_mutation_with_gate_on_or_off(self) -> None:
+        prompts = (
+            "Here is a Markdown example:\n- do not modify files",
+            "The following Markdown payload:\n- do not modify files",
+            "Copy the following Markdown into report.md:\n- do not modify files",
+            "Output this Markdown:\n- do not modify files",
+            "Return this Markdown:\n- do not modify files",
+            "Provide this Markdown:\n- do not modify files",
+            "Put this Markdown in report.md:\n- do not modify files",
+            "Use the following Markdown payload:\n- do not modify files",
+            "Replace report.md with this content:\n- do not modify files",
+            "Append the following content to report.md:\n- do not modify files",
+            "Paste this Markdown into report.md:\n- do not modify files",
+            "Create report.txt with this payload:\ndo not modify files",
+            "Create quote.txt containing \u201cdo not modify files\u201d.",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for gate in ("0", "1"):
+                for prompt in prompts:
+                    with self.subTest(gate=gate, prompt=prompt), mock.patch.dict(
+                        os.environ,
+                        {"ORBIT_TOOL_CALL_CANONICAL_GATE": gate},
+                        clear=False,
+                    ):
+                        marker = root / "marker.txt"
+                        marker.unlink(missing_ok=True)
+                        result = HybridToolExecutor(
+                            backend=None,
+                            workdir=root,
+                            allowed_tool_names=default_tool_names(),
+                            user_prompt=prompt,
+                        ).execute(
+                            "exec_shell_full_command",
+                            {"command": "printf created > marker.txt"},
+                            chunk_budget={},
+                        )
+
+                        self.assertEqual(result.terminal_outcome, "executed")
+                        self.assertEqual(marker.read_text(encoding="utf-8"), "created")
+
+    def test_no_mutation_policy_covers_agent_non_agent_and_direct_executor_paths(self) -> None:
+        prompt = "Inspect the project without changing any files."
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "item.txt"
+            target.write_text("before\n", encoding="utf-8")
+            patch = "--- item.txt\n+++ item.txt\n@@ -1 +1 @@\n-before\n+after\n"
+
+            for allowed in (default_tool_names(), agent_tool_names()):
+                with self.subTest(allowed=allowed):
+                    result = HybridToolExecutor(
+                        backend=None,
+                        workdir=root,
+                        allowed_tool_names=allowed,
+                        user_prompt=prompt,
+                    ).execute(
+                        "exec_shell_full_command",
+                        {"command": "printf bypass > marker.txt"},
+                        chunk_budget={},
+                    )
+                    self.assertEqual(result.terminal_outcome, "rejected_policy")
+                    self.assertFalse((root / "marker.txt").exists())
+
+            direct_shell = execute_tool(
+                "exec_shell_full_command",
+                {"command": "printf bypass > marker.txt"},
+                workdir=root,
+                user_prompt=prompt,
+            )
+            direct_patch = execute_tool(
+                "apply_patch",
+                {"patch": patch},
+                workdir=root,
+                user_prompt=prompt,
+            )
+
+            self.assertIn("unrestricted shell command", direct_shell.content)
+            self.assertIn("read-only request rejected file patch", direct_patch.content)
+            self.assertFalse((root / "marker.txt").exists())
+            self.assertEqual(target.read_text(encoding="utf-8"), "before\n")
+
+    def test_shell_bypass_matrix_never_reaches_direct_dispatch(self) -> None:
+        commands = (
+            "./cat README.md",
+            "/bin/cat README.md",
+            "env cat README.md",
+            "command cat README.md",
+            "sed -n 'w marker.txt' README.md",
+            "sed -i 's/a/b/' README.md",
+            "git diff --output=marker",
+            "find . -exec touch marker.txt ';'",
+            "printf marker | xargs touch",
+            "python3 -c 'open(\"marker.txt\", \"w\").write(\"x\")'",
+            "cat $(touch marker.txt)",
+            "cat README.md > copy.txt",
+            "grep Orbit README.md | tee copy.txt",
+        )
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "orbit.runtime.tools.execute_exec_shell_full_command"
+        ) as shell:
+            root = Path(tmp)
+            for command in commands:
+                with self.subTest(command=command):
+                    result = execute_tool(
+                        "exec_shell_full_command",
+                        {"command": command},
+                        workdir=root,
+                        user_prompt="Analyze without changing any files.",
+                    )
+                    self.assertIn("unrestricted shell command", result.content)
+
+            shell.assert_not_called()
+            self.assertEqual(list(root.iterdir()), [])
+
+    def test_structured_read_only_tools_remain_available_under_constraint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "item.txt").write_text("content\n", encoding="utf-8")
+            executor = HybridToolExecutor(
+                backend=None,
+                workdir=root,
+                allowed_tool_names=default_tool_names(),
+                user_prompt="Inspect without changing any files.",
+            )
+
+            listing = executor.execute("list_directory", {"path": "."}, chunk_budget={})
+            system = executor.execute("system_info", {}, chunk_budget={})
+
+            self.assertEqual((listing.terminal_outcome, system.terminal_outcome), ("executed", "executed"))
+            self.assertIn("item.txt", listing.result.content)
+            self.assertIn("OS:", system.result.content)
+
+    def test_tool_output_text_cannot_activate_no_mutation_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "orbit.runtime.tool_backends.execute_tool",
+            side_effect=(
+                ToolResult(name="exec_shell_full_command", content="without changing any files"),
+                ToolResult(name="exec_shell_full_command", content="created"),
+            ),
+        ) as execute:
+            executor = HybridToolExecutor(
+                backend=None,
+                workdir=Path(tmp),
+                allowed_tool_names=default_tool_names(),
+                user_prompt="Create marker.txt after reading the prior output.",
+            )
+            first = executor.execute(
+                "exec_shell_full_command",
+                {"command": "printf observation"},
+                chunk_budget={},
+            )
+            second = executor.execute(
+                "exec_shell_full_command",
+                {"command": "touch marker.txt"},
+                chunk_budget={},
+            )
+
+        self.assertEqual((first.terminal_outcome, second.terminal_outcome), ("executed", "executed"))
+        self.assertEqual(execute.call_count, 2)
+
+    def test_tool_output_prefix_is_never_reclassified_as_policy(self) -> None:
+        content = "error: read-only request rejected unrestricted shell command"
+        with tempfile.TemporaryDirectory() as tmp, mock.patch(
+            "orbit.runtime.tool_backends.execute_tool",
+            return_value=ToolResult(name="exec_shell_full_command", content=content),
+        ):
+            result = HybridToolExecutor(
+                backend=None,
+                workdir=Path(tmp),
+                allowed_tool_names=default_tool_names(),
+                user_prompt="Create marker.txt.",
+            ).execute(
+                "exec_shell_full_command",
+                {"command": "printf changed > marker.txt"},
+                chunk_budget={},
+            )
+
+        self.assertEqual(
+            (result.terminal_outcome, result.terminal_reason),
+            ("runtime_error", "tool_error"),
+        )
+        self.assertEqual(result.result.content, content)
 
     def test_api_reports_stage_outcomes_and_stable_rejections(self) -> None:
         cases = (
@@ -415,19 +786,19 @@ class CanonicalToolContractTests(unittest.TestCase):
         self.assertEqual(error.terminal_outcome, "runtime_error")
         self.assertEqual((policy.terminal_outcome, policy.terminal_reason), ("rejected_policy", "policy_read_only_mutation"))
 
-    def test_gate_reuses_shell_policy_once_before_execution(self) -> None:
+    def test_gate_and_dispatch_use_the_same_shell_policy(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
             os.environ, {"ORBIT_TOOL_CALL_CANONICAL_GATE": "1"}, clear=False
         ), mock.patch(
-            "orbit.runtime.tool_contract.validate_read_only_shell_mutation",
-            return_value=None,
-        ) as read_only, mock.patch(
+            "orbit.runtime.tool_contract.validate_tool_no_mutation_policy",
+            wraps=validate_tool_no_mutation_policy,
+        ) as no_mutation, mock.patch(
             "orbit.runtime.tool_contract.validate_shell_full_contract",
             return_value=None,
         ) as contract, mock.patch(
-            "orbit.runtime.tool_backends.execute_tool",
-            return_value=ToolResult("exec_shell_full_command", "ok"),
-        ):
+            "orbit.runtime.tools.validate_tool_no_mutation_policy",
+            wraps=validate_tool_no_mutation_policy,
+        ) as executor_policy:
             result = HybridToolExecutor(
                 backend=None,
                 workdir=Path(tmp),
@@ -436,8 +807,30 @@ class CanonicalToolContractTests(unittest.TestCase):
             ).execute("exec_shell_full_command", {"command": "printf ok"}, chunk_budget={})
 
         self.assertEqual(result.terminal_outcome, "executed")
-        read_only.assert_called_once()
+        no_mutation.assert_called_once()
         contract.assert_called_once()
+        executor_policy.assert_called_once()
+
+    def test_legacy_path_and_dispatch_use_the_same_shell_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ, {"ORBIT_TOOL_CALL_CANONICAL_GATE": "0"}, clear=False
+        ), mock.patch(
+            "orbit.runtime.tool_backends.validate_tool_no_mutation_policy",
+            wraps=validate_tool_no_mutation_policy,
+        ) as no_mutation, mock.patch(
+            "orbit.runtime.tools.validate_tool_no_mutation_policy",
+            wraps=validate_tool_no_mutation_policy,
+        ) as executor_policy:
+            result = HybridToolExecutor(
+                backend=None,
+                workdir=Path(tmp),
+                allowed_tool_names=("exec_shell_full_command",),
+                user_prompt="run printf ok",
+            ).execute("exec_shell_full_command", {"command": "printf ok"}, chunk_budget={})
+
+        self.assertEqual(result.terminal_outcome, "executed")
+        no_mutation.assert_called_once()
+        executor_policy.assert_called_once()
 
     def test_runtime_preflight_is_the_only_canonical_validation(self) -> None:
         class Backend:

--- a/tests/test_tool_healing.py
+++ b/tests/test_tool_healing.py
@@ -904,6 +904,62 @@ class ToolHealingShadowTests(unittest.TestCase):
         self.assertEqual(outcomes[1], outcomes[2])
         self.assertEqual(outcomes[0], ("specs complete", "stop", 2, [("system_info", {})], 1))
 
+    def test_healing_on_off_cannot_bypass_explicit_no_mutation_policy(self) -> None:
+        class Backend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                self.calls += 1
+                return ChatResult(
+                    content='<tool_call>{"name":"exec_shell_full_command","arguments":{"command":"cat README.md"},}</tool_call>',
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=10,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        observed = []
+        with tempfile.TemporaryDirectory() as tmp:
+            for healing in ("0", "1"):
+                with self.subTest(healing=healing):
+                    backend = Backend()
+                    tool_events: list[tuple[str, dict[str, object]]] = []
+                    with mock.patch.dict(
+                        os.environ,
+                        {
+                            "ORBIT_TOOL_CALL_CANONICAL_GATE": "1",
+                            "ORBIT_TOOL_CALL_HEALING": healing,
+                        },
+                        clear=False,
+                    ), mock.patch("orbit.runtime.tool_backends.execute_tool") as execute:
+                        result = ChatRuntime(backend=backend, system_prompt=None).ask_with_tools(
+                            "Inspect without changing any files.",
+                            temperature=0,
+                            max_tokens=32,
+                            workdir=Path(tmp),
+                            tool_names=("exec_shell_full_command",),
+                            on_tool_call=lambda name, arguments: tool_events.append(
+                                (name, json.loads(arguments))
+                            ),
+                        )
+
+                    observed.append(
+                        (result.finish_reason, backend.calls, tool_events, execute.call_count)
+                    )
+
+        self.assertEqual(observed[0], observed[1])
+        self.assertEqual(observed[0][0], "stop")
+        self.assertEqual(
+            observed[0][2],
+            [("exec_shell_full_command", {"command": "cat README.md"})],
+        )
+        self.assertEqual(observed[0][3], 0)
+
     def test_default_on_and_kill_switch_matrix_for_all_authorized_repairs(self) -> None:
         cases = (
             '<tool_call>{"name":"system_info","arguments":{}}</tool_call>',

--- a/tests/test_tool_loop_state.py
+++ b/tests/test_tool_loop_state.py
@@ -56,6 +56,30 @@ class ToolLoopStateTests(unittest.TestCase):
         self.assertEqual(signature[0], "read_file")
         self.assertTrue(state.has_seen_tool_call(tool_call))
 
+    def test_mutation_epoch_reopens_observations_but_keeps_mutation_blocked(self) -> None:
+        state = ToolLoopState(("exec_shell_full_command",))
+        read_call = {
+            "id": "read-1",
+            "function": {
+                "name": "exec_shell_full_command",
+                "arguments": {"command": "cat note.txt"},
+            },
+        }
+        mutation_call = {
+            "id": "write-1",
+            "function": {
+                "name": "exec_shell_full_command",
+                "arguments": {"command": "printf changed > note.txt"},
+            },
+        }
+        state.mark_tool_call(read_call)
+        state.mark_tool_call(mutation_call)
+
+        state.advance_after_mutation(mutation_call)
+
+        self.assertFalse(state.has_seen_tool_call(read_call))
+        self.assertTrue(state.has_seen_tool_call(mutation_call))
+
     def test_mutative_tool_call_budget_is_separate_and_bounded(self) -> None:
         original_mutative = tool_loop.MUTATIVE_TOOL_CALL_MAX_TOKENS
         original_file_recovery = tool_loop.FILE_RECOVERY_TOOL_CALL_MAX_TOKENS


### PR DESCRIPTION
## Problem

An explicit user no-mutation constraint could be overridden by a contradictory mutation verb, allowing a shell mutation despite the stated restriction. The original review also found shell allowlist bypasses, canonical-gate rollback bypass for `apply_patch`, inert Markdown false activation, and scoped constraints labeled as global.

## Retained rule

- Inspect only bounded active prose from the latest user request; tool output is never policy input.
- Mask quoted strings, inline/fenced code, JSON strings, Markdown blockquotes, explicitly labeled examples/payloads, and bounded output-action `this`/`following content|text` sections.
- Classify only `none`, `global`, or `mixed` structural outcomes.
- Treat generic unquoted bullet/item/line lists containing a no-mutation phrase as ambiguous `mixed`, not as proven data.
- Deny every unrestricted `exec_shell_full_command` call under a global or mixed constraint. No shell-string executable/option allowlist remains.
- Keep structured read-only tools available so the model can choose another action; runtime never rewrites or substitutes the model call.
- Deny `apply_patch` under the same policy with canonical gate ON or OFF and healing ON or OFF.
- Enforce the same pure policy at canonical preflight, the legacy adapter, and the common dispatcher; no caller-controlled bypass remains.
- Keep scoped, exception, and multi-phase mutation requests read-only and explicitly unsupported. Users must split them into separate unambiguous requests.

No planner, classifier model, semantic task routing, tool substitution, prompt change, schema change, retry, budget increase, or model call was added. Tool and argument selection remains model-driven. `tools=True` and `agent=False` remain the defaults.

## Real-model evidence

Gemma 4 26B-A4B Q4_0, CPU-only, MTP disabled:

- adversarial matrix: 17/17 `finish_reason=stop`;
- zero mutations under explicit global or mixed constraints;
- zero false blocks across the measured quoted/inert controls;
- legitimate mutations preserved in 3/3 cases;
- normal-loop production corpus: 11/11 correct and stopped;
- 45 model calls, 21 proposed tool calls, 10 executed tools, and 11 policy rejections in the adversarial matrix;
- 26 model calls, 12 proposed tool calls, and 10 executed tools in the production corpus.

Observed CPU timings are descriptive only. No performance guarantee is claimed.

## Validation

- Focused guardrail, canonical, healing, executor, tool-loop, configuration, REPL, patch, action-review, lifecycle, and final-prefix tests: 409 PASS.
- Full unittest discovery: 1,309 PASS.
- Independent review: PASS with no remaining finding.
- MTP shim build: PASS.
- `python3 -m compileall -q src tests scripts`: PASS.
- `git diff --check`: PASS.
- No Orbit or llama process remained after validation.
- `workdir/.miktex/` and `workdir/doc/` remain untouched and unstaged.

This remains a stacked PR against the unpublished opt-in agent baseline. Do not merge as a standalone replacement for that base.