### PR TITLE
Retry transient native capability discovery

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -302,8 +302,17 @@ class LlamaServerBackend:
             return self._props_cache
         try:
             data = self._get_json("/props")
-        except LlamaServerError:
-            return {}
+        except LlamaServerError as exc:
+            cause = exc.__cause__
+            transient = (
+                isinstance(cause, TimeoutError)
+                or (isinstance(cause, URLError) and not isinstance(cause, HTTPError))
+                or (isinstance(cause, HTTPError) and 500 <= cause.code < 600)
+            )
+            if transient:
+                return {}
+            self._props_cache = {}
+            return self._props_cache
         self._props_cache = data if isinstance(data, dict) else {}
         return self._props_cache
 

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -303,7 +303,6 @@ class LlamaServerBackend:
         try:
             data = self._get_json("/props")
         except LlamaServerError:
-            self._props_cache = {}
             return {}
         self._props_cache = data if isinstance(data, dict) else {}
         return self._props_cache

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -33,7 +33,7 @@ from orbit.backend.payloads import (
 )
 from orbit.backend import model_names
 from orbit.runtime.kv_diag import model_call_context
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 
 class FakeStream:
@@ -272,7 +272,10 @@ class LlamaServerBackendTests(unittest.TestCase):
                     raise AssertionError(f"unexpected path: {path}")
                 self.props_calls += 1
                 if self.props_calls == 1:
-                    raise LlamaServerError("server is still starting")
+                    try:
+                        raise URLError("server is still starting")
+                    except URLError as exc:
+                        raise LlamaServerError("server is still starting") from exc
                 return {"backend": "orbit-native"}
 
             def display_model_name(self):
@@ -301,6 +304,27 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertTrue(backend._is_orbit_native_backend())
         self.assertEqual(backend.props_calls, 2)
 
+    def test_repeated_transient_props_failures_retry_once_per_operation(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", timeout=1)
+                self.props_calls = 0
+
+            def _get_json(self, path: str):
+                if path != "/props":
+                    raise AssertionError(f"unexpected path: {path}")
+                self.props_calls += 1
+                try:
+                    raise URLError("server is still starting")
+                except URLError as exc:
+                    raise LlamaServerError("server is still starting") from exc
+
+        backend = Backend()
+        for expected_calls in range(1, 4):
+            self.assertEqual(backend._props_or_empty(), {})
+            self.assertEqual(backend.props_calls, expected_calls)
+            self.assertIsNone(backend._props_cache)
+
     def test_successful_props_response_is_cached_and_fails_closed(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self, response) -> None:
@@ -326,6 +350,34 @@ class LlamaServerBackendTests(unittest.TestCase):
                 self.assertEqual(backend._is_orbit_native_backend(), expected_native)
                 self.assertEqual(backend.props_calls, 1)
                 self.assertEqual(backend._props_cache, expected_cache)
+
+    def test_permanent_props_failure_is_cached_and_fails_closed(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self, cause) -> None:
+                super().__init__(base_url="http://localhost", timeout=1)
+                self.cause = cause
+                self.props_calls = 0
+
+            def _get_json(self, path: str):
+                if path != "/props":
+                    raise AssertionError(f"unexpected path: {path}")
+                self.props_calls += 1
+                try:
+                    raise self.cause
+                except BaseException as exc:
+                    raise LlamaServerError("permanent props failure") from exc
+
+        causes = (
+            HTTPError("http://localhost/props", 404, "not found", {}, None),
+            json.JSONDecodeError("invalid JSON", "x", 0),
+        )
+        for cause in causes:
+            with self.subTest(cause=type(cause).__name__):
+                backend = Backend(cause)
+                self.assertFalse(backend._is_orbit_native_backend())
+                self.assertFalse(backend._is_orbit_native_backend())
+                self.assertEqual(backend.props_calls, 1)
+                self.assertEqual(backend._props_cache, {})
 
     def test_native_separated_reasoning_requires_verified_qwen_profile(self) -> None:
         class Backend(LlamaServerBackend):

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -260,6 +260,73 @@ class LlamaServerBackendTests(unittest.TestCase):
 
         self.assertEqual(Backend(base_url="http://localhost", timeout=1).backend_props(), {})
 
+    def test_transient_props_failure_does_not_disable_native_route_anchor(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self) -> None:
+                super().__init__(base_url="http://localhost", timeout=1)
+                self.props_calls = 0
+                self.payload = None
+
+            def _get_json(self, path: str):
+                if path != "/props":
+                    raise AssertionError(f"unexpected path: {path}")
+                self.props_calls += 1
+                if self.props_calls == 1:
+                    raise LlamaServerError("server is still starting")
+                return {"backend": "orbit-native"}
+
+            def display_model_name(self):
+                return None
+
+            def _post_native_stream(self, path, payload, *, on_delta, on_progress):
+                del on_delta, on_progress
+                self.assert_path = path
+                self.payload = payload
+                return ChatResult("ok", "fake", "stop", [], 10, 1, 0, None, None)
+
+        backend = Backend()
+        self.assertEqual(backend._props_or_empty(), {})
+        self.assertIsNone(backend._props_cache)
+
+        with model_call_context(phase="route", tools_mode="on"):
+            backend.chat(
+                [{"role": "system", "content": "route"}, {"role": "user", "content": "hi"}],
+                temperature=0,
+                max_tokens=32,
+            )
+
+        self.assertEqual(backend.props_calls, 2)
+        self.assertEqual(backend.assert_path, "/chat/stream")
+        self.assertTrue(backend.payload["qwen_route_prefix_anchor"])
+        self.assertTrue(backend._is_orbit_native_backend())
+        self.assertEqual(backend.props_calls, 2)
+
+    def test_successful_props_response_is_cached_and_fails_closed(self) -> None:
+        class Backend(LlamaServerBackend):
+            def __init__(self, response) -> None:
+                super().__init__(base_url="http://localhost", timeout=1)
+                self.response = response
+                self.props_calls = 0
+
+            def _get_json(self, path: str):
+                if path != "/props":
+                    raise AssertionError(f"unexpected path: {path}")
+                self.props_calls += 1
+                return self.response
+
+        cases = (
+            ({"backend": "orbit-native"}, True, {"backend": "orbit-native"}),
+            ({"backend": "external"}, False, {"backend": "external"}),
+            (["malformed"], False, {}),
+        )
+        for response, expected_native, expected_cache in cases:
+            with self.subTest(response=response):
+                backend = Backend(response)
+                self.assertEqual(backend._is_orbit_native_backend(), expected_native)
+                self.assertEqual(backend._is_orbit_native_backend(), expected_native)
+                self.assertEqual(backend.props_calls, 1)
+                self.assertEqual(backend._props_cache, expected_cache)
+
     def test_native_separated_reasoning_requires_verified_qwen_profile(self) -> None:
         class Backend(LlamaServerBackend):
             props: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- fixes the startup race where an initial `/props` transport failure permanently cached the backend as non-native
- keeps connection, timeout, and HTTP 5xx capability-discovery failures retryable on a later operation
- keeps successful native, confirmed non-native, malformed, and permanent failure results cached fail-closed
- restores Qwen3-Coder prewarmed route-prefix use after early client startup
- adds no polling loop and changes no checkpoint or prewarm behavior
- leaves Qwen3.6, Gemma, and non-native semantics unchanged

## Validation
- backend tests: 54/54 PASS
- affected suites: 243 executed, 241 PASS and 2 expected skips
- real Qwen3-Coder restore: PASS with route cached=768, capture=1, restore 0->1, fallback=0, last_used=restore
- compileall: PASS
- diff check: PASS
