### PR TITLE
feat(runtime): add deterministic document search

### DIFF
--- a/docs/DETERMINISTIC_DOCUMENT_SEARCH.md
+++ b/docs/DETERMINISTIC_DOCUMENT_SEARCH.md
@@ -1,0 +1,110 @@
+# Deterministic Document Search
+
+## Scope
+
+Orbit intercepts only clear literal or conceptual questions that name exactly
+one confined local text file. This prevents a long-document question from
+degrading into an accidental `cat` or `sed` prefix read. Ambiguous requests use
+the existing route and tool loop. The internal `document_search` primitive is
+not a registered model tool, so the production tool schema and its tool-mode
+prefill are unchanged.
+
+## Literal Search
+
+A literal request supplies its own exact word or phrase. Runtime validates that
+term and scans the complete stable snapshot with no model call. Search uses
+strict UTF-8, NFKC normalization, Unicode case folding unless case sensitivity
+is explicit, and controlled whole-word boundaries for single words. All
+occurrences are counted even when only a bounded number of windows is returned.
+
+A zero-match literal result has `scan_coverage=complete` and
+`semantic_coverage=exact`. It proves only that the requested string does not
+occur; it does not prove that a related concept is absent.
+
+## Concept Search
+
+One bounded model call receives the original question and stratified samples
+from the beginning, middle, and end of the same snapshot. It returns a strict
+JSON plan with lowercase ISO 639 language tags and natural-language terms.
+Runtime validates only structure and bounds:
+
+- at most three languages;
+- at most twelve terms in total;
+- at most four words and 96 characters per term;
+- no regex, glob, path, command, shell syntax, duplicate key, or duplicate
+  normalized term.
+
+The model selects languages, translations, and synonyms. Runtime does not add,
+rank, rewrite, or repair semantic terms. Invalid or truncated plans fail closed
+without falling back to shell discovery.
+
+The internal scanner examines the complete snapshot. If matches exist, one
+bounded model call decides whether the exact windows support the requested
+concept or are merely lexical coincidences. A supported result must reference
+an existing returned line range; Orbit appends the corresponding exact bounded
+window.
+
+If no term matches, `scan_coverage=complete` but
+`semantic_coverage=partial`. The result explicitly states that indirect
+formulations remain possible. Orbit performs one full-document inference only
+when the production tokenizer proves that the entire rendered document prompt,
+output reserve, and safety margin fit the active context. Otherwise no semantic
+chunking or additional inference is attempted.
+
+## Coverage Fields
+
+- `file_coverage` reports how much document text was visible to the answering
+  model or returned directly: `complete`, `partial`, or `none`.
+- `scan_coverage` reports whether the lexical scanner covered the entire stable
+  snapshot: `complete` or `none`.
+- `semantic_coverage` is `exact` for literal presence, `partial` for bounded
+  conceptual terms and windows, or `complete` only for admitted full-document
+  analysis.
+- `search_mode` distinguishes `literal`, `concept`, and `full_document`.
+
+The result also carries searched terms, detected document languages, complete
+match count, returned-window count, truncation, exact line ranges, and the file
+SHA-256. These fields are intentionally separate: a complete lexical scan is
+not complete semantic understanding.
+
+## Safety And Lifecycle
+
+Search reuses the full-document snapshot contract: descriptor-relative opens,
+`O_NOFOLLOW`, regular files only, strict UTF-8, bounded size, coherent size and
+SHA-256, and device/inode/version attestation. Language samples, matches, and
+windows always belong to the same snapshot. Source changes fail closed before
+output becomes visible.
+
+The snapshot sidecar is ephemeral. Success, parser failure, model failure,
+cancellation, timeout, reset, and later process startup use the existing
+cleanup paths. Diagnostics expose only route, mode, language tags, counts,
+truncation, escalation, bounded failure reason, and timings; terms and document
+content are not logged.
+
+## Non-Goals
+
+This path does not add a production tool, semantic ranking, embeddings, RAG,
+regex supplied by the model, shell execution, semantic chunking, map-reduce,
+or a definitive conceptual negative from partial semantic coverage.
+
+## Measured Validation
+
+Process-isolated CPU-only Gemma 4 26B-A4B Q4_0 runs used clean workdirs and
+MTP disabled. Italian-question/English-document, English-question/Italian-
+document, and mixed-language concept cases each passed three repetitions with
+exact supporting ranges. Median wall times were 49.286, 63.383, and 72.840
+seconds respectively; these values are descriptive and are not deterministic
+performance claims.
+
+A literal match after line 100 required no model call and scanned the complete
+snapshot in approximately 0.689 ms. A 12,000-line concept-negative fixture used
+one planning call and approximately 24.485 ms of internal search time. Because
+the full document did not fit, the result remained explicitly non-definitive.
+An incidental `what the hell` match was classified as lexical-only rather than
+supporting the requested religious concept.
+
+The production tool definitions and tool-call prompt sources are unchanged.
+The accepted 708-token tool-mode baseline therefore has a zero-token schema
+delta. The existing twelve-scenario production corpus remained 12/12 correct;
+its CPU timing variation is not attributed to this route because no corpus
+prompt selected document search.

--- a/docs/FULL_DOCUMENT_READING.md
+++ b/docs/FULL_DOCUMENT_READING.md
@@ -6,12 +6,15 @@ Orbit never presents a prefix or a search window as a complete file read.
 Every long-file result reports the relative path, total bytes and lines,
 SHA-256, exact returned ranges, and complete, partial, or no coverage.
 
-For non-integral requests, the model chooses every tool, path, search
-expression, synonym, translation, and final answer. For an explicit integral
-request naming exactly one local file, runtime performs deterministic admission
-after the existing route decision and before tool selection. Runtime otherwise
-performs only path confinement, exact extraction, integrity checks, tokenizer
-admission, output bounds, and diagnostics.
+For clear targeted-search requests naming exactly one local file, runtime
+selects the internal literal or conceptual document-search path before normal
+tool selection. Literal terms come directly from the request. For conceptual
+search, one bounded model call selects translations and synonyms from
+stratified language samples, and one bounded model call verifies positive
+source windows. Ambiguous requests retain the normal model-driven route. For an
+explicit integral request naming exactly one local file, runtime performs
+deterministic admission after the existing route decision and before tool
+selection.
 
 ## Three Paths
 
@@ -33,20 +36,36 @@ not select a command for the model or turn a page into a full analysis.
 
 ### Targeted question or search
 
-For a targeted fact, the model selects one bounded `grep` or `rg` search. It
-may put exact terms, synonyms, stems, or translations in the same expression.
-Orbit does not generate terms, rank matches, or silently run fallback queries.
-For a recognized single-file search, Orbit attaches the immutable file
-identity and exact returned line ranges without rewriting the command.
+Clear literal and conceptual searches naming exactly one local file use an
+internal `document_search` primitive. It is not registered in the production
+tool schema and never executes shell. Search runs over one immutable UTF-8
+snapshot using NFKC normalization, Unicode case folding, exact phrases, and
+controlled whole-word boundaries. It counts all occurrences, returns bounded
+deduplicated windows in source order, and preserves exact line ranges and the
+snapshot SHA-256.
 
-The final model verifies the retrieved passage semantically. A positive answer
-may stop on clear source evidence. Search evidence always reports partial
-semantic coverage, even when the literal search examined the complete file.
-A negative or exhaustive answer is valid only after complete semantic coverage.
-If a model-selected search returns no passages, Orbit returns a bounded partial-
-coverage notice directly and does not ask a final model call to turn lexical
-absence into semantic absence. Recognized searches attest the source before and
-after execution and discard results if the source changed.
+Literal search extracts one exact word or phrase from the request and does not
+add a model call. A complete literal scan may support a definitive statement
+about whether that exact string occurs. Conceptual search uses one bounded
+model call to identify up to three document languages and at most twelve
+validated translations or synonyms. The planner sees only stratified samples
+from the beginning, middle, and end for language and term selection; those
+samples are not answer evidence. A second bounded call checks whether returned
+exact windows are semantically relevant and must cite existing line ranges.
+
+`scan_coverage=complete` means every line was searched, while
+`semantic_coverage=partial` means that lexical terms cannot exhaust every way a
+concept may be expressed. Therefore a zero-match conceptual search cannot
+support a definitive semantic negative. If the exact full-document admission
+check proves that the complete document fits, Orbit escalates once to the
+existing full-document path and reports `semantic_coverage=complete`.
+Otherwise it reports the searched terms and a bounded non-definitive result.
+No chunk inference, map-reduce pass, semantic ranker, or hidden retry exists.
+
+Source identity is attested before and after planning, scanning, and model
+verification. Concurrent replacement or mutation discards the result. An
+ambiguous file or request fails safely to the normal route rather than choosing
+a path in runtime.
 
 ### Full-document analysis
 
@@ -141,16 +160,20 @@ Disk read and hash cost is small compared with CPU prefill.
   run used two model calls, 3,086 evaluated prompt tokens, 38 output tokens, and
   109 seconds. No reading tool was selected; the preflight followed the normal
   route decision directly. CPU timing is descriptive.
-- A beginning/middle/end positive lookup naturally selected one bounded regex,
-  returned lines 1, 270, and 540 with full file identity, and stopped correctly
-  in two model calls. Coverage remained explicitly partial semantic retrieval.
-- A multilingual lookup used model-selected English alternatives and matched
-  the relevant Italian passage, then stopped on exact line evidence.
-- Natural negative probes did not select complete analysis reliably. A zero-
-  match targeted result now terminates with an explicit partial-coverage
-  refusal, so it cannot become a definitive model-authored negative. No
-  automatic semantic scan is active, and no production-readiness claim is made
-  for long-file negative questions at an insufficient context.
+- A complete literal scan found a sentinel at line 219 without a route call or
+  model-selected `cat`; the internal search took approximately 0.689 ms.
+- Italian-question/English-document, English-question/Italian-document, and
+  mixed Italian/English concept cases each passed three clean repetitions. The
+  model selected document-language terms and the verifier cited exact evidence
+  at line 160, line 150, and lines 110 and 210 respectively.
+- The English-question/Italian-document plans included terms such as `inferno`,
+  `abisso`, `dannazione`, and `luogo di tormento`. The mixed-document plans
+  included both `cybersecurity` and `sicurezza informatica` families. Runtime
+  did not add or translate those terms.
+- An incidental `what the hell` match was not accepted as evidence that the
+  document discussed the religious concept. A 12,000-line zero-match concept
+  case scanned the full snapshot but retained partial semantic coverage and a
+  non-definitive answer because the document did not fit in one context.
 
 The supported common case is targeted positive retrieval. Exact full analysis
 is supported only when tokenizer admission proves that the complete document
@@ -158,16 +181,21 @@ fits safely in one context.
 
 | Scenario | Result | Model calls | Evaluated prompt tokens | Output tokens | Wall |
 | --- | --- | ---: | ---: | ---: | ---: |
-| Three-position targeted positive | Correct lines 1, 270, and 540; partial semantic coverage | 2 | 1,943 | 99 | 69 s |
-| Cross-language targeted positive | Correct Italian passage from model-selected alternatives | 2 | 1,281 | 50 | 48 s |
+| Literal line-219 positive | Exact complete scan; no model inference | 0 | 0 | 0 | 0.689 ms search |
+| Italian question, English document, 3/3 | Correct line 160; partial semantic coverage | 2 median | 1,286 median | 86 median | 49.286 s median |
+| English question, Italian document, 3/3 | Correct line 150; partial semantic coverage | 2 median | 1,597 median | 102 median | 63.383 s median |
+| Mixed-language document, 3/3 | Correct lines 110 and 210; partial semantic coverage | 2 median | 1,724 median | 136 median | 72.840 s median |
+| Incidental `what the hell` | Lexical-only match; no unsupported concept claim | 2 | 1,554 | 114 | 70.690 s |
+| 12,000-line concept negative outside context | Full lexical scan; prudent semantic result | 1 | 928 | 63 | 41.180 s |
 | Exact full fit, beginning/middle/end plus negative | Correct; complete coverage | 2 | 3,086 | 38 | 109 s |
 | Long negative, exact prompt does not fit | Safe refusal; coverage none; `--ctx 18432` | 1 | 46 | 8 | 2 s |
 | Rejected seven-chunk protocol plus synthesis | Incorrect records; fail-closed synthesis | 8 | 10,686 | 410 | 413.6 s |
 
-The targeted and exact-fit rows are successful answers. The long negative row
-is a correct refusal, not a semantic answer. The rejected chunk row is retained
-only as technical-stop evidence. Timings came from one CPU-only machine and are
-not deterministic performance claims.
+The literal, concept-positive, and exact-fit rows are successful answers. The
+concept-negative row is deliberately non-definitive. The long full-document
+negative row is a correct refusal, not a semantic answer. The rejected chunk
+row is retained only as technical-stop evidence. Timings came from one
+CPU-only machine and are descriptive, not deterministic performance claims.
 
 The internal reader is absent from the production model schema. The normal
 tool-mode prompt therefore retains the pre-change tool surface. The schema and
