### PR TITLE
Add Qwen3.6 shell-tool prefix reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ orbit server \
 
 Qwen MTP and Gemma-specific prefix checkpoints are not enabled for Qwen. The
 verified Qwen profile has its own default-on 768-token route checkpoint with
-`ORBIT_QWEN_ROUTE_PREFIX_REUSE=0` as its kill switch. See
+`ORBIT_QWEN_ROUTE_PREFIX_REUSE=0` as its kill switch. Exact shell tool calls
+also use a separate qualified 384-token checkpoint; disable only that path with
+`ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE=0`. See
 [`docs/QWEN_3_6_COMPATIBILITY.md`](docs/QWEN_3_6_COMPATIBILITY.md) for the exact
 identity gate, thinking behavior, tool protocol, diagnostics, and limits.
 

--- a/docs/QWEN_3_6_COMPATIBILITY.md
+++ b/docs/QWEN_3_6_COMPATIBILITY.md
@@ -154,13 +154,51 @@ prefill after capture was 1.76 seconds versus 24.38 seconds OFF on the measured
 CPU host. These timings are descriptive and not a deterministic performance
 guarantee.
 
+## Shell Tool Prefix Reuse
+
+The exact verified profile also keeps one separate process-local checkpoint
+for `exec_shell_full_command` tool-selection calls. Eligibility requires tools
+on, thinking off, the exact reviewed single shell schema, and the normal
+`tool_call` phase. It does not apply to retries, `verify_artifact`,
+`final_from_tool`, other tools, or artifact-content generation.
+
+The checkpoint captures complete Qwen 3.6 hybrid sequence state at the
+unpadded 384-token boundary inside the 439-token invariant shell prefix. Its
+identity is `qwen36-shell-tool-prefix-v1` and is bound to the verified
+model/GGUF, tokenizer, template, shell schema, system policy, rendered and
+token prefix hashes, native build, context, batch, ubatch, and thread
+configuration. It is separate from the 768-token route checkpoint and is not
+prewarmed.
+
+Reuse is enabled by default for this exact qualified path. Disable only the
+shell checkpoint with:
+
+```bash
+ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE=0 orbit server \
+  --model models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf
+```
+
+Invalid values disable safely. `/props` reports bounded shell-checkpoint
+capture, restore, fallback, invalidation, identity, token-count, and size
+diagnostics. Reset, reload, cancel, close, completion errors, identity changes,
+and restore failures invalidate the state. A failed restore performs one cold
+fallback without a retry loop.
+
+Qualification measured a 73,736,684-byte checkpoint. Cold, segmented, and
+restored logits were byte-identical with maximum absolute difference `0.0`.
+The measured `pwd` tool/final workflow fell from 51.17 to 35.47 seconds, and an
+existing-file modification workflow fell from 459.05 to 333.09 seconds. Each
+warm restore avoided 384 evaluated tokens. These CPU timings are descriptive,
+hardware-dependent qualification evidence, not a performance guarantee.
+
 ## Current Limits
 
 - Only the exact verified 35B-A3B identity and reviewed template are enabled.
 - Qwen MTP is disabled. The available Qwen draft GGUF has not been qualified
   against Orbit's target/draft lifecycle and must not be treated as supported.
 - Gemma-specific route and final-prefix checkpoints remain disabled for Qwen;
-  Qwen route reuse has its own identity, storage, eligibility, and lifecycle.
+  Qwen route and shell reuse have separate identities, storage, eligibility,
+  and lifecycle.
 - The Qwen hybrid/recurrent memory layout can reject partial KV removal. Orbit
   uses complete sequence-state capture/restore for the verified route prefix
   and falls back to a cold prefill for other incompatible cache transitions.

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -17,6 +17,10 @@ from .payloads import (
 )
 from orbit.final_prefix_config import resolve_final_prefix_reuse
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
+from orbit.native_llama.qwen36_shell_tool_prefix import (
+    exact_qwen36_shell_tool_schema,
+    resolve_qwen36_shell_tool_prefix_reuse,
+)
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
@@ -65,6 +69,11 @@ class LlamaServerBackend:
                 tools=tools,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
                 qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
+                qwen36_shell_tool_prefix_anchor=_qwen36_shell_tool_prefix_anchor_requested(
+                    native_backend=native_backend,
+                    tools=tools,
+                    thinking=self.thinking,
+                ),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
                 final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
@@ -103,6 +112,11 @@ class LlamaServerBackend:
                 stream=True,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
                 qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
+                qwen36_shell_tool_prefix_anchor=_qwen36_shell_tool_prefix_anchor_requested(
+                    native_backend=native_backend,
+                    tools=tools,
+                    thinking=self.thinking,
+                ),
                 allow_mtp_experimental=_allow_mtp_experimental_requested(native_backend=native_backend),
                 final_prefix_experiment=_final_prefix_experiment_requested(native_backend=native_backend),
             )
@@ -899,6 +913,19 @@ def _qwen_route_prefix_anchor_requested(*, native_backend: bool) -> bool:
     ):
         return False
     return current_phase() == "route" and current_tools_mode() == "on"
+
+
+def _qwen36_shell_tool_prefix_anchor_requested(
+    *,
+    native_backend: bool,
+    tools: list[dict[str, Any]] | None,
+    thinking: bool,
+) -> bool:
+    if not native_backend or thinking or not resolve_qwen36_shell_tool_prefix_reuse().enabled:
+        return False
+    if current_phase() != "tool_call" or current_tools_mode() != "on":
+        return False
+    return exact_qwen36_shell_tool_schema(tools)
 
 
 def _allow_mtp_experimental_requested(*, native_backend: bool) -> bool | None:

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -22,6 +22,7 @@ class ChatPayloadOptions:
     cache_prompt: bool = True
     route_prefix_anchor: bool = False
     qwen_route_prefix_anchor: bool = False
+    qwen36_shell_tool_prefix_anchor: bool = False
     allow_mtp_experimental: bool | None = None
     final_prefix_experiment: bool = False
     artifact_content: bool = False
@@ -43,6 +44,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["route_prefix_anchor"] = True
     if options.qwen_route_prefix_anchor:
         payload["qwen_route_prefix_anchor"] = True
+    if options.qwen36_shell_tool_prefix_anchor:
+        payload["qwen36_shell_tool_prefix_anchor"] = True
     if options.allow_mtp_experimental is not None:
         payload["allow_mtp_experimental"] = options.allow_mtp_experimental
     if options.final_prefix_experiment:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -52,6 +52,14 @@ from .qwen_route_prefix import (
     derive_qwen_route_prefix_spec,
     hash_text,
 )
+from .qwen36_shell_tool_prefix import (
+    QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION,
+    QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT,
+    QWEN36_SHELL_TOOL_TOKENIZER_IDENTITY,
+    Qwen36ShellToolPrefixSpec,
+    derive_qwen36_shell_tool_prefix_spec,
+    exact_qwen36_shell_tool_schema,
+)
 from .qwen3_coder import (
     QWEN3_CODER_ARTIFACT_GRAMMAR,
     QWEN3_CODER_ARTIFACT_PROTOCOL_ID,
@@ -107,6 +115,9 @@ class NativeClientConfig:
     qwen_route_prefix_reuse_enabled: bool = False
     qwen_route_prefix_reuse_source: str = "default"
     qwen_route_prefix_reuse_config_error: str | None = None
+    qwen36_shell_tool_prefix_reuse_enabled: bool = False
+    qwen36_shell_tool_prefix_reuse_source: str = "default"
+    qwen36_shell_tool_prefix_reuse_config_error: str | None = None
     qwen3_coder_route_prefix_reuse_enabled: bool = False
     qwen3_coder_route_prefix_reuse_source: str = "default"
     qwen3_coder_route_prefix_reuse_config_error: str | None = None
@@ -139,6 +150,14 @@ class _QwenRouteAnchorRuntimePlan:
     spec: QwenRoutePrefixSpec
     metadata: dict[str, object]
     profile_id: str = QWEN36_PROFILE_ID
+
+
+@dataclass(frozen=True)
+class _Qwen36ShellToolAnchorRuntimePlan:
+    prefix_tokens: list[int]
+    prefix_hash: str
+    state_kwargs: dict[str, str | None]
+    spec: Qwen36ShellToolPrefixSpec
 
 
 @dataclass(frozen=True)
@@ -235,6 +254,11 @@ class NativeLlamaClient:
         self._qwen_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen_route_prefix_status = QwenRoutePrefixStatus()
+        self._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState()
+        self._qwen36_shell_tool_prefix_spec: Qwen36ShellToolPrefixSpec | None = None
+        self._qwen36_shell_tool_prefix_status = QwenRoutePrefixStatus()
+        self._qwen36_shell_tool_prefix_lock = threading.RLock()
+        self._qwen36_shell_tool_prefix_epoch = 0
         self._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen3_coder_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen3_coder_route_prefix_status = QwenRoutePrefixStatus()
@@ -322,6 +346,38 @@ class NativeLlamaClient:
             "prefix_text_hash": spec.invariant_text_hash if spec is not None else None,
         }
 
