### PR TITLE
Add baseline-candidate optimization qualification

### DIFF
--- a/qualification/fixtures/optimizations-v1.json
+++ b/qualification/fixtures/optimizations-v1.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "fixtures": [
+    {
+      "name": "chat_route_first",
+      "capability": "tools",
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "request": {"prompt": "Say hello in one word.", "tools": true, "full_request": true},
+      "expect": {"route": "CHAT", "finish_reason": "stop", "max_model_calls": 2},
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "pwd_route",
+      "capability": "tools",
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "request": {"prompt": "Determine the absolute current working directory using a local capability.", "tools": true},
+      "expect": {
+        "route": "FILESYSTEM",
+        "tool_calls": [{"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}],
+        "finish_reason": "stop",
+        "max_model_calls": 1
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "pwd_final",
+      "capability": "tools",
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "request": {"prompt": "Run exactly the local shell command `pwd`, then answer with only its output.", "tools": true},
+      "expect": {
+        "tool_calls": [{"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}],
+        "finish_reason": "stop",
+        "max_model_calls": 6,
+        "final_reports_workdir": true
+      },
+      "parity": {"mode": "structural"}
+    },
+    {
+      "name": "chat_route_second",
+      "capability": "tools",
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "request": {"prompt": "Who designed you? Answer briefly.", "tools": true, "full_request": true},
+      "expect": {"route": "CHAT", "finish_reason": "stop", "max_model_calls": 2},
+      "parity": {"mode": "structural"}
+    }
+  ]
+}

--- a/scripts/orbit_qualify.py
+++ b/scripts/orbit_qualify.py
@@ -48,7 +48,7 @@ def main() -> int:
         run = QualificationRunner(
             fixture_set=fixture_set,
             profile=profile,
-            provenance=_provenance(args.profile, fixture_set.content_hash, profile, props, args.server_pid),
+            provenance=build_provenance(args.profile, fixture_set.content_hash, profile, props, args.server_pid),
             executor=RuntimeFixtureExecutor(backend, process_pid=args.server_pid),
             workdir=Path(workdir),
         ).run(tuple(args.fixture_names) if args.fixture_names else None)
@@ -57,7 +57,7 @@ def main() -> int:
     return 0 if run.overall_status is Status.PASS else 1
 
 
-def _provenance(
+def build_provenance(
     expected_profile: str,
     fixture_hash: str,
     profile: dict[str, Any],

--- a/scripts/orbit_qualify_compare.py
+++ b/scripts/orbit_qualify_compare.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+for path in (ROOT, SRC):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from orbit.backend.llama_server import LlamaServerBackend  # noqa: E402
+from orbit.qualification.fixtures import load_fixture_set  # noqa: E402
+from orbit.qualification.reporting import format_comparison_summary, write_comparison  # noqa: E402
+from orbit.qualification.runner import (  # noqa: E402
+    QualificationRunner,
+    RuntimeFixtureExecutor,
+    build_optimization_comparison,
+)
+from orbit.qualification.schema import ComparisonExecution  # noqa: E402
+from scripts.orbit_qualify import build_provenance  # noqa: E402
+
+
+CONTROLLED_ENV = frozenset({
+    "ORBIT_KV_PREFIX_PREWARM",
+    "ORBIT_QWEN_ROUTE_PREFIX_REUSE",
+    "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE",
+})
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compare two process-isolated Orbit qualification modes.")
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--fixtures", default=str(ROOT / "qualification/fixtures/optimizations-v1.json"))
+    parser.add_argument("--fixture", action="append", dest="fixture_names")
+    parser.add_argument("--baseline-env", action="append", default=[])
+    parser.add_argument("--candidate-env", action="append", default=[])
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--ctx", type=int, default=8192)
+    parser.add_argument("--threads", type=int, default=6)
+    parser.add_argument("--threads-batch", type=int, default=6)
+    parser.add_argument("--batch", type=int, default=256)
+    parser.add_argument("--ubatch", type=int, default=128)
+    parser.add_argument("--startup-timeout", type=float, default=180.0)
+    parser.add_argument("--request-timeout", type=float, default=900.0)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    baseline_env = _parse_overrides(args.baseline_env)
+    candidate_env = _parse_overrides(args.candidate_env)
+    fixture_set = load_fixture_set(args.fixtures)
+    selected = tuple(args.fixture_names) if args.fixture_names else None
+    with tempfile.TemporaryDirectory(prefix="orbit-qualification-comparison-") as directory:
+        root = Path(directory)
+        fixture_root = root / "fixtures"
+        baseline = _run_side(
+            "baseline", baseline_env, args, fixture_set, selected, fixture_root, root / "baseline.log"
+        )
+        _reset_fixture_root(fixture_root, root)
+        candidate = _run_side(
+            "candidate", candidate_env, args, fixture_set, selected, fixture_root, root / "candidate.log"
+        )
+    comparison = build_optimization_comparison(fixture_set, baseline, candidate)
+    write_comparison(comparison, args.output)
+    print(format_comparison_summary(comparison))
+    return 0 if comparison.performance_comparison_valid else 1
+
+
+def _run_side(
+    label,
+    overrides,
+    args,
+    fixture_set,
+    selected,
+    fixture_root: Path,
+    log_path: Path,
+) -> ComparisonExecution:
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    for name in CONTROLLED_ENV:
+        env.pop(name, None)
+    env.update(overrides)
+    env["PYTHONPATH"] = str(SRC)
+    command = _server_command(args, port)
+    started = time.perf_counter()
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            command, cwd=ROOT, env=env, stdout=log, stderr=subprocess.STDOUT, text=True
+        )
+    try:
+        backend = LlamaServerBackend(base_url=base_url, timeout=args.request_timeout)
+        _wait_ready(backend, process, args.startup_timeout, log_path)
+        startup_wall = time.perf_counter() - started
+        props = backend.backend_props()
+        profile = props.get("model_compatibility")
+        if not isinstance(profile, dict):
+            raise RuntimeError("server did not expose model compatibility metadata")
+        fixture_root.mkdir(parents=True, exist_ok=False)
+        run = QualificationRunner(
+            fixture_set=fixture_set,
+            profile=profile,
+            provenance=build_provenance(
+                args.profile, fixture_set.content_hash, profile, props, process.pid
+            ),
+            executor=RuntimeFixtureExecutor(backend, process_pid=process.pid),
+            workdir=fixture_root,
+        ).run(selected)
+        return ComparisonExecution(
+            label=label,
+            server_pid=process.pid,
+            startup_wall_seconds=startup_wall,
+            configuration=_configuration(args, overrides),
+            result=run,
+        )
+    finally:
+        _stop(process)
+
+
+def _server_command(args, port: int) -> list[str]:
+    return [
+        sys.executable, "-m", "orbit.terminal.cli", "server",
+        "--host", "127.0.0.1", "--port", str(port),
+        "--model", str(args.model.resolve()),
+        "--ctx", str(args.ctx), "--threads", str(args.threads),
+        "--threads-batch", str(args.threads_batch), "--batch", str(args.batch),
+        "--ubatch", str(args.ubatch), "--think", "off",
+    ]
+
+
+def _wait_ready(backend, process, timeout: float, log_path: Path) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            detail = log_path.read_text(encoding="utf-8", errors="replace")[-500:]
+            raise RuntimeError(f"server exited during startup: {detail}")
+        if backend.health():
+            return
+        time.sleep(0.25)
+    raise TimeoutError(f"server did not become ready within {timeout:.0f}s")
+
+
+def _stop(process) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def _parse_overrides(values: list[str]) -> dict[str, str]:
+    result = {}
+    for value in values:
+        name, separator, setting = value.partition("=")
+        if not separator or name not in CONTROLLED_ENV or name in result:
+            raise ValueError(f"invalid or duplicate controlled environment override: {name}")
+        result[name] = setting
+    return result
+
+
+def _configuration(args, overrides: dict[str, str]) -> dict[str, object]:
+    affinity = sorted(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None
+    return {
+        "model_filename": args.model.name,
+        "ctx": args.ctx,
+        "threads": args.threads,
+        "threads_batch": args.threads_batch,
+        "batch": args.batch,
+        "ubatch": args.ubatch,
+        "thinking": "off",
+        "cpu_affinity": affinity,
+        "startup_timeout_seconds": args.startup_timeout,
+        "request_timeout_seconds": args.request_timeout,
+        "environment": dict(sorted(overrides.items())),
+        "startup_wall_scope": "process launch through healthy server readiness; model load and prewarm included",
+    }
+
+
+def _free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _reset_fixture_root(path: Path, root: Path) -> None:
+    if path.parent != root:
+        raise RuntimeError("comparison fixture root escaped its temporary directory")
+    if path.exists():
+        shutil.rmtree(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/qualification/fixtures.py
+++ b/src/orbit/qualification/fixtures.py
@@ -25,6 +25,7 @@ class FixtureError(ValueError):
 class RequestSpec:
     prompt: str
     tools: bool
+    full_request: bool = False
 
 
 @dataclass(frozen=True)
@@ -151,10 +152,15 @@ def _fixture(value: Any, version: int) -> FixtureSpec:
 
 
 def _request(value: Any, name: str) -> RequestSpec:
-    row = _object(value, f"{name}.request", {"prompt", "tools"})
-    if not isinstance(row["tools"], bool):
+    row = _object(value, f"{name}.request", {"prompt", "tools"}, {"full_request"})
+    full_request = row.get("full_request", False)
+    if not isinstance(row["tools"], bool) or not isinstance(full_request, bool):
         _fail("invalid_type", f"{name}.request.tools")
-    return RequestSpec(_string(row["prompt"], f"{name}.request.prompt"), row["tools"])
+    return RequestSpec(
+        _string(row["prompt"], f"{name}.request.prompt"),
+        row["tools"],
+        full_request,
+    )
 
 
 def _expect(value: Any, name: str) -> ExpectSpec:
@@ -340,6 +346,11 @@ def _validate_contract(
         _fail("invalid_fixture_contract", f"{name} tools fixture is inconsistent")
     if capability == "artifacts" and (not request.tools or expect.artifact is None or expect.route is not None):
         _fail("invalid_fixture_contract", f"{name} artifact fixture is inconsistent")
+    if request.full_request and not (
+        capability == "tools" and expect.route == "CHAT"
+        and not expect.tool_calls and expect.max_model_calls >= 2
+    ):
+        _fail("invalid_fixture_contract", f"{name} full request fixture is inconsistent")
     if expect.workflow is None:
         if workspace is not None:
             _fail("invalid_fixture_contract", f"{name} workspace requires a workflow")

--- a/src/orbit/qualification/reporting.py
+++ b/src/orbit/qualification/reporting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .schema import QualificationRun, as_primitive
+from .schema import OptimizationComparison, QualificationRun, as_primitive
 
 
 def result_json(run: QualificationRun) -> str:
@@ -12,6 +12,44 @@ def result_json(run: QualificationRun) -> str:
 
 def write_result(run: QualificationRun, path: Path | str) -> None:
     Path(path).write_text(result_json(run), encoding="utf-8")
+
+
+def comparison_json(comparison: OptimizationComparison) -> str:
+    return json.dumps(
+        as_primitive(comparison), ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False
+    ) + "\n"
+
+
+def write_comparison(comparison: OptimizationComparison, path: Path | str) -> None:
+    Path(path).write_text(comparison_json(comparison), encoding="utf-8")
+
+
+def format_comparison_summary(comparison: OptimizationComparison) -> str:
+    lines = [
+        f"Profile: {comparison.baseline.result.provenance.profile_identity}",
+        "",
+        "Parity",
+    ]
+    lines.extend(
+        f"  {item.fixture_name:<20} {'PASS' if item.performance_comparison_valid else 'FAIL'}"
+        + (f" ({', '.join(item.mismatches)})" if item.mismatches else "")
+        for item in comparison.parity
+    )
+    lines.extend(("", f"Performance comparison valid: {str(comparison.performance_comparison_valid).lower()}"))
+    if comparison.performance_comparison_valid and comparison.performance is not None:
+        startup = comparison.performance["startup"]
+        aggregate = comparison.performance["aggregate"]["wall"]
+        lines.extend((
+            f"Startup wall: {_change(startup)}",
+            f"Fixture wall sum: {_change(aggregate)}",
+        ))
+        lines.extend(
+            f"{name} wall: {_change(value['wall'])}"
+            for name, value in comparison.performance["fixtures"].items()
+        )
+    elif comparison.mismatches:
+        lines.append(f"Mismatches: {', '.join(comparison.mismatches)}")
+    return "\n".join(lines)
 
 
 def format_summary(run: QualificationRun) -> str:
@@ -52,3 +90,14 @@ def _count(value: int | None) -> str:
 
 def _bytes(value: int | None) -> str:
     return "unavailable" if value is None else f"{value / (1024 ** 3):.2f} GiB"
+
+
+def _change(value: dict[str, float | None]) -> str:
+    baseline = value["baseline_seconds"]
+    candidate = value["candidate_seconds"]
+    change = value["absolute_change_seconds"]
+    percent = value["percent_change"]
+    if None in (baseline, candidate, change):
+        return "unavailable"
+    suffix = f" ({percent:+.2f}%)" if percent is not None else ""
+    return f"{baseline:.2f}s -> {candidate:.2f}s, change {change:+.2f}s{suffix}"

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -31,10 +31,12 @@ from .schema import (
     ArtifactEvidence,
     CallMetric,
     CommonGate,
+    ComparisonExecution,
     ComparisonMode,
     FileStateEvidence,
     FixtureObservation,
     LifecycleOutcome,
+    OptimizationComparison,
     ParityResult,
     QualificationRun,
     Reason,
@@ -207,7 +209,22 @@ class RuntimeFixtureExecutor:
 
         route = None
         runtime = ChatRuntime(backend=self.backend)
-        if fixture.expect.route is not None:
+        if fixture.request.full_request:
+            result = runtime.ask_auto(
+                fixture.request.prompt,
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                max_loops=fixture.expect.max_model_calls,
+                allowed_tool_names=(),
+                on_tool_call=tool_call,
+                on_tool_result=tool_result,
+                on_model_step=model_step,
+                on_phase_start=phase_start,
+            )
+            final_phase = any(item.phase not in {"route", "route_retry"} for item in steps)
+            route = "CHAT" if final_phase and not tool_calls else None
+        elif fixture.expect.route is not None:
             result, route, route_call = self._route(fixture)
             tool_calls.extend(route_call)
             steps.append(ModelStepMetrics.from_result(loop=1, result=result, phase="route"))
@@ -310,6 +327,17 @@ def compare_runs(
 ) -> tuple[ParityResult, ...]:
     if baseline.provenance.fixture_set_hash != candidate.provenance.fixture_set_hash:
         raise ValueError("qualification fixture sets differ")
+    if comparison_mode is ComparisonMode.OPTIMIZATION:
+        identity_fields = (
+            "qualification_schema_version", "git_revision", "profile_identity", "model_identity",
+            "template_identity", "template_hash", "backend_identity", "backend_revision",
+            "runtime_configuration", "hardware",
+        )
+        if any(
+            getattr(baseline.provenance, field) != getattr(candidate.provenance, field)
+            for field in identity_fields
+        ):
+            raise ValueError("optimization comparison requires the same model and configuration")
     left = {item.name: item for item in baseline.fixtures}
     right = {item.name: item for item in candidate.fixtures}
     fixtures = {item.name: item for item in fixture_set.fixtures}
@@ -321,6 +349,101 @@ def compare_runs(
         )
         for name in sorted(left)
     )
+
+
+def build_optimization_comparison(
+    fixture_set: FixtureSet,
+    baseline: ComparisonExecution,
+    candidate: ComparisonExecution,
+) -> OptimizationComparison:
+    baseline = replace(baseline, startup_wall_seconds=_wall_value(baseline.startup_wall_seconds))
+    candidate = replace(candidate, startup_wall_seconds=_wall_value(candidate.startup_wall_seconds))
+    parity = compare_runs(fixture_set, baseline.result, candidate.result)
+    mismatches = []
+    if not _valid_pid(baseline.server_pid) or not _valid_pid(candidate.server_pid):
+        mismatches.append("invalid_server_pid")
+    elif baseline.server_pid == candidate.server_pid:
+        mismatches.append("process_not_isolated")
+    if baseline.label == candidate.label:
+        mismatches.append("comparison_labels_not_distinct")
+    if _fixed_configuration(baseline.configuration) != _fixed_configuration(candidate.configuration):
+        mismatches.append("execution_configuration_mismatch")
+    if baseline.result.overall_status is not Status.PASS:
+        mismatches.append("baseline_not_qualified")
+    if candidate.result.overall_status is not Status.PASS:
+        mismatches.append("candidate_not_qualified")
+    if any(not item.performance_comparison_valid for item in parity):
+        mismatches.append("fixture_parity_invalid")
+    valid = not mismatches
+    performance = None
+    if valid:
+        baseline_fixtures = {item.name: item for item in baseline.result.fixtures}
+        candidate_fixtures = {item.name: item for item in candidate.result.fixtures}
+        performance = {
+            "startup": _wall_change(
+                baseline.startup_wall_seconds,
+                candidate.startup_wall_seconds,
+            ),
+            "aggregate": _metrics_change(
+                baseline.result.aggregate_metrics,
+                candidate.result.aggregate_metrics,
+            ),
+            "fixtures": {
+                item.fixture_name: _metrics_change(
+                    baseline_fixtures[item.fixture_name].aggregate_metrics,
+                    candidate_fixtures[item.fixture_name].aggregate_metrics,
+                )
+                for item in parity
+            },
+        }
+    return OptimizationComparison(
+        baseline=baseline,
+        candidate=candidate,
+        parity=parity,
+        performance_comparison_valid=valid,
+        mismatches=tuple(mismatches),
+        performance=performance,
+    )
+
+
+def _metrics_change(baseline: AggregateMetrics, candidate: AggregateMetrics) -> dict[str, Any]:
+    return {
+        "baseline": baseline,
+        "candidate": candidate,
+        "wall": _wall_change(baseline.wall_seconds, candidate.wall_seconds),
+    }
+
+
+def _wall_change(baseline: float | None, candidate: float | None) -> dict[str, float | None]:
+    baseline = _wall_value(baseline)
+    candidate = _wall_value(candidate)
+    if baseline is None or candidate is None:
+        return {"baseline_seconds": baseline, "candidate_seconds": candidate,
+                "absolute_change_seconds": None, "percent_change": None}
+    change = candidate - baseline
+    return {
+        "baseline_seconds": baseline,
+        "candidate_seconds": candidate,
+        "absolute_change_seconds": change,
+        "percent_change": change / baseline * 100.0 if baseline > 0 else None,
+    }
+
+
+def _wall_value(value: float | None) -> float | None:
+    if (
+        not isinstance(value, (int, float)) or isinstance(value, bool)
+        or not math.isfinite(value) or value < 0
+    ):
+        return None
+    return float(value)
+
+
+def _valid_pid(value: int) -> bool:
+    return type(value) is int and value > 0
+
+
+def _fixed_configuration(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if key != "environment"}
 
 
 def _metric(value: ModelStepMetrics, wall: float | None) -> CallMetric:

--- a/src/orbit/qualification/schema.py
+++ b/src/orbit/qualification/schema.py
@@ -163,6 +163,7 @@ class FixtureObservation:
 
 @dataclass(frozen=True)
 class ParityResult:
+    fixture_name: str
     comparison_mode: ComparisonMode
     mode: ParityMode
     equivalent: bool
@@ -225,6 +226,25 @@ class QualificationRun:
     aggregate_metrics: AggregateMetrics
     overall_status: Status
     overall_detail: str
+
+
+@dataclass(frozen=True)
+class ComparisonExecution:
+    label: str
+    server_pid: int
+    startup_wall_seconds: float | None
+    configuration: dict[str, Any]
+    result: QualificationRun
+
+
+@dataclass(frozen=True)
+class OptimizationComparison:
+    baseline: ComparisonExecution
+    candidate: ComparisonExecution
+    parity: tuple[ParityResult, ...]
+    performance_comparison_valid: bool
+    mismatches: tuple[str, ...]
+    performance: dict[str, Any] | None
 
 
 def as_primitive(value: Any) -> Any:

--- a/src/orbit/qualification/schema.py
+++ b/src/orbit/qualification/schema.py
@@ -250,6 +250,8 @@ class OptimizationComparison:
 def as_primitive(value: Any) -> Any:
     if isinstance(value, Enum):
         return value.value
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
     if is_dataclass(value):
         return {item.name: as_primitive(getattr(value, item.name)) for item in fields(value)}
     if isinstance(value, dict):

--- a/src/orbit/qualification/validators.py
+++ b/src/orbit/qualification/validators.py
@@ -114,6 +114,10 @@ def compare_fixture_results(
     _different(mismatches, "finish_reason", baseline.finish_reason, candidate.finish_reason)
     _different(mismatches, "artifact_state", _artifact_state(baseline.artifact), _artifact_state(candidate.artifact))
     _different(mismatches, "workflow_state", _workflow_state(baseline.workflow), _workflow_state(candidate.workflow))
+    if comparison_mode is ComparisonMode.OPTIMIZATION:
+        _different(mismatches, "model_call_count", baseline.model_call_count, candidate.model_call_count)
+        _different(mismatches, "retry_count", baseline.retry_count, candidate.retry_count)
+        _different(mismatches, "call_behavior", _call_behavior(baseline), _call_behavior(candidate))
     if comparison_mode is ComparisonMode.OPTIMIZATION and fixture.parity_mode is ParityMode.EXACT:
         _different(
             mismatches,
@@ -121,33 +125,22 @@ def compare_fixture_results(
             baseline.final_output_sha256,
             candidate.final_output_sha256,
         )
-        _different(mismatches, "model_call_count", baseline.model_call_count, candidate.model_call_count)
-        _different(mismatches, "retry_count", baseline.retry_count, candidate.retry_count)
     unique = tuple(dict.fromkeys(mismatches))
     equivalent = not unique
     performance = None
-    performance_valid = False
-    performance_mismatches: list[str] = []
-    if comparison_mode is ComparisonMode.OPTIMIZATION and equivalent:
-        baseline_work = _model_work(baseline)
-        candidate_work = _model_work(candidate)
-        if baseline_work is None or candidate_work is None:
-            performance_mismatches.append("model_work_unavailable")
-        else:
-            _different(performance_mismatches, "model_work", baseline_work, candidate_work)
-        performance_valid = not performance_mismatches
-    all_mismatches = tuple(dict.fromkeys([*unique, *performance_mismatches]))
+    performance_valid = comparison_mode is ComparisonMode.OPTIMIZATION and equivalent
     if performance_valid:
         performance = {
             "baseline": baseline.aggregate_metrics,
             "candidate": candidate.aggregate_metrics,
         }
     return ParityResult(
+        fixture_name=fixture.name,
         comparison_mode=comparison_mode,
         mode=fixture.parity_mode,
         equivalent=equivalent,
         performance_comparison_valid=performance_valid,
-        mismatches=all_mismatches,
+        mismatches=unique,
         performance=performance,
     )
 
@@ -286,7 +279,10 @@ def _artifact_state(value: ArtifactEvidence | None):
 
 
 def _tool_outcome_state(result: FixtureResult):
-    return tuple((item.name, item.status, item.exit_code) for item in result.tool_outcomes)
+    return tuple(
+        (item.name, item.status, item.exit_code, item.content_sha256)
+        for item in result.tool_outcomes
+    )
 
 
 def _workflow_state(value: WorkflowEvidence | None):
@@ -301,14 +297,11 @@ def _workflow_state(value: WorkflowEvidence | None):
     )
 
 
-def _model_work(result: FixtureResult):
-    if any(item.input_tokens is None or item.output_tokens is None for item in result.calls):
-        return None
+def _call_behavior(result: FixtureResult):
     return tuple(
         (
             item.phase,
-            item.input_tokens,
-            item.output_tokens,
+            item.finish_reason,
             item.retry_reason,
         )
         for item in result.calls

--- a/tests/test_qualification_comparison.py
+++ b/tests/test_qualification_comparison.py
@@ -170,6 +170,21 @@ class OptimizationComparisonTests(unittest.TestCase):
         self.assertIsNone(payload["candidate"]["startup_wall_seconds"])
         self.assertIsNone(payload["performance"]["startup"]["absolute_change_seconds"])
 
+    def test_nonfinite_fixture_and_call_metrics_serialize_as_null(self) -> None:
+        baseline_value = observation(
+            value=replace(metric(), wall_seconds=float("inf")),
+            wall=float("nan"),
+        )
+        comparison = build_optimization_comparison(
+            fixtures(), side("baseline", 101, baseline_value),
+            side("candidate", 202, observation(wall=1.0)),
+        )
+        payload = json.loads(comparison_json(comparison))
+        fixture = payload["baseline"]["result"]["fixtures"][0]
+        self.assertIsNone(fixture["calls"][0]["wall_seconds"])
+        self.assertIsNone(fixture["aggregate_metrics"]["wall_seconds"])
+        self.assertIsNone(payload["performance"]["fixtures"]["pwd_route"]["wall"]["percent_change"])
+
     def test_missing_metrics_remain_null_without_changing_parity(self) -> None:
         missing = metric(input_tokens=None, evaluated=None, cached=None)
         comparison = build_optimization_comparison(

--- a/tests/test_qualification_comparison.py
+++ b/tests/test_qualification_comparison.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import unittest
+from pathlib import Path
+
+from orbit.qualification.fixtures import FixtureError, load_fixture_set, load_fixture_text
+from orbit.qualification.reporting import comparison_json, format_comparison_summary
+from orbit.qualification.runner import build_optimization_comparison, compare_runs
+from orbit.qualification.schema import (
+    AggregateMetrics,
+    CallMetric,
+    CommonGate,
+    ComparisonExecution,
+    FixtureObservation,
+    LifecycleOutcome,
+    QualificationRun,
+    Reason,
+    RunProvenance,
+    Status,
+    ToolCallRecord,
+    ToolOutcomeRecord,
+)
+from orbit.qualification.validators import validate_observation
+from scripts.orbit_qualify_compare import _parse_overrides
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def fixtures():
+    return load_fixture_text(json.dumps({
+        "schema_version": 1,
+        "fixtures": [{
+            "name": "pwd_route",
+            "capability": "tools",
+            "profiles": ["profile-a"],
+            "request": {"prompt": "pwd", "tools": True},
+            "expect": {
+                "route": "FILESYSTEM",
+                "tool_calls": [{
+                    "name": "exec_shell_full_command",
+                    "arguments": {"command": "pwd"},
+                }],
+                "finish_reason": "stop",
+                "max_model_calls": 1,
+            },
+            "parity": {"mode": "structural"},
+        }],
+    }))
+
+
+def metric(*, evaluated=800, cached=0, wall=20.0, input_tokens=800):
+    return CallMetric("route", input_tokens, evaluated, cached, 5, 30.0, 8.0, wall, "stop")
+
+
+def observation(*, call=None, value=None, wall=20.0):
+    tool = call or ToolCallRecord("exec_shell_full_command", {"command": "pwd"})
+    item = value or metric(wall=wall)
+    return FixtureObservation(
+        "FILESYSTEM", (tool,), (), "FILESYSTEM", "stop", 1, 0, (item,), None,
+        LifecycleOutcome(True, "clean"), 1024, wall_seconds=wall,
+    )
+
+
+def provenance(fixture_hash, *, profile="profile-a", model="model-a"):
+    return RunProvenance(
+        1, fixture_hash, "deadbeef", profile, model, "embedded", "template-hash",
+        "orbit-native", "backend-revision", {"ctx_size": 8192}, {"cpu": "fake"},
+        {"peak_rss_bytes": "fake"},
+    )
+
+
+def run(value, *, profile="profile-a", model="model-a"):
+    fixture_set = fixtures()
+    result = validate_observation(fixture_set.fixtures[0], value)
+    status = Status.PASS if result.status is Status.PASS else Status.FAIL
+    return QualificationRun(
+        provenance(fixture_set.content_hash, profile=profile, model=model),
+        (CommonGate("identity", Status.PASS, Reason("verified_profile", "verified")),),
+        (result,), result.aggregate_metrics, status, status.value,
+    )
+
+
+def side(label, pid, value, *, startup=10.0, environment=None, profile="profile-a", model="model-a"):
+    return ComparisonExecution(
+        label, pid, startup, {"environment": environment or {}},
+        run(value, profile=profile, model=model),
+    )
+
+
+class OptimizationComparisonTests(unittest.TestCase):
+    def test_optimization_fixture_file_has_only_controlled_cases(self) -> None:
+        value = load_fixture_set(ROOT / "qualification/fixtures/optimizations-v1.json")
+        self.assertEqual(
+            [item.name for item in value.fixtures],
+            ["chat_route_first", "pwd_route", "pwd_final", "chat_route_second"],
+        )
+        self.assertTrue(value.fixtures[0].request.full_request)
+        invalid = (ROOT / "qualification/fixtures/optimizations-v1.json").read_text().replace(
+            '"full_request": true', '"full_request": 1', 1
+        )
+        with self.assertRaisesRegex(FixtureError, "invalid_type"):
+            load_fixture_text(invalid)
+
+    def test_cache_redistribution_preserves_parity_and_reports_wall_delta(self) -> None:
+        baseline = side("baseline", 101, observation())
+        candidate = side(
+            "candidate", 202,
+            observation(value=metric(evaluated=32, cached=768, wall=2.0), wall=2.0),
+            environment={"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "1"},
+        )
+        comparison = build_optimization_comparison(fixtures(), baseline, candidate)
+        self.assertTrue(comparison.parity[0].equivalent)
+        self.assertTrue(comparison.performance_comparison_valid)
+        change = comparison.performance["fixtures"]["pwd_route"]["wall"]
+        self.assertEqual(change["absolute_change_seconds"], -18.0)
+        self.assertEqual(change["percent_change"], -90.0)
+
+    def test_extra_tool_argument_invalidates_parity_and_suppresses_gain(self) -> None:
+        baseline = side("baseline", 101, observation())
+        candidate = side("candidate", 202, observation(call=ToolCallRecord(
+            "exec_shell_full_command", {"command": "pwd", "timeout": 10}
+        ), wall=1.0))
+        comparison = build_optimization_comparison(fixtures(), baseline, candidate)
+        self.assertFalse(comparison.parity[0].equivalent)
+        self.assertIn("tool_calls", comparison.parity[0].mismatches)
+        self.assertFalse(comparison.performance_comparison_valid)
+        self.assertIsNone(comparison.performance)
+        payload = comparison_json(comparison)
+        self.assertNotIn("percent_change", payload)
+        self.assertNotIn("change +", format_comparison_summary(comparison))
+
+    def test_deterministic_tool_output_mismatch_invalidates_parity(self) -> None:
+        baseline_value = replace(
+            observation(),
+            tool_outcomes=(ToolOutcomeRecord("exec_shell_full_command", "success", 0, "a"),),
+        )
+        candidate_value = replace(
+            observation(),
+            tool_outcomes=(ToolOutcomeRecord("exec_shell_full_command", "success", 0, "b"),),
+        )
+        comparison = build_optimization_comparison(
+            fixtures(), side("baseline", 101, baseline_value), side("candidate", 202, candidate_value)
+        )
+        self.assertFalse(comparison.performance_comparison_valid)
+        self.assertIn("tool_outcomes", comparison.parity[0].mismatches)
+
+    def test_startup_and_request_wall_are_separate(self) -> None:
+        baseline = side("baseline", 101, observation(wall=20.0), startup=10.0)
+        candidate = side("candidate", 202, observation(wall=2.0), startup=30.0)
+        comparison = build_optimization_comparison(fixtures(), baseline, candidate)
+        self.assertEqual(comparison.performance["startup"]["absolute_change_seconds"], 20.0)
+        self.assertEqual(comparison.performance["aggregate"]["wall"]["absolute_change_seconds"], -18.0)
+        self.assertIn("pwd_route wall: 20.00s -> 2.00s", format_comparison_summary(comparison))
+
+    def test_zero_and_nonfinite_startup_walls_are_safe(self) -> None:
+        zero = build_optimization_comparison(
+            fixtures(), side("baseline", 101, observation(), startup=0.0),
+            side("candidate", 202, observation(), startup=1.0),
+        )
+        self.assertIsNone(zero.performance["startup"]["percent_change"])
+        nonfinite = build_optimization_comparison(
+            fixtures(), side("baseline", 101, observation(), startup=float("nan")),
+            side("candidate", 202, observation(), startup=float("inf")),
+        )
+        payload = json.loads(comparison_json(nonfinite))
+        self.assertIsNone(payload["baseline"]["startup_wall_seconds"])
+        self.assertIsNone(payload["candidate"]["startup_wall_seconds"])
+        self.assertIsNone(payload["performance"]["startup"]["absolute_change_seconds"])
+
+    def test_missing_metrics_remain_null_without_changing_parity(self) -> None:
+        missing = metric(input_tokens=None, evaluated=None, cached=None)
+        comparison = build_optimization_comparison(
+            fixtures(), side("baseline", 101, observation()),
+            side("candidate", 202, observation(value=missing)),
+        )
+        self.assertTrue(comparison.performance_comparison_valid)
+        self.assertIsNone(comparison.candidate.result.aggregate_metrics.input_tokens)
+        self.assertIsNone(comparison.performance["aggregate"]["candidate"].input_tokens)
+
+    def test_token_count_differences_are_metrics_not_operational_parity(self) -> None:
+        candidate_metric = metric(input_tokens=804, evaluated=36, cached=768, wall=2.0)
+        comparison = build_optimization_comparison(
+            fixtures(), side("baseline", 101, observation()),
+            side("candidate", 202, observation(value=candidate_metric, wall=2.0)),
+        )
+        self.assertTrue(comparison.parity[0].equivalent)
+        self.assertTrue(comparison.performance_comparison_valid)
+        self.assertEqual(comparison.performance["aggregate"]["baseline"].input_tokens, 800)
+        self.assertEqual(comparison.performance["aggregate"]["candidate"].input_tokens, 804)
+
+    def test_process_and_configuration_provenance_are_retained(self) -> None:
+        baseline = side("baseline", 101, observation(), environment={"MODE": "off"})
+        candidate = side("candidate", 202, observation(), environment={"MODE": "on"})
+        candidate = replace(
+            candidate,
+            result=replace(
+                candidate.result,
+                provenance=replace(
+                    candidate.result.provenance,
+                    measurement_scope={"peak_rss_bytes": "server PID 202"},
+                ),
+            ),
+        )
+        comparison = build_optimization_comparison(fixtures(), baseline, candidate)
+        payload = json.loads(comparison_json(comparison))
+        self.assertEqual(payload["baseline"]["server_pid"], 101)
+        self.assertEqual(payload["candidate"]["configuration"]["environment"], {"MODE": "on"})
+        same_process = build_optimization_comparison(
+            fixtures(), baseline, replace(candidate, server_pid=101)
+        )
+        self.assertFalse(same_process.performance_comparison_valid)
+        self.assertIn("process_not_isolated", same_process.mismatches)
+        invalid_process = build_optimization_comparison(
+            fixtures(), baseline, replace(candidate, server_pid=0)
+        )
+        self.assertFalse(invalid_process.performance_comparison_valid)
+        self.assertIn("invalid_server_pid", invalid_process.mismatches)
+        different_config = build_optimization_comparison(
+            fixtures(), baseline,
+            replace(candidate, configuration={"ctx": 4096, "environment": {"MODE": "on"}}),
+        )
+        self.assertFalse(different_config.performance_comparison_valid)
+        self.assertIn("execution_configuration_mismatch", different_config.mismatches)
+
+    def test_comparison_environment_is_explicit_and_bounded(self) -> None:
+        self.assertEqual(
+            _parse_overrides(["ORBIT_QWEN_ROUTE_PREFIX_REUSE=0"]),
+            {"ORBIT_QWEN_ROUTE_PREFIX_REUSE": "0"},
+        )
+        with self.assertRaisesRegex(ValueError, "invalid or duplicate"):
+            _parse_overrides(["PATH=/tmp"])
+        with self.assertRaisesRegex(ValueError, "invalid or duplicate"):
+            _parse_overrides([
+                "ORBIT_KV_PREFIX_PREWARM=off",
+                "ORBIT_KV_PREFIX_PREWARM=startup",
+            ])
+
+    def test_optimization_mode_rejects_cross_model_or_configuration_comparison(self) -> None:
+        baseline = run(observation())
+        different_model = run(observation(), profile="profile-b", model="model-b")
+        with self.assertRaisesRegex(ValueError, "same model and configuration"):
+            compare_runs(fixtures(), baseline, different_model)
+        different_config = replace(
+            baseline,
+            provenance=replace(baseline.provenance, runtime_configuration={"ctx_size": 4096}),
+        )
+        with self.assertRaisesRegex(ValueError, "same model and configuration"):
+            compare_runs(fixtures(), baseline, different_config)
+        different_revision = replace(
+            baseline,
+            provenance=replace(baseline.provenance, git_revision="different"),
+        )
+        with self.assertRaisesRegex(ValueError, "same model and configuration"):
+            compare_runs(fixtures(), baseline, different_revision)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qualification_core.py
+++ b/tests/test_qualification_core.py
@@ -130,7 +130,7 @@ class QualificationValidationTests(unittest.TestCase):
             wrong = [(name, content.replace("path: qualification.json", "path: other.json")) for name, content in valid]
             self.assertFalse(_artifact_evidence(item, root, wrong).published)  # type: ignore[union-attr]
 
-    def test_optimization_parity_requires_equivalent_work(self) -> None:
+    def test_optimization_parity_treats_token_counts_as_metrics(self) -> None:
         item = fixture()
         baseline = validate_observation(item, observation())
         same = compare_fixture_results(item, baseline, validate_observation(item, observation()))
@@ -138,8 +138,16 @@ class QualificationValidationTests(unittest.TestCase):
         different = validate_observation(item, observation(calls=(call(input_tokens=801, evaluated=33), call("final_from_tool"))))
         parity = compare_fixture_results(item, baseline, different)
         self.assertTrue(parity.equivalent)
+        self.assertTrue(parity.performance_comparison_valid)
+
+    def test_optimization_parity_requires_equivalent_call_behavior(self) -> None:
+        item = fixture()
+        baseline = validate_observation(item, observation())
+        different = validate_observation(item, observation(calls=(call(), call("retry"))))
+        parity = compare_fixture_results(item, baseline, different)
+        self.assertFalse(parity.equivalent)
         self.assertFalse(parity.performance_comparison_valid)
-        self.assertIn("model_work", parity.mismatches)
+        self.assertIn("call_behavior", parity.mismatches)
 
     def test_optimization_parity_allows_evaluated_cached_redistribution(self) -> None:
         item = fixture()
@@ -161,14 +169,13 @@ class QualificationValidationTests(unittest.TestCase):
         self.assertIsNone(incomplete.cached_tokens)
         self.assertIsNone(incomplete.prefill_tokens_per_second)
 
-    def test_missing_model_work_invalidates_performance_only(self) -> None:
+    def test_missing_token_metrics_remain_descriptive(self) -> None:
         item = fixture()
         baseline = validate_observation(item, observation())
         missing = observation(calls=(call(input_tokens=None), call("final_from_tool")))
         parity = compare_fixture_results(item, baseline, validate_observation(item, missing))
         self.assertTrue(parity.equivalent)
-        self.assertFalse(parity.performance_comparison_valid)
-        self.assertIn("model_work_unavailable", parity.mismatches)
+        self.assertTrue(parity.performance_comparison_valid)
 
     def test_argument_mismatch_invalidates_optimization_comparison(self) -> None:
         item = fixture()
@@ -292,6 +299,29 @@ class QualificationRunnerReportingTests(unittest.TestCase):
         self.assertEqual(value.calls[0].input_tokens, 10)
         self.assertEqual(value.calls[0].evaluated_tokens, 10)
         self.assertEqual(value.model_call_count, 1)
+
+    def test_runtime_adapter_observes_full_tools_on_chat_request(self) -> None:
+        payload = {"schema_version": 1, "fixtures": [{
+            "name": "full_chat", "capability": "tools", "profiles": ["profile-a"],
+            "request": {"prompt": "hello", "tools": True, "full_request": True},
+            "expect": {"route": "CHAT", "finish_reason": "stop", "max_model_calls": 2},
+            "parity": {"mode": "structural"},
+        }]}
+
+        class Backend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                self.calls += 1
+                content = '{"route":"CHAT"}' if self.calls == 1 else "Hello"
+                return ChatResult(content, "fake", "stop", [], 10, 1, 0, 20.0, 5.0)
+
+        item = load_fixture_text(json.dumps(payload)).fixtures[0]
+        with tempfile.TemporaryDirectory() as directory:
+            value = RuntimeFixtureExecutor(Backend()).execute(item, Path(directory))
+        self.assertEqual((value.route, value.model_call_count), ("CHAT", 2))
+        self.assertEqual([call.phase for call in value.calls], ["route", "chat_final"])
 
     def test_runtime_adapter_detects_visible_reasoning_markup(self) -> None:
         item = self.fixture_set().fixtures[0]


### PR DESCRIPTION
## Summary

- adds same-model baseline/candidate optimization comparison
- enforces correctness/parity before performance
- records isolated process/config provenance
- invalidates comparisons on route/tool/args/phases/outcomes/config mismatch
- permits valid evaluated/cached redistribution
- suppresses gain when parity is invalid
- keeps startup, per-request and aggregate wall metrics separate
- leaves production runtime/backend behavior unchanged

## Validated comparisons

- Qwen3-Coder route-prefix OFF/ON: parity 3/3
- Qwen3-Coder prewarm OFF/ON: parity 2/2
- Qwen3.6 route-prefix OFF/ON: parity 3/3
- negative control with an extra timeout argument: correctly invalidated

## Validation

- qualification: 60/60 PASS
- affected suites: 400/400 PASS
- compileall: PASS
- staged diff check: PASS

## Known limits

- single-run descriptive timing only
- no TTFT or statistical-significance machinery
- no cross-model gain comparison
- lifecycle Slice 4 is not included