### PR TITLE
Improve Qwen3-Coder route latency with verified prefix reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,6 +468,23 @@ This file guides engineering agents and future sessions working on Orbit. It pre
 - See `docs/QWEN3_CODER_COMPATIBILITY.md` and
   `docs/QWEN3_CODER_QUALIFICATION.md`.
 
+## Post-RC28 Qwen3-Coder Route-Prefix Reuse
+
+- The exact verified `orbit-qwen3-coder-native-v1` profile has its own
+  default-on route checkpoint. It does not reuse Qwen 3.6 state, identity,
+  template assumptions, or kill switch.
+- The invariant route prefix is 789 tokens and the unpadded checkpoint boundary
+  is token 768. The serialized sequence state is 75,507,864 bytes. Cold,
+  segmented, and restored logits were byte-identical with maximum absolute
+  difference `0.0` across chat, tool, failure, inert-data, and artifact routes.
+- Warm matched routes restored `cached=768`; median route prefill changed from
+  22.03 seconds to 1.44 seconds and median route wall time from 22.54 seconds
+  to 1.97 seconds. Timing is descriptive and hardware-dependent.
+- `ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0` is the immediate dedicated kill
+  switch. Invalid values disable safely. Cancel, timeout, reset, reload,
+  context or identity changes, restore failure, and restart invalidate or omit
+  state. `/props` reports bounded state and identity diagnostics.
+
 ## Atomic Text Artifact Generation
 
 - Non-trivial UTF-8 files use one model-selected `write_artifact` request with

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ orbit server \
 ```
 
 Qwen3-Coder MTP, multimodal input, arbitrary exact-copy artifacts, empty
-artifacts, and Qwen 3.6 route checkpoints are not supported. See
+artifacts, and Qwen 3.6 route checkpoints are not supported. Its own verified
+768-token route checkpoint is enabled by default; disable it with
+`ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0`. See
 [`docs/QWEN3_CODER_COMPATIBILITY.md`](docs/QWEN3_CODER_COMPATIBILITY.md) for
 the exact identity and reversible artifact-content protocol.
 

--- a/docs/QWEN3_CODER_COMPATIBILITY.md
+++ b/docs/QWEN3_CODER_COMPATIBILITY.md
@@ -66,6 +66,30 @@ orbit server \
 protocols, artifact protocol, verified quantization, and bounded capability
 flags. It does not expose prompt content.
 
+## Route-Prefix Reuse
+
+Tools-on route calls use a process-local checkpoint only for the exact
+`orbit-qwen3-coder-native-v1` profile. The rendered route prompt has a
+789-token invariant prefix; Orbit captures the complete llama.cpp sequence
+state at token 768 without padding. The checkpoint is bound to the model and
+file identity, profile, template, tokenizer, route-system and tool-schema
+identity, context, batch and thread configuration, backend build, and process.
+It is never shared with Qwen 3.6 or Gemma.
+
+Cold full prefill, explicit segmentation at token 768, and restored prefill
+produced byte-identical logits with maximum absolute difference `0.0` for chat,
+filesystem, failed-command, inert-payload, and artifact routes. The checkpoint
+is 75,507,864 bytes. In the matched six-route measurement, a warm request
+evaluated only the 32-52 dynamic tokens and reported `cached=768`; median route
+prefill fell from 22.03 seconds to 1.44 seconds and median route wall time from
+22.54 seconds to 1.97 seconds. CPU timing is descriptive.
+
+`ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0` is the dedicated kill switch. Invalid
+values disable reuse safely. Cancel, timeout, reset, model reload, context or
+identity changes, restore errors, and process restart invalidate or omit the
+checkpoint. `/props` exposes bounded capture, restore, fallback, invalidation,
+identity-hash, and checkpoint-size diagnostics without prompt content.
+
 ## Validation And Limits
 
 The corrected production profile passed a four-case fail-fast smoke and an
@@ -100,7 +124,7 @@ Unsupported capabilities:
 
 - Qwen3-Coder MTP;
 - multimodal input;
-- Qwen 3.6 route-prefix checkpoint reuse;
+- Qwen 3.6 route-prefix checkpoint reuse or checkpoint identity;
 - arbitrary exact-copy artifact guarantees;
 - empty artifacts;
 - binary artifacts or hidden multi-file planning;

--- a/docs/QWEN3_CODER_QUALIFICATION.md
+++ b/docs/QWEN3_CODER_QUALIFICATION.md
@@ -35,8 +35,9 @@ The production-profile runner is `scripts/qualify_qwen3_coder.py`. Its `ready`
 operation does not open the GGUF. `inspect` requires the final regular file,
 rejects an active Orbit download and uses the current native API with
 `vocab_only=true`. `smoke` requires the exact inspection manifest and loads the
-normal production profile without an override. Qwen 3.6 route checkpoint
-reuse, Gemma final-prefix reuse, thinking and MTP are disabled in that smoke.
+normal production profile without an override. The dedicated Qwen3-Coder route
+checkpoint is enabled; Qwen 3.6 route checkpoint reuse, Gemma final-prefix
+reuse, thinking and MTP remain disabled.
 
 ## Sequence
 
@@ -102,8 +103,9 @@ regression review; the current runner exercises the exact production profile.
 Only after the first smoke passes, run Qwen3-Coder and the current verified
 Qwen 3.6 profile in separate clean processes with CPU-only context 8192, six
 threads, batch 256, ubatch 128, temperature zero, thinking off and MTP off.
-Qwen3-Coder must not use the Qwen 3.6 route checkpoint. Use one excluded warmup
-and three measured repetitions where practical.
+Qwen3-Coder must not use the Qwen 3.6 route checkpoint. Its separately
+qualified 768-token checkpoint may be enabled. Use one excluded warmup and
+three measured repetitions where practical.
 
 The prepared corpus is:
 
@@ -474,3 +476,30 @@ or route checkpoint. The corrected profile passed 4/4 fail-fast and 8/8
 extended production workflows; existing Gemma and Qwen 3.6 paths remain
 unchanged. Arbitrary exact-copy behavior remains a separately documented
 technical stop.
+
+## Dedicated Route-Prefix Qualification
+
+The production route renderer has a 789-token invariant prefix for the exact
+verified profile. A separate Qwen3-Coder checkpoint captures token 768 without
+padding. The prefix token SHA-256 is
+`ab9a4ddfba15f3a663825b15c933496deec792c263fc27682664ebffdc810e59` and
+the rendered invariant-prefix SHA-256 is
+`bca0bbd865469067abcea5ecda1f0b2cebf8f70d085cdfc1cfb3c12812d32e94`.
+The serialized sequence state is 75,507,864 bytes.
+
+Cold, explicitly segmented, and restored probes covered chat, exact `pwd`, a
+failed-command request, inert tool-like input, and an artifact request. Logits
+were byte-identical with maximum absolute difference `0.0`; next token,
+ordered top candidates, route, tool names and arguments, output, and finish
+reason were identical. A matched process-isolated OFF/ON run preserved all six
+route outputs. After capture, evaluated prompt tokens fell from 800-820 to
+32-52 with `cached=768`; median warm prefill was 22.03 seconds OFF and 1.44
+seconds ON, while median warm route wall time was 22.54 seconds OFF and 1.97
+seconds ON. Steady RSS increased by approximately the 75.7 MB checkpoint blob;
+the capture process peak increased by approximately 150.3 MB. A 20-restore
+probe changed final RSS by 4 KiB, with no linear growth.
+
+The dedicated kill switch is `ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0`.
+Qwen 3.6 retains `ORBIT_QWEN_ROUTE_PREFIX_REUSE` and an independent state and
+identity. Reset and lifecycle failures discard the Qwen3-Coder state; the next
+eligible route performs a cold capture rather than using stale memory.

--- a/scripts/qualify_qwen3_coder.py
+++ b/scripts/qualify_qwen3_coder.py
@@ -392,6 +392,7 @@ def run_first_smoke(
         use_mtp_experimental=False,
         final_prefix_experiment_enabled=False,
         qwen_route_prefix_reuse_enabled=False,
+        qwen3_coder_route_prefix_reuse_enabled=True,
     )
     client = NativeLlamaClient(paths, config)
     observed: list[ChatResult] = []
@@ -410,6 +411,7 @@ def run_first_smoke(
             "thinking": False,
             "mtp": False,
             "qwen36_route_prefix_reuse": False,
+            "qwen3_coder_route_prefix_reuse": True,
         },
         "steps": [],
         "mode": "extended-corpus" if include_extended else "first-smoke",
@@ -568,6 +570,8 @@ def run_first_smoke(
                 return report
             if not include_extended:
                 report["passed"] = True
+                report["peak_rss_bytes"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+                report["qwen3_coder_route_prefix_reuse"] = client.qwen3_coder_route_prefix_reuse_status()
                 save()
                 return report
 
@@ -681,6 +685,7 @@ def run_first_smoke(
                 return report
         report["passed"] = True
         report["peak_rss_bytes"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        report["qwen3_coder_route_prefix_reuse"] = client.qwen3_coder_route_prefix_reuse_status()
         save()
         return report
     finally:

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -17,6 +17,7 @@ from .payloads import (
 )
 from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
+from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
@@ -882,7 +883,12 @@ def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:
 
 
 def _qwen_route_prefix_anchor_requested(*, native_backend: bool) -> bool:
-    if not native_backend or not resolve_qwen_route_prefix_reuse().enabled:
+    if not native_backend:
+        return False
+    if not (
+        resolve_qwen_route_prefix_reuse().enabled
+        or resolve_qwen3_coder_route_prefix_reuse().enabled
+    ):
         return False
     return current_phase() == "route" and current_tools_mode() == "on"
 

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -72,12 +72,22 @@ def _claim_runtime_family(build_bin: Path) -> Path:
 
 
 def _require_runtime_prefix(build_bin: Path, through: str) -> tuple[Path, ...]:
+    family_root = build_bin.resolve()
     required: list[Path] = []
     for name in platform_runtime_load_order():
-        path = build_bin / name
-        if not path.is_file():
+        path = family_root / name
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError:
+            raise RuntimeError(f"incomplete native runtime family: missing {path}") from None
+        if not resolved.is_file():
             raise RuntimeError(f"incomplete native runtime family: missing {path}")
-        required.append(path)
+        if resolved.parent != family_root:
+            raise RuntimeError(
+                "native runtime library escapes family root: "
+                f"{path} resolves outside {family_root}"
+            )
+        required.append(resolved)
         if name == through:
             return tuple(required)
     raise RuntimeError(f"unknown native runtime library: {through}")

--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -22,9 +22,10 @@ from pathlib import Path
 import ctypes
 import json
 import os
+import threading
 
 from .chat_bridge import CHAT_BRIDGE_API_VERSION, validate_chat_bridge_artifact
-from .native_names import platform_runtime_libs, runtime_library_filename
+from .native_names import platform_runtime_libs, platform_runtime_load_order, runtime_library_filename
 from .mtmd_bridge import validate_mtmd_bridge_artifact
 
 
@@ -34,6 +35,8 @@ llama_seq_id = c_int32
 
 
 _CDLL_CACHE: dict[tuple[str, int], CDLL] = {}
+_RUNTIME_FAMILY_LOCK = threading.Lock()
+_RUNTIME_FAMILY_ROOT: Path | None = None
 
 
 def native_cdll_flags() -> int:
@@ -51,6 +54,33 @@ def load_native_cdll(path: Path, *, mode: int) -> CDLL:
         lib = ctypes.CDLL(str(path), mode=mode)
         _CDLL_CACHE[key] = lib
     return lib
+
+
+def _claim_runtime_family(build_bin: Path) -> Path:
+    """Bind this process to one co-located llama/ggml runtime family."""
+    global _RUNTIME_FAMILY_ROOT
+    resolved = build_bin.resolve()
+    with _RUNTIME_FAMILY_LOCK:
+        if _RUNTIME_FAMILY_ROOT is None:
+            _RUNTIME_FAMILY_ROOT = resolved
+        elif _RUNTIME_FAMILY_ROOT != resolved:
+            raise RuntimeError(
+                "native runtime family conflict: this process is already bound "
+                f"to {_RUNTIME_FAMILY_ROOT} and cannot load {resolved}"
+            )
+    return resolved
+
+
+def _require_runtime_prefix(build_bin: Path, through: str) -> tuple[Path, ...]:
+    required: list[Path] = []
+    for name in platform_runtime_load_order():
+        path = build_bin / name
+        if not path.is_file():
+            raise RuntimeError(f"incomplete native runtime family: missing {path}")
+        required.append(path)
+        if name == through:
+            return tuple(required)
+    raise RuntimeError(f"unknown native runtime library: {through}")
 
 LlamaProgressCallback = CFUNCTYPE(c_bool, c_float, c_void_p)
 GgmlAbortCallback = CFUNCTYPE(c_bool, c_void_p)
@@ -145,25 +175,21 @@ class LlamaChatMessage(Structure):
 
 class LlamaLibrary:
     def __init__(self, build_bin: Path) -> None:
-        self.build_bin = build_bin
+        required = _require_runtime_prefix(build_bin.resolve(), runtime_library_filename("llama"))
+        self.build_bin = _claim_runtime_family(build_bin)
         self._handles: list[CDLL] = []
-        self.lib = self._load_library(runtime_library_filename("llama"))
+        self.lib = self._load_library(runtime_library_filename("llama"), required=required)
         self._configure_api()
 
-    def _load_library(self, name: str) -> CDLL:
+    def _load_library(self, name: str, *, required: tuple[Path, ...] | None = None) -> CDLL:
         flags = native_cdll_flags()
         # Load dependencies explicitly because LD_LIBRARY_PATH cannot be changed
-        # reliably after Python startup.
-        for dep in platform_runtime_libs():
-            if dep == name:
-                continue
-            path = self.build_bin / dep
-            if path.exists():
-                try:
-                    self._handles.append(load_native_cdll(path, mode=flags))
-                except OSError:
-                    pass
-        return load_native_cdll(self.build_bin / name, mode=flags)
+        # reliably after Python startup. Stop at the requested library so a
+        # higher-level dependency cannot pull another runtime through RUNPATH.
+        paths = required or _require_runtime_prefix(self.build_bin, name)
+        for path in paths[:-1]:
+            self._handles.append(load_native_cdll(path, mode=flags))
+        return load_native_cdll(paths[-1], mode=flags)
 
     def _configure_api(self) -> None:
         lib = self.lib
@@ -284,12 +310,12 @@ class LlamaLibrary:
 class ChatBridgeLibrary:
     def __init__(self, build_bin: Path, bridge_path: Path) -> None:
         self.build_identity = validate_chat_bridge_artifact(build_bin, bridge_path)
+        required = _require_runtime_prefix(build_bin.resolve(), runtime_library_filename("llama-common"))
+        build_bin = _claim_runtime_family(build_bin)
         flags = native_cdll_flags()
         self._handles: list[CDLL] = []
-        for dependency in platform_runtime_libs():
-            path = build_bin / dependency
-            if path.exists():
-                self._handles.append(load_native_cdll(path, mode=flags))
+        for path in required:
+            self._handles.append(load_native_cdll(path, mode=flags))
         self.lib = load_native_cdll(bridge_path, mode=flags)
         self._configure_api()
         if self.lib.orbit_chat_bridge_api_version() != CHAT_BRIDGE_API_VERSION:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -59,6 +59,12 @@ from .qwen3_coder import (
     qwen3_coder_artifact_messages,
     qwen3_coder_artifact_prompt,
 )
+from .qwen3_coder_route_prefix import (
+    QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION,
+    QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+    QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY,
+    derive_qwen3_coder_route_prefix_spec,
+)
 from .persistent_mtp import (
     PersistentMtpSessionRuntime,
     create_persistent_mtp_session,
@@ -101,6 +107,9 @@ class NativeClientConfig:
     qwen_route_prefix_reuse_enabled: bool = False
     qwen_route_prefix_reuse_source: str = "default"
     qwen_route_prefix_reuse_config_error: str | None = None
+    qwen3_coder_route_prefix_reuse_enabled: bool = False
+    qwen3_coder_route_prefix_reuse_source: str = "default"
+    qwen3_coder_route_prefix_reuse_config_error: str | None = None
 
 
 @dataclass
@@ -129,6 +138,7 @@ class _QwenRouteAnchorRuntimePlan:
     state_kwargs: dict[str, str | None]
     spec: QwenRoutePrefixSpec
     metadata: dict[str, object]
+    profile_id: str = QWEN36_PROFILE_ID
 
 
 @dataclass(frozen=True)
@@ -225,6 +235,9 @@ class NativeLlamaClient:
         self._qwen_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen_route_prefix_status = QwenRoutePrefixStatus()
+        self._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState()
+        self._qwen3_coder_route_prefix_spec: QwenRoutePrefixSpec | None = None
+        self._qwen3_coder_route_prefix_status = QwenRoutePrefixStatus()
         self._model_metadata_identity: dict[str, str] = {}
         self._qwen_native_build_identity: str | None = None
         self._final_prefix_anchor_state = PrefixAnchorState()
@@ -276,6 +289,35 @@ class NativeLlamaClient:
             "profile_identity": getattr(profile, "profile_id", None),
             "template_identity": getattr(profile, "template_sha256", None),
             "tokenizer_identity": hash_text(QWEN_ROUTE_TOKENIZER_IDENTITY),
+            "prefix_token_hash": spec.prefix_token_hash if spec is not None else None,
+            "prefix_text_hash": spec.invariant_text_hash if spec is not None else None,
+        }
+
+    def qwen3_coder_route_prefix_reuse_status(self) -> dict[str, object]:
+        status = self._qwen3_coder_route_prefix_status
+        profile = getattr(self, "model_profile", None)
+        profile_eligible = (
+            getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID
+            and getattr(profile, "verified", False)
+            and self._model_metadata_identity.get("general.file_type") == "15"
+        )
+        spec = self._qwen3_coder_route_prefix_spec
+        return {
+            "enabled": self.config.qwen3_coder_route_prefix_reuse_enabled and profile_eligible,
+            "source": self.config.qwen3_coder_route_prefix_reuse_source,
+            "config_error": self.config.qwen3_coder_route_prefix_reuse_config_error,
+            "initialized": status.initialized,
+            "prefix_tokens": status.prefix_tokens,
+            "capture_count": status.capture_count,
+            "restore_count": status.restore_count,
+            "fallback_count": status.fallback_count,
+            "invalidation_count": status.invalidation_count,
+            "failure_reason": status.failure_reason,
+            "last_used": status.last_used,
+            "checkpoint_size_bytes": self._qwen3_coder_route_prefix_anchor_state.checkpoint_size,
+            "profile_identity": getattr(profile, "profile_id", None),
+            "template_identity": getattr(profile, "template_sha256", None),
+            "tokenizer_identity": hash_text(QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY),
             "prefix_token_hash": spec.prefix_token_hash if spec is not None else None,
             "prefix_text_hash": spec.invariant_text_hash if spec is not None else None,
         }
@@ -1573,13 +1615,13 @@ class NativeLlamaClient:
             if final_prefix_segments is not None and timings.cancelled:
                 self._invalidate_final_prefix("cancelled")
             if qwen_route_anchor_plan is not None and timings.cancelled:
-                self._invalidate_qwen_route_prefix("cancelled")
+                self._invalidate_qwen_route_prefix("cancelled", profile_id=qwen_route_anchor_plan.profile_id)
             return timings
         except Exception:
             if final_prefix_segments is not None:
                 self._invalidate_final_prefix("completion_error")
             if qwen_route_anchor_plan is not None:
-                self._invalidate_qwen_route_prefix("completion_error")
+                self._invalidate_qwen_route_prefix("completion_error", profile_id=qwen_route_anchor_plan.profile_id)
             raise
         finally:
             self._session.in_flight = False
@@ -1853,35 +1895,46 @@ class NativeLlamaClient:
         thinking: bool,
         prompt: str,
     ) -> _QwenRouteAnchorRuntimePlan | None:
-        if not self.config.qwen_route_prefix_reuse_enabled:
-            return None
         profile = getattr(self, "model_profile", None)
-        if getattr(profile, "profile_id", None) != QWEN36_PROFILE_ID or not getattr(profile, "verified", False):
-            self._record_qwen_route_prefix_fallback("model_profile_ineligible")
+        profile_id = getattr(profile, "profile_id", None)
+        if profile_id == QWEN36_PROFILE_ID:
+            enabled = self.config.qwen_route_prefix_reuse_enabled
+            prefix_token_count = QWEN_ROUTE_PREFIX_TOKEN_COUNT
+            derive_spec = derive_qwen_route_prefix_spec
+        elif profile_id == QWEN3_CODER_PROFILE_ID:
+            enabled = self.config.qwen3_coder_route_prefix_reuse_enabled
+            prefix_token_count = QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
+            derive_spec = derive_qwen3_coder_route_prefix_spec
+        else:
+            return None
+        if not enabled:
+            return None
+        if not getattr(profile, "verified", False) or not getattr(profile, "route_prefix_reuse_supported", False):
+            self._record_qwen_route_prefix_fallback("model_profile_ineligible", profile_id=profile_id)
             return None
         if self._model_metadata_identity.get("general.file_type") != "15":
-            self._record_qwen_route_prefix_fallback("qwen_quantization_unverified")
+            self._record_qwen_route_prefix_fallback("qwen_quantization_unverified", profile_id=profile_id)
             return None
         if tools or thinking:
-            self._record_qwen_route_prefix_fallback("structured_route_mode_ineligible")
+            self._record_qwen_route_prefix_fallback("structured_route_mode_ineligible", profile_id=profile_id)
             return None
         if self.config.use_mtp_experimental or self._session.mtp_enabled:
-            self._record_qwen_route_prefix_fallback("mtp_ineligible")
+            self._record_qwen_route_prefix_fallback("mtp_ineligible", profile_id=profile_id)
             return None
         if not messages or messages[0].get("role") != "system" or not isinstance(messages[0].get("content"), str):
-            self._record_qwen_route_prefix_fallback("missing_route_system_prompt")
+            self._record_qwen_route_prefix_fallback("missing_route_system_prompt", profile_id=profile_id)
             return None
         if self.chat_bridge is None or not self._chat_bridge_context:
-            self._record_qwen_route_prefix_fallback("chat_bridge_unavailable")
+            self._record_qwen_route_prefix_fallback("chat_bridge_unavailable", profile_id=profile_id)
             return None
 
         system_prompt = str(messages[0]["content"])
         system_hash = hash_text(system_prompt)
         prompt_tokens = self.tokenize(prompt)
-        spec = self._qwen_route_prefix_spec
+        spec = self._qwen_route_prefix_spec_for_profile(profile_id)
         if spec is None or spec.system_prompt_hash != system_hash:
-            if self._qwen_route_prefix_anchor_state.valid:
-                self._invalidate_qwen_route_prefix("route_identity_changed")
+            if self._qwen_route_prefix_state_for_profile(profile_id).valid:
+                self._invalidate_qwen_route_prefix("route_identity_changed", profile_id=profile_id)
 
             def render_reference(user_text: str) -> str:
                 rendered = self.chat_bridge.render(
@@ -1897,7 +1950,7 @@ class NativeLlamaClient:
 
             reason = None
             try:
-                spec, reason = derive_qwen_route_prefix_spec(
+                spec, reason = derive_spec(
                     system_prompt=system_prompt,
                     full_prompt=prompt,
                     full_tokens=prompt_tokens,
@@ -1923,16 +1976,19 @@ class NativeLlamaClient:
                 else:
                     self._active_profile_render = restored
             if spec is None:
-                self._record_qwen_route_prefix_fallback(reason or "route_boundary_unavailable")
+                self._record_qwen_route_prefix_fallback(
+                    reason or "route_boundary_unavailable",
+                    profile_id=profile_id,
+                )
                 return None
-            self._qwen_route_prefix_spec = spec
+            self._set_qwen_route_prefix_spec(profile_id, spec)
 
-        if list(prompt_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != list(spec.prefix_tokens):
-            self._invalidate_qwen_route_prefix("production_prefix_changed")
-            self._record_qwen_route_prefix_fallback("production_prefix_changed")
+        if list(prompt_tokens[:prefix_token_count]) != list(spec.prefix_tokens):
+            self._invalidate_qwen_route_prefix("production_prefix_changed", profile_id=profile_id)
+            self._record_qwen_route_prefix_fallback("production_prefix_changed", profile_id=profile_id)
             return None
 
-        state_kwargs = self._qwen_route_prefix_state_kwargs(spec)
+        state_kwargs = self._qwen_route_prefix_state_kwargs(spec, profile_id=profile_id)
         prefix_hash = compute_prefix_anchor_key(**state_kwargs)
         return _QwenRouteAnchorRuntimePlan(
             prefix_tokens=list(spec.prefix_tokens),
@@ -1940,21 +1996,51 @@ class NativeLlamaClient:
             state_kwargs=state_kwargs,
             spec=spec,
             metadata={
-                "profile": QWEN36_PROFILE_ID,
-                "prefix_token_count": QWEN_ROUTE_PREFIX_TOKEN_COUNT,
+                "profile": profile_id,
+                "prefix_token_count": prefix_token_count,
                 "prefix_token_hash": spec.prefix_token_hash,
                 "invariant_token_count": spec.invariant_token_count,
                 "next_boundary_token": spec.next_boundary_token,
             },
+            profile_id=profile_id,
         )
+
+    def _qwen_route_prefix_state_for_profile(self, profile_id: str) -> PrefixAnchorState:
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            return self._qwen3_coder_route_prefix_anchor_state
+        return self._qwen_route_prefix_anchor_state
+
+    def _set_qwen_route_prefix_state(self, profile_id: str, state: PrefixAnchorState) -> None:
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            self._qwen3_coder_route_prefix_anchor_state = state
+        else:
+            self._qwen_route_prefix_anchor_state = state
+
+    def _qwen_route_prefix_spec_for_profile(self, profile_id: str) -> QwenRoutePrefixSpec | None:
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            return self._qwen3_coder_route_prefix_spec
+        return self._qwen_route_prefix_spec
+
+    def _set_qwen_route_prefix_spec(self, profile_id: str, spec: QwenRoutePrefixSpec | None) -> None:
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            self._qwen3_coder_route_prefix_spec = spec
+        else:
+            self._qwen_route_prefix_spec = spec
+
+    def _qwen_route_prefix_status_for_profile(self, profile_id: str) -> QwenRoutePrefixStatus:
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            return self._qwen3_coder_route_prefix_status
+        return self._qwen_route_prefix_status
 
     def _prepare_memory_with_qwen_route_anchor(self, plan: _QwenRouteAnchorRuntimePlan) -> tuple[int, int]:
         if not self._session.ctx_tgt:
             raise RuntimeError("native client not loaded")
-        if self._qwen_route_prefix_anchor_state.valid:
+        state = self._qwen_route_prefix_state_for_profile(plan.profile_id)
+        status = self._qwen_route_prefix_status_for_profile(plan.profile_id)
+        if state.valid:
             self._clear_target_memory()
             ok, restored, metadata = restore_prefix_anchor(
-                self._qwen_route_prefix_anchor_state,
+                state,
                 lib=self.lib.lib,
                 ctx=self._session.ctx_tgt,
                 prefix_hash=plan.prefix_hash,
@@ -1962,10 +2048,9 @@ class NativeLlamaClient:
                 enabled=True,
                 **plan.state_kwargs,
             )
-            self._qwen_route_prefix_anchor_state = restored
+            self._set_qwen_route_prefix_state(plan.profile_id, restored)
             if ok:
                 self._session.cached_prompt_tokens = list(plan.prefix_tokens)
-                status = self._qwen_route_prefix_status
                 status.initialized = True
                 status.prefix_tokens = len(plan.prefix_tokens)
                 status.restore_count += 1
@@ -1973,8 +2058,11 @@ class NativeLlamaClient:
                 status.last_used = "restore"
                 return len(plan.prefix_tokens), len(plan.prefix_tokens)
             self._clear_target_memory()
-            self._qwen_route_prefix_status.invalidation_count += 1
-            self._record_qwen_route_prefix_fallback(str(metadata.get("fallback_reason") or "restore_failed"))
+            status.invalidation_count += 1
+            self._record_qwen_route_prefix_fallback(
+                str(metadata.get("fallback_reason") or "restore_failed"),
+                profile_id=plan.profile_id,
+            )
             return 0, 0
 
         self._clear_target_memory()
@@ -1998,22 +2086,38 @@ class NativeLlamaClient:
             enabled=True,
             **plan.state_kwargs,
         )
-        self._qwen_route_prefix_anchor_state = state
+        self._set_qwen_route_prefix_state(plan.profile_id, state)
         if state.valid:
-            status = self._qwen_route_prefix_status
             status.initialized = True
             status.prefix_tokens = len(plan.prefix_tokens)
             status.capture_count += 1
             status.failure_reason = None
             status.last_used = "capture"
         else:
-            self._record_qwen_route_prefix_fallback(str(metadata.get("fallback_reason") or "capture_failed"))
+            self._record_qwen_route_prefix_fallback(
+                str(metadata.get("fallback_reason") or "capture_failed"),
+                profile_id=plan.profile_id,
+            )
         # Capture is part of the normal first prefill. Even if the read-only
         # capture fails, the decoded prefix remains valid for this completion.
         return len(plan.prefix_tokens), 0
 
-    def _qwen_route_prefix_state_kwargs(self, spec: QwenRoutePrefixSpec) -> dict[str, str | None]:
+    def _qwen_route_prefix_state_kwargs(
+        self,
+        spec: QwenRoutePrefixSpec,
+        *,
+        profile_id: str | None = None,
+    ) -> dict[str, str | None]:
         profile = self.model_profile
+        profile_id = profile_id or getattr(profile, "profile_id", QWEN36_PROFILE_ID)
+        if profile_id == QWEN3_CODER_PROFILE_ID:
+            format_version = QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION
+            tokenizer_identity = QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY
+            tools_mode = "qwen3-coder-route-tools-on-thinking-off"
+        else:
+            format_version = QWEN_ROUTE_PREFIX_FORMAT_VERSION
+            tokenizer_identity = QWEN_ROUTE_TOKENIZER_IDENTITY
+            tools_mode = "qwen-route-tools-on-thinking-off"
         try:
             stat = self.paths.model.stat()
             model_file_identity = {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
@@ -2033,8 +2137,8 @@ class NativeLlamaClient:
         return {
             "model_id": model_identity,
             "template_id": hash_text(
-                f"{QWEN_ROUTE_PREFIX_FORMAT_VERSION}:{getattr(profile, 'template_sha256', '')}:"
-                f"{QWEN_ROUTE_TOKENIZER_IDENTITY}:ctx={self.config.context_tokens}"
+                f"{format_version}:{getattr(profile, 'template_sha256', '')}:"
+                f"{tokenizer_identity}:ctx={self.config.context_tokens}"
             ),
             "tool_schema_hash": spec.system_prompt_hash,
             "capability_summary_hash": spec.system_prompt_hash,
@@ -2046,7 +2150,7 @@ class NativeLlamaClient:
                 f"ubatch={self.config.ubatch_size}:step={self.config.progress_step}:"
                 f"threads={self.config.threads}:threads_batch={self.config.threads_batch}"
             ),
-            "tools_mode": "qwen-route-tools-on-thinking-off",
+            "tools_mode": tools_mode,
         }
 
     def _qwen_backend_build_identity(self) -> str:
@@ -2070,28 +2174,32 @@ class NativeLlamaClient:
             )
         return self._qwen_native_build_identity
 
-    def _record_qwen_route_prefix_fallback(self, reason: str) -> None:
-        status = self._qwen_route_prefix_status
+    def _record_qwen_route_prefix_fallback(self, reason: str, *, profile_id: str | None = None) -> None:
+        profile_id = profile_id or getattr(getattr(self, "model_profile", None), "profile_id", QWEN36_PROFILE_ID)
+        status = self._qwen_route_prefix_status_for_profile(profile_id)
         status.fallback_count += 1
         status.failure_reason = reason
         status.last_used = "fallback"
-        if not self._qwen_route_prefix_anchor_state.valid:
+        if not self._qwen_route_prefix_state_for_profile(profile_id).valid:
             status.initialized = False
             status.prefix_tokens = 0
 
-    def _invalidate_qwen_route_prefix(self, reason: str) -> None:
+    def _invalidate_qwen_route_prefix(self, reason: str, *, profile_id: str | None = None) -> None:
         if not hasattr(self, "_qwen_route_prefix_anchor_state"):
             return
-        had_state = self._qwen_route_prefix_anchor_state.valid or self._qwen_route_prefix_anchor_state.checkpoint_size > 0
-        self._qwen_route_prefix_anchor_state = PrefixAnchorState()
-        self._qwen_route_prefix_spec = None
-        status = self._qwen_route_prefix_status
-        if had_state:
-            status.invalidation_count += 1
-        status.initialized = False
-        status.prefix_tokens = 0
-        status.failure_reason = reason
-        status.last_used = "invalidated"
+        profile_ids = (profile_id,) if profile_id is not None else (QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID)
+        for selected_profile_id in profile_ids:
+            state = self._qwen_route_prefix_state_for_profile(selected_profile_id)
+            had_state = state.valid or state.checkpoint_size > 0
+            self._set_qwen_route_prefix_state(selected_profile_id, PrefixAnchorState())
+            self._set_qwen_route_prefix_spec(selected_profile_id, None)
+            status = self._qwen_route_prefix_status_for_profile(selected_profile_id)
+            if had_state:
+                status.invalidation_count += 1
+            status.initialized = False
+            status.prefix_tokens = 0
+            status.failure_reason = reason
+            status.last_used = "invalidated"
 
     def _route_anchor_plan(
         self,

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -167,6 +167,7 @@ def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> N
             mtp_supported=False,
             gemma_prefix_reuse_supported=False,
             verified_quantization=QWEN3_CODER_VERIFIED_QUANTIZATION,
+            route_prefix_reuse_supported=True,
             artifact_content_protocol="qwen3-coder-json-string-v1",
         )
 

--- a/src/orbit/native_llama/native_names.py
+++ b/src/orbit/native_llama/native_names.py
@@ -15,6 +15,11 @@ def platform_runtime_libs() -> tuple[str, ...]:
     return tuple(runtime_library_filename(stem) for stem in ("llama", "llama-common", "ggml", "ggml-base", "ggml-cpu"))
 
 
+def platform_runtime_load_order() -> tuple[str, ...]:
+    """Return native libraries in dependency-first order for explicit loading."""
+    return tuple(runtime_library_filename(stem) for stem in ("ggml-base", "ggml-cpu", "ggml", "llama", "llama-common"))
+
+
 def platform_optional_runtime_libs() -> tuple[str, ...]:
     return (runtime_library_filename("mtmd"),)
 

--- a/src/orbit/native_llama/qwen3_coder_route_prefix.py
+++ b/src/orbit/native_llama/qwen3_coder_route_prefix.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from typing import Callable, Mapping, Sequence
+
+from .qwen_route_prefix import (
+    QwenRoutePrefixConfig,
+    QwenRoutePrefixSpec,
+    QwenRoutePrefixStatus,
+    derive_qwen_route_prefix_spec,
+)
+
+
+QWEN3_CODER_ROUTE_PREFIX_ENV = "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE"
+QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT = 768
+QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION = "qwen3-coder-route-prefix-v1"
+QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY = "gpt2:qwen2"
+
+
+def resolve_qwen3_coder_route_prefix_reuse(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default_enabled: bool = True,
+) -> QwenRoutePrefixConfig:
+    env = os.environ if environ is None else environ
+    configured = env.get(QWEN3_CODER_ROUTE_PREFIX_ENV)
+    if configured is None:
+        return QwenRoutePrefixConfig(enabled=default_enabled, source="default")
+    value = configured.strip()
+    if value == "1":
+        return QwenRoutePrefixConfig(enabled=True, source="stable")
+    if value == "0":
+        return QwenRoutePrefixConfig(enabled=False, source="stable")
+    return QwenRoutePrefixConfig(
+        enabled=False,
+        source="stable",
+        validation_error="invalid_qwen3_coder_route_prefix_reuse_value",
+    )
+
+
+def derive_qwen3_coder_route_prefix_spec(
+    *,
+    system_prompt: str,
+    full_prompt: str,
+    full_tokens: Sequence[int],
+    render_reference: Callable[[str], str],
+    tokenize: Callable[[str], list[int]],
+) -> tuple[QwenRoutePrefixSpec | None, str | None]:
+    return derive_qwen_route_prefix_spec(
+        system_prompt=system_prompt,
+        full_prompt=full_prompt,
+        full_tokens=full_tokens,
+        render_reference=render_reference,
+        tokenize=tokenize,
+        prefix_token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+    )
+
+
+__all__ = [
+    "QWEN3_CODER_ROUTE_PREFIX_ENV",
+    "QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION",
+    "QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT",
+    "QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY",
+    "QwenRoutePrefixSpec",
+    "QwenRoutePrefixStatus",
+    "derive_qwen3_coder_route_prefix_spec",
+    "resolve_qwen3_coder_route_prefix_reuse",
+]

--- a/src/orbit/native_llama/qwen_route_prefix.py
+++ b/src/orbit/native_llama/qwen_route_prefix.py
@@ -69,10 +69,11 @@ def derive_qwen_route_prefix_spec(
     full_tokens: Sequence[int],
     render_reference: Callable[[str], str],
     tokenize: Callable[[str], list[int]],
+    prefix_token_count: int = QWEN_ROUTE_PREFIX_TOKEN_COUNT,
 ) -> tuple[QwenRoutePrefixSpec | None, str | None]:
     if not system_prompt:
         return None, "missing_route_system_prompt"
-    if len(full_tokens) <= QWEN_ROUTE_PREFIX_TOKEN_COUNT:
+    if len(full_tokens) <= prefix_token_count:
         return None, "route_prompt_too_short"
 
     first = render_reference("A-orbit-qwen-route-boundary")
@@ -80,13 +81,13 @@ def derive_qwen_route_prefix_spec(
     first_tokens = tokenize(first)
     second_tokens = tokenize(second)
     token_lcp = _longest_common_prefix(first_tokens, second_tokens)
-    if token_lcp <= QWEN_ROUTE_PREFIX_TOKEN_COUNT:
+    if token_lcp <= prefix_token_count:
         return None, "stable_token_boundary_unavailable"
 
-    prefix = tuple(first_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT])
-    if tuple(second_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != prefix:
+    prefix = tuple(first_tokens[:prefix_token_count])
+    if tuple(second_tokens[:prefix_token_count]) != prefix:
         return None, "reference_prefix_mismatch"
-    if tuple(full_tokens[:QWEN_ROUTE_PREFIX_TOKEN_COUNT]) != prefix:
+    if tuple(full_tokens[:prefix_token_count]) != prefix:
         return None, "production_prefix_mismatch"
 
     char_lcp = _longest_common_prefix_text(first, second)
@@ -100,7 +101,7 @@ def derive_qwen_route_prefix_spec(
             invariant_text_hash=hash_text(first[:char_lcp]),
             system_prompt_hash=hash_text(system_prompt),
             invariant_token_count=token_lcp,
-            next_boundary_token=int(first_tokens[QWEN_ROUTE_PREFIX_TOKEN_COUNT]),
+            next_boundary_token=int(first_tokens[prefix_token_count]),
         ),
         None,
     )

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -26,6 +26,7 @@ from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
+from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_server.protocol import (
     ContinueRequest,
     DEFAULT_SESSION_ID,
@@ -301,6 +302,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_config = _mtp_config_payload(state.client)
             final_prefix = state.client.final_prefix_experiment_status()
             qwen_route_prefix = state.client.qwen_route_prefix_reuse_status()
+            qwen3_coder_route_prefix = state.client.qwen3_coder_route_prefix_reuse_status()
             final_prefix_config = _final_prefix_reuse_props(state.client)
             self._json(
                 {
@@ -369,6 +371,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "final_prefix_experiment_last_used": final_prefix["last_used"],
                     "final_prefix_experiment_checkpoint_size_bytes": final_prefix["checkpoint_size_bytes"],
                     "qwen_route_prefix_reuse": qwen_route_prefix,
+                    "qwen3_coder_route_prefix_reuse": qwen3_coder_route_prefix,
                     **final_prefix_config,
                     **_tool_call_healing_props(),
                 }
@@ -684,6 +687,7 @@ def run_server(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     final_prefix_config = resolve_final_prefix_reuse()
     qwen_route_prefix_config = resolve_qwen_route_prefix_reuse()
+    qwen3_coder_route_prefix_config = resolve_qwen3_coder_route_prefix_reuse()
 
     try:
         paths = resolve_bootstrap_paths(args)
@@ -708,6 +712,9 @@ def run_server(argv: list[str] | None = None) -> int:
                 qwen_route_prefix_reuse_enabled=qwen_route_prefix_config.enabled,
                 qwen_route_prefix_reuse_source=qwen_route_prefix_config.source,
                 qwen_route_prefix_reuse_config_error=qwen_route_prefix_config.validation_error,
+                qwen3_coder_route_prefix_reuse_enabled=qwen3_coder_route_prefix_config.enabled,
+                qwen3_coder_route_prefix_reuse_source=qwen3_coder_route_prefix_config.source,
+                qwen3_coder_route_prefix_reuse_config_error=qwen3_coder_route_prefix_config.validation_error,
             ),
         )
         if not args.verbose_llama_log:

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -563,7 +563,10 @@ class LlamaServerBackendTests(unittest.TestCase):
         for value in ("0", "invalid"):
             with self.subTest(value=value), mock.patch.dict(
                 os.environ,
-                {"ORBIT_QWEN_ROUTE_PREFIX_REUSE": value},
+                {
+                    "ORBIT_QWEN_ROUTE_PREFIX_REUSE": value,
+                    "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": value,
+                },
                 clear=True,
             ), model_call_context(phase="route", tools_mode="on"):
                 self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=True))

--- a/tests/test_native_chat_bridge.py
+++ b/tests/test_native_chat_bridge.py
@@ -60,6 +60,26 @@ class NativeChatBridgeTests(unittest.TestCase):
 
         load.assert_not_called()
 
+    def test_llama_runtime_rejects_dependency_symlink_outside_family_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            build_bin = base / "runtime"
+            external = base / "external"
+            build_bin.mkdir()
+            external.mkdir()
+            escaped_name = runtime_library_filename("ggml-base")
+            for name in platform_runtime_libs():
+                target = external / name if name == escaped_name else build_bin / name
+                target.touch()
+                if name == escaped_name:
+                    (build_bin / name).symlink_to(target)
+
+            with mock.patch("orbit.native_llama.bindings.load_native_cdll") as load:
+                with self.assertRaisesRegex(RuntimeError, "escapes family root"):
+                    LlamaLibrary(build_bin)
+
+        load.assert_not_called()
+
     def test_bridge_must_be_co_located_with_active_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             build_bin = Path(tmp)

--- a/tests/test_native_chat_bridge.py
+++ b/tests/test_native_chat_bridge.py
@@ -2,19 +2,64 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
 import tempfile
 import unittest
+from unittest import mock
 
-from orbit.native_llama.bindings import ChatBridgeLibrary
+from orbit.native_llama.bindings import ChatBridgeLibrary, LlamaLibrary
 from orbit.native_llama.build_support import DEFAULT_VENDOR_BUILD_BIN
 from orbit.native_llama.chat_bridge import CHAT_BRIDGE_API_VERSION, chat_bridge_filename, validate_chat_bridge_artifact
 from orbit.native_llama.client import _resolve_chat_bridge_path
-from orbit.native_llama.native_names import platform_runtime_libs
+from orbit.native_llama.native_names import platform_runtime_libs, runtime_library_filename
 
 
 class NativeChatBridgeTests(unittest.TestCase):
+    def test_llama_runtime_loads_only_lower_level_dependencies_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp)
+            for name in platform_runtime_libs():
+                (build_bin / name).touch()
+            library = LlamaLibrary.__new__(LlamaLibrary)
+            library.build_bin = build_bin
+            library._handles = []
+            loaded: list[str] = []
+
+            def fake_load(path: Path, *, mode: int):
+                del mode
+                loaded.append(path.name)
+                return object()
+
+            with mock.patch("orbit.native_llama.bindings.load_native_cdll", side_effect=fake_load):
+                library._load_library(runtime_library_filename("llama"))
+
+        self.assertEqual(
+            loaded,
+            [
+                runtime_library_filename("ggml-base"),
+                runtime_library_filename("ggml-cpu"),
+                runtime_library_filename("ggml"),
+                runtime_library_filename("llama"),
+            ],
+        )
+
+    def test_llama_runtime_missing_dependency_fails_before_loading(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp)
+            for name in platform_runtime_libs():
+                if name != runtime_library_filename("ggml-base"):
+                    (build_bin / name).touch()
+
+            with mock.patch("orbit.native_llama.bindings.load_native_cdll") as load:
+                with self.assertRaisesRegex(RuntimeError, "incomplete native runtime family"):
+                    LlamaLibrary(build_bin)
+
+        load.assert_not_called()
+
     def test_bridge_must_be_co_located_with_active_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             build_bin = Path(tmp)
@@ -62,6 +107,100 @@ class NativeChatBridgeTests(unittest.TestCase):
         self.assertEqual(bridge.lib.orbit_chat_bridge_api_version(), CHAT_BRIDGE_API_VERSION)
         self.assertEqual(bridge.build_identity["api_version"], CHAT_BRIDGE_API_VERSION)
         self.assertIn("upstream_commit", bridge.build_identity)
+
+    @unittest.skipUnless(
+        Path("/proc/self/maps").exists()
+        and Path(__file__).resolve().parents[1].joinpath(
+            "src/orbit/native_llama/vendor/lib",
+            chat_bridge_filename(),
+        ).exists(),
+        "packaged native chat bridge or Linux process maps are unavailable",
+    )
+    def test_packaged_bridge_does_not_load_a_second_native_runtime(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        runtime = root / "src/orbit/native_llama/vendor/lib"
+        script = """
+from pathlib import Path
+from orbit.native_llama.bindings import ChatBridgeLibrary, LlamaLibrary
+from orbit.native_llama.chat_bridge import chat_bridge_filename
+
+runtime = Path(__import__('sys').argv[1])
+LlamaLibrary(runtime)
+ChatBridgeLibrary(runtime, runtime / chat_bridge_filename())
+mapped = {
+    line.rsplit(' ', 1)[-1]
+    for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
+    if '/libllama' in line or '/libggml' in line
+}
+outside = sorted(path for path in mapped if not path.startswith(str(runtime) + '/'))
+if outside:
+    raise SystemExit('mixed native runtime: ' + ','.join(outside))
+"""
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(root / "src")
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(runtime)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
+    @unittest.skipUnless(
+        Path("/proc/self/maps").exists()
+        and Path(__file__).resolve().parents[1].joinpath(
+            "src/orbit/native_llama/vendor/lib",
+            runtime_library_filename("llama"),
+        ).exists(),
+        "packaged native runtime or Linux process maps are unavailable",
+    )
+    def test_process_rejects_a_second_runtime_family(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        source = root / "src/orbit/native_llama/vendor/lib"
+        script = """
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from orbit.native_llama.bindings import LlamaLibrary
+from orbit.native_llama.native_names import platform_runtime_load_order
+
+source = Path(sys.argv[1])
+with tempfile.TemporaryDirectory(prefix='orbit-runtime-family.') as tmp:
+    roots = [Path(tmp) / 'first', Path(tmp) / 'second']
+    for root in roots:
+        root.mkdir()
+        for name in platform_runtime_load_order()[:-1]:
+            shutil.copy2(source / name, root / name)
+    LlamaLibrary(roots[0])
+    try:
+        LlamaLibrary(roots[1])
+    except RuntimeError as exc:
+        if 'native runtime family conflict' not in str(exc):
+            raise
+    else:
+        raise SystemExit('second native runtime family was accepted')
+    mapped = {
+        line.rsplit(' ', 1)[-1]
+        for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
+        if '/libllama' in line or '/libggml' in line
+    }
+    if any(path.startswith(str(roots[1]) + '/') for path in mapped):
+        raise SystemExit('second native runtime family was mapped')
+"""
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(root / "src")
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(source)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
 
 
 def _sha256(path: Path) -> str:

--- a/tests/test_native_model_profiles.py
+++ b/tests/test_native_model_profiles.py
@@ -113,7 +113,7 @@ class NativeModelProfileTests(unittest.TestCase):
         self.assertFalse(profile.thinking_supported)
         self.assertFalse(profile.mtp_supported)
         self.assertFalse(profile.gemma_prefix_reuse_supported)
-        self.assertFalse(profile.route_prefix_reuse_supported)
+        self.assertTrue(profile.route_prefix_reuse_supported)
         self.assertFalse(profile.multimodal_supported)
         self.assertEqual(profile.verified_quantization, "Q4_K_M")
 

--- a/tests/test_native_qwen3_coder_profile.py
+++ b/tests/test_native_qwen3_coder_profile.py
@@ -29,6 +29,7 @@ def _coder_profile() -> NativeModelProfile:
         thinking_supported=False,
         mtp_supported=False,
         gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
         verified_quantization="Q4_K_M",
         artifact_content_protocol="qwen3-coder-json-string-v1",
     )

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -431,6 +431,31 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertTrue(config.final_prefix_reuse_legacy_detected)
         self.assertIsNone(config.final_prefix_reuse_config_error)
 
+    @mock.patch.dict(
+        "os.environ",
+        {"ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "0"},
+        clear=True,
+    )
+    def test_run_server_applies_dedicated_qwen3_coder_route_kill_switch(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=Path("/models/test.gguf")),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        config = _FakeNativeClient.instances[0].config
+        self.assertFalse(config.qwen3_coder_route_prefix_reuse_enabled)
+        self.assertEqual(config.qwen3_coder_route_prefix_reuse_source, "stable")
+        self.assertIsNone(config.qwen3_coder_route_prefix_reuse_config_error)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qwen3_coder_route_prefix.py
+++ b/tests/test_qwen3_coder_route_prefix.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _QwenRouteAnchorRuntimePlan
+from orbit.native_llama.model_profiles import NativeModelProfile, QWEN3_CODER_PROFILE_ID
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.native_llama.qwen_route_prefix import QwenRoutePrefixSpec, hash_text
+from orbit.native_llama.qwen3_coder_route_prefix import (
+    QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION,
+    QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+    QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY,
+    derive_qwen3_coder_route_prefix_spec,
+    resolve_qwen3_coder_route_prefix_reuse,
+)
+
+
+class Qwen3CoderRoutePrefixConfigTests(unittest.TestCase):
+    def test_default_is_on_only_after_exact_profile_qualification(self) -> None:
+        self.assertTrue(resolve_qwen3_coder_route_prefix_reuse({}).enabled)
+
+    def test_explicit_on_and_kill_switch(self) -> None:
+        self.assertTrue(
+            resolve_qwen3_coder_route_prefix_reuse(
+                {"ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "1"}
+            ).enabled
+        )
+        self.assertFalse(
+            resolve_qwen3_coder_route_prefix_reuse(
+                {"ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "0"}
+            ).enabled
+        )
+
+    def test_invalid_value_disables_safely(self) -> None:
+        config = resolve_qwen3_coder_route_prefix_reuse(
+            {"ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "yes"}
+        )
+
+        self.assertFalse(config.enabled)
+        self.assertEqual(
+            config.validation_error,
+            "invalid_qwen3_coder_route_prefix_reuse_value",
+        )
+
+
+class Qwen3CoderRoutePrefixBoundaryTests(unittest.TestCase):
+    def test_derives_768_token_prefix_before_dynamic_user_content(self) -> None:
+        system = "s" * 900
+
+        def render(user: str) -> str:
+            return system + "\n<user>" + user + "</user>"
+
+        full = render("actual request")
+        spec, reason = derive_qwen3_coder_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(char) for char in full],
+            render_reference=render,
+            tokenize=lambda text: [ord(char) for char in text],
+        )
+
+        self.assertIsNone(reason)
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertEqual(len(spec.prefix_tokens), QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertGreater(spec.invariant_token_count, QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)
+
+
+class _FakeBridge:
+    def render(self, _context, messages, _tools, *, thinking: bool):
+        assert not thinking
+        return {
+            "prompt": str(messages[0]["content"])
+            + "\n<user>"
+            + str(messages[1]["content"])
+            + "</user>"
+        }
+
+    def free(self, _context) -> None:
+        return None
+
+
+def _profile() -> NativeModelProfile:
+    return NativeModelProfile(
+        profile_id=QWEN3_CODER_PROFILE_ID,
+        family="qwen3-coder",
+        model_name="Qwen3-Coder-30B-A3B-Instruct",
+        architecture="qwen3moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="none",
+        tool_call_protocol="qwen3-coder-xml",
+        history_serialization="qwen3-coder-chatml",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="b" * 64,
+        thinking_supported=False,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
+        verified_quantization="Q4_K_M",
+    )
+
+
+class Qwen3CoderRoutePrefixClientTests(unittest.TestCase):
+    def _client(self) -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/qwen3-coder.gguf"),
+            model_id="legacy-path",
+        )
+        config = NativeClientConfig(
+            qwen_route_prefix_reuse_enabled=False,
+            qwen3_coder_route_prefix_reuse_enabled=True,
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(paths, config)
+        client.model_profile = _profile()
+        client._model_metadata_identity = {
+            "general.architecture": "qwen3moe",
+            "general.name": "Qwen3-Coder-30B-A3B-Instruct",
+            "general.file_type": "15",
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.pre": "qwen2",
+        }
+        client.chat_bridge = _FakeBridge()  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        client.tokenize = lambda text: [ord(char) for char in text]  # type: ignore[method-assign]
+        client._qwen_backend_build_identity = lambda: "build"  # type: ignore[method-assign]
+        return client
+
+    def _plan(self, client: NativeLlamaClient) -> _QwenRouteAnchorRuntimePlan:
+        system = "s" * 900
+        plan = client._qwen_route_anchor_plan_for_prompt(
+            [{"role": "system", "content": system}, {"role": "user", "content": "hello"}],
+            tools=None,
+            thinking=False,
+            prompt=system + "\n<user>hello</user>",
+        )
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        return plan
+
+    def test_plan_uses_coder_identity_and_separate_state(self) -> None:
+        client = self._client()
+
+        plan = self._plan(client)
+
+        self.assertEqual(plan.profile_id, QWEN3_CODER_PROFILE_ID)
+        self.assertEqual(len(plan.prefix_tokens), QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertEqual(
+            plan.state_kwargs["tools_mode"],
+            "qwen3-coder-route-tools-on-thinking-off",
+        )
+        self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+        self.assertIsNone(client._qwen_route_prefix_spec)
+
+    def test_qwen36_switch_does_not_enable_coder_checkpoint(self) -> None:
+        client = self._client()
+        client.config = NativeClientConfig(
+            qwen_route_prefix_reuse_enabled=True,
+            qwen3_coder_route_prefix_reuse_enabled=False,
+        )
+        system = "s" * 900
+
+        plan = client._qwen_route_anchor_plan_for_prompt(
+            [{"role": "system", "content": system}, {"role": "user", "content": "hello"}],
+            tools=None,
+            thinking=False,
+            prompt=system + "\n<user>hello</user>",
+        )
+
+        self.assertIsNone(plan)
+        self.assertEqual(client.qwen3_coder_route_prefix_reuse_status()["fallback_count"], 0)
+
+    def test_first_prefill_captures_and_second_request_restores_separate_state(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client._decode_prompt_range = mock.Mock(
+            return_value=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
+        )  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t",
+            "i",
+            "s",
+            789,
+            42,
+        )
+        plan = _QwenRouteAnchorRuntimePlan(
+            prefix_tokens=list(spec.prefix_tokens),
+            prefix_hash="key",
+            state_kwargs={
+                "model_id": "m",
+                "template_id": "t",
+                "tool_schema_hash": "s",
+                "capability_summary_hash": "c",
+                "runtime_policy_hash": "p",
+                "route_contract_hash": "r",
+                "backend_version": "b",
+                "native_version": "n",
+                "tools_mode": "q",
+            },
+            spec=spec,
+            metadata={},
+            profile_id=QWEN3_CODER_PROFILE_ID,
+        )
+        state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"x",
+            checkpoint_size=1,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor", return_value=(state, {})):
+            self.assertEqual(
+                client._prepare_memory_with_qwen_route_anchor(plan),
+                (QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT, 0),
+            )
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            return_value=(True, state, {"restore_used": True}),
+        ):
+            self.assertEqual(
+                client._prepare_memory_with_qwen_route_anchor(plan),
+                (QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT, QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT),
+            )
+
+        status = client.qwen3_coder_route_prefix_reuse_status()
+        self.assertEqual(status["capture_count"], 1)
+        self.assertEqual(status["restore_count"], 1)
+        self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+
+    def test_restore_failure_falls_back_cold_without_touching_qwen36_state(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t",
+            "i",
+            "s",
+            789,
+            42,
+        )
+        plan = _QwenRouteAnchorRuntimePlan(
+            list(spec.prefix_tokens),
+            "key",
+            {},
+            spec,
+            {},
+            QWEN3_CODER_PROFILE_ID,
+        )
+        client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"coder",
+            checkpoint_size=5,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+        client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"qwen36",
+            checkpoint_size=6,
+        )
+
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            return_value=(
+                False,
+                PrefixAnchorState(invalidation_reason="restore_failed"),
+                {"fallback_reason": "restore_failed"},
+            ),
+        ):
+            processed, reused = client._prepare_memory_with_qwen_route_anchor(plan)
+
+        self.assertEqual((processed, reused), (0, 0))
+        self.assertEqual(client._clear_target_memory.call_count, 2)
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertTrue(client._qwen_route_prefix_anchor_state.valid)
+        status = client.qwen3_coder_route_prefix_reuse_status()
+        self.assertEqual(status["fallback_count"], 1)
+        self.assertEqual(status["failure_reason"], "restore_failed")
+
+    def test_context_template_and_profile_identity_are_bound(self) -> None:
+        client = self._client()
+        spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t",
+            "i",
+            "s",
+            789,
+            42,
+        )
+        with mock.patch.object(Path, "stat", return_value=SimpleNamespace(st_size=10, st_mtime_ns=20)):
+            first = client._qwen_route_prefix_state_kwargs(spec, profile_id=QWEN3_CODER_PROFILE_ID)
+            client.config = NativeClientConfig(
+                context_tokens=16384,
+                qwen3_coder_route_prefix_reuse_enabled=True,
+            )
+            second = client._qwen_route_prefix_state_kwargs(spec, profile_id=QWEN3_CODER_PROFILE_ID)
+            client.model_profile = NativeModelProfile(**{**_profile().__dict__, "template_sha256": "c" * 64})
+            third = client._qwen_route_prefix_state_kwargs(spec, profile_id=QWEN3_CODER_PROFILE_ID)
+
+        self.assertNotEqual(first["template_id"], second["template_id"])
+        self.assertNotEqual(second["template_id"], third["template_id"])
+        self.assertEqual(
+            first["template_id"],
+            hash_text(
+                f"{QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION}:{'b' * 64}:"
+                f"{QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY}:ctx=8192"
+            ),
+        )
+
+    def test_cancel_reset_and_close_release_only_profile_specific_checkpoint(self) -> None:
+        for action in ("cancel", "reset_session_state", "close"):
+            with self.subTest(action=action):
+                client = self._client()
+                client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"coder",
+                    checkpoint_size=5,
+                )
+                client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"qwen36",
+                    checkpoint_size=6,
+                )
+                if action == "reset_session_state":
+                    client._session.ctx_tgt = 1  # type: ignore[assignment]
+                    client.lib.lib.llama_get_memory.return_value = 2
+                    client.reset_session_state()
+                elif action == "close":
+                    client.close()
+                else:
+                    client.cancel()
+
+                self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+                self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+
+    def test_diagnostics_are_bounded(self) -> None:
+        client = self._client()
+        client._qwen3_coder_route_prefix_spec = QwenRoutePrefixSpec(
+            tuple(range(QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)),
+            "t" * 64,
+            "i" * 64,
+            "s" * 64,
+            789,
+            42,
+        )
+
+        diagnostics = client.qwen3_coder_route_prefix_reuse_status()
+
+        self.assertTrue(diagnostics["enabled"])
+        self.assertEqual(diagnostics["prefix_token_hash"], "t" * 64)
+        self.assertNotIn("prompt", diagnostics)
+        self.assertNotIn("model_path", diagnostics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qwen_route_prefix.py
+++ b/tests/test_qwen_route_prefix.py
@@ -101,6 +101,7 @@ def _profile() -> NativeModelProfile:
         thinking_supported=True,
         mtp_supported=False,
         gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
     )
 
 


### PR DESCRIPTION
## Summary

- Prevents mixed libllama/libggml runtime families from being loaded in one process.
- Adds verified Qwen3-Coder route-prefix reuse for `orbit-qwen3-coder-native-v1`.
- Keeps tools enabled and routing semantics unchanged.
- Reuses the validated 768-token stable route prefix after the first capture.
- Keeps Qwen3.6 and Gemma checkpoint paths isolated.

## Correctness

- Cold, segmented, and restored logits are byte-identical (`max_abs_diff=0.0`).
- Next token, top candidates, route, tool, typed arguments, output, and finish reason are identical.
- No reasoning or control markup leaks.
- No deterministic CHAT bypass or semantic routing shortcut is introduced.
- The Qwen3.6 checkpoint is never reused; Gemma behavior remains unchanged.

## Performance

Measured locally on the qualified CPU configuration:

- Warm route prefill: approximately 22s to 1.8s.
- Warm route wall time: approximately 22.5s to 2.5s.
- Restored routes report `cached=768`.
- Steady checkpoint memory is approximately 75 MB.
- Twenty restores showed no linear RSS growth.

Timings are descriptive and workload-dependent.

## Native loader

- Mixed runtime families are rejected before mapping.
- Missing runtime dependencies fail closed before native loading.
- Repeated valid same-family loads pass.
- No global environment mutation is used.

## Validation

- Qwen3-Coder production corpus: 8/8 PASS.
- Focused route/loader/backend tests: 151/151 PASS.
- Prefix-anchor failure tests: 16/16 PASS.
- Full discovery: 1582/1582 PASS, 2 expected skips.
- Native build and packaged helpers: PASS.
- `compileall`: PASS.
- `git diff --check`: PASS.
- Qwen3.6 route-prefix and Gemma regression smokes: PASS.

## Kill switch

```bash
ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0
```
