### PR TITLE
Honor explicit chat output limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,22 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - See `docs/TOOL_LOOP_CONVERGENCE_VALIDATION.md` for the inventory, comparison,
   removal decision, compatibility rationale, and release gates.
 
+## Post-RC24 Chat Output Budget
+
+- A local post-RC24 fix removes the hidden 256-token cap from user-visible chat
+  output. An explicit CLI, JSON, or REPL `max_tokens` value is now authoritative
+  for chat responses, within the existing validated configuration range.
+- Internal route, tool-call, retry, repair, and final-from-tool budgets keep
+  their existing bounded caps. The change does not affect routing, tool
+  selection, backend decoding, or continuation behavior.
+- A real Gemma 4 26B-A4B Q4_0 smoke for `tell me about Google Deepmind` with
+  tools enabled and `max_tokens=2048` used a five-token route decision, then a
+  zero-tool 879-token chat final with `finish_reason=stop`. Before the fix, the
+  final was truncated at 256 tokens and required `/continue`.
+- Focused tests passed 266/266; full discovery passed 1,253/1,253;
+  `compileall` and `git diff --check` passed. The longer response demonstrates
+  correct budget control, not a performance improvement.
+
 ## Post-Tool Final Prose Reuse
 
 - `ORBIT_POST_TOOL_FINAL_REUSE` is enabled by default. Setting it to `0` is the immediate kill switch; setting it to `1` explicitly enables it; invalid values disable the feature safely. Diagnostics report only the bounded effective state and source (`default` or `stable`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,7 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 
 ## Post-RC24 Chat Output Budget
 
-- A local post-RC24 fix removes the hidden 256-token cap from user-visible chat
+- A post-RC24 fix removes the hidden 256-token cap from user-visible chat
   output. An explicit CLI, JSON, or REPL `max_tokens` value is now authoritative
   for chat responses, within the existing validated configuration range.
 - Internal route, tool-call, retry, repair, and final-from-tool budgets keep

--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -9,6 +9,7 @@ ROUTE_MAX_TOKENS = 64
 TOOL_CALL_MAX_TOKENS = 96
 FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = 64
 CHAT_DEFAULT_MAX_TOKENS = 192
+CHAT_USER_MAX_TOKENS = 4096
 
 FINAL_SMALL_MAX_TOKENS = 96
 FINAL_SHELL_ERROR_MAX_TOKENS = 128
@@ -61,7 +62,7 @@ def resolve_max_tokens(
         # Chat is user-visible output: an explicit CLI/REPL limit must remain
         # authoritative. Internal route, tool, retry, and repair phases keep
         # their separate bounded caps.
-        return max(requested, 64)
+        return _floor_and_cap(requested, 64, CHAT_USER_MAX_TOKENS)
     if kind == "final_from_tool":
         return _final_from_tool_tokens(requested, evidence, evidence_chars)
     if kind == "chat_final_retry":

--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -9,7 +9,6 @@ ROUTE_MAX_TOKENS = 64
 TOOL_CALL_MAX_TOKENS = 96
 FILE_RECOVERY_TOOL_CALL_MAX_TOKENS = 64
 CHAT_DEFAULT_MAX_TOKENS = 192
-CHAT_MAX_TOKENS = 256
 
 FINAL_SMALL_MAX_TOKENS = 96
 FINAL_SHELL_ERROR_MAX_TOKENS = 128
@@ -59,7 +58,10 @@ def resolve_max_tokens(
     if kind == "chat":
         if requested is None:
             return CHAT_DEFAULT_MAX_TOKENS
-        return _floor_and_cap(requested, 64, CHAT_MAX_TOKENS)
+        # Chat is user-visible output: an explicit CLI/REPL limit must remain
+        # authoritative. Internal route, tool, retry, and repair phases keep
+        # their separate bounded caps.
+        return max(requested, 64)
     if kind == "final_from_tool":
         return _final_from_tool_tokens(requested, evidence, evidence_chars)
     if kind == "chat_final_retry":

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -27,6 +27,7 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("chat", 32), 64)
         self.assertEqual(resolve_max_tokens("chat", 512), 512)
         self.assertEqual(resolve_max_tokens("chat", 2048), 2048)
+        self.assertEqual(resolve_max_tokens("chat", 8192), 4096)
 
     def test_final_from_tool_structural_evidence_budgets(self) -> None:
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=80), 96)

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -22,10 +22,11 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("tool_call", 512), 96)
         self.assertEqual(resolve_max_tokens("tool_call_file_recovery", 512), 64)
 
