### PR TITLE
Add agentic workflow qualification

### DIFF
--- a/qualification/fixtures/workflows-v1.json
+++ b/qualification/fixtures/workflows-v1.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "fixtures": [
+    {
+      "name": "bug_fix_and_test",
+      "capability": "tools",
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "workspace": {
+        "files": [
+          {"path": "calculator.py", "content": "def add(left, right):\n    return left - right\n"},
+          {
+            "path": "test_calculator.py",
+            "content": "import unittest\n\nfrom calculator import add\n\n\nclass CalculatorTests(unittest.TestCase):\n    def test_adds_integers(self):\n        self.assertEqual(add(2, 3), 5)\n        self.assertEqual(add(-1, 1), 0)\n\n\nif __name__ == \"__main__\":\n    unittest.main()\n"
+          },
+          {"path": "README.md", "content": "# Calculator fixture\n\nOnly calculator.py may be changed.\n"}
+        ]
+      },
+      "request": {
+        "prompt": "Inspect this small Python project and fix the bug in calculator.py. Limit the edit scope to the required operator change in calculator.py; test_calculator.py and README.md are reference inputs whose hashes are checked by qualification. After the edit, run `python3 -m unittest -q`. Finish only after that command passes.",
+        "tools": true
+      },
+      "expect": {
+        "finish_reason": "stop",
+        "max_model_calls": 8,
+        "workflow": {
+          "files": [
+            {"path": "calculator.py", "content": "def add(left, right):\n    return left + right\n"}
+          ],
+          "unchanged_files": ["test_calculator.py", "README.md"],
+          "max_tool_calls": 8,
+          "timeout_seconds": 900,
+          "test_runner": "python_unittest"
+        }
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "existing_file_modification",
+      "capability": "tools",
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "workspace": {
+        "files": [
+          {"path": "settings.ini", "content": "[service]\nmode=development\nretries=2\n"},
+          {"path": "notes.txt", "content": "This unrelated file must remain unchanged.\n"}
+        ]
+      },
+      "request": {
+        "prompt": "Inspect settings.ini, then change mode to production and retries to 5. Limit the change scope to those two values in settings.ini while preserving its section, ordering, newline, and every other byte. notes.txt is a reference input whose hash is checked by qualification. Verify the resulting file before answering.",
+        "tools": true
+      },
+      "expect": {
+        "finish_reason": "stop",
+        "max_model_calls": 9,
+        "workflow": {
+          "files": [
+            {"path": "settings.ini", "content": "[service]\nmode=production\nretries=5\n"}
+          ],
+          "unchanged_files": ["notes.txt"],
+          "max_tool_calls": 7,
+          "timeout_seconds": 900
+        }
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "failed_command_recovery",
+      "capability": "tools",
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "workspace": {
+        "files": [
+          {"path": "fallback.txt", "content": "RECOVERY_OK\n"},
+          {"path": "sentinel.txt", "content": "unchanged\n"}
+        ]
+      },
+      "request": {
+        "prompt": "First run exactly `cat missing.txt`; it is expected to fail and a second identical attempt is outside the contract. Recover by reading fallback.txt, then create recovered.txt containing exactly the same bytes as fallback.txt. fallback.txt and sentinel.txt are reference inputs whose hashes are checked by qualification. Verify recovered.txt before answering.",
+        "tools": true
+      },
+      "expect": {
+        "finish_reason": "stop",
+        "max_model_calls": 7,
+        "workflow": {
+          "files": [
+            {"path": "recovered.txt", "content": "RECOVERY_OK\n"}
+          ],
+          "unchanged_files": ["fallback.txt", "sentinel.txt"],
+          "max_tool_calls": 7,
+          "timeout_seconds": 900,
+          "require_recovery": true
+        }
+      },
+      "parity": {"mode": "structural"}
+    }
+  ]
+}

--- a/src/orbit/qualification/fixtures.py
+++ b/src/orbit/qualification/fixtures.py
@@ -46,6 +46,31 @@ class ArtifactExpectation:
 
 
 @dataclass(frozen=True)
+class FileSpec:
+    path: str
+    content: str
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.content.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class WorkspaceSpec:
+    files: tuple[FileSpec, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowExpectation:
+    files: tuple[FileSpec, ...]
+    unchanged_files: tuple[str, ...]
+    max_tool_calls: int
+    timeout_seconds: int
+    test_runner: str | None = None
+    require_recovery: bool = False
+
+
+@dataclass(frozen=True)
 class ExpectSpec:
     finish_reason: str
     max_model_calls: int
@@ -54,6 +79,7 @@ class ExpectSpec:
     exact_output: str | None = None
     final_reports_workdir: bool = False
     artifact: ArtifactExpectation | None = None
+    workflow: WorkflowExpectation | None = None
 
 
 @dataclass(frozen=True)
@@ -65,6 +91,7 @@ class FixtureSpec:
     expect: ExpectSpec
     parity_mode: ParityMode
     fixture_hash: str
+    workspace: WorkspaceSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -100,7 +127,7 @@ def load_fixture_text(text: str) -> FixtureSet:
 
 def _fixture(value: Any, version: int) -> FixtureSpec:
     required = {"name", "capability", "profiles", "request", "expect", "parity"}
-    row = _object(value, "fixture", required)
+    row = _object(value, "fixture", required, {"workspace"})
     name = _identifier(row["name"], "name")
     capability = _identifier(row["capability"], "capability")
     if capability not in CAPABILITY_REQUIREMENTS:
@@ -117,9 +144,10 @@ def _fixture(value: Any, version: int) -> FixtureSpec:
         _fail("invalid_parity_mode", name)
     request = _request(row["request"], name)
     expect = _expect(row["expect"], name)
-    _validate_contract(name, capability, request, expect)
+    workspace = _workspace(row["workspace"], name) if "workspace" in row else None
+    _validate_contract(name, capability, request, expect, workspace)
     digest = hashlib.sha256(_canonical({"schema_version": version, "fixture": row})).hexdigest()
-    return FixtureSpec(name, capability, profiles, request, expect, parity_mode, digest)
+    return FixtureSpec(name, capability, profiles, request, expect, parity_mode, digest, workspace)
 
 
 def _request(value: Any, name: str) -> RequestSpec:
@@ -131,7 +159,7 @@ def _request(value: Any, name: str) -> RequestSpec:
 
 def _expect(value: Any, name: str) -> ExpectSpec:
     required = {"finish_reason", "max_model_calls"}
-    optional = {"route", "tool_calls", "exact_output", "final_reports_workdir", "artifact"}
+    optional = {"route", "tool_calls", "exact_output", "final_reports_workdir", "artifact", "workflow"}
     row = _object(value, f"{name}.expect", required, optional)
     raw_calls = row.get("tool_calls", [])
     if not isinstance(raw_calls, list):
@@ -147,6 +175,7 @@ def _expect(value: Any, name: str) -> ExpectSpec:
         exact_output=_optional_string(row.get("exact_output"), f"{name}.expect.exact_output"),
         final_reports_workdir=report_workdir,
         artifact=_artifact(row["artifact"], name) if "artifact" in row else None,
+        workflow=_workflow(row["workflow"], name) if "workflow" in row else None,
     )
 
 
@@ -164,6 +193,61 @@ def _artifact(value: Any, name: str) -> ArtifactExpectation:
     if not isinstance(row["publication"], bool) or not isinstance(row["verification"], bool):
         _fail("invalid_type", f"{name}.artifact publication/verification")
     return ArtifactExpectation(_relative_path(row["path"], f"{name}.artifact.path"), row["json_equals"], row["publication"], row["verification"])
+
+
+def _workspace(value: Any, name: str) -> WorkspaceSpec:
+    row = _object(value, f"{name}.workspace", {"files"})
+    files = _files(row["files"], f"{name}.workspace.files")
+    _unique_paths(files, "duplicate_workspace_path", name)
+    return WorkspaceSpec(files)
+
+
+def _workflow(value: Any, name: str) -> WorkflowExpectation:
+    required = {"files", "unchanged_files", "max_tool_calls", "timeout_seconds"}
+    row = _object(value, f"{name}.workflow", required, {"test_runner", "require_recovery"})
+    files = _files(row["files"], f"{name}.workflow.files")
+    _unique_paths(files, "duplicate_expected_path", name)
+    raw_unchanged = row["unchanged_files"]
+    if not isinstance(raw_unchanged, list):
+        _fail("invalid_type", f"{name}.workflow.unchanged_files must be an array")
+    unchanged = tuple(_relative_path(item, f"{name}.workflow.unchanged_files") for item in raw_unchanged)
+    if len(unchanged) != len(set(unchanged)):
+        _fail("duplicate_unchanged_path", name)
+    if set(unchanged) & {item.path for item in files}:
+        _fail("invalid_fixture_contract", f"{name} expected and unchanged files overlap")
+    test_runner = row.get("test_runner")
+    if test_runner is not None and test_runner != "python_unittest":
+        _fail("invalid_test_runner", name)
+    require_recovery = row.get("require_recovery", False)
+    if not isinstance(require_recovery, bool):
+        _fail("invalid_type", f"{name}.workflow.require_recovery")
+    return WorkflowExpectation(
+        files=files,
+        unchanged_files=unchanged,
+        max_tool_calls=_bounded_positive(row["max_tool_calls"], f"{name}.workflow.max_tool_calls", 16),
+        timeout_seconds=_bounded_positive(row["timeout_seconds"], f"{name}.workflow.timeout_seconds", 1800),
+        test_runner=test_runner,
+        require_recovery=require_recovery,
+    )
+
+
+def _files(value: Any, path: str) -> tuple[FileSpec, ...]:
+    if not isinstance(value, list) or not value:
+        _fail("invalid_type", f"{path} must be a non-empty array")
+    files = []
+    for index, item in enumerate(value):
+        row = _object(item, f"{path}[{index}]", {"path", "content"})
+        files.append(FileSpec(
+            _relative_path(row["path"], f"{path}[{index}].path"),
+            _text(row["content"], f"{path}[{index}].content"),
+        ))
+    return tuple(files)
+
+
+def _unique_paths(files: tuple[FileSpec, ...], code: str, detail: str) -> None:
+    paths = tuple(item.path for item in files)
+    if len(paths) != len(set(paths)):
+        _fail(code, detail)
 
 
 def _object(value: Any, path: str, required: set[str], optional: set[str] = set()) -> dict[str, Any]:
@@ -190,6 +274,12 @@ def _unique(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 def _string(value: Any, path: str) -> str:
     if not isinstance(value, str) or not value:
         _fail("invalid_type", f"{path} must be a non-empty string")
+    return value
+
+
+def _text(value: Any, path: str) -> str:
+    if not isinstance(value, str):
+        _fail("invalid_type", f"{path} must be a string")
     return value
 
 
@@ -225,11 +315,24 @@ def _positive(value: Any, path: str) -> int:
     return result
 
 
+def _bounded_positive(value: Any, path: str, maximum: int) -> int:
+    result = _positive(value, path)
+    if result > maximum:
+        _fail("invalid_value", f"{path} must be at most {maximum}")
+    return result
+
+
 def _canonical(value: Any) -> bytes:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
-def _validate_contract(name: str, capability: str, request: RequestSpec, expect: ExpectSpec) -> None:
+def _validate_contract(
+    name: str,
+    capability: str,
+    request: RequestSpec,
+    expect: ExpectSpec,
+    workspace: WorkspaceSpec | None,
+) -> None:
     has_tool_contract = bool(expect.route or expect.tool_calls or expect.final_reports_workdir)
     if capability == "chat" and (request.tools or has_tool_contract or expect.artifact is not None):
         _fail("invalid_fixture_contract", f"{name} chat fixture exposes tool behavior")
@@ -237,6 +340,24 @@ def _validate_contract(name: str, capability: str, request: RequestSpec, expect:
         _fail("invalid_fixture_contract", f"{name} tools fixture is inconsistent")
     if capability == "artifacts" and (not request.tools or expect.artifact is None or expect.route is not None):
         _fail("invalid_fixture_contract", f"{name} artifact fixture is inconsistent")
+    if expect.workflow is None:
+        if workspace is not None:
+            _fail("invalid_fixture_contract", f"{name} workspace requires a workflow")
+        return
+    if (
+        capability != "tools"
+        or not request.tools
+        or workspace is None
+        or expect.route is not None
+        or expect.tool_calls
+        or expect.exact_output is not None
+        or expect.final_reports_workdir
+        or expect.artifact is not None
+    ):
+        _fail("invalid_fixture_contract", f"{name} workflow fixture is inconsistent")
+    workspace_paths = {item.path for item in workspace.files}
+    if set(expect.workflow.unchanged_files) - workspace_paths:
+        _fail("invalid_fixture_contract", f"{name} unchanged file is absent from workspace")
 
 
 def _fail(code: str, detail: str):

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -447,7 +447,7 @@ def _unexpected_paths(workdir: Path, allowed_paths: set[str]) -> tuple[str, ...]
         relative = path.relative_to(workdir).as_posix()
         if relative in allowed_paths or relative in allowed_parents:
             continue
-        if _is_declared_python_cache(path.relative_to(workdir), python_sources):
+        if not path.is_symlink() and _is_declared_python_cache(path.relative_to(workdir), python_sources):
             continue
         unexpected.append(relative)
     return tuple(sorted(unexpected))

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import stat
+import subprocess
+import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -19,6 +22,7 @@ from orbit.runtime.command_request import (
 )
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+from orbit.runtime.shell_guardrails import shell_failure_from_output
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 from .fixtures import CAPABILITY_REQUIREMENTS, FixtureSet, FixtureSpec
@@ -28,6 +32,7 @@ from .schema import (
     CallMetric,
     CommonGate,
     ComparisonMode,
+    FileStateEvidence,
     FixtureObservation,
     LifecycleOutcome,
     ParityResult,
@@ -35,7 +40,10 @@ from .schema import (
     Reason,
     RunProvenance,
     Status,
+    TestEvidence,
     ToolCallRecord,
+    ToolOutcomeRecord,
+    WorkflowEvidence,
 )
 from .validators import compare_fixture_results, unavailable_result, validate_observation
 
@@ -74,7 +82,13 @@ class QualificationRunner:
                 fixture_workdir = self.workdir / fixture.name
                 fixture_workdir.mkdir(parents=True, exist_ok=False)
                 try:
+                    _prepare_workspace(fixture, fixture_workdir)
                     observation = self.executor.execute(fixture, fixture_workdir)
+                    if fixture.expect.workflow is not None:
+                        observation = replace(
+                            observation,
+                            workflow=_workflow_evidence(fixture, fixture_workdir, observation),
+                        )
                     results.append(validate_observation(fixture, observation, workdir=fixture_workdir))
                 except Exception as error:
                     results.append(
@@ -166,6 +180,7 @@ class RuntimeFixtureExecutor:
         phase_starts: list[float] = []
         tool_calls: list[ToolCallRecord] = []
         tool_results: list[tuple[str, str]] = []
+        tool_outcomes: list[ToolOutcomeRecord] = []
         protocol_issue = None
 
         def phase_start(_phase: ModelPhaseStart) -> None:
@@ -188,6 +203,7 @@ class RuntimeFixtureExecutor:
 
         def tool_result(name: str, _chars: int, _kind: str, content: str) -> None:
             tool_results.append((name, content))
+            tool_outcomes.append(_tool_outcome(name, content))
 
         route = None
         runtime = ChatRuntime(backend=self.backend)
@@ -219,13 +235,21 @@ class RuntimeFixtureExecutor:
                 on_phase_start=phase_start,
             )
         else:
-            names = tuple(item.name for item in fixture.expect.tool_calls)
+            names = (
+                ("exec_shell_full_command",)
+                if fixture.expect.workflow is not None
+                else tuple(item.name for item in fixture.expect.tool_calls)
+            )
             result = runtime.ask_with_tools(
                 fixture.request.prompt,
                 temperature=0,
                 max_tokens=160,
                 workdir=workdir,
-                max_loops=6,
+                max_loops=(
+                    fixture.expect.max_model_calls
+                    if fixture.expect.workflow is not None
+                    else 6
+                ),
                 tool_names=names or None,
                 on_tool_call=tool_call,
                 on_tool_result=tool_result,
@@ -259,6 +283,7 @@ class RuntimeFixtureExecutor:
             peak_rss_bytes=_peak_rss_bytes(self.process_pid),
             wall_seconds=time.perf_counter() - started,
             protocol_issue=protocol_issue,
+            tool_outcomes=tuple(tool_outcomes),
         )
 
     def _route(self, fixture: FixtureSpec):
@@ -348,6 +373,169 @@ def _tool_record(value: dict[str, Any]) -> ToolCallRecord:
         str(function.get("name") or ""),
         arguments if isinstance(arguments, dict) else {},
     )
+
+
+def _tool_outcome(name: str, content: str) -> ToolOutcomeRecord:
+    failure = shell_failure_from_output(content) if name == "exec_shell_full_command" else None
+    failed = failure is not None or content.startswith("error:") or "\nerror:" in content
+    return ToolOutcomeRecord(
+        name=name,
+        status="failure" if failed else "success",
+        exit_code=failure.exit_code if failure is not None else None,
+        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    )
+
+
+def _prepare_workspace(fixture: FixtureSpec, workdir: Path) -> None:
+    if fixture.workspace is None:
+        return
+    for item in fixture.workspace.files:
+        target = workdir / item.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(item.content, encoding="utf-8", newline="")
+
+
+def _workflow_evidence(
+    fixture: FixtureSpec,
+    workdir: Path,
+    observation: FixtureObservation,
+) -> WorkflowEvidence:
+    expected = fixture.expect.workflow
+    assert expected is not None
+    paths = tuple(dict.fromkeys([*(item.path for item in expected.files), *expected.unchanged_files]))
+    files = tuple(_file_state(workdir, path) for path in paths)
+    allowed_paths = {
+        *(item.path for item in fixture.workspace.files),
+        *(item.path for item in expected.files),
+    }
+    failed = tuple(
+        (index, call)
+        for index, (call, outcome) in enumerate(zip(observation.tool_calls, observation.tool_outcomes))
+        if outcome.status == "failure"
+    )
+    failed_signatures = tuple(
+        (call.name, json.dumps(call.arguments, sort_keys=True, separators=(",", ":")))
+        for _index, call in failed
+    )
+    success_indices = tuple(
+        index for index, outcome in enumerate(observation.tool_outcomes) if outcome.status == "success"
+    )
+    return WorkflowEvidence(
+        files=files,
+        unexpected_paths=_unexpected_paths(workdir, allowed_paths),
+        failed_tool_calls=len(failed),
+        recovery_observed=bool(failed and success_indices and max(success_indices) > failed[0][0]),
+        repeated_failed_command=len(failed_signatures) != len(set(failed_signatures)),
+        test=_run_workflow_test(expected.test_runner, expected.timeout_seconds, workdir, observation),
+    )
+
+
+def _unexpected_paths(workdir: Path, allowed_paths: set[str]) -> tuple[str, ...]:
+    allowed_parents = {
+        parent.as_posix()
+        for value in allowed_paths
+        for parent in Path(value).parents
+        if parent.as_posix() != "."
+    }
+    python_sources = {
+        (Path(value).parent / "__pycache__", Path(value).stem)
+        for value in allowed_paths
+        if value.endswith(".py")
+    }
+    unexpected = []
+    for path in workdir.rglob("*"):
+        relative = path.relative_to(workdir).as_posix()
+        if relative in allowed_paths or relative in allowed_parents:
+            continue
+        if _is_declared_python_cache(path.relative_to(workdir), python_sources):
+            continue
+        unexpected.append(relative)
+    return tuple(sorted(unexpected))
+
+
+def _is_declared_python_cache(
+    relative: Path,
+    sources: set[tuple[Path, str]],
+) -> bool:
+    for cache_directory, stem in sources:
+        if relative == cache_directory:
+            return True
+        if relative.parent == cache_directory:
+            prefix = f"{stem}.cpython-"
+            if relative.name.startswith(prefix) and relative.name.endswith(".pyc"):
+                return True
+    return False
+
+
+def _file_state(workdir: Path, relative: str) -> FileStateEvidence:
+    parts = Path(relative).parts
+    if any(
+        workdir.joinpath(*parts[:index]).is_symlink()
+        for index in range(1, len(parts))
+    ):
+        return FileStateEvidence(relative, True, False, None, None)
+    path = workdir / relative
+    try:
+        info = path.lstat()
+        regular = stat.S_ISREG(info.st_mode) and not path.is_symlink()
+        content = path.read_bytes() if regular else None
+    except OSError:
+        return FileStateEvidence(relative, False, False, None, None)
+    return FileStateEvidence(
+        relative,
+        True,
+        regular,
+        len(content) if content is not None else None,
+        hashlib.sha256(content).hexdigest() if content is not None else None,
+    )
+
+
+def _run_workflow_test(
+    runner: str | None,
+    timeout_seconds: int,
+    workdir: Path,
+    observation: FixtureObservation,
+) -> TestEvidence | None:
+    if runner is None:
+        return None
+    assert runner == "python_unittest"
+    command = "python3 -m unittest -q"
+    observed = any(
+        call.name == "exec_shell_full_command"
+        and _has_successful_command_tail(call.arguments.get("command"), command)
+        and index < len(observation.tool_outcomes)
+        and observation.tool_outcomes[index].status == "success"
+        for index, call in enumerate(observation.tool_calls)
+    )
+    env = dict(os.environ)
+    env.update({"HOME": str(workdir), "PWD": str(workdir)})
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "unittest", "-q"],
+            cwd=workdir,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        status = "pass" if completed.returncode == 0 else "failure"
+        exit_code = completed.returncode
+    except subprocess.TimeoutExpired:
+        status, exit_code = "timeout", None
+    except OSError:
+        status, exit_code = "error", None
+    return TestEvidence(runner, status, exit_code, observed, time.perf_counter() - started)
+
+
+def _has_successful_command_tail(raw: Any, expected: str) -> bool:
+    if not isinstance(raw, str):
+        return False
+    if "||" in raw or ";" in raw or "\n" in raw:
+        return False
+    segments = tuple(segment.strip() for segment in raw.split("&&") if segment.strip())
+    return bool(segments) and segments[-1] == expected
 
 
 def _artifact_evidence(

--- a/src/orbit/qualification/schema.py
+++ b/src/orbit/qualification/schema.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
+import hashlib
 import math
 from typing import Any
 
@@ -33,6 +34,14 @@ class Reason:
 class ToolCallRecord:
     name: str
     arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolOutcomeRecord:
+    name: str
+    status: str
+    exit_code: int | None
+    content_sha256: str | None = None
 
 
 @dataclass(frozen=True)
@@ -102,6 +111,38 @@ class LifecycleOutcome:
 
 
 @dataclass(frozen=True)
+class FileStateEvidence:
+    path: str
+    exists: bool
+    regular_file: bool
+    byte_count: int | None
+    sha256: str | None
+
+    @classmethod
+    def from_bytes(cls, path: str, content: bytes) -> FileStateEvidence:
+        return cls(path, True, True, len(content), hashlib.sha256(content).hexdigest())
+
+
+@dataclass(frozen=True)
+class TestEvidence:
+    runner: str
+    status: str
+    exit_code: int | None
+    model_invocation_observed: bool
+    wall_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowEvidence:
+    files: tuple[FileStateEvidence, ...]
+    unexpected_paths: tuple[str, ...]
+    failed_tool_calls: int
+    recovery_observed: bool
+    repeated_failed_command: bool
+    test: TestEvidence | None
+
+
+@dataclass(frozen=True)
 class FixtureObservation:
     route: str | None
     tool_calls: tuple[ToolCallRecord, ...]
@@ -116,6 +157,8 @@ class FixtureObservation:
     peak_rss_bytes: int | None
     wall_seconds: float | None = None
     protocol_issue: str | None = None
+    tool_outcomes: tuple[ToolOutcomeRecord, ...] = ()
+    workflow: WorkflowEvidence | None = None
 
 
 @dataclass(frozen=True)
@@ -147,6 +190,8 @@ class FixtureResult:
     aggregate_metrics: AggregateMetrics
     artifact: ArtifactEvidence | None
     lifecycle: LifecycleOutcome
+    tool_outcomes: tuple[ToolOutcomeRecord, ...]
+    workflow: WorkflowEvidence | None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/qualification/validators.py
+++ b/src/orbit/qualification/validators.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from .fixtures import FixtureSpec
+from .fixtures import FileSpec, FixtureSpec
 from .schema import (
     AggregateMetrics, ArtifactEvidence, ComparisonMode, FixtureObservation, FixtureResult,
-    LifecycleOutcome, ParityMode, ParityResult, Reason, Status,
+    LifecycleOutcome, ParityMode, ParityResult, Reason, Status, WorkflowEvidence,
 )
 
 
@@ -59,6 +59,8 @@ def _result(
         ),
         artifact=observation.artifact,
         lifecycle=observation.lifecycle,
+        tool_outcomes=observation.tool_outcomes,
+        workflow=observation.workflow,
     )
 
 
@@ -103,12 +105,15 @@ def compare_fixture_results(
     if baseline.status is not Status.PASS or candidate.status is not Status.PASS:
         mismatches.append("status")
     _different(mismatches, "route", baseline.route, candidate.route)
-    baseline_tools = _parity_tools(fixture, baseline, comparison_mode)
-    candidate_tools = _parity_tools(fixture, candidate, comparison_mode)
-    _different(mismatches, "tool_calls", baseline_tools, candidate_tools)
-    _different(mismatches, "executed_tools", baseline.executed_tools, candidate.executed_tools)
+    if comparison_mode is ComparisonMode.OPTIMIZATION or fixture.expect.workflow is None:
+        baseline_tools = _parity_tools(fixture, baseline, comparison_mode)
+        candidate_tools = _parity_tools(fixture, candidate, comparison_mode)
+        _different(mismatches, "tool_calls", baseline_tools, candidate_tools)
+        _different(mismatches, "executed_tools", baseline.executed_tools, candidate.executed_tools)
+        _different(mismatches, "tool_outcomes", _tool_outcome_state(baseline), _tool_outcome_state(candidate))
     _different(mismatches, "finish_reason", baseline.finish_reason, candidate.finish_reason)
     _different(mismatches, "artifact_state", _artifact_state(baseline.artifact), _artifact_state(candidate.artifact))
+    _different(mismatches, "workflow_state", _workflow_state(baseline.workflow), _workflow_state(candidate.workflow))
     if comparison_mode is ComparisonMode.OPTIMIZATION and fixture.parity_mode is ParityMode.EXACT:
         _different(
             mismatches,
@@ -167,6 +172,8 @@ def _first_failure(
             "model_call_limit",
             f"expected at most {expect.max_model_calls}, got {observation.model_call_count}",
         )
+    if expect.workflow is not None:
+        return _workflow_failure(fixture, observation)
     if expect.route is not None and observation.route != expect.route:
         return Reason("route_mismatch", f"expected {expect.route!r}, got {observation.route!r}")
     if len(observation.tool_calls) != len(expect.tool_calls):
@@ -198,6 +205,58 @@ def _first_failure(
     return None
 
 
+def _workflow_failure(fixture: FixtureSpec, observation: FixtureObservation) -> Reason | None:
+    expected = fixture.expect.workflow
+    actual = observation.workflow
+    assert expected is not None
+    if len(observation.tool_calls) > expected.max_tool_calls:
+        return Reason("tool_call_limit", f"expected at most {expected.max_tool_calls}, got {len(observation.tool_calls)}")
+    if len(observation.tool_calls) != len(observation.tool_outcomes):
+        return Reason("tool_execution_incomplete", "selected and completed tool-call counts differ")
+    if any(item.name != "exec_shell_full_command" for item in observation.tool_calls):
+        return Reason("workflow_tool_mismatch", "workflow selected a tool outside its shell capability")
+    if observation.wall_seconds is not None and observation.wall_seconds > expected.timeout_seconds:
+        return Reason("workflow_timeout", "fixture execution exceeded its declared timeout")
+    states = {item.path: item for item in actual.files} if actual is not None else {}
+    for item in expected.files:
+        mismatch = _file_mismatch(item, states.get(item.path))
+        if mismatch:
+            return Reason("filesystem_state_mismatch", f"{item.path}: {mismatch}")
+    workspace = {item.path: item for item in fixture.workspace.files} if fixture.workspace else {}
+    for path in expected.unchanged_files:
+        mismatch = _file_mismatch(workspace[path], states.get(path))
+        if mismatch:
+            return Reason("unrelated_file_changed", f"{path}: {mismatch}")
+    if actual is not None and actual.unexpected_paths:
+        return Reason("unexpected_filesystem_state", actual.unexpected_paths[0])
+    if expected.test_runner is not None:
+        if actual is None or actual.test is None:
+            return Reason("test_evidence_missing", "post-workflow test evidence is unavailable")
+        if actual.test.status != "pass":
+            return Reason("test_failure", f"{expected.test_runner} did not pass")
+        if not actual.test.model_invocation_observed:
+            return Reason("model_test_run_missing", "model did not complete the declared test command")
+    if expected.require_recovery:
+        if actual is None or actual.failed_tool_calls < 1:
+            return Reason("failed_command_missing", "workflow did not observe the required command failure")
+        if actual.repeated_failed_command:
+            return Reason("repeated_failed_command", "the same failing tool call was repeated")
+        if not actual.recovery_observed:
+            return Reason("recovery_missing", "no successful tool call followed the failure")
+    return None
+
+
+def _file_mismatch(expected: FileSpec, actual) -> str | None:
+    if actual is None or not actual.exists:
+        return "file is missing"
+    if not actual.regular_file:
+        return "path is not a regular file"
+    raw = expected.content.encode("utf-8")
+    if actual.byte_count != len(raw) or actual.sha256 != expected.sha256:
+        return "byte count or SHA-256 differs"
+    return None
+
+
 def _artifact_failure(expected, actual: ArtifactEvidence | None) -> Reason | None:
     if actual is None:
         return Reason("artifact_evidence_missing", "no artifact evidence was captured")
@@ -223,6 +282,22 @@ def _artifact_state(value: ArtifactEvidence | None):
         value.verified,
         value.exists,
         value.canonical_json_sha256,
+    )
+
+
+def _tool_outcome_state(result: FixtureResult):
+    return tuple((item.name, item.status, item.exit_code) for item in result.tool_outcomes)
+
+
+def _workflow_state(value: WorkflowEvidence | None):
+    if value is None:
+        return None
+    return (
+        tuple((item.path, item.exists, item.regular_file, item.byte_count, item.sha256) for item in value.files),
+        value.unexpected_paths,
+        value.test.status if value.test is not None else None,
+        value.recovery_observed,
+        value.repeated_failed_command,
     )
 
 

--- a/tests/test_qualification_workflows.py
+++ b/tests/test_qualification_workflows.py
@@ -295,6 +295,28 @@ class WorkflowRunnerTests(unittest.TestCase):
         self.assertFalse(state.regular_file)
         self.assertIsNone(state.sha256)
 
+    def test_python_cache_symlinks_are_unexpected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as outside:
+            root = Path(directory)
+            external = Path(outside)
+            (root / "calculator.py").write_text("pass\n", encoding="utf-8")
+            (external / "calculator.cpython-313.pyc").write_bytes(b"cache")
+            (root / "__pycache__").symlink_to(external, target_is_directory=True)
+            self.assertEqual(_unexpected_paths(root, {"calculator.py"}), ("__pycache__",))
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as outside:
+            root = Path(directory)
+            external = Path(outside)
+            (root / "calculator.py").write_text("pass\n", encoding="utf-8")
+            cache = root / "__pycache__"
+            cache.mkdir()
+            target = external / "payload"
+            target.write_bytes(b"cache")
+            (cache / "calculator.cpython-313.pyc").symlink_to(target)
+            self.assertEqual(
+                _unexpected_paths(root, {"calculator.py"}),
+                ("__pycache__/calculator.cpython-313.pyc",),
+            )
+
     def test_runtime_model_loop_bound_is_independent_from_tool_call_bound(self) -> None:
         fixture = next(
             item for item in load_fixture_set(WORKFLOW_FIXTURES).fixtures

--- a/tests/test_qualification_workflows.py
+++ b/tests/test_qualification_workflows.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from orbit.backend.base import ChatResult
+from orbit.qualification.fixtures import FixtureError, load_fixture_set, load_fixture_text
+from orbit.qualification.runner import (
+    QualificationRunner,
+    RuntimeFixtureExecutor,
+    _file_state,
+    _unexpected_paths,
+)
+from orbit.qualification.schema import (
+    CallMetric,
+    ComparisonMode,
+    FileStateEvidence,
+    FixtureObservation,
+    LifecycleOutcome,
+    RunProvenance,
+    Status,
+    TestEvidence,
+    ToolCallRecord,
+    ToolOutcomeRecord,
+    WorkflowEvidence,
+)
+from orbit.qualification.validators import compare_fixture_results, validate_observation
+from orbit.runtime.shell_guardrails import classify_explicit_no_mutation_constraint
+
+
+ROOT = Path(__file__).parents[1]
+WORKFLOW_FIXTURES = ROOT / "qualification/fixtures/workflows-v1.json"
+
+
+def workflow_document() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "fixtures": [{
+            "name": "modify", "capability": "tools", "profiles": ["profile-a", "profile-b"],
+            "workspace": {"files": [
+                {"path": "value.txt", "content": "old\n"},
+                {"path": "keep.txt", "content": "keep\n"},
+            ]},
+            "request": {"prompt": "Change value.txt.", "tools": True},
+            "expect": {
+                "finish_reason": "stop", "max_model_calls": 5,
+                "workflow": {
+                    "files": [{"path": "value.txt", "content": "new\n"}],
+                    "unchanged_files": ["keep.txt"], "max_tool_calls": 4, "timeout_seconds": 30,
+                },
+            },
+            "parity": {"mode": "structural"},
+        }],
+    }
+
+
+def metric() -> CallMetric:
+    return CallMetric("tool_call", 20, 20, 0, 5, 10.0, 5.0, 1.0, "stop")
+
+
+def evidence(
+    *,
+    content: bytes = b"new\n",
+    outcomes: tuple[ToolOutcomeRecord, ...] = (ToolOutcomeRecord("exec_shell_full_command", "success", None),),
+    test: TestEvidence | None = None,
+    recovery: bool = False,
+    repeated: bool = False,
+    unexpected: tuple[str, ...] = (),
+) -> WorkflowEvidence:
+    return WorkflowEvidence(
+        files=(
+            FileStateEvidence.from_bytes("value.txt", content),
+            FileStateEvidence.from_bytes("keep.txt", b"keep\n"),
+        ),
+        unexpected_paths=unexpected,
+        failed_tool_calls=sum(item.status == "failure" for item in outcomes),
+        recovery_observed=recovery,
+        repeated_failed_command=repeated,
+        test=test,
+    )
+
+
+def observation(
+    *,
+    calls: tuple[ToolCallRecord, ...] = (
+        ToolCallRecord("exec_shell_full_command", {"command": "printf 'new\\n' > value.txt"}),
+    ),
+    workflow: WorkflowEvidence | None = None,
+    outcomes: tuple[ToolOutcomeRecord, ...] | None = None,
+) -> FixtureObservation:
+    recorded = outcomes or tuple(ToolOutcomeRecord(item.name, "success", None) for item in calls)
+    return FixtureObservation(
+        route=None, tool_calls=calls, executed_tools=tuple(item.name for item in calls),
+        final_output="updated", finish_reason="stop", model_call_count=2, retry_count=0,
+        calls=(metric(), metric()), artifact=None, lifecycle=LifecycleOutcome(True, "clean"),
+        peak_rss_bytes=None, tool_outcomes=recorded,
+        workflow=workflow or evidence(outcomes=recorded),
+    )
+
+
+def provenance(content_hash: str) -> RunProvenance:
+    return RunProvenance(
+        1, content_hash, "deadbeef", "profile-a", "model", "embedded", "hash",
+        "native", "revision", {}, {}, {"peak_rss_bytes": "unavailable"},
+    )
+
+
+class WorkflowFixtureSchemaTests(unittest.TestCase):
+    def test_workflow_fixture_file_has_exact_three_contracts(self) -> None:
+        fixtures = load_fixture_set(WORKFLOW_FIXTURES)
+        self.assertEqual(
+            [item.name for item in fixtures.fixtures],
+            ["bug_fix_and_test", "existing_file_modification", "failed_command_recovery"],
+        )
+        self.assertTrue(all(item.workspace and item.expect.workflow for item in fixtures.fixtures))
+        self.assertTrue(all(
+            classify_explicit_no_mutation_constraint(item.request.prompt) == "none"
+            for item in fixtures.fixtures
+        ))
+
+    def test_workspace_and_workflow_schema_fail_closed(self) -> None:
+        cases = []
+        unknown = workflow_document()
+        unknown["fixtures"][0]["workspace"]["command"] = "rm -rf /"  # type: ignore[index]
+        cases.append((unknown, "unknown_key"))
+        boolean = workflow_document()
+        boolean["fixtures"][0]["expect"]["workflow"]["max_tool_calls"] = True  # type: ignore[index]
+        cases.append((boolean, "invalid_type"))
+        unsafe = workflow_document()
+        unsafe["fixtures"][0]["workspace"]["files"][0]["path"] = "../escape"  # type: ignore[index]
+        cases.append((unsafe, "invalid_value"))
+        duplicate = workflow_document()
+        duplicate["fixtures"][0]["workspace"]["files"].append(  # type: ignore[index]
+            {"path": "value.txt", "content": "other"}
+        )
+        cases.append((duplicate, "duplicate_workspace_path"))
+        for payload, reason in cases:
+            with self.subTest(reason=reason), self.assertRaisesRegex(FixtureError, reason):
+                load_fixture_text(json.dumps(payload))
+
+
+class WorkflowValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = load_fixture_text(json.dumps(workflow_document())).fixtures[0]
+
+    def test_success_and_cross_model_strategy_diversity(self) -> None:
+        left = validate_observation(self.fixture, observation())
+        right = validate_observation(self.fixture, observation(
+            calls=(
+                ToolCallRecord("exec_shell_full_command", {"command": "cat value.txt"}),
+                ToolCallRecord("exec_shell_full_command", {"command": "sed -i s/old/new/ value.txt"}),
+            ),
+            outcomes=(
+                ToolOutcomeRecord("exec_shell_full_command", "success", None),
+                ToolOutcomeRecord("exec_shell_full_command", "success", None),
+            ),
+        ))
+        self.assertEqual((left.status, right.status), (Status.PASS, Status.PASS))
+        parity = compare_fixture_results(self.fixture, left, right, comparison_mode=ComparisonMode.CROSS_MODEL)
+        self.assertTrue(parity.equivalent)
+        self.assertFalse(parity.performance_comparison_valid)
+
+    def test_tool_bound_and_filesystem_mismatches_fail(self) -> None:
+        too_many = tuple(
+            ToolCallRecord("exec_shell_full_command", {"command": f"echo {index}"}) for index in range(5)
+        )
+        cases = (
+            (observation(calls=too_many, outcomes=tuple(
+                ToolOutcomeRecord("exec_shell_full_command", "success", None) for _ in too_many
+            )), "tool_call_limit"),
+            (observation(workflow=evidence(content=b"wrong\n")), "filesystem_state_mismatch"),
+            (observation(workflow=WorkflowEvidence(
+                files=(
+                    FileStateEvidence.from_bytes("value.txt", b"new\n"),
+                    FileStateEvidence.from_bytes("keep.txt", b"changed\n"),
+                ),
+                unexpected_paths=(),
+                failed_tool_calls=0, recovery_observed=False, repeated_failed_command=False, test=None,
+            )), "unrelated_file_changed"),
+            (observation(workflow=evidence(unexpected=("unexpected.txt",))), "unexpected_filesystem_state"),
+        )
+        for value, reason in cases:
+            with self.subTest(reason=reason):
+                self.assertEqual(validate_observation(self.fixture, value).reason.code, reason)
+
+    def test_model_and_tool_limits_are_independent_and_inclusive(self) -> None:
+        at_model_bound = replace(observation(), model_call_count=5)
+        over_model_bound = replace(observation(), model_call_count=6)
+        at_tool_bound = tuple(
+            ToolCallRecord("exec_shell_full_command", {"command": f"echo {index}"})
+            for index in range(4)
+        )
+        at_tool_outcomes = tuple(
+            ToolOutcomeRecord("exec_shell_full_command", "success", 0)
+            for _item in at_tool_bound
+        )
+        self.assertEqual(validate_observation(self.fixture, at_model_bound).status, Status.PASS)
+        self.assertEqual(
+            validate_observation(self.fixture, over_model_bound).reason.code,
+            "model_call_limit",
+        )
+        self.assertEqual(
+            validate_observation(
+                self.fixture,
+                observation(calls=at_tool_bound, outcomes=at_tool_outcomes),
+            ).status,
+            Status.PASS,
+        )
+
+    def test_recovery_accepts_different_successful_strategy(self) -> None:
+        contract = replace(self.fixture.expect.workflow, require_recovery=True)
+        fixture = replace(self.fixture, expect=replace(self.fixture.expect, workflow=contract))
+        calls = (
+            ToolCallRecord("exec_shell_full_command", {"command": "cat absent.txt"}),
+            ToolCallRecord("exec_shell_full_command", {"command": "printf 'new\\n' > value.txt"}),
+        )
+        outcomes = (
+            ToolOutcomeRecord("exec_shell_full_command", "failure", 1),
+            ToolOutcomeRecord("exec_shell_full_command", "success", 0),
+        )
+        value = observation(
+            calls=calls,
+            outcomes=outcomes,
+            workflow=evidence(outcomes=outcomes, recovery=True),
+        )
+        self.assertEqual(validate_observation(fixture, value).status, Status.PASS)
+
+    def test_test_failure_and_recovery_loop_fail(self) -> None:
+        payload = workflow_document()
+        contract = payload["fixtures"][0]["expect"]["workflow"]  # type: ignore[index]
+        contract["test_runner"] = "python_unittest"
+        contract["require_recovery"] = True
+        item = load_fixture_text(json.dumps(payload)).fixtures[0]
+        failed_test = TestEvidence("python_unittest", "failure", 1, False)
+        failed = ToolOutcomeRecord("exec_shell_full_command", "failure", 1)
+        cases = (
+            (observation(workflow=evidence(outcomes=(failed,), test=failed_test), outcomes=(failed,)), "test_failure"),
+            (observation(
+                calls=(
+                    ToolCallRecord("exec_shell_full_command", {"command": "false"}),
+                    ToolCallRecord("exec_shell_full_command", {"command": "false"}),
+                ),
+                workflow=evidence(
+                    outcomes=(failed, failed), recovery=False, repeated=True,
+                    test=TestEvidence("python_unittest", "pass", 0, True),
+                ),
+                outcomes=(failed, failed),
+            ), "repeated_failed_command"),
+        )
+        for value, reason in cases:
+            with self.subTest(reason=reason):
+                self.assertEqual(validate_observation(item, value).reason.code, reason)
+
+    def test_declared_test_must_be_run_by_the_model(self) -> None:
+        payload = workflow_document()
+        payload["fixtures"][0]["expect"]["workflow"]["test_runner"] = "python_unittest"  # type: ignore[index]
+        item = load_fixture_text(json.dumps(payload)).fixtures[0]
+        value = observation(workflow=evidence(test=TestEvidence("python_unittest", "pass", 0, False)))
+        self.assertEqual(validate_observation(item, value).reason.code, "model_test_run_missing")
+
+
+class WorkflowRunnerTests(unittest.TestCase):
+    def test_filesystem_inventory_rejects_extra_paths_but_allows_declared_python_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "calculator.py").write_text("pass\n", encoding="utf-8")
+            (root / "test_calculator.py").write_text("pass\n", encoding="utf-8")
+            cache = root / "__pycache__"
+            cache.mkdir()
+            (cache / "calculator.cpython-313.pyc").write_bytes(b"cache")
+            (cache / "test_calculator.cpython-313.pyc").write_bytes(b"cache")
+            allowed = {"calculator.py", "test_calculator.py"}
+            self.assertEqual(_unexpected_paths(root, allowed), ())
+            (cache / "undeclared.cpython-313.pyc").write_bytes(b"cache")
+            self.assertEqual(
+                _unexpected_paths(root, allowed),
+                ("__pycache__/undeclared.cpython-313.pyc",),
+            )
+            (cache / "undeclared.cpython-313.pyc").unlink()
+            (root / "unexpected.txt").write_text("mutation\n", encoding="utf-8")
+            self.assertEqual(_unexpected_paths(root, allowed), ("unexpected.txt",))
+
+    def test_file_state_rejects_symlink_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as outside:
+            root = Path(directory)
+            external = Path(outside)
+            (external / "value.txt").write_text("new\n", encoding="utf-8")
+            (root / "nested").symlink_to(external, target_is_directory=True)
+            state = _file_state(root, "nested/value.txt")
+        self.assertTrue(state.exists)
+        self.assertFalse(state.regular_file)
+        self.assertIsNone(state.sha256)
+
+    def test_runtime_model_loop_bound_is_independent_from_tool_call_bound(self) -> None:
+        fixture = next(
+            item for item in load_fixture_set(WORKFLOW_FIXTURES).fixtures
+            if item.name == "existing_file_modification"
+        )
+        captured: dict[str, object] = {}
+
+        class RuntimeSpy:
+            def __init__(self, backend) -> None:
+                pass
+
+            def ask_with_tools(self, prompt, **kwargs):
+                captured.update(kwargs)
+                return ChatResult("complete", "fake", "stop", [], 0, 0, 0, None, None)
+
+        with tempfile.TemporaryDirectory() as directory, patch(
+            "orbit.qualification.runner.ChatRuntime", RuntimeSpy
+        ):
+            RuntimeFixtureExecutor(object()).execute(fixture, Path(directory))  # type: ignore[arg-type]
+        self.assertEqual(captured["max_loops"], fixture.expect.max_model_calls)
+        self.assertNotEqual(
+            fixture.expect.max_model_calls,
+            fixture.expect.workflow.max_tool_calls,  # type: ignore[union-attr]
+        )
+
+    def test_runner_prepares_workspace_and_observes_final_state(self) -> None:
+        fixtures = load_fixture_text(json.dumps(workflow_document()))
+
+        class Executor:
+            def execute(self, fixture, workdir: Path) -> FixtureObservation:
+                self.assert_initial = (workdir / "value.txt").read_text(encoding="utf-8")
+                if self.assert_initial != "old\n":
+                    raise AssertionError("workspace was not prepared")
+                (workdir / "value.txt").write_text("new\n", encoding="utf-8")
+                return observation()
+
+        profile = {"compatibility_profile": "profile-a", "verified": True, "capabilities": {"tools": True}}
+        with tempfile.TemporaryDirectory() as directory:
+            run = QualificationRunner(
+                fixtures, profile, provenance(fixtures.content_hash), Executor(), Path(directory)
+            ).run()
+        self.assertEqual(run.fixtures[0].status, Status.PASS)
+        self.assertEqual(run.fixtures[0].workflow.files[0].path, "value.txt")  # type: ignore[union-attr]
+
+    def test_runner_executes_declared_test_and_records_pass(self) -> None:
+        fixtures = load_fixture_set(WORKFLOW_FIXTURES)
+        bug_fix = replace(
+            next(item for item in fixtures.fixtures if item.name == "bug_fix_and_test"),
+            profiles=("profile-a",),
+        )
+
+        class Executor:
+            def execute(self, fixture, workdir: Path) -> FixtureObservation:
+                (workdir / "calculator.py").write_text(
+                    "def add(left, right):\n    return left + right\n", encoding="utf-8"
+                )
+                return observation(
+                    calls=(ToolCallRecord(
+                        "exec_shell_full_command",
+                        {"command": "sed -i s/-/+/ calculator.py && python3 -m unittest -q"},
+                    ),),
+                    outcomes=(ToolOutcomeRecord("exec_shell_full_command", "success", 0),),
+                )
+
+        one = type(fixtures)(fixtures.schema_version, (bug_fix,), fixtures.content_hash)
+        profile = {"compatibility_profile": "profile-a", "verified": True, "capabilities": {"tools": True}}
+        with tempfile.TemporaryDirectory() as directory:
+            run = QualificationRunner(one, profile, provenance(one.content_hash), Executor(), Path(directory)).run()
+        self.assertEqual(run.fixtures[0].status, Status.PASS)
+        self.assertEqual(run.fixtures[0].workflow.test.status, "pass")  # type: ignore[union-attr]
+
+    def test_runner_rejects_test_failure_masked_before_mutation(self) -> None:
+        fixtures = load_fixture_set(WORKFLOW_FIXTURES)
+        bug_fix = replace(
+            next(item for item in fixtures.fixtures if item.name == "bug_fix_and_test"),
+            profiles=("profile-a",),
+        )
+
+        class Executor:
+            def execute(self, fixture, workdir: Path) -> FixtureObservation:
+                (workdir / "calculator.py").write_text(
+                    "def add(left, right):\n    return left + right\n", encoding="utf-8"
+                )
+                command = "python3 -m unittest -q || true; sed -i s/-/+/ calculator.py"
+                return observation(
+                    calls=(ToolCallRecord("exec_shell_full_command", {"command": command}),),
+                    outcomes=(ToolOutcomeRecord("exec_shell_full_command", "success", 0),),
+                )
+
+        one = type(fixtures)(fixtures.schema_version, (bug_fix,), fixtures.content_hash)
+        profile = {"compatibility_profile": "profile-a", "verified": True, "capabilities": {"tools": True}}
+        with tempfile.TemporaryDirectory() as directory:
+            run = QualificationRunner(
+                one, profile, provenance(one.content_hash), Executor(), Path(directory)
+            ).run()
+        self.assertEqual(run.fixtures[0].status, Status.FAIL)
+        self.assertEqual(run.fixtures[0].reason.code, "model_test_run_missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds deterministic qualification for bug repair, existing-file modification, and failed-command recovery
- validates final filesystem and test outcomes instead of model strategy
- keeps cross-model call, tool, and token differences valid
- adds independent model and tool call bounds
- rejects masked test failures, undeclared mutations, and symlink-parent escapes
- leaves production runtime and backend behavior unchanged

## Real evidence

- Gemma: 2/3
- Qwen3.6: 2/3
- Qwen3-Coder: 3/3
- Gemma and Qwen3.6 bug-fix failures are genuine model outcomes, not fixture-specific
- failed-command recovery passes for all three profiles

## Validation

- qualification tests: 46/46 PASS
- qualification and affected suites: 378/378 PASS
- compileall: PASS
- diff check: PASS

## Known limit

Qualification call limits are acceptance bounds; production `max_loops` and request timeout remain execution bounds.
