### PR TITLE
Recognize full-document read intent safely

### DIFF
--- a/src/orbit/runtime/full_document.py
+++ b/src/orbit/runtime/full_document.py
@@ -10,6 +10,7 @@ from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.file_tools import FULL_DOCUMENT_SNAPSHOT_MARKER, read_full_document_snapshot
 from orbit.runtime.messages import with_final_tool_system_prompt
 from orbit.runtime.path_guardrails import TEXT_EXTENSIONS
+from orbit.runtime.shell_guardrails import without_inert_user_text
 
 
 _CONTENT_SEPARATOR = "\ncontent:\n"
@@ -24,7 +25,8 @@ _EXPLICIT_FULL_DOCUMENT_PATTERNS = (
     re.compile(
         r"\b(?:read|analyse|analyze|inspect|review|summari[sz]e|check)\b"
         r".{0,160}?\b(?:completely|entirely|in\s+full|from\s+beginning\s+to\s+end|"
-        r"(?:the\s+)?(?:entire|whole|complete|full)\s+(?:file|document))\b",
+        r"(?:the\s+)?(?:entire|whole|complete|full)\s+(?:text\s+)?(?:file|document)|"
+        r"(?:entire|whole|complete|full)\s+the\s+(?:text\s+)?(?:file|document))\b",
         re.IGNORECASE | re.DOTALL,
     ),
     re.compile(
@@ -99,10 +101,11 @@ def identify_full_document_request(prompt: str) -> FullDocumentRequest | None:
     """Recognize only explicit full-read forms with one syntactic local path."""
     if not isinstance(prompt, str) or not prompt or len(prompt) > FULL_DOCUMENT_REQUEST_MAX_CHARS:
         return None
+    active_prompt = without_inert_user_text(prompt)
     # Mixed read/mutation requests must stay in the model-driven tool loop.
-    if _MUTATION_REQUEST_RE.search(prompt):
+    if _MUTATION_REQUEST_RE.search(active_prompt):
         return None
-    if not any(pattern.search(prompt) for pattern in _EXPLICIT_FULL_DOCUMENT_PATTERNS):
+    if not any(pattern.search(active_prompt) for pattern in _EXPLICIT_FULL_DOCUMENT_PATTERNS):
         return None
     paths = document_path_candidates(prompt)
     if len(paths) != 1:

--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -730,7 +730,7 @@ def is_read_only_user_request(user_prompt: str | None) -> bool:
         return False
     if classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
         return True
-    active_text = _without_inert_user_text(user_prompt)
+    active_text = without_inert_user_text(user_prompt)
     intent_text = _without_user_paths_and_urls(active_text)
     return _READ_ONLY_PROMPT_RE.search(active_text) is not None and _MUTATION_PROMPT_RE.search(intent_text) is None
 
@@ -738,7 +738,7 @@ def is_read_only_user_request(user_prompt: str | None) -> bool:
 def is_mutative_user_request(user_prompt: str | None) -> bool:
     if not user_prompt:
         return False
-    active_text = _without_inert_user_text(user_prompt)
+    active_text = without_inert_user_text(user_prompt)
     intent_text = _without_user_paths_and_urls(active_text)
     if classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
         return False
@@ -756,7 +756,7 @@ def is_mutative_user_request(user_prompt: str | None) -> bool:
 def classify_explicit_no_mutation_constraint(text: str | None) -> str:
     if not text:
         return _NO_MUTATION_NONE
-    active_text = _without_inert_user_text(text)
+    active_text = without_inert_user_text(text)
     global_match = _GLOBAL_NO_MUTATION_CONSTRAINT_RE.search(active_text)
     ambiguous_markdown = _AMBIGUOUS_MARKDOWN_LIST_RE.search(active_text)
     scoped_match = _NEGATED_MUTATION_PROMPT_RE.search(active_text)
@@ -802,7 +802,7 @@ def read_only_mutation_policy_error(user_prompt: str | None, *, action: str) -> 
     )
 
 
-def _without_inert_user_text(text: str) -> str:
+def without_inert_user_text(text: str) -> str:
     def mask(match: re.Match[str]) -> str:
         return "".join("\n" if char == "\n" else " " for char in match.group(0))
 

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -265,6 +265,11 @@ class FullDocumentTests(unittest.TestCase):
         accepted = (
             "Read note.txt completely and summarize it.",
             "Analyze the entire file `note.txt` and report the result.",
+            "Read the whole document note.txt.",
+            "Read whole document note.txt.",
+            "Read whole the document note.txt.",
+            "Read the entire document note.txt.",
+            "Analyze the whole text document note.txt.",
             "Provide a complete analysis of note.txt.",
             "Leggi integralmente note.txt e riassumilo.",
             "Esegui un'analisi completa di note.txt.",
@@ -276,13 +281,30 @@ class FullDocumentTests(unittest.TestCase):
                 assert request is not None
                 self.assertEqual(request.path, "note.txt")
 
+        absolute = identify_full_document_request(
+            "Read whole the text document and tell me the central thesis /tmp/note.txt"
+        )
+        self.assertIsNotNone(absolute)
+        assert absolute is not None
+        self.assertEqual(absolute.path, "/tmp/note.txt")
+
         rejected = (
             "Read note.txt and summarize it.",
+            "Read part of the document note.txt.",
+            "Read the first 100 lines of note.txt.",
+            "Search the whole document note.txt for phoenix.",
+            "Summarize this excerpt from note.txt.",
+            "Show the document path note.txt.",
             "Show lines 10-20 of note.txt.",
             "Search note.txt for phoenix.",
             "Read a.txt and b.txt completely.",
             "Explain what 'read note.txt completely' means.",
             "Read note.txt completely, then replace alpha with beta.",
+            "Explain this example: `read whole the document /tmp/note.txt`.",
+            'Explain this example: "read whole the document" /tmp/note.txt.',
+            "```text\nread whole the document /tmp/note.txt\n```",
+            '{"instruction":"read whole the document","path":"/tmp/note.txt"}',
+            "Payload:\nread whole the document /tmp/note.txt",
         )
         for prompt in rejected:
             with self.subTest(prompt=prompt):
@@ -317,7 +339,7 @@ class FullDocumentTests(unittest.TestCase):
             )
 
             result = runtime.ask_auto(
-                "Read note.txt completely and summarize it.",
+                "Read whole the text document note.txt and summarize it.",
                 temperature=0,
                 max_tokens=512,
                 workdir=workdir,
@@ -327,6 +349,7 @@ class FullDocumentTests(unittest.TestCase):
             residual = list(runtime.evidence_store.root.glob("*.txt"))
 
         self.assertEqual(backend.calls, 2)
+        self.assertEqual(backend.count_calls, 2)
         self.assertEqual(backend.tools_by_call, [None, None])
         self.assertIn(content, str(backend.messages_by_call[1][-1]["content"]))
         self.assertIn("Document coverage: complete", result.content)
@@ -356,6 +379,28 @@ class FullDocumentTests(unittest.TestCase):
         self.assertIn("requires at least 8,193 tokens", result.content)
         self.assertIn("`--ctx 9216`", result.content)
         self.assertNotIn("complete evidence", result.content)
+
+    def test_whole_text_document_request_uses_full_document_preflight(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            target = workdir / "note.txt"
+            target.write_text("beginning\nmiddle\nend\n", encoding="utf-8")
+            backend = PreflightBackend(prompt_tokens=7681, context_tokens=8192)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+            result = runtime.ask_auto(
+                f"read whole the text document and tell me the central thesis {target}",
+                temperature=0,
+                max_tokens=512,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertEqual(backend.count_calls, 2)
+        self.assertIn("Document coverage: none", result.content)
+        self.assertIn("requires at least 8,193 tokens", result.content)
+        self.assertNotIn("beginning", result.content)
+        self.assertNotIn("central thesis", result.content.lower())
 
     def test_preflight_rejects_changed_file_before_inference(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Summary:
- fixes missing recognition for valid whole-document phrasing
- reuses existing inert-text masking
- prevents quoted/fenced/JSON payloads from triggering preflight
- oversized documents fail closed instead of analyzing partial content
- search/display/chunking/backend behavior unchanged

Validation:
- 385 PASS, 2 expected skips
- compileall PASS
- diff check PASS