### PR TITLE
Prewarm Qwen3-Coder route prefix at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,6 +484,17 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   switch. Invalid values disable safely. Cancel, timeout, reset, reload,
   context or identity changes, restore failure, and restart invalidate or omit
   state. `/props` reports bounded state and identity diagnostics.
+- Native tools-on startup captures this same checkpoint before server readiness.
+  Qualification measured a 21.62-second capture; the first real greeting route
+  restored `cached=768`, evaluated 32 dynamic tokens, and took 2.01 seconds,
+  versus 800 evaluated tokens and 36.59 seconds without startup prewarm in that
+  matched run. Timings are descriptive.
+- `ORBIT_KV_PREFIX_PREWARM=off` disables startup capture but leaves lazy
+  Qwen3-Coder reuse enabled: the first eligible route captures and later routes
+  restore. Prewarm failures accept no partial state and fall back to that cold
+  path without a startup retry. An operator SIGINT during Qwen3-Coder prewarm
+  exits before the server binds instead of exposing the cold fallback. Qwen3.6
+  and Gemma behavior remains unchanged.
 
 ## Atomic Text Artifact Generation
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ orbit server \
 
 Qwen3-Coder MTP, multimodal input, arbitrary exact-copy artifacts, empty
 artifacts, and Qwen 3.6 route checkpoints are not supported. Its own verified
-768-token route checkpoint is enabled by default; disable it with
+768-token route checkpoint is enabled by default and prewarmed synchronously
+before a tools-on server becomes ready. Disable only startup prewarm with
+`ORBIT_KV_PREFIX_PREWARM=off`, or disable Qwen3-Coder checkpoint reuse with
 `ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0`. See
 [`docs/QWEN3_CODER_COMPATIBILITY.md`](docs/QWEN3_CODER_COMPATIBILITY.md) for
 the exact identity and reversible artifact-content protocol.
