### PR TITLE
feat(native): add verified Qwen 3.6 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 
 ### RC24
 
-- Current published baseline: `v0.0.1-rc24`.
+- Published predecessor: `v0.0.1-rc24`.
 - Release URL: https://github.com/guelfoweb/orbit/releases/tag/v0.0.1-rc24
 - Release-notes commit: `41dbc63f19cd5d88a2b0f1aee1d44a29557bc431`.
 - Tag object: `52ce691fe724d3c8c6272345f24e07bcdfe684b7`.
@@ -185,6 +185,31 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   broad multi-deliverable agentic workflows. The production llama.cpp vendor
   remains `b9551` at upstream commit
   `379ac6673b5cd75c7b4e07d1521c50f1e093878c`.
+
+### RC25
+
+- Current published baseline: `v0.0.1-rc25`.
+- Release URL: https://github.com/guelfoweb/orbit/releases/tag/v0.0.1-rc25
+- Release-notes commit: `452a8583a7f5eb5cb3fc077d2462801949245719`.
+- Tag object: `76b8f4160fd8e1b212422e8531a7a73d499541fd`.
+- Tag commit: `452a8583a7f5eb5cb3fc077d2462801949245719`.
+- Prerelease: yes. Draft: false. Latest: false.
+- Focus: deterministic long-document display, complete literal search,
+  bounded multilingual concept search, tokenizer-proven full-document
+  admission, and explicit file, scan, and semantic coverage.
+- Literal search scans one stable snapshot with zero model calls. Concept
+  search uses at most one bounded multilingual planner and one verifier over
+  exact evidence windows. Semantic chunking remains a technical stop.
+- RC25 validation: document-search tests PASS with 42 tests; shared runtime,
+  path, and evidence tests PASS with 329 tests; full discovery PASS with 1,349
+  tests; native and MTP helper rebuild PASS; strict Gemma target, draft MTP,
+  and mmproj smoke PASS; production corpus PASS 12/12; final-prefix default
+  `cached=64` and kill switch `cached=4` PASS; `compileall` and
+  `git diff --check` PASS.
+- RC25 makes no complete semantic-recall or deterministic performance claim.
+  See `docs/FULL_DOCUMENT_READING.md`,
+  `docs/DETERMINISTIC_DOCUMENT_SEARCH.md`, and
+  `docs/releases/v0.0.1-rc25.md`.
 
 ## RC24 Tool-Loop Convergence
 
@@ -286,6 +311,39 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - Current vendor provenance is upstream `b9551` at `379ac6673b5cd75c7b4e07d1521c50f1e093878c`, source-tree hash `4adb967e643363e7dc4d01d632b3a8471e0df2ec84ff304d364dc182f63e7ee1`, and Orbit patchset hash `dea2f205ed2a73d09ad203e08ba85545474742dbb0191f4f1a9b3a86beb4b435`.
 - Native CMake builds receive vendor commit/build metadata explicitly. `LLAMA_COMMIT` must never be inferred from the enclosing Orbit repository.
 - This hardening does not update the production llama.cpp revision. See `docs/NATIVE_MTMD_ABI.md`.
+
+## Qwen 3.6 Native Compatibility
+
+- Native Qwen support is restricted to the verified
+  `Qwen3.6-35B-A3B-Q4_K_M.gguf` identity. The profile ID is
+  `orbit-qwen36-native-v1`, the GGUF architecture is `qwen35moe`, and the
+  embedded-template SHA-256 is
+  `e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259`.
+- Profile authorization uses GGUF architecture, model identity, tokenizer
+  metadata, `general.file_type=15` (`Q4_K_M`), and the exact template hash.
+  Filename matching alone never enables the profile. Other Qwen variants,
+  templates, and quantizations fail before inference.
+- A revision-bound native chat bridge applies the official embedded template,
+  passes `enable_thinking` explicitly, and separates reasoning, visible
+  content, and Qwen XML tool calls. Structured phases force thinking off;
+  reasoning never reaches route or canonical tool parsers.
+- Qwen route-prefix reuse is default-on only for the exact verified profile.
+  It captures the complete hybrid sequence state at a 768-token batch-aligned
+  boundary within the 810-token invariant route prefix. The checkpoint is
+  81,608,684 bytes and is model, quantization, context, template, tokenizer,
+  schema, backend-build, and process bound.
+- Cold, explicitly segmented, captured, and restored probes produced
+  byte-identical logits with maximum absolute difference `0.0`. The measured
+  11-route comparison reduced evaluated prompt tokens from 9,094 to 1,414 and
+  restored 7,680 tokens with zero fallback and identical outputs, tools, and
+  arguments. CPU timings are descriptive, not a universal speed guarantee.
+- `ORBIT_QWEN_ROUTE_PREFIX_REUSE=0` is the immediate kill switch. Invalid
+  values disable reuse safely. Cancel, timeout, reset, restart, context or
+  identity changes, and restore errors invalidate the process-local blob.
+- Qwen MTP and Qwen multimodal input are unsupported. Gemma rendering,
+  checkpoints, MTP/mmproj, and tool behavior remain separate and unchanged.
+- See `docs/QWEN_3_6_COMPATIBILITY.md` for the exact identity, protocol,
+  diagnostics, validation evidence, and current limits.
 
 ## MTP
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # orbit
 
-Orbit is a small Python-first local runtime for Gemma 4 26B-A4B on CPU-only
-machines. The primary path is the native `orbit server` backend, using
+Orbit is a small Python-first local runtime for Gemma 4 26B-A4B and the
+verified Qwen 3.6 35B-A3B profile on CPU-only machines. The primary path is the
+native `orbit server` backend, using
 vendored `llama.cpp`/`ggml` libraries built and loaded by Orbit. It does not
 require an external `llama-server` process for normal use.
 
@@ -13,7 +14,7 @@ Linux is the main target environment. macOS may work. Windows is not a target.
 
 ## Current Scope
 
-- local CLI and native HTTP server for Gemma 4 26B-A4B
+- local CLI and native HTTP server for Gemma 4 26B-A4B and verified Qwen 3.6
 - CPU-first native backend
 - explicit shell tools when tools mode is enabled
 - streaming terminal output and compact progress phases
@@ -32,6 +33,7 @@ and is not a guaranteed performance win.
 - Linux recommended
 - CMake for building the vendored native libraries
 - Gemma 4 26B-A4B target GGUF
+- optional verified Qwen 3.6 35B-A3B Q4_K_M target GGUF
 - optional Gemma 4 `mmproj` GGUF for multimodal input
 - optional MTP draft GGUF for `orbit server --mtp`
 
@@ -86,6 +88,22 @@ In another terminal:
 ```bash
 orbit --workdir workdir --think off "hi, how are you?"
 ```
+
+The verified Qwen 3.6 profile uses the model's reviewed embedded template and a
+revision-bound native parser bridge:
+
+```bash
+orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf
+orbit server \
+  --model models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf \
+  --think off
+```
+
+Qwen MTP and Gemma-specific prefix checkpoints are not enabled for Qwen. The
+verified Qwen profile has its own default-on 768-token route checkpoint with
+`ORBIT_QWEN_ROUTE_PREFIX_REUSE=0` as its kill switch. See
+[`docs/QWEN_3_6_COMPATIBILITY.md`](docs/QWEN_3_6_COMPATIBILITY.md) for the exact
+identity gate, thinking behavior, tool protocol, diagnostics, and limits.
 
 Enable tools only when you want to expose model-driven shell access:
 

--- a/docs/QWEN_3_6_COMPATIBILITY.md
+++ b/docs/QWEN_3_6_COMPATIBILITY.md
@@ -1,0 +1,170 @@
+# Qwen 3.6 Native Compatibility
+
+## Supported Profile
+
+Orbit has a verified native compatibility profile for:
+
+- model family: Qwen 3.6;
+- model identity: `Qwen3.6-35B-A3B`;
+- GGUF architecture: `qwen35moe`;
+- quantization identity: `general.file_type=15` (`Q4_K_M`);
+- tokenizer metadata: `gpt2` with `qwen35` pre-tokenization;
+- validated artifact: `Qwen3.6-35B-A3B-Q4_K_M.gguf`;
+- llama.cpp vendor: Orbit's current revision-bound native build.
+
+Detection does not use the filename. The native backend verifies the GGUF
+architecture, model identity, tokenizer metadata, and exact embedded template
+hash before selecting the profile. An unrecognized Qwen variant or template
+fails before inference instead of running the Gemma protocol silently.
+
+The reviewed embedded template is byte-identical to the official Qwen 3.6
+template used for validation. Its SHA-256 is
+`e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259`.
+
+## Rendering And Parsing
+
+Qwen rendering and output parsing use a revision-bound native Orbit bridge
+compiled against the active llama.cpp headers and libraries. Python passes
+JSON messages, JSON tool definitions, primitive flags, and an opaque model
+handle. It does not reproduce the upstream chat-parser structures.
+
+The bridge:
+
+- applies the embedded template through llama.cpp's Jinja implementation;
+- passes `enable_thinking` explicitly;
+- separates visible content from reasoning content;
+- parses the Qwen 3.6 XML tool protocol into OpenAI-compatible tool calls;
+- preserves exact JSON tool arguments for Orbit's canonical validation;
+- is co-located with, and cryptographically bound to, the active native
+  libraries, headers, compiler identity, source provenance, and bridge source.
+
+Orbit keeps the existing runtime tool loop. Canonical validation, formal
+healing, permissions, no-mutation policy, repeated-call protection, and tool
+executors are unchanged.
+
+## Thinking
+
+Thinking is disabled by default. Orbit also forces it off for strict structured
+phases, including route selection, tool selection, document-search planning,
+document-search verification, and formal repair.
+
+When the user explicitly enables thinking, the native parser returns reasoning
+separately from visible assistant content. Reasoning is never sent to route or
+tool-call parsers and is not retained in normal conversation history. A small
+thinking budget can end before Qwen produces visible content; this is reported
+honestly as `finish_reason=length`.
+
+The verified Qwen profile uses one native completion for explicit chat
+thinking instead of Orbit's legacy two-pass reasoning prompt. The backend
+returns reasoning and visible content as separate fields, while history keeps
+only the visible answer. In the validation host, a greeting exhausted a
+256-token budget in reasoning but completed with `finish_reason=stop` at a
+512-token user-selected budget. Orbit does not raise that budget automatically.
+
+## Tools And History
+
+The profile supports the Qwen 3.6 tool envelope:
+
+```text
+<tool_call><function=NAME><parameter=ARG>VALUE</parameter></function></tool_call>
+```
+
+Tool declarations, assistant tool calls, tool results, and post-tool
+continuations are rendered by the official template. A budget-truncated or
+malformed envelope cannot become an executable call merely because the parser
+found a partial structure. Orbit accepts at most one executable call per model
+turn under the existing canonical contract.
+
+The official template permits a system message only at the beginning. Later
+Orbit evidence cards keep their chronological position and exact content but
+are serialized as ordinary input turns for this profile. Tool messages and
+assistant tool-call history retain their native roles.
+
+## Startup
+
+Build the native libraries and compatibility bridge, then start the server with
+the explicit GGUF path:
+
+```bash
+python3 scripts/build_native.py
+orbit server \
+  --model models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf \
+  --think off
+```
+
+Inspect bounded compatibility diagnostics:
+
+```bash
+curl -s http://127.0.0.1:12120/props | python3 -m json.tool
+```
+
+Relevant fields include the detected family, compatibility profile, template
+source and hash, reasoning protocol, tool protocol, effective thinking state,
+and verification result. Prompts and generated reasoning are not included.
+
+## Route Prefix Reuse
+
+The exact verified Qwen 3.6 Q4_K_M profile reuses a process-local checkpoint
+for the first 768 tokens of tools-on route prompts. The boundary is part of
+the invariant official-template prefix and stops before user or conversation
+content. No padding or prompt text was added to create the boundary.
+
+The first eligible route performs its normal prefill and captures the complete
+hybrid sequence state. Later routes restore both attention KV and recurrent
+state, then evaluate only the dynamic suffix. The checkpoint is model,
+quantization, context, template, tokenizer, route-contract, backend-build, and
+process bound. It is never shared with Gemma, MTP, thinking-enabled phases, or
+another Qwen profile.
+
+Reuse is enabled by default only after exact cold, segmented, and restored
+logits equivalence was established for the verified profile. Disable it
+immediately with:
+
+```bash
+ORBIT_QWEN_ROUTE_PREFIX_REUSE=0 orbit server \
+  --model models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf
+```
+
+`ORBIT_QWEN_ROUTE_PREFIX_REUSE=1` enables it explicitly. Invalid values disable
+reuse safely. `/props` reports bounded capture, restore, fallback,
+invalidation, identity, token-count, and checkpoint-size diagnostics without
+prompt content.
+
+The validated checkpoint is 81,608,684 bytes. It is invalidated on cancel,
+timeout, reset, restart, model or context replacement, profile/template/schema
+identity change, restore failure, and completion error. A restore error clears
+partial state and performs one cold prefill without recursive retry.
+
+The verified boundary is 768 production tokens. The full invariant prefix is
+810 tokens for the measured route fixtures; 768 is the longest useful
+production-batch-aligned boundary below it. The token immediately after the
+checkpoint is token ID 1802. The boundary token hash is
+`095416e9dcf73f8a9db7b39b1d3f289da66a705c32418c194964938d58876b9b`.
+
+Cold full prefill, explicit segmentation at token 768, and capture/restore
+produced byte-identical logits in the native validation probe: maximum absolute
+logit difference `0.0`, identical logits hash, next token, ordered candidates,
+generated route, and finish reason. A process-isolated 11-case route corpus
+also produced identical output hashes and decisions. OFF evaluated 9,094
+prompt tokens in 287.8 seconds; ON evaluated 1,414 in 57.9 seconds, including
+the first capture. Ten restores avoided exactly 7,680 evaluated tokens. Median
+prefill after capture was 1.76 seconds versus 24.38 seconds OFF on the measured
+CPU host. These timings are descriptive and not a deterministic performance
+guarantee.
+
+## Current Limits
+
+- Only the exact verified 35B-A3B identity and reviewed template are enabled.
+- Qwen MTP is disabled. The available Qwen draft GGUF has not been qualified
+  against Orbit's target/draft lifecycle and must not be treated as supported.
+- Gemma-specific route and final-prefix checkpoints remain disabled for Qwen;
+  Qwen route reuse has its own identity, storage, eligibility, and lifecycle.
+- The Qwen hybrid/recurrent memory layout can reject partial KV removal. Orbit
+  uses complete sequence-state capture/restore for the verified route prefix
+  and falls back to a cold prefill for other incompatible cache transitions.
+- Qwen thinking can consume a substantial decode budget before visible output.
+- CPU wall time depends on model, prompt, context, threads, and host state; no
+  deterministic speed claim is made.
+
+Gemma 4 remains a separate compatibility profile. Qwen support does not change
+the Gemma renderer, tokenizer, tool protocol, MTP path, or prefix-reuse gates.

--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -18,6 +18,7 @@ class ChatResult:
     cached_tokens: int | None
     prompt_tokens_per_second: float | None
     generation_tokens_per_second: float | None
+    reasoning_content: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -11,6 +11,7 @@ from .base import ChatResult, Message, ModelInfo, StreamProgress, TokenCount
 from .model_names import resolve_model_display_name
 from .payloads import ChatPayloadOptions, build_chat_payload
 from orbit.final_prefix_config import resolve_final_prefix_reuse
+from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
@@ -49,6 +50,7 @@ class LlamaServerBackend:
                 thinking=self.thinking,
                 tools=tools,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
                 final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
@@ -87,6 +89,7 @@ class LlamaServerBackend:
                 tools=tools,
                 stream=True,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
                 final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
@@ -187,6 +190,14 @@ class LlamaServerBackend:
             return props
         props.update(tool_call_healing_status())
         return props
+
+    def uses_native_separated_reasoning(self) -> bool:
+        compatibility = self._props_or_empty().get("model_compatibility")
+        return bool(
+            isinstance(compatibility, dict)
+            and compatibility.get("verified") is True
+            and compatibility.get("reasoning_protocol") == "qwen-think"
+        )
 
     def execute_server_tool(self, name: str, arguments: dict[str, Any]) -> str:
         data = self._post_json("/tools", {"tool": name, "params": arguments})
@@ -343,6 +354,9 @@ def _parse_chat_result(data: dict[str, Any]) -> ChatResult:
     if not tool_calls and parsed_raw_tool_calls:
         tool_calls = parsed_raw_tool_calls
         content = ""
+    reasoning_content = message.get("reasoning_content")
+    if not isinstance(reasoning_content, str):
+        reasoning_content = ""
 
     usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
     timings = data.get("timings") if isinstance(data.get("timings"), dict) else {}
@@ -358,6 +372,7 @@ def _parse_chat_result(data: dict[str, Any]) -> ChatResult:
         cached_tokens=_int_or_none(details.get("cached_tokens")),
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
+        reasoning_content=reasoning_content,
     )
 
 
@@ -369,6 +384,7 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
     finish_reason: str | None = None
     usage: dict[str, Any] = {}
     timings: dict[str, Any] = {}
+    reasoning_parts: list[str] = []
 
     for raw_line in response:
         line = raw_line.decode("utf-8", errors="replace").strip()
@@ -402,6 +418,9 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
         if isinstance(text, str) and text:
             content_parts.append(text)
             content_filter.write(text)
+        reasoning = delta.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning:
+            reasoning_parts.append(reasoning)
         _merge_stream_tool_calls(tool_calls_by_index, delta.get("tool_calls"))
 
     content_filter.finish()
@@ -423,6 +442,7 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
         cached_tokens=_int_or_none(details.get("cached_tokens")),
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
+        reasoning_content="".join(reasoning_parts),
     )
 
 