+    def qwen36_shell_tool_prefix_reuse_status(self) -> dict[str, object]:
+        with self._qwen36_shell_tool_prefix_lock:
+            status = self._qwen36_shell_tool_prefix_status
+            profile = getattr(self, "model_profile", None)
+            profile_eligible = (
+                getattr(profile, "profile_id", None) == QWEN36_PROFILE_ID
+                and getattr(profile, "verified", False)
+                and self._model_metadata_identity.get("general.file_type") == "15"
+            )
+            spec = self._qwen36_shell_tool_prefix_spec
+            return {
+                "enabled": self.config.qwen36_shell_tool_prefix_reuse_enabled and profile_eligible,
+                "source": self.config.qwen36_shell_tool_prefix_reuse_source,
+                "config_error": self.config.qwen36_shell_tool_prefix_reuse_config_error,
+                "initialized": status.initialized,
+                "prefix_tokens": status.prefix_tokens,
+                "capture_count": status.capture_count,
+                "restore_count": status.restore_count,
+                "fallback_count": status.fallback_count,
+                "invalidation_count": status.invalidation_count,
+                "failure_reason": status.failure_reason,
+                "last_used": status.last_used,
+                "checkpoint_size_bytes": self._qwen36_shell_tool_prefix_anchor_state.checkpoint_size,
+                "checkpoint_identity": QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION,
+                "profile_identity": getattr(profile, "profile_id", None),
+                "template_identity": getattr(profile, "template_sha256", None),
+                "tokenizer_identity": hash_text(QWEN36_SHELL_TOOL_TOKENIZER_IDENTITY),
+                "prefix_token_hash": spec.prefix_token_hash if spec is not None else None,
+                "prefix_text_hash": spec.invariant_text_hash if spec is not None else None,
+                "tool_schema_hash": spec.tool_schema_hash if spec is not None else None,
+            }
+
     def compatibility_diagnostics(self) -> dict[str, object]:
         profile = getattr(self, "model_profile", None)
         if profile is None:
@@ -358,6 +414,7 @@ class NativeLlamaClient:
     def close(self) -> None:
         lib = self.lib.lib
         self._invalidate_qwen_route_prefix("client_closed")
+        self._invalidate_qwen36_shell_tool_prefix("client_closed")
         self._free_persistent_mtp_session()
         if self.chat_bridge is not None and self._chat_bridge_context:
             self.chat_bridge.free(self._chat_bridge_context)
@@ -381,6 +438,7 @@ class NativeLlamaClient:
     def cancel(self) -> None:
         self._invalidate_final_prefix("cancelled")
         self._invalidate_qwen_route_prefix("cancelled")
+        self._invalidate_qwen36_shell_tool_prefix("cancelled")
         self._session.cancel_requested = True
         self._session.continuation_ready = False
         self.cancel_event.set()
@@ -390,6 +448,7 @@ class NativeLlamaClient:
         self.cancel_event.clear()
 
     def load(self, on_progress=None) -> None:
+        self._invalidate_qwen36_shell_tool_prefix("model_reload")
         lib = self.lib.lib
         lib.ggml_backend_load_all()
 
@@ -610,6 +669,7 @@ class NativeLlamaClient:
         self._profile_last_parsed_content = ""
         self._invalidate_final_prefix("session_reset")
         self._invalidate_qwen_route_prefix("session_reset")
+        self._invalidate_qwen36_shell_tool_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
         try:
@@ -953,6 +1013,7 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
+        qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
@@ -998,6 +1059,12 @@ class NativeLlamaClient:
             thinking=thinking,
             prompt=prompt,
         ) if qwen_route_prefix_anchor else None
+        qwen36_shell_tool_anchor_plan = self._qwen36_shell_tool_anchor_plan_for_prompt(
+            messages,
+            tools=tools,
+            thinking=thinking,
+            prompt=prompt,
+        ) if qwen36_shell_tool_prefix_anchor else None
         route_anchor_segments = self._route_anchor_segments_for_prompt(
             messages,
             tools=tools,
@@ -1029,6 +1096,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_anchor_segments=route_anchor_segments,
             qwen_route_anchor_plan=qwen_route_anchor_plan,
+            qwen36_shell_tool_anchor_plan=qwen36_shell_tool_anchor_plan,
             final_prefix_segments=final_prefix_segments,
             kv_diag_messages=messages,
             on_progress=on_progress,
@@ -1046,6 +1114,7 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
+        qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
@@ -1061,6 +1130,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+            qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
             final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
@@ -1221,6 +1291,7 @@ class NativeLlamaClient:
         thinking: bool,
         route_prefix_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
+        qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
         final_prefix_experiment: bool = False,
         on_progress=None,
@@ -1237,6 +1308,7 @@ class NativeLlamaClient:
                 thinking=thinking,
                 route_prefix_anchor=route_prefix_anchor,
                 qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+                qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
                 allow_mtp_experimental=allow_mtp_experimental,
                 final_prefix_experiment=final_prefix_experiment,
                 on_progress=on_progress,
@@ -1305,6 +1377,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+            qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
             final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
@@ -1329,6 +1402,7 @@ class NativeLlamaClient:
         thinking: bool,
         route_prefix_anchor: bool,
         qwen_route_prefix_anchor: bool,
+        qwen36_shell_tool_prefix_anchor: bool,
         allow_mtp_experimental: bool | None,
         final_prefix_experiment: bool,
         on_progress=None,
@@ -1376,6 +1450,7 @@ class NativeLlamaClient:
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+            qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
             final_prefix_experiment=final_prefix_experiment,
             on_progress=on_progress,
@@ -1675,6 +1750,7 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         route_anchor_segments: RoutePromptSegments | None = None,
         qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
+        qwen36_shell_tool_anchor_plan: _Qwen36ShellToolAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
@@ -1717,6 +1793,7 @@ class NativeLlamaClient:
                 max_tokens=max_tokens,
                 route_anchor_segments=route_anchor_segments,
                 qwen_route_anchor_plan=qwen_route_anchor_plan,
+                qwen36_shell_tool_anchor_plan=qwen36_shell_tool_anchor_plan,
                 final_prefix_segments=final_prefix_segments,
                 kv_diag_messages=kv_diag_messages,
                 on_progress=on_progress,
@@ -1737,6 +1814,8 @@ class NativeLlamaClient:
                 self._invalidate_final_prefix("completion_error")
             if qwen_route_anchor_plan is not None:
                 self._invalidate_qwen_route_prefix("completion_error", profile_id=qwen_route_anchor_plan.profile_id)
+            if qwen36_shell_tool_anchor_plan is not None:
+                self._invalidate_qwen36_shell_tool_prefix("completion_error")
             raise
         finally:
             self._session.in_flight = False
@@ -1877,6 +1956,7 @@ class NativeLlamaClient:
         max_tokens: int = 16,
         route_anchor_segments: RoutePromptSegments | None = None,
         qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
+        qwen36_shell_tool_anchor_plan: _Qwen36ShellToolAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
@@ -1900,6 +1980,13 @@ class NativeLlamaClient:
         if qwen_route_anchor_plan is not None and prompt_tokens[: len(qwen_route_anchor_plan.prefix_tokens)] != qwen_route_anchor_plan.prefix_tokens:
             self._record_qwen_route_prefix_fallback("production_prefix_changed")
             qwen_route_anchor_plan = None
+        if (
+            qwen36_shell_tool_anchor_plan is not None
+            and prompt_tokens[: len(qwen36_shell_tool_anchor_plan.prefix_tokens)]
+            != qwen36_shell_tool_anchor_plan.prefix_tokens
+        ):
+            self._record_qwen36_shell_tool_prefix_fallback("production_prefix_changed")
+            qwen36_shell_tool_anchor_plan = None
         final_plan = self._final_prefix_plan(prompt, prompt_tokens, final_prefix_segments)
         anchor_metadata: dict[str, object] | None = None
         processed_start = 0
@@ -1907,6 +1994,10 @@ class NativeLlamaClient:
             processed_start, reused = self._prepare_memory_with_final_prefix(final_plan, prompt_tokens)
         elif qwen_route_anchor_plan is not None:
             processed_start, reused = self._prepare_memory_with_qwen_route_anchor(qwen_route_anchor_plan)
+        elif qwen36_shell_tool_anchor_plan is not None:
+            processed_start, reused = self._prepare_memory_with_qwen36_shell_tool_anchor(
+                qwen36_shell_tool_anchor_plan
+            )
         elif anchor_plan is None:
             reused = self._prepare_memory_for_prompt(prompt_tokens)
         else:
@@ -1916,7 +2007,14 @@ class NativeLlamaClient:
                 processed_start = reused
         processed = 0
         step = max(1, min(self.config.progress_step, self.config.batch_size))
-        processed = processed_start if final_plan is not None or qwen_route_anchor_plan is not None or (anchor_plan is not None and anchor_metadata is not None) else reused
+        processed = (
+            processed_start
+            if final_plan is not None
+            or qwen_route_anchor_plan is not None
+            or qwen36_shell_tool_anchor_plan is not None
+            or (anchor_plan is not None and anchor_metadata is not None)
+            else reused
+        )
         if on_progress:
             on_progress(NativeProgress("prefill", processed, n_prompt))
         token_array = (llama_token * n_prompt)(*prompt_tokens)
@@ -2119,6 +2217,282 @@ class NativeLlamaClient:
             },
             profile_id=profile_id,
         )
