### PR TITLE
Add capability-based qualification harness

### DIFF
--- a/qualification/fixtures/core-v1.json
+++ b/qualification/fixtures/core-v1.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "fixtures": [
+    {
+      "name": "simple_chat",
+      "capability": "chat",
+      "profiles": [
+        "orbit-gemma4-native-v1",
+        "orbit-qwen36-native-v1",
+        "orbit-qwen3-coder-native-v1"
+      ],
+      "request": {
+        "prompt": "Reply with exactly ORBIT_QUALIFICATION_CHAT_OK and nothing else.",
+        "tools": false
+      },
+      "expect": {
+        "finish_reason": "stop",
+        "max_model_calls": 1,
+        "exact_output": "ORBIT_QUALIFICATION_CHAT_OK"
+      },
+      "parity": {"mode": "exact"}
+    },
+    {
+      "name": "pwd_route",
+      "capability": "tools",
+      "profiles": [
+        "orbit-gemma4-native-v1",
+        "orbit-qwen36-native-v1",
+        "orbit-qwen3-coder-native-v1"
+      ],
+      "request": {
+        "prompt": "Determine the absolute current working directory using a local capability.",
+        "tools": true
+      },
+      "expect": {
+        "route": "FILESYSTEM",
+        "tool_calls": [
+          {"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}
+        ],
+        "finish_reason": "stop",
+        "max_model_calls": 1
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "pwd_final",
+      "capability": "tools",
+      "profiles": [
+        "orbit-gemma4-native-v1",
+        "orbit-qwen36-native-v1",
+        "orbit-qwen3-coder-native-v1"
+      ],
+      "request": {
+        "prompt": "Run exactly the local shell command `pwd`, then answer with only its output.",
+        "tools": true
+      },
+      "expect": {
+        "tool_calls": [
+          {"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}
+        ],
+        "finish_reason": "stop",
+        "max_model_calls": 6,
+        "final_reports_workdir": true
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "json_artifact",
+      "capability": "artifacts",
+      "profiles": [
+        "orbit-gemma4-native-v1",
+        "orbit-qwen36-native-v1",
+        "orbit-qwen3-coder-native-v1"
+      ],
+      "request": {
+        "prompt": "Create qualification.json with this valid JSON integer, then verify the artifact:\n\n3141592653589793238462643383279502884197169399375105820974944592",
+        "tools": true
+      },
+      "expect": {
+        "tool_calls": [
+          {"name": "write_artifact"},
+          {"name": "verify_artifact"}
+        ],
+        "finish_reason": "stop",
+        "max_model_calls": 6,
+        "artifact": {
+          "path": "qualification.json",
+          "json_equals": 3141592653589793238462643383279502884197169399375105820974944592,
+          "publication": true,
+          "verification": true
+        }
+      },
+      "parity": {"mode": "structural"}
+    }
+  ]
+}

--- a/scripts/orbit_qualify.py
+++ b/scripts/orbit_qualify.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.llama_server import LlamaServerBackend  # noqa: E402
+from orbit.qualification.fixtures import load_fixture_set  # noqa: E402
+from orbit.qualification.reporting import format_summary, write_result  # noqa: E402
+from orbit.qualification.runner import QualificationRunner, RuntimeFixtureExecutor  # noqa: E402
+from orbit.qualification.schema import RunProvenance, Status  # noqa: E402
+from orbit.terminal.runtime_status import collect_host_info  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Qualify an independently managed Orbit server.")
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--server-pid", type=int)
+    parser.add_argument("--fixtures", default=str(ROOT / "qualification/fixtures/core-v1.json"))
+    parser.add_argument("--fixture", action="append", dest="fixture_names")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--request-timeout", type=float, default=900.0)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    backend = LlamaServerBackend(base_url=args.base_url, timeout=args.request_timeout)
+    if not backend.health():
+        raise RuntimeError("Orbit server is not healthy")
+    props = backend.backend_props()
+    profile = props.get("model_compatibility")
+    if not isinstance(profile, dict):
+        raise RuntimeError("server did not expose model compatibility metadata")
+    fixture_set = load_fixture_set(args.fixtures)
+    with tempfile.TemporaryDirectory(prefix="orbit-qualification-") as workdir:
+        run = QualificationRunner(
+            fixture_set=fixture_set,
+            profile=profile,
+            provenance=_provenance(args.profile, fixture_set.content_hash, profile, props, args.server_pid),
+            executor=RuntimeFixtureExecutor(backend, process_pid=args.server_pid),
+            workdir=Path(workdir),
+        ).run(tuple(args.fixture_names) if args.fixture_names else None)
+    write_result(run, args.output)
+    print(format_summary(run))
+    return 0 if run.overall_status is Status.PASS else 1
+
+
+def _provenance(
+    expected_profile: str,
+    fixture_hash: str,
+    profile: dict[str, Any],
+    props: dict[str, Any],
+    server_pid: int | None,
+) -> RunProvenance:
+    capabilities = props.get("native_backend_capabilities")
+    capabilities = capabilities if isinstance(capabilities, dict) else {}
+    backend = capabilities.get("backend")
+    backend = backend if isinstance(backend, dict) else {}
+    runtime_keys = ("ctx_size", "threads", "threads_batch", "batch_size", "ubatch_size", "parallel_slots")
+    return RunProvenance(
+        qualification_schema_version=1, fixture_set_hash=fixture_hash,
+        git_revision=_git_revision(), profile_identity=expected_profile,
+        model_identity=_string(profile.get("model_name")) or _string(props.get("model_id")),
+        template_identity=_string(profile.get("template_source")), template_hash=_string(profile.get("template_hash")),
+        backend_identity=_string(props.get("backend")),
+        backend_revision=_string(backend.get("commit")) or _string(backend.get("build_number")),
+        runtime_configuration={key: props.get(key) for key in runtime_keys}, hardware=asdict(collect_host_info()),
+        measurement_scope={
+            "call_wall_seconds": "client elapsed model call; transport included; tool execution excluded",
+            "aggregate_wall_seconds": "sum of fixture execution; server startup and model load excluded",
+            "prefill_tokens_per_second": "sum evaluated / sum per-call evaluated seconds; complete calls only",
+            "generation_tokens_per_second": "sum output / sum per-call decode seconds; complete calls only",
+            "peak_rss_bytes": (
+                f"Linux VmHWM for server PID {server_pid}; process lifetime including model load"
+                if server_pid is not None else "unavailable without --server-pid"
+            ),
+        },
+    )
+
+
+def _git_revision() -> str | None:
+    result = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True, capture_output=True, check=False)
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _string(value: Any) -> str | None:
+    return str(value) if isinstance(value, (str, int)) else None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/qualification/__init__.py
+++ b/src/orbit/qualification/__init__.py
@@ -1,0 +1,5 @@
+"""Observational qualification helpers for verified Orbit profiles."""
+
+from .schema import ComparisonMode, ParityMode, Status
+
+__all__ = ["ComparisonMode", "ParityMode", "Status"]

--- a/src/orbit/qualification/fixtures.py
+++ b/src/orbit/qualification/fixtures.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .schema import ParityMode
+
+SCHEMA_VERSION = 1
+CAPABILITY_REQUIREMENTS = {
+    "chat": ("chat",),
+    "tools": ("tools",),
+    "artifacts": ("write_artifact", "verify_artifact"),
+}
+
+
+class FixtureError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+    prompt: str
+    tools: bool
+
+
+@dataclass(frozen=True)
+class ToolExpectation:
+    name: str
+    arguments: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ArtifactExpectation:
+    path: str
+    json_equals: Any
+    publication: bool
+    verification: bool
+
+    @property
+    def canonical_json_sha256(self) -> str:
+        return hashlib.sha256(_canonical(self.json_equals)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ExpectSpec:
+    finish_reason: str
+    max_model_calls: int
+    route: str | None = None
+    tool_calls: tuple[ToolExpectation, ...] = ()
+    exact_output: str | None = None
+    final_reports_workdir: bool = False
+    artifact: ArtifactExpectation | None = None
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    name: str
+    capability: str
+    profiles: tuple[str, ...]
+    request: RequestSpec
+    expect: ExpectSpec
+    parity_mode: ParityMode
+    fixture_hash: str
+
+
+@dataclass(frozen=True)
+class FixtureSet:
+    schema_version: int
+    fixtures: tuple[FixtureSpec, ...]
+    content_hash: str
+
+
+def load_fixture_set(path: Path | str) -> FixtureSet:
+    return load_fixture_text(Path(path).read_text(encoding="utf-8"))
+
+
+def load_fixture_text(text: str) -> FixtureSet:
+    try:
+        raw = json.loads(text, object_pairs_hook=_unique, parse_constant=lambda item: _fail("invalid_constant", item))
+    except FixtureError:
+        raise
+    except (json.JSONDecodeError, TypeError, ValueError) as error:
+        raise FixtureError(f"invalid_json: {error}") from error
+    root = _object(raw, "document", {"schema_version", "fixtures"})
+    version = _integer(root["schema_version"], "schema_version")
+    if version != SCHEMA_VERSION:
+        _fail("unsupported_schema_version", str(version))
+    if not isinstance(root["fixtures"], list):
+        _fail("invalid_type", "fixtures must be an array")
+    fixtures = tuple(_fixture(item, version) for item in root["fixtures"])
+    names = [item.name for item in fixtures]
+    if len(names) != len(set(names)):
+        _fail("duplicate_fixture", "fixture names must be unique")
+    return FixtureSet(version, fixtures, hashlib.sha256(_canonical(root)).hexdigest())
+
+
+def _fixture(value: Any, version: int) -> FixtureSpec:
+    required = {"name", "capability", "profiles", "request", "expect", "parity"}
+    row = _object(value, "fixture", required)
+    name = _identifier(row["name"], "name")
+    capability = _identifier(row["capability"], "capability")
+    if capability not in CAPABILITY_REQUIREMENTS:
+        _fail("unsupported_capability", capability)
+    if not isinstance(row["profiles"], list) or not row["profiles"]:
+        _fail("invalid_type", f"{name}.profiles must be a non-empty array")
+    profiles = tuple(_string(item, f"{name}.profiles") for item in row["profiles"])
+    if len(profiles) != len(set(profiles)):
+        _fail("duplicate_profile", name)
+    parity = _object(row["parity"], f"{name}.parity", {"mode"})
+    try:
+        parity_mode = ParityMode(_string(parity["mode"], f"{name}.parity.mode"))
+    except ValueError:
+        _fail("invalid_parity_mode", name)
+    request = _request(row["request"], name)
+    expect = _expect(row["expect"], name)
+    _validate_contract(name, capability, request, expect)
+    digest = hashlib.sha256(_canonical({"schema_version": version, "fixture": row})).hexdigest()
+    return FixtureSpec(name, capability, profiles, request, expect, parity_mode, digest)
+
+
+def _request(value: Any, name: str) -> RequestSpec:
+    row = _object(value, f"{name}.request", {"prompt", "tools"})
+    if not isinstance(row["tools"], bool):
+        _fail("invalid_type", f"{name}.request.tools")
+    return RequestSpec(_string(row["prompt"], f"{name}.request.prompt"), row["tools"])
+
+
+def _expect(value: Any, name: str) -> ExpectSpec:
+    required = {"finish_reason", "max_model_calls"}
+    optional = {"route", "tool_calls", "exact_output", "final_reports_workdir", "artifact"}
+    row = _object(value, f"{name}.expect", required, optional)
+    raw_calls = row.get("tool_calls", [])
+    if not isinstance(raw_calls, list):
+        _fail("invalid_type", f"{name}.expect.tool_calls")
+    report_workdir = row.get("final_reports_workdir", False)
+    if not isinstance(report_workdir, bool):
+        _fail("invalid_type", f"{name}.expect.final_reports_workdir")
+    return ExpectSpec(
+        finish_reason=_string(row["finish_reason"], f"{name}.expect.finish_reason"),
+        max_model_calls=_positive(row["max_model_calls"], f"{name}.expect.max_model_calls"),
+        route=_optional_string(row.get("route"), f"{name}.expect.route"),
+        tool_calls=tuple(_tool(item, name) for item in raw_calls),
+        exact_output=_optional_string(row.get("exact_output"), f"{name}.expect.exact_output"),
+        final_reports_workdir=report_workdir,
+        artifact=_artifact(row["artifact"], name) if "artifact" in row else None,
+    )
+
+
+def _tool(value: Any, name: str) -> ToolExpectation:
+    row = _object(value, f"{name}.tool_call", {"name"}, {"arguments"})
+    arguments = row.get("arguments")
+    if arguments is not None:
+        arguments = _object(arguments, f"{name}.tool_call.arguments", set(), set(arguments) if isinstance(arguments, dict) else set())
+    return ToolExpectation(_string(row["name"], f"{name}.tool_call.name"), arguments)
+
+
+def _artifact(value: Any, name: str) -> ArtifactExpectation:
+    keys = {"path", "json_equals", "publication", "verification"}
+    row = _object(value, f"{name}.artifact", keys)
+    if not isinstance(row["publication"], bool) or not isinstance(row["verification"], bool):
+        _fail("invalid_type", f"{name}.artifact publication/verification")
+    return ArtifactExpectation(_relative_path(row["path"], f"{name}.artifact.path"), row["json_equals"], row["publication"], row["verification"])
+
+
+def _object(value: Any, path: str, required: set[str], optional: set[str] = set()) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _fail("invalid_type", f"{path} must be an object")
+    unknown = sorted(set(value) - required - optional)
+    missing = sorted(required - set(value))
+    if unknown:
+        _fail("unknown_key", f"{path}.{unknown[0]}")
+    if missing:
+        _fail("missing_key", f"{path}.{missing[0]}")
+    return value
+
+
+def _unique(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("duplicate_key", key)
+        result[key] = value
+    return result
+
+
+def _string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value:
+        _fail("invalid_type", f"{path} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: Any, path: str) -> str | None:
+    return None if value is None else _string(value, path)
+
+
+def _identifier(value: Any, path: str) -> str:
+    result = _string(value, path)
+    if re.fullmatch(r"[a-z][a-z0-9_]*", result) is None:
+        _fail("invalid_value", f"{path} is not an identifier")
+    return result
+
+
+def _relative_path(value: Any, path: str) -> str:
+    result = _string(value, path)
+    parsed = PurePosixPath(result)
+    if "\x00" in result or result == "." or parsed.is_absolute() or ".." in parsed.parts or parsed.as_posix() != result:
+        _fail("invalid_value", f"{path} is not a confined relative path")
+    return result
+
+
+def _integer(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        _fail("invalid_type", f"{path} must be an integer")
+    return value
+
+
+def _positive(value: Any, path: str) -> int:
+    result = _integer(value, path)
+    if result < 1:
+        _fail("invalid_value", f"{path} must be positive")
+    return result
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _validate_contract(name: str, capability: str, request: RequestSpec, expect: ExpectSpec) -> None:
+    has_tool_contract = bool(expect.route or expect.tool_calls or expect.final_reports_workdir)
+    if capability == "chat" and (request.tools or has_tool_contract or expect.artifact is not None):
+        _fail("invalid_fixture_contract", f"{name} chat fixture exposes tool behavior")
+    if capability == "tools" and (not request.tools or expect.artifact is not None):
+        _fail("invalid_fixture_contract", f"{name} tools fixture is inconsistent")
+    if capability == "artifacts" and (not request.tools or expect.artifact is None or expect.route is not None):
+        _fail("invalid_fixture_contract", f"{name} artifact fixture is inconsistent")
+
+
+def _fail(code: str, detail: str):
+    raise FixtureError(f"{code}: {detail}")

--- a/src/orbit/qualification/reporting.py
+++ b/src/orbit/qualification/reporting.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .schema import QualificationRun, as_primitive
+
+
+def result_json(run: QualificationRun) -> str:
+    return json.dumps(as_primitive(run), ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def write_result(run: QualificationRun, path: Path | str) -> None:
+    Path(path).write_text(result_json(run), encoding="utf-8")
+
+
+def format_summary(run: QualificationRun) -> str:
+    metrics = run.aggregate_metrics
+    lines = [f"Profile: {run.provenance.profile_identity}", "", "Common"]
+    lines.extend(f"  {item.name:<16} {item.status.value}" for item in run.common)
+    lines.extend(("", "Fixtures"))
+    lines.extend(f"  {item.name:<16} {item.status.value}" for item in run.fixtures)
+    lines.extend(
+        (
+            "",
+            "Metrics",
+            f"  input           {_count(metrics.input_tokens)}",
+            f"  evaluated       {_count(metrics.evaluated_tokens)}",
+            f"  cached          {_count(metrics.cached_tokens)}",
+            f"  output          {_count(metrics.output_tokens)}",
+            f"  calls           {metrics.calls}",
+            f"  prefill         {_rate(metrics.prefill_tokens_per_second)}",
+            f"  decode          {_rate(metrics.generation_tokens_per_second)}",
+            f"  fixture wall sum {metrics.wall_seconds:.2f} s",
+            f"  server VmHWM    {_bytes(metrics.peak_rss_bytes)}",
+            "  TTFT            unavailable",
+            "",
+            "Overall:",
+            run.overall_detail,
+        )
+    )
+    return "\n".join(lines)
+
+
+def _rate(value: float | None) -> str:
+    return "unavailable" if value is None else f"{value:.2f} tok/s"
+
+
+def _count(value: int | None) -> str:
+    return "unavailable" if value is None else str(value)
+
+
+def _bytes(value: int | None) -> str:
+    return "unavailable" if value is None else f"{value / (1024 ** 3):.2f} GiB"

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -233,7 +233,10 @@ class RuntimeFixtureExecutor:
                 on_phase_start=phase_start,
             )
 
-        if _has_control_markup(result.content):
+        if (
+            _has_control_markup(result.content)
+            and result.content != fixture.expect.exact_output
+        ):
             protocol_issue = "visible_control_markup"
         calls = tuple(_metric(item, step_walls[index]) for index, item in enumerate(steps))
         artifact = _artifact_evidence(fixture, workdir, tool_results)
@@ -308,7 +311,7 @@ def _metric(value: ModelStepMetrics, wall: float | None) -> CallMetric:
         phase=value.phase,
         input_tokens=input_tokens,
         evaluated_tokens=evaluated,
-        cached_tokens=cached_tokens,
+        cached_tokens=cached_tokens if valid_cache else None,
         output_tokens=_token_count(value.completion_tokens),
         prefill_tokens_per_second=_positive_rate(value.prompt_tokens_per_second),
         generation_tokens_per_second=_positive_rate(value.generation_tokens_per_second),

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import stat
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from orbit.backend.base import ChatBackend
+from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.command_request import (
+    command_tool_call_from_content,
+    command_tool_call_from_tool_calls,
+    parse_command_decision,
+    parse_command_decision_from_tool_calls,
+)
+from orbit.runtime.kv_diag import model_call_context
+from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
+
+from .fixtures import CAPABILITY_REQUIREMENTS, FixtureSet, FixtureSpec
+from .schema import (
+    AggregateMetrics,
+    ArtifactEvidence,
+    CallMetric,
+    CommonGate,
+    ComparisonMode,
+    FixtureObservation,
+    LifecycleOutcome,
+    ParityResult,
+    QualificationRun,
+    Reason,
+    RunProvenance,
+    Status,
+    ToolCallRecord,
+)
+from .validators import compare_fixture_results, unavailable_result, validate_observation
+
+
+class FixtureExecutor(Protocol):
+    def execute(self, fixture: FixtureSpec, workdir: Path) -> FixtureObservation: ...
+
+
+@dataclass
+class QualificationRunner:
+    fixture_set: FixtureSet
+    profile: dict[str, Any]
+    provenance: RunProvenance
+    executor: FixtureExecutor
+    workdir: Path
+
+    def run(self, names: tuple[str, ...] | None = None) -> QualificationRun:
+        selected = self._selected(names)
+        profile_id = self.profile.get("compatibility_profile")
+        verified = self.profile.get("verified") is True and profile_id == self.provenance.profile_identity
+        identity = CommonGate(
+            "identity",
+            Status.PASS if verified else Status.FAIL,
+            Reason(
+                "verified_profile" if verified else "unverified_profile",
+                "profile identity is verified" if verified else "profile identity is not verified",
+            ),
+        )
+        results = []
+        if verified:
+            for fixture in selected:
+                applicability = self._applicability(fixture, str(profile_id))
+                if applicability is not None:
+                    results.append(applicability)
+                    continue
+                fixture_workdir = self.workdir / fixture.name
+                fixture_workdir.mkdir(parents=True, exist_ok=False)
+                try:
+                    observation = self.executor.execute(fixture, fixture_workdir)
+                    results.append(validate_observation(fixture, observation, workdir=fixture_workdir))
+                except Exception as error:
+                    results.append(
+                        unavailable_result(
+                            fixture,
+                            code="execution_error",
+                            detail=f"fixture execution failed ({type(error).__name__})",
+                            status=Status.TECHNICAL_STOP,
+                        )
+                    )
+
+        lifecycle_ok = all(item.lifecycle.clean for item in results)
+        protocol_ok = all(item.reason.code != "protocol_leak" for item in results)
+        common = (
+            identity,
+            CommonGate(
+                "lifecycle",
+                Status.PASS if lifecycle_ok else Status.FAIL,
+                Reason(
+                    "clean" if lifecycle_ok else "residue",
+                    "fixture lifecycle is clean" if lifecycle_ok else "fixture lifecycle residue detected",
+                ),
+            ),
+            CommonGate(
+                "protocol",
+                Status.PASS if protocol_ok else Status.FAIL,
+                Reason(
+                    "valid" if protocol_ok else "control_leak",
+                    "protocol output is structurally valid" if protocol_ok else "visible control markup detected",
+                ),
+            ),
+        )
+        calls = tuple(call for result in results for call in result.calls)
+        aggregate = AggregateMetrics.from_calls(
+            calls,
+            sum(item.aggregate_metrics.wall_seconds for item in results),
+            max((item.aggregate_metrics.peak_rss_bytes or 0 for item in results), default=0) or None,
+        )
+        overall = _overall(common, results)
+        return QualificationRun(
+            provenance=self.provenance,
+            common=common,
+            fixtures=tuple(results),
+            aggregate_metrics=aggregate,
+            overall_status=overall,
+            overall_detail=(
+                "QUALIFIED FOR TESTED CAPABILITIES" if overall is Status.PASS else overall.value
+            ),
+        )
+
+    def _selected(self, names: tuple[str, ...] | None) -> tuple[FixtureSpec, ...]:
+        if names is None:
+            return self.fixture_set.fixtures
+        wanted = set(names)
+        selected = tuple(item for item in self.fixture_set.fixtures if item.name in wanted)
+        missing = sorted(wanted - {item.name for item in selected})
+        if missing:
+            raise ValueError(f"unknown qualification fixture: {missing[0]}")
+        return selected
+
+    def _applicability(self, fixture: FixtureSpec, profile_id: str):
+        if profile_id not in fixture.profiles:
+            return unavailable_result(
+                fixture,
+                code="profile_not_applicable",
+                detail="fixture does not declare this profile",
+            )
+        capabilities = self.profile.get("capabilities")
+        capabilities = capabilities if isinstance(capabilities, dict) else {}
+        required = CAPABILITY_REQUIREMENTS[fixture.capability]
+        if not all(capabilities.get(name) is True for name in required):
+            return unavailable_result(
+                fixture,
+                code="capability_not_supported",
+                detail=f"profile does not declare {fixture.capability}",
+            )
+        return None
+
+
+class RuntimeFixtureExecutor:
+    def __init__(self, backend: ChatBackend, *, process_pid: int | None = None) -> None:
+        self.backend = backend
+        self.process_pid = process_pid
+
+    def execute(self, fixture: FixtureSpec, workdir: Path) -> FixtureObservation:
+        started = time.perf_counter()
+        steps: list[ModelStepMetrics] = []
+        step_walls: list[float | None] = []
+        phase_starts: list[float] = []
+        tool_calls: list[ToolCallRecord] = []
+        tool_results: list[tuple[str, str]] = []
+        protocol_issue = None
+
+        def phase_start(_phase: ModelPhaseStart) -> None:
+            phase_starts.append(time.perf_counter())
+
+        def model_step(step: ModelStepMetrics) -> None:
+            steps.append(step)
+            step_walls.append(time.perf_counter() - phase_starts.pop(0) if phase_starts else None)
+
+        def tool_call(name: str, raw: str) -> None:
+            nonlocal protocol_issue
+            try:
+                arguments = json.loads(raw)
+                if not isinstance(arguments, dict):
+                    raise ValueError("tool arguments are not an object")
+            except (json.JSONDecodeError, TypeError, ValueError):
+                arguments = {}
+                protocol_issue = "malformed_tool_arguments"
+            tool_calls.append(ToolCallRecord(name, arguments))
+
+        def tool_result(name: str, _chars: int, _kind: str, content: str) -> None:
+            tool_results.append((name, content))
+
+        route = None
+        runtime = ChatRuntime(backend=self.backend)
+        if fixture.expect.route is not None:
+            result, route, route_call = self._route(fixture)
+            tool_calls.extend(route_call)
+            steps.append(ModelStepMetrics.from_result(loop=1, result=result, phase="route"))
+            step_walls.append(time.perf_counter() - started)
+        elif not fixture.request.tools:
+            route = "CHAT"
+            result = runtime.ask_chat(
+                fixture.request.prompt,
+                temperature=0,
+                max_tokens=64,
+                on_model_step=model_step,
+                on_phase_start=phase_start,
+            )
+        elif fixture.expect.artifact is not None:
+            result = runtime.ask_auto(
+                fixture.request.prompt,
+                temperature=0,
+                max_tokens=512,
+                workdir=workdir,
+                max_loops=6,
+                allowed_tool_names=("write_artifact",),
+                on_tool_call=tool_call,
+                on_tool_result=tool_result,
+                on_model_step=model_step,
+                on_phase_start=phase_start,
+            )
+        else:
+            names = tuple(item.name for item in fixture.expect.tool_calls)
+            result = runtime.ask_with_tools(
+                fixture.request.prompt,
+                temperature=0,
+                max_tokens=160,
+                workdir=workdir,
+                max_loops=6,
+                tool_names=names or None,
+                on_tool_call=tool_call,
+                on_tool_result=tool_result,
+                on_model_step=model_step,
+                on_phase_start=phase_start,
+            )
+
+        if _has_control_markup(result.content):
+            protocol_issue = "visible_control_markup"
+        calls = tuple(_metric(item, step_walls[index]) for index, item in enumerate(steps))
+        artifact = _artifact_evidence(fixture, workdir, tool_results)
+        residue = _artifact_residue(workdir)
+        lifecycle = LifecycleOutcome(
+            not residue,
+            "clean" if not residue else "private artifact state remains",
+        )
+        return FixtureObservation(
+            route=route,
+            tool_calls=tuple(tool_calls),
+            executed_tools=tuple(name for name, _content in tool_results),
+            final_output=result.content,
+            finish_reason=result.finish_reason,
+            model_call_count=len(calls),
+            retry_count=sum(bool(item.retry_reason or "retry" in item.phase) for item in calls),
+            calls=calls,
+            artifact=artifact,
+            lifecycle=lifecycle,
+            peak_rss_bytes=_peak_rss_bytes(self.process_pid),
+            wall_seconds=time.perf_counter() - started,
+            protocol_issue=protocol_issue,
+        )
+
+    def _route(self, fixture: FixtureSpec):
+        allowed = tuple(item.name for item in fixture.expect.tool_calls) or ("exec_shell_full_command",)
+        messages = [
+            {"role": "system", "content": ROUTE_SYSTEM_PROMPT},
+            {"role": "user", "content": fixture.request.prompt},
+        ]
+        with model_call_context(phase="route", tools_mode="on"):
+            result = self.backend.chat(messages, temperature=0, max_tokens=64)
+        decision = parse_command_decision_from_tool_calls(result.tool_calls) or parse_command_decision(result.content)
+        raw_call = command_tool_call_from_tool_calls(result.tool_calls, allowed)
+        raw_call = raw_call or command_tool_call_from_content(result.content, allowed)
+        calls = (_tool_record(raw_call),) if raw_call is not None else ()
+        return result, decision.route.value if decision else None, calls
+
+
+def compare_runs(
+    fixture_set: FixtureSet,
+    baseline: QualificationRun,
+    candidate: QualificationRun,
+    *,
+    comparison_mode: ComparisonMode = ComparisonMode.OPTIMIZATION,
+) -> tuple[ParityResult, ...]:
+    if baseline.provenance.fixture_set_hash != candidate.provenance.fixture_set_hash:
+        raise ValueError("qualification fixture sets differ")
+    left = {item.name: item for item in baseline.fixtures}
+    right = {item.name: item for item in candidate.fixtures}
+    fixtures = {item.name: item for item in fixture_set.fixtures}
+    if set(left) != set(right) or not set(left) <= set(fixtures):
+        raise ValueError("qualification result fixtures differ")
+    return tuple(
+        compare_fixture_results(
+            fixtures[name], left[name], right[name], comparison_mode=comparison_mode
+        )
+        for name in sorted(left)
+    )
+
+
+def _metric(value: ModelStepMetrics, wall: float | None) -> CallMetric:
+    input_tokens = _token_count(value.prompt_tokens)
+    cached_tokens = _token_count(value.cached_tokens)
+    valid_cache = (
+        input_tokens is not None
+        and cached_tokens is not None
+        and cached_tokens <= input_tokens
+    )
+    evaluated = input_tokens - cached_tokens if valid_cache else None
+    return CallMetric(
+        phase=value.phase,
+        input_tokens=input_tokens,
+        evaluated_tokens=evaluated,
+        cached_tokens=cached_tokens,
+        output_tokens=_token_count(value.completion_tokens),
+        prefill_tokens_per_second=_positive_rate(value.prompt_tokens_per_second),
+        generation_tokens_per_second=_positive_rate(value.generation_tokens_per_second),
+        wall_seconds=wall,
+        finish_reason=value.finish_reason,
+        retry_reason=value.retry_reason,
+    )
+
+
+def _token_count(value: int | None) -> int | None:
+    return value if type(value) is int and value >= 0 else None
+
+
+def _positive_rate(value: float | None) -> float | None:
+    if (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value > 0
+    ):
+        return float(value)
+    return None
+
+
+def _tool_record(value: dict[str, Any]) -> ToolCallRecord:
+    function = value.get("function") if isinstance(value, dict) else None
+    function = function if isinstance(function, dict) else {}
+    raw = function.get("arguments")
+    try:
+        arguments = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError:
+        arguments = {}
+    return ToolCallRecord(
+        str(function.get("name") or ""),
+        arguments if isinstance(arguments, dict) else {},
+    )
+
+
+def _artifact_evidence(
+    fixture: FixtureSpec,
+    workdir: Path,
+    results: list[tuple[str, str]],
+) -> ArtifactEvidence | None:
+    expected = fixture.expect.artifact
+    if expected is None:
+        return None
+    path = workdir / expected.path
+    publication = _evidence_fields(results, "write_artifact")
+    verification = _evidence_fields(results, "verify_artifact")
+    exists = False
+    content = None
+    try:
+        info = path.lstat()
+        exists = stat.S_ISREG(info.st_mode) and not path.is_symlink()
+        content = path.read_bytes() if exists else None
+    except OSError:
+        pass
+    actual_hash = hashlib.sha256(content).hexdigest() if content is not None else None
+    expected_bytes = str(len(content)) if content is not None else None
+    publication_action = publication.get("publication_action")
+    published = (
+        publication.get("artifact_publication") == "complete"
+        and publication.get("path") == expected.path
+        and publication.get("bytes") == expected_bytes
+        and publication.get("sha256") == actual_hash
+        and publication_action in frozenset({"created", "replaced"})
+    )
+    verified = (
+        verification.get("artifact_verification") == "complete"
+        and verification.get("path") == expected.path
+        and verification.get("bytes") == expected_bytes
+        and verification.get("sha256") == actual_hash
+        and verification.get("publication_action") == publication_action
+        and verification.get("status") == "pass"
+    )
+    canonical = None
+    if content is not None:
+        try:
+            value = json.loads(content.decode("utf-8"))
+            encoded = json.dumps(
+                value,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            canonical = hashlib.sha256(encoded).hexdigest()
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            pass
+    return ArtifactEvidence(
+        path=expected.path,
+        published=published,
+        verified=verified,
+        exists=exists,
+        byte_count=len(content) if content is not None else None,
+        sha256=actual_hash,
+        publication_action=publication_action,
+        verification_check=verification.get("check"),
+        canonical_json_sha256=canonical,
+    )
+
+
+def _evidence_fields(results: list[tuple[str, str]], tool: str) -> dict[str, str]:
+    fields = {}
+    for name, content in results:
+        if name != tool:
+            continue
+        for line in content.splitlines():
+            key, separator, value = line.partition(":")
+            if not separator:
+                continue
+            fields[key] = value.strip()
+    return fields
+
+
+def _artifact_residue(workdir: Path) -> bool:
+    for path in workdir.rglob(".orbit-artifact-*"):
+        if path.name == ".orbit-artifact-state" and path.is_dir() and not any(path.iterdir()):
+            continue
+        return True
+    return False
+
+
+def _peak_rss_bytes(pid: int | None) -> int | None:
+    if pid is None:
+        return None
+    try:
+        for line in Path(f"/proc/{pid}/status").read_text(encoding="ascii").splitlines():
+            if line.startswith("VmHWM:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _has_control_markup(text: str) -> bool:
+    markers = (
+        "<think>", "</think>", "<|channel>", "<channel|>",
+        "<|im_start|>", "<|im_end|>", "<|tool_call|>",
+        "<tool_call>", "</tool_call>", "<start_of_turn>", "<end_of_turn>",
+    )
+    return any(marker in text for marker in markers)
+
+
+def _overall(common, results) -> Status:
+    common_statuses = [item.status for item in common]
+    applicable = [item.status for item in results if item.applicable]
+    if Status.FAIL in common_statuses or Status.FAIL in applicable:
+        return Status.FAIL
+    if Status.TECHNICAL_STOP in common_statuses or Status.TECHNICAL_STOP in applicable:
+        return Status.TECHNICAL_STOP
+    if Status.PASS in applicable:
+        return Status.PASS
+    return Status.NOT_APPLICABLE

--- a/src/orbit/qualification/schema.py
+++ b/src/orbit/qualification/schema.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+import math
+from typing import Any
+
+
+class Status(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    TECHNICAL_STOP = "TECHNICAL_STOP"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class ParityMode(str, Enum):
+    EXACT = "exact"
+    STRUCTURAL = "structural"
+
+
+class ComparisonMode(str, Enum):
+    OPTIMIZATION = "optimization"
+    CROSS_MODEL = "cross_model"
+
+
+@dataclass(frozen=True)
+class Reason:
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ToolCallRecord:
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CallMetric:
+    phase: str
+    input_tokens: int | None
+    evaluated_tokens: int | None
+    cached_tokens: int | None
+    output_tokens: int | None
+    prefill_tokens_per_second: float | None
+    generation_tokens_per_second: float | None
+    wall_seconds: float | None
+    finish_reason: str | None
+    retry_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class AggregateMetrics:
+    input_tokens: int | None
+    evaluated_tokens: int | None
+    cached_tokens: int | None
+    output_tokens: int | None
+    calls: int
+    wall_seconds: float
+    prefill_tokens_per_second: float | None
+    generation_tokens_per_second: float | None
+    peak_rss_bytes: int | None
+    ttft_seconds: None = None
+
+    @classmethod
+    def from_calls(
+        cls,
+        calls: tuple[CallMetric, ...],
+        wall_seconds: float,
+        peak_rss_bytes: int | None,
+    ) -> AggregateMetrics:
+        input_tokens = _complete_sum(item.input_tokens for item in calls)
+        evaluated = _complete_sum(item.evaluated_tokens for item in calls)
+        cached = _complete_sum(item.cached_tokens for item in calls)
+        output = _complete_sum(item.output_tokens for item in calls)
+        return cls(
+            input_tokens=input_tokens, evaluated_tokens=evaluated, cached_tokens=cached, output_tokens=output,
+            calls=len(calls), wall_seconds=wall_seconds,
+            prefill_tokens_per_second=_weighted_rate(calls, "evaluated_tokens", "prefill_tokens_per_second"),
+            generation_tokens_per_second=_weighted_rate(calls, "output_tokens", "generation_tokens_per_second"),
+            peak_rss_bytes=peak_rss_bytes,
+        )
+
+
+@dataclass(frozen=True)
+class ArtifactEvidence:
+    path: str
+    published: bool
+    verified: bool
+    exists: bool
+    byte_count: int | None
+    sha256: str | None
+    publication_action: str | None = None
+    verification_check: str | None = None
+    canonical_json_sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class LifecycleOutcome:
+    clean: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class FixtureObservation:
+    route: str | None
+    tool_calls: tuple[ToolCallRecord, ...]
+    executed_tools: tuple[str, ...]
+    final_output: str
+    finish_reason: str | None
+    model_call_count: int
+    retry_count: int
+    calls: tuple[CallMetric, ...]
+    artifact: ArtifactEvidence | None
+    lifecycle: LifecycleOutcome
+    peak_rss_bytes: int | None
+    wall_seconds: float | None = None
+    protocol_issue: str | None = None
+
+
+@dataclass(frozen=True)
+class ParityResult:
+    comparison_mode: ComparisonMode
+    mode: ParityMode
+    equivalent: bool
+    performance_comparison_valid: bool
+    mismatches: tuple[str, ...]
+    performance: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class FixtureResult:
+    name: str
+    capability: str
+    fixture_hash: str
+    status: Status
+    reason: Reason
+    applicable: bool
+    route: str | None
+    tool_calls: tuple[ToolCallRecord, ...]
+    executed_tools: tuple[str, ...]
+    final_output_sha256: str | None
+    finish_reason: str | None
+    model_call_count: int
+    retry_count: int
+    calls: tuple[CallMetric, ...]
+    aggregate_metrics: AggregateMetrics
+    artifact: ArtifactEvidence | None
+    lifecycle: LifecycleOutcome
+
+
+@dataclass(frozen=True)
+class CommonGate:
+    name: str
+    status: Status
+    reason: Reason
+
+
+@dataclass(frozen=True)
+class RunProvenance:
+    qualification_schema_version: int
+    fixture_set_hash: str
+    git_revision: str | None
+    profile_identity: str
+    model_identity: str | None
+    template_identity: str | None
+    template_hash: str | None
+    backend_identity: str | None
+    backend_revision: str | None
+    runtime_configuration: dict[str, Any]
+    hardware: dict[str, Any]
+    measurement_scope: dict[str, str]
+
+
+@dataclass(frozen=True)
+class QualificationRun:
+    provenance: RunProvenance
+    common: tuple[CommonGate, ...]
+    fixtures: tuple[FixtureResult, ...]
+    aggregate_metrics: AggregateMetrics
+    overall_status: Status
+    overall_detail: str
+
+
+def as_primitive(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return {item.name: as_primitive(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, dict):
+        return {str(key): as_primitive(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [as_primitive(item) for item in value]
+    return value
+
+
+def _complete_sum(values) -> int | None:
+    items = tuple(values)
+    return sum(items) if all(type(item) is int and item >= 0 for item in items) else None
+
+
+def _weighted_rate(calls: tuple[CallMetric, ...], token_field: str, rate_field: str) -> float | None:
+    pairs = tuple((getattr(item, token_field), getattr(item, rate_field)) for item in calls)
+    if any(type(tokens) is not int or tokens < 0 for tokens, _rate in pairs):
+        return None
+    contributing = tuple((tokens, rate) for tokens, rate in pairs if tokens)
+    if not contributing or any(
+        not isinstance(rate, (int, float)) or isinstance(rate, bool) or not math.isfinite(rate) or rate <= 0
+        for _tokens, rate in contributing
+    ):
+        return None
+    total = sum(tokens for tokens, _rate in contributing)
+    seconds = sum(tokens / rate for tokens, rate in contributing)
+    return total / seconds if seconds else None

--- a/src/orbit/qualification/validators.py
+++ b/src/orbit/qualification/validators.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from .fixtures import FixtureSpec
+from .schema import (
+    AggregateMetrics, ArtifactEvidence, ComparisonMode, FixtureObservation, FixtureResult,
+    LifecycleOutcome, ParityMode, ParityResult, Reason, Status,
+)
+
+
+def validate_observation(
+    fixture: FixtureSpec,
+    observation: FixtureObservation,
+    *,
+    workdir: Path | None = None,
+) -> FixtureResult:
+    failure = _first_failure(fixture, observation, workdir)
+    status = Status.FAIL if failure else Status.PASS
+    reason = failure or Reason("validated", "all deterministic expectations passed")
+    return _result(fixture, observation, status, reason, applicable=True)
+
+
+def _result(
+    fixture: FixtureSpec,
+    observation: FixtureObservation,
+    status: Status,
+    reason: Reason,
+    *,
+    applicable: bool,
+) -> FixtureResult:
+    wall = observation.wall_seconds
+    if wall is None:
+        wall = sum(item.wall_seconds or 0.0 for item in observation.calls)
+    return FixtureResult(
+        name=fixture.name,
+        capability=fixture.capability,
+        fixture_hash=fixture.fixture_hash,
+        status=status,
+        reason=reason,
+        applicable=applicable,
+        route=observation.route,
+        tool_calls=observation.tool_calls,
+        executed_tools=observation.executed_tools,
+        final_output_sha256=(
+            hashlib.sha256(observation.final_output.encode("utf-8")).hexdigest()
+            if observation.model_call_count or observation.final_output
+            else None
+        ),
+        finish_reason=observation.finish_reason,
+        model_call_count=observation.model_call_count,
+        retry_count=observation.retry_count,
+        calls=observation.calls,
+        aggregate_metrics=AggregateMetrics.from_calls(
+            observation.calls,
+            wall,
+            observation.peak_rss_bytes,
+        ),
+        artifact=observation.artifact,
+        lifecycle=observation.lifecycle,
+    )
+
+
+def unavailable_result(
+    fixture: FixtureSpec,
+    *,
+    code: str,
+    detail: str,
+    status: Status = Status.NOT_APPLICABLE,
+) -> FixtureResult:
+    observation = FixtureObservation(
+        route=None,
+        tool_calls=(),
+        executed_tools=(),
+        final_output="",
+        finish_reason=None,
+        model_call_count=0,
+        retry_count=0,
+        calls=(),
+        artifact=None,
+        lifecycle=LifecycleOutcome(clean=True, detail="not executed"),
+        peak_rss_bytes=None,
+        wall_seconds=0.0,
+    )
+    return _result(
+        fixture,
+        observation,
+        status,
+        Reason(code, detail),
+        applicable=status is not Status.NOT_APPLICABLE,
+    )
+
+
+def compare_fixture_results(
+    fixture: FixtureSpec,
+    baseline: FixtureResult,
+    candidate: FixtureResult,
+    *,
+    comparison_mode: ComparisonMode = ComparisonMode.OPTIMIZATION,
+) -> ParityResult:
+    mismatches: list[str] = []
+    if baseline.status is not Status.PASS or candidate.status is not Status.PASS:
+        mismatches.append("status")
+    _different(mismatches, "route", baseline.route, candidate.route)
+    baseline_tools = _parity_tools(fixture, baseline, comparison_mode)
+    candidate_tools = _parity_tools(fixture, candidate, comparison_mode)
+    _different(mismatches, "tool_calls", baseline_tools, candidate_tools)
+    _different(mismatches, "executed_tools", baseline.executed_tools, candidate.executed_tools)
+    _different(mismatches, "finish_reason", baseline.finish_reason, candidate.finish_reason)
+    _different(mismatches, "artifact_state", _artifact_state(baseline.artifact), _artifact_state(candidate.artifact))
+    if comparison_mode is ComparisonMode.OPTIMIZATION and fixture.parity_mode is ParityMode.EXACT:
+        _different(
+            mismatches,
+            "output_hash",
+            baseline.final_output_sha256,
+            candidate.final_output_sha256,
+        )
+        _different(mismatches, "model_call_count", baseline.model_call_count, candidate.model_call_count)
+        _different(mismatches, "retry_count", baseline.retry_count, candidate.retry_count)
+    unique = tuple(dict.fromkeys(mismatches))
+    equivalent = not unique
+    performance = None
+    performance_valid = False
+    performance_mismatches: list[str] = []
+    if comparison_mode is ComparisonMode.OPTIMIZATION and equivalent:
+        baseline_work = _model_work(baseline)
+        candidate_work = _model_work(candidate)
+        if baseline_work is None or candidate_work is None:
+            performance_mismatches.append("model_work_unavailable")
+        else:
+            _different(performance_mismatches, "model_work", baseline_work, candidate_work)
+        performance_valid = not performance_mismatches
+    all_mismatches = tuple(dict.fromkeys([*unique, *performance_mismatches]))
+    if performance_valid:
+        performance = {
+            "baseline": baseline.aggregate_metrics,
+            "candidate": candidate.aggregate_metrics,
+        }
+    return ParityResult(
+        comparison_mode=comparison_mode,
+        mode=fixture.parity_mode,
+        equivalent=equivalent,
+        performance_comparison_valid=performance_valid,
+        mismatches=all_mismatches,
+        performance=performance,
+    )
+
+
+def _first_failure(
+    fixture: FixtureSpec,
+    observation: FixtureObservation,
+    workdir: Path | None,
+) -> Reason | None:
+    expect = fixture.expect
+    if not observation.lifecycle.clean:
+        return Reason("lifecycle_not_clean", observation.lifecycle.detail)
+    if observation.protocol_issue is not None:
+        return Reason("protocol_leak", observation.protocol_issue)
+    if observation.finish_reason != expect.finish_reason:
+        return Reason(
+            "finish_reason_mismatch",
+            f"expected {expect.finish_reason!r}, got {observation.finish_reason!r}",
+        )
+    if observation.model_call_count > expect.max_model_calls:
+        return Reason(
+            "model_call_limit",
+            f"expected at most {expect.max_model_calls}, got {observation.model_call_count}",
+        )
+    if expect.route is not None and observation.route != expect.route:
+        return Reason("route_mismatch", f"expected {expect.route!r}, got {observation.route!r}")
+    if len(observation.tool_calls) != len(expect.tool_calls):
+        return Reason(
+            "tool_call_count_mismatch",
+            f"expected {len(expect.tool_calls)}, got {len(observation.tool_calls)}",
+        )
+    for index, (expected, actual) in enumerate(zip(expect.tool_calls, observation.tool_calls)):
+        if expected.name != actual.name:
+            return Reason(
+                "tool_name_mismatch",
+                f"call {index}: expected {expected.name!r}, got {actual.name!r}",
+            )
+        if expected.arguments is not None and expected.arguments != actual.arguments:
+            return Reason(
+                "tool_arguments_mismatch",
+                f"call {index}: typed arguments differ",
+            )
+    if expect.route is None and observation.executed_tools != tuple(item.name for item in expect.tool_calls):
+        return Reason("tool_execution_mismatch", "ordered executed tools differ from selected tools")
+    if expect.exact_output is not None and observation.final_output != expect.exact_output:
+        return Reason("exact_output_mismatch", "visible output differs from authoritative fixture text")
+    if expect.final_reports_workdir and (
+        workdir is None or str(workdir.resolve()) not in observation.final_output
+    ):
+        return Reason("final_workdir_mismatch", "final output does not report the fixture workdir")
+    if expect.artifact is not None:
+        return _artifact_failure(expect.artifact, observation.artifact)
+    return None
+
+
+def _artifact_failure(expected, actual: ArtifactEvidence | None) -> Reason | None:
+    if actual is None:
+        return Reason("artifact_evidence_missing", "no artifact evidence was captured")
+    if actual.path != expected.path:
+        return Reason("artifact_path_mismatch", f"expected {expected.path!r}, got {actual.path!r}")
+    if expected.publication and not (actual.published and actual.exists):
+        return Reason("artifact_publication_missing", "artifact was not published and present")
+    if expected.verification and not actual.verified:
+        return Reason("artifact_verification_missing", "model-selected verification did not complete")
+    if actual.byte_count is None or actual.sha256 is None:
+        return Reason("artifact_hash_missing", "byte count or SHA-256 is unavailable")
+    if actual.canonical_json_sha256 != expected.canonical_json_sha256:
+        return Reason("artifact_json_mismatch", "parsed JSON value differs from the fixture")
+    return None
+
+
+def _artifact_state(value: ArtifactEvidence | None):
+    if value is None:
+        return None
+    return (
+        value.path,
+        value.published,
+        value.verified,
+        value.exists,
+        value.canonical_json_sha256,
+    )
+
+
+def _model_work(result: FixtureResult):
+    if any(item.input_tokens is None or item.output_tokens is None for item in result.calls):
+        return None
+    return tuple(
+        (
+            item.phase,
+            item.input_tokens,
+            item.output_tokens,
+            item.retry_reason,
+        )
+        for item in result.calls
+    )
+
+
+def _parity_tools(fixture: FixtureSpec, result: FixtureResult, mode: ComparisonMode):
+    if mode is ComparisonMode.OPTIMIZATION:
+        return result.tool_calls
+    return tuple(
+        (actual.name, actual.arguments if expected.arguments is not None else None)
+        for expected, actual in zip(fixture.expect.tool_calls, result.tool_calls)
+    )
+
+
+def _different(items: list[str], name: str, baseline, candidate) -> None:
+    if baseline != candidate:
+        items.append(name)

--- a/tests/test_qualification_core.py
+++ b/tests/test_qualification_core.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.backend.base import ChatResult
+from orbit.qualification.fixtures import load_fixture_text
+from orbit.qualification.reporting import format_summary, result_json
+from orbit.qualification.runner import QualificationRunner, RuntimeFixtureExecutor, _artifact_evidence, compare_runs
+from orbit.qualification.schema import (
+    AggregateMetrics, ArtifactEvidence, CallMetric, ComparisonMode, FixtureObservation, LifecycleOutcome,
+    RunProvenance, Status, ToolCallRecord,
+)
+from orbit.qualification.validators import compare_fixture_results, validate_observation
+
+
+def fixture(*, artifact: bool = False):
+    expect: dict[str, object] = {
+        "route": "FILESYSTEM", "tool_calls": [{"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}],
+        "finish_reason": "stop", "max_model_calls": 3,
+    }
+    capability = "tools"
+    if artifact:
+        capability = "artifacts"
+        expect = {
+            "tool_calls": [{"name": "write_artifact"}, {"name": "verify_artifact"}],
+            "finish_reason": "stop", "max_model_calls": 5,
+            "artifact": {"path": "qualification.json", "json_equals": {"orbit": "qualified", "version": 1},
+                         "publication": True, "verification": True},
+        }
+    payload = {"schema_version": 1, "fixtures": [{
+        "name": "fixture", "capability": capability, "profiles": ["profile-a"],
+        "request": {"prompt": "test", "tools": True}, "expect": expect,
+        "parity": {"mode": "structural"},
+    }]}
+    return load_fixture_text(json.dumps(payload)).fixtures[0]
+
+
+def call(
+    phase: str = "route", *, input_tokens: int | None = 800, evaluated: int = 32,
+    cached: int | None = 768, output: int | None = 5, prefill: float | None = 30.0,
+) -> CallMetric:
+    return CallMetric(phase, input_tokens, evaluated, cached, output, prefill, 8.0, 1.5, "stop")
+
+
+def observation(**changes: object) -> FixtureObservation:
+    values: dict[str, object] = {
+        "route": "FILESYSTEM", "tool_calls": (ToolCallRecord("exec_shell_full_command", {"command": "pwd"}),),
+        "executed_tools": (),
+        "final_output": "/tmp/workdir", "finish_reason": "stop", "model_call_count": 2,
+        "retry_count": 0, "calls": (call(), call("final_from_tool")), "artifact": None,
+        "lifecycle": LifecycleOutcome(True, "clean"), "peak_rss_bytes": 2048,
+    }
+    values.update(changes)
+    return FixtureObservation(**values)  # type: ignore[arg-type]
+
+
+def provenance(fixture_hash: str) -> RunProvenance:
+    return RunProvenance(1, fixture_hash, "deadbeef", "profile-a", "model-a", "embedded", "abc",
+                         "orbit-native", "rev-a", {"ctx": 8192}, {"cpu": "fake"},
+                         {"aggregate_wall_seconds": "fixtures", "peak_rss_bytes": "fake"})
+
+
+class FakeExecutor:
+    def __init__(self, error: bool = False) -> None:
+        self.error = error
+        self.names: list[str] = []
+
+    def execute(self, item, workdir: Path) -> FixtureObservation:
+        self.names.append(item.name)
+        if self.error:
+            raise RuntimeError("sensitive backend detail")
+        return FixtureObservation("CHAT", (), (), "OK", "stop", 1, 0, (call("chat"),), None,
+                                  LifecycleOutcome(True, "clean"), 2048)
+
+
+class FakeChatBackend:
+    def __init__(self, content: str = "OK") -> None:
+        self.content = content
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        return ChatResult(self.content, "fake", "stop", [], 10, 1, 0, 20.0, 5.0)
+
+
+class QualificationValidationTests(unittest.TestCase):
+    def test_exact_route_and_arguments_pass(self) -> None:
+        result = validate_observation(fixture(), observation())
+        self.assertEqual((result.status, result.reason.code), (Status.PASS, "validated"))
+
+    def test_route_argument_finish_call_and_lifecycle_failures(self) -> None:
+        cases = (
+            (observation(route="CHAT"), "route_mismatch"),
+            (observation(tool_calls=(ToolCallRecord("exec_shell_full_command", {"command": "pwd", "timeout": 10}),)), "tool_arguments_mismatch"),
+            (observation(finish_reason="length"), "finish_reason_mismatch"),
+            (observation(model_call_count=4), "model_call_limit"),
+            (observation(lifecycle=LifecycleOutcome(False, "residue")), "lifecycle_not_clean"),
+        )
+        for value, reason in cases:
+            with self.subTest(reason=reason):
+                self.assertEqual(validate_observation(fixture(), value).reason.code, reason)
+
+    def test_artifact_publication_verification_and_json_are_structural(self) -> None:
+        raw = b'{"version":1,"orbit":"qualified"}\n'
+        canonical = hashlib.sha256(b'{"orbit":"qualified","version":1}').hexdigest()
+        evidence = ArtifactEvidence("qualification.json", True, True, True, len(raw),
+                                    hashlib.sha256(raw).hexdigest(), "created", "text_integrity", canonical)
+        value = observation(route=None, tool_calls=(ToolCallRecord("write_artifact", {}), ToolCallRecord("verify_artifact", {})),
+                            executed_tools=("write_artifact", "verify_artifact"), artifact=evidence)
+        self.assertEqual(validate_observation(fixture(artifact=True), value).status, Status.PASS)
+        missing_execution = observation(route=None, tool_calls=value.tool_calls, executed_tools=(), artifact=evidence)
+        self.assertEqual(validate_observation(fixture(artifact=True), missing_execution).reason.code,
+                         "tool_execution_mismatch")
+        bad = observation(route=None, tool_calls=value.tool_calls, executed_tools=value.executed_tools, artifact=ArtifactEvidence(
+            "qualification.json", True, False, True, 2, hashlib.sha256(b"{}").hexdigest()))
+        self.assertEqual(validate_observation(fixture(artifact=True), bad).reason.code, "artifact_verification_missing")
+
+    def test_artifact_evidence_is_bound_to_actual_path_size_and_hash(self) -> None:
+        item = fixture(artifact=True)
+        raw = b'{"orbit":"qualified","version":1}'
+        digest = hashlib.sha256(raw).hexdigest()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "qualification.json").write_bytes(raw)
+            valid = [("write_artifact", f"artifact_publication: complete\npath: qualification.json\nbytes: {len(raw)}\nsha256: {digest}\npublication_action: created"),
+                     ("verify_artifact", f"artifact_verification: complete\npath: qualification.json\nbytes: {len(raw)}\nsha256: {digest}\npublication_action: created\nstatus: pass")]
+            self.assertTrue(_artifact_evidence(item, root, valid).verified)  # type: ignore[union-attr]
+            wrong = [(name, content.replace("path: qualification.json", "path: other.json")) for name, content in valid]
+            self.assertFalse(_artifact_evidence(item, root, wrong).published)  # type: ignore[union-attr]
+
+    def test_optimization_parity_requires_equivalent_work(self) -> None:
+        item = fixture()
+        baseline = validate_observation(item, observation())
+        same = compare_fixture_results(item, baseline, validate_observation(item, observation()))
+        self.assertTrue(same.performance_comparison_valid)
+        different = validate_observation(item, observation(calls=(call(input_tokens=801, evaluated=33), call("final_from_tool"))))
+        parity = compare_fixture_results(item, baseline, different)
+        self.assertTrue(parity.equivalent)
+        self.assertFalse(parity.performance_comparison_valid)
+        self.assertIn("model_work", parity.mismatches)
+
+    def test_optimization_parity_allows_evaluated_cached_redistribution(self) -> None:
+        item = fixture()
+        baseline = validate_observation(item, observation())
+        redistributed = observation(calls=(call(evaluated=100, cached=700), call("final_from_tool")))
+        parity = compare_fixture_results(item, baseline, validate_observation(item, redistributed))
+        self.assertTrue(parity.equivalent)
+        self.assertTrue(parity.performance_comparison_valid)
+
+    def test_aggregate_rates_are_weighted_and_missing_metrics_propagate(self) -> None:
+        calls = (call(input_tokens=100, evaluated=100, cached=0, prefill=10.0),
+                 call(input_tokens=300, evaluated=300, cached=0, prefill=30.0))
+        aggregate = AggregateMetrics.from_calls(calls, 2.0, None)
+        self.assertEqual(aggregate.input_tokens, 400)
+        self.assertAlmostEqual(aggregate.prefill_tokens_per_second or 0, 20.0)
+        incomplete = AggregateMetrics.from_calls(
+            (calls[0], call(input_tokens=300, evaluated=300, cached=None, prefill=None)), 2.0, None,
+        )
+        self.assertIsNone(incomplete.cached_tokens)
+        self.assertIsNone(incomplete.prefill_tokens_per_second)
+
+    def test_missing_model_work_invalidates_performance_only(self) -> None:
+        item = fixture()
+        baseline = validate_observation(item, observation())
+        missing = observation(calls=(call(input_tokens=None), call("final_from_tool")))
+        parity = compare_fixture_results(item, baseline, validate_observation(item, missing))
+        self.assertTrue(parity.equivalent)
+        self.assertFalse(parity.performance_comparison_valid)
+        self.assertIn("model_work_unavailable", parity.mismatches)
+
+    def test_argument_mismatch_invalidates_optimization_comparison(self) -> None:
+        item = fixture()
+        left = validate_observation(item, observation())
+        right = validate_observation(item, observation(tool_calls=(
+            ToolCallRecord("exec_shell_full_command", {"command": "pwd", "timeout": 10}),)))
+        parity = compare_fixture_results(item, left, right)
+        self.assertFalse(parity.equivalent)
+        self.assertFalse(parity.performance_comparison_valid)
+
+    def test_cross_model_parity_ignores_token_and_call_count_diversity(self) -> None:
+        item = fixture()
+        left = validate_observation(item, observation())
+        right = validate_observation(item, observation(
+            final_output="model-specific wording", model_call_count=3,
+            calls=(call(input_tokens=50, evaluated=50, cached=0, output=9),) * 3,
+        ))
+        parity = compare_fixture_results(item, left, right, comparison_mode=ComparisonMode.CROSS_MODEL)
+        self.assertTrue(parity.equivalent)
+        self.assertFalse(parity.performance_comparison_valid)
+        self.assertIsNone(parity.performance)
+
+    def test_visible_control_markup_fails_protocol_gate(self) -> None:
+        result = validate_observation(fixture(), observation(protocol_issue="visible_control_markup"))
+        self.assertEqual(result.reason.code, "protocol_leak")
+
+
+class QualificationRunnerReportingTests(unittest.TestCase):
+    def fixture_set(self):
+        payload = {"schema_version": 1, "fixtures": [
+            {"name": "simple_chat", "capability": "chat", "profiles": ["profile-a"],
+             "request": {"prompt": "Reply OK", "tools": False},
+             "expect": {"finish_reason": "stop", "max_model_calls": 1, "exact_output": "OK"},
+             "parity": {"mode": "exact"}},
+            {"name": "other", "capability": "tools", "profiles": ["profile-b"],
+             "request": {"prompt": "pwd", "tools": True},
+             "expect": {"finish_reason": "stop", "max_model_calls": 1},
+             "parity": {"mode": "structural"}},
+            {"name": "unsupported", "capability": "artifacts", "profiles": ["profile-a"],
+             "request": {"prompt": "write", "tools": True},
+             "expect": {"finish_reason": "stop", "max_model_calls": 3,
+                        "tool_calls": [{"name": "write_artifact"}, {"name": "verify_artifact"}],
+                        "artifact": {"path": "x.json", "json_equals": 1,
+                                     "publication": True, "verification": True}},
+             "parity": {"mode": "structural"}},
+        ]}
+        return load_fixture_text(json.dumps(payload))
+
+    def run_harness(self, profile: dict[str, object], executor: FakeExecutor, names=None):
+        fixtures = self.fixture_set()
+        with tempfile.TemporaryDirectory() as directory:
+            return QualificationRunner(fixtures, profile, provenance(fixtures.content_hash), executor,
+                                       Path(directory)).run(names)
+
+    def test_pass_and_not_applicable_are_distinct(self) -> None:
+        executor = FakeExecutor()
+        run = self.run_harness({"compatibility_profile": "profile-a", "verified": True,
+                        "capabilities": {"chat": True, "tools": True, "write_artifact": False}}, executor)
+        self.assertEqual([item.status for item in run.fixtures],
+                         [Status.PASS, Status.NOT_APPLICABLE, Status.NOT_APPLICABLE])
+        self.assertEqual(executor.names, ["simple_chat"])
+
+    def test_execution_error_is_bounded_technical_stop(self) -> None:
+        run = self.run_harness({"compatibility_profile": "profile-a", "verified": True,
+                        "capabilities": {"chat": True}}, FakeExecutor(True), ("simple_chat",))
+        self.assertEqual(run.fixtures[0].status, Status.TECHNICAL_STOP)
+        self.assertNotIn("sensitive", run.fixtures[0].reason.detail)
+
+    def test_unverified_profile_never_executes(self) -> None:
+        executor = FakeExecutor()
+        run = self.run_harness({"compatibility_profile": "profile-a", "verified": False,
+                        "capabilities": {"chat": True}}, executor)
+        self.assertEqual(run.common[0].status, Status.FAIL)
+        self.assertEqual(executor.names, [])
+
+    def test_all_not_applicable_is_not_a_qualified_pass(self) -> None:
+        run = self.run_harness({"compatibility_profile": "profile-a", "verified": True,
+                        "capabilities": {"chat": False}}, FakeExecutor(), ("simple_chat",))
+        self.assertEqual(run.fixtures[0].status, Status.NOT_APPLICABLE)
+        self.assertEqual(run.overall_status, Status.NOT_APPLICABLE)
+
+    def test_profile_identity_mismatch_fails_without_execution(self) -> None:
+        executor = FakeExecutor()
+        run = self.run_harness({"compatibility_profile": "unknown", "verified": True,
+                        "capabilities": {"chat": True}}, executor, ("simple_chat",))
+        self.assertEqual(run.common[0].status, Status.FAIL)
+        self.assertEqual(executor.names, [])
+
+    def test_json_and_terminal_reporting_are_stable(self) -> None:
+        run = self.run_harness({"compatibility_profile": "profile-a", "verified": True,
+                        "capabilities": {"chat": True}}, FakeExecutor(), ("simple_chat",))
+        payload = json.loads(result_json(run))
+        self.assertEqual(result_json(run), result_json(run))
+        self.assertEqual(payload["fixtures"][0]["status"], "PASS")
+        self.assertIsNone(payload["aggregate_metrics"]["ttft_seconds"])
+        self.assertEqual(payload["provenance"]["measurement_scope"]["peak_rss_bytes"], "fake")
+        summary = format_summary(run)
+        self.assertIn("QUALIFIED FOR TESTED CAPABILITIES", summary)
+        self.assertNotIn("score", summary.lower())
+
+    def test_run_level_cross_model_comparison_is_descriptive(self) -> None:
+        profile = {"compatibility_profile": "profile-a", "verified": True,
+                   "capabilities": {"chat": True}}
+        left = self.run_harness(profile, FakeExecutor(), ("simple_chat",))
+        right = self.run_harness(profile, FakeExecutor(), ("simple_chat",))
+        comparison = compare_runs(self.fixture_set(), left, right, comparison_mode=ComparisonMode.CROSS_MODEL)
+        self.assertTrue(comparison[0].equivalent)
+        self.assertFalse(comparison[0].performance_comparison_valid)
+
+    def test_exact_chat_output_mismatch_fails(self) -> None:
+        item = self.fixture_set().fixtures[0]
+        value = FixtureObservation("CHAT", (), (), "Almost OK", "stop", 1, 0, (call("chat"),), None,
+                                   LifecycleOutcome(True, "clean"), 1024)
+        self.assertEqual(validate_observation(item, value).reason.code, "exact_output_mismatch")
+
+    def test_runtime_adapter_observes_production_chat_runtime(self) -> None:
+        item = self.fixture_set().fixtures[0]
+        with tempfile.TemporaryDirectory() as directory:
+            value = RuntimeFixtureExecutor(FakeChatBackend()).execute(item, Path(directory))
+        self.assertEqual(value.final_output, "OK")
+        self.assertEqual(value.calls[0].input_tokens, 10)
+        self.assertEqual(value.calls[0].evaluated_tokens, 10)
+        self.assertEqual(value.model_call_count, 1)
+
+    def test_runtime_adapter_detects_visible_reasoning_markup(self) -> None:
+        item = self.fixture_set().fixtures[0]
+        with tempfile.TemporaryDirectory() as directory:
+            value = RuntimeFixtureExecutor(FakeChatBackend("<think>private</think>OK")).execute(item, Path(directory))
+        self.assertEqual(value.protocol_issue, "visible_control_markup")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qualification_core.py
+++ b/tests/test_qualification_core.py
@@ -299,6 +299,42 @@ class QualificationRunnerReportingTests(unittest.TestCase):
             value = RuntimeFixtureExecutor(FakeChatBackend("<think>private</think>OK")).execute(item, Path(directory))
         self.assertEqual(value.protocol_issue, "visible_control_markup")
 
+    def test_runtime_adapter_allows_authoritative_inert_control_text(self) -> None:
+        payload = {"schema_version": 1, "fixtures": [{
+            "name": "quoted_marker", "capability": "chat", "profiles": ["profile-a"],
+            "request": {"prompt": "Quote the literal marker.", "tools": False},
+            "expect": {
+                "finish_reason": "stop", "max_model_calls": 1,
+                "exact_output": 'The literal string "<tool_call>" is inert.',
+            },
+            "parity": {"mode": "exact"},
+        }]}
+        item = load_fixture_text(json.dumps(payload)).fixtures[0]
+        with tempfile.TemporaryDirectory() as directory:
+            value = RuntimeFixtureExecutor(
+                FakeChatBackend('The literal string "<tool_call>" is inert.')
+            ).execute(item, Path(directory))
+        self.assertIsNone(value.protocol_issue)
+
+    def test_runtime_adapter_rejects_inconsistent_cache_accounting(self) -> None:
+        item = self.fixture_set().fixtures[0]
+        backend = FakeChatBackend()
+        original_chat = backend.chat
+
+        def inconsistent_chat(messages, *, temperature, max_tokens, tools=None):
+            result = original_chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+            return ChatResult(
+                result.content, result.model, result.finish_reason, result.tool_calls,
+                10, result.completion_tokens, 20, result.prompt_tokens_per_second,
+                result.generation_tokens_per_second,
+            )
+
+        backend.chat = inconsistent_chat  # type: ignore[method-assign]
+        with tempfile.TemporaryDirectory() as directory:
+            value = RuntimeFixtureExecutor(backend).execute(item, Path(directory))
+        self.assertIsNone(value.calls[0].evaluated_tokens)
+        self.assertIsNone(value.calls[0].cached_tokens)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qualification_fixtures.py
+++ b/tests/test_qualification_fixtures.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from orbit.qualification.fixtures import FixtureError, load_fixture_text
+
+
+def document() -> dict[str, object]:
+    return {"schema_version": 1, "fixtures": [{
+        "name": "simple_chat", "capability": "chat", "profiles": ["profile-a"],
+        "request": {"prompt": "Reply exactly OK", "tools": False},
+        "expect": {"finish_reason": "stop", "max_model_calls": 1, "exact_output": "OK"},
+        "parity": {"mode": "exact"},
+    }]}
+
+
+class QualificationFixtureTests(unittest.TestCase):
+    def test_valid_schema_and_canonical_hash(self) -> None:
+        compact = load_fixture_text(json.dumps(document(), separators=(",", ":")))
+        formatted = load_fixture_text(json.dumps(document(), indent=2, sort_keys=True))
+        self.assertEqual(compact.content_hash, formatted.content_hash)
+        self.assertEqual(compact.fixtures[0].fixture_hash, formatted.fixtures[0].fixture_hash)
+        self.assertEqual(compact.fixtures[0].request.prompt, "Reply exactly OK")
+
+    def test_duplicate_key_is_rejected(self) -> None:
+        with self.assertRaisesRegex(FixtureError, "duplicate_key"):
+            load_fixture_text('{"schema_version":1,"schema_version":1,"fixtures":[]}')
+
+    def test_unknown_keys_are_rejected_at_each_level(self) -> None:
+        for path in ("root", "request"):
+            value = document()
+            if path == "root":
+                value["future"] = True
+            else:
+                value["fixtures"][0]["request"]["temperature"] = 0  # type: ignore[index]
+            with self.subTest(path=path), self.assertRaisesRegex(FixtureError, "unknown_key"):
+                load_fixture_text(json.dumps(value))
+
+    def test_missing_required_field_is_rejected(self) -> None:
+        payload = document()
+        del payload["fixtures"][0]["request"]["prompt"]  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "missing_key"):
+            load_fixture_text(json.dumps(payload))
+
+    def test_bad_version_type_and_value_are_rejected(self) -> None:
+        for value, reason in ((2, "unsupported_schema_version"), (True, "invalid_type")):
+            payload = document()
+            payload["schema_version"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(FixtureError, reason):
+                load_fixture_text(json.dumps(payload))
+
+    def test_invalid_field_types_are_rejected(self) -> None:
+        payload = document()
+        payload["fixtures"][0]["expect"]["max_model_calls"] = True  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "invalid_type"):
+            load_fixture_text(json.dumps(payload))
+
+    def test_invalid_parity_duplicate_profile_and_nan_are_rejected(self) -> None:
+        payload = document()
+        payload["fixtures"][0]["parity"]["mode"] = "semantic"  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "invalid_parity_mode"):
+            load_fixture_text(json.dumps(payload))
+        payload = document()
+        payload["fixtures"][0]["profiles"] = ["profile-a", "profile-a"]  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "duplicate_profile"):
+            load_fixture_text(json.dumps(payload))
+        for constant in ("NaN", "Infinity", "-Infinity"):
+            raw = json.dumps(document()).replace('"max_model_calls": 1', f'"max_model_calls": {constant}')
+            with self.subTest(constant=constant), self.assertRaisesRegex(FixtureError, "invalid_constant"):
+                load_fixture_text(raw)
+
+    def test_fixture_names_and_artifact_paths_are_confined(self) -> None:
+        payload = document()
+        payload["fixtures"][0]["name"] = "../escape"  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "invalid_value"):
+            load_fixture_text(json.dumps(payload))
+        payload = json.loads(
+            (Path(__file__).parents[1] / "qualification/fixtures/core-v1.json").read_text()
+        )
+        for invalid in ("../escape.json", "/tmp/escape.json", ".", "bad\x00name"):
+            payload["fixtures"][3]["expect"]["artifact"]["path"] = invalid
+            with self.subTest(path=invalid), self.assertRaisesRegex(FixtureError, "invalid_value"):
+                load_fixture_text(json.dumps(payload))
+
+    def test_capability_names_and_fixture_contracts_are_fail_closed(self) -> None:
+        payload = document()
+        payload["fixtures"][0]["capability"] = "chta"  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "unsupported_capability"):
+            load_fixture_text(json.dumps(payload))
+        payload = document()
+        payload["fixtures"][0]["request"]["tools"] = True  # type: ignore[index]
+        with self.assertRaisesRegex(FixtureError, "invalid_fixture_contract"):
+            load_fixture_text(json.dumps(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a Python-first qualification layer that observes existing Orbit runtime/backend behavior.
- Adds strict, versioned JSON fixtures and canonical `PASS`, `FAIL`, `TECHNICAL_STOP`, and `NOT_APPLICABLE` results.
- Separates same-model optimization parity from cross-model capability qualification.
- Records authoritative token, timing, and RSS provenance with JSON and compact terminal reporting.
- Leaves production runtime and backend behavior unchanged.

## Initial vertical slice

- Deterministic simple chat.
- Exact `pwd` route.
- `pwd` tool execution plus final response.
- Generative JSON artifact plus verification.
- Applies to the verified Gemma, Qwen3.6, and Qwen3-Coder profiles according to declared capabilities.

## Parity

- Correctness and parity are checked before performance.
- Extra typed tool arguments invalidate optimization parity.
- Cross-model qualification permits different wording, token counts, output lengths, and call strategies within fixture bounds.
- No LLM judge and no universal score are introduced.

## Metrics

- Authoritative input, cached, evaluated, and output token accounting.
- Weighted prefill and decode rates with missing data propagated as unavailable.
- Explicit call-wall and fixture-wall semantics.
- Linux server-process `VmHWM` RSS when a server PID is supplied.
- TTFT is intentionally unavailable rather than estimated.

## Validation

- Qualification tests: 30/30 PASS.
- Qualification plus affected profile/runtime/artifact/tool-loop tests: 195/195 PASS.
- Real Qwen3.6 cold/restore validation PASS: `cached=0` on capture and `cached=768` on restore with identical route, tool, arguments, and finish reason.
- `compileall`: PASS.
- Cached diff and whitespace checks: PASS.
- Production behavior: unchanged.

## Known limits

- Four fixtures only.
- No TTFT instrumentation.
- No statistical benchmarking.
- RSS is currently Linux/server-PID specific.
- MTP, multimodal, prefix, prewarm, and release qualification remain specialized and outside this slice.

The first slice contains approximately 1,149 non-test nonblank lines. The size comes from strict validation and metric provenance; it does not introduce a second runtime, plugin framework, DAG, model registry, or LLM-judge subsystem.