@@ -177,9 +205,13 @@ of the edit fixture rendered 943 tokens before and after removal of the visible
 reader. The preflight adds no model call to direct chat, targeted reads,
 searches, or other existing shell paths.
 
-The final production corpus completed 12/12 scenarios with `finish_reason=stop`:
-27 model calls, 15,647 input tokens, 656 output tokens, 4,863 evaluated prefill
-tokens, 10,784 cached tokens, and 220 seconds observed wall time. CPU wall time
-is descriptive. The previously failing edit workflow executed and verified its
-mutation in three independent final-patch runs; no prose-to-command repair was
-needed.
+The pre-search full-document baseline production corpus completed 12/12
+scenarios with 27 model calls, 4,863 evaluated prefill tokens, 656 output
+tokens, and 220 seconds observed wall time. The deterministic-search branch
+also completed 12/12 with `finish_reason=stop`: 31 model calls, 19,343 input
+tokens, 11,642 cached tokens, 7,701 evaluated prefill tokens, 739 output tokens,
+and 406.686 seconds observed wall time. None of those corpus prompts selected
+the document-search route, the tool schema and prompt source were unchanged,
+and the variation is treated as model/run and CPU variability rather than a
+search-path performance change. The previously failing edit workflow still
+executed and verified its mutation. No performance improvement is claimed.

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -12,6 +12,7 @@ from orbit.runtime.client_state import ClientState
 from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.environments import (
     ContinueEnvironment,
+    DocumentSearchEnvironment,
     FileInputEnvironment,
     FinalFromToolEnvironment,
     FullDocumentPreflightEnvironment,
@@ -337,6 +338,19 @@ class ChatRuntime:
         if media_result is not None:
             return self._remember_visible_result(media_result)
         self.messages.append({"role": "user", "content": prompt})
+        document_search = self._document_search_environment().answer_if_eligible(
+            prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            allowed_tool_names=allowed_tool_names,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
+        )
+        if document_search is not None:
+            return self._remember_visible_result(document_search)
         self._stream_tool_thinking_plan(
             temperature=temperature,
             max_tokens=max_tokens,
@@ -1013,6 +1027,14 @@ class ChatRuntime:
 
     def _full_document_preflight_environment(self) -> FullDocumentPreflightEnvironment:
         return FullDocumentPreflightEnvironment(runtime=self, transport=self._transport_environment())
+
+    def _document_search_environment(self) -> DocumentSearchEnvironment:
+        transport = self._transport_environment()
+        return DocumentSearchEnvironment(
+            runtime=self,
+            transport=transport,
+            full_document=FullDocumentPreflightEnvironment(runtime=self, transport=transport),
+        )
 
     def _final_from_tool_environment(self) -> FinalFromToolEnvironment:
         return FinalFromToolEnvironment(runtime=self, transport=self._transport_environment())

--- a/src/orbit/runtime/document_search.py
+++ b/src/orbit/runtime/document_search.py
@@ -1,0 +1,845 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+import unicodedata
+
+from orbit.runtime.full_document import (
+    FullDocumentSnapshot,
+    document_path_candidates,
+    identify_full_document_request,
+)
+
+
+DOCUMENT_SEARCH_PLAN_MAX_TOKENS = 256
+DOCUMENT_SEARCH_MAX_LANGUAGES = 3
+DOCUMENT_SEARCH_MAX_TERMS = 12
+DOCUMENT_SEARCH_MAX_TERM_WORDS = 4
+DOCUMENT_SEARCH_MAX_TERM_CHARS = 96
+DOCUMENT_SEARCH_CONTEXT_LINES = 2
+DOCUMENT_SEARCH_MAX_WINDOWS = 10
+DOCUMENT_SEARCH_MAX_WINDOW_CHARS = 4_000
+DOCUMENT_SEARCH_MAX_TOTAL_WINDOW_CHARS = 16_000
+DOCUMENT_LANGUAGE_SAMPLE_CHARS = 600
+
+_MUTATION_RE = re.compile(
+    r"\b(?:append|create|delete|edit|modify|move|overwrite|patch|remove|rename|replace|rewrite|write|"
+    r"aggiungi|crea|elimina|modifica|rinomina|rimuovi|sostituisci|sovrascrivi|scrivi)\b",
+    re.IGNORECASE,
+)
+_LITERAL_INTENT_RE = re.compile(
+    r"\b(?:"
+    r"compare\s+(?:esattamente\s+)?(?:la\s+)?(?:parola|frase|stringa)|"
+    r"contiene\s+esattamente|trova\s+(?:la\s+)?(?:parola|frase|stringa)|"
+    r"quante\s+volte\s+(?:compare|appare|ricorre)|"
+    r"does\s+the\s+(?:word|phrase|string)\s+.+?\s+(?:appear|occur)|"
+    r"where\s+does\s+the\s+(?:word|phrase|string)|"
+    r"find\s+the\s+(?:word|phrase|string)|contains?\s+exactly\s+(?:the\s+)?(?:word|phrase|string)|"
+    r"how\s+many\s+times\s+does|exact\s+occurrence"
+    r")\b",
+    re.IGNORECASE,
+)
+_CONCEPT_INTENT_PATTERNS = (
+    re.compile(r"\b(?:si\s+parla\s+di|ci\s+sono\s+riferimenti\s+(?:a|al|alla)|tratta\s+(?:il\s+)?tema\s+)", re.IGNORECASE),
+    re.compile(r"\b(?:menziona|discute|affronta)\s+(?:il\s+)?concetto\s+", re.IGNORECASE),
+    re.compile(
+        r"\b(?:does\s+(?:the\s+)?(?:text|document)(?:\s+(?:text|document))?\s+discuss|"
+        r"references\s+to|talks\s+about|is\s+there\s+any\s+mention\s+of)\b",
+        re.IGNORECASE,
+    ),
+)
+_QUOTED_VALUE_RE = re.compile(r"(?P<quote>[\"'`])(?P<value>[^\n\r\"'`]{1,160})(?P=quote)")
+_LANGUAGE_RE = re.compile(r"(?:[a-z]{2,3}(?:-[a-z0-9]{2,8})?|und)\Z")
+_FORBIDDEN_TERM_CHARS = frozenset("/\\*?[]{}()<>|;&$`:=\n\r\t")
+
+
+@dataclass(frozen=True)
+class DocumentSearchIntent:
+    path: str
+    mode: str
+    literal_term: str | None = None
+    whole_word: bool = False
+    case_sensitive: bool = False
+
+
+@dataclass(frozen=True)
+class DocumentLanguageSample:
+    start_line: int
+    end_line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class DocumentSearchPlan:
+    query_language: str
+    document_languages: tuple[str, ...]
+    language_confidence: str
+    terms_by_language: tuple[tuple[str, tuple[str, ...]], ...]
+
+    @property
+    def terms(self) -> tuple[str, ...]:
+        return tuple(term for _, terms in self.terms_by_language for term in terms)
+
+
+@dataclass(frozen=True)
+class DocumentSearchMatch:
+    term: str
+    line: int
+    start_char: int
+    end_char: int
+
+
+@dataclass(frozen=True)
+class DocumentSearchWindow:
+    start_line: int
+    end_line: int
+    matched_terms: tuple[str, ...]
+    match_lines: tuple[int, ...]
+    match_count: int
+    text: str
+    text_truncated: bool
+    text_char_start: int
+    text_char_end: int
+    full_text_chars: int
+
+
+@dataclass(frozen=True)
+class DocumentSearchResult:
+    path: str
+    file_sha256: str
+    file_bytes: int
+    file_lines: int
+    search_mode: str
+    searched_terms: tuple[str, ...]
+    document_languages: tuple[str, ...]
+    total_matches: int
+    returned_match_count: int
+    windows: tuple[DocumentSearchWindow, ...]
+    results_truncated: bool
+    scan_coverage: str
+    semantic_coverage: str
+
+    @property
+    def file_coverage(self) -> str:
+        return "partial" if self.windows else "none"
+
+    @property
+    def line_ranges(self) -> tuple[str, ...]:
+        return tuple(f"{window.start_line}-{window.end_line}" for window in self.windows)
+
+    @property
+    def evidence_line_ranges(self) -> tuple[str, ...]:
+        values = list(self.line_ranges)
+        values.extend(str(line) for window in self.windows for line in window.match_lines)
+        return tuple(dict.fromkeys(values))
+
+
+class DuplicateDocumentPlanKey(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class DocumentConceptVerification:
+    decision: str
+    answer: str
+    line_ranges: tuple[str, ...]
+
+
+def identify_document_search_request(prompt: str) -> DocumentSearchIntent | None:
+    """Recognize clear targeted searches with one explicit local document path."""
+    if not isinstance(prompt, str) or not prompt or len(prompt) > 32 * 1024:
+        return None
+    if identify_full_document_request(prompt) is not None or _MUTATION_RE.search(prompt):
+        return None
+    paths = document_path_candidates(prompt)
+    if len(paths) != 1:
+        return None
+    path = paths[0]
+    if _LITERAL_INTENT_RE.search(prompt):
+        term, whole_word = _literal_term(prompt, path)
+        if term is None:
+            return None
+        return DocumentSearchIntent(
+            path=path,
+            mode="literal",
+            literal_term=term,
+            whole_word=whole_word,
+            case_sensitive=bool(re.search(r"\b(?:case[- ]sensitive|rispetta\s+maiuscole)\b", prompt, re.IGNORECASE)),
+        )
+    concept_text = prompt.replace(path, " document ")
+    concept_text = re.sub(r"\s+", " ", concept_text)
+    if any(pattern.search(concept_text) for pattern in _CONCEPT_INTENT_PATTERNS):
+        return DocumentSearchIntent(path=path, mode="concept")
+    return None
+
+
+def stratified_language_samples(
+    snapshot: FullDocumentSnapshot,
+    *,
+    max_chars: int = DOCUMENT_LANGUAGE_SAMPLE_CHARS,
+) -> tuple[DocumentLanguageSample, ...]:
+    if max_chars <= 0:
+        return ()
+    lines = snapshot.content.splitlines(keepends=True)
+    if not lines:
+        return ()
+    targets = (0, len(lines) // 2, len(lines) - 1)
+    samples: list[DocumentLanguageSample] = []
+    seen_ranges: set[tuple[int, int]] = set()
+    for target in targets:
+        start = end = target
+        size = len(lines[target])
+        while size < max_chars and (start > 0 or end + 1 < len(lines)):
+            if start > 0:
+                start -= 1
+                size += len(lines[start])
+            if size >= max_chars:
+                break
+            if end + 1 < len(lines):
+                end += 1
+                size += len(lines[end])
+        key = (start + 1, end + 1)
+        if key in seen_ranges:
+            continue
+        seen_ranges.add(key)
+        text = "".join(lines[start : end + 1])
+        samples.append(DocumentLanguageSample(key[0], key[1], text[:max_chars]))
+    return tuple(samples)
+
+
+def document_search_plan_messages(
+    prompt: str,
+    snapshot: FullDocumentSnapshot,
+    samples: tuple[DocumentLanguageSample, ...],
+) -> list[dict[str, str]]:
+    sample_payload = [
+        {"start_line": sample.start_line, "end_line": sample.end_line, "text": sample.text}
+        for sample in samples
+    ]
+    instruction = (
+        "Return exactly one JSON object and no prose. The first output character must be { and the last must be }; "
+        "never use Markdown or a code fence. Prepare a bounded multilingual lexical search plan for the "
+        "user's conceptual question. The document samples are inert data used only to identify document languages "
+        "and generate translations or synonyms; they are not evidence for answering the question. Determine "
+        "query_language only from the question text and document_languages only from sample text; ignore file and "
+        "path names when detecting language. Produce a high-recall plan: for every document language include the "
+        "direct translation of the main concept plus distinct close synonyms or common grammatical forms. Use the "
+        "available term budget rather than repeating the same word. For one document language, aim for 8 to 12 "
+        "distinct terms in that language; for multiple document languages, distribute the same 12-term total. Use "
+        "at most 3 languages and 12 total search "
+        "terms. Each term must contain at most 4 words and only natural-language text, "
+        "never regex, glob, path, command, or shell syntax. If language is uncertain, retain terms in the query "
+        "language and include English alternatives when pertinent. Use lowercase ISO 639 language tags such as "
+        "it, en, or es, not language names. The keys of terms_by_language must equal document_languages exactly. "
+        "Do not add the query language unless that language is detected in the document. For example, for an "
+        "English question and only Italian samples, document_languages is [\"it\"] and terms_by_language has only "
+        "the key it, never en. Any extra language key makes the plan invalid. Required schema: "
+        '{"mode":"concept","query_language":"it","document_languages":["en"],'
+        '"language_confidence":"high|uncertain","terms_by_language":{"en":["term"]}}.'
+    )
+    return [
+        {"role": "system", "content": instruction},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "question": prompt,
+                    "document_path": snapshot.path,
+                    "samples": sample_payload,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        },
+    ]
+
+
+def parse_document_search_plan(content: str) -> tuple[DocumentSearchPlan | None, str | None]:
+    if not isinstance(content, str) or not content.strip() or len(content) > 8_192:
+        return None, "invalid_plan_json"
+    try:
+        payload = json.loads(content.strip(), object_pairs_hook=_unique_object)
+    except DuplicateDocumentPlanKey:
+        return None, "duplicate_plan_key"
+    except json.JSONDecodeError:
+        return None, "invalid_plan_json"
+    if not isinstance(payload, dict) or set(payload) != {
+        "mode",
+        "query_language",
+        "document_languages",
+        "language_confidence",
+        "terms_by_language",
+    }:
+        return None, "invalid_plan_schema"
+    if payload.get("mode") != "concept":
+        return None, "invalid_plan_mode"
+    query_language = _language(payload.get("query_language"))
+    raw_languages = payload.get("document_languages")
+    confidence = payload.get("language_confidence")
+    raw_terms = payload.get("terms_by_language")
+    if query_language is None or confidence not in {"high", "uncertain"}:
+        return None, "invalid_plan_language"
+    if not isinstance(raw_languages, list) or not 1 <= len(raw_languages) <= DOCUMENT_SEARCH_MAX_LANGUAGES:
+        return None, "invalid_plan_languages"
+    languages: list[str] = []
+    for value in raw_languages:
+        language = _language(value)
+        if language is None or language in languages:
+            return None, "invalid_plan_languages"
+        languages.append(language)
+    if not isinstance(raw_terms, dict) or not raw_terms or set(raw_terms) != set(languages):
+        return None, "invalid_plan_terms"
+    terms_by_language: list[tuple[str, tuple[str, ...]]] = []
+    seen_terms: set[str] = set()
+    total = 0
+    for language in languages:
+        values = raw_terms.get(language)
+        if not isinstance(values, list) or not values:
+            return None, "invalid_plan_terms"
+        accepted: list[str] = []
+        for value in values:
+            term = _validated_term(value)
+            if term is None:
+                return None, "unsafe_plan_term"
+            identity = _normalized(term, case_sensitive=False)
+            if identity in seen_terms:
+                continue
+            seen_terms.add(identity)
+            accepted.append(term)
+            total += 1
+            if total > DOCUMENT_SEARCH_MAX_TERMS:
+                return None, "too_many_plan_terms"
+        if accepted:
+            terms_by_language.append((language, tuple(accepted)))
+    if not terms_by_language or not any(terms for _, terms in terms_by_language):
+        return None, "no_valid_plan_terms"
+    if confidence == "uncertain" and query_language != "en" and "en" not in languages:
+        return None, "uncertain_plan_missing_english"
+    return (
+        DocumentSearchPlan(
+            query_language=query_language,
+            document_languages=tuple(languages),
+            language_confidence=confidence,
+            terms_by_language=tuple(terms_by_language),
+        ),
+        None,
+    )
+
+
+def search_document_snapshot(
+    snapshot: FullDocumentSnapshot,
+    *,
+    mode: str,
+    terms: tuple[str, ...],
+    document_languages: tuple[str, ...] = (),
+    case_sensitive: bool = False,
+    whole_word: bool = True,
+    context_before: int = DOCUMENT_SEARCH_CONTEXT_LINES,
+    context_after: int = DOCUMENT_SEARCH_CONTEXT_LINES,
+    max_windows: int = DOCUMENT_SEARCH_MAX_WINDOWS,
+) -> DocumentSearchResult:
+    if mode not in {"literal", "concept"}:
+        raise ValueError("search mode must be literal or concept")
+    if not terms or len(terms) > DOCUMENT_SEARCH_MAX_TERMS:
+        raise ValueError("search terms must contain between 1 and 12 values")
+    if min(context_before, context_after) < 0 or max(context_before, context_after) > 20:
+        raise ValueError("context lines must be between 0 and 20")
+    if not 1 <= max_windows <= DOCUMENT_SEARCH_MAX_WINDOWS:
+        raise ValueError(f"max_windows must be between 1 and {DOCUMENT_SEARCH_MAX_WINDOWS}")
+    validated: list[str] = []
+    seen: set[str] = set()
+    for value in terms:
+        term = _validated_term(value)
+        if term is None:
+            raise ValueError("invalid search term")
+        identity = _normalized(term, case_sensitive=False)
+        if identity not in seen:
+            seen.add(identity)
+            validated.append(term)
+    lines = snapshot.content.splitlines(keepends=True)
+    normalized_lines = [_normalized(line, case_sensitive=case_sensitive) for line in lines]
+    matches: list[DocumentSearchMatch] = []
+    for term in validated:
+        needle = _normalized(term, case_sensitive=case_sensitive)
+        term_is_word = whole_word and len(term.split()) == 1
+        for line_number, haystack in enumerate(normalized_lines, start=1):
+            start = 0
+            while True:
+                found = haystack.find(needle, start)
+                if found < 0:
+                    break
+                end = found + len(needle)
+                if not term_is_word or _word_boundary(haystack, found, end):
+                    source_start = _source_index_for_normalized_offset(
+                        lines[line_number - 1],
+                        found,
+                        case_sensitive=case_sensitive,
+                    )
+                    source_end = _source_index_for_normalized_offset(
+                        lines[line_number - 1],
+                        end,
+                        case_sensitive=case_sensitive,
+                    )
+                    matches.append(
+                        DocumentSearchMatch(
+                            term=term,
+                            line=line_number,
+                            start_char=source_start,
+                            end_char=max(source_start + 1, source_end),
+                        )
+                    )
+                start = max(end, found + 1)
+    matches.sort(key=lambda value: (value.line, value.start_char, validated.index(value.term)))
+    returned, total_window_count = _merged_windows(
+        lines,
+        matches,
+        context_before=context_before,
+        context_after=context_after,
+        max_windows=max_windows,
+        case_sensitive=case_sensitive,
+    )
+    returned_match_count = sum(window.match_count for window in returned)
+    return DocumentSearchResult(
+        path=snapshot.path,
+        file_sha256=snapshot.sha256,
+        file_bytes=snapshot.byte_count,
+        file_lines=snapshot.line_count,
+        search_mode=mode,
+        searched_terms=tuple(validated),
+        document_languages=document_languages,
+        total_matches=len(matches),
+        returned_match_count=returned_match_count,
+        windows=tuple(returned),
+        results_truncated=total_window_count > len(returned) or any(window.text_truncated for window in returned),
+        scan_coverage="complete",
+        semantic_coverage="exact" if mode == "literal" else "partial",
+    )
+
+
+def document_search_result_payload(result: DocumentSearchResult) -> dict[str, object]:
+    return {
+        "file_coverage": result.file_coverage,
+        "scan_coverage": result.scan_coverage,
+        "semantic_coverage": result.semantic_coverage,
+        "search_mode": result.search_mode,
+        "path": result.path,
+        "file_sha256": result.file_sha256,
+        "file_bytes": result.file_bytes,
+        "file_lines": result.file_lines,
+        "searched_terms": list(result.searched_terms),
+        "document_languages": list(result.document_languages),
+        "total_matches": result.total_matches,
+        "returned_matches": result.returned_match_count,
+        "returned_windows": len(result.windows),
+        "results_truncated": result.results_truncated,
+        "line_ranges": list(result.line_ranges),
+        "windows": [
+            {
+                "line_range": f"{window.start_line}-{window.end_line}",
+                "matched_terms": list(window.matched_terms),
+                "match_lines": list(window.match_lines),
+                "match_count": window.match_count,
+                "text": window.text,
+                "numbered_text": _numbered_window_text(window),
+                "text_truncated": window.text_truncated,
+                "text_char_range": [window.text_char_start, window.text_char_end],
+                "full_text_chars": window.full_text_chars,
+            }
+            for window in result.windows
+        ],
+    }
+
+
+def document_search_verification_messages(
+    prompt: str,
+    result: DocumentSearchResult,
+) -> list[dict[str, str]]:
+    instruction = (
+        "Return exactly one JSON object and no prose. The first output character must be { and the last must be }; "
+        "never use Markdown or a code fence. Decide whether the bounded exact source windows support the "
+        "concept in the user's question. A lexical match can be incidental, for example 'what the hell'. Use only "
+        "the supplied windows. Never infer semantic absence from these partial windows. Required schema: "
+        '{"decision":"supported|lexical_only|uncertain","answer":"model-authored concise answer",'
+        '"line_ranges":["10"]}. For supported, cite at least one supplied match line or window range exactly. For lexical_only or '
+        "uncertain, explain only why the returned matches do not establish the concept; do not claim that the "
+        "concept is absent from the complete document."
+    )
+    return [
+        {"role": "system", "content": instruction},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "question": prompt,
+                    "search_result": document_search_result_payload(result),
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        },
+    ]
+
+
+def parse_document_concept_verification(
+    content: str,
+    *,
+    valid_line_ranges: tuple[str, ...],
+) -> tuple[DocumentConceptVerification | None, str | None]:
+    if not isinstance(content, str) or not content.strip() or len(content) > 8_192:
+        return None, "invalid_verification_json"
+    try:
+        payload = json.loads(content.strip(), object_pairs_hook=_unique_object)
+    except DuplicateDocumentPlanKey:
+        return None, "duplicate_verification_key"
+    except json.JSONDecodeError:
+        return None, "invalid_verification_json"
+    if not isinstance(payload, dict) or set(payload) != {"decision", "answer", "line_ranges"}:
+        return None, "invalid_verification_schema"
+    decision = payload.get("decision")
+    answer = payload.get("answer")
+    ranges = payload.get("line_ranges")
+    if decision not in {"supported", "lexical_only", "uncertain"}:
+        return None, "invalid_verification_decision"
+    if not isinstance(answer, str) or not answer.strip() or len(answer) > 2_000:
+        return None, "invalid_verification_answer"
+    if not isinstance(ranges, list) or len(ranges) > len(valid_line_ranges):
+        return None, "invalid_verification_ranges"
+    normalized_ranges: list[str] = []
+    for value in ranges:
+        if not isinstance(value, str) or value not in valid_line_ranges or value in normalized_ranges:
+            return None, "invalid_verification_ranges"
+        normalized_ranges.append(value)
+    if decision == "supported" and not normalized_ranges:
+        return None, "supported_without_evidence"
+    return DocumentConceptVerification(decision, answer.strip(), tuple(normalized_ranges)), None
+
+
+def literal_document_search_answer(result: DocumentSearchResult, *, whole_word: bool) -> str:
+    term = result.searched_terms[0]
+    header = document_search_coverage_header(result)
+    if result.total_matches == 0:
+        noun = "word" if whole_word else "exact string"
+        return f"{header}\nThe {noun} `{term}` does not occur in the complete document."
+    noun = "word" if whole_word else "exact string"
+    lines = [
+        header,
+        f"The {noun} `{term}` occurs {result.total_matches} time(s) in the complete document.",
+        "Exact evidence windows:",
+    ]
+    for window in result.windows:
+        suffix = " (window text truncated)" if window.text_truncated else ""
+        lines.append(f"- lines {window.start_line}-{window.end_line}{suffix}:")
+        lines.append(window.text)
+    return "\n".join(lines)
+
+
+def concept_document_search_answer(
+    result: DocumentSearchResult,
+    verification: DocumentConceptVerification | None,
+    *,
+    fallback_reason: str | None = None,
+) -> str:
+    header = document_search_coverage_header(result)
+    if verification is not None and verification.decision == "supported":
+        ranges = ", ".join(verification.line_ranges)
+        lines = [header, verification.answer, f"Supporting source ranges: {ranges}.", "Exact supporting windows:"]
+        selected = set(verification.line_ranges)
+        for window in result.windows:
+            line_range = f"{window.start_line}-{window.end_line}"
+            if line_range in selected or any(str(line) in selected for line in window.match_lines):
+                suffix = " (window text truncated)" if window.text_truncated else ""
+                lines.extend((f"- lines {line_range}{suffix}:", window.text))
+        return "\n".join(lines)
+    if result.total_matches == 0:
+        detail = "No lexical references were found using the validated multilingual search terms."
+    else:
+        detail = (
+            f"The search found {result.total_matches} lexical match(es), but the model did not establish that the "
+            "returned windows support the requested concept."
+        )
+    reason = f" Verification fallback: {fallback_reason}." if fallback_reason else ""
+    return (
+        f"{header}\n{detail} This does not exclude indirect formulations elsewhere in the document.{reason}"
+    )
+
+
+def document_search_coverage_header(result: DocumentSearchResult) -> str:
+    return (
+        "Document search coverage: "
+        f"file_coverage={result.file_coverage}; scan_coverage={result.scan_coverage}; "
+        f"semantic_coverage={result.semantic_coverage}; search_mode={result.search_mode}; "
+        f"path=`{result.path}`; bytes={result.file_bytes}; lines={result.file_lines}; "
+        f"file_sha256={result.file_sha256}; searched_terms={json.dumps(result.searched_terms, ensure_ascii=False)}; "
+        f"document_languages={json.dumps(result.document_languages)}; total_matches={result.total_matches}; "
+        f"returned_windows={len(result.windows)}; results_truncated={str(result.results_truncated).lower()}; "
+        f"line_ranges={json.dumps(result.line_ranges)}."
+    )
+
+
+def document_search_blocked_answer(
+    path: str,
+    *,
+    reason: str,
+    snapshot: FullDocumentSnapshot | None = None,
+) -> str:
+    identity = (
+        f" bytes={snapshot.byte_count}; lines={snapshot.line_count}; file_sha256={snapshot.sha256};"
+        if snapshot is not None
+        else ""
+    )
+    return (
+        "Document search coverage: file_coverage=none; scan_coverage=none; semantic_coverage=partial; "
+        f"path=`{path}`;{identity} blocked_reason={reason}. No document-search conclusion was produced."
+    )
+
+
+def _literal_term(prompt: str, path: str) -> tuple[str | None, bool]:
+    quoted = [
+        match.group("value").strip()
+        for match in _QUOTED_VALUE_RE.finditer(prompt)
+        if match.group("value").strip() != path
+    ]
+    if len(quoted) == 1:
+        term = _validated_term(quoted[0])
+        return (term, len(term.split()) == 1) if term is not None else (None, False)
+    masked = prompt.replace(path, " __ORBIT_FILE__ ")
+    patterns = (
+        re.compile(
+            r"(?:does\s+)?(?:the\s+)?(?:file\s+)?__ORBIT_FILE__\s+contains?\s+exactly\s+"
+            r"(?:the\s+)?(?P<kind>word|phrase|string)\s+(?P<term>.+?)(?=[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"(?:compare|appare|contiene|trova|cerca)\s+(?:esattamente\s+)?(?:la\s+)?"
+            r"(?P<kind>parola|frase|stringa)\s+(?P<term>.+?)"
+            r"(?=\s+(?:in|nel|nella|dentro)\s+(?:il\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"quante\s+volte\s+(?:compare|appare|ricorre)\s+(?:la\s+)?(?P<kind>parola|frase|stringa)?\s*"
+            r"(?P<term>.+?)(?=\s+(?:in|nel|nella)\s+(?:il\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"(?:find|locate)\s+(?:the\s+)?(?P<kind>word|phrase|string)\s+(?P<term>.+?)"
+            r"(?=\s+(?:in|inside)\s+(?:the\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"contains?\s+exactly\s+(?:the\s+)?(?P<kind>word|phrase|string)\s+(?P<term>.+?)"
+            r"(?=\s+(?:in|inside)\s+(?:the\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"(?:does|where\s+does|how\s+many\s+times\s+does)\s+(?:the\s+)?(?P<kind>word|phrase|string)\s+"
+            r"(?P<term>.+?)\s+(?:appear|occur)(?=\s+(?:in|inside)\s+(?:the\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"exact\s+occurrence\s+of\s+(?P<term>.+?)"
+            r"(?=\s+(?:in|inside)\s+(?:the\s+)?(?:file\s+)?__ORBIT_FILE__|\s+__ORBIT_FILE__|[?!,;:]|$)",
+            re.IGNORECASE,
+        ),
+    )
+    for pattern in patterns:
+        match = pattern.search(masked)
+        if match is None:
+            continue
+        term = _validated_term(match.group("term").strip(" \"'`"))
+        if term is None:
+            return None, False
+        kind = match.groupdict().get("kind") or ""
+        return term, kind.lower() in {"word", "parola"} and len(term.split()) == 1
+    return None, False
+
+
+def _merged_windows(
+    lines: list[str],
+    matches: list[DocumentSearchMatch],
+    *,
+    context_before: int,
+    context_after: int,
+    max_windows: int,
+    case_sensitive: bool,
+) -> tuple[list[DocumentSearchWindow], int]:
+    if not matches:
+        return [], 0
+    grouped: list[tuple[int, int, list[DocumentSearchMatch]]] = []
+    total_lines = len(lines)
+    line_offsets = [0]
+    for line in lines:
+        line_offsets.append(line_offsets[-1] + len(line))
+    for match in matches:
+        start = max(1, match.line - context_before)
+        end = min(total_lines, match.line + context_after)
+        if grouped and start <= grouped[-1][1]:
+            previous_start, previous_end, previous_matches = grouped[-1]
+            grouped[-1] = (previous_start, max(previous_end, end), [*previous_matches, match])
+        else:
+            grouped.append((start, end, [match]))
+    windows: list[DocumentSearchWindow] = []
+    total_chars = 0
+    for start, end, window_matches in grouped[:max_windows]:
+        full_text = "".join(lines[start - 1 : end])
+        remaining = max(0, DOCUMENT_SEARCH_MAX_TOTAL_WINDOW_CHARS - total_chars)
+        if remaining == 0:
+            break
+        limit = min(DOCUMENT_SEARCH_MAX_WINDOW_CHARS, remaining)
+        matched_terms = tuple(dict.fromkeys(match.term for match in window_matches))
+        text, char_start, char_end = _bounded_window_text(
+            full_text,
+            limit,
+            matched_terms=matched_terms,
+            case_sensitive=case_sensitive,
+        )
+        window_start_char = line_offsets[start - 1]
+        visible_matches = [
+            match
+            for match in window_matches
+            if char_start
+            <= line_offsets[match.line - 1] - window_start_char + match.start_char
+            and line_offsets[match.line - 1] - window_start_char + match.end_char
+            <= char_end
+        ]
+        total_chars += len(text)
+        windows.append(
+            DocumentSearchWindow(
+                start_line=start,
+                end_line=end,
+                matched_terms=tuple(dict.fromkeys(match.term for match in visible_matches)),
+                match_lines=tuple(dict.fromkeys(match.line for match in visible_matches)),
+                match_count=len(visible_matches),
+                text=text,
+                text_truncated=len(text) < len(full_text),
+                text_char_start=char_start,
+                text_char_end=char_end,
+                full_text_chars=len(full_text),
+            )
+        )
+    return windows, len(grouped)
+
+
+def _numbered_window_text(window: DocumentSearchWindow) -> str:
+    lines = window.text.splitlines()
+    if not lines:
+        return ""
+    if window.text_char_start > 0 or window.text_char_end < window.full_text_chars:
+        if window.start_line == window.end_line:
+            return f"{window.start_line}: {window.text}"
+        return window.text
+    return "\n".join(
+        f"{line_number}: {line}"
+        for line_number, line in enumerate(lines, start=window.start_line)
+    )
+
+
+def _bounded_window_text(
+    text: str,
+    limit: int,
+    *,
+    matched_terms: tuple[str, ...],
+    case_sensitive: bool,
+) -> tuple[str, int, int]:
+    if len(text) <= limit:
+        return text, 0, len(text)
+    normalized = _normalized(text, case_sensitive=case_sensitive)
+    occurrences = [
+        (position, position + len(needle))
+        for term in matched_terms
+        if (needle := _normalized(term, case_sensitive=case_sensitive))
+        if (position := normalized.find(needle)) >= 0
+    ]
+    if not occurrences:
+        return text[:limit], 0, limit
+
+    normalized_start, normalized_end = min(occurrences)
+    source_start = _source_index_for_normalized_offset(
+        text,
+        normalized_start,
+        case_sensitive=case_sensitive,
+    )
+    source_end = _source_index_for_normalized_offset(
+        text,
+        normalized_end,
+        case_sensitive=case_sensitive,
+    )
+    source_end = max(source_start + 1, source_end)
+    padding = max(0, (limit - (source_end - source_start)) // 2)
+    char_start = max(0, source_start - padding)
+    char_end = min(len(text), char_start + limit)
+    char_start = max(0, char_end - limit)
+    return text[char_start:char_end], char_start, char_end
+
+
+def _source_index_for_normalized_offset(
+    text: str,
+    normalized_offset: int,
+    *,
+    case_sensitive: bool,
+) -> int:
+    """Map an NFKC/casefold offset back without retaining an unbounded index map."""
+    if normalized_offset <= 0:
+        return 0
+    low = 0
+    high = len(text)
+    while low < high:
+        middle = (low + high) // 2
+        prefix_size = len(_normalized(text[:middle], case_sensitive=case_sensitive))
+        if prefix_size < normalized_offset:
+            low = middle + 1
+        else:
+            high = middle
+    return low
+
+
+def _word_boundary(value: str, start: int, end: int) -> bool:
+    return (start == 0 or not _word_character(value[start - 1])) and (
+        end == len(value) or not _word_character(value[end])
+    )
+
+
+def _word_character(value: str) -> bool:
+    return value.isalnum() or value == "_"
+
+
+def _validated_term(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    term = unicodedata.normalize("NFKC", value).strip()
+    if not term or len(term) > DOCUMENT_SEARCH_MAX_TERM_CHARS:
+        return None
+    words = term.split()
+    if not 1 <= len(words) <= DOCUMENT_SEARCH_MAX_TERM_WORDS:
+        return None
+    if any(
+        character in _FORBIDDEN_TERM_CHARS or unicodedata.category(character).startswith("C")
+        for character in term
+    ):
+        return None
+    if any(word.startswith("-") for word in words):
+        return None
+    if not all(character.isalnum() or character.isspace() or character in "_'’-" for character in term):
+        return None
+    return " ".join(words)
+
+
+def _normalized(value: str, *, case_sensitive: bool) -> str:
+    normalized = unicodedata.normalize("NFKC", value)
+    return normalized if case_sensitive else normalized.casefold()
+
+
+def _language(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if _LANGUAGE_RE.fullmatch(normalized) else None
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise DuplicateDocumentPlanKey(key)
+        value[key] = item
+    return value

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -5,11 +5,25 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable
 import json
 import re
+import time
 
 from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.runtime.completion_budget import CompletionBudget, resolve_max_tokens
 from orbit.runtime.continue_controller import ContinueController
+from orbit.runtime.document_search import (
+    DOCUMENT_SEARCH_PLAN_MAX_TOKENS,
+    concept_document_search_answer,
+    document_search_blocked_answer,
+    document_search_plan_messages,
+    document_search_verification_messages,
+    identify_document_search_request,
+    literal_document_search_answer,
+    parse_document_concept_verification,
+    parse_document_search_plan,
+    search_document_snapshot,
+    stratified_language_samples,
+)
 from orbit.runtime.file_input_resolver import FileInputResolver
 from orbit.runtime.file_tools import read_full_document_snapshot
 from orbit.runtime.final_policy import (
@@ -26,6 +40,8 @@ from orbit.runtime.final_policy import (
     looks_like_incomplete_final,
 )
 from orbit.runtime.full_document import (
+    FullDocumentAdmission,
+    assess_full_document_admission,
     attest_full_document_snapshot,
     exact_coverage_notice,
     file_display_coverage_notice,
@@ -40,7 +56,7 @@ from orbit.runtime.full_document import (
     targeted_search_coverage_notice,
     targeted_search_no_match_notice,
 )
-from orbit.runtime.kv_diag import current_tools_mode, model_call_context
+from orbit.runtime.kv_diag import current_tools_mode, emit_document_search, model_call_context
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import TOOL_CALL_JSON_RETRY_PROMPT
 from orbit.runtime.thinking_mode import ThinkingMode, last_assistant_has_open_reasoning
@@ -431,12 +447,17 @@ class FullDocumentPreflightEnvironment:
                 },
             )
         try:
-            return self._answer_snapshot(
+            admission = assess_full_document_admission(
+                self.runtime.backend,
                 prompt,
-                snapshot=snapshot,
+                snapshot,
+                max_tokens=max_tokens,
+                workdir=workdir,
+            )
+            return self.answer_admitted_snapshot(
+                admission,
                 route_result=route_result,
                 temperature=temperature,
-                max_tokens=max_tokens,
                 workdir=workdir,
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
@@ -447,66 +468,22 @@ class FullDocumentPreflightEnvironment:
             if record is not None and self.runtime.evidence_store is not None:
                 self.runtime.evidence_store.discard(record.evidence_id)
 
-    def _answer_snapshot(
+    def answer_admitted_snapshot(
         self,
-        prompt: str,
+        admission: FullDocumentAdmission,
         *,
-        snapshot,
-        route_result: ChatResult,
+        route_result: ChatResult | None,
         temperature: float,
-        max_tokens: int,
         workdir: Path,
         on_final_delta: Callable[[str], None] | None,
         on_progress: Callable[[StreamProgress], None] | None,
         on_model_step: Callable[[ModelStepMetrics], None] | None,
         on_phase_start: Callable[[ModelPhaseStart], None] | None,
-    ) -> ChatResult:
-        user_message: Message = {"role": "user", "content": prompt}
-        output_reserve = resolve_max_tokens(
-            "final_from_tool",
-            max_tokens,
-            evidence_kind="read",
-            evidence_chars=snapshot.char_count,
-        )
-        reason = full_document_control_marker(snapshot)
-        reason = f"unsafe_model_control_markup:{reason}" if reason is not None else None
-        messages: list[Message] | None = None
-        first_count = second_count = text_count = None
-        if reason is None:
-            try:
-                messages = full_document_messages(user_message, snapshot)
-            except ValueError:
-                reason = "document_delimiter_collision"
-            else:
-                count_chat = getattr(self.runtime.backend, "count_chat_tokens", None)
-                count_text = getattr(self.runtime.backend, "count_text_tokens", None)
-                first_count = count_chat(messages, tools=None, thinking=False) if callable(count_chat) else None
-                text_count = count_text(snapshot.content) if callable(count_text) else None
-                second_count = count_chat(messages, tools=None, thinking=False) if callable(count_chat) else None
-                if not _token_count_is_exact(first_count):
-                    reason = "exact_token_identity_unavailable"
-                elif not _same_token_attestation(first_count, second_count):
-                    reason = "tokenizer_template_or_context_changed"
-                else:
-                    source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
-                    if source_error is not None:
-                        reason = source_error
-
-        prompt_tokens = first_count.tokens if first_count is not None else None
-        active_context = first_count.context_tokens if first_count is not None else None
-        file_tokens = text_count.tokens if text_count is not None else None
-        required_context = (
-            required_full_document_context(prompt_tokens, output_reserve)
-            if prompt_tokens is not None
-            else None
-        )
-        if (
-            reason is None
-            and messages is not None
-            and required_context is not None
-            and active_context is not None
-            and required_context <= active_context
-        ):
+        coverage_prefix: str = "",
+    ) -> ChatResult | None:
+        snapshot = admission.snapshot
+        if admission.compatible:
+            assert admission.messages is not None
             if on_phase_start is not None:
                 on_phase_start(
                     ModelPhaseStart(
@@ -520,9 +497,9 @@ class FullDocumentPreflightEnvironment:
             with self.transport.backend_thinking(False):
                 with model_call_context(phase="full_document", tools_mode="on"):
                     result = self.transport.chat_once(
-                        messages,
+                        list(admission.messages),
                         temperature=temperature,
-                        max_tokens=output_reserve,
+                        max_tokens=admission.output_reserve,
                         on_final_delta=buffered_deltas.append if buffered_deltas is not None else None,
                         on_progress=on_progress,
                     )
@@ -539,7 +516,7 @@ class FullDocumentPreflightEnvironment:
                     on_final_delta(notice)
                 self.runtime.messages.append({"role": "assistant", "content": notice})
                 return blocked
-            prefix = exact_coverage_notice(snapshot)
+            prefix = coverage_prefix + exact_coverage_notice(snapshot)
             if on_final_delta is not None:
                 on_final_delta(prefix)
                 if result.content:
@@ -547,19 +524,18 @@ class FullDocumentPreflightEnvironment:
             result = replace(result, content=prefix + result.content)
             self.runtime.messages.append({"role": "assistant", "content": result.content})
             return result
-
-        if reason is None:
-            reason = "context_too_small"
+        if route_result is None:
+            return None
         return self._blocked(
             route_result,
             full_document_blocked_notice(
                 snapshot,
-                reason=reason,
-                file_tokens=file_tokens,
-                prompt_tokens=prompt_tokens,
-                output_reserve=output_reserve,
-                required_context=required_context,
-                active_context=active_context,
+                reason=admission.reason or "context_too_small",
+                file_tokens=admission.file_tokens,
+                prompt_tokens=admission.prompt_tokens,
+                output_reserve=admission.output_reserve,
+                required_context=admission.required_context,
+                active_context=admission.active_context,
             ),
             on_final_delta=on_final_delta,
         )
@@ -578,27 +554,426 @@ class FullDocumentPreflightEnvironment:
         return result
 
 
-def _token_count_is_exact(value) -> bool:
-    return (
-        value is not None
-        and isinstance(value.tokens, int)
-        and isinstance(value.context_tokens, int)
-        and isinstance(value.rendered_hash, str)
-        and len(value.rendered_hash) == 64
-        and isinstance(value.token_hash, str)
-        and len(value.token_hash) == 64
+@dataclass(frozen=True)
+class DocumentSearchEnvironment:
+    runtime: ChatRuntime
+    transport: TransportEnvironment
+    full_document: FullDocumentPreflightEnvironment
+
+    def answer_if_eligible(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        workdir: Path,
+        allowed_tool_names: tuple[str, ...] | None,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+    ) -> ChatResult | None:
+        intent = identify_document_search_request(prompt)
+        if intent is None:
+            return None
+        if allowed_tool_names is not None and "exec_shell_full_command" not in allowed_tool_names:
+            return None
+        raw = read_full_document_snapshot(intent.path, workdir=workdir)
+        if raw.startswith("error:"):
+            return self._visible(
+                _runtime_result(
+                    document_search_blocked_answer(
+                        intent.path,
+                        reason=raw.removeprefix("error:").strip().replace(" ", "_")[:160],
+                    )
+                ),
+                on_final_delta=on_final_delta,
+            )
+        snapshot = parse_full_document_snapshot(raw)
+        if snapshot is None:
+            return self._visible(
+                _runtime_result(document_search_blocked_answer(intent.path, reason="snapshot_integrity_failure")),
+                on_final_delta=on_final_delta,
+            )
+        marker = full_document_control_marker(snapshot)
+        if marker is not None:
+            return self._visible(
+                _runtime_result(
+                    document_search_blocked_answer(
+                        intent.path,
+                        reason=f"unsafe_model_control_markup:{marker}",
+                        snapshot=snapshot,
+                    )
+                ),
+                on_final_delta=on_final_delta,
+            )
+
+        record = None
+        if self.runtime.evidence_store is not None:
+            record = self.runtime.evidence_store.add(
+                "document_search",
+                raw,
+                metadata={
+                    "ephemeral": "full_document_snapshot",
+                    "mode": intent.mode,
+                    "path": snapshot.path,
+                },
+            )
+        try:
+            if intent.mode == "literal":
+                assert intent.literal_term is not None
+                return self._literal(
+                    intent.literal_term,
+                    whole_word=intent.whole_word,
+                    case_sensitive=intent.case_sensitive,
+                    snapshot=snapshot,
+                    workdir=workdir,
+                    on_final_delta=on_final_delta,
+                )
+            return self._concept(
+                prompt,
+                snapshot=snapshot,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                workdir=workdir,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
+            )
+        finally:
+            if record is not None and self.runtime.evidence_store is not None:
+                self.runtime.evidence_store.discard(record.evidence_id)
+
+    def _literal(
+        self,
+        term: str,
+        *,
+        whole_word: bool,
+        case_sensitive: bool,
+        snapshot,
+        workdir: Path,
+        on_final_delta: Callable[[str], None] | None,
+    ) -> ChatResult:
+        started = time.monotonic()
+        source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+        if source_error is not None:
+            return self._visible(
+                _runtime_result(document_search_blocked_answer(snapshot.path, reason=source_error, snapshot=snapshot)),
+                on_final_delta=on_final_delta,
+            )
+        result = search_document_snapshot(
+            snapshot,
+            mode="literal",
+            terms=(term,),
+            case_sensitive=case_sensitive,
+            whole_word=whole_word,
+        )
+        source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+        if source_error is not None:
+            return self._visible(
+                _runtime_result(document_search_blocked_answer(snapshot.path, reason=source_error, snapshot=snapshot)),
+                on_final_delta=on_final_delta,
+            )
+        emit_document_search(
+            {
+                "route": "deterministic_document_search",
+                "search_mode": "literal",
+                "document_languages": [],
+                "term_count": 1,
+                "total_matches": result.total_matches,
+                "returned_windows": len(result.windows),
+                "results_truncated": result.results_truncated,
+                "full_document_escalation": False,
+                "fallback_reason": None,
+                "planning_ms": 0.0,
+                "search_ms": _elapsed_ms(started),
+            }
+        )
+        return self._visible(
+            _runtime_result(literal_document_search_answer(result, whole_word=whole_word)),
+            on_final_delta=on_final_delta,
+        )
+
+    def _concept(
+        self,
+        prompt: str,
+        *,
+        snapshot,
+        temperature: float,
+        max_tokens: int,
+        workdir: Path,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+    ) -> ChatResult:
+        samples = stratified_language_samples(snapshot)
+        plan_messages = document_search_plan_messages(prompt, snapshot, samples)
+        if on_phase_start is not None:
+            on_phase_start(ModelPhaseStart("document_search_plan", streamed=False, attempt=1, reason="concept_terms"))
+        plan_started = time.monotonic()
+        with self.transport.backend_thinking(False):
+            with model_call_context(phase="document_search_plan", tools_mode="on"):
+                plan_result = self.transport.chat_once(
+                    plan_messages,
+                    temperature=temperature,
+                    max_tokens=DOCUMENT_SEARCH_PLAN_MAX_TOKENS,
+                    on_final_delta=None,
+                    on_progress=on_progress,
+                )
+        planning_ms = _elapsed_ms(plan_started)
+        if on_model_step is not None:
+            on_model_step(ModelStepMetrics.from_result(loop=1, result=plan_result, phase="document_search_plan"))
+        if plan_result.finish_reason in {"cancelled", "timeout"}:
+            self.runtime.messages.append({"role": "assistant", "content": plan_result.content})
+            return plan_result
+        if plan_result.finish_reason != "stop":
+            return self._visible(
+                replace(
+                    plan_result,
+                    content=document_search_blocked_answer(
+                        snapshot.path,
+                        reason=f"planner_finish_reason:{plan_result.finish_reason}",
+                        snapshot=snapshot,
+                    ),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+        plan, plan_error = parse_document_search_plan(plan_result.content)
+        if plan is None:
+            emit_document_search(
+                {
+                    "route": "deterministic_document_search",
+                    "search_mode": "concept",
+                    "document_languages": [],
+                    "term_count": 0,
+                    "total_matches": 0,
+                    "returned_windows": 0,
+                    "results_truncated": False,
+                    "full_document_escalation": False,
+                    "fallback_reason": plan_error,
+                    "planning_ms": planning_ms,
+                    "search_ms": 0.0,
+                }
+            )
+            return self._visible(
+                replace(
+                    plan_result,
+                    content=document_search_blocked_answer(
+                        snapshot.path,
+                        reason=plan_error or "invalid_plan",
+                        snapshot=snapshot,
+                    ),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+        source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+        if source_error is not None:
+            return self._visible(
+                replace(
+                    plan_result,
+                    content=document_search_blocked_answer(snapshot.path, reason=source_error, snapshot=snapshot),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+
+        search_started = time.monotonic()
+        search_result = search_document_snapshot(
+            snapshot,
+            mode="concept",
+            terms=plan.terms,
+            document_languages=plan.document_languages,
+            whole_word=True,
+        )
+        search_ms = _elapsed_ms(search_started)
+        source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+        if source_error is not None:
+            return self._visible(
+                replace(
+                    plan_result,
+                    content=document_search_blocked_answer(snapshot.path, reason=source_error, snapshot=snapshot),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+
+        if search_result.total_matches == 0:
+            admission = assess_full_document_admission(
+                self.runtime.backend,
+                prompt,
+                snapshot,
+                max_tokens=max_tokens,
+                workdir=workdir,
+            )
+            if admission.compatible:
+                emit_document_search(
+                    {
+                        "route": "deterministic_document_search",
+                        "search_mode": "concept",
+                        "document_languages": list(plan.document_languages),
+                        "term_count": len(plan.terms),
+                        "total_matches": 0,
+                        "returned_windows": 0,
+                        "results_truncated": False,
+                        "full_document_escalation": True,
+                        "fallback_reason": None,
+                        "planning_ms": planning_ms,
+                        "search_ms": search_ms,
+                    }
+                )
+                prefix = (
+                    "Document search escalation: initial_scan_coverage=complete; "
+                    "initial_semantic_coverage=partial; initial_matches=0; initial_search_mode=concept; "
+                    "escalation=full_document.\n"
+                    "Full-document analysis coverage: file_coverage=complete; scan_coverage=complete; "
+                    "semantic_coverage=complete; search_mode=full_document.\n"
+                )
+                complete = self.full_document.answer_admitted_snapshot(
+                    admission,
+                    route_result=None,
+                    temperature=temperature,
+                    workdir=workdir,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
+                    coverage_prefix=prefix,
+                )
+                assert complete is not None
+                return complete
+            emit_document_search(
+                {
+                    "route": "deterministic_document_search",
+                    "search_mode": "concept",
+                    "document_languages": list(plan.document_languages),
+                    "term_count": len(plan.terms),
+                    "total_matches": 0,
+                    "returned_windows": 0,
+                    "results_truncated": False,
+                    "full_document_escalation": False,
+                    "fallback_reason": admission.reason,
+                    "planning_ms": planning_ms,
+                    "search_ms": search_ms,
+                }
+            )
+            return self._visible(
+                replace(
+                    plan_result,
+                    content=concept_document_search_answer(
+                        search_result,
+                        None,
+                        fallback_reason=admission.reason,
+                    ),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+
+        verify_messages = document_search_verification_messages(prompt, search_result)
+        if on_phase_start is not None:
+            on_phase_start(ModelPhaseStart("document_search_verify", streamed=False, attempt=1, reason="match_relevance"))
+        with self.transport.backend_thinking(False):
+            with model_call_context(phase="document_search_verify", tools_mode="on"):
+                verification_result = self.transport.chat_once(
+                    verify_messages,
+                    temperature=temperature,
+                    max_tokens=resolve_max_tokens(
+                        "final_from_tool",
+                        max_tokens,
+                        evidence_kind="read",
+                        evidence_chars=sum(len(window.text) for window in search_result.windows),
+                    ),
+                    on_final_delta=None,
+                    on_progress=on_progress,
+                )
+        if on_model_step is not None:
+            on_model_step(
+                ModelStepMetrics.from_result(loop=2, result=verification_result, phase="document_search_verify")
+            )
+        if verification_result.finish_reason in {"cancelled", "timeout"}:
+            self.runtime.messages.append({"role": "assistant", "content": verification_result.content})
+            return verification_result
+        if verification_result.finish_reason != "stop":
+            verification = None
+            verification_error = f"verification_finish_reason:{verification_result.finish_reason}"
+        else:
+            verification, verification_error = parse_document_concept_verification(
+                verification_result.content,
+                valid_line_ranges=search_result.evidence_line_ranges,
+            )
+        source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+        if source_error is not None:
+            return self._visible(
+                replace(
+                    verification_result,
+                    content=document_search_blocked_answer(snapshot.path, reason=source_error, snapshot=snapshot),
+                    finish_reason="stop",
+                    tool_calls=[],
+                ),
+                on_final_delta=on_final_delta,
+            )
+        emit_document_search(
+            {
+                "route": "deterministic_document_search",
+                "search_mode": "concept",
+                "document_languages": list(plan.document_languages),
+                "term_count": len(plan.terms),
+                "total_matches": search_result.total_matches,
+                "returned_windows": len(search_result.windows),
+                "results_truncated": search_result.results_truncated,
+                "full_document_escalation": False,
+                "fallback_reason": verification_error,
+                "planning_ms": planning_ms,
+                "search_ms": search_ms,
+            }
+        )
+        content = concept_document_search_answer(
+            search_result,
+            verification,
+            fallback_reason=verification_error,
+        )
+        return self._visible(
+            replace(verification_result, content=content, finish_reason="stop", tool_calls=[]),
+            on_final_delta=on_final_delta,
+        )
+
+    def _visible(
+        self,
+        result: ChatResult,
+        *,
+        on_final_delta: Callable[[str], None] | None,
+    ) -> ChatResult:
+        if on_final_delta is not None and result.content:
+            on_final_delta(result.content)
+        self.runtime.messages.append({"role": "assistant", "content": result.content})
+        return result
+
+
+def _runtime_result(content: str) -> ChatResult:
+    return ChatResult(
+        content=content,
+        model=None,
+        finish_reason="stop",
+        tool_calls=[],
+        prompt_tokens=0,
+        completion_tokens=0,
+        cached_tokens=0,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
     )
 
 
-def _same_token_attestation(first, second) -> bool:
-    return (
-        _token_count_is_exact(first)
-        and _token_count_is_exact(second)
-        and first.tokens == second.tokens
-        and first.context_tokens == second.context_tokens
-        and first.rendered_hash == second.rendered_hash
-        and first.token_hash == second.token_hash
-    )
+def _elapsed_ms(started: float) -> float:
+    return round((time.monotonic() - started) * 1000.0, 3)
 
 
 @dataclass(frozen=True)

--- a/src/orbit/runtime/full_document.py
+++ b/src/orbit/runtime/full_document.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 
 from orbit.backend.base import Message
+from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.file_tools import FULL_DOCUMENT_SNAPSHOT_MARKER, read_full_document_snapshot
 from orbit.runtime.messages import with_final_tool_system_prompt
 from orbit.runtime.path_guardrails import TEXT_EXTENSIONS
@@ -78,6 +79,22 @@ class FullDocumentRequest:
     path: str
 
 
+@dataclass(frozen=True)
+class FullDocumentAdmission:
+    snapshot: FullDocumentSnapshot
+    messages: tuple[Message, ...] | None
+    output_reserve: int
+    file_tokens: int | None
+    prompt_tokens: int | None
+    required_context: int | None
+    active_context: int | None
+    reason: str | None
+
+    @property
+    def compatible(self) -> bool:
+        return self.reason is None and self.messages is not None
+
+
 def identify_full_document_request(prompt: str) -> FullDocumentRequest | None:
     """Recognize only explicit full-read forms with one syntactic local path."""
     if not isinstance(prompt, str) or not prompt or len(prompt) > FULL_DOCUMENT_REQUEST_MAX_CHARS:
@@ -87,7 +104,7 @@ def identify_full_document_request(prompt: str) -> FullDocumentRequest | None:
         return None
     if not any(pattern.search(prompt) for pattern in _EXPLICIT_FULL_DOCUMENT_PATTERNS):
         return None
-    paths = _document_path_candidates(prompt)
+    paths = document_path_candidates(prompt)
     if len(paths) != 1:
         return None
     return FullDocumentRequest(path=paths[0])
@@ -116,7 +133,7 @@ def attest_full_document_snapshot(snapshot: FullDocumentSnapshot, *, workdir: Pa
     return None
 
 
-def _document_path_candidates(prompt: str) -> list[str]:
+def document_path_candidates(prompt: str) -> list[str]:
     values: list[str] = []
     occupied: list[tuple[int, int]] = []
     for match in _QUOTED_PATH_RE.finditer(prompt):
@@ -146,6 +163,94 @@ def _clean_document_path(value: str) -> str | None:
 
 def required_full_document_context(prompt_tokens: int, output_reserve: int) -> int:
     return prompt_tokens + output_reserve + FULL_DOCUMENT_SAFETY_MARGIN_TOKENS
+
+
+def assess_full_document_admission(
+    backend,
+    prompt: str,
+    snapshot: FullDocumentSnapshot,
+    *,
+    max_tokens: int,
+    workdir: Path,
+) -> FullDocumentAdmission:
+    output_reserve = resolve_max_tokens(
+        "final_from_tool",
+        max_tokens,
+        evidence_kind="read",
+        evidence_chars=snapshot.char_count,
+    )
+    reason = full_document_control_marker(snapshot)
+    reason = f"unsafe_model_control_markup:{reason}" if reason is not None else None
+    messages: list[Message] | None = None
+    first_count = second_count = text_count = None
+    if reason is None:
+        try:
+            messages = full_document_messages({"role": "user", "content": prompt}, snapshot)
+        except ValueError:
+            reason = "document_delimiter_collision"
+        else:
+            count_chat = getattr(backend, "count_chat_tokens", None)
+            count_text = getattr(backend, "count_text_tokens", None)
+            first_count = count_chat(messages, tools=None, thinking=False) if callable(count_chat) else None
+            text_count = count_text(snapshot.content) if callable(count_text) else None
+            second_count = count_chat(messages, tools=None, thinking=False) if callable(count_chat) else None
+            if not _token_count_is_exact(first_count):
+                reason = "exact_token_identity_unavailable"
+            elif not _same_token_attestation(first_count, second_count):
+                reason = "tokenizer_template_or_context_changed"
+            else:
+                source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+                if source_error is not None:
+                    reason = source_error
+
+    prompt_tokens = first_count.tokens if first_count is not None else None
+    active_context = first_count.context_tokens if first_count is not None else None
+    file_tokens = text_count.tokens if text_count is not None else None
+    required_context = (
+        required_full_document_context(prompt_tokens, output_reserve)
+        if prompt_tokens is not None
+        else None
+    )
+    if (
+        reason is None
+        and required_context is not None
+        and active_context is not None
+        and required_context > active_context
+    ):
+        reason = "context_too_small"
+    return FullDocumentAdmission(
+        snapshot=snapshot,
+        messages=tuple(messages) if messages is not None else None,
+        output_reserve=output_reserve,
+        file_tokens=file_tokens,
+        prompt_tokens=prompt_tokens,
+        required_context=required_context,
+        active_context=active_context,
+        reason=reason,
+    )
+
+
+def _token_count_is_exact(value) -> bool:
+    return (
+        value is not None
+        and isinstance(value.tokens, int)
+        and isinstance(value.context_tokens, int)
+        and isinstance(value.rendered_hash, str)
+        and len(value.rendered_hash) == 64
+        and isinstance(value.token_hash, str)
+        and len(value.token_hash) == 64
+    )
+
+
+def _same_token_attestation(first, second) -> bool:
+    return (
+        _token_count_is_exact(first)
+        and _token_count_is_exact(second)
+        and first.tokens == second.tokens
+        and first.context_tokens == second.context_tokens
+        and first.rendered_hash == second.rendered_hash
+        and first.token_hash == second.token_hash
+    )
 
 
 def parse_full_document_snapshot(raw: str) -> FullDocumentSnapshot | None:

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -586,6 +586,30 @@ def emit_evidence_lineage(metadata: dict[str, Any]) -> None:
     _emit(event)
 
 
+def emit_document_search(metadata: dict[str, Any]) -> None:
+    if not enabled():
+        return
+    languages = metadata.get("document_languages")
+    languages = languages if isinstance(languages, list) else []
+    event = {
+        "event": "document_search",
+        "route": _safe_str(metadata.get("route")),
+        "search_mode": _safe_str(metadata.get("search_mode")),
+        "document_languages": [
+            value[:16] for value in languages[:3] if isinstance(value, str) and value
+        ],
+        "term_count": _safe_int(metadata.get("term_count")),
+        "total_matches": _safe_int(metadata.get("total_matches")),
+        "returned_windows": _safe_int(metadata.get("returned_windows")),
+        "results_truncated": bool(metadata.get("results_truncated")),
+        "full_document_escalation": bool(metadata.get("full_document_escalation")),
+        "fallback_reason": _safe_str(metadata.get("fallback_reason")),
+        "planning_ms": _safe_float(metadata.get("planning_ms")),
+        "search_ms": _safe_float(metadata.get("search_ms")),
+    }
+    _emit(event)
+
+
 def _next_call_context(phase: str, tools_mode: str | None) -> dict[str, Any]:
     request = _REQUEST.get()
     call_id = next(_CALL_IDS)
@@ -696,6 +720,13 @@ def _safe_int(value: object) -> int | None:
 
 def _safe_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _safe_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    return round(numeric, 3) if numeric >= 0 and numeric == numeric else None
 
 
 def _component_changes(request_id: str | None, phase: str, tools_mode: str | None, fingerprint: PromptFingerprint) -> list[str]:

--- a/tests/test_document_search.py
+++ b/tests/test_document_search.py
@@ -1,0 +1,845 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult, TokenCount
+from orbit.runtime import ChatRuntime
+from orbit.runtime.document_search import (
+    DocumentSearchPlan,
+    concept_document_search_answer,
+    identify_document_search_request,
+    parse_document_concept_verification,
+    parse_document_search_plan,
+    search_document_snapshot,
+    stratified_language_samples,
+)
+from orbit.runtime.evidence import EvidenceStore
+from orbit.runtime.file_tools import read_full_document_snapshot
+from orbit.runtime.full_document import parse_full_document_snapshot
+from orbit.runtime.tools import tool_definitions
+
+
+def _chat_result(content: str, *, finish_reason: str = "stop") -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=[],
+        prompt_tokens=100,
+        completion_tokens=10,
+        cached_tokens=0,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
+    )
+
+
+class SearchBackend:
+    def __init__(self, responses: list[ChatResult], *, prompt_tokens: int = 100, context_tokens: int = 8192) -> None:
+        self.responses = list(responses)
+        self.prompt_tokens = prompt_tokens
+        self.context_tokens = context_tokens
+        self.calls = 0
+        self.messages_by_call: list[list[dict[str, object]]] = []
+        self.tools_by_call: list[object] = []
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        self.calls += 1
+        self.messages_by_call.append(messages)
+        self.tools_by_call.append(tools)
+        if not self.responses:
+            raise AssertionError("unexpected model call")
+        return self.responses.pop(0)
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None):
+        result = self.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+        if on_delta is not None and result.content:
+            on_delta(result.content)
+        return result
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        return TokenCount(
+            tokens=self.prompt_tokens,
+            context_tokens=self.context_tokens,
+            rendered_hash="a" * 64,
+            token_hash="b" * 64,
+        )
+
+    def count_text_tokens(self, text):
+        return TokenCount(tokens=max(1, len(text) // 4), context_tokens=self.context_tokens)
+
+
+class DocumentSearchPrimitiveTests(unittest.TestCase):
+    def _snapshot(self, content: str):
+        temporary = tempfile.TemporaryDirectory()
+        workdir = Path(temporary.name)
+        (workdir / "note.txt").write_text(content, encoding="utf-8")
+        snapshot = parse_full_document_snapshot(read_full_document_snapshot("note.txt", workdir=workdir))
+        self.addCleanup(temporary.cleanup)
+        assert snapshot is not None
+        return workdir, snapshot
+
+    def test_literal_matches_beginning_after_100_and_last_line(self) -> None:
+        lines = ["target first\n", *[f"line {index}\n" for index in range(2, 151)], "target last\n"]
+        _, snapshot = self._snapshot("".join(lines))
+
+        result = search_document_snapshot(snapshot, mode="literal", terms=("target",), context_before=0, context_after=0)
+
+        self.assertEqual(result.total_matches, 2)
+        self.assertEqual(result.line_ranges, ("1-1", "151-151"))
+        self.assertEqual(result.evidence_line_ranges, ("1-1", "151-151", "1", "151"))
+        self.assertEqual(result.scan_coverage, "complete")
+        self.assertEqual(result.semantic_coverage, "exact")
+
+    def test_literal_absence_is_exact_complete_scan(self) -> None:
+        _, snapshot = self._snapshot("alpha\nbeta\n")
+
+        result = search_document_snapshot(snapshot, mode="literal", terms=("gamma",))
+
+        self.assertEqual(result.total_matches, 0)
+        self.assertEqual(result.file_coverage, "none")
+        self.assertEqual(result.scan_coverage, "complete")
+        self.assertEqual(result.semantic_coverage, "exact")
+
+    def test_phrase_casefold_unicode_and_nfkc(self) -> None:
+        _, snapshot = self._snapshot("ACCESS CONTROL\nCaffè sicuro\nＡＩ systems\n")
+
+        phrase = search_document_snapshot(snapshot, mode="literal", terms=("access control",), whole_word=False)
+        accent = search_document_snapshot(snapshot, mode="literal", terms=("CAFFÈ",))
+        nfkc = search_document_snapshot(snapshot, mode="literal", terms=("AI",))
+
+        self.assertEqual((phrase.total_matches, accent.total_matches, nfkc.total_matches), (1, 1, 1))
+
+    def test_whole_word_does_not_match_substring(self) -> None:
+        _, snapshot = self._snapshot("inferno infernale superinferno\n")
+
+        word = search_document_snapshot(snapshot, mode="literal", terms=("inferno",), whole_word=True)
+        substring = search_document_snapshot(snapshot, mode="literal", terms=("inferno",), whole_word=False)
+
+        self.assertEqual(word.total_matches, 1)
+        self.assertEqual(substring.total_matches, 2)
+
+    def test_overlapping_windows_are_merged(self) -> None:
+        _, snapshot = self._snapshot("one\ntarget\nmiddle\ntarget\nfive\n")
+
+        result = search_document_snapshot(snapshot, mode="literal", terms=("target",), context_before=1, context_after=1)
+
+        self.assertEqual(result.total_matches, 2)
+        self.assertEqual(len(result.windows), 1)
+        self.assertEqual(result.line_ranges, ("1-5",))
+
+    def test_total_count_survives_window_truncation(self) -> None:
+        content = "".join(f"target {index}\nfiller\n" for index in range(20))
+        _, snapshot = self._snapshot(content)
+
+        result = search_document_snapshot(
+            snapshot,
+            mode="literal",
+            terms=("target",),
+            context_before=0,
+            context_after=0,
+            max_windows=3,
+        )
+
+        self.assertEqual(result.total_matches, 20)
+        self.assertEqual(len(result.windows), 3)
+        self.assertTrue(result.results_truncated)
+
+    def test_truncated_long_line_keeps_the_match_visible(self) -> None:
+        _, snapshot = self._snapshot("a" * 8_000 + " TARGET " + "z" * 8_000 + "\n")
+
+        result = search_document_snapshot(
+            snapshot,
+            mode="literal",
+            terms=("target",),
+            context_before=0,
+            context_after=0,
+        )
+
+        self.assertEqual(result.total_matches, 1)
+        self.assertEqual(len(result.windows), 1)
+        self.assertTrue(result.windows[0].text_truncated)
+        self.assertTrue(result.results_truncated)
+        self.assertIn("TARGET", result.windows[0].text)
+        self.assertGreater(result.windows[0].text_char_start, 0)
+
+    def test_truncated_window_counts_only_visible_matches_as_returned(self) -> None:
+        _, snapshot = self._snapshot("TARGET " + "x" * 8_000 + " TARGET\n")
+
+        result = search_document_snapshot(
+            snapshot,
+            mode="literal",
+            terms=("target",),
+            context_before=0,
+            context_after=0,
+        )
+
+        self.assertEqual(result.total_matches, 2)
+        self.assertEqual(result.returned_match_count, 1)
+        self.assertEqual(result.windows[0].match_count, 1)
+        self.assertTrue(result.results_truncated)
+
+    def test_concept_terms_are_deduplicated_before_search(self) -> None:
+        _, snapshot = self._snapshot("damnation and hell\n")
+
+        result = search_document_snapshot(snapshot, mode="concept", terms=("hell", "HELL", "damnation"))
+
+        self.assertEqual(result.searched_terms, ("hell", "damnation"))
+        self.assertEqual(result.total_matches, 2)
+        self.assertEqual(result.semantic_coverage, "partial")
+
+    def test_language_samples_are_stratified(self) -> None:
+        _, snapshot = self._snapshot("".join(f"line {index}\n" for index in range(300)))
+
+        samples = stratified_language_samples(snapshot, max_chars=80)
+
+        self.assertEqual(len(samples), 3)
+        self.assertEqual(samples[0].start_line, 1)
+        self.assertLess(samples[0].end_line, samples[1].start_line)
+        self.assertGreater(samples[-1].end_line, 290)
+
+
+class DocumentSearchPlanTests(unittest.TestCase):
+    def _plan(self, **overrides) -> str:
+        value = {
+            "mode": "concept",
+            "query_language": "it",
+            "document_languages": ["en"],
+            "language_confidence": "high",
+            "terms_by_language": {"en": ["hell", "damnation", "underworld"]},
+        }
+        value.update(overrides)
+        return json.dumps(value)
+
+    def test_italian_question_english_document_plan(self) -> None:
+        plan, error = parse_document_search_plan(self._plan())
+
+        self.assertIsNone(error)
+        assert plan is not None
+        self.assertEqual(plan.query_language, "it")
+        self.assertEqual(plan.document_languages, ("en",))
+        self.assertEqual(plan.terms, ("hell", "damnation", "underworld"))
+
+    def test_english_question_italian_document_plan(self) -> None:
+        plan, error = parse_document_search_plan(
+            self._plan(
+                query_language="en",
+                document_languages=["it"],
+                terms_by_language={"it": ["inferno", "dannazione"]},
+            )
+        )
+
+        self.assertIsNone(error)
+        assert plan is not None
+        self.assertEqual(plan.document_languages, ("it",))
+        self.assertIn("dannazione", plan.terms)
+
+    def test_multilingual_plan(self) -> None:
+        plan, error = parse_document_search_plan(
+            self._plan(
+                document_languages=["it", "en"],
+                terms_by_language={"it": ["dannazione"], "en": ["damnation"]},
+            )
+        )
+
+        self.assertIsNone(error)
+        assert plan is not None
+        self.assertEqual(plan.document_languages, ("it", "en"))
+
+    def test_uncertain_language_requires_english_fallback(self) -> None:
+        plan, error = parse_document_search_plan(
+            self._plan(
+                document_languages=["it"],
+                language_confidence="uncertain",
+                terms_by_language={"it": ["inferno"]},
+            )
+        )
+
+        self.assertIsNone(plan)
+        self.assertEqual(error, "uncertain_plan_missing_english")
+
+    def test_invalid_json_duplicate_keys_and_schema_fail_closed(self) -> None:
+        values = (
+            "not json",
+            '{"mode":"concept","mode":"concept"}',
+            json.dumps({"mode": "concept"}),
+        )
+        for value in values:
+            with self.subTest(value=value):
+                plan, error = parse_document_search_plan(value)
+                self.assertIsNone(plan)
+                self.assertIsNotNone(error)
+
+    def test_regex_glob_path_and_shell_terms_are_rejected(self) -> None:
+        for term in ("hell.*", "*.txt", "../secret", "rm -rf /"):
+            with self.subTest(term=term):
+                plan, error = parse_document_search_plan(self._plan(terms_by_language={"en": [term]}))
+                self.assertIsNone(plan)
+                self.assertEqual(error, "unsafe_plan_term")
+
+    def test_more_than_twelve_terms_is_rejected(self) -> None:
+        terms = [f"term{index}" for index in range(13)]
+
+        plan, error = parse_document_search_plan(self._plan(terms_by_language={"en": terms}))
+
+        self.assertIsNone(plan)
+        self.assertEqual(error, "too_many_plan_terms")
+
+    def test_cross_language_duplicate_terms_are_deduplicated(self) -> None:
+        plan, error = parse_document_search_plan(
+            self._plan(
+                document_languages=["it", "en"],
+                terms_by_language={"it": ["Inferno"], "en": ["inferno", "hell"]},
+            )
+        )
+
+        self.assertIsNone(error)
+        assert plan is not None
+        self.assertEqual(plan.terms, ("Inferno", "hell"))
+
+    def test_no_terms_after_validation_is_rejected(self) -> None:
+        plan, error = parse_document_search_plan(self._plan(terms_by_language={"en": []}))
+
+        self.assertIsNone(plan)
+        self.assertEqual(error, "invalid_plan_terms")
+
+    def test_verification_requires_existing_evidence_range(self) -> None:
+        valid = json.dumps({"decision": "supported", "answer": "Relevant evidence.", "line_ranges": ["10-12"]})
+        invalid = json.dumps({"decision": "supported", "answer": "Invented.", "line_ranges": ["99-100"]})
+
+        accepted, accepted_error = parse_document_concept_verification(valid, valid_line_ranges=("10-12",))
+        rejected, rejected_error = parse_document_concept_verification(invalid, valid_line_ranges=("10-12",))
+
+        self.assertIsNone(accepted_error)
+        self.assertIsNotNone(accepted)
+        self.assertIsNone(rejected)
+        self.assertEqual(rejected_error, "invalid_verification_ranges")
+
+    def test_verification_accepts_an_exact_matched_line(self) -> None:
+        content = json.dumps({"decision": "supported", "answer": "Relevant evidence.", "line_ranges": ["10"]})
+
+        accepted, error = parse_document_concept_verification(
+            content,
+            valid_line_ranges=("8-12", "10"),
+        )
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(accepted)
+
+
+class DocumentSearchRoutingTests(unittest.TestCase):
+    def test_clear_literal_and_concept_requests_are_distinguished(self) -> None:
+        cases = {
+            "Compare esattamente la parola inferno in note.txt?": ("literal", "inferno"),
+            "Quante volte compare la frase access control in note.txt?": ("literal", "access control"),
+            "Does note.txt contain exactly the word inferno?": ("literal", "inferno"),
+            "Nel testo note.txt si parla di inferno?": ("concept", None),
+            "Does the document note.txt discuss cybersecurity?": ("concept", None),
+        }
+        for prompt, expected in cases.items():
+            with self.subTest(prompt=prompt):
+                intent = identify_document_search_request(prompt)
+                self.assertIsNotNone(intent)
+                assert intent is not None
+                self.assertEqual((intent.mode, intent.literal_term), expected)
+
+    def test_range_full_mutation_and_non_document_requests_do_not_intercept(self) -> None:
+        prompts = (
+            "Mostra le prime 100 righe di note.txt.",
+            "Read note.txt completely and summarize it.",
+            "Find the word alpha in note.txt and replace it.",
+            "Tell me about inferno.",
+        )
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertIsNone(identify_document_search_request(prompt))
+
+    def test_ambiguous_files_do_not_select_one(self) -> None:
+        self.assertIsNone(identify_document_search_request("Does a.txt or b.txt discuss cybersecurity?"))
+
+
+class DocumentSearchRuntimeTests(unittest.TestCase):
+    def _runtime(self, workdir: Path, backend: SearchBackend) -> ChatRuntime:
+        return ChatRuntime(
+            backend=backend,
+            system_prompt=None,
+            evidence_store=EvidenceStore(workdir / ".evidence"),
+        )
+
+    def test_literal_path_scans_without_route_or_cat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("".join(["start\n"] * 120 + ["inferno\n"]), encoding="utf-8")
+            backend = SearchBackend([])
+            runtime = self._runtime(workdir, backend)
+            tools: list[tuple[str, str]] = []
+
+            result = runtime.ask_auto(
+                "Compare esattamente la parola inferno in note.txt?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+                on_tool_call=lambda name, arguments: tools.append((name, arguments)),
+            )
+
+        self.assertEqual(backend.calls, 0)
+        self.assertEqual(tools, [])
+        self.assertIn("119-121", result.content)
+        self.assertIn("scan_coverage=complete", result.content)
+
+    def test_literal_missing_is_definitive_only_for_exact_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+            runtime = self._runtime(workdir, SearchBackend([]))
+
+            result = runtime.ask_auto(
+                "Compare esattamente la parola inferno in note.txt?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertIn("does not occur in the complete document", result.content)
+        self.assertIn("semantic_coverage=exact", result.content)
+
+    def test_multilingual_concept_plan_and_positive_verification(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell", "damnation"]},
+                }
+            )
+        )
+        verification = _chat_result(
+            json.dumps(
+                {
+                    "decision": "supported",
+                    "answer": "The passage explicitly discusses damnation.",
+                    "line_ranges": ["128-132"],
+                }
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            lines = ["neutral\n"] * 129 + ["eternal damnation is discussed here\n"] + ["neutral\n"] * 3
+            (workdir / "note.txt").write_text("".join(lines), encoding="utf-8")
+            backend = SearchBackend([plan, verification])
+            runtime = self._runtime(workdir, backend)
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(backend.tools_by_call, [None, None])
+        self.assertIn("document_languages=[\"en\"]", result.content)
+        self.assertIn("Supporting source ranges: 128-132", result.content)
+        self.assertIn("eternal damnation is discussed here", result.content)
+        self.assertNotIn("cat ", str(backend.messages_by_call))
+
+    def test_lexical_false_positive_cannot_become_definitive_negative(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell"]},
+                }
+            )
+        )
+        verification = _chat_result(
+            json.dumps(
+                {
+                    "decision": "lexical_only",
+                    "answer": "The phrase is merely an exclamation.",
+                    "line_ranges": ["1-1"],
+                }
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("what the hell\n", encoding="utf-8")
+            runtime = self._runtime(workdir, SearchBackend([plan, verification]))
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertIn("did not establish", result.content)
+        self.assertIn("does not exclude indirect formulations", result.content)
+
+    def test_length_truncated_verification_cannot_support_a_concept(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell"]},
+                }
+            )
+        )
+        truncated = _chat_result(
+            json.dumps(
+                {
+                    "decision": "supported",
+                    "answer": "The passage discusses hell.",
+                    "line_ranges": ["1"],
+                }
+            ),
+            finish_reason="length",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("hell is discussed here\n", encoding="utf-8")
+            runtime = self._runtime(workdir, SearchBackend([plan, truncated]))
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertNotIn("Supporting source ranges", result.content)
+        self.assertIn("did not establish", result.content)
+        self.assertIn("verification_finish_reason:length", result.content)
+
+    def test_no_match_outside_context_is_prudent(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell", "damnation"]},
+                }
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("neutral\n" * 200, encoding="utf-8")
+            backend = SearchBackend([plan], prompt_tokens=9000, context_tokens=8192)
+            runtime = self._runtime(workdir, backend)
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("No lexical references were found", result.content)
+        self.assertIn("does not exclude indirect formulations", result.content)
+        self.assertNotIn("does not discuss", result.content)
+
+    def test_no_match_that_fits_escalates_once_to_complete_document(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "en",
+                    "document_languages": ["it"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"it": ["sicurezza informatica"]},
+                }
+            )
+        )
+        complete = _chat_result("The complete document does not discuss cybersecurity.")
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("testo neutro\n", encoding="utf-8")
+            backend = SearchBackend([plan, complete], prompt_tokens=100, context_tokens=8192)
+            runtime = self._runtime(workdir, backend)
+
+            result = runtime.ask_auto(
+                "Does note.txt discuss cybersecurity?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 2)
+        self.assertIn("escalation=full_document", result.content)
+        self.assertIn("semantic_coverage=complete", result.content)
+        self.assertIn("Document coverage: complete", result.content)
+        self.assertIn("does not discuss cybersecurity", result.content)
+
+    def test_invalid_plan_fails_closed_without_shell_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("neutral\n", encoding="utf-8")
+            backend = SearchBackend([_chat_result("not-json")])
+            runtime = self._runtime(workdir, backend)
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("invalid_plan_json", result.content)
+        self.assertIn("scan_coverage=none", result.content)
+
+    def test_nonexistent_symlink_and_fifo_fail_before_model_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "target.txt").write_text("inferno\n", encoding="utf-8")
+            (workdir / "link.txt").symlink_to(workdir / "target.txt")
+            os.mkfifo(workdir / "pipe.txt")
+            for path in ("missing.txt", "link.txt", "pipe.txt"):
+                with self.subTest(path=path):
+                    backend = SearchBackend([])
+                    runtime = self._runtime(workdir, backend)
+                    result = runtime.ask_auto(
+                        f"Compare esattamente la parola inferno in {path}?",
+                        temperature=0,
+                        max_tokens=256,
+                        workdir=workdir,
+                    )
+                    self.assertEqual(backend.calls, 0)
+                    self.assertIn("scan_coverage=none", result.content)
+
+    def test_source_change_discards_literal_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("inferno\n", encoding="utf-8")
+            runtime = self._runtime(workdir, SearchBackend([]))
+            with patch(
+                "orbit.runtime.environments.attest_full_document_snapshot",
+                side_effect=[None, "source_identity_changed"],
+            ):
+                result = runtime.ask_auto(
+                    "Compare esattamente la parola inferno in note.txt?",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=workdir,
+                )
+
+        self.assertIn("source_identity_changed", result.content)
+        self.assertNotIn("occurs 1 time", result.content)
+
+    def test_ephemeral_snapshot_is_cleaned_on_success_and_planner_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("inferno\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            literal_runtime = ChatRuntime(backend=SearchBackend([]), system_prompt=None, evidence_store=store)
+            literal_runtime.ask_auto(
+                "Compare esattamente la parola inferno in note.txt?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+            self.assertEqual(list(store.root.glob("*.txt")), [])
+
+            failed_runtime = ChatRuntime(
+                backend=SearchBackend([_chat_result("invalid")]),
+                system_prompt=None,
+                evidence_store=store,
+            )
+            failed_runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+            self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_cancelled_planner_cleans_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("neutral\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            runtime = ChatRuntime(
+                backend=SearchBackend([_chat_result("", finish_reason="cancelled")]),
+                system_prompt=None,
+                evidence_store=store,
+            )
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+        self.assertEqual(result.finish_reason, "cancelled")
+        self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_planner_timeout_cleans_snapshot(self) -> None:
+        class TimeoutBackend(SearchBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                raise TimeoutError("timed out")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("neutral\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            runtime = ChatRuntime(backend=TimeoutBackend([]), system_prompt=None, evidence_store=store)
+
+            with self.assertRaises(TimeoutError):
+                runtime.ask_auto(
+                    "Nel testo note.txt si parla di inferno?",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=workdir,
+                )
+
+        self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_cancelled_verification_cleans_snapshot(self) -> None:
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell"]},
+                }
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("hell\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            runtime = ChatRuntime(
+                backend=SearchBackend([plan, _chat_result("", finish_reason="cancelled")]),
+                system_prompt=None,
+                evidence_store=store,
+            )
+
+            result = runtime.ask_auto(
+                "Nel testo note.txt si parla di inferno?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+            self.assertEqual(result.finish_reason, "cancelled")
+            self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_verification_timeout_cleans_snapshot(self) -> None:
+        class VerificationTimeoutBackend(SearchBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                if self.calls == 1:
+                    raise TimeoutError("timed out")
+                return super().chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+
+        plan = _chat_result(
+            json.dumps(
+                {
+                    "mode": "concept",
+                    "query_language": "it",
+                    "document_languages": ["en"],
+                    "language_confidence": "high",
+                    "terms_by_language": {"en": ["hell"]},
+                }
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("hell\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            runtime = ChatRuntime(
+                backend=VerificationTimeoutBackend([plan]),
+                system_prompt=None,
+                evidence_store=store,
+            )
+
+            with self.assertRaises(TimeoutError):
+                runtime.ask_auto(
+                    "Nel testo note.txt si parla di inferno?",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=workdir,
+                )
+
+            self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_reset_has_no_document_search_state_to_retain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("inferno\n", encoding="utf-8")
+            store = EvidenceStore(workdir / ".evidence")
+            runtime = ChatRuntime(backend=SearchBackend([]), system_prompt=None, evidence_store=store)
+            runtime.ask_auto(
+                "Compare esattamente la parola inferno in note.txt?",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+            )
+
+            runtime.reset()
+
+        self.assertEqual(runtime.messages, [])
+        self.assertEqual(store.records, {})
+        self.assertEqual(list(store.root.glob("*.txt")), [])
+
+    def test_diagnostics_are_bounded_and_do_not_log_terms_or_windows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            log_path = workdir / "diag.jsonl"
+            secret = "private-inferno-marker"
+            (workdir / "note.txt").write_text(secret + "\n", encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": str(log_path)},
+                clear=False,
+            ):
+                runtime = self._runtime(workdir, SearchBackend([]))
+                runtime.ask_auto(
+                    "Compare esattamente la parola private-inferno-marker in note.txt?",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=workdir,
+                )
+            events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+            search_events = [event for event in events if event.get("event") == "document_search"]
+
+        self.assertEqual(len(search_events), 1)
+        serialized = json.dumps(search_events[0])
+        self.assertNotIn(secret, serialized)
+        self.assertEqual(search_events[0]["term_count"], 1)
+        self.assertEqual(search_events[0]["total_matches"], 1)
+
+    def test_production_schema_remains_unchanged(self) -> None:
+        self.assertEqual(
+            [definition["function"]["name"] for definition in tool_definitions()],
+            ["exec_shell_full_command", "fetch_url", "list_directory", "system_info"],
+        )
+        self.assertNotIn("document_search", str(tool_definitions()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This change adds deterministic long-document literal and multilingual concept search without adding a model-visible tool or increasing the production tool prompt. It builds on the stable full-document snapshot and tokenizer admission path from #158.

## Problem solved

For targeted questions over long files, the normal shell path could expose only an initial bounded page and miss evidence later in the document. The runtime now recognizes unambiguous document-search requests before normal tool selection and scans one attested snapshot completely.

## Retained architecture

- literal search performs a complete deterministic scan with zero model calls, exact line evidence, Unicode NFKC/casefold handling, and exact total counts;
- concept search uses one bounded multilingual planner, a complete deterministic lexical scan of model-selected terms, and one verifier over exact bounded windows;
- concept negatives remain non-definitive unless tokenizer-proven full-document analysis completes in one call;
- full-document analysis still runs only when the exact production tokenizer proves the rendered prompt, output reserve, and safety margin fit;
- snapshot identity, SHA-256, O_NOFOLLOW, inode/version revalidation, SSD cleanup, and lifecycle failure handling remain authoritative;
- file, scan, and semantic coverage are reported separately.

Semantic chunking and map-reduce remain rejected because their measured CPU wall time and cumulative prefill were incompatible with usable latency. No RAG, embeddings, shell search, model-generated regex, or new production tool is introduced.

## Validation

- document-search tests: 42/42 PASS;
- shared runtime/path/evidence tests: 329/329 PASS;
- full discovery: 1,349/1,349 PASS;
- final-prefix/post-tool/native MTP focused tests: 42/42 PASS;
- native build and MTP shim: PASS;
- strict Gemma 4 26B-A4B draft MTP and mmproj smoke: PASS;
- production corpus: 12/12 operational PASS, all `finish_reason=stop`;
- tool-mode baseline: 708 tokens, delta 0;
- final-prefix default capture/restore: `cached=64`; kill switch: `cached=4`;
- compileall and `git diff --check`: PASS;
- no residual Orbit or llama processes.

Real-model 26B smokes passed literal sentinels at beginning, middle, and EOF with zero model calls. Italian-question/English-document, English-question/Italian-document, synonym-only, and positive citation cases returned exact supporting ranges. Partial no-match and incidental `what the hell` cases produced no false definitive negative or unsupported positive. Cancel, timeout, planner/verifier non-stop, and concurrent mutation paths failed safely and left zero residual snapshots.

CPU timings are descriptive, not deterministic performance claims.

## Known limits

- maximum 12 planner terms and 3 languages;
- semantic recall depends on model-selected planner terms;
- no definitive concept negative outside complete full-document semantic coverage;
- no semantic chunking or arbitrary large-file semantic scan;
- visible match counts include only matches represented in bounded evidence windows.

## Scope

The branch is based directly on current `origin/main` and contains one commit. Production tool schema and prompt sources are unchanged; `workdir/.miktex/` and `workdir/doc/` are excluded.