@@ -439,6 +459,7 @@ def _parse_native_stream(
     finish_reason: str | None = None
     usage: dict[str, Any] = {}
     timings: dict[str, Any] = {}
+    reasoning_parts: list[str] = []
     current_event: str | None = None
     current_data_lines: list[str] = []
     stream_done = False
@@ -466,6 +487,10 @@ def _parse_native_stream(
             if isinstance(text, str) and text:
                 content_parts.append(text)
                 content_filter.write(text)
+        elif current_event == "reasoning":
+            text = data.get("text")
+            if isinstance(text, str) and text:
+                reasoning_parts.append(text)
         elif current_event.startswith("progress.") and on_progress:
             phase = current_event.split(".", maxsplit=1)[1]
             progress = StreamProgress(
@@ -524,6 +549,7 @@ def _parse_native_stream(
         cached_tokens=_int_or_none(details.get("cached_tokens")),
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
+        reasoning_content="".join(reasoning_parts),
     )
 
 
@@ -768,6 +794,12 @@ def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:
     if not native_backend:
         return False
     if not prefix_anchor_enabled():
+        return False
+    return current_phase() == "route" and current_tools_mode() == "on"
+
+
+def _qwen_route_prefix_anchor_requested(*, native_backend: bool) -> bool:
+    if not native_backend or not resolve_qwen_route_prefix_reuse().enabled:
         return False
     return current_phase() == "route" and current_tools_mode() == "on"
 

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -16,6 +16,7 @@ class ChatPayloadOptions:
     stream: bool = False
     cache_prompt: bool = True
     route_prefix_anchor: bool = False
+    qwen_route_prefix_anchor: bool = False
     allow_mtp_experimental: bool | None = None
     final_prefix_experiment: bool = False
 
@@ -34,6 +35,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["stream"] = True
     if options.route_prefix_anchor:
         payload["route_prefix_anchor"] = True
+    if options.qwen_route_prefix_anchor:
+        payload["qwen_route_prefix_anchor"] = True
     if options.allow_mtp_experimental is not None:
         payload["allow_mtp_experimental"] = options.allow_mtp_experimental
     if options.final_prefix_experiment:

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -23,6 +23,7 @@ import ctypes
 import json
 import os
 
+from .chat_bridge import CHAT_BRIDGE_API_VERSION, validate_chat_bridge_artifact
 from .native_names import platform_runtime_libs, runtime_library_filename
 from .mtmd_bridge import validate_mtmd_bridge_artifact
 
@@ -221,6 +222,12 @@ class LlamaLibrary:
 
         lib.llama_model_get_vocab.argtypes = [c_void_p]
         lib.llama_model_get_vocab.restype = c_void_p
+        lib.llama_model_meta_count.argtypes = [c_void_p]
+        lib.llama_model_meta_count.restype = c_int32
+        lib.llama_model_meta_key_by_index.argtypes = [c_void_p, c_int32, POINTER(c_char), c_size_t]
+        lib.llama_model_meta_key_by_index.restype = c_int32
+        lib.llama_model_meta_val_str_by_index.argtypes = [c_void_p, c_int32, POINTER(c_char), c_size_t]
+        lib.llama_model_meta_val_str_by_index.restype = c_int32
         lib.llama_vocab_n_tokens.argtypes = [c_void_p]
         lib.llama_vocab_n_tokens.restype = c_int32
         lib.llama_model_chat_template.argtypes = [c_void_p, c_char_p]
@@ -270,6 +277,105 @@ class LlamaLibrary:
         lib.llama_sampler_reset.restype = None
         lib.llama_sampler_free.argtypes = [c_void_p]
         lib.llama_sampler_free.restype = None
+
+
+class ChatBridgeLibrary:
+    def __init__(self, build_bin: Path, bridge_path: Path) -> None:
+        self.build_identity = validate_chat_bridge_artifact(build_bin, bridge_path)
+        flags = native_cdll_flags()
+        self._handles: list[CDLL] = []
+        for dependency in platform_runtime_libs():
+            path = build_bin / dependency
+            if path.exists():
+                self._handles.append(load_native_cdll(path, mode=flags))
+        self.lib = load_native_cdll(bridge_path, mode=flags)
+        self._configure_api()
+        if self.lib.orbit_chat_bridge_api_version() != CHAT_BRIDGE_API_VERSION:
+            raise RuntimeError("unsupported Orbit chat bridge API version")
+
+    def _configure_api(self) -> None:
+        lib = self.lib
+        lib.orbit_chat_bridge_api_version.argtypes = []
+        lib.orbit_chat_bridge_api_version.restype = c_uint32
+        lib.orbit_chat_bridge_last_error.argtypes = []
+        lib.orbit_chat_bridge_last_error.restype = c_char_p
+        lib.orbit_chat_bridge_create.argtypes = [c_void_p]
+        lib.orbit_chat_bridge_create.restype = c_void_p
+        lib.orbit_chat_bridge_free.argtypes = [c_void_p]
+        lib.orbit_chat_bridge_free.restype = None
+        lib.orbit_chat_bridge_render.argtypes = [
+            c_void_p,
+            c_char_p,
+            c_char_p,
+            c_bool,
+            POINTER(c_char),
+            c_size_t,
+        ]
+        lib.orbit_chat_bridge_render.restype = c_int
+        lib.orbit_chat_bridge_parse.argtypes = [
+            c_void_p,
+            c_char_p,
+            c_bool,
+            POINTER(c_char),
+            c_size_t,
+        ]
+        lib.orbit_chat_bridge_parse.restype = c_int
+
+    def create(self, model: c_void_p) -> c_void_p:
+        context = self.lib.orbit_chat_bridge_create(model)
+        if not context:
+            raise RuntimeError(f"failed to initialize Orbit chat bridge: {self.last_error()}")
+        return context
+
+    def free(self, context: c_void_p | None) -> None:
+        if context:
+            self.lib.orbit_chat_bridge_free(context)
+
+    def render(
+        self,
+        context: c_void_p,
+        messages: list[dict[str, object]],
+        tools: list[dict[str, object]],
+        *,
+        thinking: bool,
+    ) -> dict[str, object]:
+        messages_json = json.dumps(messages, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        tools_json = json.dumps(tools, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        return self._json_call(
+            self.lib.orbit_chat_bridge_render,
+            context,
+            messages_json,
+            tools_json,
+            thinking,
+        )
+
+    def parse(self, context: c_void_p, generated_text: str, *, partial: bool) -> dict[str, object]:
+        return self._json_call(
+            self.lib.orbit_chat_bridge_parse,
+            context,
+            generated_text.encode("utf-8"),
+            partial,
+        )
+
+    def _json_call(self, function, *args) -> dict[str, object]:
+        needed = function(*args, None, 0)
+        if needed < 0:
+            raise RuntimeError(self.last_error())
+        buffer = (c_char * (needed + 1))()
+        written = function(*args, buffer, len(buffer))
+        if written < 0 or written > needed:
+            raise RuntimeError(self.last_error())
+        try:
+            value = json.loads(bytes(buffer[:written]).decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise RuntimeError("Orbit chat bridge returned invalid JSON") from exc
+        if not isinstance(value, dict):
+            raise RuntimeError("Orbit chat bridge returned a non-object result")
+        return value
+
+    def last_error(self) -> str:
+        value = self.lib.orbit_chat_bridge_last_error()
+        return value.decode("utf-8", errors="replace") if value else "unknown chat bridge error"
 
 
 class MtmdLibrary:

--- a/src/orbit/native_llama/build_cli.py
+++ b/src/orbit/native_llama/build_cli.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 from .build_support import BUNDLED_SOURCE_ROOT, DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_ROOT, validate_llama_source_root
+from .chat_bridge import build_chat_bridge, install_chat_bridge
 from .llama_provenance import load_llama_provenance
 from .mtp_accept_probe import build_mtp_accept_probe_helper
 from .mtp_completion import build_mtp_completion_helper
@@ -280,6 +281,12 @@ def _copy_runtime_libraries(build_bin: Path) -> None:
 
 
 def _build_packaged_shims(source_root: Path, build_bin: Path) -> None:
+    chat_bridge, _provenance = build_chat_bridge(
+        llama_root=source_root,
+        build_dir=build_bin,
+        build_bin=build_bin,
+    )
+    install_chat_bridge(chat_bridge, DEFAULT_VENDOR_LIB_DIR)
     mtmd_bridge, _provenance = build_mtmd_bridge(
         llama_root=source_root,
         build_dir=build_bin,

--- a/src/orbit/native_llama/capabilities.py
+++ b/src/orbit/native_llama/capabilities.py
@@ -10,11 +10,11 @@ from typing import Any, Protocol
 
 from .bindings import load_native_cdll, native_cdll_flags
 from .chat_template import render_gemma4_chat, render_gemma4_route_prompt_segments
+from .model_profiles import GEMMA4_PROFILE_ID, QWEN36_PROFILE_ID
 from .native_names import runtime_library_filename
 
 
 CAPABILITY_SCHEMA_VERSION = 1
-GEMMA4_PROFILE_ID = "orbit-gemma4-native-v1"
 GEMMA4_RENDERER_FIXTURE_SUITE_VERSION = 1
 GEMMA4_TOOL_PROTOCOL_TEXT_HASH = "ab72a1f741975b8b541ae3f3842a2ac0593dec6477dd41f1ea105410077eee1c"
 GEMMA4_RENDERER_FIXTURE_HASHES = {
@@ -33,8 +33,56 @@ VERIFIED_LLAMA_CPP_COMMITS = frozenset({"6f79e02"})
 
 class _TokenizingClient(Protocol):
     paths: object
+    model_profile: object
 
     def tokenize(self, prompt: str) -> list[int]: ...
+
+
+def safe_native_capability_manifest(client: _TokenizingClient, *, final_system_prompt: str) -> dict[str, object]:
+    profile = getattr(client, "model_profile", None)
+    if getattr(profile, "profile_id", None) == GEMMA4_PROFILE_ID:
+        return safe_gemma4_capability_manifest(client, final_system_prompt=final_system_prompt)
+    if getattr(profile, "profile_id", None) == QWEN36_PROFILE_ID:
+        build_bin = _client_build_bin(client)
+        build = read_llama_cpp_build_info(build_bin) if build_bin is not None else _unavailable_build("build_bin_unavailable")
+        return {
+            "schema_version": CAPABILITY_SCHEMA_VERSION,
+            "profile_id": QWEN36_PROFILE_ID,
+            "status": "verified" if getattr(profile, "verified", False) else "unverified",
+            "verification_scope": "model_metadata_template_identity_and_revision_bound_parser",
+            "behavior_enforced": True,
+            "backend": {
+                "engine": "llama.cpp",
+                "build_number": build.build_number,
+                "commit": build.commit,
+                "target": build.target,
+                "compiler": build.compiler,
+                "library_hash": build.library_hash,
+                "source": build.source,
+                "error": build.error,
+            },
+            "renderer": {
+                "implementation": getattr(profile, "renderer", "unknown"),
+                "template_source": getattr(profile, "template_source", "unknown"),
+                "template_hash": getattr(profile, "template_sha256", ""),
+                "reasoning_protocol": getattr(profile, "reasoning_protocol", "unknown"),
+                "tool_call_protocol": getattr(profile, "tool_call_protocol", "unknown"),
+                "history_serialization": getattr(profile, "history_serialization", "unknown"),
+            },
+            "requirements": {
+                "chat_bridge": "co-located-revision-bound",
+                "mtp_supported": False,
+                "gemma_prefix_reuse_supported": False,
+            },
+        }
+    return {
+        "schema_version": CAPABILITY_SCHEMA_VERSION,
+        "profile_id": "unsupported",
+        "status": "unverified",
+        "verification_scope": "model_profile_detection",
+        "behavior_enforced": True,
+        "error": getattr(profile, "failure_reason", "model_profile_uninitialized"),
+    }
 
 
 @dataclass(frozen=True)

--- a/src/orbit/native_llama/chat_bridge.py
+++ b/src/orbit/native_llama/chat_bridge.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+from .build_support import compile_cpp_helper
+from .llama_provenance import LlamaProvenance, load_llama_provenance
+from .native_names import platform_runtime_libs, runtime_library_filename
+
+
+CHAT_BRIDGE_API_VERSION = 1
+CHAT_BRIDGE_BUILD_FLAGS = "-std=c++17;-shared;-fPIC;-fvisibility=hidden"
+
+
+def chat_bridge_filename() -> str:
+    return runtime_library_filename("orbit-chat-bridge")
+
+
+def build_chat_bridge(
+    *,
+    llama_root: Path,
+    build_dir: Path,
+    build_bin: Path,
+    runner=subprocess.run,
+) -> tuple[Path, LlamaProvenance]:
+    provenance = load_llama_provenance(llama_root)
+    source = Path(__file__).parent / "vendor" / "shim" / "orbit_chat_bridge.cpp"
+    output = build_dir / chat_bridge_filename()
+    identity = _build_identity(
+        source=source,
+        llama_root=llama_root,
+        build_bin=build_bin,
+        provenance=provenance,
+    )
+    identity_path = _identity_path(output)
+    identity_matches = False
+    if output.exists() and identity_path.exists():
+        try:
+            stored = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity_matches = stored.get("build") == identity and stored.get("artifact_sha256") == _sha256(output)
+        except (OSError, ValueError):
+            identity_matches = False
+
+    artifact = compile_cpp_helper(
+        artifact_label="chat compatibility bridge",
+        source=source,
+        output=output,
+        llama_root=llama_root,
+        build_bin=build_bin,
+        runner=runner,
+        shared=True,
+        extra_compile_args=("-fvisibility=hidden",),
+        extra_include_dirs=(llama_root / "vendor",),
+        force=not identity_matches,
+    )
+    identity_path.write_text(
+        json.dumps(
+            {"build": identity, "artifact_sha256": _sha256(artifact)},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return artifact, provenance
+
+
+def install_chat_bridge(artifact: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(artifact, destination / artifact.name)
+    identity = _identity_path(artifact)
+    if identity.exists():
+        shutil.copy2(identity, destination / identity.name)
+
+
+def validate_chat_bridge_artifact(build_bin: Path, bridge_path: Path) -> dict[str, object]:
+    try:
+        stored = json.loads(_identity_path(bridge_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("missing or invalid Orbit chat bridge identity") from exc
+    build = stored.get("build")
+    if not isinstance(build, dict):
+        raise RuntimeError("invalid Orbit chat bridge build identity")
+    if stored.get("artifact_sha256") != _sha256(bridge_path):
+        raise RuntimeError("Orbit chat bridge artifact identity mismatch")
+    libraries = build.get("libraries")
+    if not isinstance(libraries, dict):
+        raise RuntimeError("missing Orbit chat bridge library identity")
+    for name in platform_runtime_libs():
+        expected = libraries.get(name)
+        path = build_bin / name
+        if not isinstance(expected, str) or not path.exists() or _sha256(path) != expected:
+            raise RuntimeError(f"Orbit chat bridge library identity mismatch: {name}")
+    return build
+
+
+def _build_identity(
+    *,
+    source: Path,
+    llama_root: Path,
+    build_bin: Path,
+    provenance: LlamaProvenance,
+) -> dict[str, object]:
+    compiler = os.environ.get("CXX", "c++")
+    version = subprocess.run([compiler, "--version"], capture_output=True, text=True, check=False)
+    inputs = {
+        "bridge_source": source,
+        "llama_header": llama_root / "include" / "llama.h",
+        "chat_header": llama_root / "common" / "chat.h",
+        "common_header": llama_root / "common" / "common.h",
+        "json_header": llama_root / "vendor" / "nlohmann" / "json.hpp",
+        "provenance_manifest": llama_root.parents[1] / "LLAMA_PROVENANCE.json",
+    }
+    return {
+        "schema_version": 1,
+        "api_version": CHAT_BRIDGE_API_VERSION,
+        "compiler": compiler,
+        "compiler_version": (version.stdout or version.stderr).splitlines()[0],
+        "bridge_build_flags": CHAT_BRIDGE_BUILD_FLAGS,
+        "upstream_commit": provenance.upstream_commit,
+        "upstream_tag": provenance.upstream_tag,
+        "source_tree_sha256": provenance.source_tree_sha256,
+        "patchset_sha256": provenance.patchset_sha256,
+        "source_inputs": {name: _sha256(path) for name, path in inputs.items() if path.exists()},
+        "libraries": {
+            name: _sha256(build_bin / name)
+            for name in platform_runtime_libs()
+            if (build_bin / name).exists()
+        },
+    }
+
+
+def _identity_path(artifact: Path) -> Path:
+    return artifact.with_name(f"{artifact.name}.identity.json")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import codecs
 import ctypes
 import hashlib
+import json
 from ctypes import POINTER, byref, c_char, c_float, cast, c_ubyte, create_string_buffer, c_void_p, sizeof
 from dataclasses import dataclass, replace
 import os
@@ -12,6 +13,7 @@ import threading
 from orbit.final_prefix_config import FINAL_PREFIX_TOKEN_COUNT
 
 from .bindings import (
+    ChatBridgeLibrary,
     GgmlAbortCallback,
     GgmlLogCallback,
     LlamaLibrary,
@@ -21,10 +23,12 @@ from .bindings import (
     llama_token,
     llama_pos,
 )
+from .chat_bridge import chat_bridge_filename
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativeProgress, NativeTimings
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
+from .model_profiles import QWEN36_PROFILE_ID, NativeModelProfile, detect_native_model_profile
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
 from .mtp_accept_probe import MtpAcceptProbeResult, run_mtp_accept_probe
@@ -39,6 +43,15 @@ from .prefix_anchor import (
     prefix_anchor_enabled,
     restore_prefix_anchor,
 )
+from .qwen_route_prefix import (
+    QWEN_ROUTE_PREFIX_FORMAT_VERSION,
+    QWEN_ROUTE_PREFIX_TOKEN_COUNT,
+    QWEN_ROUTE_TOKENIZER_IDENTITY,
+    QwenRoutePrefixSpec,
+    QwenRoutePrefixStatus,
+    derive_qwen_route_prefix_spec,
+    hash_text,
+)
 from .persistent_mtp import (
     PersistentMtpSessionRuntime,
     create_persistent_mtp_session,
@@ -50,6 +63,13 @@ from .session_state import DEFAULT_NATIVE_SESSION_ID, NativeSessionSnapshot, Nat
 
 
 DEFAULT_MEDIA_MARKER = "<__media__>"
+
+
+@dataclass(frozen=True)
+class _ProfileParsedOutput:
+    content: str
+    reasoning_content: str
+    tool_calls: tuple[dict[str, object], ...]
 
 
 @dataclass(frozen=True)
@@ -71,6 +91,9 @@ class NativeClientConfig:
     final_prefix_reuse_source: str = "default"
     final_prefix_reuse_config_error: str | None = None
     final_prefix_reuse_legacy_detected: bool = False
+    qwen_route_prefix_reuse_enabled: bool = False
+    qwen_route_prefix_reuse_source: str = "default"
+    qwen_route_prefix_reuse_config_error: str | None = None
 
 
 @dataclass
@@ -89,6 +112,15 @@ class _RouteAnchorRuntimePlan:
     segments: RoutePromptSegments
     prefix_tokens: list[int]
     prefix_hash: str
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _QwenRouteAnchorRuntimePlan:
+    prefix_tokens: list[int]
+    prefix_hash: str
+    state_kwargs: dict[str, str | None]
+    spec: QwenRoutePrefixSpec
     metadata: dict[str, object]
 
 
@@ -135,6 +167,11 @@ def _resolve_mtmd_bridge_path(paths: NativeLlamaPaths) -> Path | None:
     return bridge if bridge.exists() else None
 
 
+def _resolve_chat_bridge_path(paths: NativeLlamaPaths) -> Path | None:
+    bridge = paths.build_bin / chat_bridge_filename()
+    return bridge if bridge.exists() else None
+
+
 class NativeLlamaClient:
     def __init__(self, paths: NativeLlamaPaths, config: NativeClientConfig | None = None) -> None:
         self.paths = paths
@@ -150,6 +187,12 @@ class NativeLlamaClient:
         self._callbacks: list[object] = []
         self._model: c_void_p | None = None
         self._vocab: c_void_p | None = None
+        self.model_profile: NativeModelProfile | None = None
+        self.chat_bridge: ChatBridgeLibrary | None = None
+        self._chat_bridge_context: c_void_p | None = None
+        self._active_profile_render: dict[str, object] | None = None
+        self._profile_last_raw_output = ""
+        self._profile_last_parsed_content = ""
         self._mtmd_ctx: c_void_p | None = None
         self._media_marker = (
             self.mtmd.lib.orbit_mtmd_default_marker().decode("utf-8", errors="replace")
@@ -172,6 +215,11 @@ class NativeLlamaClient:
         self._last_prompt_decode_batch_n_tokens = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
         self._route_prefix_prefill_lock = threading.Lock()
+        self._qwen_route_prefix_anchor_state = PrefixAnchorState()
+        self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
+        self._qwen_route_prefix_status = QwenRoutePrefixStatus()
+        self._model_metadata_identity: dict[str, str] = {}
+        self._qwen_native_build_identity: str | None = None
         self._final_prefix_anchor_state = PrefixAnchorState()
         self._final_prefix_status = FinalPrefixExperimentStatus()
 
@@ -182,8 +230,10 @@ class NativeLlamaClient:
 
     def final_prefix_experiment_status(self) -> dict[str, object]:
         status = self._final_prefix_status
+        profile = getattr(self, "model_profile", None)
+        profile_eligible = profile is None or profile.gemma_prefix_reuse_supported
         return {
-            "enabled": self.config.final_prefix_experiment_enabled,
+            "enabled": self.config.final_prefix_experiment_enabled and profile_eligible,
             "initialized": status.initialized,
             "prefix_tokens": status.prefix_tokens,
             "capture_count": status.capture_count,
@@ -193,6 +243,51 @@ class NativeLlamaClient:
             "last_used": status.last_used,
             "checkpoint_size_bytes": self._final_prefix_anchor_state.checkpoint_size,
         }
+
+    def qwen_route_prefix_reuse_status(self) -> dict[str, object]:
+        status = self._qwen_route_prefix_status
+        profile = getattr(self, "model_profile", None)
+        profile_eligible = (
+            getattr(profile, "profile_id", None) == QWEN36_PROFILE_ID
+            and getattr(profile, "verified", False)
+            and self._model_metadata_identity.get("general.file_type") == "15"
+        )
+        spec = self._qwen_route_prefix_spec
+        return {
+            "enabled": self.config.qwen_route_prefix_reuse_enabled and profile_eligible,
+            "source": self.config.qwen_route_prefix_reuse_source,
+            "config_error": self.config.qwen_route_prefix_reuse_config_error,
+            "initialized": status.initialized,
+            "prefix_tokens": status.prefix_tokens,
+            "capture_count": status.capture_count,
+            "restore_count": status.restore_count,
+            "fallback_count": status.fallback_count,
+            "invalidation_count": status.invalidation_count,
+            "failure_reason": status.failure_reason,
+            "last_used": status.last_used,
+            "checkpoint_size_bytes": self._qwen_route_prefix_anchor_state.checkpoint_size,
+            "profile_identity": getattr(profile, "profile_id", None),
+            "template_identity": getattr(profile, "template_sha256", None),
+            "tokenizer_identity": hash_text(QWEN_ROUTE_TOKENIZER_IDENTITY),
+            "prefix_token_hash": spec.prefix_token_hash if spec is not None else None,
+            "prefix_text_hash": spec.invariant_text_hash if spec is not None else None,
+        }
+
+    def compatibility_diagnostics(self) -> dict[str, object]:
+        profile = getattr(self, "model_profile", None)
+        if profile is None:
+            return {
+                "model_family": "unknown",
+                "compatibility_profile": "uninitialized",
+                "verified": False,
+                "failure_reason": "model_profile_uninitialized",
+            }
+        diagnostics = profile.diagnostics(thinking_enabled=self.config.thinking)
+        diagnostics["chat_bridge_loaded"] = self.chat_bridge is not None
+        diagnostics["chat_bridge_revision_bound"] = bool(
+            self.chat_bridge is not None and self.chat_bridge.build_identity
+        )
+        return diagnostics
 
     def _current_backend_mode(self) -> str:
         if not self.config.use_mtp_experimental:
@@ -213,7 +308,11 @@ class NativeLlamaClient:
 
     def close(self) -> None:
         lib = self.lib.lib
+        self._invalidate_qwen_route_prefix("client_closed")
         self._free_persistent_mtp_session()
+        if self.chat_bridge is not None and self._chat_bridge_context:
+            self.chat_bridge.free(self._chat_bridge_context)
+            self._chat_bridge_context = None
         if self._mtmd_ctx:
             assert self.mtmd is not None
             self.mtmd.lib.orbit_mtmd_context_free(self._mtmd_ctx)
@@ -232,6 +331,7 @@ class NativeLlamaClient:
 
     def cancel(self) -> None:
         self._invalidate_final_prefix("cancelled")
+        self._invalidate_qwen_route_prefix("cancelled")
         self._session.cancel_requested = True
         self._session.continuation_ready = False
         self.cancel_event.set()
@@ -262,6 +362,13 @@ class NativeLlamaClient:
         if not self._model:
             raise RuntimeError(f"failed to load model: {self.paths.model}")
 
+        try:
+            self._initialize_model_profile()
+        except Exception:
+            lib.llama_model_free(self._model)
+            self._model = None
+            raise
+
         ctx_params = lib.llama_context_default_params()
         ctx_params.n_ctx = self.config.context_tokens
         ctx_params.n_batch = self.config.batch_size
@@ -289,9 +396,72 @@ class NativeLlamaClient:
         self._initialize_mtp_decode_probe()
         self._initialize_persistent_mtp_session()
 
+    def _initialize_model_profile(self) -> None:
+        if not self._model:
+            raise RuntimeError("native model is not loaded")
+        metadata = self._read_model_metadata()
+        self._model_metadata_identity = dict(metadata)
+        template_ptr = self.lib.lib.llama_model_chat_template(self._model, None)
+        template = template_ptr.decode("utf-8", errors="replace") if template_ptr else ""
+        profile = detect_native_model_profile(metadata, template)
+        self.model_profile = profile
+        if not profile.verified:
+            raise RuntimeError(
+                "unsupported or unverified native model compatibility: "
+                f"family={profile.family}; reason={profile.failure_reason}"
+            )
+        if not profile.uses_native_chat_bridge:
+            return
+        bridge_path = _resolve_chat_bridge_path(self.paths)
+        if bridge_path is None:
+            raise RuntimeError(
+                "Qwen 3.6 requires the co-located Orbit chat compatibility bridge; "
+                "run `orbit build-native` for this llama.cpp revision"
+            )
+        bridge = ChatBridgeLibrary(self.paths.build_bin, bridge_path)
+        self._chat_bridge_context = bridge.create(self._model)
+        self.chat_bridge = bridge
+
+    def _read_model_metadata(self) -> dict[str, str]:
+        if not self._model:
+            return {}
+        lib = self.lib.lib
+        metadata: dict[str, str] = {}
+        count = max(0, int(lib.llama_model_meta_count(self._model)))
+        for index in range(count):
+            key = self._model_metadata_text(lib.llama_model_meta_key_by_index, index)
+            if key not in {
+                "general.architecture",
+                "general.name",
+                "general.file_type",
+                "tokenizer.ggml.model",
+                "tokenizer.ggml.pre",
+                "tokenizer.ggml.bos_token_id",
+                "tokenizer.ggml.eos_token_id",
+            }:
+                continue
+            metadata[key] = self._model_metadata_text(lib.llama_model_meta_val_str_by_index, index)
+        return metadata
+
+    def _model_metadata_text(self, function, index: int) -> str:
+        if not self._model:
+            return ""
+        needed = int(function(self._model, index, None, 0))
+        if needed < 0:
+            return ""
+        buffer = create_string_buffer(needed + 1)
+        written = int(function(self._model, index, buffer, len(buffer)))
+        if written < 0:
+            return ""
+        return bytes(buffer[:written]).decode("utf-8", errors="replace")
+
     def _initialize_mtp_probe(self) -> None:
         if not self.config.mtp_probe_enabled:
             self.mtp_probe = MtpProbeResult(enabled=False, initialized=False, error=None)
+            return
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self.mtp_probe = MtpProbeResult(enabled=True, initialized=False, error="model_profile_mtp_unsupported")
             return
         self.mtp_probe = run_mtp_probe(llama_root=self.paths.llama_root, paths=self.paths)
 
@@ -299,17 +469,29 @@ class NativeLlamaClient:
         if not self.config.mtp_dry_run_enabled:
             self.mtp_dry_run = MtpDryRunResult(enabled=False, success=False, error=None)
             return
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self.mtp_dry_run = MtpDryRunResult(enabled=True, success=False, error="model_profile_mtp_unsupported")
+            return
         self.mtp_dry_run = run_mtp_dry_run(llama_root=self.paths.llama_root, paths=self.paths)
 
     def _initialize_mtp_accept_probe(self) -> None:
         if not self.config.mtp_accept_probe_enabled:
             self.mtp_accept_probe = MtpAcceptProbeResult(enabled=False, success=False, error=None)
             return
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self.mtp_accept_probe = MtpAcceptProbeResult(enabled=True, success=False, error="model_profile_mtp_unsupported")
+            return
         self.mtp_accept_probe = run_mtp_accept_probe(llama_root=self.paths.llama_root, paths=self.paths)
 
     def _initialize_mtp_decode_probe(self) -> None:
         if not self.config.mtp_decode_probe_enabled:
             self.mtp_decode_probe = MtpDecodeProbeResult(enabled=False, success=False, error=None)
+            return
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self.mtp_decode_probe = MtpDecodeProbeResult(enabled=True, success=False, error="model_profile_mtp_unsupported")
             return
         self.mtp_decode_probe = run_mtp_decode_probe(llama_root=self.paths.llama_root, paths=self.paths)
 
@@ -321,6 +503,10 @@ class NativeLlamaClient:
         self._session.mtp_failed = False
         self._session.mtp_failure_reason = None
         if not self.config.use_mtp_experimental:
+            return
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self._session.mtp_failure_reason = "model_profile_mtp_unsupported"
             return
         if not self.paths.mtp_available or self.paths.draft_mtp_model is None:
             self._session.mtp_failure_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
@@ -362,7 +548,11 @@ class NativeLlamaClient:
         self._session.prompt_cache_mode = None
         self._session.continuation_ready = False
         self._session.last_metrics = None
+        self._active_profile_render = None
+        self._profile_last_raw_output = ""
+        self._profile_last_parsed_content = ""
         self._invalidate_final_prefix("session_reset")
+        self._invalidate_qwen_route_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
         try:
@@ -464,6 +654,9 @@ class NativeLlamaClient:
         tools_mode: str = "on",
         should_cancel=None,
     ) -> NativeRoutePrefixPrefillResult:
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.gemma_prefix_reuse_supported:
+            return _route_prefix_prefill_skipped("model_profile_ineligible")
         if tools_mode != "on":
             return _route_prefix_prefill_skipped("tools_mode_ineligible")
         if not prefix_anchor_enabled():
@@ -581,6 +774,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        qwen_route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
@@ -620,6 +814,12 @@ class NativeLlamaClient:
             finally:
                 self._session.in_flight = False
         prompt = self.apply_chat_template(messages, tools=tools, thinking=thinking)
+        qwen_route_anchor_plan = self._qwen_route_anchor_plan_for_prompt(
+            messages,
+            tools=tools,
+            thinking=thinking,
+            prompt=prompt,
+        ) if qwen_route_prefix_anchor else None
         route_anchor_segments = self._route_anchor_segments_for_prompt(
             messages,
             tools=tools,
@@ -632,7 +832,14 @@ class NativeLlamaClient:
             thinking=thinking,
             prompt=prompt,
         ) if self._final_prefix_experiment_eligible(final_prefix_experiment) else None
-        allow_mtp = not tools and route_anchor_segments is None
+        allow_mtp = (
+            not tools
+            and route_anchor_segments is None
+            and (
+                getattr(self, "model_profile", None) is None
+                or getattr(self, "model_profile").mtp_supported
+            )
+        )
         if final_prefix_segments is not None:
             allow_mtp = False
         if allow_mtp_experimental is False:
@@ -643,6 +850,7 @@ class NativeLlamaClient:
             allow_mtp_experimental=allow_mtp,
             thinking=thinking,
             route_anchor_segments=route_anchor_segments,
+            qwen_route_anchor_plan=qwen_route_anchor_plan,
             final_prefix_segments=final_prefix_segments,
             kv_diag_messages=messages,
             on_progress=on_progress,
@@ -659,6 +867,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        qwen_route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
@@ -673,6 +882,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            qwen_route_prefix_anchor=qwen_route_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
             final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
@@ -719,12 +929,29 @@ class NativeLlamaClient:
         tools: list[dict] | None,
         thinking: bool,
         route_prefix_anchor: bool = False,
+        qwen_route_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
     ) -> NativeCompletion:
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and profile.uses_native_chat_bridge:
+            return self._complete_profile_chat_text_once(
+                messages,
+                max_tokens=max_tokens,
+                stop=stop,
+                tools=tools,
+                thinking=thinking,
+                route_prefix_anchor=route_prefix_anchor,
+                qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+                allow_mtp_experimental=allow_mtp_experimental,
+                final_prefix_experiment=final_prefix_experiment,
+                on_progress=on_progress,
+                on_token=on_token,
+                should_cancel=should_cancel,
+            )
         parts: list[str] = []
         channel_filter = None if thinking else _ControlChannelStreamFilter()
         thought_label_filter = None if thinking else _LeadingThoughtLabelFilter()
@@ -786,6 +1013,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            qwen_route_prefix_anchor=qwen_route_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
             final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
@@ -800,6 +1028,98 @@ class NativeLlamaClient:
         self._session.continuation_ready = _can_continue_from_completion(completion, thinking=thinking)
         return completion
 
+    def _complete_profile_chat_text_once(
+        self,
+        messages: list[NativeMessage],
+        *,
+        max_tokens: int,
+        stop: tuple[str, ...],
+        tools: list[dict] | None,
+        thinking: bool,
+        route_prefix_anchor: bool,
+        qwen_route_prefix_anchor: bool,
+        allow_mtp_experimental: bool | None,
+        final_prefix_experiment: bool,
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeCompletion:
+        raw_parts: list[str] = []
+        visible_parts: list[str] = []
+        emitted_content = ""
+        stop_filter = _StopSequenceStreamFilter(stop, emit=visible_parts.append) if stop else None
+
+        def emit_visible(delta: str) -> None:
+            if not delta:
+                return
+            if stop_filter is not None:
+                for emitted in stop_filter.write(delta):
+                    if on_token:
+                        on_token(emitted)
+                if stop_filter.stopped:
+                    self.cancel()
+                return
+            visible_parts.append(delta)
+            if on_token:
+                on_token(delta)
+
+        def collect(raw: str) -> None:
+            nonlocal emitted_content
+            raw_parts.append(raw)
+            if tools:
+                return
+            try:
+                parsed = self._parse_profile_output("".join(raw_parts), partial=True)
+            except RuntimeError:
+                return
+            if not parsed.content.startswith(emitted_content):
+                return
+            delta = parsed.content[len(emitted_content) :]
+            emitted_content = parsed.content
+            emit_visible(delta)
+
+        timings = self.complete_chat(
+            messages,
+            max_tokens=max_tokens,
+            tools=tools,
+            thinking=thinking,
+            route_prefix_anchor=route_prefix_anchor,
+            qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+            allow_mtp_experimental=allow_mtp_experimental,
+            final_prefix_experiment=final_prefix_experiment,
+            on_progress=on_progress,
+            on_token=collect,
+            should_cancel=should_cancel,
+        )
+        raw_content = "".join(raw_parts)
+        try:
+            parsed = self._parse_profile_output(raw_content, partial=False)
+        except RuntimeError:
+            if not timings.cancelled and timings.output_tokens < max_tokens:
+                raise
+            parsed = self._parse_profile_output(raw_content, partial=True)
+
+        if (not tools or not parsed.tool_calls) and parsed.content.startswith(emitted_content):
+            emit_visible(parsed.content[len(emitted_content) :])
+        if stop_filter is not None:
+            for emitted in stop_filter.finish():
+                if on_token:
+                    on_token(emitted)
+
+        content = _trim_at_stop(parsed.content, stop)
+        self._profile_last_raw_output = raw_content
+        self._profile_last_parsed_content = content
+        completion = NativeCompletion(
+            content=content,
+            timings=timings,
+            stopped_by_stop=bool(stop_filter and stop_filter.stopped),
+            reasoning_content=parsed.reasoning_content,
+            reasoning_tokens=self._content_token_count(parsed.reasoning_content),
+            tool_calls=tuple(parsed.tool_calls),
+        )
+        self._session.continuation_ready = _can_continue_from_completion(completion, thinking=False)
+        return completion
+
     def _continue_chat_text_from_current_context(
         self,
         *,
@@ -810,6 +1130,15 @@ class NativeLlamaClient:
         on_token=None,
         should_cancel=None,
     ) -> NativeCompletion:
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and profile.uses_native_chat_bridge:
+            return self._continue_profile_chat_text_from_current_context(
+                max_tokens=max_tokens,
+                stop=stop,
+                on_progress=on_progress,
+                on_token=on_token,
+                should_cancel=should_cancel,
+            )
         parts: list[str] = []
         stop_filter = _StopSequenceStreamFilter(stop, emit=parts.append) if stop else None
 
@@ -840,6 +1169,48 @@ class NativeLlamaClient:
         if not thinking:
             content = _strip_reasoning_preamble(content)
         return NativeCompletion(content=content, timings=timings, stopped_by_stop=bool(stop_filter and stop_filter.stopped))
+
+    def _continue_profile_chat_text_from_current_context(
+        self,
+        *,
+        max_tokens: int,
+        stop: tuple[str, ...],
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeCompletion:
+        raw_parts: list[str] = []
+        timings = self._continue_generation_from_current_context(
+            max_tokens=max_tokens,
+            on_progress=on_progress,
+            on_token=raw_parts.append,
+            should_cancel=should_cancel,
+        )
+        raw_content = self._profile_last_raw_output + "".join(raw_parts)
+        try:
+            parsed = self._parse_profile_output(raw_content, partial=False)
+        except RuntimeError:
+            if not timings.cancelled and timings.output_tokens < max_tokens:
+                raise
+            parsed = self._parse_profile_output(raw_content, partial=True)
+        prior_content = self._profile_last_parsed_content
+        if not parsed.content.startswith(prior_content):
+            raise RuntimeError("Qwen continuation changed previously parsed visible content")
+        content = _trim_at_stop(parsed.content[len(prior_content) :], stop)
+        if on_token and content:
+            on_token(content)
+        self._profile_last_raw_output = raw_content
+        self._profile_last_parsed_content = parsed.content
+        completion = NativeCompletion(
+            content=content,
+            timings=timings,
+            stopped_by_stop=content != parsed.content[len(prior_content) :],
+            reasoning_content=parsed.reasoning_content,
+            reasoning_tokens=self._content_token_count(parsed.reasoning_content),
+            tool_calls=tuple(parsed.tool_calls),
+        )
+        self._session.continuation_ready = _can_continue_from_completion(completion, thinking=False)
+        return completion
 
     def continue_chat_text_current_context(
         self,
@@ -1010,6 +1381,7 @@ class NativeLlamaClient:
         allow_mtp_experimental: bool = True,
         thinking: bool | None = None,
         route_anchor_segments: RoutePromptSegments | None = None,
+        qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
@@ -1049,6 +1421,7 @@ class NativeLlamaClient:
                 prompt,
                 max_tokens=max_tokens,
                 route_anchor_segments=route_anchor_segments,
+                qwen_route_anchor_plan=qwen_route_anchor_plan,
                 final_prefix_segments=final_prefix_segments,
                 kv_diag_messages=kv_diag_messages,
                 on_progress=on_progress,
@@ -1059,10 +1432,14 @@ class NativeLlamaClient:
             self._session.continuation_ready = _can_continue_from_timings(timings)
             if final_prefix_segments is not None and timings.cancelled:
                 self._invalidate_final_prefix("cancelled")
+            if qwen_route_anchor_plan is not None and timings.cancelled:
+                self._invalidate_qwen_route_prefix("cancelled")
             return timings
         except Exception:
             if final_prefix_segments is not None:
                 self._invalidate_final_prefix("completion_error")
+            if qwen_route_anchor_plan is not None:
+                self._invalidate_qwen_route_prefix("completion_error")
             raise
         finally:
             self._session.in_flight = False
@@ -1077,6 +1454,11 @@ class NativeLlamaClient:
         on_token=None,
     ) -> NativeTimings | None:
         thinking = self._thinking_enabled(thinking)
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.mtp_supported:
+            self.mtp_fallback_reason = "model_profile_mtp_unsupported"
+            self.last_mtp_completion = MtpCompletionResult(enabled=False, success=False, error=self.mtp_fallback_reason)
+            return None
         if thinking:
             self.mtp_fallback_reason = "thinking-mode"
             self.last_mtp_completion = MtpCompletionResult(enabled=self.config.use_mtp_experimental, success=False, error="thinking-mode")
@@ -1197,6 +1579,7 @@ class NativeLlamaClient:
         *,
         max_tokens: int = 16,
         route_anchor_segments: RoutePromptSegments | None = None,
+        qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
@@ -1215,11 +1598,16 @@ class NativeLlamaClient:
         previous_prompt_tokens = list(self._session.cached_prompt_tokens)
         pf_start = lib.llama_time_us()
         anchor_plan = self._route_anchor_plan(prompt, prompt_tokens, route_anchor_segments)
+        if qwen_route_anchor_plan is not None and prompt_tokens[: len(qwen_route_anchor_plan.prefix_tokens)] != qwen_route_anchor_plan.prefix_tokens:
+            self._record_qwen_route_prefix_fallback("production_prefix_changed")
+            qwen_route_anchor_plan = None
         final_plan = self._final_prefix_plan(prompt, prompt_tokens, final_prefix_segments)
         anchor_metadata: dict[str, object] | None = None
         processed_start = 0
         if final_plan is not None:
             processed_start, reused = self._prepare_memory_with_final_prefix(final_plan, prompt_tokens)
+        elif qwen_route_anchor_plan is not None:
+            processed_start, reused = self._prepare_memory_with_qwen_route_anchor(qwen_route_anchor_plan)
         elif anchor_plan is None:
             reused = self._prepare_memory_for_prompt(prompt_tokens)
         else:
@@ -1229,7 +1617,7 @@ class NativeLlamaClient:
                 processed_start = reused
         processed = 0
         step = max(1, min(self.config.progress_step, self.config.batch_size))
-        processed = processed_start if final_plan is not None or (anchor_plan is not None and anchor_metadata is not None) else reused
+        processed = processed_start if final_plan is not None or qwen_route_anchor_plan is not None or (anchor_plan is not None and anchor_metadata is not None) else reused
         if on_progress:
             on_progress(NativeProgress("prefill", processed, n_prompt))
         token_array = (llama_token * n_prompt)(*prompt_tokens)
@@ -1312,6 +1700,254 @@ class NativeLlamaClient:
                     break
                 raise RuntimeError(f"llama_decode failed during prefill: {decode_rc}")
         return processed
+
+    def _qwen_route_anchor_plan_for_prompt(
+        self,
+        messages: list[NativeMessage],
+        *,
+        tools: list[dict] | None,
+        thinking: bool,
+        prompt: str,
+    ) -> _QwenRouteAnchorRuntimePlan | None:
+        if not self.config.qwen_route_prefix_reuse_enabled:
+            return None
+        profile = getattr(self, "model_profile", None)
+        if getattr(profile, "profile_id", None) != QWEN36_PROFILE_ID or not getattr(profile, "verified", False):
+            self._record_qwen_route_prefix_fallback("model_profile_ineligible")
+            return None
+        if self._model_metadata_identity.get("general.file_type") != "15":
+            self._record_qwen_route_prefix_fallback("qwen_quantization_unverified")
+            return None
+        if tools or thinking:
+            self._record_qwen_route_prefix_fallback("structured_route_mode_ineligible")
+            return None
+        if self.config.use_mtp_experimental or self._session.mtp_enabled:
+            self._record_qwen_route_prefix_fallback("mtp_ineligible")
+            return None
+        if not messages or messages[0].get("role") != "system" or not isinstance(messages[0].get("content"), str):
+            self._record_qwen_route_prefix_fallback("missing_route_system_prompt")
+            return None
+        if self.chat_bridge is None or not self._chat_bridge_context:
+            self._record_qwen_route_prefix_fallback("chat_bridge_unavailable")
+            return None
+
+        system_prompt = str(messages[0]["content"])
+        system_hash = hash_text(system_prompt)
+        prompt_tokens = self.tokenize(prompt)
+        spec = self._qwen_route_prefix_spec
+        if spec is None or spec.system_prompt_hash != system_hash:
+            if self._qwen_route_prefix_anchor_state.valid:
+                self._invalidate_qwen_route_prefix("route_identity_changed")
+
+            def render_reference(user_text: str) -> str:
+                rendered = self.chat_bridge.render(
+                    self._chat_bridge_context,
+                    [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_text}],
+                    [],
+                    thinking=False,
+                )
+                value = rendered.get("prompt")
+                if not isinstance(value, str) or not value:
+                    raise RuntimeError("empty Qwen route reference prompt")
+                return value
+
+            reason = None
+            try:
+                spec, reason = derive_qwen_route_prefix_spec(
+                    system_prompt=system_prompt,
+                    full_prompt=prompt,
+                    full_tokens=prompt_tokens,
+                    render_reference=render_reference,
+                    tokenize=self.tokenize,
+                )
+            except Exception as exc:
+                spec = None
+                reason = f"route_boundary_probe_failed:{type(exc).__name__}"
+            finally:
+                # The bridge parser is tied to the most recent render. Restore the
+                # exact production render after the two boundary-only fixtures.
+                restored = self.chat_bridge.render(
+                    self._chat_bridge_context,
+                    self._serialize_profile_messages([dict(message) for message in messages]),
+                    [],
+                    thinking=False,
+                )
+                restored_prompt = restored.get("prompt")
+                if restored_prompt != prompt:
+                    spec = None
+                    reason = "production_render_not_repeatable"
+                else:
+                    self._active_profile_render = restored
+            if spec is None:
+                self._record_qwen_route_prefix_fallback(reason or "route_boundary_unavailable")
+                return None
+            self._qwen_route_prefix_spec = spec
+
+        if list(prompt_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != list(spec.prefix_tokens):
+            self._invalidate_qwen_route_prefix("production_prefix_changed")
+            self._record_qwen_route_prefix_fallback("production_prefix_changed")
+            return None
+
+        state_kwargs = self._qwen_route_prefix_state_kwargs(spec)
+        prefix_hash = compute_prefix_anchor_key(**state_kwargs)
+        return _QwenRouteAnchorRuntimePlan(
+            prefix_tokens=list(spec.prefix_tokens),
+            prefix_hash=prefix_hash,
+            state_kwargs=state_kwargs,
+            spec=spec,
+            metadata={
+                "profile": QWEN36_PROFILE_ID,
+                "prefix_token_count": QWEN_ROUTE_PREFIX_TOKEN_COUNT,
+                "prefix_token_hash": spec.prefix_token_hash,
+                "invariant_token_count": spec.invariant_token_count,
+                "next_boundary_token": spec.next_boundary_token,
+            },
+        )
+
+    def _prepare_memory_with_qwen_route_anchor(self, plan: _QwenRouteAnchorRuntimePlan) -> tuple[int, int]:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        if self._qwen_route_prefix_anchor_state.valid:
+            self._clear_target_memory()
+            ok, restored, metadata = restore_prefix_anchor(
+                self._qwen_route_prefix_anchor_state,
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **plan.state_kwargs,
+            )
+            self._qwen_route_prefix_anchor_state = restored
+            if ok:
+                self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+                status = self._qwen_route_prefix_status
+                status.initialized = True
+                status.prefix_tokens = len(plan.prefix_tokens)
+                status.restore_count += 1
+                status.failure_reason = None
+                status.last_used = "restore"
+                return len(plan.prefix_tokens), len(plan.prefix_tokens)
+            self._clear_target_memory()
+            self._qwen_route_prefix_status.invalidation_count += 1
+            self._record_qwen_route_prefix_fallback(str(metadata.get("fallback_reason") or "restore_failed"))
+            return 0, 0
+
+        self._clear_target_memory()
+        token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
+        step = max(1, min(self.config.progress_step, self.config.batch_size))
+        self._decode_prompt_range(
+            token_array,
+            processed=0,
+            end=len(plan.prefix_tokens),
+            step=step,
+            total=len(plan.prefix_tokens),
+            on_progress=None,
+            should_cancel=None,
+        )
+        self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+        state, metadata = capture_prefix_anchor(
+            lib=self.lib.lib,
+            ctx=self._session.ctx_tgt,
+            prefix_hash=plan.prefix_hash,
+            token_count=len(plan.prefix_tokens),
+            enabled=True,
+            **plan.state_kwargs,
+        )
+        self._qwen_route_prefix_anchor_state = state
+        if state.valid:
+            status = self._qwen_route_prefix_status
+            status.initialized = True
+            status.prefix_tokens = len(plan.prefix_tokens)
+            status.capture_count += 1
+            status.failure_reason = None
+            status.last_used = "capture"
+        else:
+            self._record_qwen_route_prefix_fallback(str(metadata.get("fallback_reason") or "capture_failed"))
+        # Capture is part of the normal first prefill. Even if the read-only
+        # capture fails, the decoded prefix remains valid for this completion.
+        return len(plan.prefix_tokens), 0
+
+    def _qwen_route_prefix_state_kwargs(self, spec: QwenRoutePrefixSpec) -> dict[str, str | None]:
+        profile = self.model_profile
+        try:
+            stat = self.paths.model.stat()
+            model_file_identity = {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
+        except OSError:
+            model_file_identity = {"size": None, "mtime_ns": None}
+        model_identity = hash_text(
+            json.dumps(
+                {
+                    "profile": getattr(profile, "profile_id", None),
+                    "metadata": self._model_metadata_identity,
+                    "file": model_file_identity,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        return {
+            "model_id": model_identity,
+            "template_id": hash_text(
+                f"{QWEN_ROUTE_PREFIX_FORMAT_VERSION}:{getattr(profile, 'template_sha256', '')}:"
+                f"{QWEN_ROUTE_TOKENIZER_IDENTITY}:ctx={self.config.context_tokens}"
+            ),
+            "tool_schema_hash": spec.system_prompt_hash,
+            "capability_summary_hash": spec.system_prompt_hash,
+            "runtime_policy_hash": spec.invariant_text_hash,
+            "route_contract_hash": spec.prefix_token_hash,
+            "backend_version": self._qwen_backend_build_identity(),
+            "native_version": hash_text(
+                f"{runtime_library_filename('llama')}:batch={self.config.batch_size}:"
+                f"ubatch={self.config.ubatch_size}:step={self.config.progress_step}:"
+                f"threads={self.config.threads}:threads_batch={self.config.threads_batch}"
+            ),
+            "tools_mode": "qwen-route-tools-on-thinking-off",
+        }
+
+    def _qwen_backend_build_identity(self) -> str:
+        if self._qwen_native_build_identity is None:
+            from .capabilities import read_llama_cpp_build_info
+
+            build = read_llama_cpp_build_info(self.paths.build_bin)
+            self._qwen_native_build_identity = hash_text(
+                json.dumps(
+                    {
+                        "build_number": build.build_number,
+                        "commit": build.commit,
+                        "target": build.target,
+                        "compiler": build.compiler,
+                        "library_hash": build.library_hash,
+                        "source": build.source,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        return self._qwen_native_build_identity
+
+    def _record_qwen_route_prefix_fallback(self, reason: str) -> None:
+        status = self._qwen_route_prefix_status
+        status.fallback_count += 1
+        status.failure_reason = reason
+        status.last_used = "fallback"
+        if not self._qwen_route_prefix_anchor_state.valid:
+            status.initialized = False
+            status.prefix_tokens = 0
+
+    def _invalidate_qwen_route_prefix(self, reason: str) -> None:
+        if not hasattr(self, "_qwen_route_prefix_anchor_state"):
+            return
+        had_state = self._qwen_route_prefix_anchor_state.valid or self._qwen_route_prefix_anchor_state.checkpoint_size > 0
+        self._qwen_route_prefix_anchor_state = PrefixAnchorState()
+        self._qwen_route_prefix_spec = None
+        status = self._qwen_route_prefix_status
+        if had_state:
+            status.invalidation_count += 1
+        status.initialized = False
+        status.prefix_tokens = 0
+        status.failure_reason = reason
+        status.last_used = "invalidated"
 
     def _route_anchor_plan(
         self,
@@ -1451,6 +2087,17 @@ class NativeLlamaClient:
         thinking: bool,
         prompt: str,
     ) -> RoutePromptSegments | None:
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and not profile.gemma_prefix_reuse_supported:
+            emit_route_prefix_anchor_event(
+                _route_anchor_metadata(
+                    enabled=False,
+                    attempted=False,
+                    prefix_hash=None,
+                    fallback_reason="model_profile_ineligible",
+                )
+            )
+            return None
         if not prefix_anchor_enabled():
             emit_route_prefix_anchor_event(
                 _route_anchor_metadata(
@@ -1518,7 +2165,15 @@ class NativeLlamaClient:
         return segments
 
     def _final_prefix_experiment_eligible(self, requested: bool) -> bool:
-        return requested and self.config.final_prefix_experiment_enabled and not self.config.use_mtp_experimental
+        return (
+            requested
+            and self.config.final_prefix_experiment_enabled
+            and not self.config.use_mtp_experimental
+            and (
+                getattr(self, "model_profile", None) is None
+                or getattr(self, "model_profile").gemma_prefix_reuse_supported
+            )
+        )
 
     def _final_prefix_plan(
         self,
@@ -1869,7 +2524,12 @@ class NativeLlamaClient:
             if common == 0:
                 lib.llama_memory_clear(mem, True)
             else:
-                lib.llama_memory_seq_rm(mem, 0, common, -1)
+                removed = lib.llama_memory_seq_rm(mem, 0, common, -1)
+                if not removed:
+                    # Hybrid/recurrent models may reject partial state removal.
+                    # A cold prefill is the only safe fallback for a new prompt.
+                    lib.llama_memory_clear(mem, True)
+                    common = 0
         self._session.cached_prompt_tokens = list(prompt_tokens)
         return common
 
@@ -1884,6 +2544,23 @@ class NativeLlamaClient:
             raise RuntimeError("native client not loaded")
         thinking = self._thinking_enabled(thinking)
         rendered_messages = [dict(message) for message in messages]
+        profile = getattr(self, "model_profile", None)
+        if profile is not None and profile.uses_native_chat_bridge:
+            if self.chat_bridge is None or not self._chat_bridge_context:
+                raise RuntimeError("Orbit chat compatibility bridge is unavailable")
+            rendered = self.chat_bridge.render(
+                self._chat_bridge_context,
+                self._serialize_profile_messages(rendered_messages),
+                [dict(tool) for tool in (tools or [])],
+                thinking=thinking,
+            )
+            prompt = rendered.get("prompt")
+            if not isinstance(prompt, str) or not prompt:
+                raise RuntimeError("Orbit chat compatibility bridge returned an empty prompt")
+            self._active_profile_render = rendered
+            self._profile_last_raw_output = ""
+            self._profile_last_parsed_content = ""
+            return prompt
         if thinking:
             return render_gemma4_chat(rendered_messages, tools=tools, thinking=True)
         if tools or any(message.get("role") == "tool" or message.get("tool_calls") for message in rendered_messages):
@@ -1910,6 +2587,50 @@ class NativeLlamaClient:
         if not thinking:
             rendered = _strip_thinking_prompt(rendered)
         return rendered
+
+    def _serialize_profile_messages(self, messages: list[NativeMessage]) -> list[NativeMessage]:
+        profile = getattr(self, "model_profile", None)
+        if profile is None or profile.family != "qwen3.6":
+            return messages
+        serialized: list[NativeMessage] = []
+        for index, message in enumerate(messages):
+            item = dict(message)
+            if item.get("role") == "system" and index != 0:
+                # The reviewed Qwen template accepts a system role only at the
+                # beginning. Preserve later Orbit evidence cards in place as a
+                # normal input turn instead of reordering or dropping content.
+                item["role"] = "user"
+            serialized.append(item)
+        return serialized
+
+    def _parse_profile_output(self, generated_text: str, *, partial: bool) -> _ProfileParsedOutput:
+        if self.chat_bridge is None or not self._chat_bridge_context:
+            raise RuntimeError("Orbit chat compatibility parser is unavailable")
+        value = self.chat_bridge.parse(self._chat_bridge_context, generated_text, partial=partial)
+        content = value.get("content")
+        reasoning = value.get("reasoning_content")
+        raw_calls = value.get("tool_calls")
+        if not isinstance(content, str) or not isinstance(reasoning, str) or not isinstance(raw_calls, list):
+            raise RuntimeError("Orbit chat compatibility parser returned an invalid result")
+        calls: list[dict[str, object]] = []
+        for raw_call in raw_calls:
+            if not isinstance(raw_call, dict):
+                raise RuntimeError("Orbit chat compatibility parser returned an invalid tool call")
+            function = raw_call.get("function")
+            if not isinstance(function, dict):
+                raise RuntimeError("Orbit chat compatibility parser returned an invalid tool function")
+            name = function.get("name")
+            arguments = function.get("arguments")
+            if not isinstance(name, str) or not name or not isinstance(arguments, str):
+                raise RuntimeError("Orbit chat compatibility parser returned invalid tool arguments")
+            calls.append(
+                {
+                    "id": raw_call.get("id") if isinstance(raw_call.get("id"), str) else "",
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            )
+        return _ProfileParsedOutput(content=content, reasoning_content=reasoning, tool_calls=tuple(calls))
 
     def _token_to_bytes(self, token: int) -> bytes:
         if not self._vocab:
@@ -2112,6 +2833,9 @@ def _merge_completions(first: NativeCompletion, second: NativeCompletion) -> Nat
         ),
         stopped_by_stop=first.stopped_by_stop or second.stopped_by_stop,
         completed_after_thought=_has_closed_thought_with_final(merged_content),
+        reasoning_content=first.reasoning_content + second.reasoning_content,
+        reasoning_tokens=first.reasoning_tokens + second.reasoning_tokens,
+        tool_calls=second.tool_calls or first.tool_calls,
     )
 
 

--- a/src/orbit/native_llama/events.py
+++ b/src/orbit/native_llama/events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 
 NativePhase = Literal["load", "prefill", "generation"]
@@ -37,3 +37,6 @@ class NativeCompletion:
     timings: NativeTimings
     stopped_by_stop: bool = False
     completed_after_thought: bool = False
+    reasoning_content: str = ""
+    reasoning_tokens: int = 0
+    tool_calls: tuple[dict[str, Any], ...] = ()

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from typing import Mapping
+
+
+GEMMA4_PROFILE_ID = "orbit-gemma4-native-v1"
+QWEN36_PROFILE_ID = "orbit-qwen36-native-v1"
+QWEN36_OFFICIAL_TEMPLATE_SHA256 = "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259"
+QWEN36_VERIFIED_FILE_TYPE = "15"
+QWEN36_VERIFIED_QUANTIZATION = "Q4_K_M"
+
+
+@dataclass(frozen=True)
+class NativeModelProfile:
+    profile_id: str
+    family: str
+    model_name: str
+    architecture: str
+    renderer: str
+    reasoning_protocol: str
+    tool_call_protocol: str
+    history_serialization: str
+    verified: bool
+    failure_reason: str | None
+    template_source: str
+    template_sha256: str
+    thinking_supported: bool
+    mtp_supported: bool
+    gemma_prefix_reuse_supported: bool
+    verified_quantization: str | None = None
+
+    @property
+    def uses_native_chat_bridge(self) -> bool:
+        return self.renderer == "llama.cpp-jinja"
+
+    def diagnostics(self, *, thinking_enabled: bool) -> dict[str, object]:
+        return {
+            "model_family": self.family,
+            "model_name": self.model_name,
+            "compatibility_profile": self.profile_id,
+            "architecture": self.architecture,
+            "template_source": self.template_source,
+            "template_hash": self.template_sha256,
+            "renderer": self.renderer,
+            "thinking_supported": self.thinking_supported,
+            "thinking_enabled": thinking_enabled,
+            "reasoning_protocol": self.reasoning_protocol,
+            "tool_call_protocol": self.tool_call_protocol,
+            "history_serialization": self.history_serialization,
+            "verified": self.verified,
+            "failure_reason": self.failure_reason,
+            "mtp_supported": self.mtp_supported,
+            "verified_quantization": self.verified_quantization,
+        }
+
+
+def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> NativeModelProfile:
+    architecture = metadata.get("general.architecture", "").strip().lower()
+    tokenizer_model = metadata.get("tokenizer.ggml.model", "").strip().lower()
+    tokenizer_pre = metadata.get("tokenizer.ggml.pre", "").strip().lower()
+    model_name = metadata.get("general.name", "").strip()
+    file_type = metadata.get("general.file_type", "").strip()
+    template_hash = hashlib.sha256(template.encode("utf-8")).hexdigest()
+
+    if architecture == "gemma4" and tokenizer_model == "gemma4":
+        return NativeModelProfile(
+            profile_id=GEMMA4_PROFILE_ID,
+            family="gemma4",
+            model_name=model_name,
+            architecture=architecture,
+            renderer="orbit-gemma4",
+            reasoning_protocol="gemma4-control-channel",
+            tool_call_protocol="gemma4-native",
+            history_serialization="orbit-native-roles",
+            verified=True,
+            failure_reason=None,
+            template_source="orbit-reviewed",
+            template_sha256=template_hash,
+            thinking_supported=True,
+            mtp_supported=True,
+            gemma_prefix_reuse_supported=True,
+        )
+
+    qwen_identity = (
+        architecture == "qwen35moe"
+        and model_name == "Qwen3.6-35B-A3B"
+        and tokenizer_model == "gpt2"
+        and tokenizer_pre == "qwen35"
+        and file_type == QWEN36_VERIFIED_FILE_TYPE
+        and template_hash == QWEN36_OFFICIAL_TEMPLATE_SHA256
+    )
+    if qwen_identity:
+        return NativeModelProfile(
+            profile_id=QWEN36_PROFILE_ID,
+            family="qwen3.6",
+            model_name=model_name,
+            architecture=architecture,
+            renderer="llama.cpp-jinja",
+            reasoning_protocol="qwen-think",
+            tool_call_protocol="qwen3.6-xml",
+            history_serialization="qwen-leading-system-only",
+            verified=True,
+            failure_reason=None,
+            template_source="gguf-embedded-official",
+            template_sha256=template_hash,
+            thinking_supported=True,
+            mtp_supported=False,
+            gemma_prefix_reuse_supported=False,
+            verified_quantization=QWEN36_VERIFIED_QUANTIZATION,
+        )
+
+    reason = _unverified_reason(
+        architecture=architecture,
+        model_name=model_name,
+        tokenizer_model=tokenizer_model,
+        tokenizer_pre=tokenizer_pre,
+        file_type=file_type,
+        template_hash=template_hash,
+    )
+    return NativeModelProfile(
+        profile_id="unsupported",
+        family=architecture or "unknown",
+        model_name=model_name,
+        architecture=architecture or "unknown",
+        renderer="unsupported",
+        reasoning_protocol="unsupported",
+        tool_call_protocol="unsupported",
+        history_serialization="unsupported",
+        verified=False,
+        failure_reason=reason,
+        template_source="gguf-embedded" if template else "missing",
+        template_sha256=template_hash,
+        thinking_supported=False,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+    )
+
+
+def _unverified_reason(
+    *,
+    architecture: str,
+    model_name: str,
+    tokenizer_model: str,
+    tokenizer_pre: str,
+    file_type: str,
+    template_hash: str,
+) -> str:
+    if architecture == "qwen35moe":
+        if model_name != "Qwen3.6-35B-A3B":
+            return "qwen36_model_identity_mismatch"
+        if tokenizer_model != "gpt2" or tokenizer_pre != "qwen35":
+            return "qwen36_tokenizer_identity_mismatch"
+        if file_type != QWEN36_VERIFIED_FILE_TYPE:
+            return "qwen36_quantization_identity_mismatch"
+        if template_hash != QWEN36_OFFICIAL_TEMPLATE_SHA256:
+            return "qwen36_template_identity_mismatch"
+    return "unsupported_model_profile"

--- a/src/orbit/native_llama/native_artifacts.py
+++ b/src/orbit/native_llama/native_artifacts.py
@@ -16,6 +16,7 @@ LINUX_RUNTIME_LIBS = (
 OPTIONAL_RUNTIME_LIBS = (
     "libmtmd.so",
     "liborbit-mtmd-bridge.so",
+    "liborbit-chat-bridge.so",
 )
 
 SHIM_ARTIFACTS = (

--- a/src/orbit/native_llama/qwen_route_prefix.py
+++ b/src/orbit/native_llama/qwen_route_prefix.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+from typing import Callable, Mapping, Sequence
+
+
+QWEN_ROUTE_PREFIX_ENV = "ORBIT_QWEN_ROUTE_PREFIX_REUSE"
+QWEN_ROUTE_PREFIX_TOKEN_COUNT = 768
+QWEN_ROUTE_PREFIX_FORMAT_VERSION = "qwen36-route-prefix-v1"
+QWEN_ROUTE_TOKENIZER_IDENTITY = "gpt2:qwen35"
+
+
+@dataclass(frozen=True)
+class QwenRoutePrefixConfig:
+    enabled: bool
+    source: str
+    validation_error: str | None = None
+
+
+@dataclass(frozen=True)
+class QwenRoutePrefixSpec:
+    prefix_tokens: tuple[int, ...]
+    prefix_token_hash: str
+    invariant_text_hash: str
+    system_prompt_hash: str
+    invariant_token_count: int
+    next_boundary_token: int
+
+
+@dataclass
+class QwenRoutePrefixStatus:
+    initialized: bool = False
+    prefix_tokens: int = 0
+    capture_count: int = 0
+    restore_count: int = 0
+    fallback_count: int = 0
+    invalidation_count: int = 0
+    failure_reason: str | None = None
+    last_used: str | None = None
+
+
+def resolve_qwen_route_prefix_reuse(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default_enabled: bool = True,
+) -> QwenRoutePrefixConfig:
+    env = os.environ if environ is None else environ
+    configured = env.get(QWEN_ROUTE_PREFIX_ENV)
+    if configured is None:
+        return QwenRoutePrefixConfig(enabled=default_enabled, source="default")
+    value = configured.strip()
+    if value == "1":
+        return QwenRoutePrefixConfig(enabled=True, source="stable")
+    if value == "0":
+        return QwenRoutePrefixConfig(enabled=False, source="stable")
+    return QwenRoutePrefixConfig(
+        enabled=False,
+        source="stable",
+        validation_error="invalid_qwen_route_prefix_reuse_value",
+    )
+
+
+def derive_qwen_route_prefix_spec(
+    *,
+    system_prompt: str,
+    full_prompt: str,
+    full_tokens: Sequence[int],
+    render_reference: Callable[[str], str],
+    tokenize: Callable[[str], list[int]],
+) -> tuple[QwenRoutePrefixSpec | None, str | None]:
+    if not system_prompt:
+        return None, "missing_route_system_prompt"
+    if len(full_tokens) <= QWEN_ROUTE_PREFIX_TOKEN_COUNT:
+        return None, "route_prompt_too_short"
+
+    first = render_reference("A-orbit-qwen-route-boundary")
+    second = render_reference("Z-orbit-qwen-route-boundary")
+    first_tokens = tokenize(first)
+    second_tokens = tokenize(second)
+    token_lcp = _longest_common_prefix(first_tokens, second_tokens)
+    if token_lcp <= QWEN_ROUTE_PREFIX_TOKEN_COUNT:
+        return None, "stable_token_boundary_unavailable"
+
+    prefix = tuple(first_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT])
+    if tuple(second_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != prefix:
+        return None, "reference_prefix_mismatch"
+    if tuple(full_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != prefix:
+        return None, "production_prefix_mismatch"
+
+    char_lcp = _longest_common_prefix_text(first, second)
+    if char_lcp <= 0 or not full_prompt.startswith(first[:char_lcp]):
+        return None, "invariant_text_boundary_mismatch"
+
+    return (
+        QwenRoutePrefixSpec(
+            prefix_tokens=prefix,
+            prefix_token_hash=hash_tokens(prefix),
+            invariant_text_hash=hash_text(first[:char_lcp]),
+            system_prompt_hash=hash_text(system_prompt),
+            invariant_token_count=token_lcp,
+            next_boundary_token=int(first_tokens[QWEN_ROUTE_PREFIX_TOKEN_COUNT]),
+        ),
+        None,
+    )
+
+
+def hash_tokens(tokens: Sequence[int]) -> str:
+    digest = hashlib.sha256()
+    for token in tokens:
+        digest.update(int(token).to_bytes(4, byteorder="little", signed=True))
+    return digest.hexdigest()
+
+
+def hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _longest_common_prefix(first: Sequence[int], second: Sequence[int]) -> int:
+    common = 0
+    limit = min(len(first), len(second))
+    while common < limit and first[common] == second[common]:
+        common += 1
+    return common
+
+
+def _longest_common_prefix_text(first: str, second: str) -> int:
+    common = 0
+    limit = min(len(first), len(second))
+    while common < limit and first[common] == second[common]:
+        common += 1
+    return common

--- a/src/orbit/native_llama/vendor/shim/orbit_chat_bridge.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_chat_bridge.cpp
@@ -1,0 +1,189 @@
+#include "chat.h"
+#include "llama.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <string>
+
+#if defined(_WIN32)
+#define ORBIT_EXPORT __declspec(dllexport)
+#else
+#define ORBIT_EXPORT __attribute__((visibility("default")))
+#endif
+
+namespace {
+
+using json = nlohmann::ordered_json;
+
+thread_local std::string last_error;
+
+struct orbit_chat_context {
+    common_chat_templates_ptr templates;
+    common_chat_format format = COMMON_CHAT_FORMAT_CONTENT_ONLY;
+    std::string generation_prompt;
+    std::string parser;
+    bool render_ready = false;
+};
+
+int copy_result(const std::string & value, char * output, size_t output_size) {
+    if (output == nullptr || output_size == 0) {
+        return static_cast<int>(value.size());
+    }
+    if (value.size() + 1 > output_size) {
+        return static_cast<int>(value.size());
+    }
+    std::memcpy(output, value.data(), value.size());
+    output[value.size()] = '\0';
+    return static_cast<int>(value.size());
+}
+
+json parsed_message_json(const common_chat_msg & message) {
+    json result = {
+        {"content", message.content},
+        {"reasoning_content", message.reasoning_content},
+        {"tool_calls", json::array()},
+    };
+    for (const auto & call : message.tool_calls) {
+        result["tool_calls"].push_back({
+            {"id", call.id},
+            {"type", "function"},
+            {"function", {
+                {"name", call.name},
+                {"arguments", call.arguments},
+            }},
+        });
+    }
+    return result;
+}
+
+}  // namespace
+
+extern "C" {
+
+ORBIT_EXPORT uint32_t orbit_chat_bridge_api_version() {
+    return 1;
+}
+
+ORBIT_EXPORT const char * orbit_chat_bridge_last_error() {
+    return last_error.c_str();
+}
+
+ORBIT_EXPORT void * orbit_chat_bridge_create(const llama_model * model) {
+    last_error.clear();
+    if (model == nullptr) {
+        last_error = "model handle is null";
+        return nullptr;
+    }
+    try {
+        auto context = std::make_unique<orbit_chat_context>();
+        context->templates = common_chat_templates_init(model, "");
+        if (!context->templates) {
+            last_error = "failed to initialize chat templates";
+            return nullptr;
+        }
+        return context.release();
+    } catch (const std::exception & exc) {
+        last_error = exc.what();
+        return nullptr;
+    }
+}
+
+ORBIT_EXPORT void orbit_chat_bridge_free(void * opaque) {
+    delete static_cast<orbit_chat_context *>(opaque);
+}
+
+ORBIT_EXPORT int orbit_chat_bridge_render(
+    void * opaque,
+    const char * messages_json,
+    const char * tools_json,
+    bool enable_thinking,
+    char * output,
+    size_t output_size
+) {
+    last_error.clear();
+    auto * context = static_cast<orbit_chat_context *>(opaque);
+    if (context == nullptr || messages_json == nullptr || tools_json == nullptr) {
+        last_error = "invalid render arguments";
+        return -1;
+    }
+    try {
+        const json messages = json::parse(messages_json);
+        const json tools = json::parse(tools_json);
+        if (!messages.is_array() || !tools.is_array()) {
+            throw std::invalid_argument("messages and tools must be arrays");
+        }
+
+        common_chat_templates_inputs inputs;
+        inputs.messages = common_chat_msgs_parse_oaicompat(messages);
+        inputs.tools = common_chat_tools_parse_oaicompat(tools);
+        inputs.add_generation_prompt = true;
+        inputs.use_jinja = true;
+        inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
+        inputs.parallel_tool_calls = false;
+        inputs.reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
+        inputs.enable_thinking = enable_thinking;
+        inputs.chat_template_kwargs["enable_thinking"] = enable_thinking ? "true" : "false";
+
+        const common_chat_params params = common_chat_templates_apply(context->templates.get(), inputs);
+        if (params.prompt.empty()) {
+            throw std::runtime_error("chat template produced an empty prompt");
+        }
+        context->format = params.format;
+        context->generation_prompt = params.generation_prompt;
+        context->parser = params.parser;
+        context->render_ready = true;
+
+        const json result = {
+            {"prompt", params.prompt},
+            {"generation_prompt", params.generation_prompt},
+            {"format", common_chat_format_name(params.format)},
+            {"supports_thinking", params.supports_thinking},
+            {"thinking_start_tag", params.thinking_start_tag},
+            {"thinking_end_tag", params.thinking_end_tag},
+            {"additional_stops", params.additional_stops},
+        };
+        return copy_result(result.dump(), output, output_size);
+    } catch (const std::exception & exc) {
+        context->render_ready = false;
+        last_error = exc.what();
+        return -1;
+    }
+}
+
+ORBIT_EXPORT int orbit_chat_bridge_parse(
+    void * opaque,
+    const char * generated_text,
+    bool is_partial,
+    char * output,
+    size_t output_size
+) {
+    last_error.clear();
+    auto * context = static_cast<orbit_chat_context *>(opaque);
+    if (context == nullptr || generated_text == nullptr || !context->render_ready) {
+        last_error = "chat parser is not initialized";
+        return -1;
+    }
+    try {
+        common_chat_parser_params params;
+        params.format = context->format;
+        params.reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
+        params.reasoning_in_content = false;
+        params.generation_prompt = context->generation_prompt;
+        params.parse_tool_calls = true;
+        if (!context->parser.empty()) {
+            params.parser.load(context->parser);
+        }
+        const common_chat_msg message = common_chat_parse(generated_text, is_partial, params);
+        return copy_result(parsed_message_json(message).dump(), output, output_size);
+    } catch (const std::exception & exc) {
+        last_error = exc.what();
+        return -1;
+    }
+}
+
+}  // extern "C"

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -13,7 +13,7 @@ import time
 from typing import Any, Mapping
 
 from orbit.final_prefix_config import resolve_final_prefix_reuse
-from orbit.native_llama.capabilities import safe_gemma4_capability_manifest
+from orbit.native_llama.capabilities import safe_native_capability_manifest
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
 from orbit.native_llama.client import (
     NativeClientConfig,
@@ -24,6 +24,7 @@ from orbit.native_llama.client import (
 from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_context as native_kv_request_context
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
+from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
 from orbit.native_server.protocol import (
     ContinueRequest,
     DEFAULT_SESSION_ID,
@@ -54,7 +55,7 @@ class OrbitNativeServer:
         self.client = client
         self.model_alias = model_alias
         self.lock = threading.Lock()
-        self.native_backend_capabilities = safe_gemma4_capability_manifest(
+        self.native_backend_capabilities = safe_native_capability_manifest(
             client,
             final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT,
         )
@@ -82,6 +83,7 @@ class OrbitNativeServer:
                 tools=request.tools,
                 thinking=thinking,
                 route_prefix_anchor=request.route_prefix_anchor,
+                qwen_route_prefix_anchor=request.qwen_route_prefix_anchor,
                 allow_mtp_experimental=request.allow_mtp_experimental,
                 final_prefix_experiment=final_prefix_experiment,
                 on_progress=on_progress,
@@ -103,6 +105,12 @@ class OrbitNativeServer:
             finish_reason = "length"
         elif timings.output_tokens >= request.max_tokens and not timings.cancelled and not stopped:
             finish_reason = "length"
+        tool_calls = getattr(completion, "tool_calls", ())
+        # A structurally parsed call must not turn a budget-truncated generation
+        # into an executable completion. The canonical gate remains authoritative
+        # after this transport-level finish reason is preserved.
+        if tool_calls and finish_reason not in {"cancelled", "length"}:
+            finish_reason = "tool_calls"
         return native_chat_response(
             content=content,
             model=self.model_alias,
@@ -115,6 +123,9 @@ class OrbitNativeServer:
             prefill_ms=timings.prefill_ms,
             generation_ms=timings.generation_ms,
             cancelled=timings.cancelled and not stopped,
+            reasoning_content=getattr(completion, "reasoning_content", ""),
+            reasoning_tokens=getattr(completion, "reasoning_tokens", 0),
+            tool_calls=tool_calls,
         )
 
     def continue_current(self, request: ContinueRequest, *, on_token=None, on_progress=None, should_cancel=None) -> dict[str, Any]:
@@ -200,11 +211,15 @@ class OrbitNativeServer:
         tools: list[dict[str, Any]],
         thinking: bool,
     ) -> dict[str, int | str]:
-        tokens, rendered_hash, token_hash = self.client.inspect_chat_tokens(
-            messages,
-            tools=tools,
-            thinking=thinking,
-        )
+        # The Qwen bridge keeps the parser associated with its latest render.
+        # Serialize inspection with completion so concurrent token accounting
+        # cannot replace parser state while generated text is being decoded.
+        with self.lock:
+            tokens, rendered_hash, token_hash = self.client.inspect_chat_tokens(
+                messages,
+                tools=tools,
+                thinking=thinking,
+            )
         return {
             "tokens": tokens,
             "context_tokens": self.client.config.context_tokens,
@@ -260,6 +275,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_last_validate_equivalence = _mtp_last_validate_equivalence_payload(state.client)
             mtp_config = _mtp_config_payload(state.client)
             final_prefix = state.client.final_prefix_experiment_status()
+            qwen_route_prefix = state.client.qwen_route_prefix_reuse_status()
             final_prefix_config = _final_prefix_reuse_props(state.client)
             self._json(
                 {
@@ -301,6 +317,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "model_id": state.client.paths.model_id,
                     "backend": "orbit-native",
                     "native_backend_capabilities": state.native_backend_capabilities,
+                    "model_compatibility": state.client.compatibility_diagnostics(),
                     "backend_mode": session["backend_mode"],
                     "thinking_mode": runtime["thinking_mode"],
                     "session_id": session["id"],
@@ -321,6 +338,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "final_prefix_experiment_failure_reason": final_prefix["failure_reason"],
                     "final_prefix_experiment_last_used": final_prefix["last_used"],
                     "final_prefix_experiment_checkpoint_size_bytes": final_prefix["checkpoint_size_bytes"],
+                    "qwen_route_prefix_reuse": qwen_route_prefix,
                     **final_prefix_config,
                     **_tool_call_healing_props(),
                 }
@@ -530,6 +548,11 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     should_cancel=lambda: disconnect.is_set() or self._client_disconnected(),
                 )
             disconnect.disarm()
+            reasoning = result.get("reasoning_content")
+            if isinstance(reasoning, str) and reasoning:
+                emit("reasoning", {"text": reasoning, "session_id": request.session_id})
+            if result.get("tool_calls"):
+                emit("tool_calls", {"tool_calls": result["tool_calls"], "session_id": request.session_id})
             emit("metrics", {"usage": result["usage"], "timings": result["timings"], "native": result["native"]})
             emit("done", {"finish_reason": result["finish_reason"], "session_id": request.session_id})
         except RuntimeError as exc:
@@ -629,6 +652,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
 def run_server(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     final_prefix_config = resolve_final_prefix_reuse()
+    qwen_route_prefix_config = resolve_qwen_route_prefix_reuse()
 
     try:
         paths = resolve_bootstrap_paths(args)
@@ -650,6 +674,9 @@ def run_server(argv: list[str] | None = None) -> int:
                 final_prefix_reuse_source=final_prefix_config.source,
                 final_prefix_reuse_config_error=final_prefix_config.validation_error,
                 final_prefix_reuse_legacy_detected=final_prefix_config.legacy_detected,
+                qwen_route_prefix_reuse_enabled=qwen_route_prefix_config.enabled,
+                qwen_route_prefix_reuse_source=qwen_route_prefix_config.source,
+                qwen_route_prefix_reuse_config_error=qwen_route_prefix_config.validation_error,
             ),
         )
         if not args.verbose_llama_log:
@@ -729,6 +756,11 @@ def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefix
         return result
     if not prefix_anchor_enabled():
         result = _startup_prewarm_skipped("anchor_disabled")
+        _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
+        return result
+    profile = getattr(client, "model_profile", None)
+    if profile is not None and not profile.gemma_prefix_reuse_supported:
+        result = _startup_prewarm_skipped("model_profile_ineligible")
         _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
         return result
     try:

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -76,6 +76,12 @@ class OrbitNativeServer:
         with self.lock:
             thinking = self.client.config.thinking if request.thinking is None else request.thinking
             final_prefix_experiment = request.final_prefix_experiment and _is_final_from_tool_prompt(request.messages)
+            qwen_route_prefix_anchor = (
+                request.qwen_route_prefix_anchor
+                and not thinking
+                and not request.tools
+                and _is_qwen_route_prompt(request.messages)
+            )
             completion = self.client.complete_chat_text(
                 request.messages,
                 max_tokens=request.max_tokens,
@@ -83,7 +89,7 @@ class OrbitNativeServer:
                 tools=request.tools,
                 thinking=thinking,
                 route_prefix_anchor=request.route_prefix_anchor,
-                qwen_route_prefix_anchor=request.qwen_route_prefix_anchor,
+                qwen_route_prefix_anchor=qwen_route_prefix_anchor,
                 allow_mtp_experimental=request.allow_mtp_experimental,
                 final_prefix_experiment=final_prefix_experiment,
                 on_progress=on_progress,
@@ -740,6 +746,14 @@ def _is_final_from_tool_prompt(messages: list[dict[str, Any]]) -> bool:
         len(messages) == 3
         and [message.get("role") for message in messages] == ["system", "user", "system"]
         and messages[0].get("content") == FINAL_FROM_TOOL_SYSTEM_PROMPT
+    )
+
+
+def _is_qwen_route_prompt(messages: list[dict[str, Any]]) -> bool:
+    return bool(
+        len(messages) >= 2
+        and messages[0].get("role") == "system"
+        and messages[0].get("content") == ROUTE_SYSTEM_PROMPT
     )
 
 

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -19,6 +19,7 @@ class ChatRequest:
     stream: bool
     tools: list[dict[str, Any]]
     route_prefix_anchor: bool
+    qwen_route_prefix_anchor: bool
     allow_mtp_experimental: bool | None
     final_prefix_experiment: bool
 
@@ -42,6 +43,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         stream=payload.get("stream") is True,
         tools=_tools_from_payload(payload.get("tools")),
         route_prefix_anchor=payload.get("route_prefix_anchor") is True,
+        qwen_route_prefix_anchor=payload.get("qwen_route_prefix_anchor") is True,
         allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
         final_prefix_experiment=payload.get("final_prefix_experiment") is True,
     )
@@ -69,12 +71,17 @@ def native_chat_response(
     prefill_ms: float,
     generation_ms: float,
     cancelled: bool,
+    reasoning_content: str = "",
+    reasoning_tokens: int = 0,
+    tool_calls: tuple[dict[str, Any], ...] = (),
 ) -> dict[str, Any]:
     return {
         "content": content,
         "model": model,
         "session_id": session_id,
         "finish_reason": finish_reason,
+        "reasoning_content": reasoning_content,
+        "tool_calls": list(tool_calls),
         "usage": {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
@@ -98,16 +105,27 @@ def native_chat_response(
             "prefill_ms": prefill_ms,
             "generation_ms": generation_ms,
             "cancelled": cancelled,
+            "reasoning_tokens": reasoning_tokens,
         },
     }
 
 
 def openai_chat_response(result: dict[str, Any], *, content: str | None = None) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": result["content"] if content is None else content,
+    }
+    reasoning = result.get("reasoning_content")
+    if isinstance(reasoning, str) and reasoning:
+        message["reasoning_content"] = reasoning
+    tool_calls = result.get("tool_calls")
+    if isinstance(tool_calls, list) and tool_calls:
+        message["tool_calls"] = tool_calls
     return {
         "model": result["model"],
         "choices": [
             {
-                "message": {"role": "assistant", "content": result["content"] if content is None else content},
+                "message": message,
                 "finish_reason": result["finish_reason"],
             }
         ],

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -327,6 +327,27 @@ class PureChatEnvironment:
         loop: int,
     ) -> ChatResult:
         self.runtime.messages.append({"role": "user", "content": user_content})
+        if self.runtime.thinking_mode and _uses_native_separated_reasoning(self.runtime.backend):
+            if on_phase_start:
+                on_phase_start(ModelPhaseStart("chat_final", streamed=False, attempt=1, reason="native_separated_reasoning"))
+            with self.transport.backend_thinking(True):
+                with model_call_context(phase="chat_final", tools_mode="off"):
+                    result = self.transport.chat_once(
+                        call_messages,
+                        temperature=temperature,
+                        max_tokens=resolve_max_tokens("chat", max_tokens),
+                        on_final_delta=None,
+                        on_progress=on_progress,
+                    )
+            if on_model_step:
+                on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="chat_final"))
+            if on_final_delta:
+                if result.reasoning_content:
+                    on_final_delta(f"<|channel>thought\n{result.reasoning_content}<channel|>")
+                if result.content:
+                    on_final_delta(result.content)
+            self.runtime.messages.append({"role": "assistant", "content": result.content})
+            return result
         if self.runtime.thinking_mode:
             thinking_max_tokens = CompletionBudget(max_tokens).internal(CHAT_THINKING_MAX_TOKENS)
             chat_max_tokens = resolve_max_tokens("chat", max_tokens)
@@ -393,6 +414,16 @@ class PureChatEnvironment:
         )
         self.runtime.messages.append({"role": "assistant", "content": result.content})
         return result
+
+
+def _uses_native_separated_reasoning(backend: object) -> bool:
+    capability = getattr(backend, "uses_native_separated_reasoning", None)
+    if not callable(capability):
+        return False
+    try:
+        return capability() is True
+    except Exception:
+        return False
 
 
 @dataclass(frozen=True)

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -21,6 +21,7 @@ from orbit.backend.llama_server import (
     _parse_model_info,
     _parse_native_stream,
     _final_prefix_experiment_requested,
+    _qwen_route_prefix_anchor_requested,
 )
 from orbit.backend.base import ChatResult
 from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
@@ -124,6 +125,38 @@ class LlamaServerBackendTests(unittest.TestCase):
                 return {}
 
         self.assertEqual(Backend(base_url="http://localhost", timeout=1).backend_props(), {})
+
+    def test_native_separated_reasoning_requires_verified_qwen_profile(self) -> None:
+        class Backend(LlamaServerBackend):
+            props: dict[str, object] = {}
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return self.props
+
+        backend = Backend(base_url="http://localhost", timeout=1)
+        backend.props = {
+            "model_compatibility": {
+                "verified": True,
+                "reasoning_protocol": "qwen-think",
+            }
+        }
+        self.assertTrue(backend.uses_native_separated_reasoning())
+
+        backend.props = {
+            "model_compatibility": {
+                "verified": True,
+                "reasoning_protocol": "gemma4-control-channel",
+            }
+        }
+        self.assertFalse(backend.uses_native_separated_reasoning())
+
+        backend.props = {
+            "model_compatibility": {
+                "verified": False,
+                "reasoning_protocol": "qwen-think",
+            }
+        }
+        self.assertFalse(backend.uses_native_separated_reasoning())
 
     def test_backend_connection_error_mentions_backend_server(self) -> None:
         backend = LlamaServerBackend(base_url="http://127.0.0.1:12120", model="fake", timeout=1)
@@ -380,6 +413,26 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertTrue(backend.payloads[1]["route_prefix_anchor"])
         self.assertNotIn("route_prefix_anchor", backend.payloads[2])
         self.assertNotIn("route_prefix_anchor", backend.payloads[3])
+
+    def test_qwen_route_prefix_request_is_bounded_to_native_route_tools_on(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "1"}, clear=True):
+            with model_call_context(phase="route", tools_mode="on"):
+                self.assertTrue(_qwen_route_prefix_anchor_requested(native_backend=True))
+            with model_call_context(phase="route", tools_mode="off"):
+                self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=True))
+            with model_call_context(phase="chat_final", tools_mode="on"):
+                self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=True))
+            with model_call_context(phase="route", tools_mode="on"):
+                self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=False))
+
+    def test_qwen_route_prefix_kill_switch_and_invalid_value_disable_request(self) -> None:
+        for value in ("0", "invalid"):
+            with self.subTest(value=value), mock.patch.dict(
+                os.environ,
+                {"ORBIT_QWEN_ROUTE_PREFIX_REUSE": value},
+                clear=True,
+            ), model_call_context(phase="route", tools_mode="on"):
+                self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=True))
 
     def test_final_prefix_experiment_payload_is_limited_to_native_final_tool_phase(self) -> None:
         class Backend(LlamaServerBackend):
@@ -969,6 +1022,36 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "tool_calls")
         self.assertEqual(result.tool_calls[0]["function"]["name"], "exec_shell_full_command")
         self.assertEqual(result.tool_calls[0]["function"]["arguments"], '{"command": "cat note.txt"}')
+
+    def test_parse_native_stream_keeps_qwen_reasoning_and_tool_calls_out_of_content(self) -> None:
+        emitted: list[str] = []
+
+        result = _parse_native_stream(
+            FakeStream(
+                [
+                    'event: reasoning\n',
+                    'data: {"text":"private planning"}\n',
+                    '\n',
+                    'event: tool_calls\n',
+                    'data: {"tool_calls":[{"id":"","type":"function","function":{"name":"system_info","arguments":"{}"}}]}\n',
+                    '\n',
+                    'event: metrics\n',
+                    'data: {"usage":{"prompt_tokens":20,"completion_tokens":8,"prompt_tokens_details":{"cached_tokens":0}},"timings":{}}\n',
+                    '\n',
+                    'event: done\n',
+                    'data: {"finish_reason":"tool_calls"}\n',
+                    '\n',
+                ]
+            ),
+            on_delta=emitted.append,
+            on_progress=None,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(result.content, "")
+        self.assertEqual(result.reasoning_content, "private planning")
+        self.assertEqual(result.finish_reason, "tool_calls")
+        self.assertEqual(result.tool_calls[0]["function"], {"name": "system_info", "arguments": "{}"})
 
 
 if __name__ == "__main__":

--- a/tests/test_native_bindings.py
+++ b/tests/test_native_bindings.py
@@ -35,6 +35,9 @@ def _stub_library() -> SimpleNamespace:
         "llama_state_seq_get_data",
         "llama_state_seq_set_data",
         "llama_model_get_vocab",
+        "llama_model_meta_count",
+        "llama_model_meta_key_by_index",
+        "llama_model_meta_val_str_by_index",
         "llama_vocab_n_tokens",
         "llama_model_chat_template",
         "llama_chat_apply_template",
@@ -76,6 +79,8 @@ class NativeBindingsTests(unittest.TestCase):
         self.assertEqual(len(library.lib.llama_state_seq_get_size.argtypes), 2)
         self.assertEqual(len(library.lib.llama_state_seq_get_data.argtypes), 4)
         self.assertEqual(len(library.lib.llama_state_seq_set_data.argtypes), 4)
+        self.assertEqual(len(library.lib.llama_model_meta_key_by_index.argtypes), 4)
+        self.assertEqual(len(library.lib.llama_model_meta_val_str_by_index.argtypes), 4)
         self.assertEqual(len(library.lib.llama_vocab_n_tokens.argtypes), 1)
         self.assertEqual(len(library.lib.llama_batch_init.argtypes), 3)
         self.assertEqual(len(library.lib.llama_batch_free.argtypes), 1)

--- a/tests/test_native_chat_bridge.py
+++ b/tests/test_native_chat_bridge.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+
+from orbit.native_llama.bindings import ChatBridgeLibrary
+from orbit.native_llama.build_support import DEFAULT_VENDOR_BUILD_BIN
+from orbit.native_llama.chat_bridge import CHAT_BRIDGE_API_VERSION, chat_bridge_filename, validate_chat_bridge_artifact
+from orbit.native_llama.client import _resolve_chat_bridge_path
+from orbit.native_llama.native_names import platform_runtime_libs
+
+
+class NativeChatBridgeTests(unittest.TestCase):
+    def test_bridge_must_be_co_located_with_active_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp)
+            paths = SimpleNamespace(build_bin=build_bin)
+            self.assertIsNone(_resolve_chat_bridge_path(paths))
+
+            bridge = build_bin / chat_bridge_filename()
+            bridge.write_bytes(b"bridge")
+            self.assertEqual(_resolve_chat_bridge_path(paths), bridge)
+
+    def test_missing_identity_fails_before_loading_native_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp)
+            bridge = build_bin / chat_bridge_filename()
+            bridge.write_bytes(b"not-a-library")
+
+            with self.assertRaisesRegex(RuntimeError, "chat bridge identity"):
+                ChatBridgeLibrary(build_bin, bridge)
+
+    def test_runtime_library_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp)
+            bridge = build_bin / chat_bridge_filename()
+            bridge.write_bytes(b"bridge")
+            libraries: dict[str, str] = {}
+            for name in platform_runtime_libs():
+                path = build_bin / name
+                path.write_bytes(name.encode())
+                libraries[name] = _sha256(path)
+            first = next(iter(libraries))
+            libraries[first] = "0" * 64
+            identity = {"build": {"libraries": libraries}, "artifact_sha256": _sha256(bridge)}
+            bridge.with_name(f"{bridge.name}.identity.json").write_text(json.dumps(identity), encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "library identity mismatch"):
+                validate_chat_bridge_artifact(build_bin, bridge)
+
+    @unittest.skipUnless(
+        (DEFAULT_VENDOR_BUILD_BIN / chat_bridge_filename()).exists(),
+        "native chat bridge is not built",
+    )
+    def test_current_native_bridge_exports_supported_stable_api(self) -> None:
+        bridge = ChatBridgeLibrary(DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_BIN / chat_bridge_filename())
+
+        self.assertEqual(bridge.lib.orbit_chat_bridge_api_version(), CHAT_BRIDGE_API_VERSION)
+        self.assertEqual(bridge.build_identity["api_version"], CHAT_BRIDGE_API_VERSION)
+        self.assertIn("upstream_commit", bridge.build_identity)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_model_profiles.py
+++ b/tests/test_native_model_profiles.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.capabilities import LlamaCppBuildInfo, safe_native_capability_manifest
+from orbit.native_llama.model_profiles import (
+    GEMMA4_PROFILE_ID,
+    QWEN36_PROFILE_ID,
+    NativeModelProfile,
+    detect_native_model_profile,
+)
+from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT
+
+
+QWEN_METADATA = {
+    "general.architecture": "qwen35moe",
+    "general.name": "Qwen3.6-35B-A3B",
+    "general.file_type": "15",
+    "tokenizer.ggml.model": "gpt2",
+    "tokenizer.ggml.pre": "qwen35",
+}
+
+
+class NativeModelProfileTests(unittest.TestCase):
+    def test_detects_verified_qwen_only_from_complete_identity(self) -> None:
+        template = "official-qwen-template"
+        digest = hashlib.sha256(template.encode()).hexdigest()
+        with mock.patch("orbit.native_llama.model_profiles.QWEN36_OFFICIAL_TEMPLATE_SHA256", digest):
+            profile = detect_native_model_profile(QWEN_METADATA, template)
+
+        self.assertEqual(profile.profile_id, QWEN36_PROFILE_ID)
+        self.assertTrue(profile.verified)
+        self.assertEqual(profile.renderer, "llama.cpp-jinja")
+        self.assertEqual(profile.tool_call_protocol, "qwen3.6-xml")
+        self.assertEqual(profile.history_serialization, "qwen-leading-system-only")
+        self.assertFalse(profile.mtp_supported)
+        self.assertFalse(profile.gemma_prefix_reuse_supported)
+        self.assertEqual(profile.verified_quantization, "Q4_K_M")
+
+    def test_qwen_template_drift_fails_closed(self) -> None:
+        profile = detect_native_model_profile(QWEN_METADATA, "unreviewed-template")
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen36_template_identity_mismatch")
+
+    def test_qwen_model_size_drift_fails_closed(self) -> None:
+        metadata = {**QWEN_METADATA, "general.name": "Qwen3.6-8B"}
+
+        profile = detect_native_model_profile(metadata, "anything")
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen36_model_identity_mismatch")
+
+    def test_qwen_quantization_drift_fails_closed(self) -> None:
+        template = "official-qwen-template"
+        digest = hashlib.sha256(template.encode()).hexdigest()
+        metadata = {**QWEN_METADATA, "general.file_type": "2"}
+
+        with mock.patch("orbit.native_llama.model_profiles.QWEN36_OFFICIAL_TEMPLATE_SHA256", digest):
+            profile = detect_native_model_profile(metadata, template)
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen36_quantization_identity_mismatch")
+
+    def test_existing_gemma_family_keeps_orbit_profile(self) -> None:
+        profile = detect_native_model_profile(
+            {
+                "general.architecture": "gemma4",
+                "general.name": "Gemma 4 26B-A4B",
+                "tokenizer.ggml.model": "gemma4",
+            },
+            "embedded-template-not-used-by-orbit-renderer",
+        )
+
+        self.assertEqual(profile.profile_id, GEMMA4_PROFILE_ID)
+        self.assertTrue(profile.verified)
+        self.assertEqual(profile.renderer, "orbit-gemma4")
+        self.assertTrue(profile.mtp_supported)
+        self.assertTrue(profile.gemma_prefix_reuse_supported)
+
+    @mock.patch("orbit.native_llama.capabilities.read_llama_cpp_build_info")
+    def test_qwen_capability_manifest_is_profile_aware(self, build_info) -> None:
+        build_info.return_value = LlamaCppBuildInfo(9551, "6f79e02", "x86_64", "GNU", "a" * 64, "runtime_symbols")
+        profile = NativeModelProfile(
+            profile_id=QWEN36_PROFILE_ID,
+            family="qwen3.6",
+            model_name="Qwen3.6-35B-A3B",
+            architecture="qwen35moe",
+            renderer="llama.cpp-jinja",
+            reasoning_protocol="qwen-think",
+            tool_call_protocol="qwen3.6-xml",
+            history_serialization="qwen-leading-system-only",
+            verified=True,
+            failure_reason=None,
+            template_source="gguf-embedded-official",
+            template_sha256="b" * 64,
+            thinking_supported=True,
+            mtp_supported=False,
+            gemma_prefix_reuse_supported=False,
+        )
+        client = SimpleNamespace(model_profile=profile, paths=SimpleNamespace(build_bin="/native"))
+
+        manifest = safe_native_capability_manifest(client, final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT)
+
+        self.assertEqual(manifest["profile_id"], QWEN36_PROFILE_ID)
+        self.assertEqual(manifest["status"], "verified")
+        self.assertTrue(manifest["behavior_enforced"])
+        self.assertEqual(manifest["renderer"]["template_hash"], "b" * 64)
+        self.assertFalse(manifest["requirements"]["mtp_supported"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_qwen_profile.py
+++ b/tests/test_native_qwen_profile.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.events import NativeTimings
+from orbit.native_llama.model_profiles import NativeModelProfile, QWEN36_PROFILE_ID
+from orbit.native_llama.paths import NativeLlamaPaths
+
+
+class _FakeChatBridge:
+    build_identity = {"schema_version": 1}
+
+    def __init__(self) -> None:
+        self.render_calls: list[tuple[list[dict[str, object]], list[dict[str, object]], bool]] = []
+
+    def render(self, _context, messages, tools, *, thinking: bool):
+        self.render_calls.append((messages, tools, thinking))
+        return {
+            "prompt": "<|im_start|>assistant\n<think>\n\n</think>\n\n",
+            "format": "peg-native",
+            "supports_thinking": True,
+            "additional_stops": [],
+        }
+
+    def parse(self, _context, generated_text: str, *, partial: bool):
+        del partial
+        if "<tool_call>" in generated_text:
+            return {
+                "content": "",
+                "reasoning_content": "",
+                "tool_calls": [
+                    {
+                        "id": "",
+                        "type": "function",
+                        "function": {"name": "exec_shell_full_command", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            }
+        reasoning = "private route analysis" if "<think>" in generated_text else ""
+        content = generated_text.split("</think>", maxsplit=1)[-1].strip() if reasoning else generated_text
+        return {"content": content, "reasoning_content": reasoning, "tool_calls": []}
+
+
+def _qwen_profile() -> NativeModelProfile:
+    return NativeModelProfile(
+        profile_id=QWEN36_PROFILE_ID,
+        family="qwen3.6",
+        model_name="Qwen3.6-35B-A3B",
+        architecture="qwen35moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="qwen-think",
+        tool_call_protocol="qwen3.6-xml",
+        history_serialization="qwen-leading-system-only",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="a" * 64,
+        thinking_supported=True,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+    )
+
+
+class NativeQwenProfileTests(unittest.TestCase):
+    def _client(self) -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/qwen.gguf"),
+            model_id="legacy-path",
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(paths, NativeClientConfig())
+        client.model_profile = _qwen_profile()
+        client.chat_bridge = _FakeChatBridge()  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        return client
+
+    def test_render_uses_bridge_and_preserves_assistant_tool_history(self) -> None:
+        client = self._client()
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [{"type": "function", "function": {"name": "x", "arguments": "{}"}}]},
+            {"role": "tool", "name": "x", "content": "ok"},
+        ]
+
+        prompt = client.apply_chat_template(messages, tools=[{"type": "function", "function": {"name": "x"}}], thinking=False)
+
+        self.assertIn("</think>", prompt)
+        bridge = client.chat_bridge
+        assert isinstance(bridge, _FakeChatBridge)
+        rendered_messages, rendered_tools, thinking = bridge.render_calls[0]
+        self.assertEqual(rendered_messages, messages)
+        self.assertEqual(rendered_tools[0]["function"]["name"], "x")
+        self.assertFalse(thinking)
+
+    def test_nonleading_system_evidence_is_preserved_in_place_as_qwen_input(self) -> None:
+        client = self._client()
+        messages = [
+            {"role": "system", "content": "initial"},
+            {"role": "user", "content": "request"},
+            {"role": "system", "content": "exact evidence"},
+        ]
+
+        client.apply_chat_template(messages, thinking=False)
+
+        bridge = client.chat_bridge
+        assert isinstance(bridge, _FakeChatBridge)
+        rendered_messages = bridge.render_calls[0][0]
+        self.assertEqual([message["role"] for message in rendered_messages], ["system", "user", "user"])
+        self.assertEqual(rendered_messages[-1]["content"], "exact evidence")
+        self.assertEqual(messages[-1]["role"], "system")
+
+    def test_reasoning_is_never_emitted_or_returned_as_visible_content(self) -> None:
+        client = self._client()
+        emitted: list[str] = []
+        timings = NativeTimings(10, 5, 0, 10, 1.0, 2.0, False)
+
+        def complete(_messages, **kwargs):
+            kwargs["on_token"]("<think>private route analysis</think>\n\n{\"route\":\"CHAT\"}")
+            return timings
+
+        with (
+            mock.patch.object(client, "complete_chat", side_effect=complete),
+            mock.patch.object(client, "_content_token_count", return_value=3),
+        ):
+            result = client.complete_chat_text(
+                [{"role": "user", "content": "hello"}],
+                max_tokens=16,
+                thinking=False,
+                on_token=emitted.append,
+            )
+
+        self.assertEqual(result.content, '{"route":"CHAT"}')
+        self.assertEqual(result.reasoning_content, "private route analysis")
+        self.assertEqual("".join(emitted), result.content)
+        self.assertNotIn("private", "".join(emitted))
+
+    def test_qwen_tool_call_arguments_remain_exact_json_for_canonical_gate(self) -> None:
+        client = self._client()
+
+        parsed = client._parse_profile_output(
+            "<tool_call><function=exec_shell_full_command><parameter=command>pwd</parameter></function></tool_call>",
+            partial=False,
+        )
+
+        self.assertEqual(parsed.content, "")
+        self.assertEqual(len(parsed.tool_calls), 1)
+        function = parsed.tool_calls[0]["function"]
+        self.assertEqual(function["name"], "exec_shell_full_command")
+        self.assertEqual(json.loads(function["arguments"]), {"command": "pwd"})
+
+    def test_tools_available_final_prose_is_emitted_after_structural_parse(self) -> None:
+        client = self._client()
+        emitted: list[str] = []
+        timings = NativeTimings(10, 4, 0, 10, 1.0, 2.0, False)
+
+        def complete(_messages, **kwargs):
+            kwargs["on_token"]("The exact tool output is QWEN_XML_OK.")
+            return timings
+
+        with (
+            mock.patch.object(client, "complete_chat", side_effect=complete),
+            mock.patch.object(client, "_content_token_count", return_value=0),
+        ):
+            result = client.complete_chat_text(
+                [{"role": "tool", "name": "x", "content": "QWEN_XML_OK"}],
+                max_tokens=16,
+                tools=[{"type": "function", "function": {"name": "x"}}],
+                thinking=False,
+                on_token=emitted.append,
+            )
+
+        self.assertEqual(result.content, "The exact tool output is QWEN_XML_OK.")
+        self.assertEqual("".join(emitted), result.content)
+
+    def test_malformed_bridge_tool_call_fails_closed(self) -> None:
+        client = self._client()
+        assert client.chat_bridge is not None
+        client.chat_bridge.parse = mock.Mock(  # type: ignore[method-assign]
+            return_value={"content": "", "reasoning_content": "", "tool_calls": [{"function": {"name": "x", "arguments": {}}}]}
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "invalid tool arguments"):
+            client._parse_profile_output("bad", partial=False)
+
+    def test_qwen_profile_disables_mtp_and_gemma_prefix_reuse(self) -> None:
+        client = self._client()
+
+        self.assertFalse(client.final_prefix_experiment_status()["enabled"])
+        self.assertFalse(client.model_profile.mtp_supported)
+        self.assertFalse(client.model_profile.gemma_prefix_reuse_supported)
+
+    def test_rejected_partial_memory_removal_falls_back_to_cold_prefill(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._session.cached_prompt_tokens = [1, 2, 3, 4]
+        native = client.lib.lib
+        native.llama_get_memory.return_value = 2
+        native.llama_memory_seq_rm.return_value = False
+
+        reused = client._prepare_memory_for_prompt([1, 2, 9])
+
+        self.assertEqual(reused, 0)
+        native.llama_memory_seq_rm.assert_called_once_with(2, 0, 2, -1)
+        native.llama_memory_clear.assert_called_once_with(2, True)
+
+    def test_supported_partial_memory_removal_preserves_lcp(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._session.cached_prompt_tokens = [1, 2, 3, 4]
+        native = client.lib.lib
+        native.llama_get_memory.return_value = 2
+        native.llama_memory_seq_rm.return_value = True
+
+        reused = client._prepare_memory_for_prompt([1, 2, 9])
+
+        self.assertEqual(reused, 2)
+        native.llama_memory_clear.assert_not_called()
+
+    def test_reset_clears_qwen_continuation_and_parser_projection_state(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._session.continuation_ready = True
+        client._active_profile_render = {"prompt": "old"}
+        client._profile_last_raw_output = "private and visible output"
+        client._profile_last_parsed_content = "visible output"
+        client.lib.lib.llama_get_memory.return_value = 2
+
+        client.reset_session_state()
+
+        self.assertFalse(client._session.continuation_ready)
+        self.assertIsNone(client._active_profile_render)
+        self.assertEqual(client._profile_last_raw_output, "")
+        self.assertEqual(client._profile_last_parsed_content, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_runtime_props.py
+++ b/tests/test_native_runtime_props.py
@@ -92,7 +92,7 @@ class NativeRuntimePropsTests(unittest.TestCase):
             thinking=False,
         )
 
-    @mock.patch("orbit.native_server.app.safe_gemma4_capability_manifest")
+    @mock.patch("orbit.native_server.app.safe_native_capability_manifest")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_server_caches_bounded_native_capability_manifest(self, _mocked_lib, build_manifest) -> None:
         build_manifest.return_value = {

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -65,6 +65,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(request.stop, ())
         self.assertEqual(request.tools, [])
         self.assertFalse(request.route_prefix_anchor)
+        self.assertFalse(request.qwen_route_prefix_anchor)
         self.assertIsNone(request.allow_mtp_experimental)
         self.assertFalse(request.final_prefix_experiment)
 
@@ -104,6 +105,10 @@ class NativeServerProtocolTests(unittest.TestCase):
     def test_parse_chat_request_accepts_route_prefix_anchor_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "route_prefix_anchor": True})
         self.assertTrue(request.route_prefix_anchor)
+
+    def test_parse_chat_request_accepts_qwen_route_prefix_anchor_flag(self) -> None:
+        request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "qwen_route_prefix_anchor": True})
+        self.assertTrue(request.qwen_route_prefix_anchor)
 
     def test_parse_chat_request_accepts_allow_mtp_flag(self) -> None:
         disabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "allow_mtp_experimental": False})
@@ -231,6 +236,36 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(response["choices"][0]["message"]["content"], "")
         self.assertEqual(response["choices"][0]["finish_reason"], "cancelled")
         self.assertEqual(response["timings"]["predicted_ms"], 0.0)
+
+    def test_openai_response_keeps_reasoning_and_tools_structurally_separate(self) -> None:
+        tool_call = {
+            "id": "",
+            "type": "function",
+            "function": {"name": "system_info", "arguments": "{}"},
+        }
+        native = native_chat_response(
+            content="",
+            model="qwen",
+            finish_reason="tool_calls",
+            session_id=DEFAULT_SESSION_ID,
+            prompt_tokens=20,
+            completion_tokens=8,
+            reused_prompt_tokens=0,
+            evaluated_prompt_tokens=20,
+            prefill_ms=1.0,
+            generation_ms=1.0,
+            cancelled=False,
+            reasoning_content="private planning",
+            reasoning_tokens=3,
+            tool_calls=(tool_call,),
+        )
+
+        response = openai_chat_response(native)
+        message = response["choices"][0]["message"]
+        self.assertEqual(message["content"], "")
+        self.assertEqual(message["reasoning_content"], "private planning")
+        self.assertEqual(message["tool_calls"], [tool_call])
+        self.assertEqual(native["native"]["reasoning_tokens"], 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -25,11 +25,14 @@ class _FakeCompletion:
     timings: _FakeTimings = field(default_factory=_FakeTimings)
     stopped_by_stop: bool = False
     completed_after_thought: bool = False
+    reasoning_content: str = ""
+    reasoning_tokens: int = 0
+    tool_calls: tuple[dict[str, object], ...] = ()
 
 
 class _FakeClient:
     def __init__(self, thinking: bool) -> None:
-        self.config = type("Config", (), {"thinking": thinking})()
+        self.config = type("Config", (), {"thinking": thinking, "context_tokens": 8192})()
         self.calls: list[bool] = []
         self.paths = type("Paths", (), {})()
         self.mtp_probe = type("Probe", (), {"enabled": False, "initialized": False, "error": None})()
@@ -50,6 +53,7 @@ class _FakeClient:
         tools,
         thinking,
         route_prefix_anchor=False,
+        qwen_route_prefix_anchor=False,
         allow_mtp_experimental=None,
         final_prefix_experiment=False,
         on_progress=None,
@@ -76,6 +80,10 @@ class _FakeClient:
                 "mtp_failure_reason": None,
             },
         )()
+
+    def inspect_chat_tokens(self, messages, *, tools, thinking):
+        del messages, tools, thinking
+        return 7, "rendered", "tokens"
 
 
 class NativeServerThinkTests(unittest.TestCase):
@@ -243,6 +251,79 @@ class NativeServerThinkTests(unittest.TestCase):
         result = server.complete(parse_chat_request({"messages": [{"role": "user", "content": "hello"}], "thinking": True}))
 
         self.assertEqual(result["finish_reason"], "cancelled")
+
+    def test_budget_truncated_tool_call_cannot_override_length_finish_reason(self) -> None:
+        client = _FakeClient(thinking=False)
+
+        def fake_complete(_messages, **kwargs):
+            return _FakeCompletion(
+                content="",
+                timings=_FakeTimings(output_tokens=16, cancelled=False),
+                tool_calls=(
+                    {
+                        "id": "",
+                        "type": "function",
+                        "function": {"name": "system_info", "arguments": "{}"},
+                    },
+                ),
+            )
+
+        client.complete_chat_text = fake_complete
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "system info"}],
+                    "max_tokens": 16,
+                }
+            )
+        )
+
+        self.assertEqual(result["finish_reason"], "length")
+        self.assertEqual(len(result["tool_calls"]), 1)
+
+    def test_complete_tool_call_uses_tool_calls_finish_reason(self) -> None:
+        client = _FakeClient(thinking=False)
+
+        def fake_complete(_messages, **kwargs):
+            return _FakeCompletion(
+                content="",
+                timings=_FakeTimings(output_tokens=8, cancelled=False),
+                tool_calls=(
+                    {
+                        "id": "",
+                        "type": "function",
+                        "function": {"name": "system_info", "arguments": "{}"},
+                    },
+                ),
+            )
+
+        client.complete_chat_text = fake_complete
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "system info"}],
+                    "max_tokens": 16,
+                }
+            )
+        )
+
+        self.assertEqual(result["finish_reason"], "tool_calls")
+
+    def test_chat_token_inspection_uses_the_completion_lock(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.count_chat_tokens(
+            [{"role": "user", "content": "hello"}],
+            tools=[],
+            thinking=False,
+        )
+
+        self.assertEqual(result["tokens"], 7)
 
     def test_error_result_handles_continue_payload_without_messages(self) -> None:
         server = OrbitNativeServer(client=_FakeClient(thinking=False), model_alias="m")

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 from orbit.native_server.app import OrbitNativeHandler, OrbitNativeServer, _DisconnectWatcher
 from orbit.native_server.protocol import openai_chat_response, parse_chat_request
-from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT
+from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 
 
 @dataclass
@@ -43,6 +43,7 @@ class _FakeClient:
         self.mtp_fallback_reason = None
         self.allow_mtp_calls: list[bool | None] = []
         self.final_prefix_calls: list[bool] = []
+        self.qwen_route_prefix_calls: list[bool] = []
 
     def complete_chat_text(
         self,
@@ -63,6 +64,7 @@ class _FakeClient:
         self.calls.append(thinking)
         self.allow_mtp_calls.append(allow_mtp_experimental)
         self.final_prefix_calls.append(final_prefix_experiment)
+        self.qwen_route_prefix_calls.append(qwen_route_prefix_anchor)
         return _FakeCompletion()
 
     def session_snapshot(self, session_id: str):
@@ -105,6 +107,28 @@ class NativeServerThinkTests(unittest.TestCase):
         server.complete(parse_chat_request({"messages": unknown_messages, "final_prefix_experiment": True}))
 
         self.assertEqual(client.final_prefix_calls, [True, False])
+
+    def test_qwen_route_prefix_requires_exact_route_prompt_family(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="fake")
+        route_messages = [
+            {"role": "system", "content": ROUTE_SYSTEM_PROMPT},
+            {"role": "user", "content": "hello"},
+        ]
+        unknown_messages = [
+            {"role": "system", "content": "different prompt"},
+            {"role": "user", "content": "hello"},
+        ]
+
+        server.complete(parse_chat_request({"messages": route_messages, "qwen_route_prefix_anchor": True}))
+        server.complete(parse_chat_request({"messages": unknown_messages, "qwen_route_prefix_anchor": True}))
+        server.complete(
+            parse_chat_request(
+                {"messages": route_messages, "qwen_route_prefix_anchor": True, "thinking": True}
+            )
+        )
+
+        self.assertEqual(client.qwen_route_prefix_calls, [True, False, False])
 
     def test_disconnect_watcher_disarm_skips_cancel_callback(self) -> None:
         called: list[str] = []

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -75,6 +75,28 @@ class PayloadTests(unittest.TestCase):
         self.assertNotIn("route_prefix_anchor", baseline)
         self.assertTrue(experimental["route_prefix_anchor"])
 
+    def test_build_chat_payload_includes_qwen_route_prefix_anchor_only_when_requested(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+            )
+        )
+        enabled = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+                qwen_route_prefix_anchor=True,
+            )
+        )
+
+        self.assertNotIn("qwen_route_prefix_anchor", baseline)
+        self.assertTrue(enabled["qwen_route_prefix_anchor"])
+
     def test_build_chat_payload_includes_allow_mtp_only_when_explicit(self) -> None:
         baseline = build_chat_payload(
             ChatPayloadOptions(

--- a/tests/test_qwen_route_prefix.py
+++ b/tests/test_qwen_route_prefix.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import (
+    NativeClientConfig,
+    NativeLlamaClient,
+    _QwenRouteAnchorRuntimePlan,
+)
+from orbit.native_llama.model_profiles import NativeModelProfile, QWEN36_PROFILE_ID
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.native_llama.qwen_route_prefix import (
+    QWEN_ROUTE_PREFIX_TOKEN_COUNT,
+    QwenRoutePrefixSpec,
+    derive_qwen_route_prefix_spec,
+    resolve_qwen_route_prefix_reuse,
+)
+
+
+class QwenRoutePrefixConfigTests(unittest.TestCase):
+    def test_default_is_on_after_exact_profile_qualification(self) -> None:
+        self.assertTrue(resolve_qwen_route_prefix_reuse({}).enabled)
+
+    def test_explicit_on_and_kill_switch(self) -> None:
+        self.assertTrue(resolve_qwen_route_prefix_reuse({"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "1"}).enabled)
+        self.assertFalse(resolve_qwen_route_prefix_reuse({"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "0"}).enabled)
+
+    def test_invalid_value_disables_safely(self) -> None:
+        config = resolve_qwen_route_prefix_reuse({"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "yes"})
+
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.validation_error, "invalid_qwen_route_prefix_reuse_value")
+
+
+class QwenRoutePrefixBoundaryTests(unittest.TestCase):
+    def test_derives_exact_token_aligned_prefix_before_user_content(self) -> None:
+        system = "s" * 900
+
+        def render(user: str) -> str:
+            return system + "\n<user>" + user + "</user>"
+
+        full = render("actual request")
+        spec, reason = derive_qwen_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(char) for char in full],
+            render_reference=render,
+            tokenize=lambda text: [ord(char) for char in text],
+        )
+
+        self.assertIsNone(reason)
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertEqual(len(spec.prefix_tokens), QWEN_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertGreater(spec.invariant_token_count, QWEN_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertEqual(list(spec.prefix_tokens), [ord(char) for char in full[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]])
+
+    def test_rejects_when_dynamic_content_reaches_boundary(self) -> None:
+        system = "s" * 700
+
+        def render(user: str) -> str:
+            return system + user
+
+        full = render("x" * 100)
+        spec, reason = derive_qwen_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(char) for char in full],
+            render_reference=render,
+            tokenize=lambda text: [ord(char) for char in text],
+        )
+
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "stable_token_boundary_unavailable")
+
+
+class _FakeBridge:
+    def render(self, _context, messages, _tools, *, thinking: bool):
+        assert not thinking
+        return {"prompt": str(messages[0]["content"]) + "\n<user>" + str(messages[1]["content"]) + "</user>"}
+
+
+def _profile() -> NativeModelProfile:
+    return NativeModelProfile(
+        profile_id=QWEN36_PROFILE_ID,
+        family="qwen3.6",
+        model_name="Qwen3.6-35B-A3B",
+        architecture="qwen35moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="qwen-think",
+        tool_call_protocol="qwen3.6-xml",
+        history_serialization="qwen-leading-system-only",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="a" * 64,
+        thinking_supported=True,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+    )
+
+
+class QwenRoutePrefixClientTests(unittest.TestCase):
+    def _client(self) -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/qwen.gguf"),
+            model_id="legacy-path",
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(paths, NativeClientConfig(qwen_route_prefix_reuse_enabled=True))
+        client.model_profile = _profile()
+        client._model_metadata_identity = {
+            "general.architecture": "qwen35moe",
+            "general.name": "Qwen3.6-35B-A3B",
+            "general.file_type": "15",
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.pre": "qwen35",
+        }
+        client.chat_bridge = _FakeBridge()  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        client.tokenize = lambda text: [ord(char) for char in text]  # type: ignore[method-assign]
+        client._qwen_backend_build_identity = lambda: "build"  # type: ignore[method-assign]
+        return client
+
+    def test_plan_is_qwen_specific_and_does_not_reuse_gemma_state(self) -> None:
+        client = self._client()
+        system = "s" * 900
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": "hello"}]
+        prompt = system + "\n<user>hello</user>"
+
+        plan = client._qwen_route_anchor_plan_for_prompt(messages, tools=None, thinking=False, prompt=prompt)
+
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(len(plan.prefix_tokens), QWEN_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertFalse(client._route_prefix_anchor_state.valid)
+        self.assertEqual(plan.state_kwargs["tools_mode"], "qwen-route-tools-on-thinking-off")
+
+    def test_unverified_quantization_is_ineligible(self) -> None:
+        client = self._client()
+        client._model_metadata_identity["general.file_type"] = "2"
+        system = "s" * 900
+
+        plan = client._qwen_route_anchor_plan_for_prompt(
+            [{"role": "system", "content": system}, {"role": "user", "content": "hello"}],
+            tools=None,
+            thinking=False,
+            prompt=system + "\n<user>hello</user>",
+        )
+
+        self.assertIsNone(plan)
+        self.assertEqual(client.qwen_route_prefix_reuse_status()["failure_reason"], "qwen_quantization_unverified")
+
+    def test_thinking_and_mtp_are_ineligible(self) -> None:
+        system = "s" * 900
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": "hello"}]
+        prompt = system + "\n<user>hello</user>"
+
+        thinking_client = self._client()
+        self.assertIsNone(
+            thinking_client._qwen_route_anchor_plan_for_prompt(
+                messages,
+                tools=None,
+                thinking=True,
+                prompt=prompt,
+            )
+        )
+        self.assertEqual(
+            thinking_client.qwen_route_prefix_reuse_status()["failure_reason"],
+            "structured_route_mode_ineligible",
+        )
+
+        mtp_client = self._client()
+        mtp_client.config = NativeClientConfig(
+            qwen_route_prefix_reuse_enabled=True,
+            use_mtp_experimental=True,
+        )
+        self.assertIsNone(
+            mtp_client._qwen_route_anchor_plan_for_prompt(
+                messages,
+                tools=None,
+                thinking=False,
+                prompt=prompt,
+            )
+        )
+        self.assertEqual(mtp_client.qwen_route_prefix_reuse_status()["failure_reason"], "mtp_ineligible")
+
+    def test_changed_route_identity_invalidates_existing_checkpoint(self) -> None:
+        client = self._client()
+        client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"x",
+            checkpoint_size=1,
+            token_count=QWEN_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+        client._qwen_route_prefix_spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t",
+            "i",
+            "different-system-hash",
+            810,
+            42,
+        )
+        system = "s" * 900
+
+        plan = client._qwen_route_anchor_plan_for_prompt(
+            [{"role": "system", "content": system}, {"role": "user", "content": "hello"}],
+            tools=None,
+            thinking=False,
+            prompt=system + "\n<user>hello</user>",
+        )
+
+        self.assertIsNotNone(plan)
+        status = client.qwen_route_prefix_reuse_status()
+        self.assertEqual(status["invalidation_count"], 1)
+        self.assertEqual(status["checkpoint_size_bytes"], 0)
+
+    def test_context_and_model_identity_change_checkpoint_key(self) -> None:
+        client = self._client()
+        spec = QwenRoutePrefixSpec(tuple(range(QWEN_ROUTE_PREFIX_TOKEN_COUNT)), "t", "i", "s", 810, 42)
+        with mock.patch.object(Path, "stat", return_value=SimpleNamespace(st_size=10, st_mtime_ns=20)):
+            first = client._qwen_route_prefix_state_kwargs(spec)
+            client.config = NativeClientConfig(context_tokens=16384, qwen_route_prefix_reuse_enabled=True)
+            second = client._qwen_route_prefix_state_kwargs(spec)
+            client._model_metadata_identity["general.name"] = "changed"
+            third = client._qwen_route_prefix_state_kwargs(spec)
+
+        self.assertNotEqual(first["template_id"], second["template_id"])
+        self.assertNotEqual(second["model_id"], third["model_id"])
+
+    def test_first_prefill_captures_and_second_request_restores(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client._decode_prompt_range = mock.Mock(return_value=QWEN_ROUTE_PREFIX_TOKEN_COUNT)  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        spec = QwenRoutePrefixSpec(tuple(range(QWEN_ROUTE_PREFIX_TOKEN_COUNT)), "t", "i", "s", 810, 42)
+        plan = _QwenRouteAnchorRuntimePlan(
+            prefix_tokens=list(spec.prefix_tokens),
+            prefix_hash="key",
+            state_kwargs={
+                "model_id": "m",
+                "template_id": "t",
+                "tool_schema_hash": "s",
+                "capability_summary_hash": "c",
+                "runtime_policy_hash": "p",
+                "route_contract_hash": "r",
+                "backend_version": "b",
+                "native_version": "n",
+                "tools_mode": "q",
+            },
+            spec=spec,
+            metadata={},
+        )
+        state = PrefixAnchorState(valid=True, checkpoint_data=b"x", checkpoint_size=1, token_count=QWEN_ROUTE_PREFIX_TOKEN_COUNT)
+
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor", return_value=(state, {})):
+            processed, reused = client._prepare_memory_with_qwen_route_anchor(plan)
+
+        self.assertEqual((processed, reused), (QWEN_ROUTE_PREFIX_TOKEN_COUNT, 0))
+        self.assertEqual(client.qwen_route_prefix_reuse_status()["capture_count"], 1)
+
+        with mock.patch("orbit.native_llama.client.restore_prefix_anchor", return_value=(True, state, {"restore_used": True})):
+            processed, reused = client._prepare_memory_with_qwen_route_anchor(plan)
+
+        self.assertEqual((processed, reused), (QWEN_ROUTE_PREFIX_TOKEN_COUNT, QWEN_ROUTE_PREFIX_TOKEN_COUNT))
+        self.assertEqual(client.qwen_route_prefix_reuse_status()["restore_count"], 1)
+        self.assertFalse(client._route_prefix_anchor_state.valid)
+
+    def test_restore_failure_clears_state_and_uses_one_cold_fallback(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        spec = QwenRoutePrefixSpec(tuple(range(QWEN_ROUTE_PREFIX_TOKEN_COUNT)), "t", "i", "s", 810, 42)
+        plan = _QwenRouteAnchorRuntimePlan(list(spec.prefix_tokens), "key", {}, spec, {})
+        state = PrefixAnchorState(valid=True, checkpoint_data=b"x", checkpoint_size=1, token_count=QWEN_ROUTE_PREFIX_TOKEN_COUNT)
+        client._qwen_route_prefix_anchor_state = state
+
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            return_value=(False, PrefixAnchorState(invalidation_reason="restore_failed"), {"fallback_reason": "restore_failed"}),
+        ):
+            processed, reused = client._prepare_memory_with_qwen_route_anchor(plan)
+
+        self.assertEqual((processed, reused), (0, 0))
+        self.assertEqual(client._clear_target_memory.call_count, 2)
+        status = client.qwen_route_prefix_reuse_status()
+        self.assertFalse(status["initialized"])
+        self.assertEqual(status["checkpoint_size_bytes"], 0)
+        self.assertEqual(status["fallback_count"], 1)
+        self.assertEqual(status["invalidation_count"], 1)
+
+    def test_cancel_invalidates_only_qwen_checkpoint(self) -> None:
+        client = self._client()
+        client._qwen_route_prefix_anchor_state = PrefixAnchorState(valid=True, checkpoint_data=b"x", checkpoint_size=1)
+        client._route_prefix_anchor_state = PrefixAnchorState(valid=True, checkpoint_data=b"g", checkpoint_size=1)
+
+        client.cancel()
+
+        self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+        self.assertTrue(client._route_prefix_anchor_state.valid)
+
+    def test_reset_releases_checkpoint_and_preserves_separate_gemma_state(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client.lib.lib.llama_get_memory.return_value = 2
+        client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"x",
+            checkpoint_size=1,
+        )
+        client._route_prefix_anchor_state = PrefixAnchorState(valid=True, checkpoint_data=b"g", checkpoint_size=1)
+
+        client.reset_session_state()
+
+        self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+        self.assertEqual(client.qwen_route_prefix_reuse_status()["checkpoint_size_bytes"], 0)
+        self.assertTrue(client._route_prefix_anchor_state.valid)
+
+    def test_diagnostics_are_bounded_and_do_not_expose_prompt_or_model_path(self) -> None:
+        client = self._client()
+        client._qwen_route_prefix_spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t" * 64,
+            "i" * 64,
+            "s" * 64,
+            810,
+            42,
+        )
+
+        diagnostics = client.qwen_route_prefix_reuse_status()
+
+        self.assertEqual(diagnostics["prefix_tokens"], 0)
+        self.assertEqual(diagnostics["prefix_token_hash"], "t" * 64)
+        self.assertEqual(diagnostics["prefix_text_hash"], "i" * 64)
+        self.assertNotIn("prompt", diagnostics)
+        self.assertNotIn("model_path", diagnostics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2149,6 +2149,51 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(backend.chat_calls, 2)
         self.assertEqual(backend.thinking_seen, [True, False])
 
+    def test_ask_chat_uses_one_call_for_verified_native_separated_reasoning(self) -> None:
+        class NativeSeparatedReasoningBackend(FakeBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.thinking = True
+                self.thinking_seen: list[bool] = []
+
+            def uses_native_separated_reasoning(self) -> bool:
+                return True
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages = messages
+                self.thinking_seen.append(self.thinking)
+                return ChatResult(
+                    content="The answer is 4.",
+                    reasoning_content="private arithmetic",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=4,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        backend = NativeSeparatedReasoningBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None, thinking_mode=True)
+        emitted: list[str] = []
+
+        result = runtime.ask_chat(
+            "What is 2 + 2?",
+            temperature=0,
+            max_tokens=256,
+            on_final_delta=emitted.append,
+        )
+
+        self.assertEqual(result.content, "The answer is 4.")
+        self.assertEqual(backend.calls, 1)
+        self.assertEqual(backend.thinking_seen, [True])
+        self.assertEqual(emitted, ["<|channel>thought\nprivate arithmetic<channel|>", "The answer is 4."])
+        self.assertEqual(runtime.messages[-1], {"role": "assistant", "content": "The answer is 4."})
+        self.assertNotIn("private arithmetic", repr(runtime.messages))
+
     def test_ask_chat_emits_distinct_phase_reasons_for_reasoning_repair(self) -> None:
         class ReasoningThenFinalBackend(FakeBackend):
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Adds native support for one exact verified Qwen 3.6 profile and a profile-specific route-prefix checkpoint. The original failure came from rendering Qwen with the Gemma protocol: thinking controls, assistant history, stop handling, reasoning separation, and XML tool calls were incompatible.

## Supported identity

- `Qwen3.6-35B-A3B-Q4_K_M.gguf` only
- profile `orbit-qwen36-native-v1`
- architecture `qwen35moe`
- `general.file_type=15` (`Q4_K_M`)
- official embedded template SHA-256 `e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259`
- metadata and template authorization; filename matching never enables support

Other Qwen variants, templates, and quantizations fail before inference. Qwen MTP and multimodal input remain unsupported.

## Protocol

- revision-bound native C++ bridge for llama.cpp Jinja rendering and chat parsing
- explicit `enable_thinking` template argument
- reasoning, visible content, and tool calls kept separate
- thinking forced off in route and other structured phases
- Qwen-native XML tool calls, tool results, and assistant history
- existing canonical validation, healing, permissions, no-mutation policy, and executors remain authoritative

## Route checkpoint

- default-on only for the exact verified profile
- kill switch `ORBIT_QWEN_ROUTE_PREFIX_REUSE=0`; invalid values disable safely
- invariant route prefix: 810 tokens
- checkpoint boundary: 768 tokens, batch-aligned, no padding
- complete attention KV and recurrent sequence state through `llama_state_seq_get_data` / `llama_state_seq_set_data`
- sampler reset independently before decode
- checkpoint size: 81,608,684 bytes
- model, quantization, context, template, tokenizer, schema, backend-build, and process bound

Cold, segmented, captured, and restored logits were byte-identical. Maximum absolute logits difference was `0.0`; logits hash, next token, ordered top candidates, route output, tool name, typed arguments, and finish reason matched.

## Validation

- focused Qwen/runtime tests: 214 PASS
- document search: 42 PASS
- full discovery: 1,395 PASS
- native build and all MTP helpers: PASS
- Qwen chat/tool/multiturn/failure/inert-data/thinking/document-search matrix: PASS
- cancel, timeout, reset, restart, restore failure, and repeated restore: PASS
- 20 repeated restores: no linear RSS growth
- Gemma final-prefix default: capture then `cached=64` PASS
- Gemma final-prefix kill switch: `cached=4` PASS
- strict Gemma target/draft MTP and mmproj: PASS
- `compileall`: PASS
- `git diff --check`: PASS

Repeated process-isolated 11-route comparison:

| Metric | OFF | ON |
|---|---:|---:|
| evaluated prompt tokens | 9,088 | 1,408 |
| cached tokens | 0 | 7,680 |
| prefill wall | 254.98 s | 40.42 s |
| total wall | 264.84 s | 50.50 s |
| median prefill after capture | 23.26 s | 1.73 s |
| median wall after capture | 24.16 s | 2.61 s |

Capture/restore/fallback was `1/10/0`; all outputs, tool names, arguments, and finish reasons were identical. CPU timings are descriptive, not a universal performance guarantee.

## Review note

Pre-commit review found and removed an unnecessary change to the legacy Gemma thinking branch. Gemma rendering, tokenizer, prompts, schema, route behavior, and legacy thinking flow remain unchanged.

## Limits

- no support claim for all Qwen models
- no portable checkpoint
- no Qwen MTP
- no Qwen multimodal support
- explicit thinking can consume substantial output budget
- no universal speedup claim
