### PR TITLE
Fix volatile RAM hardware parity

### DIFF
--- a/scripts/orbit_qualify.py
+++ b/scripts/orbit_qualify.py
@@ -82,6 +82,7 @@ def build_provenance(
             "aggregate_wall_seconds": "sum of fixture execution; server startup and model load excluded",
             "prefill_tokens_per_second": "sum evaluated / sum per-call evaluated seconds; complete calls only",
             "generation_tokens_per_second": "sum output / sum per-call decode seconds; complete calls only",
+            "hardware.ram_available": "descriptive snapshot; excluded from optimization hardware identity",
             "peak_rss_bytes": (
                 f"Linux VmHWM for server PID {server_pid}; process lifetime including model load"
                 if server_pid is not None else "unavailable without --server-pid"

--- a/src/orbit/qualification/runner.py
+++ b/src/orbit/qualification/runner.py
@@ -50,6 +50,9 @@ from .schema import (
 from .validators import compare_fixture_results, unavailable_result, validate_observation
 
 
+NON_GATING_HARDWARE_PROVENANCE_FIELDS = frozenset({"ram_available"})
+
+
 class FixtureExecutor(Protocol):
     def execute(self, fixture: FixtureSpec, workdir: Path) -> FixtureObservation: ...
 
@@ -331,12 +334,14 @@ def compare_runs(
         identity_fields = (
             "qualification_schema_version", "git_revision", "profile_identity", "model_identity",
             "template_identity", "template_hash", "backend_identity", "backend_revision",
-            "runtime_configuration", "hardware",
+            "runtime_configuration",
         )
         if any(
             getattr(baseline.provenance, field) != getattr(candidate.provenance, field)
             for field in identity_fields
-        ):
+        ) or _stable_hardware_identity(
+            baseline.provenance.hardware
+        ) != _stable_hardware_identity(candidate.provenance.hardware):
             raise ValueError("optimization comparison requires the same model and configuration")
     left = {item.name: item for item in baseline.fixtures}
     right = {item.name: item for item in candidate.fixtures}
@@ -444,6 +449,14 @@ def _valid_pid(value: int) -> bool:
 
 def _fixed_configuration(value: dict[str, Any]) -> dict[str, Any]:
     return {key: item for key, item in value.items() if key != "environment"}
+
+
+def _stable_hardware_identity(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: item
+        for key, item in value.items()
+        if key not in NON_GATING_HARDWARE_PROVENANCE_FIELDS
+    }
 
 
 def _metric(value: ModelStepMetrics, wall: float | None) -> CallMetric:

--- a/tests/test_qualification_comparison.py
+++ b/tests/test_qualification_comparison.py
@@ -240,6 +240,64 @@ class OptimizationComparisonTests(unittest.TestCase):
         self.assertFalse(different_config.performance_comparison_valid)
         self.assertIn("execution_configuration_mismatch", different_config.mismatches)
 
+    def test_volatile_available_ram_is_descriptive_and_non_gating(self) -> None:
+        hardware = {
+            "machine": "host-a", "cpu": "cpu-a", "physical_cores": "6",
+            "logical_cores": "12", "ram_total": "64 GB", "ram_available": "31 GB",
+            "os_name": "Linux",
+        }
+        baseline = side("baseline", 101, observation())
+        baseline = replace(
+            baseline,
+            result=replace(
+                baseline.result,
+                provenance=replace(baseline.result.provenance, hardware=hardware),
+            ),
+        )
+        candidate = side("candidate", 202, observation())
+        candidate = replace(
+            candidate,
+            result=replace(
+                candidate.result,
+                provenance=replace(
+                    candidate.result.provenance,
+                    hardware={**hardware, "ram_available": "30 GB"},
+                ),
+            ),
+        )
+        comparison = build_optimization_comparison(fixtures(), baseline, candidate)
+        payload = json.loads(comparison_json(comparison))
+        self.assertTrue(comparison.performance_comparison_valid)
+        self.assertEqual(payload["baseline"]["result"]["provenance"]["hardware"]["ram_available"], "31 GB")
+        self.assertEqual(payload["candidate"]["result"]["provenance"]["hardware"]["ram_available"], "30 GB")
+
+    def test_stable_hardware_mismatch_is_rejected(self) -> None:
+        hardware = {
+            "machine": "host-a", "cpu": "cpu-a", "physical_cores": "6",
+            "logical_cores": "12", "ram_total": "64 GB", "ram_available": "31 GB",
+            "os_name": "Linux",
+        }
+        baseline = run(observation())
+        baseline = replace(
+            baseline,
+            provenance=replace(baseline.provenance, hardware=hardware),
+        )
+        for field, value in (
+            ("machine", "host-b"), ("cpu", "cpu-b"), ("physical_cores", "4"),
+            ("logical_cores", "8"), ("ram_total", "32 GB"),
+            ("os_name", "OtherOS x86_64"),
+        ):
+            with self.subTest(field=field):
+                candidate = replace(
+                    baseline,
+                    provenance=replace(
+                        baseline.provenance,
+                        hardware={**hardware, field: value},
+                    ),
+                )
+                with self.assertRaisesRegex(ValueError, "same model and configuration"):
+                    compare_runs(fixtures(), baseline, candidate)
+
     def test_comparison_environment_is_explicit_and_bounded(self) -> None:
         self.assertEqual(
             _parse_overrides(["ORBIT_QWEN_ROUTE_PREFIX_REUSE=0"]),


### PR DESCRIPTION
## Summary

- excludes `ram_available` from optimization hardware identity
- retains available RAM as descriptive provenance
- preserves machine, CPU, core topology, total RAM, OS/platform, and all other stable hardware checks
- fixes false `TECHNICAL_STOP` results across sequential baseline/candidate runs
- leaves production runtime/backend behavior unchanged

## Validation

- comparison tests: 14/14 PASS
- qualification tests: 63/63 PASS
- Qwen3.6 route-prefix real comparison: 3/3 PASS
- compileall: PASS
- diff check: PASS