@@ -230,11 +232,14 @@ Disable only startup prewarm:
 ORBIT_KV_PREFIX_PREWARM=off orbit server
 ```
 
-Disable route-prefix anchor and prewarm:
+Disable the Gemma route-prefix anchor and all startup prewarm:
 
 ```bash
 ORBIT_KV_PREFIX_ANCHOR=off orbit server
 ```
+
+Qwen route checkpoints have their separate profile-specific reuse kill
+switches documented above.
 
 The prewarm cost is paid at startup. It does not remove CPU work; it shifts part
 of the first tools-on route cost before the first user request.

--- a/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
+++ b/docs/NATIVE_ROUTE_PREFIX_STARTUP_PREWARM.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-This document describes the first controlled runtime integration for native route
-prefix prewarm.
+This document describes the controlled runtime integration for native route
+prefix prewarm. It covers the Gemma route anchor and the separately identified
+Qwen3-Coder route checkpoint.
 
 The feature now runs by default when the native server starts with tools enabled.
 It can still be disabled explicitly.
@@ -28,15 +29,18 @@ When enabled, startup prewarm uses the internal native prefill-only hook to
 prepare the stable route tools-on prefix before the server starts accepting
 requests.
 
-The prewarmed prefix is the same route tools-on prefix used by real route calls:
+The prewarmed prefix is the same profile-specific route tools-on prefix used by
+real route calls:
 
 - route system contract
 - route tool schema
 - stable route template boundary
 
 The hook tokenizes the prefix with the native tokenizer, decodes only the prefix,
-captures a real KV checkpoint, and marks the checkpoint restore-ready only after
-full success.
+captures a real sequence-state checkpoint, and marks it restore-ready only after
+full success. For `orbit-qwen3-coder-native-v1`, the existing Qwen boundary proof
+renders two internal suffix fixtures but decodes only the proven 768-token
+invariant prefix; no fixture suffix is evaluated.
 
 No model response is generated during prewarm.
 
@@ -52,7 +56,7 @@ Startup prewarm does not introduce:
 - final-from-tool anchor
 - tool-call anchor
 - multiple anchors
-- fake user request
+- submitted fake user request
 - prompt workaround
 - `max_tokens=0` through the normal generation path
 - deterministic routing
@@ -76,7 +80,9 @@ This location is intentional:
 Because this is synchronous startup work, server readiness is delayed by the
 prewarm duration when the feature is enabled. With the tested Gemma 4 12B CPU
 setup, the prefill-only capture for the 693-token stable route prefix has been
-observed around 49-59 seconds.
+observed around 49-59 seconds. The verified Qwen3-Coder 30B profile captured its
+768-token checkpoint in 21.62 seconds in production-hook qualification. Timings
+are descriptive.
 
 ## Guardrails
 
@@ -88,6 +94,7 @@ Startup prewarm is eligible only when:
 - native backend/client is loaded
 - route prefix-anchor support is available
 - route tools-on stable prefix boundary is valid
+- the exact profile's route-prefix reuse switch is enabled
 
 It is skipped when:
 
@@ -99,19 +106,22 @@ It is skipped when:
 - the prefix-anchor hook reports an ineligible state
 
 Failures are not user-facing. A failed prewarm leaves the server usable; the
-first real route call falls back to the existing baseline/capture path.
+first real route call falls back to the existing baseline/capture path. Qwen3.6
+retains its existing lazy first-route capture and is unchanged by the
+Qwen3-Coder startup integration.
 
 ## Locking, Cancellation, And Failure
 
-The startup integration relies on the internal
-`NativeLlamaClient.capture_route_prefix_prefill_only(...)` lock and validity
-rules:
+The startup integration relies on the profile-specific native prefill-only
+capture methods and their shared lock and validity rules:
 
 - concurrent capture on the same native client is rejected
 - checkpoint is valid only after complete prefix decode and capture
 - decode/capture failure clears target memory and invalidates the route anchor
 - cancellation or incomplete prefill returns `restore_ready=false`
 - sampler and session history are not touched
+- an operator SIGINT during Qwen3-Coder prewarm cancels capture and exits before
+  the server binds; an ordinary capture failure retains the safe cold fallback
 
 The startup lifecycle runs before serving requests, so there should be no
 request/prewarm race in the normal startup path.
@@ -144,7 +154,9 @@ content, tool output, file content, or web content.
 ## Memory And Startup Tradeoff
 
 The route prefix checkpoint is large. On the tested Gemma 4 12B CPU setup, the
-checkpoint size is about 238 MB.
+checkpoint size is about 238 MB. The verified Qwen3-Coder checkpoint is
+75,507,864 bytes; measured steady RSS increased by roughly 92-102 MB depending
+on allocator state.
 
 Startup prewarm trades startup readiness time for lower first-route latency on
 eligible tools-on requests. It does not make tool execution faster and does not
@@ -162,6 +174,10 @@ Required validation for this integration:
 - invalid prewarm values fall back to `off`
 - hook success yields `restore_ready=true`
 - hook failure leaves the server usable with `restore_ready=false`
+- Qwen3-Coder startup capture is followed by `cached=768` restore on the first
+  real eligible route
+- `ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0` prevents Qwen3-Coder prewarm
+- Qwen3.6 and Gemma checkpoint identities and behavior remain unchanged
 - diagnostics stay metadata-only
 - existing read/list/web/fetch behavior is unchanged
 - stale-evidence and listing-to-read guardrails remain intact

--- a/docs/QWEN3_CODER_COMPATIBILITY.md
+++ b/docs/QWEN3_CODER_COMPATIBILITY.md
@@ -90,6 +90,20 @@ identity changes, restore errors, and process restart invalidate or omit the
 checkpoint. `/props` exposes bounded capture, restore, fallback, invalidation,
 identity-hash, and checkpoint-size diagnostics without prompt content.
 
+With tools enabled, native server startup synchronously captures this same
+checkpoint before accepting requests. The first real route therefore restores
+`cached=768` instead of paying the lazy capture cost. In matched qualification,
+startup capture took 21.62 seconds; the first greeting route then evaluated 32
+dynamic tokens in 2.01 seconds, versus 800 evaluated tokens and 36.59 seconds
+without prewarm in that run. Model load, startup capture, and request time are
+reported separately; timing is hardware- and load-dependent.
+
+`ORBIT_KV_PREFIX_PREWARM=off` disables only startup prewarm. The validated lazy
+behavior remains: the first eligible route captures and later routes restore. A
+prewarm failure is diagnostic and falls back to that cold path without accepting
+partial state or retrying at startup. An operator SIGINT is treated as shutdown:
+capture is cancelled and the process exits before binding the server port.
+
 ## Validation And Limits
 
 The corrected production profile passed a four-case fail-fast smoke and an

--- a/docs/QWEN3_CODER_QUALIFICATION.md
+++ b/docs/QWEN3_CODER_QUALIFICATION.md
@@ -503,3 +503,21 @@ The dedicated kill switch is `ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0`.
 Qwen 3.6 retains `ORBIT_QWEN_ROUTE_PREFIX_REUSE` and an independent state and
 identity. Reset and lifecycle failures discard the Qwen3-Coder state; the next
 eligible route performs a cold capture rather than using stale memory.
+
+Startup prewarm reuses this exact checkpoint rather than defining another
+identity or boundary. A process-isolated comparison kept reuse enabled in both
+modes. Without prewarm, the first greeting route evaluated 800 tokens in 36.59
+seconds and captured the checkpoint. With prewarm, startup captured 768 tokens
+in 21.62 seconds; the first real route restored `cached=768`, evaluated 32
+tokens, and completed in 2.01 seconds. End-to-end greeting wall time in the
+matched runtime comparison changed from 28.00 to 6.20 seconds, while server
+readiness changed from 13.98 to 37.30 seconds. The same nine-case route corpus
+produced identical output hashes, routes, tools, arguments, and finish reasons.
+
+The Qwen3-Coder checkpoint increased ready-state RSS by roughly 92 MB in the
+measured process; repeated restored routes showed no linear growth. Reset
+removed the blob and forced the next route to recapture cold. Failed startup
+capture remains diagnostic and leaves the existing cold path available.
+`ORBIT_KV_PREFIX_PREWARM=off` disables prewarm without disabling lazy reuse.
+All timings are descriptive and were measured while another user-owned model
+server remained active.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -829,6 +829,121 @@ class NativeLlamaClient:
         finally:
             self._route_prefix_prefill_lock.release()
 
+    def capture_qwen3_coder_route_prefix_prefill_only(
+        self,
+        *,
+        system_prompt: str,
+        tools_mode: str = "on",
+    ) -> NativeRoutePrefixPrefillResult:
+        profile = getattr(self, "model_profile", None)
+        if (
+            getattr(profile, "profile_id", None) != QWEN3_CODER_PROFILE_ID
+            or not getattr(profile, "verified", False)
+            or not getattr(profile, "route_prefix_reuse_supported", False)
+        ):
+            return _route_prefix_prefill_skipped("model_profile_ineligible")
+        if not self.config.qwen3_coder_route_prefix_reuse_enabled:
+            return _route_prefix_prefill_skipped("route_prefix_reuse_disabled")
+        if tools_mode != "on":
+            return _route_prefix_prefill_skipped("tools_mode_ineligible")
+        if self.config.use_mtp_experimental or self._session.mtp_enabled:
+            return _route_prefix_prefill_skipped("mtp_ineligible")
+        if not self._session.ctx_tgt or not self._vocab:
+            return _route_prefix_prefill_failed("native_client_not_loaded")
+        if self._session.in_flight:
+            return _route_prefix_prefill_skipped("native_request_in_flight")
+        if self._session.continuation_ready or self._session.cached_prompt_tokens:
+            return _route_prefix_prefill_skipped("active_context_present")
+        if self._qwen3_coder_route_prefix_anchor_state.valid:
+            return _route_prefix_prefill_skipped("checkpoint_already_initialized")
+        if not self._route_prefix_prefill_lock.acquire(blocking=False):
+            return _route_prefix_prefill_skipped("prefill_in_flight")
+
+        prefix_hash: str | None = None
+        prefix_token_count: int | None = None
+        started_us = 0
+        try:
+            if self._session.in_flight:
+                return _route_prefix_prefill_skipped("native_request_in_flight")
+            if self._session.continuation_ready or self._session.cached_prompt_tokens:
+                return _route_prefix_prefill_skipped("active_context_present")
+            if self._qwen3_coder_route_prefix_anchor_state.valid:
+                return _route_prefix_prefill_skipped("checkpoint_already_initialized")
+
+            # This boundary fixture is rendered but its dynamic suffix is never
+            # decoded. The shared Qwen planner independently proves that the
+            # captured 768 tokens are invariant across distinct user suffixes.
+            messages: list[NativeMessage] = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": "A-orbit-qwen-route-boundary"},
+            ]
+            prompt = self.apply_chat_template(messages, tools=None, thinking=False)
+            plan = self._qwen_route_anchor_plan_for_prompt(
+                messages,
+                tools=None,
+                thinking=False,
+                prompt=prompt,
+            )
+            if plan is None or plan.profile_id != QWEN3_CODER_PROFILE_ID:
+                return _route_prefix_prefill_failed("route_anchor_plan_unavailable")
+
+            prefix_hash = plan.prefix_hash
+            prefix_token_count = len(plan.prefix_tokens)
+            lib = self.lib.lib
+            started_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else 0
+            self.reset_cancel()
+            processed, reused = self._prepare_memory_with_qwen_route_anchor(plan)
+            ended_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else started_us
+            prefill_ms = max(0.0, (ended_us - started_us) / 1000.0)
+            state = self._qwen3_coder_route_prefix_anchor_state
+            if processed != prefix_token_count or reused != 0 or not state.valid:
+                self._clear_target_memory()
+                return _route_prefix_prefill_failed(
+                    state.invalidation_reason or "checkpoint_capture_failed",
+                    prefix_hash=prefix_hash,
+                    prefix_token_count=prefix_token_count,
+                    prefill_ms=prefill_ms,
+                )
+
+            checkpoint_size = state.checkpoint_size
+            step = max(1, min(self.config.progress_step, self.config.batch_size))
+            self._clear_target_memory()
+            self._session.prompt_cache_mode = None
+            return NativeRoutePrefixPrefillResult(
+                attempted=True,
+                succeeded=True,
+                skipped=False,
+                prefix_hash=prefix_hash,
+                prefix_token_count=prefix_token_count,
+                checkpoint_size_bytes=checkpoint_size,
+                prefill_ms=prefill_ms,
+                decode_calls=(prefix_token_count + step - 1) // step,
+                restore_ready=True,
+            )
+        except Exception as exc:
+            if self._session.ctx_tgt:
+                self._clear_target_memory()
+            self._invalidate_qwen_route_prefix(
+                f"startup_prewarm_failed:{type(exc).__name__}",
+                profile_id=QWEN3_CODER_PROFILE_ID,
+            )
+            ended_us = (
+                int(self.lib.lib.llama_time_us())
+                if started_us and hasattr(self.lib.lib, "llama_time_us")
+                else started_us
+            )
+            return _route_prefix_prefill_failed(
+                f"startup_prewarm_failed:{type(exc).__name__}",
+                prefix_hash=prefix_hash,
+                prefix_token_count=prefix_token_count,
+                prefill_ms=max(0.0, (ended_us - started_us) / 1000.0) if started_us else None,
+            )
+        finally:
+            self._active_profile_render = None
+            self._profile_last_raw_output = ""
+            self._profile_last_parsed_content = ""
+            self._route_prefix_prefill_lock.release()
+
     def complete_chat(
         self,
         messages: list[NativeMessage],
@@ -2068,7 +2183,7 @@ class NativeLlamaClient:
         self._clear_target_memory()
         token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
         step = max(1, min(self.config.progress_step, self.config.batch_size))
-        self._decode_prompt_range(
+        processed = self._decode_prompt_range(
             token_array,
             processed=0,
             end=len(plan.prefix_tokens),
@@ -2077,6 +2192,14 @@ class NativeLlamaClient:
             on_progress=None,
             should_cancel=None,
         )
+        if processed != len(plan.prefix_tokens) or self.cancel_event.is_set():
+            self._clear_target_memory()
+            self._set_qwen_route_prefix_state(
+                plan.profile_id,
+                PrefixAnchorState(invalidation_reason="cancelled"),
+            )
+            self._record_qwen_route_prefix_fallback("cancelled", profile_id=plan.profile_id)
+            return 0, 0
         self._session.cached_prompt_tokens = list(plan.prefix_tokens)
         state, metadata = capture_prefix_anchor(
             lib=self.lib.lib,
@@ -2087,6 +2210,14 @@ class NativeLlamaClient:
             **plan.state_kwargs,
         )
         self._set_qwen_route_prefix_state(plan.profile_id, state)
+        if self.cancel_event.is_set():
+            self._clear_target_memory()
+            self._set_qwen_route_prefix_state(
+                plan.profile_id,
+                PrefixAnchorState(invalidation_reason="cancelled"),
+            )
+            self._record_qwen_route_prefix_fallback("cancelled", profile_id=plan.profile_id)
+            return 0, 0
         if state.valid:
             status.initialized = True
             status.prefix_tokens = len(plan.prefix_tokens)

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import select
+import signal
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import socket
@@ -23,6 +24,7 @@ from orbit.native_llama.client import (
     _has_open_thought_channel,
 )
 from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_context as native_kv_request_context
+from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
@@ -720,7 +722,25 @@ def run_server(argv: list[str] | None = None) -> int:
         if not args.verbose_llama_log:
             client.set_quiet_logging()
         client.load()
-        prewarm_startup_route_prefix(client)
+        if getattr(getattr(client, "model_profile", None), "profile_id", None) != QWEN3_CODER_PROFILE_ID:
+            prewarm_startup_route_prefix(client)
+        else:
+            prewarm_interrupted = False
+            previous_sigint = signal.getsignal(signal.SIGINT)
+
+            def cancel_startup_prewarm(_signum, _frame) -> None:
+                nonlocal prewarm_interrupted
+                prewarm_interrupted = True
+                client.cancel()
+
+            signal.signal(signal.SIGINT, cancel_startup_prewarm)
+            try:
+                prewarm_startup_route_prefix(client)
+            finally:
+                signal.signal(signal.SIGINT, previous_sigint)
+            if prewarm_interrupted:
+                client.close()
+                return 130
     except (FileNotFoundError, RuntimeError) as exc:
         print(_format_native_bootstrap_error(exc), file=sys.stderr)
         return 1
@@ -805,6 +825,22 @@ def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefix
         _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
         return result
     profile = getattr(client, "model_profile", None)
+    if getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID:
+        try:
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(
+                system_prompt=ROUTE_SYSTEM_PROMPT,
+                tools_mode="on",
+            )
+        except Exception as exc:
+            result = NativeRoutePrefixPrefillResult(
+                attempted=True,
+                succeeded=False,
+                skipped=False,
+                failed_reason=f"startup_prewarm_failed:{type(exc).__name__}",
+                restore_ready=False,
+            )
+        _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
+        return result
     if profile is not None and not profile.gemma_prefix_reuse_supported:
         result = _startup_prewarm_skipped("model_profile_ineligible")
         _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import signal
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -9,6 +10,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from orbit.native_llama.client import NativeRoutePrefixPrefillResult
+from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.native_names import runtime_library_filename
 from orbit.native_server.app import (
     PREFIX_PREWARM_OFF,
@@ -30,7 +32,9 @@ class _FakeNativeClient:
         self.config = _args[1] if len(_args) > 1 else None
         self.loaded = False
         self.closed = False
+        self.cancelled = False
         self.capture_calls = 0
+        self.qwen3_coder_capture_calls = 0
         self.raise_on_capture = False
         _FakeNativeClient.instances.append(self)
 
@@ -42,6 +46,9 @@ class _FakeNativeClient:
 
     def close(self) -> None:
         self.closed = True
+
+    def cancel(self) -> None:
+        self.cancelled = True
 
     def capture_route_prefix_prefill_only(self, segments, *, tools_mode: str = "on", should_cancel=None):
         del should_cancel
@@ -71,6 +78,37 @@ class _FakeNativeClient:
             checkpoint_size_bytes=238454176,
             prefill_ms=12.0,
             decode_calls=3,
+            restore_ready=True,
+        )
+
+    def capture_qwen3_coder_route_prefix_prefill_only(self, *, system_prompt: str, tools_mode: str = "on"):
+        del system_prompt
+        self.qwen3_coder_capture_calls += 1
+        if self.raise_on_capture:
+            raise RuntimeError("synthetic capture failure")
+        if not self.config.qwen3_coder_route_prefix_reuse_enabled:
+            return NativeRoutePrefixPrefillResult(
+                attempted=False,
+                succeeded=False,
+                skipped=True,
+                skip_reason="route_prefix_reuse_disabled",
+            )
+        if tools_mode != "on":
+            return NativeRoutePrefixPrefillResult(
+                attempted=False,
+                succeeded=False,
+                skipped=True,
+                skip_reason="tools_mode_ineligible",
+            )
+        return NativeRoutePrefixPrefillResult(
+            attempted=True,
+            succeeded=True,
+            skipped=False,
+            prefix_hash="qwen3-coder-prefix-hash",
+            prefix_token_count=768,
+            checkpoint_size_bytes=75_507_864,
+            prefill_ms=10.0,
+            decode_calls=12,
             restore_ready=True,
         )
 
@@ -245,6 +283,72 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(result.generated_tokens, 0)
         self.assertEqual(client.capture_calls, 1)
 
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
+    def test_startup_prewarm_qwen3_coder_invokes_profile_hook(self) -> None:
+        client = _FakeNativeClient()
+        client.config = SimpleNamespace(qwen3_coder_route_prefix_reuse_enabled=True)
+        client.model_profile = SimpleNamespace(
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            gemma_prefix_reuse_supported=False,
+        )
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.succeeded)
+        self.assertTrue(result.restore_ready)
+        self.assertEqual(result.prefix_token_count, 768)
+        self.assertEqual(client.qwen3_coder_capture_calls, 1)
+        self.assertEqual(client.capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_startup_prewarm_off_leaves_qwen3_coder_lazy_reuse_untouched(self) -> None:
+        client = _FakeNativeClient()
+        client.config = SimpleNamespace(qwen3_coder_route_prefix_reuse_enabled=True)
+        client.model_profile = SimpleNamespace(
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            gemma_prefix_reuse_supported=False,
+        )
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertTrue(client.config.qwen3_coder_route_prefix_reuse_enabled)
+        self.assertEqual(client.qwen3_coder_capture_calls, 0)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "startup"}, clear=True)
+    def test_startup_prewarm_qwen3_coder_reuse_kill_switch_skips(self) -> None:
+        client = _FakeNativeClient()
+        client.model_profile = SimpleNamespace(
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            gemma_prefix_reuse_supported=False,
+        )
+        client.config = SimpleNamespace(qwen3_coder_route_prefix_reuse_enabled=False)
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "route_prefix_reuse_disabled")
+        self.assertEqual(client.qwen3_coder_capture_calls, 1)
+
+    @mock.patch.dict(
+        "os.environ",
+        {"ORBIT_KV_PREFIX_PREWARM": "startup", "ORBIT_KV_PREFIX_ANCHOR": "off"},
+        clear=True,
+    )
+    def test_startup_prewarm_anchor_off_skips_qwen3_coder(self) -> None:
+        client = _FakeNativeClient()
+        client.config = SimpleNamespace(qwen3_coder_route_prefix_reuse_enabled=True)
+        client.model_profile = SimpleNamespace(
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            gemma_prefix_reuse_supported=False,
+        )
+
+        result = prewarm_startup_route_prefix(client)  # type: ignore[arg-type]
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "anchor_disabled")
+        self.assertEqual(client.qwen3_coder_capture_calls, 0)
+
     @mock.patch.dict(
         "os.environ",
         {"ORBIT_KV_PREFIX_PREWARM": "startup", "ORBIT_KV_PREFIX_ANCHOR": "off", "ORBIT_KV_PREFIX_ANCHOR_EXPERIMENT": "1"},
@@ -383,6 +487,72 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(len(_FakeNativeClient.instances), 1)
         self.assertEqual(_FakeNativeClient.instances[0].capture_calls, 1)
         self.assertTrue(_FakeNativeClient.instances[0].closed)
+        self.assertTrue(_FakeHTTPServer.instances[0].closed)
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_server_sigint_during_prewarm_exits_before_binding(self) -> None:
+        _FakeNativeClient.instances.clear()
+
+        def coder_client(*args, **kwargs):
+            client = _FakeNativeClient(*args, **kwargs)
+            client.model_profile = SimpleNamespace(profile_id=QWEN3_CODER_PROFILE_ID)
+            return client
+
+        def interrupt_prewarm(_client):
+            signal.raise_signal(signal.SIGINT)
+            return NativeRoutePrefixPrefillResult(
+                attempted=True,
+                succeeded=False,
+                skipped=False,
+                failed_reason="cancelled",
+                restore_ready=False,
+            )
+
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=Path("/models/test.gguf")),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", side_effect=coder_client),
+            mock.patch("orbit.native_server.app.prewarm_startup_route_prefix", side_effect=interrupt_prewarm),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer") as http_server,
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 130)
+        self.assertEqual(len(_FakeNativeClient.instances), 1)
+        self.assertTrue(_FakeNativeClient.instances[0].cancelled)
+        self.assertTrue(_FakeNativeClient.instances[0].closed)
+        http_server.assert_not_called()
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_server_prewarm_failure_still_serves_for_cold_fallback(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        failed = NativeRoutePrefixPrefillResult(
+            attempted=True,
+            succeeded=False,
+            skipped=False,
+            failed_reason="checkpoint_capture_failed",
+            restore_ready=False,
+        )
+
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=Path("/models/test.gguf")),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.prewarm_startup_route_prefix", return_value=failed),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        self.assertFalse(_FakeNativeClient.instances[0].cancelled)
+        self.assertTrue(_FakeNativeClient.instances[0].closed)
+        self.assertEqual(len(_FakeHTTPServer.instances), 1)
         self.assertTrue(_FakeHTTPServer.instances[0].closed)
 
     @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)

--- a/tests/test_qwen3_coder_route_prefix.py
+++ b/tests/test_qwen3_coder_route_prefix.py
@@ -241,6 +241,174 @@ class Qwen3CoderRoutePrefixClientTests(unittest.TestCase):
         self.assertEqual(status["restore_count"], 1)
         self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
 
+    def test_startup_prefill_captures_before_first_request_without_sampling(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock(  # type: ignore[method-assign]
+            side_effect=lambda: client._session.cached_prompt_tokens.clear()
+        )
+        client._decode_prompt_range = mock.Mock(
+            return_value=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
+        )  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace(llama_time_us=mock.Mock(side_effect=(1_000_000, 2_000_000)))
+        state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"checkpoint",
+            checkpoint_size=75_507_864,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor", return_value=(state, {})):
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertTrue(result.succeeded)
+        self.assertTrue(result.restore_ready)
+        self.assertEqual(result.prefix_token_count, QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertEqual(result.checkpoint_size_bytes, 75_507_864)
+        self.assertEqual(result.prefill_ms, 1000.0)
+        self.assertEqual(result.sampled_tokens, 0)
+        self.assertEqual(result.generated_tokens, 0)
+        self.assertFalse(result.sampler_touched)
+        self.assertFalse(result.session_history_touched)
+        self.assertTrue(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+        status = client.qwen3_coder_route_prefix_reuse_status()
+        self.assertEqual(status["capture_count"], 1)
+        self.assertEqual(status["restore_count"], 0)
+        self.assertEqual(status["fallback_count"], 0)
+
+    def test_startup_prefill_fails_closed_when_capture_is_invalid(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock(  # type: ignore[method-assign]
+            side_effect=lambda: client._session.cached_prompt_tokens.clear()
+        )
+        client._decode_prompt_range = mock.Mock(
+            return_value=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
+        )  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace(llama_time_us=mock.Mock(side_effect=(1_000_000, 2_000_000)))
+
+        with mock.patch(
+            "orbit.native_llama.client.capture_prefix_anchor",
+            return_value=(PrefixAnchorState(invalidation_reason="capture_failed"), {}),
+        ):
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertFalse(result.succeeded)
+        self.assertFalse(result.restore_ready)
+        self.assertEqual(result.failed_reason, "capture_failed")
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+
+    def test_startup_prefill_never_captures_an_incomplete_decode(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock(  # type: ignore[method-assign]
+            side_effect=lambda: client._session.cached_prompt_tokens.clear()
+        )
+        client._decode_prompt_range = mock.Mock(
+            return_value=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT // 2
+        )  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace(llama_time_us=mock.Mock(return_value=1_000_000))
+
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor") as capture:
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertFalse(result.succeeded)
+        self.assertFalse(result.restore_ready)
+        self.assertEqual(result.failed_reason, "cancelled")
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(client._qwen3_coder_route_prefix_anchor_state.invalidation_reason, "cancelled")
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+        capture.assert_not_called()
+
+    def test_startup_prefill_discards_capture_cancelled_during_serialization(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock(  # type: ignore[method-assign]
+            side_effect=lambda: client._session.cached_prompt_tokens.clear()
+        )
+        client._decode_prompt_range = mock.Mock(
+            return_value=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
+        )  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace(llama_time_us=mock.Mock(return_value=1_000_000))
+        state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"checkpoint",
+            checkpoint_size=75_507_864,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+
+        def capture_then_cancel(**_kwargs):
+            client.cancel_event.set()
+            return state, {}
+
+        with mock.patch(
+            "orbit.native_llama.client.capture_prefix_anchor",
+            side_effect=capture_then_cancel,
+        ):
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertFalse(result.succeeded)
+        self.assertFalse(result.restore_ready)
+        self.assertEqual(result.failed_reason, "cancelled")
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(client._qwen3_coder_route_prefix_anchor_state.invalidation_reason, "cancelled")
+        self.assertEqual(client._session.cached_prompt_tokens, [])
+
+    def test_startup_prefill_respects_reuse_kill_switch_and_profile_identity(self) -> None:
+        client = self._client()
+        client.config = NativeClientConfig(qwen3_coder_route_prefix_reuse_enabled=False)
+
+        disabled = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+        client.config = NativeClientConfig(qwen3_coder_route_prefix_reuse_enabled=True)
+        client.model_profile = NativeModelProfile(
+            **{**_profile().__dict__, "profile_id": "orbit-qwen36-native-v1"}
+        )
+        wrong_profile = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertTrue(disabled.skipped)
+        self.assertEqual(disabled.skip_reason, "route_prefix_reuse_disabled")
+        self.assertTrue(wrong_profile.skipped)
+        self.assertEqual(wrong_profile.skip_reason, "model_profile_ineligible")
+
+    def test_startup_prefill_failure_releases_lock_and_preserves_cold_fallback(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock(  # type: ignore[method-assign]
+            side_effect=lambda: client._session.cached_prompt_tokens.clear()
+        )
+        client.lib.lib = SimpleNamespace(llama_time_us=mock.Mock(return_value=1_000_000))
+
+        with mock.patch.object(
+            client,
+            "_prepare_memory_with_qwen_route_anchor",
+            side_effect=RuntimeError("synthetic prewarm failure"),
+        ):
+            result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.failed_reason, "startup_prewarm_failed:RuntimeError")
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertFalse(client._route_prefix_prefill_lock.locked())
+        self.assertTrue(client.config.qwen3_coder_route_prefix_reuse_enabled)
+
+    def test_startup_prefill_does_not_recapture_an_initialized_checkpoint(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"existing",
+            checkpoint_size=8,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+
+        result = client.capture_qwen3_coder_route_prefix_prefill_only(system_prompt="s" * 900)
+
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "checkpoint_already_initialized")
+        self.assertEqual(client._qwen3_coder_route_prefix_anchor_state.checkpoint_data, b"existing")
+
     def test_restore_failure_falls_back_cold_without_touching_qwen36_state(self) -> None:
         client = self._client()
         client._session.ctx_tgt = 1  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

- Prewarms the verified Qwen3-Coder route-prefix checkpoint before server readiness.
- Keeps tools enabled and routing fully model-driven.
- Makes the first real request restore 768 cached tokens instead of capturing cold.
- Reuses the existing synchronous startup prewarm orchestration.
- Preserves the independent Qwen3.6 and Gemma paths.

## Correctness

- Cold and prewarmed logits are byte-identical with max_abs_diff=0.0.
- The matched route corpus is 9/9 identical for output, route, tool, typed arguments, and finish reason.
- The Qwen3-Coder production corpus is 8/8 PASS.
- Incomplete or cancelled decode/serialization cannot publish a partial checkpoint.
- SIGINT during Qwen3-Coder prewarm exits with code 130 before server bind/listening.
- No sampling, deterministic routing, user-dependent checkpoint state, or startup retry loop is added.

## Performance

Measured locally on the qualified CPU configuration:

- First route prefill: approximately 24.31 s to 1.39 s.
- First prewarmed route wall time: approximately 1.97 s.
- Greeting end-to-end: approximately 28.0 s to 6.2 s.
- Startup prewarm cost: approximately 22.37 s.
- Checkpoint size: 75,507,864 bytes.
- Ready-state RSS increase: approximately 92 MB.

Timings are descriptive and workload-dependent. Prewarm moves work to startup rather than removing it.

## Lifecycle

- Reset invalidates the checkpoint and the next eligible route recaptures cold.
- Ordinary prewarm failure leaves the safe lazy cold-capture path available.
- Shutdown during prewarm cannot expose partial state or bind the server.
- Repeated restore/reset qualification showed no linear RSS growth or stale checkpoint reuse.

## Switches

- ORBIT_KV_PREFIX_PREWARM=off disables startup prewarm only; lazy Qwen3-Coder reuse remains enabled.
- ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE=0 disables Qwen3-Coder checkpoint capture and restore entirely.

## Validation

- Focused prefix/bootstrap/cross-profile tests: 148/148 PASS.
- Full discovery: 1,596/1,596 PASS with 6 expected skips.
- Qwen3-Coder route corpus: 9/9 PASS.
- Qwen3-Coder production corpus: 8/8 PASS.
- Qwen3.6 route-prefix regression: PASS.
- Gemma final-prefix and strict MTP/mmproj regression: PASS.
- python3 -m compileall -q src tests scripts: PASS.
- git diff --check: PASS.

## Known limitations

- Prewarm increases server-ready time by the measured startup capture cost.
- The approximately 75.5 MB checkpoint remains process-local.
- After an explicit session reset, the next eligible route recaptures cold.
