### PR TITLE
feat(runtime): add atomic text artifact generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,7 +355,7 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   reasoning never reaches route or canonical tool parsers.
 - Qwen route-prefix reuse is default-on only for the exact verified profile.
   It captures the complete hybrid sequence state at a 768-token batch-aligned
-  boundary within the 810-token invariant route prefix. The checkpoint is
+  boundary within the revision-bound invariant route prefix. The checkpoint is
   81,608,684 bytes and is model, quantization, context, template, tokenizer,
   schema, backend-build, and process bound.
 - Cold, explicitly segmented, captured, and restored probes produced
@@ -370,6 +370,40 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   checkpoints, MTP/mmproj, and tool behavior remain separate and unchanged.
 - See `docs/QWEN_3_6_COMPATIBILITY.md` for the exact identity, protocol,
   diagnostics, validation evidence, and current limits.
+
+## Atomic Text Artifact Generation
+
+- Non-trivial UTF-8 files use one model-selected `write_artifact` request with
+  path, overwrite, and parent-creation arguments. File content is generated in
+  one dedicated native phase without tools, shell, JSON, XML, or heredoc
+  framing. The runtime never invents or repairs task content.
+- Complete content remains unpublished until the model selects the exact
+  pending path and one bounded `verify_artifact` check. That verifier is an
+  ephemeral capability and is absent from the normal tools-on registry.
+- Publication requires `finish_reason=stop`, valid UTF-8, at most 64 KiB, a
+  passing selected check, stable path identity, and an atomic same-filesystem
+  commit. Length, cancel, timeout, reset, path race, failed check, or generation
+  error publishes nothing.
+- Existing parents use an unnamed same-filesystem temporary file when
+  supported. An unsupported anonymous open/link falls back to an exclusive
+  private mode-`0600` file in the same directory; unsupported regular-file
+  `RENAME_NOREPLACE` then uses an atomic no-replace hard link without weakening
+  fsync, race checks, or post-publication attestation.
+- Atomic publication of a new parent tree still requires no-replace directory
+  rename support, and overwrite requires atomic exchange. Unsupported
+  filesystems fail closed rather than using a pathname-check/ordinary-rename
+  fallback with a TOCTOU window.
+- `create_parents` is part of the same atomic operation. Missing parents are
+  built in a private subtree and exposed with one no-replace rename. Cleanup
+  removes only Orbit-created private empty paths and never pre-existing or
+  concurrently created content. The mutation epoch advances only after
+  verification and publication both complete.
+- The dedicated 4,096-token content budget does not change route, normal tool,
+  chat, or final budgets. One file per request and native backend only are the
+  initial bounds. Semantic chunking, hidden retries, deterministic content,
+  and incomplete-envelope repair remain prohibited.
+- See `docs/ARTIFACT_GENERATION.md` for protocol, atomicity, lifecycle,
+  validation evidence, and measured CPU limits.
 
 ## MTP
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,27 +377,37 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   path, overwrite, and parent-creation arguments. File content is generated in
   one dedicated native phase without tools, shell, JSON, XML, or heredoc
   framing. The runtime never invents or repairs task content.
-- Complete content remains unpublished until the model selects the exact
-  pending path and one bounded `verify_artifact` check. That verifier is an
-  ephemeral capability and is absent from the normal tools-on registry.
-- Publication requires `finish_reason=stop`, valid UTF-8, at most 64 KiB, a
-  passing selected check, stable path identity, and an atomic same-filesystem
-  commit. Length, cancel, timeout, reset, path race, failed check, or generation
-  error publishes nothing.
+- Complete content is published only after `finish_reason=stop`, UTF-8 and
+  64-KiB validation, stable path attestation, and an atomic same-filesystem
+  commit. The exact published path is intrinsic to the pending capability; the
+  model then selects one bounded read-only `verify_artifact` check without
+  supplying another path. That ephemeral capability is absent from the normal
+  tools-on registry.
+- Length, cancel, timeout, reset, path race, or generation error before commit
+  publishes nothing. Verification never publishes or mutates. A verification
+  failure leaves the atomically published file in place and is reported as
+  published but unverified.
 - Existing parents use an unnamed same-filesystem temporary file when
   supported. An unsupported anonymous open/link falls back to an exclusive
   private mode-`0600` file in the same directory; unsupported regular-file
   `RENAME_NOREPLACE` then uses an atomic no-replace hard link without weakening
   fsync, race checks, or post-publication attestation.
-- Atomic publication of a new parent tree still requires no-replace directory
-  rename support, and overwrite requires atomic exchange. Unsupported
-  filesystems fail closed rather than using a pathname-check/ordinary-rename
-  fallback with a TOCTOU window.
-- `create_parents` is part of the same atomic operation. Missing parents are
-  built in a private subtree and exposed with one no-replace rename. Cleanup
-  removes only Orbit-created private empty paths and never pre-existing or
-  concurrently created content. The mutation epoch advances only after
-  verification and publication both complete.
+- The destination file is the atomic unit; shared parent trees are never moved
+  for publication or rollback. Overwrite requires atomic exchange, and
+  unsupported filesystems fail closed rather than using a pathname-check/
+  ordinary-rename fallback with a TOCTOU window.
+- `create_parents` explicitly authorizes descriptor-relative creation of
+  missing directories. Cleanup attempts to remove only exact directories made
+  by the request and only while empty; concurrent or pre-existing content is
+  never moved or removed. The mutation epoch advances after file publication,
+  while successful completion still requires model-selected verification.
+- Named private files use process- and inode-bound recovery manifests. Startup
+  removes only exact dead-process entries; symlinks, malformed state, changed
+  identities, linked files, and other ambiguity are preserved. Absolute zero
+  residue after power loss is not claimed because narrow pre-registration and
+  publication crash windows cannot be cleaned without risking user data.
+  Explicitly created empty parent directories may likewise remain after an
+  uncatchable crash when later ownership cannot be proved safely.
 - The dedicated 4,096-token content budget does not change route, normal tool,
   chat, or final budgets. One file per request and native backend only are the
   initial bounds. Semantic chunking, hidden retries, deterministic content,

--- a/docs/ARTIFACT_GENERATION.md
+++ b/docs/ARTIFACT_GENERATION.md
@@ -1,0 +1,143 @@
+# Atomic Text Artifact Generation
+
+## Problem
+
+Non-trivial files do not fit reliably inside a normal structured tool call.
+Qwen 3.6 may spend the tool output budget inside XML, JSON, shell quoting, or a
+heredoc and leave an incomplete envelope. Orbit must not execute or repair that
+truncated output. A separate failure mode is premature completion after the
+model creates and inspects only the destination directory.
+
+## Protocol
+
+Orbit keeps the workflow model-driven while separating the small control
+decision from the potentially long file body:
+
+1. The route model selects `write_artifact` and supplies one relative path,
+   the overwrite decision, and whether missing parents may be created.
+2. The canonical contract validates that bounded request before generation.
+3. One native content phase receives the original request and validated target
+   and emits UTF-8 file content only. It has no tools and does not parse its
+   output as JSON, XML, shell, a heredoc, or a tool call.
+4. A stopped, non-empty result of at most 64 KiB remains pending in bounded
+   memory. No destination file or parent directory exists yet.
+5. The next model round exposes only `verify_artifact`. The model selects the
+   exact pending path and one bounded check.
+6. A passing check and atomic publication complete one mutation epoch. The
+   final response remains model-authored from exact path, byte-count, SHA-256,
+   overwrite, created-parent, and verification evidence.
+
+`verify_artifact` is an ephemeral internal capability. It is not part of the
+normal tools-on registry and cannot be selected outside a pending artifact
+request. Ordinary chat and non-artifact tool routes gain no model call and do
+not receive the artifact schemas.
+
+## Checks
+
+The model may select `text_integrity` for UTF-8, byte-count, and SHA-256
+verification, or `content` when the bounded body must also be projected as
+evidence. These are the same checks for every text format. Runtime does not
+select a parser from an extension, execute content, or interpret the body as a
+program, markup, configuration, or tool protocol.
+
+The runtime validates only the selected structural check. It does not infer a
+file type, choose a check, repair content, or judge whether the artifact solves
+the user's semantic task. Format-specific correctness checks in validation,
+such as parsing source or configuration text, run outside Orbit after the
+artifact workflow completes.
+
+## Publication And Parent Directories
+
+The path stays confined to the active workdir. Absolute paths, traversal,
+control characters, symlink components, symlink destinations, FIFOs, devices,
+and other non-regular targets fail closed. Existing files require explicit
+`overwrite=true` and are attested before and during publication.
+
+Missing parents are part of the same atomic operation. Orbit records exactly
+which parents were absent when the request was prepared. After content and
+model-selected verification pass, it builds those parents and the file in one
+private directory below the deepest existing parent, fsyncs the private tree,
+and publishes the top missing parent with one no-replace rename. If another
+process creates that parent first, publication fails and preserves the
+concurrent tree. Failure cleanup removes only Orbit's private empty hierarchy;
+it never removes pre-existing or concurrently created paths.
+
+For an existing parent, Orbit uses an unnamed or private same-filesystem file
+and atomically links or exchanges it into place. Overwrite races are detected;
+the previous or concurrent destination is preserved when the requested
+identity can no longer be proven. Filesystems that reject Linux `O_TMPFILE`
+with `EOPNOTSUPP` or `EINVAL` during open or anonymous-link publication fall
+back to a mode-`0600`, exclusive, randomly named private file in that same
+directory. If that filesystem also lacks `RENAME_NOREPLACE` for regular files,
+Orbit uses an atomic no-replace hard link for the private inode and removes only
+the private name. Fsync and post-publication identity/hash attestation remain
+unchanged.
+
+Publishing a new parent tree still requires filesystem support for atomic
+no-replace directory rename, and replacing an existing file requires atomic
+exchange. Orbit fails closed when those primitives are unavailable; it does not
+fall back to a pathname check followed by a racy ordinary rename. Creation in
+an existing directory remains supported through the no-replace hard-link
+fallback described above.
+
+Parent creation is not a successful mutation by itself. The mutation epoch
+advances exactly once, only after the selected check passes and publication is
+complete.
+
+## Lifecycle
+
+`finish_reason=length`, malformed verification, cancellation, timeout, reset,
+generation error, UTF-8 failure, size failure, path race, or check failure
+publishes nothing. Pending state is turn-local and process-local. Content is
+buffered before any temporary filesystem object is created, so cancellation or
+restart during the long generation phase leaves no file, parent, or stale
+temporary artifact.
+
+The final atomic filesystem section is intentionally short and synchronous.
+Normal failures clean its private objects. As with any userspace atomic-write
+protocol, an uncatchable process or power loss in the narrow interval before a
+private staging directory is renamed can leave a hidden `.orbit-artifact-*`
+entry; it never exposes a partial destination or removes unrelated data.
+
+## Bounds And Limits
+
+- one UTF-8 file per request;
+- maximum generated content: 64 KiB;
+- dedicated content budget: 4,096 output tokens;
+- one model-selected verification action;
+- native Orbit backend only;
+- no semantic repair, chunking, map-reduce, hidden retry, or deterministic
+  task content;
+- multi-file requests require separate model-selected artifact requests and
+  are not planned by the runtime.
+
+Route selection remains model-owned. The dedicated protocol applies only when
+the model selects `write_artifact`; one measured very small JavaScript request
+selected chat and returned prose without creating a file. Orbit does not force
+or infer an artifact route to conceal that model-selection limit.
+
+The 4,096-token phase is dedicated to artifact content and does not enlarge
+route, normal tool, chat, or final budgets. CPU generation of a large artifact
+can still take minutes. Atomic publication improves reliability, not model
+generation speed.
+
+## Validation
+
+The Qwen 3.6 35B-A3B Q4_K_M validation covered standalone JavaScript, one-file
+HTML/CSS/JavaScript, Markdown, JSON, and Python. Five clean standalone Snake
+runs produced the same 3,058-byte artifact and SHA-256, selected the generic
+text-integrity check, and stopped normally. Separately, validation extracted
+the script from the 10,290-byte self-contained browser artifact and confirmed
+its syntax with `node --check`; that external check is not an Orbit verifier
+capability.
+
+A 2,048-token content probe ended at `length` and correctly published nothing.
+The retained 4,096-token bound completed the measured browser artifact.
+Cancellation during content generation and an actual server restart left no
+file, parent, or temporary entry. Timeout behavior is covered by injected
+backend timeouts; the CLI HTTP timeout is inactivity-based and does not expire
+while tokens continue to stream.
+
+Measured CPU wall time is descriptive. It ranged from about two minutes for
+small JSON and Markdown artifacts to about nine minutes for the 10 KiB browser
+game on the validation host.

--- a/docs/ARTIFACT_GENERATION.md
+++ b/docs/ARTIFACT_GENERATION.md
@@ -19,18 +19,25 @@ decision from the potentially long file body:
 3. One native content phase receives the original request and validated target
    and emits UTF-8 file content only. It has no tools and does not parse its
    output as JSON, XML, shell, a heredoc, or a tool call.
-4. A stopped, non-empty result of at most 64 KiB remains pending in bounded
-   memory. No destination file or parent directory exists yet.
-5. The next model round exposes only `verify_artifact`. The model selects the
-   exact pending path and one bounded check.
-6. A passing check and atomic publication complete one mutation epoch. The
-   final response remains model-authored from exact path, byte-count, SHA-256,
-   overwrite, created-parent, and verification evidence.
+4. A stopped, non-empty result of at most 64 KiB is validated as UTF-8 and
+   published to the exact target with an atomic file operation.
+5. Publication evidence records the exact path, byte count, SHA-256,
+   overwrite state, and any parents created by this request.
+6. The next model round exposes only `verify_artifact`. The capability is
+   intrinsically bound to the exact published path, and the model selects one
+   bounded read-only check without supplying a replacement path.
+7. The final response remains model-authored from separate publication and
+   verification evidence.
 
 `verify_artifact` is an ephemeral internal capability. It is not part of the
 normal tools-on registry and cannot be selected outside a pending artifact
 request. Ordinary chat and non-artifact tool routes gain no model call and do
 not receive the artifact schemas.
+
+Publication and verification are intentionally separate. A verification
+failure does not undo or replace an already published target. Orbit reports
+the file as published but unverified and does not claim that its content passed
+the selected check.
 
 ## Checks
 
@@ -53,14 +60,14 @@ control characters, symlink components, symlink destinations, FIFOs, devices,
 and other non-regular targets fail closed. Existing files require explicit
 `overwrite=true` and are attested before and during publication.
 
-Missing parents are part of the same atomic operation. Orbit records exactly
-which parents were absent when the request was prepared. After content and
-model-selected verification pass, it builds those parents and the file in one
-private directory below the deepest existing parent, fsyncs the private tree,
-and publishes the top missing parent with one no-replace rename. If another
-process creates that parent first, publication fails and preserves the
-concurrent tree. Failure cleanup removes only Orbit's private empty hierarchy;
-it never removes pre-existing or concurrently created paths.
+Missing parents require the model-selected `create_parents=true` argument.
+After content validation, Orbit creates each absent directory relative to an
+attested descriptor and records its exact inode. Parent directories are not
+published or rolled back as one tree. On failure Orbit attempts `rmdir` only
+for an exact directory created by this request and only while it remains empty.
+A directory containing concurrent files or directories stays at its original
+visible path. Pre-existing directories are never removed, renamed, or moved
+into private Orbit state.
 
 For an existing parent, Orbit uses an unnamed or private same-filesystem file
 and atomically links or exchanges it into place. Overwrite races are detected;
@@ -73,31 +80,46 @@ Orbit uses an atomic no-replace hard link for the private inode and removes only
 the private name. Fsync and post-publication identity/hash attestation remain
 unchanged.
 
-Publishing a new parent tree still requires filesystem support for atomic
-no-replace directory rename, and replacing an existing file requires atomic
-exchange. Orbit fails closed when those primitives are unavailable; it does not
-fall back to a pathname check followed by a racy ordinary rename. Creation in
-an existing directory remains supported through the no-replace hard-link
-fallback described above.
+The destination file, rather than a shared parent tree, is the atomic unit.
+New files use no-replace link or rename semantics and replacing an existing file
+requires atomic exchange. Orbit fails closed when those primitives are
+unavailable; it does not fall back to a pathname check followed by a racy
+ordinary rename.
 
-Parent creation is not a successful mutation by itself. The mutation epoch
-advances exactly once, only after the selected check passes and publication is
-complete.
+Parent creation is not a successful artifact publication by itself. The
+mutation epoch advances exactly once after atomic file publication; the
+workflow remains structurally incomplete until the model selects and passes a
+read-only verification.
 
 ## Lifecycle
 
-`finish_reason=length`, malformed verification, cancellation, timeout, reset,
-generation error, UTF-8 failure, size failure, path race, or check failure
-publishes nothing. Pending state is turn-local and process-local. Content is
-buffered before any temporary filesystem object is created, so cancellation or
-restart during the long generation phase leaves no file, parent, or stale
-temporary artifact.
+`finish_reason=length`, cancellation or timeout during content generation,
+generation error, UTF-8 failure, size failure, or a pre-commit path race
+publishes no destination file. Content is buffered before any temporary
+filesystem object is created, so interruption during the long generation phase
+leaves no file, parent, or private artifact entry. Once atomic publication
+succeeds, a later malformed, cancelled, timed-out, or failed verification does
+not mutate or remove the published file.
 
 The final atomic filesystem section is intentionally short and synchronous.
-Normal failures clean its private objects. As with any userspace atomic-write
-protocol, an uncatchable process or power loss in the narrow interval before a
-private staging directory is renamed can leave a hidden `.orbit-artifact-*`
-entry; it never exposes a partial destination or removes unrelated data.
+Normal failures clean its private objects. Named private files are paired with
+bounded manifests in `.orbit-artifact-state`. The manifest binds the random
+name, parent, device, inode, uid, boot identity, PID, and process start time.
+Startup cleanup stays inside the active workdir, never follows symlinks, keeps
+entries owned by a live process, and removes a dead process's entry only when
+every manifest, ownership, mode, link-count, and inode check still matches.
+Malformed, replaced, linked, or otherwise ambiguous entries are preserved.
+
+Zero residual private state after an uncatchable crash or power loss cannot be
+proved for every filesystem. A crash between private-file creation and manifest
+registration can leave an untracked private name. A crash during hard-link
+publication or overwrite exchange can leave an entry whose identity is
+ambiguous or may contain displaced user data; recovery preserves it rather than
+guessing. A crash after explicitly authorized parent creation but before file
+publication can also leave empty visible directories because Orbit cannot later
+distinguish them safely from directories retained or reused by another process.
+These narrow cases may require manual inspection. They never justify deleting a
+user-visible target or moving concurrent content.
 
 ## Bounds And Limits
 
@@ -124,12 +146,16 @@ generation speed.
 ## Validation
 
 The Qwen 3.6 35B-A3B Q4_K_M validation covered standalone JavaScript, one-file
-HTML/CSS/JavaScript, Markdown, JSON, and Python. Five clean standalone Snake
-runs produced the same 3,058-byte artifact and SHA-256, selected the generic
-text-integrity check, and stopped normally. Separately, validation extracted
-the script from the 10,290-byte self-contained browser artifact and confirmed
-its syntax with `node --check`; that external check is not an Orbit verifier
-capability.
+HTML/CSS/JavaScript, Markdown, JSON, Python, and plain text. Five clean runs of
+the original standalone Snake request produced the same 4,590-byte artifact
+with SHA-256
+`3dac570c5e1c7b24bd304bc776651eea0901db2a423bd68b00550301f723ab45`,
+selected the generic text-integrity check, and stopped normally. Each run used
+four model calls, published before the read-only verification, passed
+`node --check`, and left no private artifact entry. Separately, validation
+extracted the script from the 10,290-byte self-contained browser artifact and
+confirmed its syntax with `node --check`; that external check is not an Orbit
+verifier capability.
 
 A 2,048-token content probe ended at `length` and correctly published nothing.
 The retained 4,096-token bound completed the measured browser artifact.

--- a/docs/ARTIFACT_GENERATION.md
+++ b/docs/ARTIFACT_GENERATION.md
@@ -106,9 +106,11 @@ Normal failures clean its private objects. Named private files are paired with
 bounded manifests in `.orbit-artifact-state`. The manifest binds the random
 name, parent, device, inode, uid, boot identity, PID, and process start time.
 Startup cleanup stays inside the active workdir, never follows symlinks, keeps
-entries owned by a live process, and removes a dead process's entry only when
-every manifest, ownership, mode, link-count, and inode check still matches.
-Malformed, replaced, linked, or otherwise ambiguous entries are preserved.
+entries owned by a live process, and removes an entry only after positively
+proving that its owner process is inactive and every manifest, ownership, mode,
+link-count, and inode check still matches. Unknown owner state is always
+preserved; stale age alone never authorizes deletion. Malformed, replaced,
+linked, or otherwise ambiguous entries are preserved for manual inspection.
 
 Zero residual private state after an uncatchable crash or power loss cannot be
 proved for every filesystem. A crash between private-file creation and manifest

--- a/docs/QWEN_3_6_COMPATIBILITY.md
+++ b/docs/QWEN_3_6_COMPATIBILITY.md
@@ -135,11 +135,13 @@ timeout, reset, restart, model or context replacement, profile/template/schema
 identity change, restore failure, and completion error. A restore error clears
 partial state and performs one cold prefill without recursive retry.
 
-The verified boundary is 768 production tokens. The full invariant prefix is
-810 tokens for the measured route fixtures; 768 is the longest useful
-production-batch-aligned boundary below it. The token immediately after the
-checkpoint is token ID 1802. The boundary token hash is
-`095416e9dcf73f8a9db7b39b1d3f289da66a705c32418c194964938d58876b9b`.
+The verified boundary remains 768 production tokens and is the longest useful
+production-batch-aligned boundary below the dynamic request. The artifact
+route contract intentionally changed the revision-bound checkpoint identity.
+Its current boundary token hash is
+`baeeb55560c99e981fb169deed085f80439ab71c6251725c10a40fd02fc5268f`;
+the rendered invariant-prefix hash is
+`2adc7eef6acc7affce39eb2e774af5289a063cfe226b1a13aa5fd7dda498e05e`.
 
 Cold full prefill, explicit segmentation at token 768, and capture/restore
 produced byte-identical logits in the native validation probe: maximum absolute
@@ -163,6 +165,8 @@ guarantee.
   uses complete sequence-state capture/restore for the verified route prefix
   and falls back to a cold prefill for other incompatible cache transitions.
 - Qwen thinking can consume a substantial decode budget before visible output.
+- Non-trivial UTF-8 text artifacts use the bounded content-only protocol in
+  `docs/ARTIFACT_GENERATION.md`; Qwen MTP remains disabled for that phase.
 - CPU wall time depends on model, prompt, context, threads, and host state; no
   deterministic speed claim is made.
 

--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -68,3 +68,14 @@ class ChatBackend(Protocol):
         on_progress: Callable[[StreamProgress], None] | None = None,
     ) -> ChatResult:
         ...
+
+    def artifact_content_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        ...

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -9,7 +9,12 @@ from urllib.request import Request, urlopen
 
 from .base import ChatResult, Message, ModelInfo, StreamProgress, TokenCount
 from .model_names import resolve_model_display_name
-from .payloads import ChatPayloadOptions, build_chat_payload
+from .payloads import (
+    ARTIFACT_CONTENT_PROTOCOL_ID,
+    ARTIFACT_CONTENT_PROTOCOL_VERSION,
+    ChatPayloadOptions,
+    build_chat_payload,
+)
 from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
@@ -113,6 +118,47 @@ class LlamaServerBackend:
             )
         return self._observe_call(
             lambda: self._post_stream("/v1/chat/completions", payload, on_delta=on_delta)
+        )
+
+    def artifact_content_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        if not self._is_orbit_native_backend():
+            raise LlamaServerError("artifact content generation requires the native Orbit backend")
+        protocol = self._props_or_empty().get("artifact_content_protocol")
+        if not (
+            isinstance(protocol, dict)
+            and protocol.get("id") == ARTIFACT_CONTENT_PROTOCOL_ID
+            and protocol.get("version") == ARTIFACT_CONTENT_PROTOCOL_VERSION
+            and protocol.get("literal_stream") is True
+        ):
+            raise LlamaServerError("native Orbit backend does not support the verified artifact content protocol")
+        payload = build_chat_payload(
+            ChatPayloadOptions(
+                model=self.request_model_name(),
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                thinking=False,
+                stream=True,
+                artifact_content=True,
+            )
+        )
+        _attach_native_kv_diag_payload(payload, native_backend=True)
+        return self._observe_call(
+            lambda: self._post_native_stream(
+                "/chat/stream",
+                payload,
+                on_delta=on_delta,
+                on_progress=on_progress,
+                literal_content=True,
+            )
         )
 
     def continue_current(
@@ -322,6 +368,7 @@ class LlamaServerBackend:
         *,
         on_delta: Callable[[str], None],
         on_progress: Callable[[StreamProgress], None] | None,
+        literal_content: bool = False,
     ) -> ChatResult:
         body = json.dumps(payload).encode("utf-8")
         request = Request(
@@ -332,7 +379,12 @@ class LlamaServerBackend:
         )
         try:
             with urlopen(request, timeout=self.timeout) as response:
-                return _parse_native_stream(response, on_delta=on_delta, on_progress=on_progress)
+                return _parse_native_stream(
+                    response,
+                    on_delta=on_delta,
+                    on_progress=on_progress,
+                    literal_content=literal_content,
+                )
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise LlamaServerError(f"backend server HTTP {exc.code}: {detail}") from exc
@@ -476,10 +528,11 @@ def _parse_native_stream(
     *,
     on_delta: Callable[[str], None],
     on_progress: Callable[[StreamProgress], None] | None,
+    literal_content: bool = False,
 ) -> ChatResult:
     content_parts: list[str] = []
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
-    content_filter = _ContentStreamFilter(on_delta)
+    content_filter = None if literal_content else _ContentStreamFilter(on_delta)
     model: str | None = None
     finish_reason: str | None = None
     usage: dict[str, Any] = {}
@@ -511,7 +564,10 @@ def _parse_native_stream(
             text = data.get("text")
             if isinstance(text, str) and text:
                 content_parts.append(text)
-                content_filter.write(text)
+                if content_filter is None:
+                    on_delta(text)
+                else:
+                    content_filter.write(text)
         elif current_event == "reasoning":
             text = data.get("text")
             if isinstance(text, str) and text:
@@ -556,13 +612,15 @@ def _parse_native_stream(
 
     if not stream_done:
         flush_event()
-    content_filter.finish()
+    if content_filter is not None:
+        content_filter.finish()
     content = "".join(content_parts)
     tool_calls = [tool_calls_by_index[index] for index in sorted(tool_calls_by_index)]
-    parsed_raw_tool_calls = _parse_raw_tool_call_content(content)
-    if not tool_calls and parsed_raw_tool_calls:
-        tool_calls = parsed_raw_tool_calls
-        content = ""
+    if not literal_content:
+        parsed_raw_tool_calls = _parse_raw_tool_call_content(content)
+        if not tool_calls and parsed_raw_tool_calls:
+            tool_calls = parsed_raw_tool_calls
+            content = ""
     details = usage.get("prompt_tokens_details") if isinstance(usage.get("prompt_tokens_details"), dict) else {}
     return ChatResult(
         content=content,

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from .base import Message
 
+
+ARTIFACT_CONTENT_PROTOCOL_ID = "orbit-artifact-content-v1"
+ARTIFACT_CONTENT_PROTOCOL_VERSION = 1
+
+
 @dataclass(frozen=True)
 class ChatPayloadOptions:
     model: str
@@ -19,6 +24,7 @@ class ChatPayloadOptions:
     qwen_route_prefix_anchor: bool = False
     allow_mtp_experimental: bool | None = None
     final_prefix_experiment: bool = False
+    artifact_content: bool = False
 
 
 def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
@@ -41,6 +47,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["allow_mtp_experimental"] = options.allow_mtp_experimental
     if options.final_prefix_experiment:
         payload["final_prefix_experiment"] = True
+    if options.artifact_content:
+        payload["artifact_content"] = True
     if options.tools:
         payload["tools"] = options.tools
         payload["tool_choice"] = "auto"

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -920,6 +920,42 @@ class NativeLlamaClient:
                 break
         return result
 
+    def complete_artifact_text(
+        self,
+        messages: list[NativeMessage],
+        *,
+        max_tokens: int,
+        stop: tuple[str, ...] = (),
+        on_progress=None,
+        on_token=None,
+        should_cancel=None,
+    ) -> NativeCompletion:
+        """Generate literal artifact bytes without applying the tool-call parser."""
+        raw_parts: list[str] = []
+
+        def collect(text: str) -> None:
+            raw_parts.append(text)
+            if on_token is not None:
+                on_token(text)
+
+        timings = self.complete_chat(
+            messages,
+            max_tokens=max_tokens,
+            tools=None,
+            thinking=False,
+            route_prefix_anchor=False,
+            qwen_route_prefix_anchor=False,
+            allow_mtp_experimental=False,
+            final_prefix_experiment=False,
+            on_progress=on_progress,
+            on_token=collect,
+            should_cancel=should_cancel,
+        )
+        content = _trim_at_stop("".join(raw_parts), stop)
+        completion = NativeCompletion(content=content, timings=timings)
+        self._session.continuation_ready = False
+        return completion
+
     def _complete_chat_text_once(
         self,
         messages: list[NativeMessage],

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -12,6 +12,7 @@ import threading
 import time
 from typing import Any, Mapping
 
+from orbit.backend.payloads import ARTIFACT_CONTENT_PROTOCOL_ID, ARTIFACT_CONTENT_PROTOCOL_VERSION
 from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.capabilities import safe_native_capability_manifest
 from orbit.native_llama.chat_template import render_gemma4_route_prompt_segments
@@ -65,7 +66,15 @@ class OrbitNativeServer:
         validate_session_id(request.session_id)
         return self.complete(request, on_token=on_token, on_progress=on_progress, should_cancel=should_cancel)
 
+    def validate_request(self, request: ChatRequest) -> None:
+        thinking = self.client.config.thinking if request.thinking is None else request.thinking
+        if request.artifact_content and (request.tools or thinking or request.stop):
+            raise ValueError(
+                "artifact content generation requires tools, thinking, and stop sequences to be disabled"
+            )
+
     def complete(self, request: ChatRequest, *, on_token=None, on_progress=None, should_cancel=None) -> dict[str, Any]:
+        self.validate_request(request)
         parts: list[str] = []
 
         def collect(text: str) -> None:
@@ -82,20 +91,30 @@ class OrbitNativeServer:
                 and not request.tools
                 and _is_qwen_route_prompt(request.messages)
             )
-            completion = self.client.complete_chat_text(
-                request.messages,
-                max_tokens=request.max_tokens,
-                stop=request.stop,
-                tools=request.tools,
-                thinking=thinking,
-                route_prefix_anchor=request.route_prefix_anchor,
-                qwen_route_prefix_anchor=qwen_route_prefix_anchor,
-                allow_mtp_experimental=request.allow_mtp_experimental,
-                final_prefix_experiment=final_prefix_experiment,
-                on_progress=on_progress,
-                on_token=collect,
-                should_cancel=should_cancel,
-            )
+            if request.artifact_content:
+                completion = self.client.complete_artifact_text(
+                    request.messages,
+                    max_tokens=request.max_tokens,
+                    stop=request.stop,
+                    on_progress=on_progress,
+                    on_token=collect,
+                    should_cancel=should_cancel,
+                )
+            else:
+                completion = self.client.complete_chat_text(
+                    request.messages,
+                    max_tokens=request.max_tokens,
+                    stop=request.stop,
+                    tools=request.tools,
+                    thinking=thinking,
+                    route_prefix_anchor=request.route_prefix_anchor,
+                    qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+                    allow_mtp_experimental=request.allow_mtp_experimental,
+                    final_prefix_experiment=final_prefix_experiment,
+                    on_progress=on_progress,
+                    on_token=collect,
+                    should_cancel=should_cancel,
+                )
         timings = completion.timings
         content, stopped = trim_at_stop(completion.content, request.stop)
         stopped = stopped or completion.stopped_by_stop
@@ -322,6 +341,11 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "mtp_failure_reason": session["mtp_failure_reason"],
                     "model_id": state.client.paths.model_id,
                     "backend": "orbit-native",
+                    "artifact_content_protocol": {
+                        "id": ARTIFACT_CONTENT_PROTOCOL_ID,
+                        "version": ARTIFACT_CONTENT_PROTOCOL_VERSION,
+                        "literal_stream": True,
+                    },
                     "native_backend_capabilities": state.native_backend_capabilities,
                     "model_compatibility": state.client.compatibility_diagnostics(),
                     "backend_mode": session["backend_mode"],
@@ -507,6 +531,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
         try:
             request = parse_chat_request(payload)
             validate_session_id(request.session_id)
+            self._state().validate_request(request)
         except ValueError as exc:
             self._json({"error": str(exc)}, status=400)
             return

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -22,6 +22,7 @@ class ChatRequest:
     qwen_route_prefix_anchor: bool
     allow_mtp_experimental: bool | None
     final_prefix_experiment: bool
+    artifact_content: bool
 
 
 @dataclass(frozen=True)
@@ -46,6 +47,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         qwen_route_prefix_anchor=payload.get("qwen_route_prefix_anchor") is True,
         allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
         final_prefix_experiment=payload.get("final_prefix_experiment") is True,
+        artifact_content=payload.get("artifact_content") is True,
     )
 
 

--- a/src/orbit/runtime/artifacts.py
+++ b/src/orbit/runtime/artifacts.py
@@ -4,10 +4,13 @@ from dataclasses import dataclass
 import ctypes
 import errno
 import hashlib
+import json
 import os
 from pathlib import Path
+import re
 import secrets
 import stat
+import time
 from typing import Any, Callable
 
 from orbit.backend.base import ChatResult, Message, StreamProgress
@@ -20,6 +23,12 @@ MAX_ARTIFACT_BYTES = 64 * 1024
 MAX_ARTIFACT_PATH_CHARS = 512
 MAX_ARTIFACT_VERIFICATION_CHARS = 12 * 1024
 _TEMP_PREFIX = ".orbit-artifact-"
+_RECOVERY_DIRECTORY = ".orbit-artifact-state"
+_RECOVERY_MANIFEST_RE = re.compile(r"^([0-9a-f]{32})\.json$")
+_RECOVERY_VERSION = 1
+_RECOVERY_MAX_MANIFESTS = 128
+_RECOVERY_MAX_MANIFEST_BYTES = 4096
+_RECOVERY_STALE_SECONDS = 300
 _UNSUPPORTED_TMPFILE_ERRNOS = frozenset(
     value
     for value in (
@@ -42,10 +51,10 @@ _UNSUPPORTED_RENAME_NOREPLACE_ERRNOS = frozenset(
 )
 
 ARTIFACT_VERIFICATION_PROMPT = (
-    "Artifact content generation completed, but nothing has been published yet. "
-    "Select exactly one verify_artifact call for the exact pending path. "
+    "The artifact was published atomically and now requires a read-only check. "
+    "Select exactly one verify_artifact call for this published artifact. "
     "Choose content when bounded body evidence is needed, otherwise choose text_integrity. "
-    "A passing check will publish the artifact atomically. Return only one tool call."
+    "The verifier cannot publish or mutate anything. Return only one tool call."
 )
 
 
@@ -58,7 +67,8 @@ def write_artifact_definition() -> dict[str, Any]:
                 "Create one non-trivial UTF-8 text file through a dedicated content-only generation phase. "
                 "Use this instead of embedding file content in shell, JSON, XML, or a heredoc. "
                 "Missing parents are created only when create_parents is true. "
-                "The file and any new parents are published atomically only after complete generation."
+                "The destination file is published atomically only after complete generation; "
+                "new empty parents created by a failed request are removed when still safe."
             ),
             "parameters": {
                 "type": "object",
@@ -89,16 +99,12 @@ def verify_artifact_definition() -> dict[str, Any]:
         "function": {
             "name": ARTIFACT_VERIFY_TOOL_NAME,
             "description": (
-                "Select a bounded verification for the generated content of the pending write_artifact request. "
-                "A passing check atomically completes that already-authorized publication; the verifier never edits or executes the content."
+                "Read and verify the exact artifact already published by write_artifact. "
+                "The verifier never publishes, edits, executes, or otherwise mutates the content."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Exact relative path returned by write_artifact.",
-                    },
                     "check": {
                         "type": "string",
                         "description": (
@@ -110,7 +116,7 @@ def verify_artifact_definition() -> dict[str, Any]:
                         ],
                     },
                 },
-                "required": ["path", "check"],
+                "required": ["check"],
                 "additionalProperties": False,
             },
         },
@@ -153,11 +159,8 @@ def artifact_content_messages(
         {
             "role": "system",
             "content": (
-                "Produce only the complete UTF-8 body to publish at the validated destination. "
-                "The first output character must belong to the file body, and the last output character must complete that body. "
-                "Do not output the path or discuss saving. Do not add a wrapper, fence, tool envelope, or transfer framing around the body. "
-                "Preserve every piece of text required inside the artifact, even when it resembles control syntax. "
-                "Fully implement every requirement in the original request without placeholders, stubs, abbreviations, or omissions."
+                "Generate one complete bounded UTF-8 text artifact. "
+                "Do not use tools, shell, JSON/XML envelopes, Markdown fences, transfer syntax, placeholders, or explanatory prose."
             ),
         },
         {
@@ -166,7 +169,9 @@ def artifact_content_messages(
                 f"Original request:\n{user_request}\n\n"
                 f"Validated destination: {path}\n"
                 f"Overwrite authorized: {'yes' if overwrite else 'no'}\n"
-                f"Maximum UTF-8 size: {MAX_ARTIFACT_BYTES} bytes."
+                f"Maximum UTF-8 size: {MAX_ARTIFACT_BYTES} bytes.\n\n"
+                "Output the complete file body now. Output file content only; "
+                "do not output or discuss the destination path."
             ),
         },
     ]
@@ -180,6 +185,7 @@ class ArtifactPublication:
     overwrite: bool
     created_parent_directories: tuple[str, ...] = ()
     directory_sync_complete: bool = True
+    file_version: tuple[int, int, int, int, int] | None = None
 
     def evidence(self) -> str:
         return "\n".join(
@@ -192,7 +198,8 @@ class ArtifactPublication:
                 "created_parent_directories: "
                 + (", ".join(self.created_parent_directories) if self.created_parent_directories else "none"),
                 "directory_sync: " + ("complete" if self.directory_sync_complete else "unconfirmed"),
-                "verification_completed: true",
+                "verification_required: true",
+                "verification_completed: false",
             ]
         )
 
@@ -201,6 +208,43 @@ class ArtifactGenerationError(RuntimeError):
     def __init__(self, message: str, *, result: ChatResult) -> None:
         super().__init__(message)
         self.result = result
+
+
+@dataclass
+class ArtifactPrivateLease:
+    workdir: Path
+    manifest_name: str
+    token: str
+    _released: bool = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        try:
+            state_fd = _open_recovery_directory(self.workdir, create=False)
+        except (OSError, ValueError):
+            return
+        if state_fd < 0:
+            return
+        try:
+            try:
+                os.unlink(self.manifest_name, dir_fd=state_fd)
+            except OSError:
+                return
+            else:
+                _try_fsync(state_fd)
+        finally:
+            os.close(state_fd)
+        _remove_empty_recovery_directory(self.workdir)
+
+
+@dataclass(frozen=True)
+class ArtifactCleanupResult:
+    scanned: int = 0
+    removed: int = 0
+    preserved: int = 0
+    errors: int = 0
 
 
 def _open_private_artifact_temp(parent_fd: int) -> tuple[int, str | None, bool]:
@@ -238,68 +282,391 @@ def _open_named_artifact_temp(parent_fd: int) -> tuple[int, str]:
     return fd, name
 
 
+def _open_recovery_directory(workdir: Path, *, create: bool) -> int:
+    root = workdir.expanduser().resolve()
+    root_fd = os.open(
+        root,
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        if create:
+            try:
+                os.mkdir(_RECOVERY_DIRECTORY, 0o700, dir_fd=root_fd)
+            except FileExistsError:
+                pass
+        try:
+            state_fd = os.open(
+                _RECOVERY_DIRECTORY,
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=root_fd,
+            )
+        except FileNotFoundError:
+            return -1
+        state = os.fstat(state_fd)
+        if state.st_uid != os.getuid() or stat.S_IMODE(state.st_mode) != 0o700:
+            os.close(state_fd)
+            raise ValueError("artifact recovery directory is not safely owned")
+        return state_fd
+    finally:
+        os.close(root_fd)
+
+
+def _register_private_entry(
+    *,
+    workdir: Path,
+    parent_relative: Path,
+    temp_name: str,
+    temp_fd: int,
+) -> ArtifactPrivateLease:
+    token_match = re.fullmatch(r"\.orbit-artifact-([0-9a-f]{32})\.tmp", temp_name)
+    if token_match is None:
+        raise ValueError("artifact private name is invalid")
+    token = token_match.group(1)
+    value = os.fstat(temp_fd)
+    boot_id, process_start = _current_process_identity()
+    manifest = {
+        "version": _RECOVERY_VERSION,
+        "token": token,
+        "parent": parent_relative.as_posix(),
+        "temp_name": temp_name,
+        "device": value.st_dev,
+        "inode": value.st_ino,
+        "uid": value.st_uid,
+        "created_ns": time.time_ns(),
+        "pid": os.getpid(),
+        "boot_id": boot_id,
+        "process_start": process_start,
+    }
+    raw = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    state_fd = _open_recovery_directory(workdir, create=True)
+    manifest_name = f"{token}.json"
+    manifest_fd = -1
+    try:
+        manifest_fd = os.open(
+            manifest_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=state_fd,
+        )
+        _write_all(manifest_fd, raw)
+        os.fsync(manifest_fd)
+        _try_fsync(state_fd)
+    except BaseException:
+        if manifest_fd >= 0:
+            os.close(manifest_fd)
+            manifest_fd = -1
+        try:
+            os.unlink(manifest_name, dir_fd=state_fd)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        if manifest_fd >= 0:
+            os.close(manifest_fd)
+        os.close(state_fd)
+    return ArtifactPrivateLease(
+        workdir=workdir.expanduser().resolve(),
+        manifest_name=manifest_name,
+        token=token,
+    )
+
+
+def _remove_empty_recovery_directory(workdir: Path) -> None:
+    root = workdir.expanduser().resolve()
+    try:
+        root_fd = os.open(
+            root,
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError:
+        return
+    try:
+        try:
+            os.rmdir(_RECOVERY_DIRECTORY, dir_fd=root_fd)
+        except OSError:
+            pass
+    finally:
+        os.close(root_fd)
+
+
+def cleanup_stale_artifact_entries(
+    workdir: Path,
+    *,
+    stale_seconds: int = _RECOVERY_STALE_SECONDS,
+) -> ArtifactCleanupResult:
+    try:
+        state_fd = _open_recovery_directory(workdir, create=False)
+    except (OSError, ValueError):
+        return ArtifactCleanupResult(preserved=1, errors=1)
+    if state_fd < 0:
+        return ArtifactCleanupResult()
+    scanned = removed = preserved = errors = 0
+    try:
+        try:
+            names = sorted(os.listdir(state_fd))[:_RECOVERY_MAX_MANIFESTS]
+        except OSError:
+            return ArtifactCleanupResult(preserved=1, errors=1)
+        for manifest_name in names:
+            if _RECOVERY_MANIFEST_RE.fullmatch(manifest_name) is None:
+                preserved += 1
+                continue
+            scanned += 1
+            try:
+                manifest_fd = os.open(
+                    manifest_name,
+                    os.O_RDONLY
+                    | getattr(os, "O_CLOEXEC", 0)
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=state_fd,
+                )
+                try:
+                    info = os.fstat(manifest_fd)
+                    if (
+                        not stat.S_ISREG(info.st_mode)
+                        or info.st_uid != os.getuid()
+                        or stat.S_IMODE(info.st_mode) != 0o600
+                        or info.st_size > _RECOVERY_MAX_MANIFEST_BYTES
+                    ):
+                        preserved += 1
+                        continue
+                    raw = _read_fd(manifest_fd, _RECOVERY_MAX_MANIFEST_BYTES)
+                finally:
+                    os.close(manifest_fd)
+                value = json.loads(raw.decode("utf-8"))
+                entry = _validated_recovery_manifest(value, manifest_name=manifest_name)
+                if entry is None:
+                    preserved += 1
+                    continue
+                owner_active = _artifact_owner_active(entry)
+                age_ns = max(0, time.time_ns() - entry["created_ns"])
+                if owner_active is True or (
+                    owner_active is None
+                    and age_ns < max(0, stale_seconds) * 1_000_000_000
+                ):
+                    preserved += 1
+                    continue
+                parent_fd = _open_recovery_parent(workdir, entry["parent"])
+                try:
+                    try:
+                        temp_fd = os.open(
+                            entry["temp_name"],
+                            os.O_RDONLY
+                            | getattr(os, "O_CLOEXEC", 0)
+                            | getattr(os, "O_NOFOLLOW", 0)
+                            | getattr(os, "O_NONBLOCK", 0),
+                            dir_fd=parent_fd,
+                        )
+                    except FileNotFoundError:
+                        os.unlink(manifest_name, dir_fd=state_fd)
+                        removed += 1
+                        continue
+                    except OSError:
+                        preserved += 1
+                        continue
+                    try:
+                        current = os.fstat(temp_fd)
+                        path_current = os.stat(
+                            entry["temp_name"],
+                            dir_fd=parent_fd,
+                            follow_symlinks=False,
+                        )
+                        if (
+                            not stat.S_ISREG(current.st_mode)
+                            or current.st_uid != entry["uid"]
+                            or stat.S_IMODE(current.st_mode) != 0o600
+                            or current.st_nlink != 1
+                            or (current.st_dev, current.st_ino) != (entry["device"], entry["inode"])
+                            or not _same_inode(current, path_current)
+                        ):
+                            preserved += 1
+                            continue
+                    finally:
+                        os.close(temp_fd)
+                    os.unlink(entry["temp_name"], dir_fd=parent_fd)
+                    os.unlink(manifest_name, dir_fd=state_fd)
+                    _try_fsync(parent_fd)
+                    removed += 1
+                finally:
+                    os.close(parent_fd)
+            except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+                errors += 1
+                preserved += 1
+    finally:
+        os.close(state_fd)
+    _remove_empty_recovery_directory(workdir)
+    return ArtifactCleanupResult(
+        scanned=scanned,
+        removed=removed,
+        preserved=preserved,
+        errors=errors,
+    )
+
+
+def _validated_recovery_manifest(value: object, *, manifest_name: str) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or set(value) != {
+        "version",
+        "token",
+        "parent",
+        "temp_name",
+        "device",
+        "inode",
+        "uid",
+        "created_ns",
+        "pid",
+        "boot_id",
+        "process_start",
+    }:
+        return None
+    token = value.get("token")
+    parent = value.get("parent")
+    temp_name = value.get("temp_name")
+    boot_id = value.get("boot_id")
+    numeric = (
+        value.get("device"),
+        value.get("inode"),
+        value.get("uid"),
+        value.get("created_ns"),
+        value.get("pid"),
+        value.get("process_start"),
+    )
+    if (
+        value.get("version") != _RECOVERY_VERSION
+        or not isinstance(token, str)
+        or manifest_name != f"{token}.json"
+        or not isinstance(parent, str)
+        or not isinstance(temp_name, str)
+        or temp_name != f"{_TEMP_PREFIX}{token}.tmp"
+        or not isinstance(boot_id, str)
+        or re.fullmatch(r"[0-9a-f-]{1,64}", boot_id) is None
+        or any(isinstance(item, bool) or not isinstance(item, int) or item < 0 for item in numeric)
+    ):
+        return None
+    supplied = Path(parent)
+    if supplied.is_absolute() or any(part in {"", ".."} for part in supplied.parts):
+        return None
+    return value
+
+
+def _current_process_identity() -> tuple[str, int]:
+    try:
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(encoding="ascii").strip().lower()
+        process_start = _read_process_start(os.getpid())
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise RuntimeError("artifact recovery requires a verifiable process identity") from exc
+    if re.fullmatch(r"[0-9a-f-]{1,64}", boot_id) is None:
+        raise RuntimeError("artifact recovery boot identity is invalid")
+    return boot_id, process_start
+
+
+def _read_process_start(pid: int) -> int:
+    raw = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+    marker = raw.rfind(") ")
+    if marker < 0:
+        raise ValueError("process identity is malformed")
+    fields = raw[marker + 2 :].split()
+    if len(fields) <= 19:
+        raise ValueError("process identity is incomplete")
+    return int(fields[19])
+
+
+def _artifact_owner_active(entry: dict[str, Any]) -> bool | None:
+    try:
+        current_boot = Path("/proc/sys/kernel/random/boot_id").read_text(
+            encoding="ascii"
+        ).strip().lower()
+    except (OSError, UnicodeError):
+        return None
+    if current_boot != entry["boot_id"]:
+        return False
+    try:
+        return _read_process_start(entry["pid"]) == entry["process_start"]
+    except FileNotFoundError:
+        return False
+    except (OSError, UnicodeError, ValueError):
+        return None
+
+
+def _open_recovery_parent(workdir: Path, parent: str) -> int:
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    current_fd = os.open(workdir.expanduser().resolve(), directory_flags)
+    try:
+        if parent not in {"", "."}:
+            for part in Path(parent).parts:
+                next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+                os.close(current_fd)
+                current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
 @dataclass
 class PendingArtifact:
-    target: PreparedArtifactTarget
+    publication: ArtifactPublication
+    workdir: Path
     generation: ChatResult
-    content: str
-    raw: bytes
     _closed: bool = False
 
     @property
     def path(self) -> str:
-        return self.target.relative_path.as_posix()
+        return self.publication.path
 
     def evidence(self) -> str:
-        return "\n".join(
-            [
-                "artifact_generation: complete",
-                f"path: {self.path}",
-                f"bytes: {len(self.raw)}",
-                f"sha256: {hashlib.sha256(self.raw).hexdigest()}",
-                "publication_status: pending",
-                "verification_required: true",
-            ]
-        )
+        return self.publication.evidence()
 
-    def verify_and_publish(
+    def verify(
         self,
         arguments: dict[str, object],
-        *,
-        workdir: Path,
-    ) -> tuple[ArtifactPublication, str]:
+    ) -> str:
         if self._closed:
-            raise ValueError("artifact request is no longer pending")
-        path = arguments.get("path")
+            raise ValueError("artifact verification is no longer pending")
+        if set(arguments) != {"check"}:
+            raise ValueError("artifact verification arguments are invalid")
         check = arguments.get("check")
-        if path != self.path:
-            raise ValueError("artifact verification path does not match the pending request")
+        raw = _read_published_artifact(
+            self.publication,
+            workdir=self.workdir,
+        )
         detail, content_lines = _verify_artifact_bytes(
-            self.raw,
+            raw,
             check=check,
         )
-        try:
-            publication = self.target.publish(self.content)
-        finally:
-            self.abort()
+        self._closed = True
         lines = [
-            publication.evidence(),
             "artifact_verification: complete",
-            f"path: {publication.path}",
+            f"path: {self.publication.path}",
             f"check: {check}",
-            f"bytes: {len(self.raw)}",
-            f"sha256: {publication.sha256}",
+            f"bytes: {len(raw)}",
+            f"sha256: {self.publication.sha256}",
             "status: pass",
             f"detail: {detail}",
             *content_lines,
         ]
-        return publication, "\n".join(lines)
+        return "\n".join(lines)
 
     def abort(self) -> None:
         if self._closed:
             return
         self._closed = True
-        self.target.close()
 
     def __del__(self) -> None:
         self.abort()
@@ -351,12 +718,20 @@ class PreparedArtifactTarget:
         temp_name: str | None = None
         temp_fd = -1
         unnamed_temp = False
+        temp_lease: ArtifactPrivateLease | None = None
         temp_cleanup_safe = False
         published_new_file = False
         directory_sync_complete = True
         try:
             temp_fd, temp_name, unnamed_temp = _open_private_artifact_temp(self.parent_fd)
             temp_cleanup_safe = temp_name is not None
+            if temp_name is not None:
+                temp_lease = _register_private_entry(
+                    workdir=self.workdir,
+                    parent_relative=self.existing_parent_relative,
+                    temp_name=temp_name,
+                    temp_fd=temp_fd,
+                )
             _write_all(temp_fd, raw)
             if replacing_existing:
                 assert self.destination_mode is not None
@@ -385,6 +760,12 @@ class PreparedArtifactTarget:
                     temp_fd, temp_name = _open_named_artifact_temp(self.parent_fd)
                     unnamed_temp = False
                     temp_cleanup_safe = True
+                    temp_lease = _register_private_entry(
+                        workdir=self.workdir,
+                        parent_relative=self.existing_parent_relative,
+                        temp_name=temp_name,
+                        temp_fd=temp_fd,
+                    )
                     _write_all(temp_fd, raw)
                     if replacing_existing:
                         assert self.destination_mode is not None
@@ -395,6 +776,14 @@ class PreparedArtifactTarget:
                 else:
                     temp_name = link_name if replacing_existing else None
                     published_new_file = not replacing_existing
+                    if temp_name is not None:
+                        temp_cleanup_safe = True
+                        temp_lease = _register_private_entry(
+                            workdir=self.workdir,
+                            parent_relative=self.existing_parent_relative,
+                            temp_name=temp_name,
+                            temp_fd=temp_fd,
+                        )
             if replacing_existing:
                 assert temp_name is not None and self.destination_version is not None
                 _rename_exchange(
@@ -440,6 +829,9 @@ class PreparedArtifactTarget:
                 os.unlink(temp_name, dir_fd=self.parent_fd)
                 temp_name = None
                 temp_cleanup_safe = False
+                if temp_lease is not None:
+                    temp_lease.release()
+                    temp_lease = None
                 directory_sync_complete = _try_fsync(self.parent_fd) and directory_sync_complete
             elif not unnamed_temp:
                 assert temp_name is not None
@@ -452,11 +844,14 @@ class PreparedArtifactTarget:
                 temp_name = None
                 temp_cleanup_safe = False
                 published_new_file = True
+                if temp_lease is not None:
+                    temp_lease.release()
+                    temp_lease = None
                 directory_sync_complete = _try_fsync(self.parent_fd)
             elif not replacing_existing:
                 directory_sync_complete = _try_fsync(self.parent_fd)
             try:
-                _attest_published_artifact(
+                published_version = _attest_published_artifact(
                     self.parent_fd,
                     basename,
                     expected_identity=generated_identity,
@@ -483,42 +878,44 @@ class PreparedArtifactTarget:
                     os.unlink(temp_name, dir_fd=self.parent_fd)
                 except FileNotFoundError:
                     pass
+            if temp_lease is not None:
+                temp_lease.release()
+        assert published_version is not None
         return ArtifactPublication(
             path=self.relative_path.as_posix(),
             bytes_written=len(raw),
             sha256=generated_sha256,
             overwrite=replacing_existing,
             directory_sync_complete=directory_sync_complete,
+            file_version=published_version,
         )
 
     def _publish_with_new_parents(self, raw: bytes) -> ArtifactPublication:
         self._attest_existing_parent()
-        top_name = self.missing_parent_parts[0]
-        try:
-            os.stat(top_name, dir_fd=self.parent_fd, follow_symlinks=False)
-        except FileNotFoundError:
-            pass
-        else:
-            raise ValueError("artifact parent path changed before atomic publication")
-
-        stage_name = f"{_TEMP_PREFIX}{secrets.token_hex(16)}.tmp"
-        os.mkdir(stage_name, 0o700, dir_fd=self.parent_fd)
         directory_flags = (
             os.O_RDONLY
             | getattr(os, "O_CLOEXEC", 0)
             | getattr(os, "O_DIRECTORY", 0)
             | getattr(os, "O_NOFOLLOW", 0)
         )
-        dir_fds: list[int] = []
-        file_fd = -1
-        published = False
+        opened_fds: list[int] = [os.dup(self.parent_fd)]
+        created: list[tuple[int, str, int, str]] = []
+        current_relative = self.existing_parent_relative
+        temp_fd = -1
+        temp_name: str | None = None
+        temp_cleanup_safe = False
+        temp_lease: ArtifactPrivateLease | None = None
+        published_identity: tuple[int, int, int] | None = None
+        published_version: tuple[int, int, int, int, int] | None = None
         directory_sync_complete = True
         try:
-            stage_fd = os.open(stage_name, directory_flags, dir_fd=self.parent_fd)
-            dir_fds.append(stage_fd)
-            current_fd = stage_fd
-            for part in self.missing_parent_parts[1:]:
-                os.mkdir(part, 0o755, dir_fd=current_fd)
+            current_fd = opened_fds[-1]
+            for part in self.missing_parent_parts:
+                self._attest_existing_parent()
+                try:
+                    os.mkdir(part, 0o755, dir_fd=current_fd)
+                except FileExistsError as exc:
+                    raise ValueError("artifact parent path changed before publication") from exc
                 try:
                     next_fd = os.open(part, directory_flags, dir_fd=current_fd)
                 except BaseException:
@@ -527,111 +924,146 @@ class PreparedArtifactTarget:
                     except OSError:
                         pass
                     raise
-                dir_fds.append(next_fd)
+                opened_fds.append(next_fd)
+                current = os.stat(part, dir_fd=current_fd, follow_symlinks=False)
+                opened = os.fstat(next_fd)
+                if not stat.S_ISDIR(current.st_mode) or not _same_inode(current, opened):
+                    raise ValueError("artifact parent path changed during creation")
+                current_relative = current_relative / part
+                created.append((current_fd, part, next_fd, current_relative.as_posix()))
                 os.fchmod(next_fd, 0o755)
-                os.fsync(current_fd)
+                directory_sync_complete = _try_fsync(current_fd) and directory_sync_complete
                 current_fd = next_fd
-            file_fd = os.open(
-                self.relative_path.name,
-                os.O_RDWR
-                | os.O_CREAT
-                | os.O_EXCL
-                | getattr(os, "O_CLOEXEC", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
-                0o600,
-                dir_fd=current_fd,
-            )
-            _write_all(file_fd, raw)
-            os.fsync(file_fd)
-            generated_sha256 = _sha256_fd(file_fd)
-            if generated_sha256 != hashlib.sha256(raw).hexdigest():
-                raise ValueError("artifact changed before atomic parent publication")
-            os.fsync(current_fd)
+            _attest_created_directories(created)
             self._attest_existing_parent()
             try:
-                os.stat(top_name, dir_fd=self.parent_fd, follow_symlinks=False)
+                os.stat(self.relative_path.name, dir_fd=current_fd, follow_symlinks=False)
             except FileNotFoundError:
                 pass
             else:
-                raise ValueError("artifact parent path changed before atomic publication")
-            os.fchmod(stage_fd, 0o755)
-            os.fsync(stage_fd)
-            _rename_noreplace(
-                old_dir_fd=self.parent_fd,
-                old_name=stage_name,
-                new_dir_fd=self.parent_fd,
-                new_name=top_name,
-            )
-            published = True
+                raise ValueError("artifact destination changed before publication")
+
+            temp_fd, temp_name, unnamed_temp = _open_private_artifact_temp(current_fd)
+            temp_cleanup_safe = temp_name is not None
+            if temp_name is not None:
+                temp_lease = _register_private_entry(
+                    workdir=self.workdir,
+                    parent_relative=current_relative,
+                    temp_name=temp_name,
+                    temp_fd=temp_fd,
+                )
+            _write_all(temp_fd, raw)
+            os.fsync(temp_fd)
+            generated_identity = _file_identity(os.fstat(temp_fd))
+            generated_sha256 = hashlib.sha256(raw).hexdigest()
+            if _sha256_fd(temp_fd) != generated_sha256:
+                raise ValueError("artifact temporary content changed before publication")
+            _attest_created_directories(created)
+            self._attest_existing_parent()
             try:
-                directory_sync_complete = _try_fsync(self.parent_fd)
-                _attest_published_artifact_path(
-                    self.parent_fd,
-                    self.missing_parent_parts,
+                os.stat(self.relative_path.name, dir_fd=current_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise ValueError("artifact destination changed before publication")
+            if unnamed_temp:
+                try:
+                    os.link(
+                        f"/proc/self/fd/{temp_fd}",
+                        self.relative_path.name,
+                        dst_dir_fd=current_fd,
+                        follow_symlinks=True,
+                    )
+                except OSError as exc:
+                    if exc.errno not in _UNSUPPORTED_TMPFILE_ERRNOS:
+                        raise
+                    os.close(temp_fd)
+                    temp_fd = -1
+                    temp_fd, temp_name = _open_named_artifact_temp(current_fd)
+                    temp_cleanup_safe = True
+                    temp_lease = _register_private_entry(
+                        workdir=self.workdir,
+                        parent_relative=current_relative,
+                        temp_name=temp_name,
+                        temp_fd=temp_fd,
+                    )
+                    _write_all(temp_fd, raw)
+                    os.fsync(temp_fd)
+                    generated_identity = _file_identity(os.fstat(temp_fd))
+                    _attest_created_directories(created)
+                    self._attest_existing_parent()
+                    _commit_named_file_noreplace(
+                        old_dir_fd=current_fd,
+                        old_name=temp_name,
+                        new_dir_fd=current_fd,
+                        new_name=self.relative_path.name,
+                    )
+                    temp_name = None
+                    temp_cleanup_safe = False
+                    if temp_lease is not None:
+                        temp_lease.release()
+                        temp_lease = None
+            else:
+                assert temp_name is not None
+                _commit_named_file_noreplace(
+                    old_dir_fd=current_fd,
+                    old_name=temp_name,
+                    new_dir_fd=current_fd,
+                    new_name=self.relative_path.name,
+                )
+                temp_name = None
+                temp_cleanup_safe = False
+                if temp_lease is not None:
+                    temp_lease.release()
+                    temp_lease = None
+            published_identity = generated_identity
+            try:
+                directory_sync_complete = _try_fsync(current_fd) and directory_sync_complete
+                published_version = _attest_published_artifact(
+                    current_fd,
                     self.relative_path.name,
-                    expected_identity=_file_identity(os.fstat(file_fd)),
+                    expected_identity=generated_identity,
                     expected_sha256=generated_sha256,
                 )
+                _attest_created_directories(created)
                 self._attest_existing_parent()
             except BaseException:
                 try:
-                    _attest_published_artifact_path(
-                        self.parent_fd,
-                        self.missing_parent_parts,
-                        self.relative_path.name,
-                        expected_identity=_file_identity(os.fstat(file_fd)),
+                    _retract_published_file(
+                        parent_fd=current_fd,
+                        basename=self.relative_path.name,
+                        expected_identity=generated_identity,
                         expected_sha256=generated_sha256,
                     )
-                except ValueError:
-                    # Preserve a tree whose content or identity was changed by
-                    # another actor; it is no longer safe for Orbit to remove.
+                    published_identity = None
+                except (OSError, ValueError):
                     pass
-                else:
-                    _retract_published_directory(
-                        parent_fd=self.parent_fd,
-                        published_name=top_name,
-                        private_name=stage_name,
-                        expected_directory_fd=stage_fd,
-                    )
-                    published = False
                 raise
         finally:
-            if not published:
-                if file_fd >= 0 and dir_fds:
-                    try:
-                        os.unlink(self.relative_path.name, dir_fd=dir_fds[-1])
-                    except FileNotFoundError:
-                        pass
-                for index in range(len(dir_fds) - 1, 0, -1):
-                    os.close(dir_fds[index])
-                    try:
-                        os.rmdir(self.missing_parent_parts[index], dir_fd=dir_fds[index - 1])
-                    except OSError:
-                        pass
-                if dir_fds:
-                    os.close(dir_fds[0])
+            if temp_fd >= 0:
+                os.close(temp_fd)
+            if temp_name is not None and temp_cleanup_safe:
                 try:
-                    os.rmdir(stage_name, dir_fd=self.parent_fd)
-                except OSError:
+                    os.unlink(temp_name, dir_fd=opened_fds[-1])
+                except FileNotFoundError:
                     pass
-            else:
-                for directory_fd in reversed(dir_fds):
-                    os.close(directory_fd)
-            if file_fd >= 0:
-                os.close(file_fd)
+            if temp_lease is not None:
+                temp_lease.release()
+            if published_identity is None:
+                _remove_created_directories(created)
+            for directory_fd in reversed(opened_fds):
+                os.close(directory_fd)
 
-        created: list[str] = []
-        current = self.existing_parent_relative
-        for part in self.missing_parent_parts:
-            current = current / part
-            created.append(current.as_posix())
+        created_paths = tuple(item[3] for item in created)
+        assert published_identity is not None and published_version is not None
         return ArtifactPublication(
             path=self.relative_path.as_posix(),
             bytes_written=len(raw),
             sha256=hashlib.sha256(raw).hexdigest(),
             overwrite=False,
-            created_parent_directories=tuple(created),
+            created_parent_directories=created_paths,
             directory_sync_complete=directory_sync_complete,
+            file_version=published_version,
         )
 
     def _attest_existing_parent(self) -> None:
@@ -780,6 +1212,7 @@ def begin_artifact_generation(
     generate = getattr(backend, "artifact_content_stream", None)
     if not callable(generate):
         raise RuntimeError("artifact content generation requires the native Orbit backend")
+    cleanup_stale_artifact_entries(workdir)
     target = prepare_artifact_target(
         path,
         overwrite=overwrite,
@@ -830,11 +1263,12 @@ def begin_artifact_generation(
                 f"artifact content failed validation: {exc}",
                 result=result,
             ) from exc
+        publication = target.publish(result.content)
+        target.close()
         return PendingArtifact(
-            target=target,
+            publication=publication,
+            workdir=workdir.expanduser().resolve(),
             generation=result,
-            content=result.content,
-            raw=raw,
         )
     except BaseException:
         target.close()
@@ -862,6 +1296,59 @@ def _verify_artifact_bytes(
             _bounded_verification_text(text, MAX_ARTIFACT_VERIFICATION_CHARS),
         ]
     return detail, content_lines
+
+
+def _read_published_artifact(
+    publication: ArtifactPublication,
+    *,
+    workdir: Path,
+) -> bytes:
+    if publication.file_version is None:
+        raise ValueError("artifact publication identity is unavailable")
+    relative = Path(publication.path)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    current_fd = os.open(workdir, directory_flags)
+    file_fd = -1
+    try:
+        for part in relative.parts[:-1]:
+            next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        file_fd = os.open(
+            relative.name,
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=current_fd,
+        )
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode) or _file_version(before) != publication.file_version:
+            raise ValueError("published artifact changed before verification")
+        raw = _read_fd(file_fd, MAX_ARTIFACT_BYTES)
+        after = os.fstat(file_fd)
+        path_version = _file_version(
+            os.stat(relative.name, dir_fd=current_fd, follow_symlinks=False)
+        )
+        if (
+            _file_version(after) != publication.file_version
+            or path_version != publication.file_version
+            or len(raw) != publication.bytes_written
+            or hashlib.sha256(raw).hexdigest() != publication.sha256
+        ):
+            raise ValueError("published artifact changed during verification")
+        return raw
+    except OSError as exc:
+        raise ValueError("published artifact is unavailable for verification") from exc
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+        os.close(current_fd)
 
 
 def _write_all(fd: int, raw: bytes) -> None:
@@ -906,6 +1393,33 @@ def _file_identity_from_version(value: tuple[int, int, int, int, int]) -> tuple[
 
 def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
     return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _attest_created_directories(created: list[tuple[int, str, int, str]]) -> None:
+    for parent_fd, name, directory_fd, _relative in created:
+        opened = os.fstat(directory_fd)
+        try:
+            current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise ValueError("artifact parent directory changed during publication") from exc
+        if not stat.S_ISDIR(current.st_mode) or not _same_inode(current, opened):
+            raise ValueError("artifact parent directory changed during publication")
+
+
+def _remove_created_directories(created: list[tuple[int, str, int, str]]) -> None:
+    for parent_fd, name, directory_fd, _relative in reversed(created):
+        try:
+            current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            opened = os.fstat(directory_fd)
+        except OSError:
+            continue
+        if not stat.S_ISDIR(current.st_mode) or not _same_inode(current, opened):
+            continue
+        try:
+            os.rmdir(name, dir_fd=parent_fd)
+        except OSError:
+            # A non-empty or concurrently changed directory remains visible.
+            continue
 
 
 def _rollback_artifact_overwrite(
@@ -985,41 +1499,6 @@ def _retract_published_file(
     _try_fsync(parent_fd)
 
 
-def _retract_published_directory(
-    *,
-    parent_fd: int,
-    published_name: str,
-    private_name: str,
-    expected_directory_fd: int,
-) -> None:
-    """Move an exact Orbit-created tree back to its private staging name."""
-
-    try:
-        _rename_noreplace(
-            old_dir_fd=parent_fd,
-            old_name=published_name,
-            new_dir_fd=parent_fd,
-            new_name=private_name,
-        )
-    except OSError as exc:
-        raise ValueError("artifact parent publication rollback failed safely") from exc
-    moved = os.stat(private_name, dir_fd=parent_fd, follow_symlinks=False)
-    expected = os.fstat(expected_directory_fd)
-    if not stat.S_ISDIR(moved.st_mode) or not _same_inode(moved, expected):
-        try:
-            _rename_noreplace(
-                old_dir_fd=parent_fd,
-                old_name=private_name,
-                new_dir_fd=parent_fd,
-                new_name=published_name,
-            )
-        except OSError as exc:
-            raise ValueError(
-                "artifact parent path changed and unrelated tree was preserved under a private name"
-            ) from exc
-        raise ValueError("artifact parent path changed after atomic publication")
-
-
 def _read_fd(fd: int, maximum: int) -> bytes:
     os.lseek(fd, 0, os.SEEK_SET)
     chunks: list[bytes] = []
@@ -1046,7 +1525,7 @@ def _attest_published_artifact(
     *,
     expected_identity: tuple[int, int, int],
     expected_sha256: str,
-) -> None:
+) -> tuple[int, int, int, int, int]:
     flags = (
         os.O_RDONLY
         | getattr(os, "O_CLOEXEC", 0)
@@ -1074,50 +1553,11 @@ def _attest_published_artifact(
             or path_version != version_after_read
         ):
             raise ValueError("artifact destination changed after atomic publication")
+        return version_after_read
     except OSError as exc:
         raise ValueError("artifact destination changed after atomic publication") from exc
     finally:
         os.close(fd)
-
-
-def _attest_published_artifact_path(
-    parent_fd: int,
-    directory_parts: tuple[str, ...],
-    basename: str,
-    *,
-    expected_identity: tuple[int, int, int],
-    expected_sha256: str,
-) -> None:
-    directory_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
-    opened_fds = [os.dup(parent_fd)]
-    edges: list[tuple[int, str, tuple[int, int]]] = []
-    try:
-        for part in directory_parts:
-            next_fd = os.open(part, directory_flags, dir_fd=opened_fds[-1])
-            current = os.fstat(next_fd)
-            identity = (current.st_dev, current.st_ino)
-            edges.append((opened_fds[-1], part, identity))
-            opened_fds.append(next_fd)
-        _attest_published_artifact(
-            opened_fds[-1],
-            basename,
-            expected_identity=expected_identity,
-            expected_sha256=expected_sha256,
-        )
-        for ancestor_fd, name, expected in reversed(edges):
-            current = os.stat(name, dir_fd=ancestor_fd, follow_symlinks=False)
-            if not stat.S_ISDIR(current.st_mode) or (current.st_dev, current.st_ino) != expected:
-                raise ValueError("artifact parent path changed after atomic publication")
-    except OSError as exc:
-        raise ValueError("artifact parent path changed after atomic publication") from exc
-    finally:
-        for fd in reversed(opened_fds):
-            os.close(fd)
 
 
 def _directory_path_matches(

--- a/src/orbit/runtime/artifacts.py
+++ b/src/orbit/runtime/artifacts.py
@@ -245,6 +245,9 @@ class ArtifactCleanupResult:
     removed: int = 0
     preserved: int = 0
     errors: int = 0
+    owner_active: int = 0
+    owner_inactive: int = 0
+    owner_unknown: int = 0
 
 
 def _open_private_artifact_temp(parent_fd: int) -> tuple[int, str | None, bool]:
@@ -407,6 +410,9 @@ def cleanup_stale_artifact_entries(
     *,
     stale_seconds: int = _RECOVERY_STALE_SECONDS,
 ) -> ArtifactCleanupResult:
+    # Retained for call compatibility. Age never substitutes for positive
+    # proof that the owning process is inactive.
+    del stale_seconds
     try:
         state_fd = _open_recovery_directory(workdir, create=False)
     except (OSError, ValueError):
@@ -414,6 +420,7 @@ def cleanup_stale_artifact_entries(
     if state_fd < 0:
         return ArtifactCleanupResult()
     scanned = removed = preserved = errors = 0
+    owner_active_count = owner_inactive_count = owner_unknown_count = 0
     try:
         try:
             names = sorted(os.listdir(state_fd))[:_RECOVERY_MAX_MANIFESTS]
@@ -451,13 +458,15 @@ def cleanup_stale_artifact_entries(
                     preserved += 1
                     continue
                 owner_active = _artifact_owner_active(entry)
-                age_ns = max(0, time.time_ns() - entry["created_ns"])
-                if owner_active is True or (
-                    owner_active is None
-                    and age_ns < max(0, stale_seconds) * 1_000_000_000
-                ):
+                if owner_active is True:
+                    owner_active_count += 1
                     preserved += 1
                     continue
+                if owner_active is None:
+                    owner_unknown_count += 1
+                    preserved += 1
+                    continue
+                owner_inactive_count += 1
                 parent_fd = _open_recovery_parent(workdir, entry["parent"])
                 try:
                     try:
@@ -512,6 +521,9 @@ def cleanup_stale_artifact_entries(
         removed=removed,
         preserved=preserved,
         errors=errors,
+        owner_active=owner_active_count,
+        owner_inactive=owner_inactive_count,
+        owner_unknown=owner_unknown_count,
     )
 
 

--- a/src/orbit/runtime/artifacts.py
+++ b/src/orbit/runtime/artifacts.py
@@ -1,0 +1,1266 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ctypes
+import errno
+import hashlib
+import os
+from pathlib import Path
+import secrets
+import stat
+from typing import Any, Callable
+
+from orbit.backend.base import ChatResult, Message, StreamProgress
+
+
+ARTIFACT_TOOL_NAME = "write_artifact"
+ARTIFACT_VERIFY_TOOL_NAME = "verify_artifact"
+ARTIFACT_CONTENT_MAX_TOKENS = 4_096
+MAX_ARTIFACT_BYTES = 64 * 1024
+MAX_ARTIFACT_PATH_CHARS = 512
+MAX_ARTIFACT_VERIFICATION_CHARS = 12 * 1024
+_TEMP_PREFIX = ".orbit-artifact-"
+_UNSUPPORTED_TMPFILE_ERRNOS = frozenset(
+    value
+    for value in (
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EINVAL", None),
+        getattr(errno, "ENOENT", None),
+    )
+    if value is not None
+)
+_UNSUPPORTED_RENAME_NOREPLACE_ERRNOS = frozenset(
+    value
+    for value in (
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EINVAL", None),
+        getattr(errno, "ENOSYS", None),
+    )
+    if value is not None
+)
+
+ARTIFACT_VERIFICATION_PROMPT = (
+    "Artifact content generation completed, but nothing has been published yet. "
+    "Select exactly one verify_artifact call for the exact pending path. "
+    "Choose content when bounded body evidence is needed, otherwise choose text_integrity. "
+    "A passing check will publish the artifact atomically. Return only one tool call."
+)
+
+
+def write_artifact_definition() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": ARTIFACT_TOOL_NAME,
+            "description": (
+                "Create one non-trivial UTF-8 text file through a dedicated content-only generation phase. "
+                "Use this instead of embedding file content in shell, JSON, XML, or a heredoc. "
+                "Missing parents are created only when create_parents is true. "
+                "The file and any new parents are published atomically only after complete generation."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative destination path inside the active workdir.",
+                    },
+                    "overwrite": {
+                        "type": "boolean",
+                        "description": "Set true only when the user authorized replacing an existing regular file.",
+                    },
+                    "create_parents": {
+                        "type": "boolean",
+                        "description": "Set true only when missing parent directories should be created.",
+                    },
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def verify_artifact_definition() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": ARTIFACT_VERIFY_TOOL_NAME,
+            "description": (
+                "Select a bounded verification for the generated content of the pending write_artifact request. "
+                "A passing check atomically completes that already-authorized publication; the verifier never edits or executes the content."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Exact relative path returned by write_artifact.",
+                    },
+                    "check": {
+                        "type": "string",
+                        "description": (
+                            "Use content for bounded body evidence or text_integrity for UTF-8, byte-count, and hash verification."
+                        ),
+                        "enum": [
+                            "content",
+                            "text_integrity",
+                        ],
+                    },
+                },
+                "required": ["path", "check"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def validate_artifact_path(path: object, *, workdir: Path) -> str | None:
+    if not isinstance(path, str) or not path.strip():
+        return "error: artifact path must be a non-empty string"
+    if len(path) > MAX_ARTIFACT_PATH_CHARS:
+        return f"error: artifact path exceeds {MAX_ARTIFACT_PATH_CHARS} characters"
+    if "\x00" in path or any(ord(char) < 32 for char in path):
+        return "error: artifact path contains an unsafe control character"
+    supplied = Path(path)
+    if supplied.is_absolute():
+        return "error: artifact path must be relative to the workdir"
+    lexical_parts = path.split("/")
+    if lexical_parts and lexical_parts[0] == ".":
+        lexical_parts = lexical_parts[1:]
+    if any(part in {"", ".", ".."} for part in lexical_parts):
+        return "error: artifact path must identify one file inside the workdir"
+    root = workdir.expanduser().resolve()
+    lexical = Path(os.path.abspath(root / supplied))
+    try:
+        relative = lexical.relative_to(root)
+    except ValueError:
+        return "error: artifact path escapes workdir"
+    if not relative.parts or any(part in {"", ".", ".."} for part in supplied.parts):
+        return "error: artifact path must identify one file inside the workdir"
+    return None
+
+
+def artifact_content_messages(
+    *,
+    user_request: str,
+    path: str,
+    overwrite: bool,
+) -> list[Message]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "Produce only the complete UTF-8 body to publish at the validated destination. "
+                "The first output character must belong to the file body, and the last output character must complete that body. "
+                "Do not output the path or discuss saving. Do not add a wrapper, fence, tool envelope, or transfer framing around the body. "
+                "Preserve every piece of text required inside the artifact, even when it resembles control syntax. "
+                "Fully implement every requirement in the original request without placeholders, stubs, abbreviations, or omissions."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Original request:\n{user_request}\n\n"
+                f"Validated destination: {path}\n"
+                f"Overwrite authorized: {'yes' if overwrite else 'no'}\n"
+                f"Maximum UTF-8 size: {MAX_ARTIFACT_BYTES} bytes."
+            ),
+        },
+    ]
+
+
+@dataclass(frozen=True)
+class ArtifactPublication:
+    path: str
+    bytes_written: int
+    sha256: str
+    overwrite: bool
+    created_parent_directories: tuple[str, ...] = ()
+    directory_sync_complete: bool = True
+
+    def evidence(self) -> str:
+        return "\n".join(
+            [
+                "artifact_publication: complete",
+                f"path: {self.path}",
+                f"bytes: {self.bytes_written}",
+                f"sha256: {self.sha256}",
+                f"overwrite: {'true' if self.overwrite else 'false'}",
+                "created_parent_directories: "
+                + (", ".join(self.created_parent_directories) if self.created_parent_directories else "none"),
+                "directory_sync: " + ("complete" if self.directory_sync_complete else "unconfirmed"),
+                "verification_completed: true",
+            ]
+        )
+
+
+class ArtifactGenerationError(RuntimeError):
+    def __init__(self, message: str, *, result: ChatResult) -> None:
+        super().__init__(message)
+        self.result = result
+
+
+def _open_private_artifact_temp(parent_fd: int) -> tuple[int, str | None, bool]:
+    tmpfile = getattr(os, "O_TMPFILE", 0)
+    if tmpfile:
+        try:
+            fd = os.open(
+                ".",
+                os.O_RDWR | tmpfile | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+                dir_fd=parent_fd,
+            )
+        except OSError as exc:
+            if exc.errno not in _UNSUPPORTED_TMPFILE_ERRNOS:
+                raise
+        else:
+            return fd, None, True
+
+    fd, name = _open_named_artifact_temp(parent_fd)
+    return fd, name, False
+
+
+def _open_named_artifact_temp(parent_fd: int) -> tuple[int, str]:
+    name = f"{_TEMP_PREFIX}{secrets.token_hex(16)}.tmp"
+    fd = os.open(
+        name,
+        os.O_RDWR
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=parent_fd,
+    )
+    return fd, name
+
+
+@dataclass
+class PendingArtifact:
+    target: PreparedArtifactTarget
+    generation: ChatResult
+    content: str
+    raw: bytes
+    _closed: bool = False
+
+    @property
+    def path(self) -> str:
+        return self.target.relative_path.as_posix()
+
+    def evidence(self) -> str:
+        return "\n".join(
+            [
+                "artifact_generation: complete",
+                f"path: {self.path}",
+                f"bytes: {len(self.raw)}",
+                f"sha256: {hashlib.sha256(self.raw).hexdigest()}",
+                "publication_status: pending",
+                "verification_required: true",
+            ]
+        )
+
+    def verify_and_publish(
+        self,
+        arguments: dict[str, object],
+        *,
+        workdir: Path,
+    ) -> tuple[ArtifactPublication, str]:
+        if self._closed:
+            raise ValueError("artifact request is no longer pending")
+        path = arguments.get("path")
+        check = arguments.get("check")
+        if path != self.path:
+            raise ValueError("artifact verification path does not match the pending request")
+        detail, content_lines = _verify_artifact_bytes(
+            self.raw,
+            check=check,
+        )
+        try:
+            publication = self.target.publish(self.content)
+        finally:
+            self.abort()
+        lines = [
+            publication.evidence(),
+            "artifact_verification: complete",
+            f"path: {publication.path}",
+            f"check: {check}",
+            f"bytes: {len(self.raw)}",
+            f"sha256: {publication.sha256}",
+            "status: pass",
+            f"detail: {detail}",
+            *content_lines,
+        ]
+        return publication, "\n".join(lines)
+
+    def abort(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.target.close()
+
+    def __del__(self) -> None:
+        self.abort()
+
+
+@dataclass
+class PreparedArtifactTarget:
+    workdir: Path
+    relative_path: Path
+    parent_fd: int
+    parent_device: int
+    parent_inode: int
+    existing_parent_relative: Path
+    missing_parent_parts: tuple[str, ...]
+    destination_version: tuple[int, int, int, int, int] | None
+    destination_fd: int
+    destination_sha256: str | None
+    destination_mode: int | None
+    overwrite: bool
+
+    def close(self) -> None:
+        if self.destination_fd >= 0:
+            os.close(self.destination_fd)
+            self.destination_fd = -1
+        if self.parent_fd >= 0:
+            os.close(self.parent_fd)
+            self.parent_fd = -1
+
+    def __enter__(self) -> PreparedArtifactTarget:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def publish(self, content: str) -> ArtifactPublication:
+        raw = content.encode("utf-8", errors="strict")
+        if not raw:
+            raise ValueError("artifact generation returned empty content")
+        if len(raw) > MAX_ARTIFACT_BYTES:
+            raise ValueError(
+                f"artifact content exceeds {MAX_ARTIFACT_BYTES} bytes: {len(raw)}"
+            )
+        generated_sha256 = hashlib.sha256(raw).hexdigest()
+        if self.missing_parent_parts:
+            return self._publish_with_new_parents(raw)
+        self._attest_parent_and_destination()
+        basename = self.relative_path.name
+        replacing_existing = self.destination_version is not None
+        temp_name: str | None = None
+        temp_fd = -1
+        unnamed_temp = False
+        temp_cleanup_safe = False
+        published_new_file = False
+        directory_sync_complete = True
+        try:
+            temp_fd, temp_name, unnamed_temp = _open_private_artifact_temp(self.parent_fd)
+            temp_cleanup_safe = temp_name is not None
+            _write_all(temp_fd, raw)
+            if replacing_existing:
+                assert self.destination_mode is not None
+                os.fchmod(temp_fd, self.destination_mode)
+            os.fsync(temp_fd)
+            generated_identity = _file_identity(os.fstat(temp_fd))
+            self._attest_parent_and_destination()
+            if unnamed_temp:
+                link_name = (
+                    f"{_TEMP_PREFIX}{secrets.token_hex(16)}.tmp"
+                    if replacing_existing
+                    else basename
+                )
+                try:
+                    os.link(
+                        f"/proc/self/fd/{temp_fd}",
+                        link_name,
+                        dst_dir_fd=self.parent_fd,
+                        follow_symlinks=True,
+                    )
+                except OSError as exc:
+                    if exc.errno not in _UNSUPPORTED_TMPFILE_ERRNOS:
+                        raise
+                    os.close(temp_fd)
+                    temp_fd = -1
+                    temp_fd, temp_name = _open_named_artifact_temp(self.parent_fd)
+                    unnamed_temp = False
+                    temp_cleanup_safe = True
+                    _write_all(temp_fd, raw)
+                    if replacing_existing:
+                        assert self.destination_mode is not None
+                        os.fchmod(temp_fd, self.destination_mode)
+                    os.fsync(temp_fd)
+                    generated_identity = _file_identity(os.fstat(temp_fd))
+                    self._attest_parent_and_destination()
+                else:
+                    temp_name = link_name if replacing_existing else None
+                    published_new_file = not replacing_existing
+            if replacing_existing:
+                assert temp_name is not None and self.destination_version is not None
+                _rename_exchange(
+                    old_dir_fd=self.parent_fd,
+                    old_name=temp_name,
+                    new_dir_fd=self.parent_fd,
+                    new_name=basename,
+                )
+                temp_cleanup_safe = False
+                try:
+                    replaced_version = _file_version(
+                        os.stat(temp_name, dir_fd=self.parent_fd, follow_symlinks=False)
+                    )
+                    published_identity = _file_identity(
+                        os.stat(basename, dir_fd=self.parent_fd, follow_symlinks=False)
+                    )
+                    held_destination = os.fstat(self.destination_fd)
+                    held_identity = _file_identity(held_destination)
+                    held_sha256 = _sha256_fd(self.destination_fd)
+                    self._attest_existing_parent()
+                    if (
+                        _file_identity_from_version(self.destination_version) != held_identity
+                        or _file_identity_from_version(replaced_version) != held_identity
+                        or held_sha256 != self.destination_sha256
+                        or published_identity != generated_identity
+                    ):
+                        raise ValueError("artifact destination changed during atomic overwrite")
+                except BaseException:
+                    if _rollback_artifact_overwrite(
+                        parent_fd=self.parent_fd,
+                        temp_name=temp_name,
+                        basename=basename,
+                        generated_identity=generated_identity,
+                        destination_fd=self.destination_fd,
+                    ):
+                        temp_cleanup_safe = True
+                    else:
+                        # The private name may hold displaced user data. Preserve
+                        # it rather than guessing which concurrent entry is safe.
+                        temp_name = None
+                    raise
+                directory_sync_complete = _try_fsync(self.parent_fd)
+                os.unlink(temp_name, dir_fd=self.parent_fd)
+                temp_name = None
+                temp_cleanup_safe = False
+                directory_sync_complete = _try_fsync(self.parent_fd) and directory_sync_complete
+            elif not unnamed_temp:
+                assert temp_name is not None
+                _commit_named_file_noreplace(
+                    old_dir_fd=self.parent_fd,
+                    old_name=temp_name,
+                    new_dir_fd=self.parent_fd,
+                    new_name=basename,
+                )
+                temp_name = None
+                temp_cleanup_safe = False
+                published_new_file = True
+                directory_sync_complete = _try_fsync(self.parent_fd)
+            elif not replacing_existing:
+                directory_sync_complete = _try_fsync(self.parent_fd)
+            try:
+                _attest_published_artifact(
+                    self.parent_fd,
+                    basename,
+                    expected_identity=generated_identity,
+                    expected_sha256=generated_sha256,
+                )
+                self._attest_existing_parent()
+            except BaseException:
+                if published_new_file:
+                    _retract_published_file(
+                        parent_fd=self.parent_fd,
+                        basename=basename,
+                        expected_identity=generated_identity,
+                        expected_sha256=generated_sha256,
+                    )
+                    published_new_file = False
+                raise
+        except FileExistsError as exc:
+            raise ValueError(f"artifact destination already exists: {self.relative_path}") from exc
+        finally:
+            if temp_fd >= 0:
+                os.close(temp_fd)
+            if temp_name is not None and temp_cleanup_safe:
+                try:
+                    os.unlink(temp_name, dir_fd=self.parent_fd)
+                except FileNotFoundError:
+                    pass
+        return ArtifactPublication(
+            path=self.relative_path.as_posix(),
+            bytes_written=len(raw),
+            sha256=generated_sha256,
+            overwrite=replacing_existing,
+            directory_sync_complete=directory_sync_complete,
+        )
+
+    def _publish_with_new_parents(self, raw: bytes) -> ArtifactPublication:
+        self._attest_existing_parent()
+        top_name = self.missing_parent_parts[0]
+        try:
+            os.stat(top_name, dir_fd=self.parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise ValueError("artifact parent path changed before atomic publication")
+
+        stage_name = f"{_TEMP_PREFIX}{secrets.token_hex(16)}.tmp"
+        os.mkdir(stage_name, 0o700, dir_fd=self.parent_fd)
+        directory_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        dir_fds: list[int] = []
+        file_fd = -1
+        published = False
+        directory_sync_complete = True
+        try:
+            stage_fd = os.open(stage_name, directory_flags, dir_fd=self.parent_fd)
+            dir_fds.append(stage_fd)
+            current_fd = stage_fd
+            for part in self.missing_parent_parts[1:]:
+                os.mkdir(part, 0o755, dir_fd=current_fd)
+                try:
+                    next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+                except BaseException:
+                    try:
+                        os.rmdir(part, dir_fd=current_fd)
+                    except OSError:
+                        pass
+                    raise
+                dir_fds.append(next_fd)
+                os.fchmod(next_fd, 0o755)
+                os.fsync(current_fd)
+                current_fd = next_fd
+            file_fd = os.open(
+                self.relative_path.name,
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=current_fd,
+            )
+            _write_all(file_fd, raw)
+            os.fsync(file_fd)
+            generated_sha256 = _sha256_fd(file_fd)
+            if generated_sha256 != hashlib.sha256(raw).hexdigest():
+                raise ValueError("artifact changed before atomic parent publication")
+            os.fsync(current_fd)
+            self._attest_existing_parent()
+            try:
+                os.stat(top_name, dir_fd=self.parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise ValueError("artifact parent path changed before atomic publication")
+            os.fchmod(stage_fd, 0o755)
+            os.fsync(stage_fd)
+            _rename_noreplace(
+                old_dir_fd=self.parent_fd,
+                old_name=stage_name,
+                new_dir_fd=self.parent_fd,
+                new_name=top_name,
+            )
+            published = True
+            try:
+                directory_sync_complete = _try_fsync(self.parent_fd)
+                _attest_published_artifact_path(
+                    self.parent_fd,
+                    self.missing_parent_parts,
+                    self.relative_path.name,
+                    expected_identity=_file_identity(os.fstat(file_fd)),
+                    expected_sha256=generated_sha256,
+                )
+                self._attest_existing_parent()
+            except BaseException:
+                try:
+                    _attest_published_artifact_path(
+                        self.parent_fd,
+                        self.missing_parent_parts,
+                        self.relative_path.name,
+                        expected_identity=_file_identity(os.fstat(file_fd)),
+                        expected_sha256=generated_sha256,
+                    )
+                except ValueError:
+                    # Preserve a tree whose content or identity was changed by
+                    # another actor; it is no longer safe for Orbit to remove.
+                    pass
+                else:
+                    _retract_published_directory(
+                        parent_fd=self.parent_fd,
+                        published_name=top_name,
+                        private_name=stage_name,
+                        expected_directory_fd=stage_fd,
+                    )
+                    published = False
+                raise
+        finally:
+            if not published:
+                if file_fd >= 0 and dir_fds:
+                    try:
+                        os.unlink(self.relative_path.name, dir_fd=dir_fds[-1])
+                    except FileNotFoundError:
+                        pass
+                for index in range(len(dir_fds) - 1, 0, -1):
+                    os.close(dir_fds[index])
+                    try:
+                        os.rmdir(self.missing_parent_parts[index], dir_fd=dir_fds[index - 1])
+                    except OSError:
+                        pass
+                if dir_fds:
+                    os.close(dir_fds[0])
+                try:
+                    os.rmdir(stage_name, dir_fd=self.parent_fd)
+                except OSError:
+                    pass
+            else:
+                for directory_fd in reversed(dir_fds):
+                    os.close(directory_fd)
+            if file_fd >= 0:
+                os.close(file_fd)
+
+        created: list[str] = []
+        current = self.existing_parent_relative
+        for part in self.missing_parent_parts:
+            current = current / part
+            created.append(current.as_posix())
+        return ArtifactPublication(
+            path=self.relative_path.as_posix(),
+            bytes_written=len(raw),
+            sha256=hashlib.sha256(raw).hexdigest(),
+            overwrite=False,
+            created_parent_directories=tuple(created),
+            directory_sync_complete=directory_sync_complete,
+        )
+
+    def _attest_existing_parent(self) -> None:
+        opened_parent = os.fstat(self.parent_fd)
+        if (
+            opened_parent.st_dev,
+            opened_parent.st_ino,
+        ) != (self.parent_device, self.parent_inode) or not _directory_path_matches(
+            self.workdir,
+            self.existing_parent_relative,
+            expected_device=self.parent_device,
+            expected_inode=self.parent_inode,
+        ):
+            raise ValueError("artifact parent directory changed during generation")
+
+    def _attest_parent_and_destination(self) -> None:
+        self._attest_existing_parent()
+        try:
+            current = os.stat(
+                self.relative_path.name,
+                dir_fd=self.parent_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            current_version = None
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise ValueError("artifact destination is not a regular file")
+            current_version = _file_version(current)
+        if current_version != self.destination_version:
+            raise ValueError("artifact destination changed during generation")
+
+
+def prepare_artifact_target(
+    path: object,
+    *,
+    overwrite: object,
+    create_parents: object = False,
+    workdir: Path,
+) -> PreparedArtifactTarget:
+    error = validate_artifact_path(path, workdir=workdir)
+    if error:
+        raise ValueError(error.removeprefix("error: "))
+    if not isinstance(overwrite, bool):
+        raise ValueError("artifact overwrite must be a boolean")
+    if not isinstance(create_parents, bool):
+        raise ValueError("artifact create_parents must be a boolean")
+    assert isinstance(path, str)
+    root = workdir.expanduser().resolve()
+    relative = Path(os.path.abspath(root / path)).relative_to(root)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    parent_fd = os.open(root, directory_flags)
+    destination_fd = -1
+    existing_parent_parts: list[str] = []
+    missing_parent_parts: tuple[str, ...] = ()
+    try:
+        for index, part in enumerate(relative.parts[:-1]):
+            try:
+                next_fd = os.open(part, directory_flags, dir_fd=parent_fd)
+            except FileNotFoundError:
+                if not create_parents:
+                    raise ValueError(f"artifact parent directory does not exist: {relative.parent.as_posix()}")
+                missing_parent_parts = tuple(relative.parts[index:-1])
+                break
+            os.close(parent_fd)
+            parent_fd = next_fd
+            existing_parent_parts.append(part)
+        parent_stat = os.fstat(parent_fd)
+        if missing_parent_parts:
+            destination_version = None
+            destination_sha256 = None
+            destination_mode = None
+        else:
+            try:
+                destination = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                destination_version = None
+                destination_mode = None
+            else:
+                if not stat.S_ISREG(destination.st_mode):
+                    raise ValueError("artifact destination is not a regular file")
+                if not overwrite:
+                    raise ValueError(f"artifact destination already exists: {relative.as_posix()}")
+                destination_version = _file_version(destination)
+                if destination.st_size > MAX_ARTIFACT_BYTES:
+                    raise ValueError(
+                        f"existing artifact exceeds {MAX_ARTIFACT_BYTES} bytes"
+                    )
+                destination_fd = os.open(
+                    relative.name,
+                    os.O_RDONLY
+                    | getattr(os, "O_CLOEXEC", 0)
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_NONBLOCK", 0),
+                    dir_fd=parent_fd,
+                )
+                opened_destination = os.fstat(destination_fd)
+                if not stat.S_ISREG(opened_destination.st_mode):
+                    raise ValueError("artifact destination is not a regular file")
+                if _file_version(opened_destination) != destination_version:
+                    raise ValueError("artifact destination changed during preparation")
+                destination_mode = stat.S_IMODE(opened_destination.st_mode) & 0o777
+                existing_raw = _read_fd(destination_fd, MAX_ARTIFACT_BYTES)
+                existing_raw.decode("utf-8", errors="strict")
+                destination_sha256 = hashlib.sha256(existing_raw).hexdigest()
+            if destination_version is None:
+                destination_sha256 = None
+                destination_mode = None
+        return PreparedArtifactTarget(
+            workdir=root,
+            relative_path=relative,
+            parent_fd=parent_fd,
+            parent_device=parent_stat.st_dev,
+            parent_inode=parent_stat.st_ino,
+            existing_parent_relative=Path(*existing_parent_parts),
+            missing_parent_parts=missing_parent_parts,
+            destination_version=destination_version,
+            destination_fd=destination_fd,
+            destination_sha256=destination_sha256,
+            destination_mode=destination_mode,
+            overwrite=overwrite,
+        )
+    except BaseException:
+        if destination_fd >= 0:
+            os.close(destination_fd)
+        os.close(parent_fd)
+        raise
+
+
+def begin_artifact_generation(
+    *,
+    backend: Any,
+    user_request: str,
+    path: str,
+    overwrite: bool,
+    create_parents: bool,
+    workdir: Path,
+    temperature: float,
+    on_progress: Callable[[StreamProgress], None] | None,
+) -> PendingArtifact:
+    generate = getattr(backend, "artifact_content_stream", None)
+    if not callable(generate):
+        raise RuntimeError("artifact content generation requires the native Orbit backend")
+    target = prepare_artifact_target(
+        path,
+        overwrite=overwrite,
+        create_parents=create_parents,
+        workdir=workdir,
+    )
+    try:
+        messages = artifact_content_messages(
+            user_request=user_request,
+            path=target.relative_path.as_posix(),
+            overwrite=overwrite,
+        )
+        result = generate(
+            messages,
+            temperature=temperature,
+            max_tokens=ARTIFACT_CONTENT_MAX_TOKENS,
+            on_delta=lambda _text: None,
+            on_progress=on_progress,
+        )
+        if result.finish_reason != "stop":
+            raise ArtifactGenerationError(
+                f"artifact content was not published: finish_reason={result.finish_reason or 'unknown'}",
+                result=result,
+            )
+        if result.tool_calls or result.reasoning_content:
+            raise ArtifactGenerationError(
+                "artifact content was not published: unexpected structured model output",
+                result=result,
+            )
+        if (
+            isinstance(result.completion_tokens, int)
+            and result.completion_tokens > ARTIFACT_CONTENT_MAX_TOKENS
+        ):
+            raise ArtifactGenerationError(
+                "artifact content was not published: output token limit exceeded",
+                result=result,
+            )
+        try:
+            raw = result.content.encode("utf-8", errors="strict")
+            if not raw:
+                raise ValueError("artifact generation returned empty content")
+            if len(raw) > MAX_ARTIFACT_BYTES:
+                raise ValueError(
+                    f"artifact content exceeds {MAX_ARTIFACT_BYTES} bytes: {len(raw)}"
+                )
+        except (UnicodeError, ValueError) as exc:
+            raise ArtifactGenerationError(
+                f"artifact content failed validation: {exc}",
+                result=result,
+            ) from exc
+        return PendingArtifact(
+            target=target,
+            generation=result,
+            content=result.content,
+            raw=raw,
+        )
+    except BaseException:
+        target.close()
+        raise
+
+
+def _verify_artifact_bytes(
+    raw: bytes,
+    *,
+    check: object,
+) -> tuple[str, list[str]]:
+    if check not in {
+        "content",
+        "text_integrity",
+    }:
+        raise ValueError("artifact verification check is invalid")
+    text = raw.decode("utf-8", errors="strict")
+    detail = "UTF-8 content, byte count, and SHA-256 are valid."
+    content_lines: list[str] = []
+    if check == "content":
+        content_lines = [
+            "content_coverage: "
+            + ("complete" if len(raw) <= MAX_ARTIFACT_VERIFICATION_CHARS else "partial"),
+            "content:",
+            _bounded_verification_text(text, MAX_ARTIFACT_VERIFICATION_CHARS),
+        ]
+    return detail, content_lines
+
+
+def _write_all(fd: int, raw: bytes) -> None:
+    view = memoryview(raw)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("short artifact write")
+        view = view[written:]
+
+
+def _try_fsync(fd: int) -> bool:
+    try:
+        os.fsync(fd)
+    except OSError:
+        return False
+    return True
+
+
+def _bounded_verification_text(text: str, maximum: int) -> str:
+    raw = text.encode("utf-8")
+    if len(raw) <= maximum:
+        return text
+    head_limit = max(0, (maximum * 2) // 3)
+    tail_limit = max(0, maximum - head_limit)
+    head = raw[:head_limit].decode("utf-8", errors="ignore")
+    tail = raw[-tail_limit:].decode("utf-8", errors="ignore") if tail_limit else ""
+    return f"{head}\n[verification content truncated]\n{tail}"
+
+
+def _file_version(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns)
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_size)
+
+
+def _file_identity_from_version(value: tuple[int, int, int, int, int]) -> tuple[int, int, int]:
+    return value[:3]
+
+
+def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _rollback_artifact_overwrite(
+    *,
+    parent_fd: int,
+    temp_name: str,
+    basename: str,
+    generated_identity: tuple[int, int, int],
+    destination_fd: int,
+) -> bool:
+    """Restore the entry displaced by the generated inode without deleting either."""
+
+    del destination_fd
+    try:
+        published = os.stat(basename, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    if (published.st_dev, published.st_ino, published.st_size) != generated_identity:
+        return False
+    try:
+        _rename_exchange(
+            old_dir_fd=parent_fd,
+            old_name=temp_name,
+            new_dir_fd=parent_fd,
+            new_name=basename,
+        )
+        private = os.stat(temp_name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    return (
+        private.st_dev,
+        private.st_ino,
+        private.st_size,
+    ) == generated_identity
+
+
+def _retract_published_file(
+    *,
+    parent_fd: int,
+    basename: str,
+    expected_identity: tuple[int, int, int],
+    expected_sha256: str,
+) -> None:
+    """Remove only exact, unmodified generated content after privatizing it."""
+
+    private_name = f"{_TEMP_PREFIX}{secrets.token_hex(16)}.rollback"
+    try:
+        _rename_noreplace(
+            old_dir_fd=parent_fd,
+            old_name=basename,
+            new_dir_fd=parent_fd,
+            new_name=private_name,
+        )
+    except OSError as exc:
+        raise ValueError("artifact publication rollback failed safely") from exc
+    try:
+        _attest_published_artifact(
+            parent_fd,
+            private_name,
+            expected_identity=expected_identity,
+            expected_sha256=expected_sha256,
+        )
+    except (OSError, ValueError):
+        try:
+            _rename_noreplace(
+                old_dir_fd=parent_fd,
+                old_name=private_name,
+                new_dir_fd=parent_fd,
+                new_name=basename,
+            )
+        except OSError as exc:
+            raise ValueError(
+                "artifact path changed and unrelated entry was preserved under a private name"
+            ) from exc
+        raise ValueError("artifact destination changed after atomic publication")
+    os.unlink(private_name, dir_fd=parent_fd)
+    _try_fsync(parent_fd)
+
+
+def _retract_published_directory(
+    *,
+    parent_fd: int,
+    published_name: str,
+    private_name: str,
+    expected_directory_fd: int,
+) -> None:
+    """Move an exact Orbit-created tree back to its private staging name."""
+
+    try:
+        _rename_noreplace(
+            old_dir_fd=parent_fd,
+            old_name=published_name,
+            new_dir_fd=parent_fd,
+            new_name=private_name,
+        )
+    except OSError as exc:
+        raise ValueError("artifact parent publication rollback failed safely") from exc
+    moved = os.stat(private_name, dir_fd=parent_fd, follow_symlinks=False)
+    expected = os.fstat(expected_directory_fd)
+    if not stat.S_ISDIR(moved.st_mode) or not _same_inode(moved, expected):
+        try:
+            _rename_noreplace(
+                old_dir_fd=parent_fd,
+                old_name=private_name,
+                new_dir_fd=parent_fd,
+                new_name=published_name,
+            )
+        except OSError as exc:
+            raise ValueError(
+                "artifact parent path changed and unrelated tree was preserved under a private name"
+            ) from exc
+        raise ValueError("artifact parent path changed after atomic publication")
+
+
+def _read_fd(fd: int, maximum: int) -> bytes:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = os.read(fd, min(64 * 1024, maximum + 1 - total))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > maximum:
+            raise ValueError(f"artifact content exceeds {maximum} bytes")
+    os.lseek(fd, 0, os.SEEK_SET)
+    return b"".join(chunks)
+
+
+def _sha256_fd(fd: int) -> str:
+    return hashlib.sha256(_read_fd(fd, MAX_ARTIFACT_BYTES)).hexdigest()
+
+
+def _attest_published_artifact(
+    parent_fd: int,
+    basename: str,
+    *,
+    expected_identity: tuple[int, int, int],
+    expected_sha256: str,
+) -> None:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        fd = os.open(basename, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise ValueError("artifact destination changed after atomic publication") from exc
+    try:
+        current = os.fstat(fd)
+        if not stat.S_ISREG(current.st_mode):
+            raise ValueError("artifact destination changed after atomic publication")
+        version_before_read = _file_version(current)
+        digest = _sha256_fd(fd)
+        version_after_read = _file_version(os.fstat(fd))
+        path_version = _file_version(
+            os.stat(basename, dir_fd=parent_fd, follow_symlinks=False)
+        )
+        if (
+            _file_identity(current) != expected_identity
+            or digest != expected_sha256
+            or version_before_read != version_after_read
+            or path_version != version_after_read
+        ):
+            raise ValueError("artifact destination changed after atomic publication")
+    except OSError as exc:
+        raise ValueError("artifact destination changed after atomic publication") from exc
+    finally:
+        os.close(fd)
+
+
+def _attest_published_artifact_path(
+    parent_fd: int,
+    directory_parts: tuple[str, ...],
+    basename: str,
+    *,
+    expected_identity: tuple[int, int, int],
+    expected_sha256: str,
+) -> None:
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    opened_fds = [os.dup(parent_fd)]
+    edges: list[tuple[int, str, tuple[int, int]]] = []
+    try:
+        for part in directory_parts:
+            next_fd = os.open(part, directory_flags, dir_fd=opened_fds[-1])
+            current = os.fstat(next_fd)
+            identity = (current.st_dev, current.st_ino)
+            edges.append((opened_fds[-1], part, identity))
+            opened_fds.append(next_fd)
+        _attest_published_artifact(
+            opened_fds[-1],
+            basename,
+            expected_identity=expected_identity,
+            expected_sha256=expected_sha256,
+        )
+        for ancestor_fd, name, expected in reversed(edges):
+            current = os.stat(name, dir_fd=ancestor_fd, follow_symlinks=False)
+            if not stat.S_ISDIR(current.st_mode) or (current.st_dev, current.st_ino) != expected:
+                raise ValueError("artifact parent path changed after atomic publication")
+    except OSError as exc:
+        raise ValueError("artifact parent path changed after atomic publication") from exc
+    finally:
+        for fd in reversed(opened_fds):
+            os.close(fd)
+
+
+def _directory_path_matches(
+    root: Path,
+    relative: Path,
+    *,
+    expected_device: int,
+    expected_inode: int,
+) -> bool:
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    current_fd = -1
+    try:
+        current_fd = os.open(root, directory_flags)
+        for part in relative.parts:
+            next_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        current = os.fstat(current_fd)
+        return (current.st_dev, current.st_ino) == (expected_device, expected_inode)
+    except OSError:
+        return False
+    finally:
+        if current_fd >= 0:
+            os.close(current_fd)
+
+
+def _rename_noreplace(
+    *,
+    old_dir_fd: int,
+    old_name: str,
+    new_dir_fd: int,
+    new_name: str,
+) -> None:
+    _renameat2(
+        old_dir_fd=old_dir_fd,
+        old_name=old_name,
+        new_dir_fd=new_dir_fd,
+        new_name=new_name,
+        flags=1,  # RENAME_NOREPLACE
+    )
+
+
+def _commit_named_file_noreplace(
+    *,
+    old_dir_fd: int,
+    old_name: str,
+    new_dir_fd: int,
+    new_name: str,
+) -> None:
+    try:
+        _rename_noreplace(
+            old_dir_fd=old_dir_fd,
+            old_name=old_name,
+            new_dir_fd=new_dir_fd,
+            new_name=new_name,
+        )
+        return
+    except OSError as exc:
+        if exc.errno not in _UNSUPPORTED_RENAME_NOREPLACE_ERRNOS:
+            raise
+    source_fd = os.open(
+        old_name,
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0),
+        dir_fd=old_dir_fd,
+    )
+    try:
+        source = os.fstat(source_fd)
+        if not stat.S_ISREG(source.st_mode):
+            raise ValueError("artifact temporary file is not regular")
+        expected_identity = _file_identity(source)
+        expected_sha256 = _sha256_fd(source_fd)
+    finally:
+        os.close(source_fd)
+    os.link(
+        old_name,
+        new_name,
+        src_dir_fd=old_dir_fd,
+        dst_dir_fd=new_dir_fd,
+        follow_symlinks=False,
+    )
+    try:
+        os.unlink(old_name, dir_fd=old_dir_fd)
+    except BaseException:
+        _retract_published_file(
+            parent_fd=new_dir_fd,
+            basename=new_name,
+            expected_identity=expected_identity,
+            expected_sha256=expected_sha256,
+        )
+        raise
+
+
+def _rename_exchange(
+    *,
+    old_dir_fd: int,
+    old_name: str,
+    new_dir_fd: int,
+    new_name: str,
+) -> None:
+    _renameat2(
+        old_dir_fd=old_dir_fd,
+        old_name=old_name,
+        new_dir_fd=new_dir_fd,
+        new_name=new_name,
+        flags=2,  # RENAME_EXCHANGE
+    )
+
+
+def _renameat2(
+    *,
+    old_dir_fd: int,
+    old_name: str,
+    new_dir_fd: int,
+    new_name: str,
+    flags: int,
+) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        raise OSError(errno.ENOTSUP, "atomic artifact publication requires renameat2")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        old_dir_fd,
+        os.fsencode(old_name),
+        new_dir_fd,
+        os.fsencode(new_name),
+        flags,
+    )
+    if result != 0:
+        code = ctypes.get_errno()
+        raise OSError(code, os.strerror(code), new_name)

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1110,7 +1110,6 @@ class ChatRuntime:
             "web_search",
             "fetch",
             "artifact",
-            "artifact_pending",
             "artifact_verification",
             "artifact_error",
         }:

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -650,7 +650,14 @@ class ChatRuntime:
         tools = decision_tool_names(decision, prompt)
         if allowed_tool_names is not None:
             allowed = set(allowed_tool_names)
-            tools = tuple(tool for tool in tools if tool in allowed)
+            artifact_workflow = "write_artifact" in tools and "write_artifact" in allowed
+            tools = tuple(
+                tool
+                for tool in tools
+                if tool in allowed
+            )
+            if artifact_workflow:
+                tools = (*tools, "verify_artifact")
             if (
                 not tools
                 and decision.route in {ToolRoute.FILESYSTEM, ToolRoute.FILE_EDIT, ToolRoute.WEB}
@@ -1099,7 +1106,14 @@ class ChatRuntime:
         record = next(iter(self.evidence_store.recent_records(1)), None)
         if record is None:
             return False
-        if record.kind in {"web_search", "fetch"}:
+        if record.kind in {
+            "web_search",
+            "fetch",
+            "artifact",
+            "artifact_pending",
+            "artifact_verification",
+            "artifact_error",
+        }:
             return False
         return record.raw_chars >= FINAL_FROM_TOOL_COMPACT_MIN_RAW_CHARS
 

--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -15,6 +15,7 @@ FETCH_URL_TOOL_ALIASES = {"fetch_url"}
 LIST_DIRECTORY_TOOL_ALIASES = {"list_directory"}
 LIST_DIRECTORY_KEYS = ("path", "recursive", "max_depth", "max_entries", "include_hidden", "dirs_first", "files_only", "dirs_only")
 SYSTEM_INFO_TOOL_ALIASES = {"system_info"}
+ARTIFACT_TOOL_ALIASES = {"write_artifact"}
 SYSTEM_INFO_KEYS = ("include_disks", "include_cpu", "include_memory", "include_os", "include_runtime", "include_gpu", "human_readable")
 
 
@@ -105,6 +106,8 @@ def _canonical_route_reason(text: str) -> str | None:
         return "canonical_chat"
     if keys == {"command"} and _nonempty_string(value.get("command")):
         return "canonical_command"
+    if _has_artifact_request(value):
+        return "canonical_artifact"
     if keys == {"url"} and _nonempty_string(value.get("url")):
         return "canonical_url"
     if keys and keys <= set(LIST_DIRECTORY_KEYS) and _canonical_list_directory(value):
@@ -147,7 +150,7 @@ def _nonempty_string(value: Any) -> bool:
 def _looks_like_route_syntax(text: str) -> bool:
     if text.startswith(("{", "[", "```", "<|tool_call>")):
         return True
-    return any(marker in text for marker in ('{"route"', '{"command"', '{"url"', '{"path"', '{"include_'))
+    return any(marker in text for marker in ('{"route"', '{"command"', '{"url"', '{"path"', '{"include_', '{"tool"'))
 
 
 def parse_tool_command(content: str) -> ToolRoute | None:
@@ -164,6 +167,10 @@ def parse_command_decision_from_tool_calls(tool_calls: list[dict[str, Any]]) -> 
         if not isinstance(name, str):
             continue
         args = parse_tool_arguments_or_empty(function.get("arguments"))
+        if name in ARTIFACT_TOOL_ALIASES:
+            # Preserve the selected capability so malformed artifact arguments
+            # reach its canonical contract instead of becoming a shell call.
+            return RouteDecision(ToolRoute.FILESYSTEM, ("write_artifact",))
         if _has_command(args) or name in SHELL_TOOL_ALIASES:
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
         if name in WEB_SEARCH_TOOL_ALIASES and _web_search_command_from_args(args):
@@ -182,7 +189,7 @@ def command_tool_call_from_tool_calls(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info", "write_artifact"} & allowed):
         return None
     for tool_call in tool_calls:
         function = tool_call.get("function")
@@ -193,6 +200,12 @@ def command_tool_call_from_tool_calls(
             continue
         raw_arguments = function.get("arguments")
         args = parse_tool_arguments_or_empty(raw_arguments)
+        if name in ARTIFACT_TOOL_ALIASES:
+            if "write_artifact" not in allowed:
+                return None
+            # Return the exact call, including malformed arguments, so the
+            # canonical artifact schema can reject it without tool substitution.
+            return tool_call
         parsed_valid_command = _has_command(args)
         if not parsed_valid_command and isinstance(raw_arguments, str):
             args = _extract_loose_command_object(raw_arguments) or _extract_last_json_object(raw_arguments) or {}
@@ -230,7 +243,7 @@ def command_tool_call_from_content(
     allowed_tool_names: tuple[str, ...],
 ) -> dict[str, Any] | None:
     allowed = set(allowed_tool_names)
-    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info"} & allowed):
+    if not ({"exec_shell_full_command", "fetch_url", "list_directory", "system_info", "write_artifact"} & allowed):
         return None
     raw_command = _extract_raw_tool_call_command(content)
     if raw_command:
@@ -253,6 +266,8 @@ def command_tool_call_from_content(
             return None
         return _tool_call("system_info", raw_system_info)
     value = _parse_command_json_object(content) or _extract_last_json_object(content) or _extract_loose_command_object(content)
+    if _has_artifact_request(value) and "write_artifact" in allowed:
+        return _tool_call("write_artifact", _artifact_args(value["arguments"]))
     if not _has_command(value):
         if _has_url(value) and "fetch_url" in allowed:
             return _tool_call("fetch_url", {"url": value["url"]})
@@ -279,6 +294,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
     if _parse_raw_tool_call_decision(text) is not None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
     value = _parse_command_json_object(text)
+    if _has_artifact_request(value):
+        return RouteDecision(ToolRoute.FILESYSTEM, ("write_artifact",))
     if _has_command(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     if _has_url(value):
@@ -293,6 +310,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
     for line in text.splitlines():
         value = _parse_command_json_object(_strip_json_fence(line.strip()))
+        if _has_artifact_request(value):
+            return RouteDecision(ToolRoute.FILESYSTEM, ("write_artifact",))
         if _has_command(value):
             return RouteDecision(ToolRoute.FILESYSTEM, ("exec_shell_full_command",))
         if _has_url(value):
@@ -322,6 +341,7 @@ def command_stream_state(text: str, *, max_prefix_chars: int = ROUTE_STREAM_PREF
         or _is_partial_prefix(stripped, '{"path"')
         or _is_partial_prefix(stripped, '{"include_')
         or _is_partial_prefix(stripped, '{"route"')
+        or _is_partial_prefix(stripped, '{"tool"')
     ):
         return "pending"
     if stripped.startswith("<|tool_call>"):
@@ -334,6 +354,7 @@ def command_stream_state(text: str, *, max_prefix_chars: int = ROUTE_STREAM_PREF
         or stripped.startswith('{"path"')
         or stripped.startswith('{"include_')
         or stripped.startswith('{"route"')
+        or stripped.startswith('{"tool"')
     ):
         if _looks_like_complete_json_object(stripped):
             return "route" if parse_tool_command(stripped) is not None else "not_command"
@@ -389,14 +410,30 @@ class CommandStreamFilter:
 def tool_names_for_decision(route: ToolRoute, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if route == ToolRoute.FILESYSTEM:
-        return ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
+        return (
+            "exec_shell_full_command",
+            "fetch_url",
+            "list_directory",
+            "system_info",
+        )
     return ()
 
 
 def decision_tool_names(decision: RouteDecision, prompt: str | None = None) -> tuple[str, ...]:
     del prompt
     if decision.tool_names:
-        return tuple(name for name in decision.tool_names if name in {"exec_shell_full_command", "fetch_url", "list_directory", "system_info"})
+        return tuple(
+            name
+            for name in decision.tool_names
+            if name
+            in {
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            }
+        )
     return tool_names_for_decision(decision.route)
 
 
@@ -548,10 +585,44 @@ def _system_info_args(value: dict[str, Any]) -> dict[str, Any]:
     return {key: value[key] for key in SYSTEM_INFO_KEYS if key in value}
 
 
+def _has_artifact_request(value: dict[str, Any] | None) -> bool:
+    if not isinstance(value, dict) or set(value) != {"tool", "arguments"}:
+        return False
+    return value.get("tool") == "write_artifact" and _valid_artifact_args(value.get("arguments"))
+
+
+def _valid_artifact_args(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if not set(value).issubset({"path", "overwrite", "create_parents"}):
+        return False
+    path = value.get("path")
+    if not isinstance(path, str) or not path.strip():
+        return False
+    return all(
+        key not in value or isinstance(value[key], bool)
+        for key in ("overwrite", "create_parents")
+    )
+
+
+def _artifact_args(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value[key]
+        for key in ("path", "overwrite", "create_parents")
+        if key in value
+    }
+
+
 def _has_chat_route(value: dict[str, Any] | None) -> bool:
     if not isinstance(value, dict):
         return False
-    if _has_command(value) or _has_url(value) or _has_list_directory_args(value) or _has_system_info_args(value):
+    if (
+        _has_command(value)
+        or _has_url(value)
+        or _has_list_directory_args(value)
+        or _has_system_info_args(value)
+        or _has_artifact_request(value)
+    ):
         return False
     route = value.get("route")
     return isinstance(route, str) and route.strip().upper() == ToolRoute.CHAT.value
@@ -575,8 +646,8 @@ def _parse_command_json_object(content: str) -> dict[str, Any] | None:
     if not text:
         return None
     try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
+        parsed = json.loads(text, object_pairs_hook=_unique_json_object)
+    except (json.JSONDecodeError, _DuplicateJsonKey):
         return None
     return parsed if isinstance(parsed, dict) else None
 
@@ -586,8 +657,8 @@ def _extract_last_json_object(content: str) -> dict[str, Any] | None:
     for candidate in reversed(matches):
         normalized = re.sub(r'([,{]\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:', r'\1"\2":', candidate)
         try:
-            parsed = json.loads(normalized)
-        except json.JSONDecodeError:
+            parsed = json.loads(normalized, object_pairs_hook=_unique_json_object)
+        except (json.JSONDecodeError, _DuplicateJsonKey):
             continue
         if isinstance(parsed, dict):
             return parsed

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -135,7 +135,10 @@ class EvidenceStore:
         ephemeral_ids = [
             record.evidence_id
             for record in self.records.values()
-            if record.metadata.get("ephemeral") == "full_document_snapshot"
+            if record.metadata.get("ephemeral") in {
+                "full_document_snapshot",
+                "artifact_pending",
+            }
         ]
         for evidence_id in ephemeral_ids:
             self.discard(evidence_id)
@@ -430,6 +433,14 @@ def _optional_int(value: object) -> int | None:
 
 def _classify_kind(tool_name: str, content: str, metadata: dict[str, object]) -> str:
     command = str(metadata.get("command") or "")
+    if tool_name == "write_artifact" and content.lstrip().lower().startswith("error:"):
+        return "artifact_error"
+    if tool_name == "write_artifact" and "artifact_publication: complete" in content:
+        return "artifact"
+    if tool_name == "write_artifact" and "artifact_generation: complete" in content:
+        return "artifact_pending"
+    if tool_name == "verify_artifact":
+        return "artifact_verification"
     if (
         tool_name == "read_file"
         or "full_document_snapshot: true" in content
@@ -452,6 +463,8 @@ def _classify_kind(tool_name: str, content: str, metadata: dict[str, object]) ->
 
 
 def _status_for(kind: str, content: str, metadata: dict[str, object]) -> str:
+    if kind in {"artifact_error", "artifact_verification"} and content.lstrip().lower().startswith("error:"):
+        return "error"
     if kind == "web_search":
         if content.lstrip().lower().startswith("error:"):
             return "error"
@@ -473,6 +486,14 @@ def _enriched_metadata(kind: str, content: str, metadata: dict[str, object]) -> 
         enriched.update(_shell_metadata(content))
     if kind == "read":
         enriched.update(_document_metadata(content))
+    if kind in {"artifact", "artifact_pending"}:
+        enriched.update(_artifact_metadata(content))
+    if kind == "artifact_pending":
+        enriched["ephemeral"] = "artifact_pending"
+    if kind == "artifact_error":
+        enriched["artifact_error_detail"] = content.strip()
+    if kind == "artifact_verification":
+        enriched.update(_artifact_verification_metadata(content))
     if kind == "grep_search":
         enriched.update(_grep_metadata(content, metadata))
     enriched = _enrich_excerpts(content, enriched)
@@ -489,6 +510,35 @@ def _document_metadata(content: str) -> dict[str, object]:
     if isinstance(coverage, str) and coverage:
         metadata["document_coverage"] = coverage
     return metadata
+
+
+def _artifact_metadata(content: str) -> dict[str, object]:
+    return {
+        "artifact_path": _line_value(content, "path") or "",
+        "artifact_bytes": _line_value(content, "bytes") or "",
+        "artifact_sha256": _line_value(content, "sha256") or "",
+        "artifact_overwrite": _line_value(content, "overwrite") or "",
+        "created_parent_directories": _line_value(content, "created_parent_directories") or "",
+        "artifact_directory_sync": _line_value(content, "directory_sync") or "",
+        "verification_required": _line_value(content, "verification_required") or "",
+        "artifact_verification_completed": _line_value(content, "verification_completed") or "",
+    }
+
+
+def _artifact_verification_metadata(content: str) -> dict[str, object]:
+    return {
+        "artifact_path": _line_value(content, "path") or "",
+        "artifact_bytes": _line_value(content, "bytes") or "",
+        "artifact_sha256": _line_value(content, "sha256") or "",
+        "artifact_overwrite": _line_value(content, "overwrite") or "",
+        "created_parent_directories": _line_value(content, "created_parent_directories") or "",
+        "artifact_directory_sync": _line_value(content, "directory_sync") or "",
+        "artifact_verification_completed": _line_value(content, "verification_completed") or "",
+        "artifact_check": _line_value(content, "check") or "",
+        "artifact_verification_status": _line_value(content, "status") or "",
+        "artifact_verification_detail": _line_value(content, "detail") or "",
+        "artifact_content_coverage": _line_value(content, "content_coverage") or "",
+    }
 
 
 def _web_metadata(content: str, metadata: dict[str, object]) -> dict[str, object]:
@@ -597,6 +647,19 @@ def _card_metadata_lines(record: EvidenceRecord, *, compact: bool) -> list[str]:
         "files_count",
         "first_matches",
         "sidecar_status",
+        "artifact_path",
+        "artifact_bytes",
+        "artifact_sha256",
+        "artifact_overwrite",
+        "created_parent_directories",
+        "artifact_directory_sync",
+        "artifact_verification_completed",
+        "artifact_check",
+        "artifact_verification_status",
+        "artifact_verification_detail",
+        "artifact_content_coverage",
+        "verification_required",
+        "artifact_error_detail",
     )
     lines: list[str] = []
     for key in keys:
@@ -648,12 +711,46 @@ def _compact_final_prompt_card(record: EvidenceRecord) -> str:
 def _should_use_small_final_prompt_card(record: EvidenceRecord) -> bool:
     if record.raw_chars > COMPACT_FINAL_RAW_EXCERPT_CHARS:
         return False
-    return record.kind in {"shell", "grep_search", "unknown"}
+    return record.kind in {
+        "artifact",
+        "artifact_error",
+        "artifact_pending",
+        "artifact_verification",
+        "shell",
+        "grep_search",
+        "unknown",
+    }
 
 
 def _small_final_prompt_metadata_keys(record: EvidenceRecord) -> tuple[str, ...]:
     if record.kind == "grep_search":
         return ("query", "exit_code", "match_count", "files_count", "file_paths", "first_matches")
+    if record.kind in {"artifact", "artifact_pending"}:
+        return (
+            "artifact_path",
+            "artifact_bytes",
+            "artifact_sha256",
+            "artifact_overwrite",
+            "created_parent_directories",
+            "artifact_directory_sync",
+            "verification_required",
+        )
+    if record.kind == "artifact_verification":
+        return (
+            "artifact_path",
+            "artifact_bytes",
+            "artifact_sha256",
+            "artifact_overwrite",
+            "created_parent_directories",
+            "artifact_directory_sync",
+            "artifact_verification_completed",
+            "artifact_check",
+            "artifact_verification_status",
+            "artifact_verification_detail",
+            "artifact_content_coverage",
+        )
+    if record.kind == "artifact_error":
+        return ("artifact_error_detail",)
     return ("exit_code", "stdout_excerpt", "stderr_excerpt", "sidecar_status")
 
 
@@ -693,6 +790,32 @@ def _route_operational_card(record: EvidenceRecord) -> str:
         keys = ("query", "match_count", "files_count", "file_paths", "search_coverage", "semantic_coverage")
     elif record.kind == "web_search":
         keys = ("query", "result_count", "top_domains")
+    elif record.kind in {"artifact", "artifact_pending"}:
+        keys = (
+            "artifact_path",
+            "artifact_bytes",
+            "artifact_sha256",
+            "artifact_overwrite",
+            "created_parent_directories",
+            "artifact_directory_sync",
+            "verification_required",
+        )
+    elif record.kind == "artifact_error":
+        keys = ("artifact_error_detail",)
+    elif record.kind == "artifact_verification":
+        keys = (
+            "artifact_path",
+            "artifact_bytes",
+            "artifact_sha256",
+            "artifact_overwrite",
+            "created_parent_directories",
+            "artifact_directory_sync",
+            "artifact_verification_completed",
+            "artifact_check",
+            "artifact_verification_status",
+            "artifact_verification_detail",
+            "artifact_content_coverage",
+        )
     elif record.kind in {"shell", "unknown"}:
         keys = ("exit_code", "stdout_chars", "stderr_chars", "stdout_excerpt", "stderr_excerpt")
         if record.raw_chars <= POST_TOOL_ROUTE_SMALL_RAW_CHARS:

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -137,7 +137,6 @@ class EvidenceStore:
             for record in self.records.values()
             if record.metadata.get("ephemeral") in {
                 "full_document_snapshot",
-                "artifact_pending",
             }
         ]
         for evidence_id in ephemeral_ids:
@@ -437,8 +436,6 @@ def _classify_kind(tool_name: str, content: str, metadata: dict[str, object]) ->
         return "artifact_error"
     if tool_name == "write_artifact" and "artifact_publication: complete" in content:
         return "artifact"
-    if tool_name == "write_artifact" and "artifact_generation: complete" in content:
-        return "artifact_pending"
     if tool_name == "verify_artifact":
         return "artifact_verification"
     if (
@@ -486,10 +483,8 @@ def _enriched_metadata(kind: str, content: str, metadata: dict[str, object]) -> 
         enriched.update(_shell_metadata(content))
     if kind == "read":
         enriched.update(_document_metadata(content))
-    if kind in {"artifact", "artifact_pending"}:
+    if kind == "artifact":
         enriched.update(_artifact_metadata(content))
-    if kind == "artifact_pending":
-        enriched["ephemeral"] = "artifact_pending"
     if kind == "artifact_error":
         enriched["artifact_error_detail"] = content.strip()
     if kind == "artifact_verification":
@@ -714,7 +709,6 @@ def _should_use_small_final_prompt_card(record: EvidenceRecord) -> bool:
     return record.kind in {
         "artifact",
         "artifact_error",
-        "artifact_pending",
         "artifact_verification",
         "shell",
         "grep_search",
@@ -725,7 +719,7 @@ def _should_use_small_final_prompt_card(record: EvidenceRecord) -> bool:
 def _small_final_prompt_metadata_keys(record: EvidenceRecord) -> tuple[str, ...]:
     if record.kind == "grep_search":
         return ("query", "exit_code", "match_count", "files_count", "file_paths", "first_matches")
-    if record.kind in {"artifact", "artifact_pending"}:
+    if record.kind == "artifact":
         return (
             "artifact_path",
             "artifact_bytes",
@@ -790,7 +784,7 @@ def _route_operational_card(record: EvidenceRecord) -> str:
         keys = ("query", "match_count", "files_count", "file_paths", "search_coverage", "semantic_coverage")
     elif record.kind == "web_search":
         keys = ("query", "result_count", "top_domains")
-    elif record.kind in {"artifact", "artifact_pending"}:
+    elif record.kind == "artifact":
         keys = (
             "artifact_path",
             "artifact_bytes",

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -106,6 +106,9 @@ def build_final_tool_policy(
     verified_mutation_result = has_verified_mutation_evidence(call_messages)
     verified_artifact_result = has_verified_artifact_evidence(call_messages)
     failed_artifact_result = has_failed_artifact_evidence(call_messages)
+    unverified_published_artifact_result = has_unverified_published_artifact_evidence(
+        call_messages
+    )
     system_info_result = has_tool_result(call_messages, "system_info")
     operational_status_result = shell_full_result and is_operational_status_request(prompt)
     brief_request = is_brief_final_request(prompt)
@@ -125,6 +128,12 @@ def build_final_tool_policy(
             "then state exactly what the selected verification confirmed. Do not describe the artifact as pre-existing. "
         )
         if verified_artifact_result
+        else (
+            "The artifact was atomically published in this turn, but its required read-only verification failed. "
+            "Name the exact artifact path and report the observed verification failure. "
+            "State that the file remains published, but do not claim that its content passed verification or satisfies the request. "
+        )
+        if unverified_published_artifact_result
         else (
             "The artifact workflow failed before verified publication, so no artifact was published. "
             "Name the exact requested path and report the observed verification failure. "
@@ -463,8 +472,6 @@ def has_verified_artifact_evidence(messages: list[Message]) -> bool:
     if not isinstance(publication_content, str) or not (
         "artifact_publication: complete" in publication_content
         or ("kind: artifact" in publication_content and "status: ok" in publication_content)
-        or "artifact_generation: complete" in publication_content
-        or ("kind: artifact_pending" in publication_content and "status: ok" in publication_content)
     ):
         return False
     for message in messages[publication_index + 1 :]:
@@ -493,8 +500,8 @@ def has_failed_artifact_evidence(messages: list[Message]) -> bool:
     ):
         return True
     if not (
-        "artifact_generation: complete" in pending_content
-        or ("kind: artifact_pending" in pending_content and "status: ok" in pending_content)
+        "artifact_publication: complete" in pending_content
+        or ("kind: artifact" in pending_content and "status: ok" in pending_content)
     ):
         return False
     return any(
@@ -510,6 +517,24 @@ def has_failed_artifact_evidence(messages: list[Message]) -> bool:
         )
         for message in messages[pending_index + 1 :]
     )
+
+
+def has_unverified_published_artifact_evidence(messages: list[Message]) -> bool:
+    publication_index = _latest_artifact_request_index(messages)
+    if publication_index is None:
+        return False
+    publication_content = messages[publication_index].get("content")
+    if not isinstance(publication_content, str) or not (
+        "artifact_publication: complete" in publication_content
+        or ("kind: artifact" in publication_content and "status: ok" in publication_content)
+    ):
+        return False
+    verification_messages = [
+        message
+        for message in messages[publication_index + 1 :]
+        if message.get("role") == "tool" and message.get("name") == "verify_artifact"
+    ]
+    return bool(verification_messages) and not has_verified_artifact_evidence(messages)
 
 
 def _latest_artifact_request_index(messages: list[Message]) -> int | None:

--- a/src/orbit/runtime/final_policy.py
+++ b/src/orbit/runtime/final_policy.py
@@ -104,6 +104,8 @@ def build_final_tool_policy(
     list_like_result = directory_listing_result and is_compact_list_request(prompt)
     shell_full_result = has_tool_result(call_messages, "exec_shell_full_command")
     verified_mutation_result = has_verified_mutation_evidence(call_messages)
+    verified_artifact_result = has_verified_artifact_evidence(call_messages)
+    failed_artifact_result = has_failed_artifact_evidence(call_messages)
     system_info_result = has_tool_result(call_messages, "system_info")
     operational_status_result = shell_full_result and is_operational_status_request(prompt)
     brief_request = is_brief_final_request(prompt)
@@ -117,8 +119,22 @@ def build_final_tool_policy(
         and not (large_file_excerpt or web_fetch_result or pdf_text_result or list_like_result or operational_status_result)
     )
     mutation_instruction = (
-        "The mutation command completed successfully and the later read-only output verified the result. "
-        "State both the completed change and what the verification confirmed. "
+        (
+            "The model-selected bounded check passed and the artifact was atomically published in this turn. "
+            "Name the exact artifact path. State that this turn created or overwrote it as indicated by evidence, "
+            "then state exactly what the selected verification confirmed. Do not describe the artifact as pre-existing. "
+        )
+        if verified_artifact_result
+        else (
+            "The artifact workflow failed before verified publication, so no artifact was published. "
+            "Name the exact requested path and report the observed verification failure. "
+            "Do not claim that the file exists, is valid, or contains the requested content. "
+        )
+        if failed_artifact_result
+        else (
+            "The mutation command completed successfully and the later read-only output verified the result. "
+            "State both the completed change and what the verification confirmed. "
+        )
         if verified_mutation_result
         else ""
     )
@@ -204,6 +220,18 @@ def build_final_tool_policy(
                     "Return every listed path exactly once, one per line. "
                     "Preserve directory markers. Omit sizes and other metadata unless requested. "
                     "No introduction or conclusion. Stop after the final path."
+                ),
+            },
+        ]
+    elif verified_artifact_result or failed_artifact_result:
+        call_messages = [
+            *call_messages,
+            {
+                "role": "user",
+                "content": (
+                    mutation_instruction
+                    + "Answer the latest request directly and concisely from the publication and verification evidence. "
+                    "Do not call tools again or add unsupported claims."
                 ),
             },
         ]
@@ -424,6 +452,75 @@ def has_verified_mutation_evidence(messages: list[Message]) -> bool:
         and is_mutating_shell_command(mutation_command)
         and verification_command
         and not is_mutating_shell_command(verification_command)
+    )
+
+
+def has_verified_artifact_evidence(messages: list[Message]) -> bool:
+    publication_index = _latest_artifact_request_index(messages)
+    if publication_index is None:
+        return False
+    publication_content = messages[publication_index].get("content")
+    if not isinstance(publication_content, str) or not (
+        "artifact_publication: complete" in publication_content
+        or ("kind: artifact" in publication_content and "status: ok" in publication_content)
+        or "artifact_generation: complete" in publication_content
+        or ("kind: artifact_pending" in publication_content and "status: ok" in publication_content)
+    ):
+        return False
+    for message in messages[publication_index + 1 :]:
+        if message.get("role") != "tool" or message.get("name") != "verify_artifact":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip() or _is_error_tool_content(content):
+            continue
+        if (
+            "artifact_verification: complete" in content
+            or ("kind: artifact_verification" in content and "status: ok" in content)
+        ):
+            return True
+    return False
+
+
+def has_failed_artifact_evidence(messages: list[Message]) -> bool:
+    pending_index = _latest_artifact_request_index(messages)
+    if pending_index is None:
+        return False
+    pending_content = messages[pending_index].get("content")
+    if not isinstance(pending_content, str):
+        return False
+    if _is_error_tool_content(pending_content) or (
+        "kind: artifact_error" in pending_content and "status: error" in pending_content
+    ):
+        return True
+    if not (
+        "artifact_generation: complete" in pending_content
+        or ("kind: artifact_pending" in pending_content and "status: ok" in pending_content)
+    ):
+        return False
+    return any(
+        message.get("role") == "tool"
+        and message.get("name") == "verify_artifact"
+        and isinstance(message.get("content"), str)
+        and (
+            _is_error_tool_content(message["content"])
+            or (
+                "kind: artifact_verification" in message["content"]
+                and "status: error" in message["content"]
+            )
+        )
+        for message in messages[pending_index + 1 :]
+    )
+
+
+def _latest_artifact_request_index(messages: list[Message]) -> int | None:
+    return next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if messages[index].get("role") == "tool"
+            and messages[index].get("name") == "write_artifact"
+        ),
+        None,
     )
 
 

--- a/src/orbit/runtime/kv_diag.py
+++ b/src/orbit/runtime/kv_diag.py
@@ -211,6 +211,39 @@ class _DiagnosticBackend:
             ),
         )
 
+    def artifact_content_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        generate = getattr(self._backend, "artifact_content_stream", None)
+        if not callable(generate):
+            raise RuntimeError("artifact content generation requires the native Orbit backend")
+        timings = _ProgressTimings()
+
+        def wrapped_progress(progress: StreamProgress) -> None:
+            timings.observe(progress)
+            if on_progress is not None:
+                on_progress(progress)
+
+        return self._record_call(
+            messages,
+            tools=None,
+            streamed=True,
+            progress_timings=timings,
+            invoke=lambda: generate(
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_delta=on_delta,
+                on_progress=wrapped_progress if on_progress is not None else None,
+            ),
+        )
+
     def continue_current(self, *args: Any, **kwargs: Any) -> ChatResult:
         call_context = _next_call_context(_PHASE.get() or "continue", _TOOLS_MODE.get())
         started = time.monotonic()

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -80,8 +80,9 @@ Do not claim no access for local/system/web.
 Never use <|tool_call>, call:shell, markdown, fences, or prose for shell.
 Do not write long prose in the route pass.
 
-Example:
-specs of this computer -> {{"include_cpu":true,"include_memory":true,"include_disks":true,"include_os":true}}
+Create/save one bounded UTF-8 text file ->
+{{"tool":"write_artifact","arguments":{{"path":"x","overwrite":false,"create_parents":true}}}}
+Use model-selected values; never emit file content in this route pass.
 
 For analysis, prefer content, source, binaries, strings, logs, archives, or fetched data, not metadata."""
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -482,6 +482,8 @@ def validate_tool_no_mutation_policy(
 ) -> str | None:
     if name == "exec_shell_full_command":
         return validate_read_only_shell_mutation(arguments, user_prompt=user_prompt)
+    if name == "write_artifact" and classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
+        return read_only_mutation_policy_error(user_prompt, action="artifact creation")
     return None
 
 

--- a/src/orbit/runtime/tool_arguments.py
+++ b/src/orbit/runtime/tool_arguments.py
@@ -4,13 +4,35 @@ import json
 from typing import Any
 
 
-def parse_tool_arguments(arguments: str | dict[str, Any]) -> dict[str, Any] | str:
+class _DuplicateToolArgument(ValueError):
+    pass
+
+
+def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateToolArgument(key)
+        result[key] = value
+    return result
+
+
+def parse_tool_arguments(
+    arguments: str | dict[str, Any],
+    *,
+    reject_duplicate_keys: bool = False,
+) -> dict[str, Any] | str:
     if isinstance(arguments, dict):
         return arguments
     if not isinstance(arguments, str) or not arguments.strip():
         return {}
     try:
-        parsed = json.loads(arguments)
+        parsed = json.loads(
+            arguments,
+            object_pairs_hook=_unique_json_object if reject_duplicate_keys else None,
+        )
+    except _DuplicateToolArgument as exc:
+        return f"error: duplicate JSON tool argument: {exc}"
     except json.JSONDecodeError as exc:
         return f"error: invalid JSON tool arguments: {exc}"
     if not isinstance(parsed, dict):

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from orbit.runtime.shell_guardrails import (
     validate_shell_full_contract,
@@ -46,11 +46,15 @@ class HybridToolExecutor:
         allowed_tool_names: tuple[str, ...],
         user_prompt: str | None = None,
         prefer_server: bool = True,
+        artifact_writer: Callable[[dict[str, Any]], ToolExecution] | None = None,
+        artifact_verifier: Callable[[dict[str, Any]], ToolExecution] | None = None,
     ) -> None:
         del backend, prefer_server
         self.workdir = workdir
         self.allowed_tool_names = allowed_tool_names
         self.user_prompt = user_prompt
+        self.artifact_writer = artifact_writer
+        self.artifact_verifier = artifact_verifier
 
     def tool_definitions(self) -> list[dict[str, Any]]:
         return tool_definitions(self.allowed_tool_names)
@@ -70,7 +74,7 @@ class HybridToolExecutor:
             decision = validate_canonical_tool_call(
                 name,
                 arguments,
-                tool_definitions=tool_definitions(),
+                tool_definitions=tool_definitions(self.allowed_tool_names),
                 allowed_tool_names=self.allowed_tool_names,
                 workdir=self.workdir,
                 user_prompt=self.user_prompt,
@@ -98,14 +102,17 @@ class HybridToolExecutor:
                 "rejected_permission",
                 "tool_not_enabled",
             )
-        if name not in {"exec_shell_full_command", "fetch_url", "list_directory", "system_info"}:
+        if name not in {"exec_shell_full_command", "fetch_url", "list_directory", "system_info", "write_artifact", "verify_artifact"}:
             return ToolExecution(
                 ToolResult(name=name, content=f"error: unknown tool: {name}"),
                 "orbit",
                 "rejected_schema",
                 "unknown_tool",
             )
-        parsed = parse_tool_arguments(arguments)
+        parsed = parse_tool_arguments(
+            arguments,
+            reject_duplicate_keys=name in {"write_artifact", "verify_artifact"},
+        )
         if isinstance(parsed, str):
             return ToolExecution(ToolResult(name=name, content=parsed), "orbit", "rejected_parse", "invalid_arguments")
         if not canonical_validated:
@@ -117,6 +124,24 @@ class HybridToolExecutor:
                     "rejected_policy",
                     "policy_read_only_mutation",
                 )
+        if name == "write_artifact":
+            if self.artifact_writer is None:
+                return ToolExecution(
+                    ToolResult(name=name, content="error: artifact generation is unavailable on this backend"),
+                    "orbit",
+                    "runtime_error",
+                    "artifact_backend_unavailable",
+                )
+            return self.artifact_writer(parsed)
+        if name == "verify_artifact":
+            if self.artifact_verifier is None:
+                return ToolExecution(
+                    ToolResult(name=name, content="error: artifact verification is unavailable"),
+                    "orbit-artifact",
+                    "runtime_error",
+                    "artifact_verifier_unavailable",
+                )
+            return self.artifact_verifier(parsed)
         if name == "exec_shell_full_command" and not canonical_validated:
             contract_error = validate_shell_full_contract(parsed, user_prompt=self.user_prompt)
             if contract_error:

--- a/src/orbit/runtime/tool_contract.py
+++ b/src/orbit/runtime/tool_contract.py
@@ -7,6 +7,7 @@ import shlex
 from typing import Any, Iterable
 from urllib.parse import urlparse
 
+from orbit.runtime.artifacts import ARTIFACT_TOOL_NAME, ARTIFACT_VERIFY_TOOL_NAME, validate_artifact_path
 from orbit.runtime.directory_listing import MAX_DEPTH_LIMIT, MAX_ENTRIES_LIMIT
 from orbit.runtime.path_guardrails import resolve_inside_workdir
 from orbit.runtime.shell_guardrails import (
@@ -241,6 +242,26 @@ def _policy_and_operational(
         if limit is None:
             limit = _integer_limit(arguments, "max_entries", 1, MAX_ENTRIES_LIMIT)
         return neutral, limit or neutral
+    if name in {ARTIFACT_TOOL_NAME, ARTIFACT_VERIFY_TOOL_NAME}:
+        path = arguments.get("path")
+        path_error = validate_artifact_path(path, workdir=workdir)
+        if path_error:
+            return neutral, ContractStageOutcome(
+                False,
+                "invalid_artifact_path",
+                "arguments.path",
+                path_error,
+            )
+        if name == ARTIFACT_TOOL_NAME:
+            policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
+            if policy_error:
+                return ContractStageOutcome(
+                    False,
+                    "policy_read_only_mutation",
+                    "arguments.path",
+                    policy_error,
+                ), neutral
+        return neutral, neutral
     return neutral, neutral
 
 

--- a/src/orbit/runtime/tool_contract.py
+++ b/src/orbit/runtime/tool_contract.py
@@ -243,16 +243,15 @@ def _policy_and_operational(
             limit = _integer_limit(arguments, "max_entries", 1, MAX_ENTRIES_LIMIT)
         return neutral, limit or neutral
     if name in {ARTIFACT_TOOL_NAME, ARTIFACT_VERIFY_TOOL_NAME}:
-        path = arguments.get("path")
-        path_error = validate_artifact_path(path, workdir=workdir)
-        if path_error:
-            return neutral, ContractStageOutcome(
-                False,
-                "invalid_artifact_path",
-                "arguments.path",
-                path_error,
-            )
         if name == ARTIFACT_TOOL_NAME:
+            path_error = validate_artifact_path(arguments.get("path"), workdir=workdir)
+            if path_error:
+                return neutral, ContractStageOutcome(
+                    False,
+                    "invalid_artifact_path",
+                    "arguments.path",
+                    path_error,
+                )
             policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
             if policy_error:
                 return ContractStageOutcome(

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -158,9 +158,7 @@ def run_tool_loop(
     artifact_verification_required = False
     artifact_path_pending_verification: str | None = None
     artifact_pending_verification: PendingArtifact | None = None
-    artifact_pending_evidence_id: str | None = None
     artifact_publication_completed: ArtifactPublication | None = None
-    artifact_mutation_call_pending: dict[str, object] | None = None
     artifact_finalization_required = False
     active_tools = tools
     active_allowed_tool_names = allowed_tool_names
@@ -173,6 +171,7 @@ def run_tool_loop(
 
     def write_artifact(arguments: dict[str, object]) -> ToolExecution:
         nonlocal artifact_path_pending_verification, artifact_pending_verification
+        nonlocal artifact_publication_completed
         path = arguments.get("path")
         overwrite = arguments.get("overwrite", False)
         create_parents = arguments.get("create_parents", False)
@@ -245,14 +244,14 @@ def run_tool_loop(
             )
         artifact_pending_verification = pending
         artifact_path_pending_verification = pending.path
+        artifact_publication_completed = pending.publication
         return ToolExecution(
             ToolResult(ARTIFACT_TOOL_NAME, pending.evidence()),
             "orbit-artifact",
         )
 
     def verify_artifact(arguments: dict[str, object]) -> ToolExecution:
-        nonlocal artifact_pending_verification, artifact_pending_evidence_id
-        nonlocal artifact_publication_completed
+        nonlocal artifact_pending_verification
         pending = artifact_pending_verification
         if pending is None:
             return ToolExecution(
@@ -261,7 +260,7 @@ def run_tool_loop(
                 "rejected_guardrail",
                 "artifact_verification_not_pending",
             )
-        if set(arguments) != {"path", "check"}:
+        if set(arguments) != {"check"}:
             pending.abort()
             artifact_pending_verification = None
             return ToolExecution(
@@ -271,10 +270,7 @@ def run_tool_loop(
                 "invalid_arguments",
             )
         try:
-            publication, content = pending.verify_and_publish(
-                arguments,
-                workdir=Path(workdir),
-            )
+            content = pending.verify(arguments)
         except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
             pending.abort()
             artifact_pending_verification = None
@@ -285,28 +281,16 @@ def run_tool_loop(
                 "artifact_verification_failed",
             )
         artifact_pending_verification = None
-        artifact_pending_evidence_id = None
-        artifact_publication_completed = publication
         return ToolExecution(
             ToolResult(ARTIFACT_VERIFY_TOOL_NAME, content),
             "orbit-artifact",
         )
 
     def abort_pending_artifact() -> None:
-        nonlocal artifact_pending_verification, artifact_pending_evidence_id
+        nonlocal artifact_pending_verification
         if artifact_pending_verification is not None:
             artifact_pending_verification.abort()
             artifact_pending_verification = None
-        if artifact_pending_evidence_id is not None:
-            for message in runtime.messages:
-                if message.get("evidence_id") == artifact_pending_evidence_id:
-                    message.pop("evidence_id", None)
-                    message["content"] = (
-                        "error: artifact request did not reach verified publication; "
-                        "no artifact was published"
-                    )
-            evidence_store.discard(artifact_pending_evidence_id)
-            artifact_pending_evidence_id = None
 
     def balance_cancelled_artifact_call(tool_call: dict[str, object]) -> None:
         cancellation = ToolResult(
@@ -657,12 +641,12 @@ def run_tool_loop(
         # repair state. It updates turn-local state, while runtime counters stay
         # here to avoid leaking telemetry into the state objects themselves.
         nonlocal artifact_path_pending_verification, artifact_verification_required
-        nonlocal artifact_mutation_call_pending
         if tool_result.name == ARTIFACT_TOOL_NAME:
             turn.shell_mutation_attempted = True
             if execution_outcome == "executed":
+                state.advance_after_mutation(tool_call)
+                turn.shell_mutation_succeeded = True
                 artifact_verification_required = True
-                artifact_mutation_call_pending = tool_call
                 repair.mutation_verification_pending = True
                 runtime.mutation_verifications += 1
             else:
@@ -674,7 +658,6 @@ def run_tool_loop(
                 turn.last_error = execution_reason
                 artifact_verification_required = False
                 artifact_path_pending_verification = None
-                artifact_mutation_call_pending = None
                 repair.shell_error_final_pending = True
                 turn.mark_exhausted()
             return
@@ -998,10 +981,6 @@ def run_tool_loop(
                     ),
                 )
                 runtime.messages.append(history_message)
-                if tool_result.name == ARTIFACT_TOOL_NAME:
-                    evidence_id = history_message.get("evidence_id")
-                    if isinstance(evidence_id, str):
-                        artifact_pending_evidence_id = evidence_id
                 if should_handoff_to_final_from_tool():
                     return answer_from_tool_results(
                         temperature=temperature,
@@ -1259,7 +1238,6 @@ def run_tool_loop(
             abort_pending_artifact()
             artifact_verification_required = False
             artifact_path_pending_verification = None
-            artifact_mutation_call_pending = None
             record_terminal(
                 attempt_id=attempt_id,
                 report=shadow_report,
@@ -1270,7 +1248,7 @@ def run_tool_loop(
             )
             return artifact_failure_result(
                 result,
-                "error: artifact verification did not complete; no artifact was published",
+                "error: artifact was published but verification did not complete",
             )
         truncated_tool_attempt = (
             result.finish_reason == "length"
@@ -1310,10 +1288,9 @@ def run_tool_loop(
                 abort_pending_artifact()
                 artifact_verification_required = False
                 artifact_path_pending_verification = None
-                artifact_mutation_call_pending = None
                 return artifact_failure_result(
                     result,
-                    "error: artifact verification did not complete; no artifact was published",
+                    "error: artifact was published but verification did not complete",
                 )
             record_post_tool_final_reuse_fallback("finish_reason")
             record_terminal(
@@ -1379,10 +1356,9 @@ def run_tool_loop(
                 if executing_mutation_verification and artifact_verification_required:
                     artifact_verification_required = False
                     artifact_path_pending_verification = None
-                    artifact_mutation_call_pending = None
                     return artifact_failure_result(
                         result,
-                        "error: artifact verification did not complete; no artifact was published",
+                        "error: artifact was published but verification did not complete",
                     )
                 return runtime._chat_final(
                     with_chat_system_prompt(runtime.messages),
@@ -1420,7 +1396,6 @@ def run_tool_loop(
                 abort_pending_artifact()
                 artifact_verification_required = False
                 artifact_path_pending_verification = None
-                artifact_mutation_call_pending = None
                 record_terminal(
                     attempt_id=attempt_id,
                     report=shadow_report,
@@ -1431,7 +1406,7 @@ def run_tool_loop(
                 )
                 return artifact_failure_result(
                     result,
-                    "error: artifact verification was not selected; no artifact was published",
+                    "error: artifact was published but verification was not selected",
                 )
             route_tool_call = command_like_tool_call(result.content, active_allowed_tool_names)
             if route_tool_call is not None:
@@ -1474,7 +1449,6 @@ def run_tool_loop(
                 if verification_decision.accepted and verification_decision.normalized_call is not None
                 else {}
             )
-            verification_path = arguments.get("path")
             verification_check = arguments.get("check")
             path = artifact_path_pending_verification
             invalid_verification = (
@@ -1482,7 +1456,6 @@ def run_tool_loop(
                 or not verification_decision.accepted
                 or name != ARTIFACT_VERIFY_TOOL_NAME
                 or not path
-                or verification_path != path
                 or verification_check
                 not in {
                     "content",
@@ -1493,7 +1466,6 @@ def run_tool_loop(
                 abort_pending_artifact()
                 artifact_verification_required = False
                 artifact_path_pending_verification = None
-                artifact_mutation_call_pending = None
                 record_terminal(
                     attempt_id=attempt_id,
                     report=shadow_report,
@@ -1504,7 +1476,7 @@ def run_tool_loop(
                 )
                 return artifact_failure_result(
                     result,
-                    "error: artifact verification was invalid; no artifact was published",
+                    "error: artifact was published but verification was invalid",
                 )
             canonical_decision = verification_decision
         if result.tool_calls and canonical_gate_enabled and canonical_decision is None:
@@ -1809,12 +1781,8 @@ def run_tool_loop(
                 and "status: pass" in tool_result.content
                 and artifact_publication_completed is not None
             ):
-                if artifact_mutation_call_pending is not None:
-                    state.advance_after_mutation(artifact_mutation_call_pending)
-                turn.shell_mutation_succeeded = True
                 artifact_verification_required = False
                 artifact_path_pending_verification = None
-                artifact_mutation_call_pending = None
                 artifact_publication_completed = None
                 artifact_finalization_required = True
             if (
@@ -1839,10 +1807,6 @@ def run_tool_loop(
                 ),
             )
             runtime.messages.append(history_message)
-            if tool_result.name == ARTIFACT_TOOL_NAME:
-                evidence_id = history_message.get("evidence_id")
-                if isinstance(evidence_id, str):
-                    artifact_pending_evidence_id = evidence_id
             if artifact_finalization_required:
                 turn.mark_finalizable()
                 return answer_from_tool_results(
@@ -1907,7 +1871,7 @@ def run_tool_loop(
         )
         return artifact_failure_result(
             base_result,
-            "error: artifact verification could not run within the bounded tool loop; no artifact was published",
+            "error: artifact was published but verification could not run within the bounded tool loop",
         )
     return last_result or ChatResult(
         content="error: tool loop did not produce a response",

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -9,6 +9,15 @@ from typing import Callable
 from orbit.backend import ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.post_tool_final_reuse_config import resolve_post_tool_final_reuse
+from orbit.runtime.artifacts import (
+    ARTIFACT_TOOL_NAME,
+    ARTIFACT_VERIFY_TOOL_NAME,
+    ARTIFACT_VERIFICATION_PROMPT,
+    ArtifactPublication,
+    ArtifactGenerationError,
+    PendingArtifact,
+    begin_artifact_generation,
+)
 from orbit.runtime.capabilities import LocalCapabilities
 from orbit.runtime.command_request import command_like_tool_call, command_tool_call_from_tool_calls
 from orbit.runtime.completion_budget import resolve_max_tokens
@@ -50,7 +59,7 @@ from orbit.runtime.shell_guardrails import (
     should_verify_shell_mutation,
 )
 from orbit.runtime.tool_arguments import parse_tool_arguments_or_empty
-from orbit.runtime.tool_backends import HybridToolExecutor
+from orbit.runtime.tool_backends import HybridToolExecutor, ToolExecution
 from orbit.runtime.tool_calls import execute_tool_call
 from orbit.runtime.tool_contract import (
     CanonicalToolDecision,
@@ -76,7 +85,7 @@ from orbit.runtime.tool_loop_state import (
     ToolTurnState,
 )
 from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
-from orbit.runtime.tools import default_tool_names
+from orbit.runtime.tools import ToolResult, default_tool_names
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 from orbit.runtime.web import fetch_url_result_error, fetch_url_result_has_text, fetch_url_result_status
 from orbit.tool_contract_config import resolve_tool_call_canonical_gate
@@ -115,6 +124,8 @@ def run_tool_loop(
     user_turn_id: str | None = None,
 ) -> ChatResult:
     allowed_tool_names = tool_names or default_tool_names()
+    if ARTIFACT_TOOL_NAME in allowed_tool_names and ARTIFACT_VERIFY_TOOL_NAME not in allowed_tool_names:
+        allowed_tool_names = (*allowed_tool_names, ARTIFACT_VERIFY_TOOL_NAME)
     executor = HybridToolExecutor(
         backend=runtime.backend if hasattr(runtime.backend, "server_tools") else None,
         workdir=workdir,
@@ -144,6 +155,15 @@ def run_tool_loop(
     suppress_tool_delta = (lambda _delta: None) if on_final_delta is not None and shell_full_enabled else None
     terminal_attempt_ids: set[str] = set()
     canonical_decisions: dict[str, CanonicalToolDecision] = {}
+    artifact_verification_required = False
+    artifact_path_pending_verification: str | None = None
+    artifact_pending_verification: PendingArtifact | None = None
+    artifact_pending_evidence_id: str | None = None
+    artifact_publication_completed: ArtifactPublication | None = None
+    artifact_mutation_call_pending: dict[str, object] | None = None
+    artifact_finalization_required = False
+    active_tools = tools
+    active_allowed_tool_names = allowed_tool_names
 
     # These local helpers still couple policy and runtime counters in one place.
     # The state objects only store turn-local facts; they do not decide tasks.
@@ -151,12 +171,179 @@ def run_tool_loop(
     def answer_from_tool_results(**kwargs) -> ChatResult:
         return runtime._answer_from_tool_results(**kwargs)
 
+    def write_artifact(arguments: dict[str, object]) -> ToolExecution:
+        nonlocal artifact_path_pending_verification, artifact_pending_verification
+        path = arguments.get("path")
+        overwrite = arguments.get("overwrite", False)
+        create_parents = arguments.get("create_parents", False)
+        if (
+            not set(arguments).issubset({"path", "overwrite", "create_parents"})
+            or not isinstance(path, str)
+            or not isinstance(overwrite, bool)
+            or not isinstance(create_parents, bool)
+        ):
+            return ToolExecution(
+                ToolResult(ARTIFACT_TOOL_NAME, "error: invalid artifact arguments"),
+                "orbit-artifact",
+                "rejected_schema",
+                "invalid_arguments",
+            )
+        if on_phase_start:
+            on_phase_start(
+                ModelPhaseStart(
+                    "artifact_content",
+                    streamed=False,
+                    attempt=1,
+                    reason="model_selected_artifact",
+                )
+            )
+        try:
+            with model_call_context(phase="artifact_content", tools_mode="on"):
+                pending = begin_artifact_generation(
+                    backend=runtime.backend,
+                    user_request=user_prompt or "",
+                    path=path,
+                    overwrite=overwrite,
+                    create_parents=create_parents,
+                    workdir=Path(workdir),
+                    temperature=temperature,
+                    on_progress=on_progress,
+                )
+        except ArtifactGenerationError as exc:
+            if on_model_step:
+                on_model_step(
+                    ModelStepMetrics.from_result(
+                        loop=state.tool_rounds + 1,
+                        result=exc.result,
+                        phase="artifact_content",
+                    )
+                )
+            if exc.result.finish_reason == "cancelled":
+                raise
+            return ToolExecution(
+                ToolResult(ARTIFACT_TOOL_NAME, f"error: {exc}"),
+                "orbit-artifact",
+                "runtime_error",
+                "artifact_generation_incomplete",
+            )
+        except TimeoutError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            return ToolExecution(
+                ToolResult(ARTIFACT_TOOL_NAME, f"error: artifact generation did not complete: {exc}"),
+                "orbit-artifact",
+                "runtime_error",
+                "artifact_generation_failed",
+            )
+        if on_model_step:
+            on_model_step(
+                ModelStepMetrics.from_result(
+                    loop=state.tool_rounds + 1,
+                    result=pending.generation,
+                    phase="artifact_content",
+                )
+            )
+        artifact_pending_verification = pending
+        artifact_path_pending_verification = pending.path
+        return ToolExecution(
+            ToolResult(ARTIFACT_TOOL_NAME, pending.evidence()),
+            "orbit-artifact",
+        )
+
+    def verify_artifact(arguments: dict[str, object]) -> ToolExecution:
+        nonlocal artifact_pending_verification, artifact_pending_evidence_id
+        nonlocal artifact_publication_completed
+        pending = artifact_pending_verification
+        if pending is None:
+            return ToolExecution(
+                ToolResult(ARTIFACT_VERIFY_TOOL_NAME, "error: no artifact request is pending verification"),
+                "orbit-artifact",
+                "rejected_guardrail",
+                "artifact_verification_not_pending",
+            )
+        if set(arguments) != {"path", "check"}:
+            pending.abort()
+            artifact_pending_verification = None
+            return ToolExecution(
+                ToolResult(ARTIFACT_VERIFY_TOOL_NAME, "error: invalid artifact verification arguments"),
+                "orbit-artifact",
+                "rejected_schema",
+                "invalid_arguments",
+            )
+        try:
+            publication, content = pending.verify_and_publish(
+                arguments,
+                workdir=Path(workdir),
+            )
+        except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+            pending.abort()
+            artifact_pending_verification = None
+            return ToolExecution(
+                ToolResult(ARTIFACT_VERIFY_TOOL_NAME, f"error: artifact verification failed: {exc}"),
+                "orbit-artifact",
+                "runtime_error",
+                "artifact_verification_failed",
+            )
+        artifact_pending_verification = None
+        artifact_pending_evidence_id = None
+        artifact_publication_completed = publication
+        return ToolExecution(
+            ToolResult(ARTIFACT_VERIFY_TOOL_NAME, content),
+            "orbit-artifact",
+        )
+
+    def abort_pending_artifact() -> None:
+        nonlocal artifact_pending_verification, artifact_pending_evidence_id
+        if artifact_pending_verification is not None:
+            artifact_pending_verification.abort()
+            artifact_pending_verification = None
+        if artifact_pending_evidence_id is not None:
+            for message in runtime.messages:
+                if message.get("evidence_id") == artifact_pending_evidence_id:
+                    message.pop("evidence_id", None)
+                    message["content"] = (
+                        "error: artifact request did not reach verified publication; "
+                        "no artifact was published"
+                    )
+            evidence_store.discard(artifact_pending_evidence_id)
+            artifact_pending_evidence_id = None
+
+    def balance_cancelled_artifact_call(tool_call: dict[str, object]) -> None:
+        cancellation = ToolResult(
+            ARTIFACT_TOOL_NAME,
+            "error: artifact generation was cancelled; no artifact was published",
+        )
+        runtime.messages.append(tool_result_message(tool_call, cancellation))
+        if on_tool_result is not None:
+            on_tool_result(
+                cancellation.name,
+                len(cancellation.content),
+                "orbit-artifact",
+                cancellation.content,
+            )
+
+    def artifact_failure_result(result: ChatResult, message: str) -> ChatResult:
+        abort_pending_artifact()
+        failure = replace(
+            result,
+            content=message,
+            finish_reason="stop",
+            tool_calls=[],
+        )
+        runtime.messages.append({"role": "assistant", "content": message})
+        if on_final_delta is not None:
+            on_final_delta(message)
+        return failure
+
+    executor.artifact_writer = write_artifact
+    executor.artifact_verifier = verify_artifact
+
     def observe_shadow(result: ChatResult, *, attempt_id: str | None, phase: str = "tool_call"):
         return observe_tool_attempt_shadow(
             text=result.content,
             tool_calls=result.tool_calls,
-            tool_definitions=tools,
-            allowed_tool_names=allowed_tool_names,
+            tool_definitions=active_tools,
+            allowed_tool_names=active_allowed_tool_names,
             workdir=Path(workdir),
             user_prompt=user_prompt,
             finish_reason=result.finish_reason,
@@ -189,8 +376,8 @@ def run_tool_loop(
             active_outcome=outcome,
             terminal_reason=reason,
             phase=phase,
-            tool_definitions=tools,
-            allowed_tool_names=allowed_tool_names,
+            tool_definitions=active_tools,
+            allowed_tool_names=active_allowed_tool_names,
             workdir=Path(workdir),
             user_prompt=user_prompt,
             canonical_decision=canonical_decisions.get(attempt_id),
@@ -208,8 +395,8 @@ def run_tool_loop(
             return None
         resolved = decision or validate_canonical_tool_call_payload(
             tool_call,
-            tool_definitions=tools,
-            allowed_tool_names=allowed_tool_names,
+            tool_definitions=active_tools,
+            allowed_tool_names=active_allowed_tool_names,
             workdir=Path(workdir),
             user_prompt=user_prompt,
         )
@@ -469,6 +656,28 @@ def run_tool_loop(
         # This remains the main transition reducer for tool evidence and bounded
         # repair state. It updates turn-local state, while runtime counters stay
         # here to avoid leaking telemetry into the state objects themselves.
+        nonlocal artifact_path_pending_verification, artifact_verification_required
+        nonlocal artifact_mutation_call_pending
+        if tool_result.name == ARTIFACT_TOOL_NAME:
+            turn.shell_mutation_attempted = True
+            if execution_outcome == "executed":
+                artifact_verification_required = True
+                artifact_mutation_call_pending = tool_call
+                repair.mutation_verification_pending = True
+                runtime.mutation_verifications += 1
+            else:
+                turn.last_error = execution_reason
+            return
+        if tool_result.name == ARTIFACT_VERIFY_TOOL_NAME:
+            if execution_outcome != "executed":
+                abort_pending_artifact()
+                turn.last_error = execution_reason
+                artifact_verification_required = False
+                artifact_path_pending_verification = None
+                artifact_mutation_call_pending = None
+                repair.shell_error_final_pending = True
+                turn.mark_exhausted()
+            return
         if tool_result.name not in {"exec_shell_full_command", "fetch_url"}:
             return
         command = _shell_command_from_tool_call(tool_call)
@@ -679,6 +888,7 @@ def run_tool_loop(
             if (
                 (is_mutation_verification or is_mutation_verification_repair)
                 and not repair.mutation_semantic_repair_used
+                and not artifact_verification_required
             ):
                 request_mutation_semantic_repair()
             if has_required_direct_evidence() or repair.shell_error_final_pending:
@@ -744,12 +954,17 @@ def run_tool_loop(
                 signature = state.mark_tool_call(tool_call)
                 if on_tool_call:
                     on_tool_call(*signature)
-                execution = execute_tool_call(
-                    tool_call,
-                    chunk_budget=state.chunk_budget,
-                    executor=executor,
-                    canonical_decision=initial_decision,
-                )
+                try:
+                    execution = execute_tool_call(
+                        tool_call,
+                        chunk_budget=state.chunk_budget,
+                        executor=executor,
+                        canonical_decision=initial_decision,
+                    )
+                except ArtifactGenerationError as exc:
+                    abort_pending_artifact()
+                    balance_cancelled_artifact_call(tool_call)
+                    return exc.result
                 tool_result = execution.result
                 update_state_after_tool_result(
                     tool_call,
@@ -763,23 +978,30 @@ def run_tool_loop(
                     execution_outcome=execution.terminal_outcome,
                     execution_reason=execution.terminal_reason,
                 )
-                if execution.terminal_outcome == "executed" and _tool_call_is_mutating(tool_call):
+                if (
+                    execution.terminal_outcome == "executed"
+                    and _tool_call_is_mutating(tool_call)
+                    and tool_result.name != ARTIFACT_TOOL_NAME
+                ):
                     state.advance_after_mutation(tool_call)
                 if on_tool_result:
                     on_tool_result(tool_result.name, len(tool_result.content), execution.source, tool_result.content)
-                runtime.messages.append(
-                    tool_result_message(
+                history_message = tool_result_message(
+                    tool_call,
+                    tool_result,
+                    evidence_store=evidence_store,
+                    metadata=_tool_evidence_metadata(
                         tool_call,
-                        tool_result,
-                        evidence_store=evidence_store,
-                        metadata=_tool_evidence_metadata(
-                            tool_call,
-                            source=execution.source,
-                            user_turn_id=user_turn_id,
-                            produced_by_phase="initial_tool_call",
-                        ),
-                    )
+                        source=execution.source,
+                        user_turn_id=user_turn_id,
+                        produced_by_phase="initial_tool_call",
+                    ),
                 )
+                runtime.messages.append(history_message)
+                if tool_result.name == ARTIFACT_TOOL_NAME:
+                    evidence_id = history_message.get("evidence_id")
+                    if isinstance(evidence_id, str):
+                        artifact_pending_evidence_id = evidence_id
                 if should_handoff_to_final_from_tool():
                     return answer_from_tool_results(
                         temperature=temperature,
@@ -864,10 +1086,40 @@ def run_tool_loop(
             or executing_completion_guard
             or executing_minimal_patch_guard
         )
+        active_tools = tools
+        active_allowed_tool_names = allowed_tool_names
+        if executing_mutation_verification and artifact_verification_required:
+            active_allowed_tool_names = tuple(
+                name for name in allowed_tool_names if name == ARTIFACT_VERIFY_TOOL_NAME
+            )
+            active_tools = [
+                definition
+                for definition in tools
+                if definition.get("function", {}).get("name") in active_allowed_tool_names
+            ]
+        elif ARTIFACT_VERIFY_TOOL_NAME in active_allowed_tool_names:
+            active_allowed_tool_names = tuple(
+                name for name in active_allowed_tool_names if name != ARTIFACT_VERIFY_TOOL_NAME
+            )
+            active_tools = [
+                definition
+                for definition in tools
+                if definition.get("function", {}).get("name") in active_allowed_tool_names
+            ]
         call_messages = with_tool_call_system_prompt(runtime.messages)
         if capability_context:
             call_messages = [*call_messages, {"role": "system", "content": capability_context}]
-        if repair.shell_repair_prompt_pending is not None:
+        if executing_mutation_verification and artifact_verification_required:
+            path_line = (
+                f"\nExact artifact path: {artifact_path_pending_verification}"
+                if artifact_path_pending_verification
+                else ""
+            )
+            call_messages = [
+                *call_messages,
+                {"role": "user", "content": ARTIFACT_VERIFICATION_PROMPT + path_line},
+            ]
+        elif repair.shell_repair_prompt_pending is not None:
             call_messages = [*call_messages, {"role": "user", "content": repair.shell_repair_prompt_pending}]
         elif repair.shell_empty_result_check_pending:
             call_messages = [*call_messages, {"role": "user", "content": SHELL_FULL_EMPTY_RESULT_CHECK_PROMPT}]
@@ -906,10 +1158,14 @@ def run_tool_loop(
             ),
             file_recovery=turn.pending_file_recovery_guard,
         )
+        artifact_verification_round = executing_mutation_verification and artifact_verification_required
         tool_delta_callback = (
             suppress_tool_delta
-            if shell_full_enabled
-            and (state.tool_rounds > 0 or repair.contract_retry_pending)
+            if artifact_verification_round
+            or (
+                shell_full_enabled
+                and (state.tool_rounds > 0 or repair.contract_retry_pending)
+            )
             else on_final_delta
         )
         if on_phase_start:
@@ -921,17 +1177,22 @@ def run_tool_loop(
                     reason="model_tool_call",
                 )
             )
-        result, shadow_report, attempt_id = observed_model_call(
-            lambda: runtime._chat_tool_call_once(
-                call_messages,
-                temperature=temperature,
-                max_tokens=tool_max_tokens,
-                tools=tools,
-                on_final_delta=tool_delta_callback,
-                on_progress=on_progress,
-            ),
-            phase="tool_call",
-        )
+        try:
+            result, shadow_report, attempt_id = observed_model_call(
+                lambda: runtime._chat_tool_call_once(
+                    call_messages,
+                    temperature=temperature,
+                    max_tokens=tool_max_tokens,
+                    tools=active_tools,
+                    on_final_delta=tool_delta_callback,
+                    on_progress=on_progress,
+                ),
+                phase="tool_call",
+            )
+        except BaseException:
+            if artifact_verification_round:
+                abort_pending_artifact()
+            raise
         produced_by_phase: str | None = "tool_call"
         last_result = result
         if on_model_step:
@@ -970,7 +1231,7 @@ def run_tool_loop(
                     retry_messages,
                     temperature=temperature,
                     max_tokens=tool_max_tokens,
-                    tools=tools,
+                    tools=active_tools,
                     on_final_delta=suppress_tool_delta,
                     on_progress=on_progress,
                 ),
@@ -990,6 +1251,27 @@ def run_tool_loop(
             elif result.tool_calls:
                 repair.contract_retry_pending = False
         turn.clear_pending_after_model_call()
+        if (
+            executing_mutation_verification
+            and artifact_verification_required
+            and result.finish_reason in {"cancelled", "error", "length", "timeout"}
+        ):
+            abort_pending_artifact()
+            artifact_verification_required = False
+            artifact_path_pending_verification = None
+            artifact_mutation_call_pending = None
+            record_terminal(
+                attempt_id=attempt_id,
+                report=shadow_report,
+                result=result,
+                outcome="rejected_guardrail",
+                reason="artifact_verification_incomplete",
+                phase=produced_by_phase or "tool_call",
+            )
+            return artifact_failure_result(
+                result,
+                "error: artifact verification did not complete; no artifact was published",
+            )
         truncated_tool_attempt = (
             result.finish_reason == "length"
             and not result.tool_calls
@@ -997,7 +1279,7 @@ def run_tool_loop(
             .detect(
                 text=result.content,
                 tool_calls=[],
-                registered_tool_names=allowed_tool_names,
+                registered_tool_names=active_allowed_tool_names,
             )
             .detected
         )
@@ -1024,6 +1306,15 @@ def run_tool_loop(
             request_minimal_patch_guard()
             continue
         if result.finish_reason == "length" and not result.tool_calls and state.tool_rounds > 0:
+            if artifact_verification_required:
+                abort_pending_artifact()
+                artifact_verification_required = False
+                artifact_path_pending_verification = None
+                artifact_mutation_call_pending = None
+                return artifact_failure_result(
+                    result,
+                    "error: artifact verification did not complete; no artifact was published",
+                )
             record_post_tool_final_reuse_fallback("finish_reason")
             record_terminal(
                 attempt_id=attempt_id,
@@ -1054,7 +1345,7 @@ def run_tool_loop(
                 phase=produced_by_phase or "tool_call",
             )
             result, shadow_report, attempt_id = observed_model_call(
-                lambda: _backend_tool_retry(runtime, call_messages, temperature, max_tokens, tools),
+                lambda: _backend_tool_retry(runtime, call_messages, temperature, max_tokens, active_tools),
                 phase="tool_call_retry",
             )
             produced_by_phase = "tool_call_retry"
@@ -1070,7 +1361,7 @@ def run_tool_loop(
                 phase=produced_by_phase or "tool_call",
             )
             result, shadow_report, attempt_id = observed_model_call(
-                lambda: _backend_tool_retry(runtime, call_messages, temperature, tool_max_tokens, tools),
+                lambda: _backend_tool_retry(runtime, call_messages, temperature, tool_max_tokens, active_tools),
                 phase="tool_call_retry",
             )
             produced_by_phase = "tool_call_retry"
@@ -1085,6 +1376,14 @@ def run_tool_loop(
                     reason="empty_after_retry",
                     phase=produced_by_phase,
                 )
+                if executing_mutation_verification and artifact_verification_required:
+                    artifact_verification_required = False
+                    artifact_path_pending_verification = None
+                    artifact_mutation_call_pending = None
+                    return artifact_failure_result(
+                        result,
+                        "error: artifact verification did not complete; no artifact was published",
+                    )
                 return runtime._chat_final(
                     with_chat_system_prompt(runtime.messages),
                     temperature=temperature,
@@ -1111,13 +1410,30 @@ def run_tool_loop(
                 tool_calls=[],
             )
         if result.tool_calls:
-            route_tool_call = command_tool_call_from_tool_calls(result.tool_calls, allowed_tool_names)
+            route_tool_call = command_tool_call_from_tool_calls(result.tool_calls, active_allowed_tool_names)
             if route_tool_call is not None:
                 if canonical_gate_enabled and _is_exact_canonical_tool_call(result.tool_calls[0]):
                     route_tool_call = result.tool_calls[0]
                 result = replace(result, content="", finish_reason="tool_calls", tool_calls=[route_tool_call])
         if not result.tool_calls:
-            route_tool_call = command_like_tool_call(result.content, allowed_tool_names)
+            if executing_mutation_verification and artifact_verification_required:
+                abort_pending_artifact()
+                artifact_verification_required = False
+                artifact_path_pending_verification = None
+                artifact_mutation_call_pending = None
+                record_terminal(
+                    attempt_id=attempt_id,
+                    report=shadow_report,
+                    result=result,
+                    outcome="rejected_guardrail",
+                    reason="artifact_verification_missing",
+                    phase=produced_by_phase or "tool_call",
+                )
+                return artifact_failure_result(
+                    result,
+                    "error: artifact verification was not selected; no artifact was published",
+                )
+            route_tool_call = command_like_tool_call(result.content, active_allowed_tool_names)
             if route_tool_call is not None:
                 result = replace(result, content="", finish_reason="tool_calls", tool_calls=[route_tool_call])
         repaired_decision: CanonicalToolDecision | None = None
@@ -1125,8 +1441,8 @@ def run_tool_loop(
             repaired = build_tool_call_repair(
                 text=result.content,
                 tool_calls=result.tool_calls,
-                tool_definitions=tools,
-                allowed_tool_names=allowed_tool_names,
+                tool_definitions=active_tools,
+                allowed_tool_names=active_allowed_tool_names,
                 workdir=Path(workdir),
                 user_prompt=user_prompt,
                 finish_reason=result.finish_reason,
@@ -1142,7 +1458,56 @@ def run_tool_loop(
                     tool_calls=[repaired.tool_call],
                 )
         canonical_decision: CanonicalToolDecision | None = None
-        if result.tool_calls and canonical_gate_enabled:
+        if result.tool_calls and executing_mutation_verification and artifact_verification_required:
+            verification_call = result.tool_calls[0]
+            function = verification_call.get("function")
+            name = function.get("name") if isinstance(function, dict) else None
+            verification_decision = validate_canonical_tool_call_payload(
+                verification_call,
+                tool_definitions=active_tools,
+                allowed_tool_names=active_allowed_tool_names,
+                workdir=Path(workdir),
+                user_prompt=user_prompt,
+            )
+            arguments = (
+                verification_decision.normalized_call.arguments
+                if verification_decision.accepted and verification_decision.normalized_call is not None
+                else {}
+            )
+            verification_path = arguments.get("path")
+            verification_check = arguments.get("check")
+            path = artifact_path_pending_verification
+            invalid_verification = (
+                len(result.tool_calls) != 1
+                or not verification_decision.accepted
+                or name != ARTIFACT_VERIFY_TOOL_NAME
+                or not path
+                or verification_path != path
+                or verification_check
+                not in {
+                    "content",
+                    "text_integrity",
+                }
+            )
+            if invalid_verification:
+                abort_pending_artifact()
+                artifact_verification_required = False
+                artifact_path_pending_verification = None
+                artifact_mutation_call_pending = None
+                record_terminal(
+                    attempt_id=attempt_id,
+                    report=shadow_report,
+                    result=result,
+                    outcome="rejected_guardrail",
+                    reason="artifact_verification_not_read_only",
+                    phase=produced_by_phase or "tool_call",
+                )
+                return artifact_failure_result(
+                    result,
+                    "error: artifact verification was invalid; no artifact was published",
+                )
+            canonical_decision = verification_decision
+        if result.tool_calls and canonical_gate_enabled and canonical_decision is None:
             canonical_decision = canonical_preflight(
                 result.tool_calls[0],
                 attempt_id=attempt_id,
@@ -1391,6 +1756,18 @@ def run_tool_loop(
                     executor=executor,
                     canonical_decision=canonical_decision,
                 )
+            except ArtifactGenerationError as exc:
+                abort_pending_artifact()
+                balance_cancelled_artifact_call(tool_call)
+                record_terminal(
+                    attempt_id=attempt_id,
+                    report=shadow_report,
+                    result=exc.result,
+                    outcome="cancelled",
+                    reason="artifact_generation_cancelled",
+                    phase="artifact_content",
+                )
+                return exc.result
             except Exception as exc:
                 timeout = isinstance(exc, TimeoutError) or "timed out" in str(exc).lower()
                 record_terminal(
@@ -1423,25 +1800,61 @@ def run_tool_loop(
                 execution_outcome=execution.terminal_outcome,
                 execution_reason=execution.terminal_reason,
             )
-            if execution.terminal_outcome == "executed" and _tool_call_is_mutating(tool_call):
+            if (
+                executing_mutation_verification
+                and artifact_verification_required
+                and execution.terminal_outcome == "executed"
+                and tool_result.name == ARTIFACT_VERIFY_TOOL_NAME
+                and "artifact_verification: complete" in tool_result.content
+                and "status: pass" in tool_result.content
+                and artifact_publication_completed is not None
+            ):
+                if artifact_mutation_call_pending is not None:
+                    state.advance_after_mutation(artifact_mutation_call_pending)
+                turn.shell_mutation_succeeded = True
+                artifact_verification_required = False
+                artifact_path_pending_verification = None
+                artifact_mutation_call_pending = None
+                artifact_publication_completed = None
+                artifact_finalization_required = True
+            if (
+                execution.terminal_outcome == "executed"
+                and _tool_call_is_mutating(tool_call)
+                and tool_result.name != ARTIFACT_TOOL_NAME
+            ):
                 state.advance_after_mutation(tool_call)
             if on_tool_result:
                 on_tool_result(tool_result.name, len(tool_result.content), execution.source, tool_result.content)
             if should_refresh_for_append(runtime.messages, tool_result.content, context_tokens=runtime.context_tokens):
                 runtime.refresh_memory_if_needed(temperature=temperature, force=True)
-            runtime.messages.append(
-                tool_result_message(
+            history_message = tool_result_message(
+                tool_call,
+                tool_result,
+                evidence_store=evidence_store,
+                metadata=_tool_evidence_metadata(
                     tool_call,
-                    tool_result,
-                    evidence_store=evidence_store,
-                    metadata=_tool_evidence_metadata(
-                        tool_call,
-                        source=execution.source,
-                        user_turn_id=user_turn_id,
-                        produced_by_phase=produced_by_phase,
-                    ),
-                )
+                    source=execution.source,
+                    user_turn_id=user_turn_id,
+                    produced_by_phase=produced_by_phase,
+                ),
             )
+            runtime.messages.append(history_message)
+            if tool_result.name == ARTIFACT_TOOL_NAME:
+                evidence_id = history_message.get("evidence_id")
+                if isinstance(evidence_id, str):
+                    artifact_pending_evidence_id = evidence_id
+            if artifact_finalization_required:
+                turn.mark_finalizable()
+                return answer_from_tool_results(
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    on_final_delta=on_final_delta,
+                    on_progress=on_progress,
+                    on_model_step=on_model_step,
+                    on_phase_start=on_phase_start,
+                    loop=loop_index + 1,
+                    use_tool_prompt=True,
+                )
             if should_handoff_to_final_from_tool():
                 return answer_from_tool_results(
                     temperature=temperature,
@@ -1480,6 +1893,22 @@ def run_tool_loop(
                 loop=loop_index + 1,
                 use_tool_prompt=state.used_tool_call_prompt,
             )
+    if artifact_pending_verification is not None or artifact_verification_required:
+        base_result = last_result or ChatResult(
+            content="",
+            model=None,
+            finish_reason=None,
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+        return artifact_failure_result(
+            base_result,
+            "error: artifact verification could not run within the bounded tool loop; no artifact was published",
+        )
     return last_result or ChatResult(
         content="error: tool loop did not produce a response",
         model=None,
@@ -1511,6 +1940,7 @@ def _is_exact_canonical_tool_call(tool_call: dict[str, object]) -> bool:
         "fetch_url",
         "list_directory",
         "system_info",
+        ARTIFACT_TOOL_NAME,
     }
 
 
@@ -1588,6 +2018,8 @@ def _tool_call_is_mutating(tool_call: dict[str, object]) -> bool:
     function = tool_call.get("function")
     if not isinstance(function, dict):
         return False
+    if function.get("name") == ARTIFACT_TOOL_NAME:
+        return True
     command = _shell_command_from_tool_call(tool_call)
     return bool(command and is_mutating_shell_command(command))
 

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -4,6 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from orbit.runtime.artifacts import (
+    ARTIFACT_TOOL_NAME,
+    ARTIFACT_VERIFY_TOOL_NAME,
+    verify_artifact_definition,
+    write_artifact_definition,
+)
 from orbit.runtime.directory_listing import execute_list_directory, list_directory_definition
 from orbit.runtime.shell_guardrails import (
     exec_shell_full_definition,
@@ -21,8 +27,15 @@ class ToolResult:
     content: str
 
 
-TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
+TOOL_NAMES = (
+    "exec_shell_full_command",
+    "fetch_url",
+    "list_directory",
+    "system_info",
+    ARTIFACT_TOOL_NAME,
+)
 DEFAULT_TOOL_NAMES = TOOL_NAMES
+_RUNTIME_TOOL_NAMES = (*TOOL_NAMES, ARTIFACT_VERIFY_TOOL_NAME)
 
 
 def tool_names() -> tuple[str, ...]:
@@ -34,10 +47,15 @@ def default_tool_names() -> tuple[str, ...]:
 
 
 def tool_definitions(names: tuple[str, ...] | None = None) -> list[dict[str, Any]]:
-    definitions = [exec_shell_full_definition(), fetch_url_definition(), list_directory_definition(), system_info_definition()]
-    if names is None:
-        return definitions
-    allowed = set(names)
+    definitions = [
+        exec_shell_full_definition(),
+        fetch_url_definition(),
+        list_directory_definition(),
+        system_info_definition(),
+        write_artifact_definition(),
+        verify_artifact_definition(),
+    ]
+    allowed = set(DEFAULT_TOOL_NAMES if names is None else names)
     return [tool for tool in definitions if tool["function"]["name"] in allowed]
 
 
@@ -50,7 +68,7 @@ def execute_tool(
     user_prompt: str | None = None,
 ) -> ToolResult:
     del chunk_budget
-    if name not in TOOL_NAMES:
+    if name not in _RUNTIME_TOOL_NAMES:
         return ToolResult(name=name, content=f"error: unknown tool: {name}")
     parsed = parse_tool_arguments(arguments)
     if isinstance(parsed, str):
@@ -64,4 +82,6 @@ def execute_tool(
         return ToolResult(name=name, content=execute_list_directory(parsed, workdir=workdir))
     if name == "system_info":
         return ToolResult(name=name, content=execute_system_info(parsed))
+    if name in {ARTIFACT_TOOL_NAME, ARTIFACT_VERIFY_TOOL_NAME}:
+        return ToolResult(name=name, content="error: artifact generation requires runtime orchestration")
     return ToolResult(name=name, content=execute_exec_shell_full_command(parsed, workdir=workdir, user_prompt=user_prompt))

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -11,6 +11,7 @@ from orbit.dev.release_confidence import main as release_confidence_main
 from orbit.native_llama.download_cli import main as native_download_main
 from orbit.native_server.app import run_server
 from orbit.runtime import ChatRuntime
+from orbit.runtime.artifacts import cleanup_stale_artifact_entries
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.media import load_audio, load_image
 from orbit.runtime.turn_trace import ModelStepMetrics
@@ -68,6 +69,8 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+
+    cleanup_stale_artifact_entries(config.workdir)
 
     backend = LlamaServerBackend(base_url=config.base_url, timeout=config.timeout)
     backend.thinking = config.think

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -53,10 +53,9 @@ def format_tool_call_event(name: str, args: str) -> str:
             parsed = json.loads(args)
         except (TypeError, ValueError):
             parsed = {}
-        path = parsed.get("path") if isinstance(parsed, dict) else None
         check = parsed.get("check") if isinstance(parsed, dict) else None
-        if isinstance(path, str) and isinstance(check, str):
-            return f"Verify: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)} ({check})"
+        if isinstance(check, str):
+            return f"Verify: published artifact ({check})"
     return f"{display_tool_name(name)} {args}"
 
 

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -15,6 +15,8 @@ DISPLAY_TOOL_NAMES = {
     "fetch_url": "fetch_url",
     "list_directory": "list_directory",
     "system_info": "system_info",
+    "write_artifact": "write_artifact",
+    "verify_artifact": "verify_artifact",
 }
 
 
@@ -38,6 +40,23 @@ def format_tool_call_event(name: str, args: str) -> str:
             return f"ListDir{suffix}: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
     if name == "system_info":
         return "SystemInfo"
+    if name == "write_artifact":
+        try:
+            parsed = json.loads(args)
+        except (TypeError, ValueError):
+            parsed = {}
+        path = parsed.get("path") if isinstance(parsed, dict) else None
+        if isinstance(path, str) and path:
+            return f"Artifact: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
+    if name == "verify_artifact":
+        try:
+            parsed = json.loads(args)
+        except (TypeError, ValueError):
+            parsed = {}
+        path = parsed.get("path") if isinstance(parsed, dict) else None
+        check = parsed.get("check") if isinstance(parsed, dict) else None
+        if isinstance(path, str) and isinstance(check, str):
+            return f"Verify: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)} ({check})"
     return f"{display_tool_name(name)} {args}"
 
 

--- a/src/orbit/terminal/tool_mode.py
+++ b/src/orbit/terminal/tool_mode.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 ToolSpec = str
 
-DEFAULT_ON_TOOL_NAMES = ("exec_shell_full_command", "fetch_url", "list_directory", "system_info")
+DEFAULT_ON_TOOL_NAMES = (
+    "exec_shell_full_command",
+    "fetch_url",
+    "list_directory",
+    "system_info",
+    "write_artifact",
+)
 
 SPECIAL_TOOL_SPECS = ("off", "on")
 USAGE = "off|on|status|refresh"

--- a/tests/test_artifact_tool_loop.py
+++ b/tests/test_artifact_tool_loop.py
@@ -58,7 +58,7 @@ class _ArtifactWorkflowBackend:
         self.initial_result = initial_result
         self.verification_call = verification_call or _tool_call(
             "verify_artifact",
-            {"path": "samples/game.js", "check": "text_integrity"},
+            {"check": "text_integrity"},
             "verify-1",
         )
         self.verification_result = verification_result
@@ -165,7 +165,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
             artifact_result=_result("x" * 2_000),
             verification_call=_tool_call(
                 "verify_artifact",
-                {"path": "samples/game.js", "check": "content"},
+                {"check": "content"},
                 "verify-content",
             ),
         )
@@ -234,9 +234,9 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     artifact_exists = (root / "samples/game.js").exists()
                     parent_exists = (root / "samples").exists()
 
-                self.assertFalse(artifact_exists)
-                self.assertFalse(parent_exists)
-                self.assertIn("no artifact was published", result.content)
+                self.assertTrue(artifact_exists)
+                self.assertTrue(parent_exists)
+                self.assertIn("published but verification was invalid", result.content)
                 self.assertEqual(backend.calls, 2)
 
     def test_malformed_artifact_call_cannot_fall_through_to_shell(self) -> None:
@@ -262,6 +262,40 @@ class ArtifactToolLoopTests(unittest.TestCase):
 
             self.assertFalse((root / "samples/game.js").exists())
             self.assertEqual(backend.artifact_calls, [])
+            self.assertNotIn("Created samples/game.js", result.content)
+
+    def test_verify_artifact_before_publication_is_structurally_unavailable(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            initial_result=_result(
+                "",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    _tool_call(
+                        "verify_artifact",
+                        {"path": "samples/game.js", "check": "text_integrity"},
+                        "verify-before-publication",
+                    )
+                ],
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                "verify samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "samples/game.js").exists())
+            self.assertEqual(backend.artifact_calls, [])
+            visible_tools = {
+                tool["function"]["name"]
+                for tools in backend.tools_seen
+                if tools is not None
+                for tool in tools
+            }
+            self.assertNotIn("verify_artifact", visible_tools)
             self.assertNotIn("Created samples/game.js", result.content)
 
     def test_cancelled_artifact_generation_terminates_without_another_model_call(self) -> None:
@@ -335,7 +369,8 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 workdir=root,
             )
 
-            self.assertIn("no artifact was published", result.content)
+            self.assertTrue((root / "samples/game.js").is_file())
+            self.assertIn("published but verification was invalid", result.content)
             self.assertNotIn(
                 "artifact_pending",
                 [record.kind for record in runtime.evidence_store.recent_records(10)],
@@ -360,8 +395,8 @@ class ArtifactToolLoopTests(unittest.TestCase):
             )
 
             self.assertEqual(backend.calls, 3)
-            self.assertFalse((root / "samples").exists())
-            self.assertIn("no artifact was published", result.content)
+            self.assertTrue((root / "samples/game.js").is_file())
+            self.assertIn("published but verification did not complete", result.content)
             self.assertNotIn(
                 "artifact_pending",
                 [record.kind for record in runtime.evidence_store.recent_records(10)],
@@ -412,7 +447,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     workdir=root,
                 )
 
-            self.assertFalse((root / "samples").exists())
+            self.assertTrue((root / "samples/game.js").is_file())
             self.assertNotIn(
                 "artifact_pending",
                 [record.kind for record in runtime.evidence_store.recent_records(10)],
@@ -436,8 +471,8 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 tool_names=("write_artifact",),
             )
 
-            self.assertFalse((root / "samples").exists())
-            self.assertIn("no artifact was published", result.content)
+            self.assertTrue((root / "samples/game.js").is_file())
+            self.assertIn("published but verification could not run", result.content)
             self.assertNotIn(
                 "artifact_pending",
                 [record.kind for record in runtime.evidence_store.recent_records(10)],
@@ -508,14 +543,15 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 workdir=root,
             )
 
-            self.assertFalse((root / "samples").exists())
+            self.assertTrue((root / "samples/game.js").is_file())
             self.assertEqual(len(backend.artifact_calls), 1)
-            self.assertIn("no artifact was published", result.content)
+            self.assertFalse((root / "samples/second.js").exists())
+            self.assertIn("published but verification was invalid", result.content)
 
     def test_verification_requires_exactly_one_call_with_canonical_gate_on_or_off(self) -> None:
         valid = _tool_call(
             "verify_artifact",
-            {"path": "samples/game.js", "check": "text_integrity"},
+            {"check": "text_integrity"},
             "verify",
         )
         second = _tool_call(
@@ -543,9 +579,9 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     workdir=root,
                 )
 
-                self.assertFalse((root / "samples").exists())
+                self.assertTrue((root / "samples/game.js").is_file())
                 self.assertEqual(len(backend.artifact_calls), 1)
-                self.assertIn("no artifact was published", result.content)
+                self.assertIn("published but verification", result.content)
 
     def test_duplicate_verification_arguments_fail_with_canonical_gate_on_or_off(self) -> None:
         duplicate = {
@@ -554,8 +590,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
             "function": {
                 "name": "verify_artifact",
                 "arguments": (
-                    '{"path":"samples/game.js","path":"samples/game.js",'
-                    '"check":"text_integrity"}'
+                    '{"check":"text_integrity","check":"text_integrity"}'
                 ),
             },
         }
@@ -573,8 +608,8 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     workdir=root,
                 )
 
-                self.assertFalse((root / "samples").exists())
-                self.assertIn("no artifact was published", result.content)
+                self.assertTrue((root / "samples/game.js").is_file())
+                self.assertIn("published but verification", result.content)
 
     def test_internal_verifier_prose_is_not_streamed(self) -> None:
         backend = _ArtifactWorkflowBackend(
@@ -591,11 +626,11 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 on_final_delta=emitted.append,
             )
 
-            self.assertFalse((root / "samples").exists())
+            self.assertTrue((root / "samples/game.js").is_file())
         self.assertEqual("".join(emitted), result.content)
         self.assertNotIn("I cannot verify", "".join(emitted))
 
-    def test_verification_must_reference_the_model_selected_artifact(self) -> None:
+    def test_verification_rejects_path_substitution(self) -> None:
         backend = _ArtifactWorkflowBackend(
             verification_call=_tool_call(
                 "verify_artifact",
@@ -612,9 +647,9 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 workdir=Path(tmp),
             )
 
-            self.assertFalse((Path(tmp) / "samples").exists())
+            self.assertTrue((Path(tmp) / "samples/game.js").is_file())
 
-        self.assertIn("no artifact was published", result.content)
+        self.assertIn("published but verification was invalid", result.content)
 
     def test_verification_extra_arguments_fail_closed_with_canonical_gate_on_or_off(self) -> None:
         for canonical_gate in ("0", "1"):
@@ -626,7 +661,6 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     verification_call=_tool_call(
                         "verify_artifact",
                         {
-                            "path": "samples/game.js",
                             "check": "text_integrity",
                             "command": "printf unexpected",
                         },
@@ -643,7 +677,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
                         workdir=root,
                     )
 
-                    self.assertFalse((root / "samples").exists())
+                    self.assertTrue((root / "samples/game.js").is_file())
                     self.assertNotIn("Created samples/game.js", result.content)
                     self.assertIn("verification was invalid", result.content)
 
@@ -667,7 +701,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "stop")
         self.assertNotIn("Created samples/game.js", result.content)
 
-    def test_cancelled_or_length_verification_aborts_pending_file_and_parents(self) -> None:
+    def test_cancelled_or_length_verification_preserves_published_file(self) -> None:
         cases = (
             ("cancelled", None),
             ("length", None),
@@ -675,7 +709,7 @@ class ArtifactToolLoopTests(unittest.TestCase):
                 "length",
                 _tool_call(
                     "verify_artifact",
-                    {"path": "samples/game.js", "check": "text_integrity"},
+                    {"check": "text_integrity"},
                     "truncated-verification",
                 ),
             ),
@@ -703,10 +737,10 @@ class ArtifactToolLoopTests(unittest.TestCase):
                     on_final_delta=emitted.append,
                 )
 
-                self.assertFalse((root / "samples").exists())
+                self.assertTrue((root / "samples/game.js").is_file())
                 self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
                 self.assertEqual(result.finish_reason, "stop")
-                self.assertIn("no artifact was published", result.content)
+                self.assertIn("artifact was published but verification", result.content)
                 self.assertEqual("".join(emitted), result.content)
                 self.assertEqual(runtime.messages[-1], {"role": "assistant", "content": result.content})
 

--- a/tests/test_artifact_tool_loop.py
+++ b/tests/test_artifact_tool_loop.py
@@ -1,0 +1,768 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from orbit.backend.base import ChatResult
+from orbit.runtime import ChatRuntime
+from orbit.runtime.artifacts import ARTIFACT_VERIFICATION_PROMPT
+
+
+def _result(
+    content: str,
+    *,
+    finish_reason: str = "stop",
+    tool_calls: list[dict] | None = None,
+) -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=tool_calls or [],
+        prompt_tokens=10,
+        completion_tokens=3,
+        cached_tokens=0,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
+    )
+
+
+def _tool_call(name: str, arguments: dict, call_id: str) -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(arguments)},
+    }
+
+
+class _ArtifactWorkflowBackend:
+    def __init__(
+        self,
+        *,
+        artifact_result: ChatResult | None = None,
+        request_path: str = "samples/game.js",
+        initial_result: ChatResult | None = None,
+        verification_call: dict | None = None,
+        verification_result: ChatResult | None = None,
+    ) -> None:
+        self.calls = 0
+        self.chat_messages = []
+        self.tools_seen = []
+        self.artifact_calls = []
+        self.artifact_result = artifact_result or _result("console.log('playable');\n")
+        self.request_path = request_path
+        self.initial_result = initial_result
+        self.verification_call = verification_call or _tool_call(
+            "verify_artifact",
+            {"path": "samples/game.js", "check": "text_integrity"},
+            "verify-1",
+        )
+        self.verification_result = verification_result
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        del temperature, max_tokens
+        self.calls += 1
+        self.chat_messages.append(messages)
+        self.tools_seen.append(tools)
+        if self.calls == 1:
+            if self.initial_result is not None:
+                return self.initial_result
+            return _result(
+                json.dumps(
+                    {
+                        "tool": "write_artifact",
+                        "arguments": {
+                            "path": self.request_path,
+                            "overwrite": False,
+                            "create_parents": True,
+                        },
+                    }
+                )
+            )
+        if tools is not None and [tool["function"]["name"] for tool in tools] == ["verify_artifact"]:
+            if self.verification_result is not None:
+                return self.verification_result
+            return _result("", finish_reason="tool_calls", tool_calls=[self.verification_call])
+        visible = "\n".join(str(message.get("content", "")) for message in messages)
+        if "artifact_verification: complete" in visible:
+            return _result("Created samples/game.js and verified its UTF-8 content, byte count, and hash.")
+        if "finish_reason=length" in visible:
+            return _result("The artifact was not created because content generation reached its limit.")
+        if any(marker in visible.lower() for marker in ("no-mutation", "read-only", "mutation constraint")):
+            return _result("The artifact was not created because the explicit no-mutation policy denied it.")
+        return _result("The artifact workflow did not complete.")
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta, on_progress=None):
+        del on_progress
+        result = self.chat(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+        )
+        if result.content:
+            on_delta(result.content)
+        return result
+
+    def artifact_content_stream(self, messages, **kwargs):
+        self.artifact_calls.append((messages, kwargs))
+        return self.artifact_result
+
+
+class ArtifactToolLoopTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._post_tool_reuse = mock.patch.dict(
+            os.environ,
+            {"ORBIT_POST_TOOL_FINAL_REUSE": "1"},
+        )
+        self._post_tool_reuse.start()
+        self.addCleanup(self._post_tool_reuse.stop)
+
+    def test_model_selected_artifact_is_published_then_verified_read_only(self) -> None:
+        backend = _ArtifactWorkflowBackend()
+        tool_calls = []
+        tool_results = []
+        phases = []
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "write a small JavaScript game and save it in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+                on_tool_call=lambda name, arguments: tool_calls.append((name, arguments)),
+                on_tool_result=lambda name, chars, source, content: tool_results.append(
+                    (name, chars, source, content)
+                ),
+                on_phase_start=lambda phase: phases.append(phase.phase),
+            )
+
+            artifact = root / "samples/game.js"
+            self.assertEqual(artifact.read_text(encoding="utf-8"), "console.log('playable');\n")
+            self.assertEqual(os.stat(root / "samples").st_mode & 0o777, 0o755)
+
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertIn("Created samples/game.js", result.content)
+        self.assertEqual([name for name, _ in tool_calls], ["write_artifact", "verify_artifact"])
+        self.assertEqual([item[0] for item in tool_results], ["write_artifact", "verify_artifact"])
+        self.assertEqual(len(backend.artifact_calls), 1)
+        self.assertEqual(
+            [tool["function"]["name"] for tool in backend.tools_seen[1]],
+            ["verify_artifact"],
+        )
+        self.assertIn(ARTIFACT_VERIFICATION_PROMPT, backend.chat_messages[1][-1]["content"])
+        self.assertIn("artifact_content", phases)
+        self.assertEqual(runtime.mutation_verifications, 1)
+        self.assertEqual(runtime.mutation_semantic_repairs, 0)
+
+    def test_artifact_final_keeps_publication_policy_when_content_evidence_is_large(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            artifact_result=_result("x" * 2_000),
+            verification_call=_tool_call(
+                "verify_artifact",
+                {"path": "samples/game.js", "check": "content"},
+                "verify-content",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertTrue((root / "samples/game.js").is_file())
+            final_messages = backend.chat_messages[-1]
+            self.assertTrue(any(message.get("name") == "write_artifact" for message in final_messages))
+            self.assertTrue(any(message.get("name") == "verify_artifact" for message in final_messages))
+            self.assertIn("Created samples/game.js", result.content)
+
+    def test_noncanonical_safe_path_uses_canonical_pending_verification_path(self) -> None:
+        backend = _ArtifactWorkflowBackend(request_path="./samples/game.js")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+            result = runtime.ask_auto(
+                "write a small JavaScript game and save it in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertEqual((root / "samples/game.js").read_text(), "console.log('playable');\n")
+            self.assertEqual(result.finish_reason, "stop")
+            verification_messages = next(
+                messages
+                for messages, tools in zip(backend.chat_messages, backend.tools_seen)
+                if tools is not None
+                and [tool["function"]["name"] for tool in tools] == ["verify_artifact"]
+            )
+            self.assertIn("Exact artifact path: samples/game.js", verification_messages[-1]["content"])
+            self.assertNotIn("Exact artifact path: ./samples/game.js", verification_messages[-1]["content"])
+
+    def test_wrong_verification_tool_is_rejected_without_execution(self) -> None:
+        for canonical_gate in ("0", "1"):
+            with self.subTest(canonical_gate=canonical_gate), mock.patch.dict(
+                os.environ,
+                {"ORBIT_TOOL_CALL_CANONICAL_GATE": canonical_gate},
+            ):
+                backend = _ArtifactWorkflowBackend(
+                    verification_call=_tool_call(
+                        "exec_shell_full_command",
+                        {"command": "printf bad >> samples/game.js"},
+                        "verify-mutation",
+                    )
+                )
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    runtime = ChatRuntime(backend=backend, system_prompt=None)
+                    result = runtime.ask_auto(
+                        "write a small JavaScript game and save it in samples",
+                        temperature=0,
+                        max_tokens=256,
+                        workdir=root,
+                    )
+                    artifact_exists = (root / "samples/game.js").exists()
+                    parent_exists = (root / "samples").exists()
+
+                self.assertFalse(artifact_exists)
+                self.assertFalse(parent_exists)
+                self.assertIn("no artifact was published", result.content)
+                self.assertEqual(backend.calls, 2)
+
+    def test_malformed_artifact_call_cannot_fall_through_to_shell(self) -> None:
+        malformed = _tool_call(
+            "write_artifact",
+            {
+                "path": "samples/game.js",
+                "command": "mkdir -p samples && printf bypassed > samples/game.js",
+            },
+            "artifact-malformed",
+        )
+        backend = _ArtifactWorkflowBackend(
+            initial_result=_result("", finish_reason="tool_calls", tool_calls=[malformed])
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "samples/game.js").exists())
+            self.assertEqual(backend.artifact_calls, [])
+            self.assertNotIn("Created samples/game.js", result.content)
+
+    def test_cancelled_artifact_generation_terminates_without_another_model_call(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            artifact_result=_result("partial", finish_reason="cancelled")
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertEqual(result.finish_reason, "cancelled")
+            self.assertEqual(backend.calls, 1)
+            self.assertFalse((root / "samples").exists())
+            self.assertEqual([message["role"] for message in runtime.messages], ["user", "assistant", "tool"])
+            self.assertEqual(runtime.messages[-1]["name"], "write_artifact")
+            self.assertIn("cancelled", runtime.messages[-1]["content"])
+
+    def test_duplicate_write_path_is_rejected_with_canonical_gate_off(self) -> None:
+        duplicate = {
+            "id": "write-duplicate",
+            "type": "function",
+            "function": {
+                "name": "write_artifact",
+                "arguments": (
+                    '{"path":"safe.txt","path":"other.txt",'
+                    '"overwrite":false,"create_parents":false}'
+                ),
+            },
+        }
+        backend = _ArtifactWorkflowBackend(
+            initial_result=_result("", finish_reason="tool_calls", tool_calls=[duplicate])
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"ORBIT_TOOL_CALL_CANONICAL_GATE": "0"},
+        ), tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                "create safe.txt",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "safe.txt").exists())
+            self.assertFalse((root / "other.txt").exists())
+            self.assertEqual(backend.artifact_calls, [])
+            self.assertNotIn("Created", result.content)
+
+    def test_rejected_verification_discards_pending_evidence(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            verification_call=_tool_call(
+                "exec_shell_full_command",
+                {"command": "printf bad >> samples/game.js"},
+                "invalid-verifier",
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertIn("no artifact was published", result.content)
+            self.assertNotIn(
+                "artifact_pending",
+                [record.kind for record in runtime.evidence_store.recent_records(10)],
+            )
+            route_context = "\n".join(
+                str(message.get("content", "")) for message in runtime._route_messages()
+            )
+            self.assertNotIn("artifact_pending", route_context)
+
+    def test_two_empty_verifier_results_fail_without_chat_fallback(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            verification_result=_result("", finish_reason="stop")
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertEqual(backend.calls, 3)
+            self.assertFalse((root / "samples").exists())
+            self.assertIn("no artifact was published", result.content)
+            self.assertNotIn(
+                "artifact_pending",
+                [record.kind for record in runtime.evidence_store.recent_records(10)],
+            )
+
+    def test_artifact_generation_timeout_propagates_without_another_model_call(self) -> None:
+        class TimeoutBackend(_ArtifactWorkflowBackend):
+            def artifact_content_stream(self, messages, **kwargs):
+                del messages, kwargs
+                raise TimeoutError("artifact timeout")
+
+        backend = TimeoutBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(TimeoutError, "artifact timeout"):
+                ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                    "create samples/game.js",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=root,
+                )
+
+            self.assertEqual(backend.calls, 1)
+            self.assertFalse((root / "samples").exists())
+
+    def test_verification_timeout_discards_pending_evidence(self) -> None:
+        class VerificationTimeoutBackend(_ArtifactWorkflowBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                if self.calls == 1:
+                    self.calls += 1
+                    raise TimeoutError("verification timeout")
+                return super().chat(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                )
+
+        backend = VerificationTimeoutBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            with self.assertRaisesRegex(TimeoutError, "verification timeout"):
+                runtime.ask_auto(
+                    "create samples/game.js",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=root,
+                )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertNotIn(
+                "artifact_pending",
+                [record.kind for record in runtime.evidence_store.recent_records(10)],
+            )
+            self.assertNotIn(
+                "artifact_pending",
+                "\n".join(str(message.get("content", "")) for message in runtime._route_messages()),
+            )
+
+    def test_loop_bound_before_verification_aborts_pending_artifact(self) -> None:
+        backend = _ArtifactWorkflowBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_with_tools(
+                "create samples/game.js",
+                temperature=0,
+                max_tokens=256,
+                max_loops=1,
+                workdir=root,
+                tool_names=("write_artifact",),
+            )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertIn("no artifact was published", result.content)
+            self.assertNotIn(
+                "artifact_pending",
+                [record.kind for record in runtime.evidence_store.recent_records(10)],
+            )
+
+    def test_successful_verification_finalizes_before_second_artifact(self) -> None:
+        class TwoArtifactBackend(_ArtifactWorkflowBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                if self.calls == 2 and tools is not None:
+                    self.calls += 1
+                    return _result(
+                        "",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            _tool_call(
+                                "write_artifact",
+                                {
+                                    "path": "samples/second.js",
+                                    "overwrite": False,
+                                    "create_parents": True,
+                                },
+                                "write-second",
+                            )
+                        ],
+                    )
+                return super().chat(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                )
+
+        backend = TwoArtifactBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                "create one JavaScript file",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertTrue((root / "samples/game.js").is_file())
+            self.assertFalse((root / "samples/second.js").exists())
+            self.assertEqual(len(backend.artifact_calls), 1)
+            self.assertEqual(result.finish_reason, "stop")
+            self.assertIn("Created samples/game.js", result.content)
+
+    def test_second_write_attempt_during_verification_is_rejected(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            verification_call=_tool_call(
+                "write_artifact",
+                {
+                    "path": "samples/second.js",
+                    "overwrite": False,
+                    "create_parents": True,
+                },
+                "second-write",
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "write one JavaScript game in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertEqual(len(backend.artifact_calls), 1)
+            self.assertIn("no artifact was published", result.content)
+
+    def test_verification_requires_exactly_one_call_with_canonical_gate_on_or_off(self) -> None:
+        valid = _tool_call(
+            "verify_artifact",
+            {"path": "samples/game.js", "check": "text_integrity"},
+            "verify",
+        )
+        second = _tool_call(
+            "write_artifact",
+            {"path": "samples/second.js", "overwrite": False, "create_parents": True},
+            "second",
+        )
+        for canonical_gate in ("0", "1"):
+            with self.subTest(canonical_gate=canonical_gate), mock.patch.dict(
+                os.environ,
+                {"ORBIT_TOOL_CALL_CANONICAL_GATE": canonical_gate},
+            ), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                backend = _ArtifactWorkflowBackend(
+                    verification_result=_result(
+                        "",
+                        finish_reason="tool_calls",
+                        tool_calls=[valid, second],
+                    )
+                )
+                result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                    "write one JavaScript game in samples",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=root,
+                )
+
+                self.assertFalse((root / "samples").exists())
+                self.assertEqual(len(backend.artifact_calls), 1)
+                self.assertIn("no artifact was published", result.content)
+
+    def test_duplicate_verification_arguments_fail_with_canonical_gate_on_or_off(self) -> None:
+        duplicate = {
+            "id": "verify-duplicate",
+            "type": "function",
+            "function": {
+                "name": "verify_artifact",
+                "arguments": (
+                    '{"path":"samples/game.js","path":"samples/game.js",'
+                    '"check":"text_integrity"}'
+                ),
+            },
+        }
+        for canonical_gate in ("0", "1"):
+            with self.subTest(canonical_gate=canonical_gate), mock.patch.dict(
+                os.environ,
+                {"ORBIT_TOOL_CALL_CANONICAL_GATE": canonical_gate},
+            ), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                backend = _ArtifactWorkflowBackend(verification_call=duplicate)
+                result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                    "write one JavaScript game in samples",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=root,
+                )
+
+                self.assertFalse((root / "samples").exists())
+                self.assertIn("no artifact was published", result.content)
+
+    def test_internal_verifier_prose_is_not_streamed(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            verification_result=_result("I cannot verify.", finish_reason="stop")
+        )
+        emitted: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = ChatRuntime(backend=backend, system_prompt=None).ask_auto(
+                "write one JavaScript game in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+                on_final_delta=emitted.append,
+            )
+
+            self.assertFalse((root / "samples").exists())
+        self.assertEqual("".join(emitted), result.content)
+        self.assertNotIn("I cannot verify", "".join(emitted))
+
+    def test_verification_must_reference_the_model_selected_artifact(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            verification_call=_tool_call(
+                "verify_artifact",
+                {"path": "samples/other.js", "check": "content"},
+                "verify-unrelated",
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "write a small JavaScript game and save it in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=Path(tmp),
+            )
+
+            self.assertFalse((Path(tmp) / "samples").exists())
+
+        self.assertIn("no artifact was published", result.content)
+
+    def test_verification_extra_arguments_fail_closed_with_canonical_gate_on_or_off(self) -> None:
+        for canonical_gate in ("0", "1"):
+            with self.subTest(canonical_gate=canonical_gate), mock.patch.dict(
+                os.environ,
+                {"ORBIT_TOOL_CALL_CANONICAL_GATE": canonical_gate},
+            ):
+                backend = _ArtifactWorkflowBackend(
+                    verification_call=_tool_call(
+                        "verify_artifact",
+                        {
+                            "path": "samples/game.js",
+                            "check": "text_integrity",
+                            "command": "printf unexpected",
+                        },
+                        "verify-extra",
+                    )
+                )
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    runtime = ChatRuntime(backend=backend, system_prompt=None)
+                    result = runtime.ask_auto(
+                        "write one JavaScript game in samples",
+                        temperature=0,
+                        max_tokens=256,
+                        workdir=root,
+                    )
+
+                    self.assertFalse((root / "samples").exists())
+                    self.assertNotIn("Created samples/game.js", result.content)
+                    self.assertIn("verification was invalid", result.content)
+
+    def test_length_artifact_is_not_published(self) -> None:
+        backend = _ArtifactWorkflowBackend(
+            artifact_result=_result("partial content", finish_reason="length")
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "write a small JavaScript game and save it in samples",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertNotIn("Created samples/game.js", result.content)
+
+    def test_cancelled_or_length_verification_aborts_pending_file_and_parents(self) -> None:
+        cases = (
+            ("cancelled", None),
+            ("length", None),
+            (
+                "length",
+                _tool_call(
+                    "verify_artifact",
+                    {"path": "samples/game.js", "check": "text_integrity"},
+                    "truncated-verification",
+                ),
+            ),
+        )
+        for finish_reason, tool_call in cases:
+            with self.subTest(
+                finish_reason=finish_reason,
+                tool_call=tool_call is not None,
+            ), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                backend = _ArtifactWorkflowBackend(
+                    verification_result=_result(
+                        "",
+                        finish_reason=finish_reason,
+                        tool_calls=[tool_call] if tool_call is not None else None,
+                    )
+                )
+                runtime = ChatRuntime(backend=backend, system_prompt=None)
+                emitted: list[str] = []
+                result = runtime.ask_auto(
+                    "write a small JavaScript game and save it in samples",
+                    temperature=0,
+                    max_tokens=256,
+                    workdir=root,
+                    on_final_delta=emitted.append,
+                )
+
+                self.assertFalse((root / "samples").exists())
+                self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+                self.assertEqual(result.finish_reason, "stop")
+                self.assertIn("no artifact was published", result.content)
+                self.assertEqual("".join(emitted), result.content)
+                self.assertEqual(runtime.messages[-1], {"role": "assistant", "content": result.content})
+
+    def test_quoted_no_mutation_phrase_does_not_block_legitimate_artifact(self) -> None:
+        backend = _ArtifactWorkflowBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                'Create samples/game.js containing the text "without changing any files".',
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertTrue((root / "samples/game.js").is_file())
+            self.assertEqual(result.finish_reason, "stop")
+
+    def test_no_mutation_policy_blocks_artifact_before_content_generation(self) -> None:
+        for canonical_gate in ("0", "1"):
+            with self.subTest(canonical_gate=canonical_gate), mock.patch.dict(
+                os.environ,
+                {"ORBIT_TOOL_CALL_CANONICAL_GATE": canonical_gate},
+            ):
+                backend = _ArtifactWorkflowBackend()
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    runtime = ChatRuntime(backend=backend, system_prompt=None)
+                    result = runtime.ask_auto(
+                        "Without changing any files, write a JavaScript game in samples.",
+                        temperature=0,
+                        max_tokens=256,
+                        workdir=root,
+                    )
+
+                    self.assertFalse((root / "samples").exists())
+
+                self.assertEqual(backend.artifact_calls, [])
+                self.assertIn("no-mutation", result.content.lower())
+
+    def test_mixed_no_mutation_constraint_blocks_artifact(self) -> None:
+        backend = _ArtifactWorkflowBackend()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            result = runtime.ask_auto(
+                "Inspect without changing files, then create samples/game.js.",
+                temperature=0,
+                max_tokens=256,
+                workdir=root,
+            )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertEqual(backend.artifact_calls, [])
+            self.assertIn("no-mutation", result.content.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,1291 @@
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+from pathlib import Path
+import stat
+import socket
+import tempfile
+import unittest
+from unittest import mock
+
+from orbit.backend.base import ChatResult
+from orbit.runtime import artifacts as artifact_module
+from orbit.runtime.artifacts import (
+    ARTIFACT_CONTENT_MAX_TOKENS,
+    MAX_ARTIFACT_BYTES,
+    artifact_content_messages,
+    begin_artifact_generation,
+    prepare_artifact_target,
+    validate_artifact_path,
+    verify_artifact_definition,
+    write_artifact_definition,
+)
+
+
+def _result(content: str, *, finish_reason: str = "stop") -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=[],
+        prompt_tokens=10,
+        completion_tokens=3,
+        cached_tokens=0,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
+    )
+
+
+class _Backend:
+    def __init__(self, result: ChatResult, *, during_call=None) -> None:
+        self.result = result
+        self.during_call = during_call
+        self.calls = []
+
+    def artifact_content_stream(self, messages, **kwargs):
+        self.calls.append((messages, kwargs))
+        if self.during_call is not None:
+            self.during_call()
+        return self.result
+
+
+class ArtifactPublicationTests(unittest.TestCase):
+    def _generate(
+        self,
+        root: Path,
+        backend: _Backend,
+        *,
+        path: str = "samples/game.js",
+        overwrite: bool = False,
+        create_parents: bool = True,
+        check: str = "text_integrity",
+    ):
+        pending = begin_artifact_generation(
+            backend=backend,
+            user_request="create a browser game",
+            path=path,
+            overwrite=overwrite,
+            create_parents=create_parents,
+            workdir=root,
+            temperature=0,
+            on_progress=None,
+        )
+        try:
+            publication, _evidence = pending.verify_and_publish(
+                {"path": path, "check": check},
+                workdir=root,
+            )
+            return pending.generation, publication
+        finally:
+            pending.abort()
+
+    def test_schema_is_small_and_content_is_not_an_argument(self) -> None:
+        function = write_artifact_definition()["function"]
+        properties = function["parameters"]["properties"]
+
+        self.assertEqual(function["name"], "write_artifact")
+        self.assertEqual(set(properties), {"path", "overwrite", "create_parents"})
+        self.assertNotIn("content", properties)
+
+        verify_function = verify_artifact_definition()["function"]
+        self.assertEqual(verify_function["name"], "verify_artifact")
+        self.assertEqual(
+            set(verify_function["parameters"]["properties"]),
+            {"path", "check"},
+        )
+        self.assertEqual(
+            verify_function["parameters"]["properties"]["check"]["enum"],
+            ["content", "text_integrity"],
+        )
+
+    def test_directory_form_destinations_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for path in ("samples/", "samples/.", "samples//game.js"):
+                with self.subTest(path=path):
+                    self.assertIn("must identify one file", validate_artifact_path(path, workdir=root))
+            self.assertIsNone(validate_artifact_path("./samples/game.js", workdir=root))
+
+    def test_content_phase_contract_requires_the_file_body_without_format_routing(self) -> None:
+        messages = artifact_content_messages(
+            user_request="create one bounded text artifact",
+            path="chosen/name.ext",
+            overwrite=False,
+        )
+
+        system = messages[0]["content"]
+        self.assertIn("first output character must belong to the file body", system)
+        self.assertIn("last output character must complete that body", system)
+        self.assertIn("even when it resembles control syntax", system)
+        self.assertIn("without placeholders, stubs", system)
+        self.assertNotIn("JavaScript", system)
+        self.assertNotIn("Python", system)
+        self.assertNotIn("HTML", system)
+        self.assertEqual(messages[1]["content"].count("chosen/name.ext"), 1)
+
+    def test_generation_and_parent_creation_remain_invisible_until_model_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("console.log('ready');\n")),
+                user_request="create a browser game",
+                path="samples/games/snake.js",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+
+            self.assertFalse((root / "samples").exists())
+            self.assertIn("publication_status: pending", pending.evidence())
+            publication, evidence = pending.verify_and_publish(
+                {"path": "samples/games/snake.js", "check": "text_integrity"},
+                workdir=root,
+            )
+
+            self.assertEqual(publication.created_parent_directories, ("samples", "samples/games"))
+            self.assertEqual((root / "samples/games/snake.js").read_text(), "console.log('ready');\n")
+            self.assertIn("artifact_publication: complete", evidence)
+            self.assertIn("artifact_verification: complete", evidence)
+
+    def test_invalid_model_selected_verification_publishes_no_file_or_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("literal content\n")),
+                user_request="create text",
+                path="new/parents/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "verification check is invalid"):
+                    pending.verify_and_publish(
+                        {"path": "new/parents/note.txt", "check": "syntax_by_extension"},
+                        workdir=root,
+                    )
+            finally:
+                pending.abort()
+
+            self.assertFalse((root / "new").exists())
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+    def test_verification_never_executes_tool_like_generated_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            content = "require('fs').writeFileSync('executed.txt', 'bad');\n"
+            pending = begin_artifact_generation(
+                backend=_Backend(_result(content)),
+                user_request="create JavaScript",
+                path="samples/check-only.js",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            pending.verify_and_publish(
+                {"path": "samples/check-only.js", "check": "text_integrity"},
+                workdir=root,
+            )
+
+            self.assertFalse((root / "executed.txt").exists())
+            self.assertEqual((root / "samples/check-only.js").read_text(), content)
+
+    def test_invalid_verification_preserves_preexisting_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            target = root / "samples/game.js"
+            target.write_text("original", encoding="utf-8")
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("const broken = ;\n")),
+                user_request="replace JavaScript",
+                path="samples/game.js",
+                overwrite=True,
+                create_parents=False,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            try:
+                with self.assertRaisesRegex(ValueError, "verification check is invalid"):
+                    pending.verify_and_publish(
+                        {"path": "samples/game.js", "check": "syntax_by_extension"},
+                        workdir=root,
+                    )
+            finally:
+                pending.abort()
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "original")
+
+    def test_model_selected_generic_checks_gate_publication(self) -> None:
+        cases = (
+            ("notes/readme.md", "# Notes\n\nComplete.\n", "content", "content_coverage: complete"),
+            ("data/config.json", '{"enabled": true, "count": 3}\n', "text_integrity", "UTF-8 content"),
+            ("src/example.py", "def answer():\n    return 42\n", "text_integrity", "UTF-8 content"),
+        )
+        for path, content, check, marker in cases:
+            with self.subTest(check=check), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                pending = begin_artifact_generation(
+                    backend=_Backend(_result(content)),
+                    user_request=f"create {path}",
+                    path=path,
+                    overwrite=False,
+                    create_parents=True,
+                    workdir=root,
+                    temperature=0,
+                    on_progress=None,
+                )
+                publication, evidence = pending.verify_and_publish(
+                    {"path": path, "check": check},
+                    workdir=root,
+                )
+
+                self.assertEqual((root / path).read_text(encoding="utf-8"), content)
+                self.assertEqual(publication.sha256, hashlib.sha256(content.encode()).hexdigest())
+                self.assertIn(marker, evidence)
+                self.assertEqual(list(root.rglob(".orbit-artifact-*")), [])
+
+    def test_missing_parent_requires_explicit_authorization_before_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backend = _Backend(_result("content"))
+            with self.assertRaisesRegex(ValueError, "parent directory does not exist"):
+                begin_artifact_generation(
+                    backend=backend,
+                    user_request="create a file",
+                    path="missing/file.txt",
+                    overwrite=False,
+                    create_parents=False,
+                    workdir=root,
+                    temperature=0,
+                    on_progress=None,
+                )
+
+            self.assertEqual(backend.calls, [])
+            self.assertFalse((root / "missing").exists())
+
+    def test_concurrent_parent_created_before_verification_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("text\n")),
+                user_request="create text",
+                path="samples/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            (root / "samples").mkdir()
+            (root / "samples/concurrent.txt").write_text("concurrent", encoding="utf-8")
+            try:
+                with self.assertRaisesRegex(ValueError, "parent path changed"):
+                    pending.verify_and_publish(
+                        {"path": "samples/note.txt", "check": "text_integrity"},
+                        workdir=root,
+                    )
+            finally:
+                pending.abort()
+
+            self.assertEqual((root / "samples/concurrent.txt").read_text(), "concurrent")
+            self.assertFalse((root / "samples/note.txt").exists())
+
+    def test_path_validation_rejects_escape_absolute_and_control_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertIsNone(validate_artifact_path("samples/game.js", workdir=root))
+            for path in ("../game.js", "/tmp/game.js", "samples/../game.js", "bad\nname.js", ""):
+                with self.subTest(path=path):
+                    self.assertIsNotNone(validate_artifact_path(path, workdir=root))
+
+    def test_complete_generation_atomically_creates_file_and_exact_parents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            content = "console.log('ready');\n"
+            backend = _Backend(
+                _result(content),
+                during_call=lambda: self.assertFalse((root / "samples").exists()),
+            )
+
+            generation, publication = self._generate(
+                root,
+                backend,
+                path="samples/games/snake.js",
+            )
+
+            target = root / "samples/games/snake.js"
+            self.assertEqual(generation.finish_reason, "stop")
+            self.assertEqual(target.read_text(encoding="utf-8"), content)
+            self.assertEqual(publication.path, "samples/games/snake.js")
+            self.assertEqual(publication.bytes_written, len(content.encode()))
+            self.assertEqual(publication.sha256, hashlib.sha256(content.encode()).hexdigest())
+            self.assertEqual(publication.created_parent_directories, ("samples", "samples/games"))
+            self.assertEqual(os.stat(root / "samples").st_mode & 0o777, 0o755)
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+            self.assertEqual(backend.calls[0][1]["max_tokens"], ARTIFACT_CONTENT_MAX_TOKENS)
+            self.assertNotIn("tools", backend.calls[0][1])
+
+    def test_length_cancel_and_timeout_publish_nothing_and_create_no_parents(self) -> None:
+        for finish_reason in ("length", "cancelled", "timeout"):
+            with self.subTest(finish_reason=finish_reason), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                backend = _Backend(_result("partial", finish_reason=finish_reason))
+                with self.assertRaisesRegex(RuntimeError, f"finish_reason={finish_reason}"):
+                    self._generate(root, backend)
+                self.assertFalse((root / "samples").exists())
+                self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            class TimeoutBackend:
+                def artifact_content_stream(self, *args, **kwargs):
+                    raise TimeoutError("timed out")
+
+            with self.assertRaises(TimeoutError):
+                self._generate(root, TimeoutBackend())
+            self.assertFalse((root / "samples").exists())
+
+    def test_existing_file_is_rejected_before_generation_unless_overwrite_is_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            target = root / "samples/game.js"
+            target.write_text("old", encoding="utf-8")
+            denied = _Backend(_result("new"))
+
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                self._generate(root, denied, create_parents=False)
+            self.assertEqual(denied.calls, [])
+            self.assertEqual(target.read_text(encoding="utf-8"), "old")
+
+            allowed = _Backend(_result("new"))
+            _, publication = self._generate(
+                root,
+                allowed,
+                overwrite=True,
+                create_parents=False,
+            )
+            self.assertTrue(publication.overwrite)
+            self.assertEqual(target.read_text(encoding="utf-8"), "new")
+
+    def test_overwrite_preserves_existing_permission_bits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            target = root / "samples/game.js"
+            target.write_text("old", encoding="utf-8")
+            target.chmod(0o755)
+
+            self._generate(
+                root,
+                _Backend(_result("new")),
+                overwrite=True,
+                create_parents=False,
+            )
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "new")
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o755)
+
+    def test_overwrite_authorization_on_absent_target_creates_without_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+
+            _, publication = self._generate(
+                root,
+                _Backend(_result("new")),
+                overwrite=True,
+                create_parents=False,
+            )
+
+            self.assertEqual((root / "samples/game.js").read_text(), "new")
+            self.assertFalse(publication.overwrite)
+            self.assertEqual(list((root / "samples").glob(".orbit-artifact-*")), [])
+
+    def test_existing_parent_falls_back_when_filesystem_rejects_o_tmpfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            content = "console.log('portable');\n"
+            real_open = os.open
+            tmpfile = getattr(os, "O_TMPFILE", 0)
+            anonymous_attempts = 0
+
+            def reject_anonymous(path, flags, mode=0o777, *, dir_fd=None):
+                nonlocal anonymous_attempts
+                if tmpfile and (flags & tmpfile) == tmpfile:
+                    anonymous_attempts += 1
+                    raise OSError(errno.EOPNOTSUPP, "Operation not supported", path)
+                return real_open(path, flags, mode, dir_fd=dir_fd)
+
+            with mock.patch("orbit.runtime.artifacts.os.open", side_effect=reject_anonymous):
+                _, publication = self._generate(
+                    root,
+                    _Backend(_result(content)),
+                    create_parents=False,
+                )
+
+            self.assertEqual(anonymous_attempts, 1)
+            self.assertEqual((root / "samples/game.js").read_text(encoding="utf-8"), content)
+            self.assertEqual(publication.sha256, hashlib.sha256(content.encode()).hexdigest())
+            self.assertEqual(list((root / "samples").glob(".orbit-artifact-*")), [])
+
+    def test_existing_parent_falls_back_when_anonymous_temp_link_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_link = os.link
+
+            def reject_proc_fd_link(src, dst, **kwargs):
+                if str(src).startswith("/proc/self/fd/"):
+                    raise OSError(errno.EINVAL, "anonymous link unsupported")
+                return real_link(src, dst, **kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts.os.link",
+                side_effect=reject_proc_fd_link,
+            ):
+                _, publication = self._generate(
+                    root,
+                    _Backend(_result("content")),
+                    create_parents=False,
+                )
+
+            self.assertEqual(publication.bytes_written, 7)
+            self.assertEqual((parent / "game.js").read_text(), "content")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_existing_parent_falls_back_when_proc_fd_link_is_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_link = os.link
+
+            def reject_proc_fd_link(src, dst, **kwargs):
+                if str(src).startswith("/proc/self/fd/"):
+                    raise OSError(errno.ENOENT, "proc is unavailable")
+                return real_link(src, dst, **kwargs)
+
+            with mock.patch("orbit.runtime.artifacts.os.link", side_effect=reject_proc_fd_link):
+                _, publication = self._generate(
+                    root,
+                    _Backend(_result("content")),
+                    create_parents=False,
+                )
+
+            self.assertEqual(publication.bytes_written, 7)
+            self.assertEqual((parent / "game.js").read_text(), "content")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_named_file_commit_falls_back_when_rename_noreplace_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            with mock.patch(
+                "orbit.runtime.artifacts._open_private_artifact_temp",
+                side_effect=lambda parent_fd: (*artifact_module._open_named_artifact_temp(parent_fd), False),
+            ), mock.patch(
+                "orbit.runtime.artifacts._rename_noreplace",
+                side_effect=OSError(errno.EINVAL, "rename noreplace unsupported"),
+            ):
+                _, publication = self._generate(
+                    root,
+                    _Backend(_result("content")),
+                    create_parents=False,
+                )
+
+            self.assertEqual(publication.bytes_written, 7)
+            self.assertEqual((parent / "game.js").read_text(), "content")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_directory_sync_failure_after_atomic_parent_publish_is_reported_honestly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch("orbit.runtime.artifacts._try_fsync", return_value=False):
+                _, publication = self._generate(root, _Backend(_result("complete")))
+
+            self.assertEqual((root / "samples/game.js").read_text(encoding="utf-8"), "complete")
+            self.assertFalse(publication.directory_sync_complete)
+            self.assertIn("directory_sync: unconfirmed", publication.evidence())
+
+    def test_generated_content_is_attested_before_parent_tree_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with (
+                mock.patch("orbit.runtime.artifacts._sha256_fd", return_value="wrong"),
+                mock.patch("orbit.runtime.artifacts._rename_noreplace") as rename,
+            ):
+                with self.assertRaisesRegex(ValueError, "before atomic parent publication"):
+                    self._generate(root, _Backend(_result("complete")))
+
+            rename.assert_not_called()
+            self.assertFalse((root / "samples").exists())
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+    def test_directory_sync_failure_after_new_file_commit_is_reported_honestly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            with mock.patch("orbit.runtime.artifacts._try_fsync", return_value=False):
+                _, publication = self._generate(
+                    root,
+                    _Backend(_result("complete")),
+                    create_parents=False,
+                )
+
+            self.assertEqual((root / "samples/game.js").read_text(), "complete")
+            self.assertFalse(publication.directory_sync_complete)
+            self.assertIn("directory_sync: unconfirmed", publication.evidence())
+            self.assertEqual(list((root / "samples").glob(".orbit-artifact-*")), [])
+
+    def test_post_commit_race_is_preserved_and_never_reported_as_generated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_try_fsync = artifact_module._try_fsync
+            raced = False
+
+            def race_during_directory_sync(fd: int) -> bool:
+                nonlocal raced
+                if not raced and stat.S_ISDIR(os.fstat(fd).st_mode):
+                    target = parent / "game.js"
+                    if target.exists():
+                        target.write_text("concurr", encoding="utf-8")
+                        raced = True
+                        return False
+                return real_try_fsync(fd)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._try_fsync",
+                side_effect=race_during_directory_sync,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed after atomic publication"):
+                    self._generate(
+                        root,
+                        _Backend(_result("complete")),
+                        create_parents=False,
+                    )
+
+            self.assertTrue(raced)
+            self.assertEqual((parent / "game.js").read_text(), "concurr")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_same_size_post_commit_rewrite_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_try_fsync = artifact_module._try_fsync
+            raced = False
+
+            def rewrite_during_directory_sync(fd: int) -> bool:
+                nonlocal raced
+                target = parent / "game.js"
+                if not raced and target.exists() and stat.S_ISDIR(os.fstat(fd).st_mode):
+                    self.assertEqual(len(target.read_bytes()), len(b"generated"))
+                    target.write_bytes(b"concurred")
+                    raced = True
+                    return False
+                return real_try_fsync(fd)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._try_fsync",
+                side_effect=rewrite_during_directory_sync,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed after atomic publication"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        create_parents=False,
+                    )
+
+            self.assertTrue(raced)
+            self.assertEqual((parent / "game.js").read_bytes(), b"concurred")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_hard_link_fallback_retracts_destination_when_temp_unlink_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_unlink = artifact_module.os.unlink
+            unlink_calls = 0
+            rename_calls = 0
+
+            def fail_first_unlink(path, *args, **kwargs):
+                nonlocal unlink_calls
+                unlink_calls += 1
+                if unlink_calls == 1:
+                    raise OSError(errno.EIO, "simulated private unlink failure")
+                return real_unlink(path, *args, **kwargs)
+
+            def reject_initial_noreplace(**kwargs):
+                nonlocal rename_calls
+                rename_calls += 1
+                if rename_calls == 1:
+                    raise OSError(errno.ENOTSUP, "unsupported")
+                return artifact_module._renameat2(flags=1, **kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._open_private_artifact_temp",
+                side_effect=lambda parent_fd: (
+                    *artifact_module._open_named_artifact_temp(parent_fd),
+                    False,
+                ),
+            ), mock.patch(
+                "orbit.runtime.artifacts._rename_noreplace",
+                side_effect=reject_initial_noreplace,
+            ), mock.patch(
+                "orbit.runtime.artifacts.os.unlink",
+                side_effect=fail_first_unlink,
+            ):
+                with self.assertRaisesRegex(OSError, "private unlink failure"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        create_parents=False,
+                    )
+
+            self.assertFalse((parent / "game.js").exists())
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_post_commit_fifo_replacement_fails_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_commit = artifact_module._commit_named_file_noreplace
+
+            def replace_with_fifo(**kwargs) -> None:
+                real_commit(**kwargs)
+                target = parent / "game.js"
+                target.unlink()
+                os.mkfifo(target)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._open_private_artifact_temp",
+                side_effect=lambda parent_fd: (*artifact_module._open_named_artifact_temp(parent_fd), False),
+            ), mock.patch(
+                "orbit.runtime.artifacts._commit_named_file_noreplace",
+                side_effect=replace_with_fifo,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed after atomic publication"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        create_parents=False,
+                    )
+
+            self.assertTrue(stat.S_ISFIFO(os.stat(parent / "game.js").st_mode))
+
+    def test_symlink_parent_symlink_target_and_fifo_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            root = Path(tmp)
+            (root / "samples").symlink_to(Path(outside), target_is_directory=True)
+            with self.assertRaises(OSError):
+                prepare_artifact_target(
+                    "samples/game.js", overwrite=False, create_parents=False, workdir=root
+                )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            (root / "other.js").write_text("other", encoding="utf-8")
+            (root / "samples/game.js").symlink_to(root / "other.js")
+            with self.assertRaisesRegex(ValueError, "not a regular file"):
+                prepare_artifact_target(
+                    "samples/game.js", overwrite=True, create_parents=False, workdir=root
+                )
+
+            fifo = root / "samples/pipe"
+            os.mkfifo(fifo)
+            with self.assertRaisesRegex(ValueError, "not a regular file"):
+                prepare_artifact_target(
+                    "samples/pipe", overwrite=True, create_parents=False, workdir=root
+                )
+
+    def test_fifo_replacement_between_stat_and_open_fails_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            target = parent / "game.js"
+            target.write_text("old", encoding="utf-8")
+            real_open = os.open
+            replaced = False
+
+            def replace_before_open(path, flags, mode=0o777, *, dir_fd=None):
+                nonlocal replaced
+                if path == "game.js" and dir_fd is not None and not replaced:
+                    replaced = True
+                    target.unlink()
+                    os.mkfifo(target)
+                    self.assertTrue(flags & getattr(os, "O_NONBLOCK", 0))
+                return real_open(path, flags, mode, dir_fd=dir_fd)
+
+            with mock.patch("orbit.runtime.artifacts.os.open", side_effect=replace_before_open):
+                with self.assertRaisesRegex(ValueError, "not a regular file"):
+                    prepare_artifact_target(
+                        "samples/game.js",
+                        overwrite=True,
+                        create_parents=False,
+                        workdir=root,
+                    )
+
+            self.assertTrue(replaced)
+            self.assertTrue(stat.S_ISFIFO(target.stat().st_mode))
+
+    def test_parent_and_destination_changes_during_generation_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+
+            def replace_parent() -> None:
+                parent.rename(root / "old-samples")
+                parent.mkdir()
+
+            backend = _Backend(_result("content"), during_call=replace_parent)
+            with self.assertRaisesRegex(ValueError, "parent directory changed"):
+                self._generate(root, backend, create_parents=False)
+            self.assertFalse((parent / "game.js").exists())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            target = parent / "game.js"
+
+            backend = _Backend(_result("content"), during_call=lambda: target.write_text("racer", encoding="utf-8"))
+            with self.assertRaisesRegex(ValueError, "destination changed"):
+                self._generate(root, backend, create_parents=False)
+            self.assertEqual(target.read_text(encoding="utf-8"), "racer")
+
+    def test_existing_parent_rename_during_commit_cannot_report_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            real_commit = artifact_module._commit_named_file_noreplace
+
+            def move_parent_then_commit(**kwargs) -> None:
+                parent.rename(root / "old-samples")
+                parent.mkdir()
+                real_commit(**kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._open_private_artifact_temp",
+                side_effect=lambda parent_fd: (*artifact_module._open_named_artifact_temp(parent_fd), False),
+            ), mock.patch(
+                "orbit.runtime.artifacts._commit_named_file_noreplace",
+                side_effect=move_parent_then_commit,
+            ):
+                with self.assertRaisesRegex(ValueError, "parent directory changed"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        create_parents=False,
+                    )
+
+            self.assertFalse((root / "samples/game.js").exists())
+            self.assertFalse((root / "old-samples/game.js").exists())
+
+    def test_overwrite_parent_rename_during_commit_rolls_back(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            target = parent / "game.js"
+            target.write_text("original", encoding="utf-8")
+            real_exchange = artifact_module._rename_exchange
+            calls = 0
+
+            def move_parent_then_exchange(**kwargs) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    parent.rename(root / "old-samples")
+                    parent.mkdir()
+                real_exchange(**kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._rename_exchange",
+                side_effect=move_parent_then_exchange,
+            ):
+                with self.assertRaisesRegex(ValueError, "parent directory changed"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        overwrite=True,
+                        create_parents=False,
+                    )
+
+            self.assertFalse((root / "samples/game.js").exists())
+            self.assertEqual((root / "old-samples/game.js").read_text(), "original")
+
+    def test_overwrite_attestation_exception_restores_displaced_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            target = parent / "game.js"
+            target.write_text("original", encoding="utf-8")
+            real_exchange = artifact_module._rename_exchange
+            calls = 0
+
+            def grow_displaced_file_after_exchange(**kwargs) -> None:
+                nonlocal calls
+                calls += 1
+                real_exchange(**kwargs)
+                if calls == 1:
+                    fd = os.open(
+                        kwargs["old_name"],
+                        os.O_WRONLY | os.O_APPEND,
+                        dir_fd=kwargs["old_dir_fd"],
+                    )
+                    try:
+                        os.write(fd, b"x" * (MAX_ARTIFACT_BYTES + 1))
+                    finally:
+                        os.close(fd)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._rename_exchange",
+                side_effect=grow_displaced_file_after_exchange,
+            ):
+                with self.assertRaisesRegex(ValueError, "exceeds"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        overwrite=True,
+                        create_parents=False,
+                    )
+
+            self.assertTrue(target.read_bytes().startswith(b"original"))
+            self.assertNotEqual(target.read_text(encoding="utf-8"), "generated")
+
+    def test_parent_permission_revoked_during_generation_publishes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+
+            def revoke_permission() -> None:
+                parent.chmod(0o500)
+
+            try:
+                with self.assertRaises(PermissionError):
+                    self._generate(
+                        root,
+                        _Backend(_result("content"), during_call=revoke_permission),
+                        create_parents=False,
+                    )
+            finally:
+                parent.chmod(0o700)
+
+            self.assertFalse((parent / "game.js").exists())
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_concurrent_parent_wins_and_is_never_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backend = _Backend(_result("content"))
+
+            def concurrent_parent(**kwargs) -> None:
+                os.mkdir(kwargs["new_name"], dir_fd=kwargs["new_dir_fd"])
+                fd = os.open(
+                    f"{kwargs['new_name']}/concurrent.txt",
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    dir_fd=kwargs["new_dir_fd"],
+                )
+                os.write(fd, b"concurrent")
+                os.close(fd)
+                raise OSError(errno.EEXIST, "exists")
+
+            with mock.patch("orbit.runtime.artifacts._rename_noreplace", side_effect=concurrent_parent):
+                with self.assertRaisesRegex(OSError, "exists"):
+                    self._generate(root, backend)
+
+            self.assertEqual((root / "samples/concurrent.txt").read_text(), "concurrent")
+            self.assertFalse((root / "samples/game.js").exists())
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+    def test_intermediate_parent_setup_failure_removes_private_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("content")),
+                user_request="create text",
+                path="one/two/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+
+            with mock.patch(
+                "orbit.runtime.artifacts.os.fchmod",
+                side_effect=OSError(errno.EIO, "injected parent setup failure"),
+            ):
+                with self.assertRaisesRegex(OSError, "injected parent setup failure"):
+                    pending.verify_and_publish(
+                        {"path": "one/two/note.txt", "check": "text_integrity"},
+                        workdir=root,
+                    )
+
+            self.assertFalse((root / "one").exists())
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+    def test_new_parent_post_commit_replacement_is_reported_without_deletion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            real_rename = artifact_module._rename_noreplace
+            calls = 0
+
+            def replace_after_commit(**kwargs) -> None:
+                nonlocal calls
+                calls += 1
+                real_rename(**kwargs)
+                if calls == 1:
+                    target = root / "samples/game.js"
+                    target.write_text("different", encoding="utf-8")
+
+            with mock.patch(
+                "orbit.runtime.artifacts._rename_noreplace",
+                side_effect=replace_after_commit,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed after atomic publication"):
+                    self._generate(root, _Backend(_result("generated")))
+
+            self.assertEqual((root / "samples/game.js").read_text(), "different")
+            self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
+
+    def test_existing_ancestor_rename_during_new_parent_commit_cannot_report_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = root / "base"
+            base.mkdir()
+            real_rename = artifact_module._rename_noreplace
+            calls = 0
+
+            def move_ancestor_then_commit(**kwargs) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    base.rename(root / "old-base")
+                    base.mkdir()
+                real_rename(**kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._rename_noreplace",
+                side_effect=move_ancestor_then_commit,
+            ):
+                with self.assertRaisesRegex(ValueError, "parent directory changed"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        path="base/nested/game.js",
+                        create_parents=True,
+                    )
+
+            self.assertFalse((root / "base/nested/game.js").exists())
+            self.assertFalse((root / "old-base/nested/game.js").exists())
+
+    def test_intermediate_parent_symlink_swap_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            root = Path(tmp)
+            nested = root / "one/two"
+            nested.mkdir(parents=True)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("generated")),
+                user_request="create text",
+                path="one/two/game.js",
+                overwrite=False,
+                create_parents=False,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            moved = Path(outside) / "one"
+            (root / "one").rename(moved)
+            (root / "one").symlink_to(moved, target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "parent directory changed"):
+                pending.verify_and_publish(
+                    {"path": "one/two/game.js", "check": "text_integrity"},
+                    workdir=root,
+                )
+
+            self.assertFalse((moved / "two/game.js").exists())
+
+    def test_concurrent_overwrite_replacement_is_rolled_back_without_data_loss(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            target = parent / "game.js"
+            target.write_text("original", encoding="utf-8")
+            real_exchange = artifact_module._rename_exchange
+            calls = 0
+
+            def replace_then_exchange(**kwargs) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    target.rename(parent / "original.saved")
+                    target.write_text("concurrent", encoding="utf-8")
+                real_exchange(**kwargs)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._rename_exchange",
+                side_effect=replace_then_exchange,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed during atomic overwrite"):
+                    self._generate(
+                        root,
+                        _Backend(_result("generated")),
+                        overwrite=True,
+                        create_parents=False,
+                    )
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "concurrent")
+            self.assertEqual((parent / "original.saved").read_text(encoding="utf-8"), "original")
+            self.assertEqual(list(parent.glob(".orbit-artifact-*")), [])
+
+    def test_oversized_and_empty_content_are_not_published(self) -> None:
+        for content, message in (("", "empty"), ("x" * (MAX_ARTIFACT_BYTES + 1), "exceeds")):
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                with self.assertRaisesRegex(RuntimeError, message):
+                    self._generate(root, _Backend(_result(content)))
+                self.assertFalse((root / "samples").exists())
+
+    def test_exact_byte_and_token_boundaries_publish_only_stopped_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            exact = _result("x" * MAX_ARTIFACT_BYTES)
+            exact = ChatResult(
+                content=exact.content,
+                model=exact.model,
+                finish_reason="stop",
+                tool_calls=exact.tool_calls,
+                prompt_tokens=exact.prompt_tokens,
+                completion_tokens=ARTIFACT_CONTENT_MAX_TOKENS,
+                cached_tokens=exact.cached_tokens,
+                prompt_tokens_per_second=exact.prompt_tokens_per_second,
+                generation_tokens_per_second=exact.generation_tokens_per_second,
+            )
+
+            _, publication = self._generate(root, _Backend(exact))
+
+            self.assertEqual(publication.bytes_written, MAX_ARTIFACT_BYTES)
+            self.assertEqual((root / "samples/game.js").stat().st_size, MAX_ARTIFACT_BYTES)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(RuntimeError, "exceeds"):
+                self._generate(
+                    root,
+                    _Backend(_result("x" * (MAX_ARTIFACT_BYTES + 1))),
+                )
+            self.assertFalse((root / "samples").exists())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            over = _result("content")
+            over = ChatResult(
+                content=over.content,
+                model=over.model,
+                finish_reason="stop",
+                tool_calls=over.tool_calls,
+                prompt_tokens=over.prompt_tokens,
+                completion_tokens=ARTIFACT_CONTENT_MAX_TOKENS + 1,
+                cached_tokens=over.cached_tokens,
+                prompt_tokens_per_second=over.prompt_tokens_per_second,
+                generation_tokens_per_second=over.generation_tokens_per_second,
+            )
+            with self.assertRaisesRegex(RuntimeError, "token limit exceeded"):
+                self._generate(root, _Backend(over))
+            self.assertFalse((root / "samples").exists())
+
+    def test_structured_or_reasoning_output_is_not_published(self) -> None:
+        base = _result("content")
+        results = (
+            ChatResult(
+                content=base.content,
+                model=base.model,
+                finish_reason="stop",
+                tool_calls=[{"function": {"name": "unexpected", "arguments": "{}"}}],
+                prompt_tokens=base.prompt_tokens,
+                completion_tokens=base.completion_tokens,
+                cached_tokens=base.cached_tokens,
+                prompt_tokens_per_second=base.prompt_tokens_per_second,
+                generation_tokens_per_second=base.generation_tokens_per_second,
+            ),
+            ChatResult(
+                content=base.content,
+                model=base.model,
+                finish_reason="stop",
+                tool_calls=[],
+                prompt_tokens=base.prompt_tokens,
+                completion_tokens=base.completion_tokens,
+                cached_tokens=base.cached_tokens,
+                prompt_tokens_per_second=base.prompt_tokens_per_second,
+                generation_tokens_per_second=base.generation_tokens_per_second,
+                reasoning_content="unexpected reasoning",
+            ),
+        )
+        for result in results:
+            with self.subTest(result=result), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                with self.assertRaisesRegex(RuntimeError, "unexpected structured"):
+                    self._generate(root, _Backend(result))
+                self.assertFalse((root / "samples").exists())
+
+    def test_invalid_utf8_and_backend_error_leave_no_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(RuntimeError, "failed validation"):
+                self._generate(root, _Backend(_result("\ud800")))
+            self.assertFalse((root / "samples").exists())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            class FailedBackend:
+                def artifact_content_stream(self, *args, **kwargs):
+                    raise RuntimeError("synthetic backend failure")
+
+            with self.assertRaisesRegex(RuntimeError, "synthetic backend failure"):
+                self._generate(root, FailedBackend())
+            self.assertFalse((root / "samples").exists())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = prepare_artifact_target(
+                "samples/game.js",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+            )
+
+            class InterruptedBackend:
+                def artifact_content_stream(self, *args, **kwargs):
+                    raise KeyboardInterrupt
+
+            with mock.patch(
+                "orbit.runtime.artifacts.prepare_artifact_target",
+                return_value=target,
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    begin_artifact_generation(
+                        backend=InterruptedBackend(),
+                        user_request="create text",
+                        path="samples/game.js",
+                        overwrite=False,
+                        create_parents=True,
+                        workdir=root,
+                        temperature=0,
+                        on_progress=None,
+                    )
+
+            self.assertEqual(target.parent_fd, -1)
+            self.assertEqual(target.destination_fd, -1)
+            self.assertFalse((root / "samples").exists())
+
+    def test_unix_socket_target_is_rejected_as_special_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "samples").mkdir()
+            target = root / "samples/game.js"
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                server.bind(str(target))
+                with self.assertRaisesRegex(ValueError, "not a regular file"):
+                    prepare_artifact_target(
+                        "samples/game.js",
+                        overwrite=True,
+                        create_parents=False,
+                        workdir=root,
+                    )
+            finally:
+                server.close()
+
+    def test_pending_artifact_cannot_be_verified_twice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("text")),
+                user_request="create text",
+                path="samples/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+            pending.verify_and_publish(
+                {"path": "samples/note.txt", "check": "text_integrity"},
+                workdir=root,
+            )
+
+            with self.assertRaisesRegex(ValueError, "no longer pending"):
+                pending.verify_and_publish(
+                    {"path": "samples/note.txt", "check": "text_integrity"},
+                    workdir=root,
+                )
+
+    def test_tool_like_text_is_written_verbatim_not_parsed(self) -> None:
+        content = '<tool_call>{"command":"rm -rf /"}</tool_call>\n```sh\ncat <<EOF\n```\n'
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._generate(root, _Backend(_result(content)))
+            self.assertEqual((root / "samples/game.js").read_text(), content)
+
+    def test_text_artifact_publication_is_content_type_neutral(self) -> None:
+        fixtures = {
+            "site/index.html": "<!doctype html><style>body{color:#123}</style><script>const ready=true;</script>\n",
+            "src/module.js": "export const value = {enabled: true};\n",
+            "src/tool.py": "def value():\n    return {'enabled': True}\n",
+            "docs/note.md": "# Note\n\n- bounded\n- verified\n",
+            "config/service.yaml": "service:\n  host: localhost\n  port: 8080\n",
+            "config/service.toml": '[service]\nhost = "localhost"\nport = 8080\n',
+            "scripts/check.sh": "#!/bin/sh\nprintf '%s\\n' 'inert content only'\n",
+            "config/app.ini": "[app]\nenabled = true\n",
+            "notes/plain.txt": "bounded plain text\nsecond line\n",
+            "fixtures/mixed.txt": (
+                "JSON: {\"quoted\": \"value\"}\n"
+                "XML: <item key='value'>text</item>\n"
+                "shell-like: cat <<'EOF'\nnot executed\nEOF\n"
+            ),
+        }
+        for path, content in fixtures.items():
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                self._generate(
+                    root,
+                    _Backend(_result(content)),
+                    path=path,
+                    check="text_integrity",
+                )
+
+                self.assertEqual((root / path).read_text(encoding="utf-8"), content)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -80,6 +80,35 @@ class ArtifactPublicationTests(unittest.TestCase):
         finally:
             pending.abort()
 
+    def _register_recovery_entry(self, root: Path):
+        parent = root / "samples"
+        parent.mkdir()
+        parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            temp_fd, temp_name = artifact_module._open_named_artifact_temp(parent_fd)
+            lease = artifact_module._register_private_entry(
+                workdir=root,
+                parent_relative=Path("samples"),
+                temp_name=temp_name,
+                temp_fd=temp_fd,
+            )
+            os.close(temp_fd)
+        finally:
+            os.close(parent_fd)
+        manifest = root / ".orbit-artifact-state" / lease.manifest_name
+        return parent, temp_name, manifest, lease
+
+    def _discard_preserved_recovery_entry(
+        self,
+        parent: Path,
+        temp_name: str,
+        lease,
+    ) -> None:
+        private = parent / temp_name
+        if private.is_symlink() or private.exists():
+            private.unlink()
+        lease.release()
+
     def test_schema_is_small_and_content_is_not_an_argument(self) -> None:
         function = write_artifact_definition()["function"]
         properties = function["parameters"]["properties"]
@@ -1366,6 +1395,209 @@ class ArtifactPublicationTests(unittest.TestCase):
             (parent / temp_name).unlink()
             lease.release()
             self.assertFalse((root / ".orbit-artifact-state").exists())
+
+    def test_recovery_preserves_active_owner_when_fresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=True,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=10**9)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(
+                (result.owner_active, result.owner_inactive, result.owner_unknown),
+                (1, 0, 0),
+            )
+            self.assertEqual(
+                set(result.__dict__),
+                {
+                    "scanned",
+                    "removed",
+                    "preserved",
+                    "errors",
+                    "owner_active",
+                    "owner_inactive",
+                    "owner_unknown",
+                },
+            )
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_preserves_active_owner_when_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=True,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(result.owner_active, 1)
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_preserves_unknown_owner_when_fresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=None,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=10**9)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(
+                (result.owner_active, result.owner_inactive, result.owner_unknown),
+                (0, 0, 1),
+            )
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_preserves_unknown_owner_when_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=None,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(result.owner_unknown, 1)
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_second_review_unknown_owner_reproducer_preserves_exact_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=None,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual(result.removed, 0)
+            self.assertEqual(result.preserved, 1)
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_cleans_inactive_owner_when_fresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, _lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=False,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=10**9)
+
+            self.assertEqual((result.removed, result.preserved), (1, 0))
+            self.assertEqual(
+                (result.owner_active, result.owner_inactive, result.owner_unknown),
+                (0, 1, 0),
+            )
+            self.assertFalse((parent / temp_name).exists())
+            self.assertFalse(manifest.exists())
+
+    def test_recovery_cleans_inactive_owner_when_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, _lease = self._register_recovery_entry(root)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=False,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual((result.removed, result.preserved), (1, 0))
+            self.assertEqual(result.owner_inactive, 1)
+            self.assertFalse((parent / temp_name).exists())
+            self.assertFalse(manifest.exists())
+
+    def test_recovery_preserves_malformed_manifest_before_owner_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+            manifest.write_text("{}", encoding="utf-8")
+            manifest.chmod(0o600)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=False,
+            ) as owner_active:
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            owner_active.assert_not_called()
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_preserves_inactive_owner_with_inode_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+            value = json.loads(manifest.read_text(encoding="utf-8"))
+            value["inode"] += 1
+            manifest.write_text(
+                json.dumps(value, sort_keys=True, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            manifest.chmod(0o600)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=False,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(result.owner_inactive, 1)
+            self.assertTrue((parent / temp_name).is_file())
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
+
+    def test_recovery_preserves_inactive_owner_with_symlink_ambiguity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent, temp_name, manifest, lease = self._register_recovery_entry(root)
+            outside = root / "outside.txt"
+            outside.write_text("outside", encoding="utf-8")
+            (parent / temp_name).unlink()
+            (parent / temp_name).symlink_to(outside)
+
+            with mock.patch(
+                "orbit.runtime.artifacts._artifact_owner_active",
+                return_value=False,
+            ):
+                result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual((result.removed, result.preserved), (0, 1))
+            self.assertEqual(result.owner_inactive, 1)
+            self.assertTrue((parent / temp_name).is_symlink())
+            self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
+            self.assertTrue(manifest.is_file())
+            self._discard_preserved_recovery_entry(parent, temp_name, lease)
 
     def test_restart_cleanup_removes_exact_private_entry_from_dead_process(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import hashlib
+import json
 import os
 from pathlib import Path
 import stat
@@ -17,6 +18,7 @@ from orbit.runtime.artifacts import (
     MAX_ARTIFACT_BYTES,
     artifact_content_messages,
     begin_artifact_generation,
+    cleanup_stale_artifact_entries,
     prepare_artifact_target,
     validate_artifact_path,
     verify_artifact_definition,
@@ -73,11 +75,8 @@ class ArtifactPublicationTests(unittest.TestCase):
             on_progress=None,
         )
         try:
-            publication, _evidence = pending.verify_and_publish(
-                {"path": path, "check": check},
-                workdir=root,
-            )
-            return pending.generation, publication
+            pending.verify({"check": check})
+            return pending.generation, pending.publication
         finally:
             pending.abort()
 
@@ -93,12 +92,13 @@ class ArtifactPublicationTests(unittest.TestCase):
         self.assertEqual(verify_function["name"], "verify_artifact")
         self.assertEqual(
             set(verify_function["parameters"]["properties"]),
-            {"path", "check"},
+            {"check"},
         )
         self.assertEqual(
             verify_function["parameters"]["properties"]["check"]["enum"],
             ["content", "text_integrity"],
         )
+        self.assertEqual(verify_function["parameters"]["required"], ["check"])
 
     def test_directory_form_destinations_are_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -116,16 +116,16 @@ class ArtifactPublicationTests(unittest.TestCase):
         )
 
         system = messages[0]["content"]
-        self.assertIn("first output character must belong to the file body", system)
-        self.assertIn("last output character must complete that body", system)
-        self.assertIn("even when it resembles control syntax", system)
-        self.assertIn("without placeholders, stubs", system)
+        self.assertIn("one complete bounded UTF-8 text artifact", system)
+        self.assertIn("Do not use tools, shell, JSON/XML envelopes", system)
+        self.assertIn("Output the complete file body now", messages[1]["content"])
+        self.assertIn("do not output or discuss the destination path", messages[1]["content"])
         self.assertNotIn("JavaScript", system)
         self.assertNotIn("Python", system)
         self.assertNotIn("HTML", system)
         self.assertEqual(messages[1]["content"].count("chosen/name.ext"), 1)
 
-    def test_generation_and_parent_creation_remain_invisible_until_model_verification(self) -> None:
+    def test_generation_publishes_before_model_selected_read_only_verification(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             pending = begin_artifact_generation(
@@ -139,19 +139,43 @@ class ArtifactPublicationTests(unittest.TestCase):
                 on_progress=None,
             )
 
-            self.assertFalse((root / "samples").exists())
-            self.assertIn("publication_status: pending", pending.evidence())
-            publication, evidence = pending.verify_and_publish(
-                {"path": "samples/games/snake.js", "check": "text_integrity"},
-                workdir=root,
+            self.assertTrue((root / "samples/games/snake.js").is_file())
+            self.assertIn("artifact_publication: complete", pending.evidence())
+            before = (root / "samples/games/snake.js").stat()
+            mutation_paths = (
+                "orbit.runtime.artifacts._renameat2",
+                "orbit.runtime.artifacts.os.unlink",
+                "orbit.runtime.artifacts.os.mkdir",
+                "orbit.runtime.artifacts.os.rmdir",
+                "orbit.runtime.artifacts.os.rename",
+                "orbit.runtime.artifacts.os.replace",
+                "orbit.runtime.artifacts.os.link",
+                "orbit.runtime.artifacts.os.write",
+                "orbit.runtime.artifacts.os.fchmod",
+                "orbit.runtime.artifacts.os.chmod",
+            )
+            patchers = [
+                mock.patch(path, side_effect=AssertionError(f"verifier mutated through {path}"))
+                for path in mutation_paths
+            ]
+            for patcher in patchers:
+                patcher.start()
+            try:
+                evidence = pending.verify({"check": "text_integrity"})
+            finally:
+                for patcher in reversed(patchers):
+                    patcher.stop()
+            after = (root / "samples/games/snake.js").stat()
+
+            self.assertEqual(pending.publication.created_parent_directories, ("samples", "samples/games"))
+            self.assertEqual((root / "samples/games/snake.js").read_text(), "console.log('ready');\n")
+            self.assertIn("artifact_verification: complete", evidence)
+            self.assertEqual(
+                (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns),
+                (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns),
             )
 
-            self.assertEqual(publication.created_parent_directories, ("samples", "samples/games"))
-            self.assertEqual((root / "samples/games/snake.js").read_text(), "console.log('ready');\n")
-            self.assertIn("artifact_publication: complete", evidence)
-            self.assertIn("artifact_verification: complete", evidence)
-
-    def test_invalid_model_selected_verification_publishes_no_file_or_parent(self) -> None:
+    def test_invalid_model_selected_verification_preserves_published_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             pending = begin_artifact_generation(
@@ -166,14 +190,11 @@ class ArtifactPublicationTests(unittest.TestCase):
             )
             try:
                 with self.assertRaisesRegex(ValueError, "verification check is invalid"):
-                    pending.verify_and_publish(
-                        {"path": "new/parents/note.txt", "check": "syntax_by_extension"},
-                        workdir=root,
-                    )
+                    pending.verify({"check": "syntax_by_extension"})
             finally:
                 pending.abort()
 
-            self.assertFalse((root / "new").exists())
+            self.assertEqual((root / "new/parents/note.txt").read_text(), "literal content\n")
             self.assertEqual(list(root.glob(".orbit-artifact-*")), [])
 
     def test_verification_never_executes_tool_like_generated_content(self) -> None:
@@ -190,15 +211,12 @@ class ArtifactPublicationTests(unittest.TestCase):
                 temperature=0,
                 on_progress=None,
             )
-            pending.verify_and_publish(
-                {"path": "samples/check-only.js", "check": "text_integrity"},
-                workdir=root,
-            )
+            pending.verify({"check": "text_integrity"})
 
             self.assertFalse((root / "executed.txt").exists())
             self.assertEqual((root / "samples/check-only.js").read_text(), content)
 
-    def test_invalid_verification_preserves_preexisting_destination(self) -> None:
+    def test_invalid_verification_preserves_completed_overwrite(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "samples").mkdir()
@@ -216,14 +234,11 @@ class ArtifactPublicationTests(unittest.TestCase):
             )
             try:
                 with self.assertRaisesRegex(ValueError, "verification check is invalid"):
-                    pending.verify_and_publish(
-                        {"path": "samples/game.js", "check": "syntax_by_extension"},
-                        workdir=root,
-                    )
+                    pending.verify({"check": "syntax_by_extension"})
             finally:
                 pending.abort()
 
-            self.assertEqual(target.read_text(encoding="utf-8"), "original")
+            self.assertEqual(target.read_text(encoding="utf-8"), "const broken = ;\n")
 
     def test_model_selected_generic_checks_gate_publication(self) -> None:
         cases = (
@@ -244,10 +259,8 @@ class ArtifactPublicationTests(unittest.TestCase):
                     temperature=0,
                     on_progress=None,
                 )
-                publication, evidence = pending.verify_and_publish(
-                    {"path": path, "check": check},
-                    workdir=root,
-                )
+                evidence = pending.verify({"check": check})
+                publication = pending.publication
 
                 self.assertEqual((root / path).read_text(encoding="utf-8"), content)
                 self.assertEqual(publication.sha256, hashlib.sha256(content.encode()).hexdigest())
@@ -273,32 +286,43 @@ class ArtifactPublicationTests(unittest.TestCase):
             self.assertEqual(backend.calls, [])
             self.assertFalse((root / "missing").exists())
 
-    def test_concurrent_parent_created_before_verification_is_preserved(self) -> None:
+    def test_concurrent_content_in_created_parent_is_not_displaced_on_rollback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            pending = begin_artifact_generation(
-                backend=_Backend(_result("text\n")),
-                user_request="create text",
-                path="samples/note.txt",
-                overwrite=False,
-                create_parents=True,
-                workdir=root,
-                temperature=0,
-                on_progress=None,
-            )
-            (root / "samples").mkdir()
-            (root / "samples/concurrent.txt").write_text("concurrent", encoding="utf-8")
-            try:
-                with self.assertRaisesRegex(ValueError, "parent path changed"):
-                    pending.verify_and_publish(
-                        {"path": "samples/note.txt", "check": "text_integrity"},
-                        workdir=root,
+            real_attest = artifact_module._attest_created_directories
+            calls = 0
+
+            def fail_after_file_publication(created) -> None:
+                nonlocal calls
+                calls += 1
+                real_attest(created)
+                if calls == 3:
+                    (root / "samples/concurrent.txt").write_text(
+                        "concurrent", encoding="utf-8"
                     )
-            finally:
-                pending.abort()
+                    (root / "samples/concurrent-dir").mkdir()
+                    raise ValueError("injected post-publication parent failure")
+
+            with mock.patch(
+                "orbit.runtime.artifacts._attest_created_directories",
+                side_effect=fail_after_file_publication,
+            ):
+                with self.assertRaisesRegex(ValueError, "injected post-publication"):
+                    begin_artifact_generation(
+                        backend=_Backend(_result("text\n")),
+                        user_request="create text",
+                        path="samples/note.txt",
+                        overwrite=False,
+                        create_parents=True,
+                        workdir=root,
+                        temperature=0,
+                        on_progress=None,
+                    )
 
             self.assertEqual((root / "samples/concurrent.txt").read_text(), "concurrent")
+            self.assertTrue((root / "samples/concurrent-dir").is_dir())
             self.assertFalse((root / "samples/note.txt").exists())
+            self.assertEqual(list(root.rglob(".orbit-artifact-*")), [])
 
     def test_path_validation_rejects_escape_absolute_and_control_text(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -529,7 +553,7 @@ class ArtifactPublicationTests(unittest.TestCase):
                 mock.patch("orbit.runtime.artifacts._sha256_fd", return_value="wrong"),
                 mock.patch("orbit.runtime.artifacts._rename_noreplace") as rename,
             ):
-                with self.assertRaisesRegex(ValueError, "before atomic parent publication"):
+                with self.assertRaisesRegex(ValueError, "temporary content changed before publication"):
                     self._generate(root, _Backend(_result("complete")))
 
             rename.assert_not_called()
@@ -904,21 +928,22 @@ class ArtifactPublicationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             backend = _Backend(_result("content"))
+            real_mkdir = os.mkdir
 
-            def concurrent_parent(**kwargs) -> None:
-                os.mkdir(kwargs["new_name"], dir_fd=kwargs["new_dir_fd"])
+            def concurrent_parent(path, mode=0o777, *, dir_fd=None) -> None:
+                real_mkdir(path, mode, dir_fd=dir_fd)
                 fd = os.open(
-                    f"{kwargs['new_name']}/concurrent.txt",
+                    f"{path}/concurrent.txt",
                     os.O_WRONLY | os.O_CREAT | os.O_EXCL,
                     0o600,
-                    dir_fd=kwargs["new_dir_fd"],
+                    dir_fd=dir_fd,
                 )
                 os.write(fd, b"concurrent")
                 os.close(fd)
-                raise OSError(errno.EEXIST, "exists")
+                raise FileExistsError(errno.EEXIST, "exists")
 
-            with mock.patch("orbit.runtime.artifacts._rename_noreplace", side_effect=concurrent_parent):
-                with self.assertRaisesRegex(OSError, "exists"):
+            with mock.patch("orbit.runtime.artifacts.os.mkdir", side_effect=concurrent_parent):
+                with self.assertRaisesRegex(ValueError, "parent path changed"):
                     self._generate(root, backend)
 
             self.assertEqual((root / "samples/concurrent.txt").read_text(), "concurrent")
@@ -928,25 +953,20 @@ class ArtifactPublicationTests(unittest.TestCase):
     def test_intermediate_parent_setup_failure_removes_private_tree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            pending = begin_artifact_generation(
-                backend=_Backend(_result("content")),
-                user_request="create text",
-                path="one/two/note.txt",
-                overwrite=False,
-                create_parents=True,
-                workdir=root,
-                temperature=0,
-                on_progress=None,
-            )
-
             with mock.patch(
                 "orbit.runtime.artifacts.os.fchmod",
                 side_effect=OSError(errno.EIO, "injected parent setup failure"),
             ):
                 with self.assertRaisesRegex(OSError, "injected parent setup failure"):
-                    pending.verify_and_publish(
-                        {"path": "one/two/note.txt", "check": "text_integrity"},
+                    begin_artifact_generation(
+                        backend=_Backend(_result("content")),
+                        user_request="create text",
+                        path="one/two/note.txt",
+                        overwrite=False,
+                        create_parents=True,
                         workdir=root,
+                        temperature=0,
+                        on_progress=None,
                     )
 
             self.assertFalse((root / "one").exists())
@@ -955,19 +975,19 @@ class ArtifactPublicationTests(unittest.TestCase):
     def test_new_parent_post_commit_replacement_is_reported_without_deletion(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            real_rename = artifact_module._rename_noreplace
-            calls = 0
+            real_attest = artifact_module._attest_published_artifact
+            replaced = False
 
-            def replace_after_commit(**kwargs) -> None:
-                nonlocal calls
-                calls += 1
-                real_rename(**kwargs)
-                if calls == 1:
+            def replace_after_commit(parent_fd, basename, **kwargs) -> None:
+                nonlocal replaced
+                if basename == "game.js" and not replaced:
+                    replaced = True
                     target = root / "samples/game.js"
                     target.write_text("different", encoding="utf-8")
+                return real_attest(parent_fd, basename, **kwargs)
 
             with mock.patch(
-                "orbit.runtime.artifacts._rename_noreplace",
+                "orbit.runtime.artifacts._attest_published_artifact",
                 side_effect=replace_after_commit,
             ):
                 with self.assertRaisesRegex(ValueError, "changed after atomic publication"):
@@ -981,20 +1001,20 @@ class ArtifactPublicationTests(unittest.TestCase):
             root = Path(tmp)
             base = root / "base"
             base.mkdir()
-            real_rename = artifact_module._rename_noreplace
+            real_attest = artifact_module._attest_created_directories
             calls = 0
 
-            def move_ancestor_then_commit(**kwargs) -> None:
+            def move_ancestor_after_commit(created) -> None:
                 nonlocal calls
                 calls += 1
-                if calls == 1:
+                if calls == 3:
                     base.rename(root / "old-base")
                     base.mkdir()
-                real_rename(**kwargs)
+                real_attest(created)
 
             with mock.patch(
-                "orbit.runtime.artifacts._rename_noreplace",
-                side_effect=move_ancestor_then_commit,
+                "orbit.runtime.artifacts._attest_created_directories",
+                side_effect=move_ancestor_after_commit,
             ):
                 with self.assertRaisesRegex(ValueError, "parent directory changed"):
                     self._generate(
@@ -1026,13 +1046,11 @@ class ArtifactPublicationTests(unittest.TestCase):
             (root / "one").rename(moved)
             (root / "one").symlink_to(moved, target_is_directory=True)
 
-            with self.assertRaisesRegex(ValueError, "parent directory changed"):
-                pending.verify_and_publish(
-                    {"path": "one/two/game.js", "check": "text_integrity"},
-                    workdir=root,
-                )
+            with self.assertRaisesRegex(ValueError, "unavailable for verification"):
+                pending.verify({"check": "text_integrity"})
 
-            self.assertFalse((moved / "two/game.js").exists())
+            self.assertTrue((moved / "two/game.js").is_file())
+            self.assertTrue((root / "one").is_symlink())
 
     def test_concurrent_overwrite_replacement_is_rolled_back_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1240,16 +1258,51 @@ class ArtifactPublicationTests(unittest.TestCase):
                 temperature=0,
                 on_progress=None,
             )
-            pending.verify_and_publish(
-                {"path": "samples/note.txt", "check": "text_integrity"},
-                workdir=root,
-            )
+            pending.verify({"check": "text_integrity"})
 
             with self.assertRaisesRegex(ValueError, "no longer pending"):
-                pending.verify_and_publish(
-                    {"path": "samples/note.txt", "check": "text_integrity"},
-                    workdir=root,
+                pending.verify({"check": "text_integrity"})
+
+    def test_verification_capability_is_intrinsically_target_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("bounded content\n")),
+                user_request="create one note",
+                path="samples/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+
+            evidence = pending.verify({"check": "text_integrity"})
+
+            self.assertIn("artifact_verification: complete", evidence)
+            self.assertIn("path: samples/note.txt", evidence)
+
+    def test_verification_rejects_path_substitution_as_an_extra_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pending = begin_artifact_generation(
+                backend=_Backend(_result("bounded content\n")),
+                user_request="create one note",
+                path="samples/note.txt",
+                overwrite=False,
+                create_parents=True,
+                workdir=root,
+                temperature=0,
+                on_progress=None,
+            )
+
+            with self.assertRaisesRegex(ValueError, "arguments are invalid"):
+                pending.verify(
+                    {"path": "samples/other.txt", "check": "text_integrity"}
                 )
+
+            self.assertTrue((root / "samples/note.txt").is_file())
+            self.assertFalse((root / "samples/other.txt").exists())
 
     def test_tool_like_text_is_written_verbatim_not_parsed(self) -> None:
         content = '<tool_call>{"command":"rm -rf /"}</tool_call>\n```sh\ncat <<EOF\n```\n'
@@ -1286,6 +1339,127 @@ class ArtifactPublicationTests(unittest.TestCase):
                 )
 
                 self.assertEqual((root / path).read_text(encoding="utf-8"), content)
+
+    def test_recovery_preserves_private_entry_owned_by_live_process(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                temp_fd, temp_name = artifact_module._open_named_artifact_temp(parent_fd)
+                assert temp_name is not None
+                lease = artifact_module._register_private_entry(
+                    workdir=root,
+                    parent_relative=Path("samples"),
+                    temp_name=temp_name,
+                    temp_fd=temp_fd,
+                )
+                os.close(temp_fd)
+            finally:
+                os.close(parent_fd)
+
+            result = cleanup_stale_artifact_entries(root, stale_seconds=0)
+
+            self.assertEqual(result.preserved, 1)
+            self.assertTrue((parent / temp_name).is_file())
+            (parent / temp_name).unlink()
+            lease.release()
+            self.assertFalse((root / ".orbit-artifact-state").exists())
+
+    def test_restart_cleanup_removes_exact_private_entry_from_dead_process(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                temp_fd, temp_name = artifact_module._open_named_artifact_temp(parent_fd)
+                assert temp_name is not None
+                lease = artifact_module._register_private_entry(
+                    workdir=root,
+                    parent_relative=Path("samples"),
+                    temp_name=temp_name,
+                    temp_fd=temp_fd,
+                )
+                os.close(temp_fd)
+            finally:
+                os.close(parent_fd)
+            manifest = root / ".orbit-artifact-state" / lease.manifest_name
+            value = json.loads(manifest.read_text(encoding="utf-8"))
+            value["pid"] = 2**30
+            manifest.write_text(
+                json.dumps(value, sort_keys=True, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            manifest.chmod(0o600)
+
+            result = cleanup_stale_artifact_entries(root)
+
+            self.assertEqual(result.removed, 1)
+            self.assertFalse((parent / temp_name).exists())
+            self.assertFalse((root / ".orbit-artifact-state").exists())
+
+    def test_recovery_preserves_ambiguous_symlink_and_similar_user_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "samples"
+            parent.mkdir()
+            user_file = parent / ".orbit-artifact-user.tmp"
+            user_file.write_text("user", encoding="utf-8")
+            outside = root / "outside.txt"
+            outside.write_text("outside", encoding="utf-8")
+            parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                temp_fd, temp_name = artifact_module._open_named_artifact_temp(parent_fd)
+                assert temp_name is not None
+                lease = artifact_module._register_private_entry(
+                    workdir=root,
+                    parent_relative=Path("samples"),
+                    temp_name=temp_name,
+                    temp_fd=temp_fd,
+                )
+                os.close(temp_fd)
+            finally:
+                os.close(parent_fd)
+            (parent / temp_name).unlink()
+            (parent / temp_name).symlink_to(outside)
+            manifest = root / ".orbit-artifact-state" / lease.manifest_name
+            value = json.loads(manifest.read_text(encoding="utf-8"))
+            value["pid"] = 2**30
+            manifest.write_text(
+                json.dumps(value, sort_keys=True, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            manifest.chmod(0o600)
+            malformed = root / ".orbit-artifact-state" / ("f" * 32 + ".json")
+            malformed.write_text("{}", encoding="utf-8")
+            malformed.chmod(0o600)
+
+            result = cleanup_stale_artifact_entries(root)
+
+            self.assertGreaterEqual(result.preserved, 2)
+            self.assertTrue((parent / temp_name).is_symlink())
+            self.assertEqual(outside.read_text(encoding="utf-8"), "outside")
+            self.assertEqual(user_file.read_text(encoding="utf-8"), "user")
+            self.assertTrue(manifest.is_file())
+            self.assertTrue(malformed.is_file())
+
+    def test_recovery_scan_failure_is_bounded_and_does_not_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state = root / ".orbit-artifact-state"
+            state.mkdir(mode=0o700)
+
+            with mock.patch(
+                "orbit.runtime.artifacts.os.listdir",
+                side_effect=PermissionError(errno.EACCES, "denied"),
+            ):
+                result = cleanup_stale_artifact_entries(root)
+
+            self.assertEqual(result.errors, 1)
+            self.assertEqual(result.preserved, 1)
+            self.assertTrue(state.is_dir())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import unittest
 import contextlib
 import io
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -23,6 +24,31 @@ from orbit.backend.base import ChatResult
 
 
 class CliTests(unittest.TestCase):
+    def test_cli_startup_runs_bounded_artifact_recovery_for_active_workdir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            config = SimpleNamespace(
+                workdir=workdir,
+                base_url="http://127.0.0.1:12120",
+                timeout=30.0,
+                think=False,
+            )
+            stream = io.StringIO()
+            with mock.patch(
+                "orbit.terminal.cli.load_app_config", return_value=config
+            ), mock.patch(
+                "orbit.terminal.cli.cleanup_stale_artifact_entries"
+            ) as cleanup, mock.patch(
+                "orbit.terminal.cli.LlamaServerBackend"
+            ), mock.patch(
+                "orbit.terminal.cli.health_text", return_value="health"
+            ), contextlib.redirect_stdout(stream):
+                code = cli.main(["--health"])
+
+            self.assertEqual(code, 0)
+            cleanup.assert_called_once_with(workdir)
+            self.assertEqual(stream.getvalue().strip(), "health")
+
     def test_one_shot_footer_reports_complete_turn_token_usage(self) -> None:
         class FakeRuntime:
             messages = []

--- a/tests/test_command_request.py
+++ b/tests/test_command_request.py
@@ -54,6 +54,7 @@ class RouteRequestTests(unittest.TestCase):
             '{"url":"https://example.com?a=1&b=2"}',
             '{"path":".","recursive":false,"max_depth":null}',
             '{"include_cpu":true,"include_memory":true}',
+            '{"tool":"write_artifact","arguments":{"path":"samples/game.js","overwrite":false,"create_parents":true}}',
         ):
             with self.subTest(content=content):
                 diagnostic = self._classify(content)
@@ -574,7 +575,10 @@ EOF"}""",
         self.assertIsNone(tool_call)
 
     def test_tool_names_for_decision_are_bounded(self) -> None:
-        self.assertEqual(tool_names_for_decision(ToolRoute.FILESYSTEM), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
+        self.assertEqual(
+            tool_names_for_decision(ToolRoute.FILESYSTEM),
+            ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"),
+        )
         self.assertEqual(tool_names_for_decision(ToolRoute.FILE_EDIT), ())
         self.assertEqual(tool_names_for_decision(ToolRoute.WEB), ())
 
@@ -597,6 +601,60 @@ EOF"}""",
     def test_command_stream_state_detects_complete_chat_route_json(self) -> None:
         self.assertEqual(command_stream_state('{"route":"CHAT"}'), "route")
         self.assertEqual(command_stream_state('{"route"'), "pending")
+
+    def test_artifact_route_is_bounded_and_preserves_model_arguments(self) -> None:
+        content = '{"tool":"write_artifact","arguments":{"path":"samples/game.js","overwrite":false,"create_parents":true}}'
+        decision = parse_command_decision(content)
+        tool_call = command_tool_call_from_content(
+            content,
+            ("write_artifact", "verify_artifact"),
+        )
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(
+            decision_tool_names(decision),
+            ("write_artifact",),
+        )
+        self.assertEqual(tool_call["function"]["name"], "write_artifact")
+        self.assertEqual(
+            json.loads(tool_call["function"]["arguments"]),
+            {"path": "samples/game.js", "overwrite": False, "create_parents": True},
+        )
+        self.assertEqual(command_stream_state(content), "route")
+
+    def test_artifact_route_rejects_duplicate_json_keys(self) -> None:
+        content = (
+            '{"tool":"write_artifact","arguments":'
+            '{"path":"safe.txt","path":"other.txt","overwrite":false}}'
+        )
+
+        self.assertIsNone(parse_command_decision(content))
+        self.assertIsNone(command_tool_call_from_content(content, ("write_artifact",)))
+
+    def test_malformed_artifact_tool_call_is_never_substituted_with_shell(self) -> None:
+        call = {
+            "id": "artifact-malformed",
+            "type": "function",
+            "function": {
+                "name": "write_artifact",
+                "arguments": json.dumps(
+                    {
+                        "path": "samples/game.js",
+                        "command": "printf bypassed > samples/game.js",
+                    }
+                ),
+            },
+        }
+
+        decision = parse_command_decision_from_tool_calls([call])
+
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision_tool_names(decision), ("write_artifact",))
+        self.assertEqual(
+            command_tool_call_from_tool_calls([call], ("write_artifact",)),
+            call,
+        )
 
     def test_command_stream_filter_suppresses_command_json(self) -> None:
         emitted: list[str] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -259,7 +259,16 @@ class ConfigTests(unittest.TestCase):
     def test_tools_on_uses_shell_fetch_url_list_directory_and_system_info(self) -> None:
         names = allowed_tool_names_for_spec("on")
 
-        self.assertEqual(names, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
+        self.assertEqual(
+            names,
+            (
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            ),
+        )
 
     def test_legacy_tools_object_config_key_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_document_search.py
+++ b/tests/test_document_search.py
@@ -836,9 +836,16 @@ class DocumentSearchRuntimeTests(unittest.TestCase):
     def test_production_schema_remains_unchanged(self) -> None:
         self.assertEqual(
             [definition["function"]["name"] for definition in tool_definitions()],
-            ["exec_shell_full_command", "fetch_url", "list_directory", "system_info"],
+            [
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            ],
         )
         self.assertNotIn("document_search", str(tool_definitions()))
+        self.assertNotIn("verify_artifact", str(tool_definitions()))
 
 
 if __name__ == "__main__":

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -59,6 +59,33 @@ class EvidenceTests(unittest.TestCase):
             self.assertFalse(sidecar.exists())
             self.assertEqual(restarted.recent_records(1), [])
 
+    def test_restart_removes_abandoned_pending_artifact_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "session.evidence"
+            first = EvidenceStore(root)
+            pending = first.add(
+                "write_artifact",
+                "\n".join(
+                    (
+                        "artifact_generation: complete",
+                        "path: note.txt",
+                        "bytes: 4",
+                        "sha256: " + "a" * 64,
+                        "publication_status: pending",
+                        "verification_required: true",
+                    )
+                ),
+            )
+            self.assertEqual(pending.metadata.get("ephemeral"), "artifact_pending")
+            sidecar = root / f"{pending.evidence_id}.txt"
+            self.assertTrue(sidecar.exists())
+
+            restarted = EvidenceStore(root)
+            restarted.load_index()
+
+            self.assertFalse(sidecar.exists())
+            self.assertEqual(restarted.recent_records(1), [])
+
     def test_repeated_ephemeral_cleanup_has_no_linear_disk_growth(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             store = EvidenceStore(Path(tmp) / "session.evidence")
@@ -83,6 +110,92 @@ class EvidenceTests(unittest.TestCase):
         self.assertTrue(record.raw_ref.startswith("evidence:"))
         self.assertIn("sha256:", record.route_card)
         self.assertIn("hello", record.final_card)
+
+    def test_artifact_publication_keeps_path_hash_and_parent_evidence(self) -> None:
+        record = build_evidence_record(
+            "write_artifact",
+            "\n".join(
+                (
+                    "artifact_publication: complete",
+                    "path: samples/game.js",
+                    "bytes: 42",
+                    "sha256: " + "a" * 64,
+                    "overwrite: false",
+                    "created_parent_directories: samples",
+                    "directory_sync: complete",
+                    "verification_completed: true",
+                )
+            ),
+        )
+
+        self.assertEqual(record.kind, "artifact")
+        self.assertEqual(record.metadata["artifact_path"], "samples/game.js")
+        self.assertEqual(record.metadata["artifact_bytes"], "42")
+        self.assertEqual(record.metadata["artifact_sha256"], "a" * 64)
+        self.assertEqual(record.metadata["artifact_directory_sync"], "complete")
+        self.assertIn("artifact_path: samples/game.js", record.final_card)
+        self.assertIn("created_parent_directories: samples", record.route_card)
+
+    def test_pending_artifact_and_verified_publication_keep_distinct_evidence(self) -> None:
+        pending = build_evidence_record(
+            "write_artifact",
+            "\n".join(
+                (
+                    "artifact_generation: complete",
+                    "path: samples/game.js",
+                    "bytes: 42",
+                    "sha256: " + "a" * 64,
+                    "publication_status: pending",
+                    "verification_required: true",
+                )
+            ),
+        )
+        verified = build_evidence_record(
+            "verify_artifact",
+            "\n".join(
+                (
+                    "artifact_publication: complete",
+                    "path: samples/game.js",
+                    "bytes: 42",
+                    "sha256: " + "a" * 64,
+                    "overwrite: false",
+                    "created_parent_directories: samples",
+                    "directory_sync: complete",
+                    "verification_completed: true",
+                    "artifact_verification: complete",
+                    "check: text_integrity",
+                    "status: pass",
+                    "detail: syntax valid",
+                )
+            ),
+        )
+
+        self.assertEqual(pending.kind, "artifact_pending")
+        self.assertEqual(verified.kind, "artifact_verification")
+        self.assertEqual(verified.metadata["created_parent_directories"], "samples")
+        self.assertEqual(verified.metadata["artifact_overwrite"], "false")
+        self.assertEqual(verified.metadata["artifact_verification_completed"], "true")
+
+    def test_failed_artifact_verification_is_structured_error_evidence(self) -> None:
+        record = build_evidence_record(
+            "verify_artifact",
+            "error: artifact verification failed: destination changed",
+        )
+
+        self.assertEqual(record.kind, "artifact_verification")
+        self.assertEqual(record.status, "error")
+        self.assertIn("kind: artifact_verification", record.final_card)
+        self.assertIn("status: error", record.final_card)
+
+    def test_failed_artifact_generation_is_structured_error_evidence(self) -> None:
+        record = build_evidence_record(
+            "write_artifact",
+            "error: artifact content was not published: finish_reason=length",
+        )
+
+        self.assertEqual(record.kind, "artifact_error")
+        self.assertEqual(record.status, "error")
+        self.assertIn("artifact content was not published", record.final_card)
 
     def test_sidecar_write_read_roundtrip(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -59,32 +59,31 @@ class EvidenceTests(unittest.TestCase):
             self.assertFalse(sidecar.exists())
             self.assertEqual(restarted.recent_records(1), [])
 
-    def test_restart_removes_abandoned_pending_artifact_evidence(self) -> None:
+    def test_restart_preserves_completed_artifact_publication_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "session.evidence"
             first = EvidenceStore(root)
-            pending = first.add(
+            publication = first.add(
                 "write_artifact",
                 "\n".join(
                     (
-                        "artifact_generation: complete",
+                        "artifact_publication: complete",
                         "path: note.txt",
                         "bytes: 4",
                         "sha256: " + "a" * 64,
-                        "publication_status: pending",
                         "verification_required: true",
                     )
                 ),
             )
-            self.assertEqual(pending.metadata.get("ephemeral"), "artifact_pending")
-            sidecar = root / f"{pending.evidence_id}.txt"
+            self.assertNotIn("ephemeral", publication.metadata)
+            sidecar = root / f"{publication.evidence_id}.txt"
             self.assertTrue(sidecar.exists())
 
             restarted = EvidenceStore(root)
             restarted.load_index()
 
-            self.assertFalse(sidecar.exists())
-            self.assertEqual(restarted.recent_records(1), [])
+            self.assertTrue(sidecar.exists())
+            self.assertEqual(restarted.recent_records(1)[0].kind, "artifact")
 
     def test_repeated_ephemeral_cleanup_has_no_linear_disk_growth(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -123,7 +122,7 @@ class EvidenceTests(unittest.TestCase):
                     "overwrite: false",
                     "created_parent_directories: samples",
                     "directory_sync: complete",
-                    "verification_completed: true",
+                    "verification_completed: false",
                 )
             ),
         )
@@ -136,22 +135,9 @@ class EvidenceTests(unittest.TestCase):
         self.assertIn("artifact_path: samples/game.js", record.final_card)
         self.assertIn("created_parent_directories: samples", record.route_card)
 
-    def test_pending_artifact_and_verified_publication_keep_distinct_evidence(self) -> None:
-        pending = build_evidence_record(
+    def test_publication_and_read_only_verification_keep_distinct_evidence(self) -> None:
+        publication = build_evidence_record(
             "write_artifact",
-            "\n".join(
-                (
-                    "artifact_generation: complete",
-                    "path: samples/game.js",
-                    "bytes: 42",
-                    "sha256: " + "a" * 64,
-                    "publication_status: pending",
-                    "verification_required: true",
-                )
-            ),
-        )
-        verified = build_evidence_record(
-            "verify_artifact",
             "\n".join(
                 (
                     "artifact_publication: complete",
@@ -161,8 +147,19 @@ class EvidenceTests(unittest.TestCase):
                     "overwrite: false",
                     "created_parent_directories: samples",
                     "directory_sync: complete",
-                    "verification_completed: true",
+                    "verification_required: true",
+                    "verification_completed: false",
+                )
+            ),
+        )
+        verified = build_evidence_record(
+            "verify_artifact",
+            "\n".join(
+                (
                     "artifact_verification: complete",
+                    "path: samples/game.js",
+                    "bytes: 42",
+                    "sha256: " + "a" * 64,
                     "check: text_integrity",
                     "status: pass",
                     "detail: syntax valid",
@@ -170,11 +167,12 @@ class EvidenceTests(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(pending.kind, "artifact_pending")
+        self.assertEqual(publication.kind, "artifact")
         self.assertEqual(verified.kind, "artifact_verification")
-        self.assertEqual(verified.metadata["created_parent_directories"], "samples")
-        self.assertEqual(verified.metadata["artifact_overwrite"], "false")
-        self.assertEqual(verified.metadata["artifact_verification_completed"], "true")
+        self.assertEqual(publication.metadata["created_parent_directories"], "samples")
+        self.assertEqual(publication.metadata["artifact_overwrite"], "false")
+        self.assertEqual(publication.metadata["artifact_verification_completed"], "false")
+        self.assertEqual(verified.metadata["artifact_check"], "text_integrity")
 
     def test_failed_artifact_verification_is_structured_error_evidence(self) -> None:
         record = build_evidence_record(

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -67,7 +67,7 @@ class FinalPolicyTests(unittest.TestCase):
                 "role": "tool",
                 "name": "write_artifact",
                 "tool_call_id": "artifact-1",
-                "content": "artifact_generation: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\npublication_status: pending",
+                "content": "artifact_publication: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\noverwrite: false",
             },
             {
                 "role": "assistant",
@@ -87,7 +87,7 @@ class FinalPolicyTests(unittest.TestCase):
                 "role": "tool",
                 "name": "verify_artifact",
                 "tool_call_id": "verify-1",
-                "content": "artifact_publication: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\noverwrite: false\nartifact_verification: complete\ncheck: text_integrity\nstatus: pass",
+                "content": "artifact_verification: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\ncheck: text_integrity\nstatus: pass",
             },
         ]
 
@@ -97,13 +97,13 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertIn("Name the exact artifact path", policy.messages[-1]["content"])
         self.assertIn("what the selected verification confirmed", policy.messages[-1]["content"])
 
-    def test_failed_artifact_verification_cannot_be_reported_as_published(self) -> None:
+    def test_failed_artifact_verification_reports_published_but_unverified(self) -> None:
         messages = [
             {"role": "user", "content": "create samples/snake.html"},
             {
                 "role": "tool",
                 "name": "write_artifact",
-                "content": "artifact_generation: complete\npath: samples/snake.html\npublication_status: pending",
+                "content": "artifact_publication: complete\npath: samples/snake.html\nbytes: 42\nsha256: " + "a" * 64,
             },
             {
                 "role": "tool",
@@ -115,8 +115,9 @@ class FinalPolicyTests(unittest.TestCase):
         policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
 
         instruction = policy.messages[-1]["content"]
-        self.assertIn("no artifact was published", instruction)
-        self.assertIn("Do not claim that the file exists", instruction)
+        self.assertIn("artifact was atomically published", instruction)
+        self.assertIn("file remains published", instruction)
+        self.assertIn("do not claim that its content passed verification", instruction)
 
     def test_failed_artifact_generation_cannot_be_reported_as_published(self) -> None:
         messages = [
@@ -162,7 +163,7 @@ class FinalPolicyTests(unittest.TestCase):
                 "content": (
                     "tool_evidence_ref: true\n"
                     "tool: write_artifact\n"
-                    "kind: artifact_pending\n"
+                    "kind: artifact\n"
                     "status: ok\n"
                     "artifact_path: samples/note.txt"
                 ),
@@ -182,8 +183,8 @@ class FinalPolicyTests(unittest.TestCase):
         policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
 
         instruction = policy.messages[-1]["content"]
-        self.assertIn("no artifact was published", instruction)
-        self.assertIn("Do not claim that the file exists", instruction)
+        self.assertIn("file remains published", instruction)
+        self.assertIn("do not claim that its content passed verification", instruction)
 
     def test_latest_failed_artifact_is_not_masked_by_previous_success(self) -> None:
         messages = [
@@ -191,7 +192,7 @@ class FinalPolicyTests(unittest.TestCase):
             {
                 "role": "tool",
                 "name": "write_artifact",
-                "content": "artifact_generation: complete\npath: samples/first.js",
+                "content": "artifact_publication: complete\npath: samples/first.js",
             },
             {
                 "role": "tool",
@@ -202,7 +203,7 @@ class FinalPolicyTests(unittest.TestCase):
             {
                 "role": "tool",
                 "name": "write_artifact",
-                "content": "artifact_generation: complete\npath: samples/second.js",
+                "content": "artifact_publication: complete\npath: samples/second.js",
             },
             {
                 "role": "tool",
@@ -214,8 +215,8 @@ class FinalPolicyTests(unittest.TestCase):
         policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
 
         instruction = policy.messages[-1]["content"]
-        self.assertIn("no artifact was published", instruction)
-        self.assertNotIn("artifact was atomically published", instruction)
+        self.assertIn("file remains published", instruction)
+        self.assertIn("artifact was atomically published", instruction)
 
     def test_html_cleaned_policy_caps_tokens_and_allows_length_retry_when_not_streamed(self) -> None:
         messages = [{"role": "tool", "name": "exec_shell_full_command", "content": "shell_output_html_cleaned: true\ntext:\ncontent"}]

--- a/tests/test_final_policy.py
+++ b/tests/test_final_policy.py
@@ -46,6 +46,177 @@ class FinalPolicyTests(unittest.TestCase):
         self.assertEqual(policy.max_tokens, 96)
         self.assertIn("Return only the listed names", policy.messages[-1]["content"])
 
+    def test_verified_artifact_final_instruction_preserves_creation_and_verification(self) -> None:
+        messages = [
+            {"role": "user", "content": "create a JavaScript game in samples"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "artifact-1",
+                        "type": "function",
+                        "function": {
+                            "name": "write_artifact",
+                            "arguments": '{"path":"samples/game.js"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "tool_call_id": "artifact-1",
+                "content": "artifact_generation: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\npublication_status: pending",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "verify-1",
+                        "type": "function",
+                        "function": {
+                            "name": "verify_artifact",
+                            "arguments": '{"path":"samples/game.js","check":"text_integrity"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "verify_artifact",
+                "tool_call_id": "verify-1",
+                "content": "artifact_publication: complete\npath: samples/game.js\nbytes: 42\nsha256: " + "a" * 64 + "\noverwrite: false\nartifact_verification: complete\ncheck: text_integrity\nstatus: pass",
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        self.assertIn("artifact was atomically published in this turn", policy.messages[-1]["content"])
+        self.assertIn("Name the exact artifact path", policy.messages[-1]["content"])
+        self.assertIn("what the selected verification confirmed", policy.messages[-1]["content"])
+
+    def test_failed_artifact_verification_cannot_be_reported_as_published(self) -> None:
+        messages = [
+            {"role": "user", "content": "create samples/snake.html"},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": "artifact_generation: complete\npath: samples/snake.html\npublication_status: pending",
+            },
+            {
+                "role": "tool",
+                "name": "verify_artifact",
+                "content": "error: artifact verification failed: selected integrity check failed",
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        instruction = policy.messages[-1]["content"]
+        self.assertIn("no artifact was published", instruction)
+        self.assertIn("Do not claim that the file exists", instruction)
+
+    def test_failed_artifact_generation_cannot_be_reported_as_published(self) -> None:
+        messages = [
+            {"role": "user", "content": "Create samples/game.js."},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": "error: artifact content was not published: finish_reason=length",
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        instruction = policy.messages[-1]["content"]
+        self.assertIn("failed before verified publication", instruction)
+        self.assertIn("no artifact was published", instruction)
+
+    def test_compact_failed_artifact_generation_cannot_be_reported_as_published(self) -> None:
+        messages = [
+            {"role": "user", "content": "Create samples/game.js."},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": (
+                    "tool_evidence_card: true\n"
+                    "kind: artifact_error\n"
+                    "status: error\n"
+                    "artifact_error_detail: generation timed out"
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        self.assertIn("no artifact was published", policy.messages[-1]["content"])
+
+    def test_compact_failed_artifact_evidence_cannot_be_reported_as_published(self) -> None:
+        messages = [
+            {"role": "user", "content": "create samples/note.txt"},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": (
+                    "tool_evidence_ref: true\n"
+                    "tool: write_artifact\n"
+                    "kind: artifact_pending\n"
+                    "status: ok\n"
+                    "artifact_path: samples/note.txt"
+                ),
+            },
+            {
+                "role": "tool",
+                "name": "verify_artifact",
+                "content": (
+                    "tool_evidence_ref: true\n"
+                    "tool: verify_artifact\n"
+                    "kind: artifact_verification\n"
+                    "status: error"
+                ),
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        instruction = policy.messages[-1]["content"]
+        self.assertIn("no artifact was published", instruction)
+        self.assertIn("Do not claim that the file exists", instruction)
+
+    def test_latest_failed_artifact_is_not_masked_by_previous_success(self) -> None:
+        messages = [
+            {"role": "user", "content": "create samples/first.js"},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": "artifact_generation: complete\npath: samples/first.js",
+            },
+            {
+                "role": "tool",
+                "name": "verify_artifact",
+                "content": "artifact_verification: complete\nstatus: pass",
+            },
+            {"role": "user", "content": "create samples/second.js"},
+            {
+                "role": "tool",
+                "name": "write_artifact",
+                "content": "artifact_generation: complete\npath: samples/second.js",
+            },
+            {
+                "role": "tool",
+                "name": "verify_artifact",
+                "content": "error: artifact verification failed: invalid syntax",
+            },
+        ]
+
+        policy = build_final_tool_policy(messages, max_tokens=256, streamed=False)
+
+        instruction = policy.messages[-1]["content"]
+        self.assertIn("no artifact was published", instruction)
+        self.assertNotIn("artifact was atomically published", instruction)
+
     def test_html_cleaned_policy_caps_tokens_and_allows_length_retry_when_not_streamed(self) -> None:
         messages = [{"role": "tool", "name": "exec_shell_full_command", "content": "shell_output_html_cleaned: true\ntext:\ncontent"}]
 

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -129,9 +129,16 @@ class FullDocumentTests(unittest.TestCase):
 
         self.assertEqual(
             names,
-            ["exec_shell_full_command", "fetch_url", "list_directory", "system_info"],
+            [
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            ],
         )
         self.assertEqual(tool_definitions(("read_file",)), [])
+        self.assertNotIn("verify_artifact", names)
 
     def test_corrupted_snapshot_fails_closed(self) -> None:
         workdir, _ = self._snapshot("alpha")

--- a/tests/test_kv_diag.py
+++ b/tests/test_kv_diag.py
@@ -99,6 +99,21 @@ def _result(content: str, *, finish_reason: str, prompt_tokens: int = 10, comple
 
 
 class KVDiagTests(unittest.TestCase):
+    def test_diagnostic_wrapper_reports_unsupported_artifact_backend_cleanly(self) -> None:
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1"}):
+            backend = instrument_backend(FakeBackend())
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "artifact content generation requires the native Orbit backend",
+        ):
+            backend.artifact_content_stream(
+                [{"role": "user", "content": "content only"}],
+                temperature=0,
+                max_tokens=16,
+                on_delta=lambda _text: None,
+            )
+
     def setUp(self) -> None:
         reset_diagnostics_for_tests()
         reset_native_diagnostics_for_tests()

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -25,7 +25,12 @@ from orbit.backend.llama_server import (
     _qwen_route_prefix_anchor_requested,
 )
 from orbit.backend.base import ChatResult
-from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
+from orbit.backend.payloads import (
+    ARTIFACT_CONTENT_PROTOCOL_ID,
+    ARTIFACT_CONTENT_PROTOCOL_VERSION,
+    ChatPayloadOptions,
+    build_chat_payload,
+)
 from orbit.backend import model_names
 from orbit.runtime.kv_diag import model_call_context
 from urllib.error import URLError
@@ -55,6 +60,74 @@ class FakeNativeStreamWithTrailingNoise:
 
 
 class LlamaServerBackendTests(unittest.TestCase):
+    def test_artifact_content_stream_is_native_content_only(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", model="fake", timeout=1)
+                self.payload = None
+
+            def _props_or_empty(self) -> dict[str, object]:
+                return {
+                    "backend": "orbit-native",
+                    "artifact_content_protocol": {
+                        "id": ARTIFACT_CONTENT_PROTOCOL_ID,
+                        "version": ARTIFACT_CONTENT_PROTOCOL_VERSION,
+                        "literal_stream": True,
+                    },
+                }
+
+            def _post_native_stream(
+                self,
+                path,
+                payload,
+                *,
+                on_delta,
+                on_progress,
+                literal_content=False,
+            ):
+                del on_delta, on_progress
+                self.assert_path = path
+                self.payload = payload
+                self.literal_content = literal_content
+                return ChatResult("content", "fake", "stop", [], 1, 1, 0, None, None)
+
+        backend = Backend()
+        result = backend.artifact_content_stream(
+            [{"role": "user", "content": "content only"}],
+            temperature=0,
+            max_tokens=2048,
+            on_delta=lambda _text: None,
+        )
+
+        self.assertEqual(result.content, "content")
+        self.assertEqual(backend.assert_path, "/chat/stream")
+        self.assertTrue(backend.payload["artifact_content"])
+        self.assertFalse(backend.payload["thinking"])
+        self.assertNotIn("tools", backend.payload)
+        self.assertTrue(backend.literal_content)
+
+    def test_artifact_content_stream_rejects_external_backend(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", model="fake", timeout=1)
+        with mock.patch.object(backend, "_is_orbit_native_backend", return_value=False):
+            with self.assertRaisesRegex(LlamaServerError, "native Orbit backend"):
+                backend.artifact_content_stream(
+                    [{"role": "user", "content": "content only"}],
+                    temperature=0,
+                    max_tokens=32,
+                    on_delta=lambda _text: None,
+                )
+
+    def test_artifact_content_stream_rejects_native_backend_without_verified_protocol(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", model="fake", timeout=1)
+        with mock.patch.object(backend, "_props_or_empty", return_value={"backend": "orbit-native"}):
+            with self.assertRaisesRegex(LlamaServerError, "verified artifact content protocol"):
+                backend.artifact_content_stream(
+                    [{"role": "user", "content": "content only"}],
+                    temperature=0,
+                    max_tokens=32,
+                    on_delta=lambda _text: None,
+                )
+
     def test_native_token_count_uses_non_generating_endpoint(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:
@@ -1083,6 +1156,31 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "tool_calls")
         self.assertEqual(result.tool_calls[0]["function"]["name"], "exec_shell_full_command")
         self.assertEqual(result.tool_calls[0]["function"]["arguments"], '{"command": "cat note.txt"}')
+
+    def test_parse_native_stream_literal_mode_preserves_raw_tool_markers(self) -> None:
+        emitted: list[str] = []
+        literal = '<|tool_call>call:exec_shell_full_command{command:<|"|>inert<|"|>}<tool_call|>'
+
+        result = _parse_native_stream(
+            FakeStream(
+                [
+                    'event: delta\n',
+                    f'data: {json.dumps({"text": literal})}\n',
+                    '\n',
+                    'event: done\n',
+                    'data: {"finish_reason":"stop"}\n',
+                    '\n',
+                ]
+            ),
+            on_delta=emitted.append,
+            on_progress=None,
+            literal_content=True,
+        )
+
+        self.assertEqual(emitted, [literal])
+        self.assertEqual(result.content, literal)
+        self.assertEqual(result.tool_calls, [])
+        self.assertEqual(result.finish_reason, "stop")
 
     def test_parse_native_stream_keeps_qwen_reasoning_and_tool_calls_out_of_content(self) -> None:
         emitted: list[str] = []

--- a/tests/test_native_qwen_profile.py
+++ b/tests/test_native_qwen_profile.py
@@ -142,6 +142,58 @@ class NativeQwenProfileTests(unittest.TestCase):
         self.assertEqual("".join(emitted), result.content)
         self.assertNotIn("private", "".join(emitted))
 
+    def test_artifact_content_bypasses_qwen_tool_parser_and_keeps_literal_markup(self) -> None:
+        client = self._client()
+        emitted: list[str] = []
+        literal = '<tool_call>{"command":"inert"}</tool_call>\nconst ready = true;'
+        timings = NativeTimings(10, 5, 0, 10, 1.0, 2.0, False)
+
+        def complete(_messages, **kwargs):
+            self.assertIsNone(kwargs["tools"])
+            self.assertFalse(kwargs["thinking"])
+            self.assertFalse(kwargs["route_prefix_anchor"])
+            self.assertFalse(kwargs["qwen_route_prefix_anchor"])
+            self.assertFalse(kwargs["allow_mtp_experimental"])
+            self.assertFalse(kwargs["final_prefix_experiment"])
+            kwargs["on_token"](literal)
+            return timings
+
+        with mock.patch.object(client, "complete_chat", side_effect=complete):
+            result = client.complete_artifact_text(
+                [{"role": "user", "content": "file content only"}],
+                max_tokens=128,
+                on_token=emitted.append,
+            )
+
+        self.assertEqual(result.content, literal)
+        self.assertEqual("".join(emitted), literal)
+        self.assertEqual(result.tool_calls, ())
+
+    def test_artifact_content_keeps_literal_control_markup_without_profile_parser(self) -> None:
+        client = self._client()
+        client.model_profile = None
+        emitted: list[str] = []
+        literal = '<think>inert XML</think>\n<tool_call>{"command":"inert"}</tool_call>'
+        timings = NativeTimings(10, 5, 0, 10, 1.0, 2.0, False)
+
+        def complete(_messages, **kwargs):
+            self.assertIsNone(kwargs["tools"])
+            self.assertFalse(kwargs["thinking"])
+            self.assertFalse(kwargs["allow_mtp_experimental"])
+            kwargs["on_token"](literal)
+            return timings
+
+        with mock.patch.object(client, "complete_chat", side_effect=complete):
+            result = client.complete_artifact_text(
+                [{"role": "user", "content": "literal fixture"}],
+                max_tokens=128,
+                on_token=emitted.append,
+            )
+
+        self.assertEqual(result.content, literal)
+        self.assertEqual("".join(emitted), literal)
+        self.assertEqual(result.tool_calls, ())
+
     def test_qwen_tool_call_arguments_remain_exact_json_for_canonical_gate(self) -> None:
         client = self._client()
 

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -68,6 +68,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertFalse(request.qwen_route_prefix_anchor)
         self.assertIsNone(request.allow_mtp_experimental)
         self.assertFalse(request.final_prefix_experiment)
+        self.assertFalse(request.artifact_content)
 
     def test_parse_chat_request_accepts_thinking_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "thinking": True})
@@ -125,6 +126,13 @@ class NativeServerProtocolTests(unittest.TestCase):
 
         self.assertTrue(enabled.final_prefix_experiment)
         self.assertFalse(ignored.final_prefix_experiment)
+
+    def test_parse_chat_request_accepts_only_boolean_artifact_content_flag(self) -> None:
+        enabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "artifact_content": True})
+        ignored = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "artifact_content": "true"})
+
+        self.assertTrue(enabled.artifact_content)
+        self.assertFalse(ignored.artifact_content)
 
     def test_parse_chat_request_rejects_malformed_payloads(self) -> None:
         bad_payloads = [

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -44,6 +44,7 @@ class _FakeClient:
         self.allow_mtp_calls: list[bool | None] = []
         self.final_prefix_calls: list[bool] = []
         self.qwen_route_prefix_calls: list[bool] = []
+        self.artifact_calls = 0
 
     def complete_chat_text(
         self,
@@ -67,6 +68,13 @@ class _FakeClient:
         self.qwen_route_prefix_calls.append(qwen_route_prefix_anchor)
         return _FakeCompletion()
 
+    def complete_artifact_text(self, messages, **kwargs):
+        del messages
+        self.artifact_calls += 1
+        if kwargs.get("on_token") is not None:
+            kwargs["on_token"]('<tool_call>{"command":"inert"}</tool_call>')
+        return _FakeCompletion(content='<tool_call>{"command":"inert"}</tool_call>')
+
     def session_snapshot(self, session_id: str):
         return type(
             "Snapshot",
@@ -89,6 +97,67 @@ class _FakeClient:
 
 
 class NativeServerThinkTests(unittest.TestCase):
+    def test_artifact_content_uses_literal_path_without_tool_parsing(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "file content only"}],
+                    "artifact_content": True,
+                    "thinking": False,
+                }
+            )
+        )
+
+        self.assertEqual(client.artifact_calls, 1)
+        self.assertEqual(result["content"], '<tool_call>{"command":"inert"}</tool_call>')
+        self.assertEqual(result["finish_reason"], "stop")
+
+    def test_artifact_content_rejects_thinking_tools_or_stop_sequences(self) -> None:
+        server = OrbitNativeServer(client=_FakeClient(thinking=False), model_alias="m")
+        tool = {"type": "function", "function": {"name": "exec_shell_full_command"}}
+
+        for payload in (
+            {"messages": [{"role": "user", "content": "x"}], "artifact_content": True, "thinking": True},
+            {"messages": [{"role": "user", "content": "x"}], "artifact_content": True, "tools": [tool]},
+            {"messages": [{"role": "user", "content": "x"}], "artifact_content": True, "stop": ["EOF"]},
+        ):
+            with self.subTest(payload=payload), self.assertRaisesRegex(ValueError, "stop sequences"):
+                server.complete(parse_chat_request(payload))
+
+    def test_artifact_stream_rejects_invalid_options_before_sending_sse_headers(self) -> None:
+        server = OrbitNativeServer(client=_FakeClient(thinking=False), model_alias="m")
+
+        class _Handler:
+            def __init__(self) -> None:
+                self.responses: list[tuple[dict[str, object], int]] = []
+                self.headers_sent = False
+
+            def _state(self):
+                return server
+
+            def _json(self, data, *, status=200):
+                self.responses.append((data, status))
+
+            def send_response(self, _status):
+                self.headers_sent = True
+
+        handler = _Handler()
+        OrbitNativeHandler._native_stream(
+            handler,
+            {
+                "messages": [{"role": "user", "content": "x"}],
+                "artifact_content": True,
+                "thinking": True,
+            },
+        )
+
+        self.assertFalse(handler.headers_sent)
+        self.assertEqual(handler.responses[0][1], 400)
+        self.assertIn("artifact content generation requires", handler.responses[0][0]["error"])
+
     def test_final_prefix_experiment_requires_exact_final_prompt_family(self) -> None:
         client = _FakeClient(thinking=False)
         server = OrbitNativeServer(client=client, model_alias="fake")

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -136,5 +136,25 @@ class PayloadTests(unittest.TestCase):
         self.assertNotIn("final_prefix_experiment", baseline)
         self.assertTrue(experimental["final_prefix_experiment"])
 
+    def test_artifact_content_flag_is_explicit_and_does_not_add_tools(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(model="m", messages=[{"role": "user", "content": "hello"}], temperature=0, max_tokens=32)
+        )
+        artifact = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "file content only"}],
+                temperature=0,
+                max_tokens=2048,
+                thinking=False,
+                artifact_content=True,
+            )
+        )
+
+        self.assertNotIn("artifact_content", baseline)
+        self.assertTrue(artifact["artifact_content"])
+        self.assertNotIn("tools", artifact)
+        self.assertNotIn("tool_choice", artifact)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -722,7 +722,16 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.ask_auto_calls, 1)
         self.assertEqual(runtime.ask_chat_calls, 0)
         self.assertIsNotNone(runtime.last_allowed_tool_names)
-        self.assertEqual(runtime.last_allowed_tool_names, ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
+        self.assertEqual(
+            runtime.last_allowed_tool_names,
+            (
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            ),
+        )
 
     def test_repl_reads_queued_prompt_before_new_input(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -353,6 +353,10 @@ class ReplTests(unittest.TestCase):
             format_tool_call_event("fetch_url", json.dumps({"url": "https://example.com"})),
             "Fetch: https://example.com",
         )
+        self.assertEqual(
+            format_tool_call_event("verify_artifact", json.dumps({"check": "text_integrity"})),
+            "Verify: published artifact (text_integrity)",
+        )
 
     def test_tool_result_event_previews_pdf_and_list_output(self) -> None:
         pdf_content = "\n".join(

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -223,7 +223,7 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(smoke_harness.TOOL_CALL_GENERATION_PROTOCOL_VERSION, 1)
         self.assertEqual(
             smoke_harness.tool_call_generation_protocol_hash(),
-            "8dd7b96d1f85cf6c0ad8202a79b80a3069691beb7180ab0dacb57cc495fe1a05",
+            "c17a5519aa519239ba5e7512e4bc7a4f1575e8549f8f1645bcd51beaa0592f23",
         )
 
     def test_tool_call_generation_configuration_hash_uses_comparable_fields_only(self) -> None:

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -223,7 +223,7 @@ class SmokeHarnessTests(unittest.TestCase):
         self.assertEqual(smoke_harness.TOOL_CALL_GENERATION_PROTOCOL_VERSION, 1)
         self.assertEqual(
             smoke_harness.tool_call_generation_protocol_hash(),
-            "dad2a2a62a258f9c8f8cfa39bbf0038d282374ee39e690cc85c7fc10ba52a5b1",
+            "8dd7b96d1f85cf6c0ad8202a79b80a3069691beb7180ab0dacb57cc495fe1a05",
         )
 
     def test_tool_call_generation_configuration_hash_uses_comparable_fields_only(self) -> None:

--- a/tests/test_tool_contract.py
+++ b/tests/test_tool_contract.py
@@ -66,6 +66,7 @@ class CanonicalToolContractTests(unittest.TestCase):
         self.assertEqual(definitions["fetch_url"]["required"], ["url"])
         self.assertEqual(definitions["list_directory"]["required"], [])
         self.assertEqual(definitions["system_info"]["required"], [])
+        self.assertEqual(definitions["write_artifact"]["required"], ["path"])
         self.assertEqual(definitions["exec_shell_full_command"]["properties"]["timeout"]["maximum"], 15)
         self.assertEqual(definitions["fetch_url"]["properties"]["timeout"]["maximum"], 15)
         self.assertEqual(definitions["list_directory"]["properties"]["max_entries"]["maximum"], 1000)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,10 +16,18 @@ from orbit.runtime.tools import default_tool_names, execute_tool, tool_definitio
 
 class ToolTests(unittest.TestCase):
     def test_shell_and_fetch_url_are_exposed(self) -> None:
-        self.assertEqual(tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
-        self.assertEqual(default_tool_names(), ("exec_shell_full_command", "fetch_url", "list_directory", "system_info"))
+        all_names = (
+            "exec_shell_full_command",
+            "fetch_url",
+            "list_directory",
+            "system_info",
+            "write_artifact",
+        )
+        default_names = all_names
+        self.assertEqual(tool_names(), all_names)
+        self.assertEqual(default_tool_names(), default_names)
         definitions = tool_definitions()
-        self.assertEqual([item["function"]["name"] for item in definitions], ["exec_shell_full_command", "fetch_url", "list_directory", "system_info"])
+        self.assertEqual([item["function"]["name"] for item in definitions], list(default_names))
 
     def test_tool_definitions_respect_allowed_names(self) -> None:
         self.assertEqual(tool_definitions(("read_file",)), [])
@@ -27,6 +35,8 @@ class ToolTests(unittest.TestCase):
         self.assertEqual(len(tool_definitions(("fetch_url",))), 1)
         self.assertEqual(len(tool_definitions(("list_directory",))), 1)
         self.assertEqual(len(tool_definitions(("system_info",))), 1)
+        self.assertEqual(len(tool_definitions(("write_artifact",))), 1)
+        self.assertEqual(len(tool_definitions(("verify_artifact",))), 1)
 
     def test_unknown_tool_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
This adds deterministic non-shell artifact creation for large text outputs via an internal write pipeline.

## Main changes
- Adds `write_artifact` and verification flow for bounded UTF-8 text artifact generation.
- Adds a dedicated content-only generation phase that never uses shell/JSON/XML/tool envelope.
- Implements atomic same-filesystem publish with explicit overwrite and safe parent creation.
- Keeps the operation model-driven and bounded:
  - write_artifact args: `path`, `overwrite`, `create_parents`
  - content phase token cap: 4096
  - content bytes cap: 64 KiB
  - runtime-only validation, lifecycle cleanup, evidence projection
- Adds targeted tests for artifact correctness, cleanup, races, cancellation/reset/timeout, overwrite rules, size/token boundaries.

## Validation
- All relevant focused and full tests passed (`PYTHONPATH=src pytest -q`): 1515 passed.
- `python3 -m compileall -q src tests scripts` passed.
- `git diff --check` passed.
- Workdir hygiene preserved (`workdir/.miktex/` and `workdir/doc/` untracked).

## Scope and limits
- One text file per request only.
- No deterministic content repair.
- No changes to route/chat/final/tool budgets except artifact-specific internal phase.
- No shell/heredoc transfer for non-trivial artifacts in this path.
- Binary artifacts and multi-file project scaffolding remain out of scope for this initial pass.