+
+    def _qwen36_shell_tool_anchor_plan_for_prompt(
+        self,
+        messages: list[NativeMessage],
+        *,
+        tools: list[dict] | None,
+        thinking: bool,
+        prompt: str,
+    ) -> _Qwen36ShellToolAnchorRuntimePlan | None:
+        profile = getattr(self, "model_profile", None)
+        if getattr(profile, "profile_id", None) != QWEN36_PROFILE_ID:
+            if self._qwen36_shell_tool_prefix_anchor_state.valid:
+                self._invalidate_qwen36_shell_tool_prefix("model_profile_changed")
+            return None
+        if not self.config.qwen36_shell_tool_prefix_reuse_enabled:
+            return None
+        if not getattr(profile, "verified", False):
+            self._record_qwen36_shell_tool_prefix_fallback("model_profile_ineligible")
+            return None
+        if self._model_metadata_identity.get("general.file_type") != "15":
+            self._record_qwen36_shell_tool_prefix_fallback("qwen_quantization_unverified")
+            return None
+        if thinking:
+            self._record_qwen36_shell_tool_prefix_fallback("shell_tool_mode_ineligible")
+            return None
+        if not exact_qwen36_shell_tool_schema(tools):
+            if self._qwen36_shell_tool_prefix_anchor_state.valid:
+                self._invalidate_qwen36_shell_tool_prefix("shell_tool_schema_changed")
+            self._record_qwen36_shell_tool_prefix_fallback("shell_tool_schema_mismatch")
+            return None
+        if self.config.use_mtp_experimental or self._session.mtp_enabled:
+            self._record_qwen36_shell_tool_prefix_fallback("mtp_ineligible")
+            return None
+        if self.chat_bridge is None or not self._chat_bridge_context:
+            self._record_qwen36_shell_tool_prefix_fallback("chat_bridge_unavailable")
+            return None
+
+        prompt_tokens = self.tokenize(prompt)
+        spec = self._qwen36_shell_tool_prefix_spec
+        if spec is None:
+
+            def render_reference(user_text: str) -> str:
+                rendered = self.chat_bridge.render(
+                    self._chat_bridge_context,
+                    [{"role": "user", "content": user_text}],
+                    [dict(tool) for tool in tools or []],
+                    thinking=False,
+                )
+                value = rendered.get("prompt")
+                if not isinstance(value, str) or not value:
+                    raise RuntimeError("empty Qwen3.6 shell reference prompt")
+                return value
+
+            reason = None
+            try:
+                spec, reason = derive_qwen36_shell_tool_prefix_spec(
+                    tools=tools,
+                    full_prompt=prompt,
+                    full_tokens=prompt_tokens,
+                    render_reference=render_reference,
+                    tokenize=self.tokenize,
+                )
+            except Exception as exc:
+                spec = None
+                reason = f"shell_boundary_probe_failed:{type(exc).__name__}"
+            finally:
+                restored = self.chat_bridge.render(
+                    self._chat_bridge_context,
+                    self._serialize_profile_messages([dict(message) for message in messages]),
+                    [dict(tool) for tool in tools or []],
+                    thinking=False,
+                )
+                restored_prompt = restored.get("prompt")
+                if restored_prompt != prompt:
+                    spec = None
+                    reason = "production_render_not_repeatable"
+                else:
+                    self._active_profile_render = restored
+            if spec is None:
+                self._record_qwen36_shell_tool_prefix_fallback(
+                    reason or "shell_boundary_unavailable"
+                )
+                return None
+            self._qwen36_shell_tool_prefix_spec = spec
+
+        if list(prompt_tokens[:QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT]) != list(spec.prefix_tokens):
+            self._invalidate_qwen36_shell_tool_prefix("production_prefix_changed")
+            self._record_qwen36_shell_tool_prefix_fallback("production_prefix_changed")
+            return None
+
+        state_kwargs = self._qwen36_shell_tool_prefix_state_kwargs(spec, messages=messages)
+        return _Qwen36ShellToolAnchorRuntimePlan(
+            prefix_tokens=list(spec.prefix_tokens),
+            prefix_hash=compute_prefix_anchor_key(**state_kwargs),
+            state_kwargs=state_kwargs,
+            spec=spec,
+        )
+
+    def _prepare_memory_with_qwen36_shell_tool_anchor(
+        self,
+        plan: _Qwen36ShellToolAnchorRuntimePlan,
+    ) -> tuple[int, int]:
+        if not self._session.ctx_tgt:
+            raise RuntimeError("native client not loaded")
+        with self._qwen36_shell_tool_prefix_lock:
+            state = self._qwen36_shell_tool_prefix_anchor_state
+            lifecycle_epoch = self._qwen36_shell_tool_prefix_epoch
+        status = self._qwen36_shell_tool_prefix_status
+        if state.valid:
+            self._clear_target_memory()
+            ok, restored, metadata = restore_prefix_anchor(
+                state,
+                lib=self.lib.lib,
+                ctx=self._session.ctx_tgt,
+                prefix_hash=plan.prefix_hash,
+                token_count=len(plan.prefix_tokens),
+                enabled=True,
+                **plan.state_kwargs,
+            )
+            if ok:
+                with self._qwen36_shell_tool_prefix_lock:
+                    if (
+                        self.cancel_event.is_set()
+                        or self._qwen36_shell_tool_prefix_epoch != lifecycle_epoch
+                    ):
+                        self._clear_target_memory()
+                        return 0, 0
+                    self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+                    status.initialized = True
+                    status.prefix_tokens = len(plan.prefix_tokens)
+                    status.restore_count += 1
+                    status.failure_reason = None
+                    status.last_used = "restore"
+                    return len(plan.prefix_tokens), len(plan.prefix_tokens)
+            with self._qwen36_shell_tool_prefix_lock:
+                if (
+                    self.cancel_event.is_set()
+                    or self._qwen36_shell_tool_prefix_epoch != lifecycle_epoch
+                ):
+                    self._clear_target_memory()
+                    return 0, 0
+                self._qwen36_shell_tool_prefix_anchor_state = restored
+                self._clear_target_memory()
+                status.invalidation_count += 1
+                self._record_qwen36_shell_tool_prefix_fallback(
+                    str(metadata.get("fallback_reason") or "restore_failed")
+                )
+                return 0, 0
+
+        self._clear_target_memory()
+        token_array = (llama_token * len(plan.prefix_tokens))(*plan.prefix_tokens)
+        step = max(1, min(self.config.progress_step, self.config.batch_size))
+        processed = self._decode_prompt_range(
+            token_array,
+            processed=0,
+            end=len(plan.prefix_tokens),
+            step=step,
+            total=len(plan.prefix_tokens),
+            on_progress=None,
+            should_cancel=None,
+        )
+        if processed != len(plan.prefix_tokens) or self.cancel_event.is_set():
+            self._clear_target_memory()
+            self._invalidate_qwen36_shell_tool_prefix("cancelled")
+            return 0, 0
+        self._session.cached_prompt_tokens = list(plan.prefix_tokens)
+        state, metadata = capture_prefix_anchor(
+            lib=self.lib.lib,
+            ctx=self._session.ctx_tgt,
+            prefix_hash=plan.prefix_hash,
+            token_count=len(plan.prefix_tokens),
+            enabled=True,
+            **plan.state_kwargs,
+        )
+        with self._qwen36_shell_tool_prefix_lock:
+            if (
+                self.cancel_event.is_set()
+                or self._qwen36_shell_tool_prefix_epoch != lifecycle_epoch
+            ):
+                self._clear_target_memory()
+                return 0, 0
+            self._qwen36_shell_tool_prefix_anchor_state = state
+            if state.valid:
+                status.initialized = True
+                status.prefix_tokens = len(plan.prefix_tokens)
+                status.capture_count += 1
+                status.failure_reason = None
+                status.last_used = "capture"
+            else:
+                self._record_qwen36_shell_tool_prefix_fallback(
+                    str(metadata.get("fallback_reason") or "capture_failed")
+                )
+            return len(plan.prefix_tokens), 0
+
+    def _qwen36_shell_tool_prefix_state_kwargs(
+        self,
+        spec: Qwen36ShellToolPrefixSpec,
+        *,
+        messages: list[NativeMessage],
+    ) -> dict[str, str | None]:
+        profile = self.model_profile
+        try:
+            stat = self.paths.model.stat()
+            model_file_identity = {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
+        except OSError:
+            model_file_identity = {"size": None, "mtime_ns": None}
+        model_identity = hash_text(
+            json.dumps(
+                {
+                    "profile": getattr(profile, "profile_id", None),
+                    "metadata": self._model_metadata_identity,
+                    "file": model_file_identity,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        system_policy_identity = hash_text(
+            json.dumps(
+                [
+                    str(message.get("content", ""))
+                    for message in messages
+                    if message.get("role") == "system"
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+        return {
+            "model_id": model_identity,
+            "template_id": hash_text(
+                f"{QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION}:"
+                f"{getattr(profile, 'template_sha256', '')}:"
+                f"{QWEN36_SHELL_TOOL_TOKENIZER_IDENTITY}:ctx={self.config.context_tokens}"
+            ),
+            "tool_schema_hash": spec.tool_schema_hash,
+            "capability_summary_hash": system_policy_identity,
+            "runtime_policy_hash": spec.invariant_text_hash,
+            "route_contract_hash": spec.prefix_token_hash,
+            "backend_version": self._qwen_backend_build_identity(),
+            "native_version": hash_text(
+                f"{runtime_library_filename('llama')}:batch={self.config.batch_size}:"
+                f"ubatch={self.config.ubatch_size}:step={self.config.progress_step}:"
+                f"threads={self.config.threads}:threads_batch={self.config.threads_batch}"
+            ),
+            "tools_mode": "qwen36-shell-tool-call-tools-on-thinking-off",
+        }
+
+    def _record_qwen36_shell_tool_prefix_fallback(self, reason: str) -> None:
+        status = self._qwen36_shell_tool_prefix_status
+        status.fallback_count += 1
+        status.failure_reason = reason
+        status.last_used = "fallback"
+        if not self._qwen36_shell_tool_prefix_anchor_state.valid:
+            status.initialized = False
+            status.prefix_tokens = 0
+
+    def _invalidate_qwen36_shell_tool_prefix(self, reason: str) -> None:
+        if not hasattr(self, "_qwen36_shell_tool_prefix_anchor_state"):
+            return
+        lock = getattr(self, "_qwen36_shell_tool_prefix_lock", None)
+        if lock is None:
+            return
+        with lock:
+            state = self._qwen36_shell_tool_prefix_anchor_state
+            had_state = state.valid or state.checkpoint_size > 0
+            self._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState()
+            self._qwen36_shell_tool_prefix_spec = None
+            self._qwen36_shell_tool_prefix_epoch += 1
+            status = self._qwen36_shell_tool_prefix_status
+            if had_state:
+                status.invalidation_count += 1
+            status.initialized = False
+            status.prefix_tokens = 0
+            status.failure_reason = reason
+            status.last_used = "invalidated"
 
     def _qwen_route_prefix_state_for_profile(self, profile_id: str) -> PrefixAnchorState:
         if profile_id == QWEN3_CODER_PROFILE_ID:

--- a/src/orbit/native_llama/qwen36_shell_tool_prefix.py
+++ b/src/orbit/native_llama/qwen36_shell_tool_prefix.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from typing import Callable, Mapping, Sequence
+
+from .qwen_route_prefix import hash_text, hash_tokens
+
+
+QWEN36_SHELL_TOOL_PREFIX_ENV = "ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE"
+QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION = "qwen36-shell-tool-prefix-v1"
+QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT = 384
+QWEN36_SHELL_TOOL_INVARIANT_TOKEN_COUNT = 439
+QWEN36_SHELL_TOOL_TOKENIZER_IDENTITY = "gpt2:qwen35"
+QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH = "4428fc45a4eded6214ba9c7dbab6e36ca90686c381494776e776f286bea9b228"
+QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH = "84cd1ab78799b6511159f660e958388f87ebc5e2dfccb102a8e1ed616c546bfd"
+QWEN36_SHELL_TOOL_SCHEMA_HASH = "a2669f863cd2f569bc6e5b009ef72dd8fb6f31a66d83c29d4861e1f510071a68"
+
+
+@dataclass(frozen=True)
+class Qwen36ShellToolPrefixConfig:
+    enabled: bool
+    source: str
+    validation_error: str | None = None
+
+
+@dataclass(frozen=True)
+class Qwen36ShellToolPrefixSpec:
+    prefix_tokens: tuple[int, ...]
+    prefix_token_hash: str
+    invariant_text_hash: str
+    tool_schema_hash: str
+    invariant_token_count: int
+    next_boundary_token: int
+
+
+def resolve_qwen36_shell_tool_prefix_reuse(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default_enabled: bool = True,
+) -> Qwen36ShellToolPrefixConfig:
+    env = os.environ if environ is None else environ
+    configured = env.get(QWEN36_SHELL_TOOL_PREFIX_ENV)
+    if configured is None:
+        return Qwen36ShellToolPrefixConfig(enabled=default_enabled, source="default")
+    value = configured.strip()
+    if value == "1":
+        return Qwen36ShellToolPrefixConfig(enabled=True, source="stable")
+    if value == "0":
+        return Qwen36ShellToolPrefixConfig(enabled=False, source="stable")
+    return Qwen36ShellToolPrefixConfig(
+        enabled=False,
+        source="stable",
+        validation_error="invalid_qwen36_shell_tool_prefix_reuse_value",
+    )
+
+
+def exact_qwen36_shell_tool_schema(tools: Sequence[object] | None) -> bool:
+    if not isinstance(tools, list) or len(tools) != 1:
+        return False
+    try:
+        payload = json.dumps(tools, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError):
+        return False
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest() == QWEN36_SHELL_TOOL_SCHEMA_HASH
+
+
+def derive_qwen36_shell_tool_prefix_spec(
+    *,
+    tools: Sequence[object] | None,
+    full_prompt: str,
+    full_tokens: Sequence[int],
+    render_reference: Callable[[str], str],
+    tokenize: Callable[[str], list[int]],
+) -> tuple[Qwen36ShellToolPrefixSpec | None, str | None]:
+    if not exact_qwen36_shell_tool_schema(tools):
+        return None, "shell_tool_schema_mismatch"
+    if len(full_tokens) <= QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT:
+        return None, "shell_tool_prompt_too_short"
+
+    first = render_reference("A-orbit-qwen36-shell-boundary")
+    second = render_reference("Z-orbit-qwen36-shell-boundary")
+    first_tokens = tokenize(first)
+    second_tokens = tokenize(second)
+    token_lcp = _longest_common_prefix(first_tokens, second_tokens)
+    if token_lcp != QWEN36_SHELL_TOOL_INVARIANT_TOKEN_COUNT:
+        return None, "qualified_invariant_token_count_changed"
+
+    prefix = tuple(first_tokens[:QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT])
+    if tuple(second_tokens[:QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT]) != prefix:
+        return None, "reference_prefix_mismatch"
+    if tuple(full_tokens[:QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT]) != prefix:
+        return None, "production_prefix_mismatch"
+    prefix_hash = hash_tokens(prefix)
+    if prefix_hash != QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH:
+        return None, "qualified_prefix_token_hash_changed"
+
+    char_lcp = _longest_common_prefix_text(first, second)
+    if char_lcp <= 0 or not full_prompt.startswith(first[:char_lcp]):
+        return None, "invariant_text_boundary_mismatch"
+    invariant_text_hash = hash_text(first[:char_lcp])
+    if invariant_text_hash != QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH:
+        return None, "qualified_rendered_prefix_hash_changed"
+
+    return (
+        Qwen36ShellToolPrefixSpec(
+            prefix_tokens=prefix,
+            prefix_token_hash=prefix_hash,
+            invariant_text_hash=invariant_text_hash,
+            tool_schema_hash=QWEN36_SHELL_TOOL_SCHEMA_HASH,
+            invariant_token_count=token_lcp,
+            next_boundary_token=int(first_tokens[QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT]),
+        ),
+        None,
+    )
+
+
+def _longest_common_prefix(first: Sequence[int], second: Sequence[int]) -> int:
+    common = 0
+    limit = min(len(first), len(second))
+    while common < limit and first[common] == second[common]:
+        common += 1
+    return common
+
+
+def _longest_common_prefix_text(first: str, second: str) -> int:
+    common = 0
+    limit = min(len(first), len(second))
+    while common < limit and first[common] == second[common]:
+        common += 1
+    return common

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -28,6 +28,10 @@ from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
+from orbit.native_llama.qwen36_shell_tool_prefix import (
+    exact_qwen36_shell_tool_schema,
+    resolve_qwen36_shell_tool_prefix_reuse,
+)
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_server.protocol import (
     ContinueRequest,
@@ -94,6 +98,11 @@ class OrbitNativeServer:
                 and not request.tools
                 and _is_qwen_route_prompt(request.messages)
             )
+            qwen36_shell_tool_prefix_anchor = (
+                request.qwen36_shell_tool_prefix_anchor
+                and not thinking
+                and exact_qwen36_shell_tool_schema(request.tools)
+            )
             if request.artifact_content:
                 completion = self.client.complete_artifact_text(
                     request.messages,
@@ -112,6 +121,7 @@ class OrbitNativeServer:
                     thinking=thinking,
                     route_prefix_anchor=request.route_prefix_anchor,
                     qwen_route_prefix_anchor=qwen_route_prefix_anchor,
+                    qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
                     allow_mtp_experimental=request.allow_mtp_experimental,
                     final_prefix_experiment=final_prefix_experiment,
                     on_progress=on_progress,
@@ -304,6 +314,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
             mtp_config = _mtp_config_payload(state.client)
             final_prefix = state.client.final_prefix_experiment_status()
             qwen_route_prefix = state.client.qwen_route_prefix_reuse_status()
+            qwen36_shell_tool_prefix = state.client.qwen36_shell_tool_prefix_reuse_status()
             qwen3_coder_route_prefix = state.client.qwen3_coder_route_prefix_reuse_status()
             final_prefix_config = _final_prefix_reuse_props(state.client)
             self._json(
@@ -373,6 +384,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "final_prefix_experiment_last_used": final_prefix["last_used"],
                     "final_prefix_experiment_checkpoint_size_bytes": final_prefix["checkpoint_size_bytes"],
                     "qwen_route_prefix_reuse": qwen_route_prefix,
+                    "qwen36_shell_tool_prefix_reuse": qwen36_shell_tool_prefix,
                     "qwen3_coder_route_prefix_reuse": qwen3_coder_route_prefix,
                     **final_prefix_config,
                     **_tool_call_healing_props(),
@@ -689,6 +701,7 @@ def run_server(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     final_prefix_config = resolve_final_prefix_reuse()
     qwen_route_prefix_config = resolve_qwen_route_prefix_reuse()
+    qwen36_shell_tool_prefix_config = resolve_qwen36_shell_tool_prefix_reuse()
     qwen3_coder_route_prefix_config = resolve_qwen3_coder_route_prefix_reuse()
 
     try:
@@ -714,6 +727,9 @@ def run_server(argv: list[str] | None = None) -> int:
                 qwen_route_prefix_reuse_enabled=qwen_route_prefix_config.enabled,
                 qwen_route_prefix_reuse_source=qwen_route_prefix_config.source,
                 qwen_route_prefix_reuse_config_error=qwen_route_prefix_config.validation_error,
+                qwen36_shell_tool_prefix_reuse_enabled=qwen36_shell_tool_prefix_config.enabled,
+                qwen36_shell_tool_prefix_reuse_source=qwen36_shell_tool_prefix_config.source,
+                qwen36_shell_tool_prefix_reuse_config_error=qwen36_shell_tool_prefix_config.validation_error,
                 qwen3_coder_route_prefix_reuse_enabled=qwen3_coder_route_prefix_config.enabled,
                 qwen3_coder_route_prefix_reuse_source=qwen3_coder_route_prefix_config.source,
                 qwen3_coder_route_prefix_reuse_config_error=qwen3_coder_route_prefix_config.validation_error,

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -20,6 +20,7 @@ class ChatRequest:
     tools: list[dict[str, Any]]
     route_prefix_anchor: bool
     qwen_route_prefix_anchor: bool
+    qwen36_shell_tool_prefix_anchor: bool
     allow_mtp_experimental: bool | None
     final_prefix_experiment: bool
     artifact_content: bool
@@ -45,6 +46,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         tools=_tools_from_payload(payload.get("tools")),
         route_prefix_anchor=payload.get("route_prefix_anchor") is True,
         qwen_route_prefix_anchor=payload.get("qwen_route_prefix_anchor") is True,
+        qwen36_shell_tool_prefix_anchor=payload.get("qwen36_shell_tool_prefix_anchor") is True,
         allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
         final_prefix_experiment=payload.get("final_prefix_experiment") is True,
         artifact_content=payload.get("artifact_content") is True,

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -23,6 +23,7 @@ from orbit.backend.llama_server import (
     _parse_native_stream,
     _final_prefix_experiment_requested,
     _qwen_route_prefix_anchor_requested,
+    _qwen36_shell_tool_prefix_anchor_requested,
 )
 from orbit.backend.base import ChatResult
 from orbit.backend.payloads import (
@@ -33,6 +34,7 @@ from orbit.backend.payloads import (
 )
 from orbit.backend import model_names
 from orbit.runtime.kv_diag import model_call_context
+from orbit.runtime.shell_guardrails import exec_shell_full_definition
 from urllib.error import HTTPError, URLError
 
 
@@ -689,6 +691,77 @@ class LlamaServerBackendTests(unittest.TestCase):
                 clear=True,
             ), model_call_context(phase="route", tools_mode="on"):
                 self.assertFalse(_qwen_route_prefix_anchor_requested(native_backend=True))
+
+    def test_qwen36_shell_prefix_request_has_exact_phase_mode_and_schema(self) -> None:
+        tools = [exec_shell_full_definition()]
+        with mock.patch.dict(os.environ, {"ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE": "1"}, clear=True):
+            with model_call_context(phase="tool_call", tools_mode="on"):
+                self.assertTrue(
+                    _qwen36_shell_tool_prefix_anchor_requested(
+                        native_backend=True,
+                        tools=tools,
+                        thinking=False,
+                    )
+                )
+                self.assertFalse(
+                    _qwen36_shell_tool_prefix_anchor_requested(
+                        native_backend=True,
+                        tools=tools,
+                        thinking=True,
+                    )
+                )
+                changed = [exec_shell_full_definition()]
+                changed[0]["function"]["parameters"]["properties"]["timeout"]["maximum"] = 16
+                self.assertFalse(
+                    _qwen36_shell_tool_prefix_anchor_requested(
+                        native_backend=True,
+                        tools=changed,
+                        thinking=False,
+                    )
+                )
+            for phase in (
+                "route",
+                "tool_call_retry",
+                "artifact_content",
+                "verify_artifact",
+                "post_tool_route",
+                "final_from_tool",
+            ):
+                with self.subTest(phase=phase), model_call_context(
+                    phase=phase,
+                    tools_mode="on",
+                ):
+                    self.assertFalse(
+                        _qwen36_shell_tool_prefix_anchor_requested(
+                            native_backend=True,
+                            tools=tools,
+                            thinking=False,
+                        )
+                    )
+            with model_call_context(phase="tool_call", tools_mode="off"):
+                self.assertFalse(
+                    _qwen36_shell_tool_prefix_anchor_requested(
+                        native_backend=True,
+                        tools=tools,
+                        thinking=False,
+                    )
+                )
+
+    def test_qwen36_shell_prefix_kill_switch_disables_request(self) -> None:
+        tools = [exec_shell_full_definition()]
+        for value in ("0", "invalid"):
+            with self.subTest(value=value), mock.patch.dict(
+                os.environ,
+                {"ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE": value},
+                clear=True,
+            ), model_call_context(phase="tool_call", tools_mode="on"):
+                self.assertFalse(
+                    _qwen36_shell_tool_prefix_anchor_requested(
+                        native_backend=True,
+                        tools=tools,
+                        thinking=False,
+                    )
+                )
 
     def test_final_prefix_experiment_payload_is_limited_to_native_final_tool_phase(self) -> None:
         class Backend(LlamaServerBackend):

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -66,6 +66,7 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(request.tools, [])
         self.assertFalse(request.route_prefix_anchor)
         self.assertFalse(request.qwen_route_prefix_anchor)
+        self.assertFalse(request.qwen36_shell_tool_prefix_anchor)
         self.assertIsNone(request.allow_mtp_experimental)
         self.assertFalse(request.final_prefix_experiment)
         self.assertFalse(request.artifact_content)
@@ -110,6 +111,15 @@ class NativeServerProtocolTests(unittest.TestCase):
     def test_parse_chat_request_accepts_qwen_route_prefix_anchor_flag(self) -> None:
         request = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "qwen_route_prefix_anchor": True})
         self.assertTrue(request.qwen_route_prefix_anchor)
+
+    def test_parse_chat_request_accepts_qwen36_shell_tool_prefix_anchor_flag(self) -> None:
+        request = parse_chat_request(
+            {
+                "messages": [{"role": "user", "content": "x"}],
+                "qwen36_shell_tool_prefix_anchor": True,
+            }
+        )
+        self.assertTrue(request.qwen36_shell_tool_prefix_anchor)
 
     def test_parse_chat_request_accepts_allow_mtp_flag(self) -> None:
         disabled = parse_chat_request({"messages": [{"role": "user", "content": "x"}], "allow_mtp_experimental": False})

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from orbit.native_server.app import OrbitNativeHandler, OrbitNativeServer, _DisconnectWatcher
 from orbit.native_server.protocol import openai_chat_response, parse_chat_request
 from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
+from orbit.runtime.shell_guardrails import exec_shell_full_definition
 
 
 @dataclass
@@ -44,6 +45,7 @@ class _FakeClient:
         self.allow_mtp_calls: list[bool | None] = []
         self.final_prefix_calls: list[bool] = []
         self.qwen_route_prefix_calls: list[bool] = []
+        self.qwen36_shell_tool_prefix_calls: list[bool] = []
         self.artifact_calls = 0
 
     def complete_chat_text(
@@ -56,6 +58,7 @@ class _FakeClient:
         thinking,
         route_prefix_anchor=False,
         qwen_route_prefix_anchor=False,
+        qwen36_shell_tool_prefix_anchor=False,
         allow_mtp_experimental=None,
         final_prefix_experiment=False,
         on_progress=None,
@@ -66,6 +69,7 @@ class _FakeClient:
         self.allow_mtp_calls.append(allow_mtp_experimental)
         self.final_prefix_calls.append(final_prefix_experiment)
         self.qwen_route_prefix_calls.append(qwen_route_prefix_anchor)
+        self.qwen36_shell_tool_prefix_calls.append(qwen36_shell_tool_prefix_anchor)
         return _FakeCompletion()
 
     def complete_artifact_text(self, messages, **kwargs):
@@ -198,6 +202,42 @@ class NativeServerThinkTests(unittest.TestCase):
         )
 
         self.assertEqual(client.qwen_route_prefix_calls, [True, False, False])
+
+    def test_qwen36_shell_prefix_requires_exact_schema_and_thinking_off(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="fake")  # type: ignore[arg-type]
+        tools = [exec_shell_full_definition()]
+
+        server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "run pwd"}],
+                    "tools": tools,
+                    "qwen36_shell_tool_prefix_anchor": True,
+                }
+            )
+        )
+        server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "run pwd"}],
+                    "tools": [{"type": "function", "function": {"name": "other"}}],
+                    "qwen36_shell_tool_prefix_anchor": True,
+                }
+            )
+        )
+        server.complete(
+            parse_chat_request(
+                {
+                    "messages": [{"role": "user", "content": "run pwd"}],
+                    "tools": tools,
+                    "thinking": True,
+                    "qwen36_shell_tool_prefix_anchor": True,
+                }
+            )
+        )
+
+        self.assertEqual(client.qwen36_shell_tool_prefix_calls, [True, False, False])
 
     def test_disconnect_watcher_disarm_skips_cancel_callback(self) -> None:
         called: list[str] = []

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -97,6 +97,28 @@ class PayloadTests(unittest.TestCase):
         self.assertNotIn("qwen_route_prefix_anchor", baseline)
         self.assertTrue(enabled["qwen_route_prefix_anchor"])
 
