### PR TITLE
fix(runtime): complete tool-result finalization

### DIFF
--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -87,9 +87,9 @@ def _final_from_tool_tokens(requested: int | None, evidence_kind: str, evidence_
         return _floor_and_cap(requested, FINAL_SHELL_ERROR_MAX_TOKENS, FINAL_SHELL_ERROR_MAX_TOKENS)
     if evidence_kind == "system_info":
         return _floor_and_cap(requested, FINAL_SYSTEM_INFO_MAX_TOKENS, FINAL_SYSTEM_INFO_MAX_TOKENS)
-    if evidence_kind in {"shell", "unknown", "grep_search"} and evidence_chars is not None and evidence_chars <= 500:
+    if evidence_kind in {"shell", "unknown", "grep_search", "directory_listing"} and evidence_chars is not None and evidence_chars <= 500:
         return _floor_and_cap(requested, FINAL_SMALL_MAX_TOKENS, FINAL_SMALL_MAX_TOKENS)
-    if evidence_kind in {"shell", "unknown", "grep_search"}:
+    if evidence_kind in {"shell", "unknown", "grep_search", "directory_listing"}:
         return _floor_and_cap(requested, FINAL_MEDIUM_MAX_TOKENS, FINAL_MEDIUM_MAX_TOKENS)
     return _floor_and_cap(requested, FINAL_MEDIUM_MAX_TOKENS, DEFAULT_MAX_TOKENS)
 

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1340,6 +1340,8 @@ class FinalFromToolEnvironment:
         record = next(iter(store.recent_records(1)), None)
         if record is None:
             return None, None
+        if record.tool_name == "list_directory":
+            return "directory_listing", record.raw_chars
         if record.tool_name == "system_info":
             return "system_info", record.raw_chars
         if record.kind in {"shell", "unknown"} and record.status == "error":

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -786,7 +786,7 @@ def has_list_like_tool_result(messages: list[Message]) -> bool:
             continue
         content = message.get("content")
         if not isinstance(content, str) or _is_error_tool_content(content):
-            continue
+            return False
         if message.get("name") == "list_directory":
             return True
         if message.get("name") != "exec_shell_full_command":

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from orbit.backend import ChatResult
 from orbit.backend.base import Message
 from orbit.runtime.completion_budget import resolve_max_tokens
+from orbit.runtime.shell_guardrails import is_mutating_shell_command
 
 
 FINAL_FROM_TOOL_MIN_TOKENS = 256
@@ -99,8 +100,10 @@ def build_final_tool_policy(
     web_fetch_result = has_html_cleaned_tool_result(call_messages)
     web_search_result = has_web_search_tool_result(call_messages)
     pdf_text_result = has_pdf_text_tool_result(call_messages)
-    list_like_result = has_list_like_tool_result(call_messages) and is_compact_list_request(prompt)
+    directory_listing_result = evidence_kind == "directory_listing" or has_list_like_tool_result(call_messages)
+    list_like_result = directory_listing_result and is_compact_list_request(prompt)
     shell_full_result = has_tool_result(call_messages, "exec_shell_full_command")
+    verified_mutation_result = has_verified_mutation_evidence(call_messages)
     system_info_result = has_tool_result(call_messages, "system_info")
     operational_status_result = shell_full_result and is_operational_status_request(prompt)
     brief_request = is_brief_final_request(prompt)
@@ -112,6 +115,12 @@ def build_final_tool_policy(
         and _has_long_shell_tool_result(messages)
         and is_shell_review_request(prompt)
         and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
+    )
+    mutation_instruction = (
+        "The mutation command completed successfully and the later read-only output verified the result. "
+        "State both the completed change and what the verification confirmed. "
+        if verified_mutation_result
+        else ""
     )
     if large_file_excerpt:
         call_messages = [
@@ -152,7 +161,8 @@ def build_final_tool_policy(
             {
                 "role": "user",
                 "content": (
-                    "Answer the latest operational/status question directly. "
+                    mutation_instruction
+                    + "Answer the latest operational/status question directly. "
                     "Use only the most recent relevant shell output. "
                     "Ignore older tool results or content analysis unless explicitly requested. "
                     "Do not summarize file or page content. "
@@ -185,13 +195,26 @@ def build_final_tool_policy(
             *call_messages,
             {"role": "user", "content": "Return only the listed names, compactly. No categories or explanations."},
         ]
+    elif directory_listing_result:
+        call_messages = [
+            *call_messages,
+            {
+                "role": "user",
+                "content": (
+                    "Return every listed path exactly once, one per line. "
+                    "Preserve directory markers. Omit sizes and other metadata unless requested. "
+                    "No introduction or conclusion. Stop after the final path."
+                ),
+            },
+        ]
     elif shell_full_result:
         call_messages = [
             *call_messages,
             {
                 "role": "user",
                 "content": (
-                    (
+                    mutation_instruction
+                    + (
                         (
                             "Use only the latest relevant shell-full output. "
                             "Answer in at most two short sentences. "
@@ -317,29 +340,36 @@ def prepare_final_tool_messages(messages: list[Message]) -> list[Message]:
 
 
 def _prune_to_latest_successful_tool_evidence(messages: list[Message]) -> list[Message]:
-    tool_message, _command = last_successful_shell_result_and_command(messages)
-    if tool_message is None:
+    selected = _selected_successful_shell_evidence(messages)
+    if not selected:
         return [dict(message) for message in messages]
-    selected_tool_call_id = tool_message.get("tool_call_id")
-    selected_tool_identity = id(tool_message)
+    selected_tool_call_ids = {
+        tool_message.get("tool_call_id")
+        for tool_message, _command in selected
+        if isinstance(tool_message.get("tool_call_id"), str)
+    }
+    selected_tool_identities = {id(tool_message) for tool_message, _command in selected}
     pruned: list[Message] = []
     for message in messages:
         role = message.get("role")
         if role == "tool" and message.get("name") == "exec_shell_full_command":
-            keep_tool = False
-            if isinstance(selected_tool_call_id, str):
-                keep_tool = message.get("tool_call_id") == selected_tool_call_id
-            else:
-                keep_tool = id(message) == selected_tool_identity
+            tool_call_id = message.get("tool_call_id")
+            keep_tool = (
+                tool_call_id in selected_tool_call_ids
+                if isinstance(tool_call_id, str)
+                else id(message) in selected_tool_identities
+            )
             if not keep_tool:
                 continue
             pruned.append(dict(message))
             continue
         if role == "assistant" and isinstance(message.get("tool_calls"), list):
             filtered_calls = list(message["tool_calls"])
-            if isinstance(selected_tool_call_id, str):
+            if selected_tool_call_ids:
                 filtered_calls = [
-                    tool_call for tool_call in filtered_calls if isinstance(tool_call, dict) and tool_call.get("id") == selected_tool_call_id
+                    tool_call
+                    for tool_call in filtered_calls
+                    if isinstance(tool_call, dict) and tool_call.get("id") in selected_tool_call_ids
                 ]
             if not filtered_calls and not str(message.get("content") or "").strip():
                 continue
@@ -352,6 +382,49 @@ def _prune_to_latest_successful_tool_evidence(messages: list[Message]) -> list[M
             continue
         pruned.append(dict(message))
     return pruned
+
+
+def _selected_successful_shell_evidence(messages: list[Message]) -> list[tuple[Message, str | None]]:
+    latest_user_index = max(
+        (index for index, message in enumerate(messages) if message.get("role") == "user"),
+        default=-1,
+    )
+    latest: tuple[int, Message, str | None] | None = None
+    mutation: tuple[int, Message, str | None] | None = None
+    for index in range(len(messages) - 1, latest_user_index, -1):
+        message = messages[index]
+        if message.get("role") != "tool" or message.get("name") != "exec_shell_full_command":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or _is_error_tool_content(content):
+            continue
+        command = _shell_command_for_tool_call_id(messages[:index], message.get("tool_call_id"))
+        if latest is None:
+            latest = (index, message, command)
+        if command and is_mutating_shell_command(command):
+            mutation = (index, message, command)
+            break
+    selected = [item for item in (mutation, latest) if item is not None]
+    if not selected:
+        tool_message, command = last_successful_shell_result_and_command(messages)
+        if tool_message is not None:
+            selected.append((-1, tool_message, command))
+    deduplicated = {id(message): (index, message, command) for index, message, command in selected}
+    return [(message, command) for index, message, command in sorted(deduplicated.values())]
+
+
+def has_verified_mutation_evidence(messages: list[Message]) -> bool:
+    selected = _selected_successful_shell_evidence(messages)
+    if len(selected) != 2:
+        return False
+    mutation_command = selected[0][1]
+    verification_command = selected[1][1]
+    return bool(
+        mutation_command
+        and is_mutating_shell_command(mutation_command)
+        and verification_command
+        and not is_mutating_shell_command(verification_command)
+    )
 
 
 def _compact_latest_tool_evidence(messages: list[Message], *, prompt: str | None) -> list[Message]:
@@ -708,10 +781,19 @@ def has_tool_result(messages: list[Message], name: str) -> bool:
 
 
 def has_list_like_tool_result(messages: list[Message]) -> bool:
-    tool_message, command = last_successful_shell_result_and_command(messages)
-    if tool_message is None:
-        return False
-    return is_list_shell_command(command)
+    for message in reversed(messages):
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or _is_error_tool_content(content):
+            continue
+        if message.get("name") == "list_directory":
+            return True
+        if message.get("name") != "exec_shell_full_command":
+            return False
+        return is_list_shell_command(
+            _shell_command_for_tool_call_id(messages, message.get("tool_call_id"))
+        )
     return False
 
 

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -35,6 +35,8 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell_error", evidence_chars=120), 128)
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="system_info", evidence_chars=300), 160)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="shell", evidence_chars=1200), 192)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="directory_listing", evidence_chars=500), 96)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="directory_listing", evidence_chars=501), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="web_search", evidence_chars=1200), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="read", evidence_chars=8000), 256)
 

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -274,6 +274,34 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("Return every listed path exactly once", policy.messages[-1]["content"])
         self.assertIn("Stop after the final path", policy.messages[-1]["content"])
 
+    def test_prior_directory_listing_does_not_override_later_tool_error(self) -> None:
+        messages = [
+            {"role": "user", "content": "List files, then run the requested check."},
+            {
+                "role": "tool",
+                "tool_call_id": "call-list",
+                "name": "list_directory",
+                "content": "[file] README.md (30 B)",
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-check",
+                "name": "exec_shell_full_command",
+                "content": "shell_command_failed: true\nexit_code: 127",
+            },
+        ]
+
+        policy = build_final_tool_policy(
+            messages,
+            max_tokens=512,
+            streamed=False,
+            evidence_kind="shell_error",
+            evidence_chars=48,
+        )
+
+        self.assertFalse(has_list_like_tool_result(messages))
+        self.assertNotIn("Return every listed path exactly once", policy.messages[-1]["content"])
+
     def test_shell_full_policy_answers_latest_request_directly(self) -> None:
         messages = [
             {"role": "user", "content": "Use the shell output and answer with the exact first line only."},

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -234,6 +234,45 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertTrue(has_list_like_tool_result(messages))
         self.assertFalse(is_compact_list_request(messages[0]["content"]))
         self.assertNotIn("Return only the listed names", policy.messages[-1]["content"])
+        self.assertIn("Return every listed path exactly once", policy.messages[-1]["content"])
+        self.assertEqual(policy.max_tokens, 192)
+
+    def test_structured_directory_listing_uses_bounded_path_instruction(self) -> None:
+        messages = [
+            {"role": "user", "content": "List all files and directories in this workdir, including subdirectories."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-list",
+                        "function": {
+                            "name": "list_directory",
+                            "arguments": {"path": ".", "recursive": True},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-list",
+                "name": "list_directory",
+                "content": "[dir] samples/\n[file] samples/demo.py (20 B)\n[file] README.md (30 B)",
+            },
+        ]
+
+        policy = build_final_tool_policy(
+            messages,
+            max_tokens=512,
+            streamed=False,
+            evidence_kind="unknown",
+            evidence_chars=75,
+        )
+
+        self.assertTrue(has_list_like_tool_result(messages))
+        self.assertEqual(policy.max_tokens, 96)
+        self.assertIn("Return every listed path exactly once", policy.messages[-1]["content"])
+        self.assertIn("Stop after the final path", policy.messages[-1]["content"])
 
     def test_shell_full_policy_answers_latest_request_directly(self) -> None:
         messages = [
@@ -408,6 +447,103 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertEqual(sum(1 for message in prepared if message.get("role") == "tool"), 1)
         self.assertIn("Useful text", str(prepared[-1].get("content")))
         self.assertNotIn("command not found", json.dumps(prepared, ensure_ascii=False))
+
+    def test_prepare_final_tool_messages_keeps_current_mutation_and_verification(self) -> None:
+        messages = [
+            {"role": "user", "content": "Replace beta with BETA in edit-target.txt and tell me what changed."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-mutate",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "sed -i 's/beta/BETA/' edit-target.txt"},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-mutate",
+                "name": "exec_shell_full_command",
+                "content": "",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-verify",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "grep BETA edit-target.txt"},
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-verify",
+                "name": "exec_shell_full_command",
+                "content": "BETA",
+            },
+        ]
+
+        prepared = prepare_final_tool_messages(messages)
+        serialized = json.dumps(prepared, ensure_ascii=False)
+
+        self.assertEqual(sum(1 for message in prepared if message.get("role") == "tool"), 2)
+        self.assertIn("sed -i", serialized)
+        self.assertIn("grep BETA", serialized)
+        self.assertIn('"content": "BETA"', serialized)
+
+        policy = build_final_tool_policy(messages, max_tokens=512, streamed=False)
+        self.assertIn("State both the completed change", policy.messages[-1]["content"])
+        self.assertIn("what the verification confirmed", policy.messages[-1]["content"])
+
+    def test_prepare_final_tool_messages_does_not_keep_prior_turn_mutation(self) -> None:
+        messages = [
+            {"role": "user", "content": "Create old.txt."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-old",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "printf old > old.txt"},
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-old", "name": "exec_shell_full_command", "content": ""},
+            {"role": "assistant", "content": "Created old.txt."},
+            {"role": "user", "content": "Read current.txt."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-read",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": {"command": "cat current.txt"},
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-read", "name": "exec_shell_full_command", "content": "current"},
+        ]
+
+        prepared = prepare_final_tool_messages(messages)
+        serialized = json.dumps(prepared, ensure_ascii=False)
+
+        self.assertNotIn("call-old", serialized)
+        self.assertNotIn("printf old", serialized)
+        self.assertIn("call-read", serialized)
 
     def test_prepare_final_tool_messages_compacts_large_pdf_tool_content(self) -> None:
         messages = [

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1263,6 +1263,39 @@ class RuntimeTests(unittest.TestCase):
         rendered = "\n".join(str(message.get("content", "")) for message in backend.messages)
         self.assertIn("evidence_context:", rendered)
 
+    def test_final_from_tool_compact_directory_evidence_keeps_listing_identity(self) -> None:
+        raw = "directory_listing: path=. recursive=true\n[dir] samples/\n[file] README.md (20 B)"
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            record = store.add("list_directory", raw, metadata={"path": ".", "recursive": True})
+            backend = FakeBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt=None, evidence_store=store)
+            runtime.messages = [
+                {"role": "user", "content": "List all files and directories in this workdir, including subdirectories."},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-list",
+                    "name": "list_directory",
+                    "content": tool_evidence_ref(record),
+                    "evidence_id": record.evidence_id,
+                },
+            ]
+
+            runtime._answer_from_tool_results(
+                temperature=0,
+                max_tokens=512,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                loop=1,
+                use_tool_prompt=False,
+            )
+
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.messages)
+        self.assertIn("evidence_context:", rendered)
+        self.assertIn("Return every listed path exactly once", rendered)
+        self.assertIn("Stop after the final path", rendered)
+
     def test_final_from_tool_small_evidence_excludes_web_and_medium(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             web_store = EvidenceStore(Path(tmp) / "web.evidence")


### PR DESCRIPTION
## Summary

This fixes the two strict Gemma production-corpus failures that blocked RC26 without changing Qwen, routing, tool execution, model-call counts, or global completion budgets.

## Root causes

- Recursive directory listings were already complete, but their final prompt did not retain listing identity. Gemma repeated size metadata and exhausted the existing 96-token final budget.
- Final evidence projection retained only the latest successful shell result. After an existing-file mutation and read-only verification, the mutation command/result was removed, so the final model could not truthfully report what changed.

Both failures reproduce on the RC25 tag, the pre-PR #160 main commit, and current main. PR #160 did not introduce them.

## Changes

- Preserve a bounded `directory_listing` evidence identity and instruct the final model to return each path once without unrequested size metadata.
- Keep the existing final budget: 96 tokens for small listings, 192 for larger listings.
- For the current user turn only, retain at most the successful mutation evidence and the latest successful read-only verification evidence.
- Add a bounded final instruction requiring the model-authored response to state both the completed mutation and the verification result.
- Preserve existing pruning for read-only and prior-turn evidence.

No tool, prompt schema, route budget, retry, model call, Qwen profile, checkpoint, MTP path, or executor behavior changes.

## Process-isolated comparison

| Revision | Listing | Mutation final |
| --- | --- | --- |
| RC25 | complete answer, `length`, 96 output tokens | mutation correct; final says it cannot confirm |
| pre-PR #160 main | same | same |
| current main | same | same |
| candidate | complete answer, `stop`, 73 output tokens | states `beta` -> `BETA` and verification, `stop` |

Candidate ON/OFF post-tool final reuse produced the same correct answers and used the same model/tool call counts. CPU wall times are descriptive and no performance guarantee is claimed.

## Validation

- Gemma production corpus: 12/12 semantic PASS, 12/12 `stop`.
- Repeated exact listing and mutation scenarios: PASS with reuse ON and OFF.
- Focused runtime/policy/canonical/healing/guardrail/config/REPL/document-search tests: 445 PASS.
- Lifecycle/session-focused tests: 160 PASS.
- Full discovery: 1,401 PASS.
- Gemma final-prefix: 1 capture, 5 restores, `cached=64`, zero fallback.
- Gemma kill switch: `cached=4`, zero capture/restore.
- Strict Gemma MTP/mmproj: initialized, usable, 2/2 `stop`, zero final-prefix activity.
- Qwen real-model corpus: 9/9 PASS with route-prefix ON and 9/9 PASS OFF; identical tools and finish reasons.
- Qwen route-prefix ON: 4,608 cached route tokens and 3,001 evaluated tokens; OFF: 0 cached and 7,606 evaluated tokens in the matched run.
- Qwen checkpoint numerical artifact remains byte-identical, maximum logits difference `0.0`.
- Native runtime and MTP shim build: PASS.
- `python3 -m compileall -q src tests scripts`: PASS.
- `git diff --check`: PASS.

## Isolation

The observational footer branch `feat/turn-token-observability` and commit `f11d608` are preserved separately and are not included in this PR.

## Independent review

The first review found that an older successful listing could override a later failed tool result. Follow-up commit `f068f70` makes listing detection consider only the latest relevant tool result and adds a focused regression test. A second complete diff review found no remaining blockers. Affected tests: 325 PASS; final full discovery: 1,401 PASS.