### PR TITLE
feat(cli): report complete turn and session token usage

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -32,9 +32,13 @@ class LlamaServerBackend:
         self._server_tools_cache: list[dict[str, Any]] | None = None
         self._props_cache: dict[str, Any] | None = None
         self._result_observer: Callable[[ChatResult], None] | None = None
+        self._failure_observer: Callable[[], None] | None = None
 
     def set_result_observer(self, observer: Callable[[ChatResult], None] | None) -> None:
         self._result_observer = observer
+
+    def set_failure_observer(self, observer: Callable[[], None] | None) -> None:
+        self._failure_observer = observer
 
     def chat(
         self,
@@ -61,16 +65,15 @@ class LlamaServerBackend:
         )
         _attach_native_kv_diag_payload(payload, native_backend=native_backend)
         if native_backend:
-            return self._with_display_model(
-                self._post_native_stream(
+            return self._observe_call(
+                lambda: self._post_native_stream(
                     "/chat/stream",
                     payload,
                     on_delta=lambda _text: None,
                     on_progress=None,
                 )
             )
-        data = self._post_json("/v1/chat/completions", payload)
-        return self._with_display_model(_parse_chat_result(data))
+        return self._observe_call(lambda: _parse_chat_result(self._post_json("/v1/chat/completions", payload)))
 
     def chat_stream(
         self,
@@ -100,15 +103,17 @@ class LlamaServerBackend:
         )
         _attach_native_kv_diag_payload(payload, native_backend=native_backend)
         if native_backend:
-            return self._with_display_model(
-                self._post_native_stream(
+            return self._observe_call(
+                lambda: self._post_native_stream(
                     "/chat/stream",
                     payload,
                     on_delta=on_delta,
                     on_progress=on_progress,
                 )
             )
-        return self._with_display_model(self._post_stream("/v1/chat/completions", payload, on_delta=on_delta))
+        return self._observe_call(
+            lambda: self._post_stream("/v1/chat/completions", payload, on_delta=on_delta)
+        )
 
     def continue_current(
         self,
@@ -121,16 +126,16 @@ class LlamaServerBackend:
             raise LlamaServerError("native continuation is unavailable for this backend")
         payload = {"max_tokens": max_tokens, "thinking": self.thinking, "stream": True}
         if on_delta is None:
-            return self._with_display_model(
-                self._post_native_stream(
+            return self._observe_call(
+                lambda: self._post_native_stream(
                     "/chat/continue/stream",
                     payload,
                     on_delta=lambda _text: None,
                     on_progress=None,
                 )
             )
-        return self._with_display_model(
-            self._post_native_stream(
+        return self._observe_call(
+            lambda: self._post_native_stream(
                 "/chat/continue/stream",
                 payload,
                 on_delta=on_delta,
@@ -263,8 +268,23 @@ class LlamaServerBackend:
         display = self.display_model_name()
         displayed = replace(result, model=display) if display else result
         if self._result_observer is not None:
-            self._result_observer(displayed)
+            try:
+                self._result_observer(displayed)
+            except Exception:
+                pass
         return displayed
+
+    def _observe_call(self, call: Callable[[], ChatResult]) -> ChatResult:
+        try:
+            result = call()
+        except BaseException:
+            if self._failure_observer is not None:
+                try:
+                    self._failure_observer()
+                except Exception:
+                    pass
+            raise
+        return self._with_display_model(result)
 
     def _post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         body = json.dumps(payload).encode("utf-8")

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -31,6 +31,10 @@ class LlamaServerBackend:
         self._display_model_name: str | None = None
         self._server_tools_cache: list[dict[str, Any]] | None = None
         self._props_cache: dict[str, Any] | None = None
+        self._result_observer: Callable[[ChatResult], None] | None = None
+
+    def set_result_observer(self, observer: Callable[[ChatResult], None] | None) -> None:
+        self._result_observer = observer
 
     def chat(
         self,
@@ -257,9 +261,10 @@ class LlamaServerBackend:
 
     def _with_display_model(self, result: ChatResult) -> ChatResult:
         display = self.display_model_name()
-        if not display:
-            return result
-        return replace(result, model=display)
+        displayed = replace(result, model=display) if display else result
+        if self._result_observer is not None:
+            self._result_observer(displayed)
+        return displayed
 
     def _post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         body = json.dumps(payload).encode("utf-8")

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -13,6 +13,7 @@ from orbit.native_server.app import run_server
 from orbit.runtime import ChatRuntime
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.media import load_audio, load_image
+from orbit.runtime.turn_trace import ModelStepMetrics
 from orbit.terminal.config import add_config_arguments, load_app_config
 from orbit.terminal.context_status import context_status_text
 from orbit.terminal.history import PromptHistory
@@ -21,7 +22,7 @@ from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, TOOL_PREFILL_
 from orbit.terminal.repl import Repl
 from orbit.terminal.commands import health_text, help_text, runtime_status, set_max_tokens, think_mode_text, tools_text
 from orbit.terminal.session_selection import select_interactive_session
-from orbit.terminal.status import estimate_context_status_tokens, format_turn_status
+from orbit.terminal.status import TokenUsageAccumulator, estimate_context_status_tokens, format_turn_status, summarize_turn_token_usage
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.theme import dim
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
@@ -168,6 +169,23 @@ def _run_one_shot(
     render_markdown_mode: str = "plain",
 ) -> int:
     prefill_estimator = PrefillEstimator()
+    model_steps: list[ModelStepMetrics] = []
+    backend_token_usage = TokenUsageAccumulator()
+    backend_usage_observer_installed = False
+
+    set_result_observer = getattr(getattr(runtime, "backend", None), "set_result_observer", None)
+    if callable(set_result_observer):
+        set_result_observer(backend_token_usage.add_result)
+        backend_usage_observer_installed = True
+
+    def record_model_step(metrics: ModelStepMetrics) -> None:
+        model_steps.append(metrics)
+        prefill_estimator.update(
+            prompt_tokens=metrics.prompt_tokens,
+            prompt_tokens_per_second=metrics.prompt_tokens_per_second,
+            profile=prefill_profile_for_phase(metrics.phase),
+        )
+
     tools_enabled = tools_are_enabled(tools)
     system_prompt = ROUTE_SYSTEM_PROMPT if tools_enabled else CHAT_SYSTEM_PROMPT
     prefill_tokens = estimate_prefill_tokens(runtime.messages, prompt, system_prompt=system_prompt)
@@ -194,6 +212,7 @@ def _run_one_shot(
                 audios=audios,
                 on_final_delta=renderer.write,
                 on_progress=renderer.progress,
+                on_model_step=record_model_step,
             )
         elif not tools_enabled:
             result = runtime.ask_chat(
@@ -202,6 +221,7 @@ def _run_one_shot(
                 max_tokens=max_tokens,
                 on_final_delta=renderer.write,
                 on_progress=renderer.progress,
+                on_model_step=record_model_step,
             )
         else:
             result = runtime.ask_auto(
@@ -212,6 +232,7 @@ def _run_one_shot(
                 allowed_tool_names=allowed_tool_names_for_spec(tools),
                 on_final_delta=renderer.write,
                 on_progress=renderer.progress,
+                on_model_step=record_model_step,
                 on_tool_call=lambda name, args: renderer.event(format_tool_call_event(name, args), restart_timer=False),
                 on_tool_result=lambda name, chars, source, content: _show_tool_result(
                     renderer,
@@ -236,11 +257,12 @@ def _run_one_shot(
         print(f"error: {exc}", file=sys.stderr)
         return 1
     renderer.finish()
-    prefill_estimator.update(
-        prompt_tokens=result.prompt_tokens,
-        prompt_tokens_per_second=result.prompt_tokens_per_second,
-        profile=prefill_profile_for_phase("final_from_tool" if tools_enabled else "chat_final"),
-    )
+    if not model_steps:
+        prefill_estimator.update(
+            prompt_tokens=result.prompt_tokens,
+            prompt_tokens_per_second=result.prompt_tokens_per_second,
+            profile=prefill_profile_for_phase("final_from_tool" if tools_enabled else "chat_final"),
+        )
     elapsed = time.monotonic() - started
     print("\n\n", end="", flush=True)
     print(
@@ -250,6 +272,11 @@ def _run_one_shot(
                 elapsed_seconds=elapsed,
                 estimated_context_tokens=estimate_context_status_tokens(runtime.messages),
                 context_tokens=runtime.context_tokens,
+                turn_token_usage=(
+                    backend_token_usage.snapshot()
+                    if backend_usage_observer_installed
+                    else summarize_turn_token_usage(model_steps)
+                ),
             )
         ),
         flush=True,

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -60,6 +60,9 @@ class Repl:
         if callable(set_result_observer):
             set_result_observer(self._record_backend_result)
             self.backend_usage_observer_installed = True
+        set_failure_observer = getattr(self.backend, "set_failure_observer", None)
+        if callable(set_failure_observer):
+            set_failure_observer(self._record_backend_failure)
 
     def run(self) -> int:
         if self.history:
@@ -211,6 +214,10 @@ class Repl:
         self.turn_backend_token_usage.add_result(result)
         self.session_token_usage.add_result(result)
 
+    def _record_backend_failure(self) -> None:
+        self.turn_backend_token_usage.add_failed_call()
+        self.session_token_usage.add_failed_call()
+
     def _turn_token_usage(self) -> TurnTokenUsage | None:
         if self.backend_usage_observer_installed:
             return self.turn_backend_token_usage.snapshot()
@@ -238,6 +245,7 @@ class Repl:
             return True
         if command == "/reset":
             print(reset_session(self.runtime, self.session))
+            self._reset_token_usage()
             self.can_continue = False
             return True
         if command == "/compact":
@@ -280,9 +288,15 @@ class Repl:
             return "sessions clear cancelled"
         removed = SessionStore.clear_for_workdir(self.config.workdir)
         self.runtime.reset()
+        self._reset_token_usage()
         self.can_continue = False
         self.session = SessionStore.new_for_workdir(self.config.workdir)
         return f"sessions cleared: {removed}"
+
+    def _reset_token_usage(self) -> None:
+        self.turn_model_steps.clear()
+        self.turn_backend_token_usage = TokenUsageAccumulator()
+        self.session_token_usage = TokenUsageAccumulator()
 
     def _handle_tools_command(self, command: str) -> str:
         value = command.removeprefix("/tools").strip().lower()

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -4,6 +4,7 @@ import sys
 import time
 from dataclasses import dataclass, field, replace
 
+from orbit.backend.base import ChatResult
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
@@ -18,13 +19,21 @@ from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TO
 from orbit.terminal.repl_input import clear_input_echo, read_prompt_input, replace_input_echo
 from orbit.terminal.runtime_status import collect_runtime_status, format_startup_banner
 from orbit.terminal.session_preview import format_recent_session_messages, has_existing_session_context
-from orbit.terminal.status import estimate_context_status_tokens, format_memory_refresh, format_turn_status
+from orbit.terminal.status import (
+    TokenUsageAccumulator,
+    TurnTokenUsage,
+    estimate_context_status_tokens,
+    format_memory_refresh,
+    format_session_token_usage,
+    format_turn_status,
+    summarize_turn_token_usage,
+)
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
 from orbit.terminal.theme import dim
 from orbit.runtime.thinking_mode import ThinkingMode
-from orbit.runtime.turn_trace import ModelPhaseStart
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
 @dataclass
@@ -38,11 +47,19 @@ class Repl:
     can_continue: bool = False
     tools_mode: ToolSpec | None = None
     queued_prompts: list[str] = field(default_factory=list)
+    turn_model_steps: list[ModelStepMetrics] = field(default_factory=list, repr=False)
+    turn_backend_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
+    session_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
+    backend_usage_observer_installed: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.tools_mode is None:
             self.tools_mode = self.config.tools
         self.backend.thinking = self.config.think
+        set_result_observer = getattr(self.backend, "set_result_observer", None)
+        if callable(set_result_observer):
+            set_result_observer(self._record_backend_result)
+            self.backend_usage_observer_installed = True
 
     def run(self) -> int:
         if self.history:
@@ -58,21 +75,16 @@ class Repl:
             try:
                 prompt = self._read_next_prompt().strip()
             except EOFError:
-                self._save_history()
-                print()
-                return 0
+                return self._finish_interactive_session(0, leading_newline=True)
             except KeyboardInterrupt:
-                self._save_history()
-                print()
-                return 130
+                return self._finish_interactive_session(130, leading_newline=True)
             if not prompt:
                 continue
             if prompt.startswith("/"):
                 clear_input_echo(prompt)
                 if self._handle_command(prompt):
                     continue
-                self._save_history()
-                return 0
+                return self._finish_interactive_session(0)
             if self.history:
                 resolution = self.history.resolve_prompt(prompt)
                 if resolution.missing_full_text:
@@ -95,6 +107,8 @@ class Repl:
         return read_prompt_input()
 
     def _ask(self, prompt: str) -> None:
+        self.turn_model_steps.clear()
+        self.turn_backend_token_usage = TokenUsageAccumulator()
         tools_enabled = tools_are_enabled(self.tools_mode or "off")
         system_prompt = ROUTE_SYSTEM_PROMPT if tools_enabled else CHAT_SYSTEM_PROMPT
         prefill_tokens = estimate_prefill_tokens(self.runtime.messages, prompt, system_prompt=system_prompt)
@@ -169,6 +183,7 @@ class Repl:
                     elapsed_seconds=elapsed_seconds,
                     estimated_context_tokens=estimate_context_status_tokens(self.runtime.messages),
                     context_tokens=self.runtime.context_tokens,
+                    turn_token_usage=self._turn_token_usage(),
                 )
             ),
             flush=True,
@@ -182,12 +197,24 @@ class Repl:
             print(dim("/continue       continue the answer"), flush=True)
             print(dim("/max-tokens N   increase output budget"), flush=True)
 
-    def _record_model_step(self, metrics) -> None:
+    def _record_model_step(self, metrics: ModelStepMetrics) -> None:
+        self.turn_model_steps.append(metrics)
+        if not self.backend_usage_observer_installed:
+            self.session_token_usage.add(metrics)
         self.prefill_estimator.update(
             prompt_tokens=metrics.prompt_tokens,
             prompt_tokens_per_second=metrics.prompt_tokens_per_second,
             profile=prefill_profile_for_phase(metrics.phase),
         )
+
+    def _record_backend_result(self, result: ChatResult) -> None:
+        self.turn_backend_token_usage.add_result(result)
+        self.session_token_usage.add_result(result)
+
+    def _turn_token_usage(self) -> TurnTokenUsage | None:
+        if self.backend_usage_observer_installed:
+            return self.turn_backend_token_usage.snapshot()
+        return summarize_turn_token_usage(self.turn_model_steps)
 
     def _record_phase_start(self, renderer: StreamRenderer, phase: ModelPhaseStart) -> None:
         renderer.set_phase_label(_phase_progress_label(phase))
@@ -237,6 +264,7 @@ class Repl:
             return True
         if command == "/status":
             print(runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode))
+            print(format_session_token_usage(self.session_token_usage.snapshot()))
             return True
         if command in {"/status ctx", "/status context"}:
             print(context_status_text(self.runtime.messages, context_tokens=self.runtime.context_tokens))
@@ -305,7 +333,16 @@ class Repl:
         if self.history:
             self.history.save()
 
+    def _finish_interactive_session(self, code: int, *, leading_newline: bool = False) -> int:
+        self._save_history()
+        if leading_newline:
+            print()
+        print(dim(format_session_token_usage(self.session_token_usage.snapshot())), flush=True)
+        return code
+
     def _ask_continue(self) -> None:
+        self.turn_model_steps.clear()
+        self.turn_backend_token_usage = TokenUsageAccumulator()
         prefill_tokens = estimate_prefill_tokens(self.runtime.messages, "")
         prefill_seconds = self.prefill_estimator.estimate_seconds(prefill_tokens)
         renderer = StreamRenderer(

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -1,9 +1,111 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from shutil import get_terminal_size
+from typing import Sequence
+
 from orbit.backend.base import ChatResult
 from orbit.runtime.kv_diag import emit_footer_metrics
 from orbit.runtime.session_memory import MemoryRefresh, estimate_message_tokens
+from orbit.runtime.turn_trace import ModelStepMetrics
 from orbit.terminal.streaming import format_elapsed
+
+
+@dataclass(frozen=True)
+class TurnTokenUsage:
+    model_calls: int
+    prompt_tokens: int | None
+    evaluated_tokens: int | None
+    cached_tokens: int | None
+    completion_tokens: int | None
+
+
+@dataclass
+class TokenUsageAccumulator:
+    model_calls: int = 0
+    prompt_tokens: int | None = 0
+    evaluated_tokens: int | None = 0
+    cached_tokens: int | None = 0
+    completion_tokens: int | None = 0
+
+    def add(self, step: ModelStepMetrics) -> None:
+        self._add_metrics(
+            prompt_tokens=step.prompt_tokens,
+            completion_tokens=step.completion_tokens,
+            cached_tokens=step.cached_tokens,
+        )
+
+    def add_result(self, result: ChatResult) -> None:
+        self._add_metrics(
+            prompt_tokens=result.prompt_tokens,
+            completion_tokens=result.completion_tokens,
+            cached_tokens=result.cached_tokens,
+        )
+
+    def _add_metrics(
+        self,
+        *,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+        cached_tokens: int | None,
+    ) -> None:
+        self.model_calls += 1
+        self.prompt_tokens = _add_optional_metric(self.prompt_tokens, prompt_tokens)
+        self.completion_tokens = _add_optional_metric(self.completion_tokens, completion_tokens)
+        if (
+            self.cached_tokens is None
+            or self.evaluated_tokens is None
+            or prompt_tokens is None
+            or cached_tokens is None
+            or not 0 <= cached_tokens <= prompt_tokens
+        ):
+            self.cached_tokens = None
+            self.evaluated_tokens = None
+        else:
+            self.cached_tokens += cached_tokens
+            self.evaluated_tokens += prompt_tokens - cached_tokens
+
+    def snapshot(self) -> TurnTokenUsage:
+        return TurnTokenUsage(
+            model_calls=self.model_calls,
+            prompt_tokens=self.prompt_tokens,
+            evaluated_tokens=self.evaluated_tokens,
+            cached_tokens=self.cached_tokens,
+            completion_tokens=self.completion_tokens,
+        )
+
+
+def summarize_turn_token_usage(model_steps: Sequence[ModelStepMetrics]) -> TurnTokenUsage | None:
+    if not model_steps:
+        return None
+
+    prompt_values = [step.prompt_tokens for step in model_steps]
+    completion_values = [step.completion_tokens for step in model_steps]
+    cache_pairs = [(step.prompt_tokens, step.cached_tokens) for step in model_steps]
+
+    prompt_tokens = sum(prompt_values) if all(value is not None for value in prompt_values) else None
+    completion_tokens = sum(completion_values) if all(value is not None for value in completion_values) else None
+    cache_metrics_complete = all(
+        prompt is not None and cached is not None and 0 <= cached <= prompt
+        for prompt, cached in cache_pairs
+    )
+    cached_tokens = sum(cached for _, cached in cache_pairs if cached is not None) if cache_metrics_complete else None
+    evaluated_tokens = (
+        sum(prompt - cached for prompt, cached in cache_pairs if prompt is not None and cached is not None)
+        if cache_metrics_complete
+        else None
+    )
+    return TurnTokenUsage(
+        model_calls=len(model_steps),
+        prompt_tokens=prompt_tokens,
+        evaluated_tokens=evaluated_tokens,
+        cached_tokens=cached_tokens,
+        completion_tokens=completion_tokens,
+    )
+
+
+def format_session_token_usage(usage: TurnTokenUsage) -> str:
+    return " | ".join(_token_usage_parts(usage, prefix="session tks"))
 
 
 def format_turn_status(
@@ -12,6 +114,8 @@ def format_turn_status(
     elapsed_seconds: float | None = None,
     estimated_context_tokens: int | None = None,
     context_tokens: int | None = None,
+    turn_token_usage: TurnTokenUsage | None = None,
+    terminal_columns: int | None = None,
 ) -> str:
     emit_footer_metrics(
         result,
@@ -20,30 +124,40 @@ def format_turn_status(
         context_tokens=context_tokens,
     )
     parts = []
-    if result.model:
-        parts.append(f"model: {result.model}")
     if estimated_context_tokens is not None and context_tokens is not None and context_tokens > 0:
         pressure = _context_pressure(estimated_context_tokens, context_tokens)
         parts.append(f"ctx: {estimated_context_tokens}/{context_tokens} ({(estimated_context_tokens / context_tokens) * 100:.0f}%)")
         if pressure:
             parts.append(f"pressure: {pressure}")
-    if result.prompt_tokens is not None or result.completion_tokens is not None:
-        cached = f", cached {result.cached_tokens}" if result.cached_tokens is not None else ""
-        parts.append(f"tks: {result.prompt_tokens}->{result.completion_tokens}{cached}")
-    if result.prompt_tokens and result.cached_tokens is not None:
-        parts.append(f"cache: {(result.cached_tokens / result.prompt_tokens) * 100:.0f}%")
-    speeds = []
+    prompt_tokens = result.prompt_tokens
+    completion_tokens = result.completion_tokens
+    cached_tokens = result.cached_tokens
+    if turn_token_usage is not None:
+        prompt_tokens = turn_token_usage.prompt_tokens
+        completion_tokens = turn_token_usage.completion_tokens
+        cached_tokens = turn_token_usage.cached_tokens
+        parts.extend(_token_usage_parts(turn_token_usage, prefix="tks"))
+    elif prompt_tokens is not None or completion_tokens is not None:
+        cached = f", cached {cached_tokens}" if cached_tokens is not None else ""
+        parts.append(f"tks: {prompt_tokens}->{completion_tokens}{cached}")
+    if turn_token_usage is None and prompt_tokens and cached_tokens is not None:
+        parts.append(f"cache: {(cached_tokens / prompt_tokens) * 100:.0f}%")
+    header = []
+    if elapsed_seconds is not None:
+        header.append(f"time elapsed: {format_elapsed(elapsed_seconds)}")
     if result.prompt_tokens_per_second is not None:
-        speeds.append(f"pf {result.prompt_tokens_per_second:.1f}/s")
+        header.append(f"pf {result.prompt_tokens_per_second:.1f}/s")
     if result.generation_tokens_per_second is not None:
-        speeds.append(f"gen {result.generation_tokens_per_second:.1f}/s")
-    if speeds:
-        parts.append(" | ".join(speeds))
+        header.append(f"gen {result.generation_tokens_per_second:.1f}/s")
     if result.finish_reason:
         parts.append(f"stop: {result.finish_reason}")
-    if elapsed_seconds is not None:
-        parts.append(f"time: {format_elapsed(elapsed_seconds)}")
-    return " | ".join(parts) if parts else "no metrics"
+    details = " | ".join(parts) if parts else "no metrics"
+    if not header:
+        return details
+    columns = terminal_columns or get_terminal_size((80, 20)).columns
+    heading = f"__ {' | '.join(header)} "
+    separator = heading + ("_" * max(0, columns - len(heading)))
+    return f"{separator}\n{details}"
 
 
 def estimate_context_status_tokens(messages: list[dict[str, object]]) -> int:
@@ -67,6 +181,33 @@ def _saved_ratio(before: int, saved: int) -> float:
     if before <= 0:
         return 0.0
     return (saved / before) * 100.0
+
+
+def _add_optional_metric(total: int | None, value: int | None) -> int | None:
+    if total is None or value is None:
+        return None
+    return total + value
+
+
+def _token_usage_parts(usage: TurnTokenUsage, *, prefix: str) -> list[str]:
+    parts = []
+    if usage.prompt_tokens is not None and usage.completion_tokens is not None:
+        total = usage.prompt_tokens + usage.completion_tokens
+        parts.append(f"{prefix}: {total} total ({usage.prompt_tokens} in + {usage.completion_tokens} out)")
+    elif usage.prompt_tokens is not None:
+        parts.append(f"{prefix}: input {usage.prompt_tokens}")
+    elif usage.completion_tokens is not None:
+        parts.append(f"{prefix}: output {usage.completion_tokens}")
+    else:
+        parts.append(f"{prefix}: unavailable")
+    if usage.evaluated_tokens is not None and usage.completion_tokens is not None:
+        work = usage.evaluated_tokens + usage.completion_tokens
+        parts.append(f"work: {work} ({usage.evaluated_tokens} prefill + {usage.completion_tokens} decode)")
+    if usage.prompt_tokens and usage.cached_tokens is not None:
+        ratio = (usage.cached_tokens / usage.prompt_tokens) * 100
+        parts.append(f"cache: {usage.cached_tokens} ({ratio:.0f}%)")
+    parts.append(f"calls: {usage.model_calls}")
+    return parts
 
 
 def _context_pressure(estimated_context_tokens: int, context_tokens: int) -> str | None:

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -18,11 +18,13 @@ class TurnTokenUsage:
     evaluated_tokens: int | None
     cached_tokens: int | None
     completion_tokens: int | None
+    failed_calls: int = 0
 
 
 @dataclass
 class TokenUsageAccumulator:
     model_calls: int = 0
+    failed_calls: int = 0
     prompt_tokens: int | None = 0
     evaluated_tokens: int | None = 0
     cached_tokens: int | None = 0
@@ -41,6 +43,14 @@ class TokenUsageAccumulator:
             completion_tokens=result.completion_tokens,
             cached_tokens=result.cached_tokens,
         )
+
+    def add_failed_call(self) -> None:
+        self.model_calls += 1
+        self.failed_calls += 1
+        self.prompt_tokens = None
+        self.evaluated_tokens = None
+        self.cached_tokens = None
+        self.completion_tokens = None
 
     def _add_metrics(
         self,
@@ -72,6 +82,7 @@ class TokenUsageAccumulator:
             evaluated_tokens=self.evaluated_tokens,
             cached_tokens=self.cached_tokens,
             completion_tokens=self.completion_tokens,
+            failed_calls=self.failed_calls,
         )
 
 
@@ -101,6 +112,7 @@ def summarize_turn_token_usage(model_steps: Sequence[ModelStepMetrics]) -> TurnT
         evaluated_tokens=evaluated_tokens,
         cached_tokens=cached_tokens,
         completion_tokens=completion_tokens,
+        failed_calls=0,
     )
 
 
@@ -207,6 +219,8 @@ def _token_usage_parts(usage: TurnTokenUsage, *, prefix: str) -> list[str]:
         ratio = (usage.cached_tokens / usage.prompt_tokens) * 100
         parts.append(f"cache: {usage.cached_tokens} ({ratio:.0f}%)")
     parts.append(f"calls: {usage.model_calls}")
+    if usage.failed_calls:
+        parts.append(f"failed: {usage.failed_calls} (token usage unavailable)")
     return parts
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,12 +16,54 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from orbit.runtime.sessions import SessionStore
+from orbit.runtime.turn_trace import ModelStepMetrics
 from orbit.terminal.session_selection import display_datetime, preview_prompt, select_interactive_session
 from orbit.terminal import cli
 from orbit.backend.base import ChatResult
 
 
 class CliTests(unittest.TestCase):
+    def test_one_shot_footer_reports_complete_turn_token_usage(self) -> None:
+        class FakeRuntime:
+            messages = []
+            context_tokens = None
+
+            def ask_chat(self, *args, **kwargs):
+                on_model_step = kwargs["on_model_step"]
+                on_model_step(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+                on_model_step(ModelStepMetrics(1, "chat_final", "stop", 300, 15, 0, 10.0, 2.0, 0))
+                return ChatResult(
+                    content="complete",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=300,
+                    completion_tokens=15,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=10.0,
+                    generation_tokens_per_second=2.0,
+                )
+
+        stream = io.StringIO()
+        with contextlib.redirect_stdout(stream):
+            code = cli._run_one_shot(
+                FakeRuntime(),
+                "hello",
+                image_paths=[],
+                audio_paths=[],
+                temperature=0.0,
+                max_tokens=32,
+                workdir=ROOT,
+                tools="off",
+                thinking=False,
+            )
+
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "tks: 420 total (400 in + 20 out) | work: 400 (380 prefill + 20 decode) | cache: 20 (5%) | calls: 2",
+            stream.getvalue(),
+        )
+
     def test_one_shot_think_on_does_not_crash(self) -> None:
         completed = _run_cli("", "--think", "on", "/think")
 

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
 
 from orbit.backend.llama_server import (
     LlamaServerBackend,
+    LlamaServerError,
     _enrich_model_info_with_props,
     _parse_chat_result,
     _parse_chat_stream,
@@ -113,6 +114,48 @@ class LlamaServerBackendTests(unittest.TestCase):
         backend.set_result_observer(None)
         backend._with_display_model(source)
         self.assertEqual(observed, [result])
+
+    def test_observer_failure_does_not_change_successful_result(self) -> None:
+        class Backend(LlamaServerBackend):
+            def display_model_name(self) -> str:
+                return "display-model"
+
+        backend = Backend(base_url="http://localhost", timeout=1)
+        backend.set_result_observer(lambda _result: (_ for _ in ()).throw(RuntimeError("observer failed")))
+        source = ChatResult("ok", "source", "stop", [], 100, 5, 20, 10.0, 2.0)
+
+        self.assertEqual(backend._with_display_model(source).content, "ok")
+
+    def test_failed_backend_call_is_observed_and_original_error_is_preserved(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", timeout=1)
+        failures: list[str] = []
+        backend.set_failure_observer(lambda: failures.append("failed"))
+
+        with self.assertRaisesRegex(LlamaServerError, "boom"):
+            backend._observe_call(lambda: (_ for _ in ()).throw(LlamaServerError("boom")))
+
+        self.assertEqual(failures, ["failed"])
+
+    def test_failure_observer_error_does_not_replace_original_error(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", timeout=1)
+        backend.set_failure_observer(
+            lambda: (_ for _ in ()).throw(RuntimeError("observer failed"))
+        )
+
+        with self.assertRaisesRegex(LlamaServerError, "original"):
+            backend._observe_call(
+                lambda: (_ for _ in ()).throw(LlamaServerError("original"))
+            )
+
+    def test_cancelled_backend_call_is_observed(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", timeout=1)
+        failures: list[str] = []
+        backend.set_failure_observer(lambda: failures.append("cancelled"))
+
+        with self.assertRaises(KeyboardInterrupt):
+            backend._observe_call(lambda: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+        self.assertEqual(failures, ["cancelled"])
 
     def test_backend_props_overlay_runtime_tool_healing_diagnostics(self) -> None:
         class Backend(LlamaServerBackend):

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -96,6 +96,24 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertIsNone(backend.count_chat_tokens([{"role": "user", "content": "hello"}]))
         self.assertIsNone(backend.count_text_tokens("hello"))
 
+    def test_result_observer_receives_every_completed_backend_result(self) -> None:
+        class Backend(LlamaServerBackend):
+            def display_model_name(self) -> str:
+                return "display-model"
+
+        backend = Backend(base_url="http://localhost", timeout=1)
+        observed: list[ChatResult] = []
+        backend.set_result_observer(observed.append)
+        source = ChatResult("ok", "source", "stop", [], 100, 5, 20, 10.0, 2.0)
+
+        result = backend._with_display_model(source)
+
+        self.assertEqual(result.model, "display-model")
+        self.assertEqual(observed, [result])
+        backend.set_result_observer(None)
+        backend._with_display_model(source)
+        self.assertEqual(observed, [result])
+
     def test_backend_props_overlay_runtime_tool_healing_diagnostics(self) -> None:
         class Backend(LlamaServerBackend):
             def _props_or_empty(self) -> dict[str, object]:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -38,7 +38,7 @@ from orbit.terminal.session_preview import format_recent_session_messages
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
-from orbit.runtime.turn_trace import ModelPhaseStart
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
 class InterruptingBackend:
@@ -128,6 +128,63 @@ class CountingRuntime(ChatRuntime):
 
 
 class ReplTests(unittest.TestCase):
+    def test_status_reports_accumulated_session_token_usage(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+        repl._record_model_step(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            handled = repl._handle_command("/status")
+
+        self.assertTrue(handled)
+        self.assertIn(
+            "session tks: 105 total (100 in + 5 out) | work: 85 (80 prefill + 5 decode) | cache: 20 (20%) | calls: 1",
+            stdout.getvalue(),
+        )
+
+    def test_exit_reports_accumulated_session_token_usage(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+        repl._record_model_step(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+        stdout = io.StringIO()
+
+        with (
+            mock.patch("builtins.input", return_value="/exit"),
+            contextlib.redirect_stdout(stdout),
+        ):
+            code = repl.run()
+
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "session tks: 105 total (100 in + 5 out) | work: 85 (80 prefill + 5 decode) | cache: 20 (20%) | calls: 1",
+            stdout.getvalue(),
+        )
+
+    def test_keyboard_interrupt_exit_reports_session_token_usage(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+        stdout = io.StringIO()
+
+        with (
+            mock.patch("builtins.input", side_effect=KeyboardInterrupt),
+            contextlib.redirect_stdout(stdout),
+        ):
+            code = repl.run()
+
+        self.assertEqual(code, 130)
+        self.assertIn("session tks: 0 total (0 in + 0 out) | work: 0 (0 prefill + 0 decode) | calls: 0", stdout.getvalue())
+
+    def test_new_turn_discards_previous_turn_token_metrics(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+        repl._record_model_step(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            repl._ask("hello")
+
+        self.assertEqual(repl.turn_model_steps, [])
+
     def test_readline_enables_bracketed_paste_when_available(self) -> None:
         fake_readline = mock.Mock()
         with mock.patch.dict(sys.modules, {"readline": fake_readline}):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -127,7 +127,31 @@ class CountingRuntime(ChatRuntime):
         )
 
 
+class ObservedBackend(InterruptingBackend):
+    def set_result_observer(self, observer) -> None:
+        self.result_observer = observer
+
+    def set_failure_observer(self, observer) -> None:
+        self.failure_observer = observer
+
+
 class ReplTests(unittest.TestCase):
+    def test_backend_observer_prevents_model_step_double_counting(self) -> None:
+        backend = ObservedBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+        repl = Repl(runtime=runtime, backend=backend, config=AppConfig(workdir=Path(".")))
+        result = ChatResult("ok", "fake", "stop", [], 100, 5, 20, 10.0, 2.0)
+
+        repl._record_model_step(ModelStepMetrics.from_result(loop=1, result=result, phase="route"))
+        backend.result_observer(result)
+
+        usage = repl.session_token_usage.snapshot()
+        self.assertEqual(usage.model_calls, 1)
+        self.assertEqual(usage.prompt_tokens, 100)
+        self.assertEqual(usage.evaluated_tokens, 80)
+        self.assertEqual(usage.cached_tokens, 20)
+        self.assertEqual(usage.completion_tokens, 5)
+
     def test_status_reports_accumulated_session_token_usage(self) -> None:
         runtime = CountingRuntime()
         repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
@@ -183,6 +207,22 @@ class ReplTests(unittest.TestCase):
         with contextlib.redirect_stdout(io.StringIO()):
             repl._ask("hello")
 
+        self.assertEqual(repl.turn_model_steps, [])
+
+    def test_reset_clears_turn_and_session_token_usage(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+        repl._record_model_step(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+        result = ChatResult("ok", "fake", "stop", [], 100, 5, 20, 10.0, 2.0)
+        repl.turn_backend_token_usage.add_result(result)
+        repl.session_token_usage.add_result(result)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            handled = repl._handle_command("/reset")
+
+        self.assertTrue(handled)
+        self.assertEqual(repl.session_token_usage.snapshot().model_calls, 0)
+        self.assertEqual(repl.turn_backend_token_usage.snapshot().model_calls, 0)
         self.assertEqual(repl.turn_model_steps, [])
 
     def test_readline_enables_bracketed_paste_when_available(self) -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -33,6 +33,17 @@ class StatusTests(unittest.TestCase):
             "session tks: 420 total (400 in + 20 out) | work: 400 (380 prefill + 20 decode) | cache: 20 (5%) | calls: 2",
         )
 
+    def test_failed_call_makes_token_total_unavailable_without_hiding_attempt(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+        usage.add_failed_call()
+
+        rendered = format_session_token_usage(usage.snapshot())
+
+        self.assertIn("session tks: unavailable", rendered)
+        self.assertIn("calls: 2", rendered)
+        self.assertIn("failed: 1 (token usage unavailable)", rendered)
+
     def test_turn_token_usage_sums_every_model_call_and_real_evaluated_tokens(self) -> None:
         steps = [
             ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0),

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -11,11 +11,72 @@ if str(SRC) not in sys.path:
 
 from orbit.backend.base import ChatResult
 from orbit.runtime.session_memory import MemoryRefresh
-from orbit.terminal.status import format_memory_refresh, format_turn_status
+from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.terminal.status import (
+    TokenUsageAccumulator,
+    format_memory_refresh,
+    format_session_token_usage,
+    format_turn_status,
+    summarize_turn_token_usage,
+)
 from orbit.terminal.theme import dim, yellow_dim
 
 
 class StatusTests(unittest.TestCase):
+    def test_session_token_usage_reports_real_processed_total(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
+        usage.add(ModelStepMetrics(1, "chat_final", "stop", 300, 15, 0, 10.0, 2.0, 0))
+
+        self.assertEqual(
+            format_session_token_usage(usage.snapshot()),
+            "session tks: 420 total (400 in + 20 out) | work: 400 (380 prefill + 20 decode) | cache: 20 (5%) | calls: 2",
+        )
+
+    def test_turn_token_usage_sums_every_model_call_and_real_evaluated_tokens(self) -> None:
+        steps = [
+            ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0),
+            ModelStepMetrics(1, "tool_call", "stop", 200, 10, 50, 10.0, 2.0, 1),
+            ModelStepMetrics(2, "post_tool_route", "stop", 300, 15, 0, 10.0, 2.0, 0),
+        ]
+
+        usage = summarize_turn_token_usage(steps)
+
+        self.assertIsNotNone(usage)
+        assert usage is not None
+        self.assertEqual(usage.model_calls, 3)
+        self.assertEqual(usage.prompt_tokens, 600)
+        self.assertEqual(usage.evaluated_tokens, 530)
+        self.assertEqual(usage.cached_tokens, 70)
+        self.assertEqual(usage.completion_tokens, 30)
+
+    def test_format_turn_status_prefers_complete_turn_totals(self) -> None:
+        result = ChatResult(
+            content="hello",
+            model="gemma4",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=300,
+            completion_tokens=15,
+            cached_tokens=0,
+            prompt_tokens_per_second=12.5,
+            generation_tokens_per_second=3.4,
+        )
+        usage = summarize_turn_token_usage(
+            [
+                ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0),
+                ModelStepMetrics(1, "tool_call", "stop", 200, 10, 50, 10.0, 2.0, 1),
+                ModelStepMetrics(2, "post_tool_route", "stop", 300, 15, 0, 10.0, 2.0, 0),
+            ]
+        )
+
+        status = format_turn_status(result, turn_token_usage=usage)
+
+        self.assertIn("tks: 630 total (600 in + 30 out)", status)
+        self.assertIn("work: 560 (530 prefill + 30 decode)", status)
+        self.assertIn("cache: 70 (12%)", status)
+        self.assertIn("calls: 3", status)
+
     def test_format_turn_status_includes_stop_tokens_cache_and_speed(self) -> None:
         status = format_turn_status(
             ChatResult(
@@ -31,12 +92,11 @@ class StatusTests(unittest.TestCase):
             )
         )
 
-        self.assertIn("model: gemma4", status)
+        self.assertNotIn("model:", status)
         self.assertIn("stop: stop", status)
         self.assertIn("tks: 10->3, cached 8", status)
         self.assertIn("cache: 80%", status)
-        self.assertIn("pf 12.5/s", status)
-        self.assertIn("gen 3.4/s", status)
+        self.assertIn("__ pf 12.5/s | gen 3.4/s", status)
 
     def test_format_turn_status_includes_context_window_and_usage_percent(self) -> None:
         status = format_turn_status(
@@ -55,7 +115,7 @@ class StatusTests(unittest.TestCase):
             context_tokens=8192,
         )
 
-        self.assertIn("model: gemma4 | ctx: 2212/8192 (27%) | stop: stop", status)
+        self.assertIn("ctx: 2212/8192 (27%) | stop: stop", status)
 
     def test_format_turn_status_includes_context_pressure(self) -> None:
         result = ChatResult(
@@ -93,9 +153,13 @@ class StatusTests(unittest.TestCase):
             generation_tokens_per_second=None,
         )
 
-        self.assertIn("time: 34s", format_turn_status(result, elapsed_seconds=34))
-        self.assertIn("time: 1m 19s", format_turn_status(result, elapsed_seconds=79))
-        self.assertTrue(format_turn_status(result, elapsed_seconds=34).endswith("stop: stop | time: 34s"))
+        short = format_turn_status(result, elapsed_seconds=34, terminal_columns=72)
+        long = format_turn_status(result, elapsed_seconds=79, terminal_columns=72)
+
+        self.assertIn("time elapsed: 34s", short)
+        self.assertIn("time elapsed: 1m 19s", long)
+        self.assertEqual(len(short.splitlines()[0]), 72)
+        self.assertTrue(short.endswith("stop: stop"))
 
     def test_dim_wraps_text_in_ansi_escape(self) -> None:
         self.assertEqual(dim("model: gemma4"), "\033[2mmodel: gemma4\033[0m")


### PR DESCRIPTION
## Summary

Adds observability-only token accounting to one-shot and interactive CLI output. The footer reports complete per-turn model-call usage, `/status` and session exit report session totals, and the model name is omitted from the footer.

## Accounting

- sums every completed backend call exactly once across route, chat, tool, retry and final phases;
- reports prompt input, evaluated prefill, cached prefix and generated output separately;
- excludes cached tokens from evaluated work;
- resets turn totals per user request and session totals on explicit session reset;
- reports failed or interrupted calls without inventing missing server usage;
- preserves post-tool final reuse and Qwen/Gemma prefix-cache accounting.

## Independent review fixes

- `/reset` and confirmed session clearing now clear observability state;
- timeout and cancellation attempts are represented truthfully as unavailable token usage;
- observer failures cannot alter successful inference or replace the original backend error.

## Validation

- focused CLI/status/backend tests: 128 PASS;
- broader runtime, checkpoint and terminal selection: 414 PASS;
- full discovery: 1,417 PASS;
- compileall: PASS;
- git diff --check: PASS;
- real Gemma chat: one call, exact footer totals, stop;
- real Gemma tool workflow: two calls, exact aggregate totals, stop;
- timeout and Ctrl+C: recoverable, failed usage explicitly unavailable;
- `/status`, `/reset` and exit totals: PASS.

## Scope

No prompt, schema, routing, inference, tool-choice, budget, checkpoint, Qwen/Gemma protocol or lifecycle semantics changed. CPU timings are descriptive; no performance guarantee is claimed.