-    def test_chat_budget_respects_requested_with_cap(self) -> None:
+    def test_chat_budget_respects_explicit_user_limit(self) -> None:
         self.assertEqual(resolve_max_tokens("chat"), 192)
         self.assertEqual(resolve_max_tokens("chat", 32), 64)
-        self.assertEqual(resolve_max_tokens("chat", 512), 256)
+        self.assertEqual(resolve_max_tokens("chat", 512), 512)
+        self.assertEqual(resolve_max_tokens("chat", 2048), 2048)
 
     def test_final_from_tool_structural_evidence_budgets(self) -> None:
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=80), 96)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -224,6 +224,72 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("OpenAI is an AI company.", final_rendered)
         self.assertIn("...", final_rendered)
 
+    def test_route_chat_final_respects_explicit_user_max_tokens(self) -> None:
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content='{"route":"CHAT"}',
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+                ChatResult(
+                    content="A complete long-form answer.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                ),
+            ]
+        )
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+        result = runtime.ask_auto(
+            "Tell me about the research lab.",
+            temperature=0,
+            max_tokens=2048,
+            workdir=Path("."),
+        )
+
+        self.assertEqual(result.content, "A complete long-form answer.")
+        self.assertEqual(backend.max_tokens_by_call, [64, 2048])
+
+    def test_tools_off_chat_respects_explicit_user_max_tokens(self) -> None:
+        backend = SequenceBackend(
+            [
+                ChatResult(
+                    content="A complete long-form answer.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    cached_tokens=None,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+            ]
+        )
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+        result = runtime.ask_chat(
+            "Tell me about the research lab.",
+            temperature=0,
+            max_tokens=2048,
+        )
+
+        self.assertEqual(result.content, "A complete long-form answer.")
+        self.assertEqual(backend.max_tokens_by_call, [2048])
+
     def test_post_tool_route_window_excludes_full_history_and_audit_marker(self) -> None:
         raw = "\n".join(f"line-{index}" for index in range(120))
         backend = SequenceBackend(


### PR DESCRIPTION
## Problem

User-facing `max_tokens` values were silently capped at 256 for chat finals. In interactive mode, `/max-tokens 2048` therefore still truncated an ordinary chat response and offered `/continue`.

## Change

- make an explicit chat output limit authoritative within the existing validated configuration range;
- retain the 64-token minimum for unusually small chat limits;
- leave route, tool-call, retry, repair, and final-from-tool caps unchanged;
- add direct chat and route-to-CHAT regression coverage.

This changes no prompt, routing decision, tool behavior, backend decoding, or continuation logic.

## Real-model validation

Gemma 4 26B-A4B Q4_0, CPU-only, MTP off, tools enabled, `max_tokens=2048`:

- route: 5 output tokens, `finish_reason=stop`;
- chat final: 879 output tokens, `finish_reason=stop`;
- tool calls: 0;
- no `/continue` required.

Before the fix the same response was truncated at the hidden 256-token cap. The longer output proves correct budget control; no performance improvement is claimed.

## Validation

- focused completion-budget/runtime/REPL/config tests: 266 PASS;
- full discovery: 1,253 PASS;
- `compileall`: PASS;
- `git diff --check`: PASS.

No protected workdir content or PDF is included.