+    def test_build_chat_payload_includes_qwen36_shell_anchor_only_when_requested(self) -> None:
+        baseline = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+            )
+        )
+        enabled = build_chat_payload(
+            ChatPayloadOptions(
+                model="m",
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=0,
+                max_tokens=32,
+                qwen36_shell_tool_prefix_anchor=True,
+            )
+        )
+
+        self.assertNotIn("qwen36_shell_tool_prefix_anchor", baseline)
+        self.assertTrue(enabled["qwen36_shell_tool_prefix_anchor"])
+
     def test_build_chat_payload_includes_allow_mtp_only_when_explicit(self) -> None:
         baseline = build_chat_payload(
             ChatPayloadOptions(

--- a/tests/test_qwen36_shell_tool_prefix.py
+++ b/tests/test_qwen36_shell_tool_prefix.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.client import (
+    NativeClientConfig,
+    NativeLlamaClient,
+    _Qwen36ShellToolAnchorRuntimePlan,
+)
+from orbit.native_llama.model_profiles import NativeModelProfile, QWEN36_PROFILE_ID
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.native_llama.qwen_route_prefix import QwenRoutePrefixSpec, hash_text, hash_tokens
+from orbit.native_llama.qwen36_shell_tool_prefix import (
+    QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION,
+    QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT,
+    QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH,
+    QWEN36_SHELL_TOOL_SCHEMA_HASH,
+    QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH,
+    Qwen36ShellToolPrefixSpec,
+    derive_qwen36_shell_tool_prefix_spec,
+    exact_qwen36_shell_tool_schema,
+    resolve_qwen36_shell_tool_prefix_reuse,
+)
+from orbit.runtime.shell_guardrails import exec_shell_full_definition
+
+
+def _profile(profile_id: str = QWEN36_PROFILE_ID) -> NativeModelProfile:
+    return NativeModelProfile(
+        profile_id=profile_id,
+        family="qwen3.6" if profile_id == QWEN36_PROFILE_ID else "other",
+        model_name="Qwen3.6-35B-A3B",
+        architecture="qwen35moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="qwen-think",
+        tool_call_protocol="qwen3.6-xml",
+        history_serialization="qwen-leading-system-only",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="a" * 64,
+        thinking_supported=True,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
+    )
+
+
+class _FakeBridge:
+    def __init__(self, production_prompt: str) -> None:
+        self.production_prompt = production_prompt
+
+    def render(self, _context, messages, _tools, *, thinking: bool):
+        assert not thinking
+        content = str(messages[0].get("content", "")) if messages else ""
+        if content.startswith("A-orbit-"):
+            return {"prompt": "a" * 500 + "A"}
+        if content.startswith("Z-orbit-"):
+            return {"prompt": "a" * 500 + "Z"}
+        return {"prompt": self.production_prompt}
+
+
+class Qwen36ShellToolPrefixConfigTests(unittest.TestCase):
+    def test_default_on_explicit_values_and_invalid_fail_closed(self) -> None:
+        self.assertTrue(resolve_qwen36_shell_tool_prefix_reuse({}).enabled)
+        self.assertTrue(
+            resolve_qwen36_shell_tool_prefix_reuse(
+                {"ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE": "1"}
+            ).enabled
+        )
+        self.assertFalse(
+            resolve_qwen36_shell_tool_prefix_reuse(
+                {"ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE": "0"}
+            ).enabled
+        )
+        invalid = resolve_qwen36_shell_tool_prefix_reuse(
+            {"ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE": "yes"}
+        )
+        self.assertFalse(invalid.enabled)
+        self.assertEqual(
+            invalid.validation_error,
+            "invalid_qwen36_shell_tool_prefix_reuse_value",
+        )
+
+    def test_exact_schema_is_bound_to_qualified_hash(self) -> None:
+        tools = [exec_shell_full_definition()]
+        self.assertTrue(exact_qwen36_shell_tool_schema(tools))
+        self.assertEqual(QWEN36_SHELL_TOOL_SCHEMA_HASH, "a2669f863cd2f569bc6e5b009ef72dd8fb6f31a66d83c29d4861e1f510071a68")
+
+        changed = [exec_shell_full_definition()]
+        changed[0]["function"]["parameters"]["properties"]["timeout"]["maximum"] = 16
+        self.assertFalse(exact_qwen36_shell_tool_schema(changed))
+        self.assertFalse(exact_qwen36_shell_tool_schema(tools + tools))
+        self.assertFalse(
+            exact_qwen36_shell_tool_schema(
+                [{"type": "function", "function": {"name": "verify_artifact"}}]
+            )
+        )
+        self.assertFalse(exact_qwen36_shell_tool_schema([]))
+        self.assertFalse(exact_qwen36_shell_tool_schema(None))
+
+
+class Qwen36ShellToolBoundaryTests(unittest.TestCase):
+    def test_qualified_boundary_has_no_user_dependent_token(self) -> None:
+        tools = [exec_shell_full_definition()]
+        stable = "s" * 439
+
+        def render(user: str) -> str:
+            return stable + user
+
+        full = render("actual")
+        tokens = [ord(char) for char in full]
+        expected_prefix_hash = hash_tokens(tokens[:QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT])
+        expected_text_hash = hash_text(stable)
+        with mock.patch.multiple(
+            "orbit.native_llama.qwen36_shell_tool_prefix",
+            QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH=expected_prefix_hash,
+            QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH=expected_text_hash,
+        ):
+            spec, reason = derive_qwen36_shell_tool_prefix_spec(
+                tools=tools,
+                full_prompt=full,
+                full_tokens=tokens,
+                render_reference=render,
+                tokenize=lambda text: [ord(char) for char in text],
+            )
+
+        self.assertIsNone(reason)
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertEqual(len(spec.prefix_tokens), 384)
+        self.assertEqual(spec.invariant_token_count, 439)
+        self.assertEqual(spec.next_boundary_token, ord("s"))
+
+    def test_boundary_rejects_changed_qualified_identity(self) -> None:
+        tools = [exec_shell_full_definition()]
+
+        def render(user: str) -> str:
+            return "s" * 439 + user
+
+        full = render("actual")
+        spec, reason = derive_qwen36_shell_tool_prefix_spec(
+            tools=tools,
+            full_prompt=full,
+            full_tokens=[ord(char) for char in full],
+            render_reference=render,
+            tokenize=lambda text: [ord(char) for char in text],
+        )
+
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "qualified_prefix_token_hash_changed")
+
+
+class Qwen36ShellToolClientTests(unittest.TestCase):
+    def _client(self) -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/qwen.gguf"),
+            model_id="legacy-path",
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(
+                paths,
+                NativeClientConfig(qwen36_shell_tool_prefix_reuse_enabled=True),
+            )
+        client.model_profile = _profile()
+        client._model_metadata_identity = {
+            "general.architecture": "qwen35moe",
+            "general.name": "Qwen3.6-35B-A3B",
+            "general.file_type": "15",
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.pre": "qwen35",
+        }
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        client._qwen_backend_build_identity = lambda: "build"  # type: ignore[method-assign]
+        return client
+
+    def _spec(self) -> Qwen36ShellToolPrefixSpec:
+        return Qwen36ShellToolPrefixSpec(
+            prefix_tokens=tuple(range(QWEN36_SHELL_TOOL_PREFIX_TOKEN_COUNT)),
+            prefix_token_hash=QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH,
+            invariant_text_hash=QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH,
+            tool_schema_hash=QWEN36_SHELL_TOOL_SCHEMA_HASH,
+            invariant_token_count=439,
+            next_boundary_token=42,
+        )
+
+    def _plan(self) -> _Qwen36ShellToolAnchorRuntimePlan:
+        spec = self._spec()
+        return _Qwen36ShellToolAnchorRuntimePlan(
+            prefix_tokens=list(spec.prefix_tokens),
+            prefix_hash="key",
+            state_kwargs={
+                "model_id": "m",
+                "template_id": "t",
+                "tool_schema_hash": "s",
+                "capability_summary_hash": "c",
+                "runtime_policy_hash": "p",
+                "route_contract_hash": "r",
+                "backend_version": "b",
+                "native_version": "n",
+                "tools_mode": "q",
+            },
+            spec=spec,
+        )
+
+    def test_planner_requires_exact_profile_schema_thinking_and_config(self) -> None:
+        client = self._client()
+        prompt = "p" * 500
+        client.chat_bridge = _FakeBridge(prompt)  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client.tokenize = lambda text: list(range(len(text)))  # type: ignore[method-assign]
+        spec = self._spec()
+        with mock.patch(
+            "orbit.native_llama.client.derive_qwen36_shell_tool_prefix_spec",
+            return_value=(spec, None),
+        ):
+            plan = client._qwen36_shell_tool_anchor_plan_for_prompt(
+                [{"role": "user", "content": "run pwd"}],
+                tools=[exec_shell_full_definition()],
+                thinking=False,
+                prompt=prompt,
+            )
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(len(plan.prefix_tokens), 384)
+
+        client._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"shell",
+            checkpoint_size=5,
+        )
+        self.assertIsNone(
+            client._qwen36_shell_tool_anchor_plan_for_prompt(
+                [{"role": "user", "content": "run pwd"}],
+                tools=[{"type": "function", "function": {"name": "other"}}],
+                thinking=False,
+                prompt=prompt,
+            )
+        )
+        self.assertFalse(client._qwen36_shell_tool_prefix_anchor_state.valid)
+        self.assertIsNone(
+            client._qwen36_shell_tool_anchor_plan_for_prompt(
+                [{"role": "user", "content": "run pwd"}],
+                tools=[exec_shell_full_definition()],
+                thinking=True,
+                prompt=prompt,
+            )
+        )
+        client.model_profile = _profile("orbit-qwen3-coder-native-v1")
+        client._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"shell",
+            checkpoint_size=5,
+        )
+        self.assertIsNone(
+            client._qwen36_shell_tool_anchor_plan_for_prompt(
+                [{"role": "user", "content": "run pwd"}],
+                tools=[exec_shell_full_definition()],
+                thinking=False,
+                prompt=prompt,
+            )
+        )
+        self.assertFalse(client._qwen36_shell_tool_prefix_anchor_state.valid)
+
+    def test_identity_binds_template_model_and_runtime_config(self) -> None:
+        client = self._client()
+        spec = self._spec()
+        with mock.patch.object(Path, "stat", return_value=SimpleNamespace(st_size=10, st_mtime_ns=20)):
+            messages = [{"role": "system", "content": "policy"}]
+            first = client._qwen36_shell_tool_prefix_state_kwargs(spec, messages=messages)
+            client.config = NativeClientConfig(
+                context_tokens=16384,
+                qwen36_shell_tool_prefix_reuse_enabled=True,
+            )
+            second = client._qwen36_shell_tool_prefix_state_kwargs(spec, messages=messages)
+            client.model_profile = _profile()
+            client.model_profile = SimpleNamespace(**{**client.model_profile.__dict__, "template_sha256": "b" * 64})
+            third = client._qwen36_shell_tool_prefix_state_kwargs(spec, messages=messages)
+            client._model_metadata_identity["general.name"] = "changed"
+            fourth = client._qwen36_shell_tool_prefix_state_kwargs(spec, messages=messages)
+            changed_policy = client._qwen36_shell_tool_prefix_state_kwargs(
+                spec,
+                messages=[{"role": "system", "content": "changed policy"}],
+            )
+
+        self.assertNotEqual(first["template_id"], second["template_id"])
+        self.assertNotEqual(second["template_id"], third["template_id"])
+        self.assertNotEqual(third["model_id"], fourth["model_id"])
+        self.assertNotEqual(fourth["capability_summary_hash"], changed_policy["capability_summary_hash"])
+        self.assertEqual(first["tool_schema_hash"], QWEN36_SHELL_TOOL_SCHEMA_HASH)
+        self.assertEqual(first["tools_mode"], "qwen36-shell-tool-call-tools-on-thinking-off")
+
+    def test_capture_restore_and_route_prefix_isolation(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client._decode_prompt_range = mock.Mock(return_value=384)  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        plan = self._plan()
+        state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"x",
+            checkpoint_size=1,
+            token_count=384,
+        )
+        client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"route",
+            checkpoint_size=5,
+        )
+
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor", return_value=(state, {})):
+            self.assertEqual(client._prepare_memory_with_qwen36_shell_tool_anchor(plan), (384, 0))
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            return_value=(True, state, {"restore_used": True}),
+        ):
+            self.assertEqual(client._prepare_memory_with_qwen36_shell_tool_anchor(plan), (384, 384))
+
+        status = client.qwen36_shell_tool_prefix_reuse_status()
+        self.assertEqual(status["capture_count"], 1)
+        self.assertEqual(status["restore_count"], 1)
+        self.assertEqual(status["fallback_count"], 0)
+        self.assertTrue(client._qwen_route_prefix_anchor_state.valid)
+
+    def test_truncated_restore_has_one_cold_fallback_and_no_loop(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client._decode_prompt_range = mock.Mock(return_value=384)  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        plan = self._plan()
+        client._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"truncated",
+            checkpoint_size=9,
+            token_count=384,
+        )
+
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            return_value=(
+                False,
+                PrefixAnchorState(invalidation_reason="checkpoint_restore_size_mismatch"),
+                {"fallback_reason": "checkpoint_restore_size_mismatch"},
+            ),
+        ):
+            self.assertEqual(client._prepare_memory_with_qwen36_shell_tool_anchor(plan), (0, 0))
+
+        replacement = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"replacement",
+            checkpoint_size=11,
+            token_count=384,
+        )
+        with mock.patch("orbit.native_llama.client.capture_prefix_anchor", return_value=(replacement, {})):
+            self.assertEqual(client._prepare_memory_with_qwen36_shell_tool_anchor(plan), (384, 0))
+
+        status = client.qwen36_shell_tool_prefix_reuse_status()
+        self.assertEqual(status["fallback_count"], 1)
+        self.assertEqual(status["capture_count"], 1)
+        self.assertTrue(status["initialized"])
+
+    def test_cancel_racing_restore_cannot_republish_checkpoint(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client.lib.lib = SimpleNamespace()
+        plan = self._plan()
+        state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"checkpoint",
+            checkpoint_size=10,
+            token_count=384,
+        )
+        client._qwen36_shell_tool_prefix_anchor_state = state
+
+        def restore_then_cancel(*_args, **_kwargs):
+            client.cancel()
+            return True, state, {"restore_used": True}
+
+        with mock.patch(
+            "orbit.native_llama.client.restore_prefix_anchor",
+            side_effect=restore_then_cancel,
+        ):
+            self.assertEqual(client._prepare_memory_with_qwen36_shell_tool_anchor(plan), (0, 0))
+
+        status = client.qwen36_shell_tool_prefix_reuse_status()
+        self.assertFalse(status["initialized"])
+        self.assertEqual(status["checkpoint_size_bytes"], 0)
+        self.assertEqual(status["restore_count"], 0)
+        self.assertEqual(status["invalidation_count"], 1)
+
+    def test_cancel_after_check_cannot_publish_capture_or_restore(self) -> None:
+        class CancelAfterCheck:
+            def __init__(self, client, *, trigger_call: int) -> None:
+                self.client = client
+                self.trigger_call = trigger_call
+                self.calls = 0
+                self.flag = False
+
+            def is_set(self) -> bool:
+                self.calls += 1
+                if self.calls == self.trigger_call:
+                    self.client.cancel()
+                    return False
+                return self.flag
+
+            def set(self) -> None:
+                self.flag = True
+
+            def clear(self) -> None:
+                self.flag = False
+
+        for mode in ("capture", "restore"):
+            with self.subTest(mode=mode):
+                client = self._client()
+                client._session.ctx_tgt = 1  # type: ignore[assignment]
+                client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+                client._decode_prompt_range = mock.Mock(return_value=384)  # type: ignore[method-assign]
+                client.lib.lib = SimpleNamespace()
+                plan = self._plan()
+                state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"checkpoint",
+                    checkpoint_size=10,
+                    token_count=384,
+                )
+                if mode == "capture":
+                    client.cancel_event = CancelAfterCheck(client, trigger_call=2)  # type: ignore[assignment]
+                    patcher = mock.patch(
+                        "orbit.native_llama.client.capture_prefix_anchor",
+                        return_value=(state, {}),
+                    )
+                else:
+                    client._qwen36_shell_tool_prefix_anchor_state = state
+                    client.cancel_event = CancelAfterCheck(client, trigger_call=1)  # type: ignore[assignment]
+                    patcher = mock.patch(
+                        "orbit.native_llama.client.restore_prefix_anchor",
+                        return_value=(True, state, {"restore_used": True}),
+                    )
+
+                with patcher:
+                    self.assertEqual(
+                        client._prepare_memory_with_qwen36_shell_tool_anchor(plan),
+                        (0, 0),
+                    )
+
+                status = client.qwen36_shell_tool_prefix_reuse_status()
+                self.assertFalse(status["initialized"])
+                self.assertEqual(status["checkpoint_size_bytes"], 0)
+                self.assertEqual(status["capture_count"], 0)
+                self.assertEqual(status["restore_count"], 0)
+                self.assertEqual(status["last_used"], "invalidated")
+
+    def test_reset_cancel_reload_and_close_release_shell_state(self) -> None:
+        for operation in ("reset", "cancel", "reload", "close"):
+            with self.subTest(operation=operation):
+                client = self._client()
+                client._qwen36_shell_tool_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"shell",
+                    checkpoint_size=5,
+                )
+                client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"route",
+                    checkpoint_size=5,
+                )
+                if operation == "reset":
+                    client._session.ctx_tgt = 1  # type: ignore[assignment]
+                    client.lib.lib.llama_get_memory.return_value = 2
+                    client.reset_session_state()
+                elif operation == "cancel":
+                    client.cancel()
+                elif operation == "reload":
+                    client._invalidate_qwen36_shell_tool_prefix("model_reload")
+                else:
+                    client._model = None
+                    client.close()
+                self.assertFalse(client._qwen36_shell_tool_prefix_anchor_state.valid)
+                if operation == "reload":
+                    self.assertTrue(client._qwen_route_prefix_anchor_state.valid)
+                else:
+                    self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+
+    def test_diagnostics_are_bounded_and_do_not_retain_unsupported_states(self) -> None:
+        client = self._client()
+        client._qwen36_shell_tool_prefix_spec = self._spec()
+        client._qwen_route_prefix_spec = QwenRoutePrefixSpec(tuple(), "route", "text", "system", 0, 0)
+
+        diagnostics = client.qwen36_shell_tool_prefix_reuse_status()
+
+        self.assertEqual(diagnostics["checkpoint_identity"], QWEN36_SHELL_TOOL_PREFIX_FORMAT_VERSION)
+        self.assertEqual(diagnostics["prefix_token_hash"], QWEN36_SHELL_TOOL_PREFIX_TOKEN_HASH)
+        self.assertEqual(diagnostics["prefix_text_hash"], QWEN36_SHELL_TOOL_RENDERED_PREFIX_HASH)
+        self.assertNotIn("prompt", diagnostics)
+        self.assertFalse(hasattr(client, "_qwen36_verify_artifact_prefix_anchor_state"))
+        self.assertFalse(hasattr(client, "_qwen36_final_from_tool_prefix_anchor_state"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds a dedicated 384-token Qwen3.6 shell checkpoint
- applies only to the exact `exec_shell_full_command` `tool_call` path
- reuses complete hybrid sequence state
- keeps route-prefix, Qwen3-Coder, and Gemma state separate
- includes fail-safe cancellation, reset, reload, and restore handling
- adds no generic checkpoint map or semantic routing changes

## Performance

- `pwd_final`: 42.10s -> 30.50s
- `existing_file_modification`: 277.70s -> 181.47s
- checkpoint: approximately 70.3 MiB
- no linear RSS growth over 20 restores

## Validation

- focused tests: 350/350 PASS
- lifecycle/isolation tests: 75/75 PASS
- full discovery: 1700/1700 PASS, 6 expected skips
- `compileall`: PASS
- diff check: PASS

Kill switch: `ORBIT_QWEN36_SHELL_TOOL_PREFIX_REUSE=0`
