### PR TITLE
Add verified startup model discovery

### DIFF
--- a/src/orbit/native_llama/model_discovery.py
+++ b/src/orbit/native_llama/model_discovery.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from ctypes import create_string_buffer
+from dataclasses import dataclass
+from pathlib import Path
+import glob
+import time
+from typing import Callable, Iterable
+
+from orbit.native_llama.bindings import GgmlLogCallback, LlamaLibrary
+from orbit.native_llama.model_profiles import (
+    VERIFIED_NATIVE_MODEL_IDENTITIES,
+    NativeModelProfile,
+    detect_native_model_profile,
+    verified_native_model_identity,
+)
+from orbit.native_llama.model_registry import (
+    ModelManifest,
+    default_hf_cache,
+    default_models_dir,
+    load_registry,
+)
+
+
+ProfileInspector = Callable[[Path], NativeModelProfile]
+
+
+def _discard_native_log(_level: int, _text: bytes, _data) -> None:
+    return None
+
+
+_QUIET_LOG_CALLBACK = GgmlLogCallback(_discard_native_log)
+PROFILE_METADATA_KEYS = frozenset(
+    {
+        "general.architecture",
+        "general.name",
+        "general.file_type",
+        "general.quantization_version",
+        "tokenizer.ggml.model",
+        "tokenizer.ggml.pre",
+        "tokenizer.ggml.add_bos_token",
+        "tokenizer.ggml.bos_token_id",
+        "tokenizer.ggml.eos_token_id",
+        "tokenizer.ggml.padding_token_id",
+        "qwen3moe.context_length",
+        "qwen3moe.expert_count",
+        "qwen3moe.expert_used_count",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ModelDiscoveryRow:
+    model: str
+    local: str
+    support: str
+    path_or_action: str
+
+
+@dataclass(frozen=True)
+class ModelDiscoveryResult:
+    rows: tuple[ModelDiscoveryRow, ...]
+    wall_ms: float
+    filesystem_scans: int
+    metadata_inspections: int
+
+
+@dataclass(frozen=True)
+class _Inspection:
+    path: Path
+    profile: NativeModelProfile | None
+
+
+class NativeProfileInspector:
+    """Inspect GGUF metadata and template without allocating model weights."""
+
+    def __init__(self, build_bin: Path) -> None:
+        self._binding = LlamaLibrary(build_bin)
+        self._lib = self._binding.lib
+        self._lib.llama_log_set(_QUIET_LOG_CALLBACK, None)
+        self._lib.ggml_backend_load_all()
+
+    def __call__(self, path: Path) -> NativeModelProfile:
+        params = self._lib.llama_model_default_params()
+        params.vocab_only = True
+        params.use_mmap = True
+        params.check_tensors = True
+        model = self._lib.llama_model_load_from_file(str(path).encode(), params)
+        if not model:
+            raise RuntimeError("vocab-only GGUF inspection failed")
+        try:
+            metadata = self._read_metadata(model)
+            template_ptr = self._lib.llama_model_chat_template(model, None)
+            template = template_ptr.decode("utf-8", errors="replace") if template_ptr else ""
+            return detect_native_model_profile(metadata, template)
+        finally:
+            self._lib.llama_model_free(model)
+
+    def _read_metadata(self, model) -> dict[str, str]:
+        metadata: dict[str, str] = {}
+        count = max(0, int(self._lib.llama_model_meta_count(model)))
+        for index in range(count):
+            key = self._metadata_text(self._lib.llama_model_meta_key_by_index, model, index)
+            if key in PROFILE_METADATA_KEYS:
+                metadata[key] = self._metadata_text(self._lib.llama_model_meta_val_str_by_index, model, index)
+        return metadata
+
+    @staticmethod
+    def _metadata_text(function, model, index: int) -> str:
+        needed = int(function(model, index, None, 0))
+        if needed < 0:
+            return ""
+        buffer = create_string_buffer(needed + 1)
+        written = int(function(model, index, buffer, len(buffer)))
+        if written < 0:
+            return ""
+        return bytes(buffer[:written]).decode("utf-8", errors="replace")
+
+
+def discover_models(
+    *,
+    models_dir: Path | None = None,
+    hf_cache: Path | None = None,
+    explicit_model: Path | None = None,
+    build_bin: Path | None = None,
+    inspector: ProfileInspector | None = None,
+    manifests: Iterable[ModelManifest] | None = None,
+) -> ModelDiscoveryResult:
+    started = time.monotonic()
+    local_root = models_dir or default_models_dir()
+    cache_root = hf_cache or default_hf_cache()
+    supported = tuple(load_registry() if manifests is None else manifests)
+    candidates, scan_count = _local_candidates(
+        local_root,
+        cache_root,
+        supported,
+        explicit_model=explicit_model,
+    )
+
+    if candidates and inspector is None and build_bin is not None:
+        try:
+            inspector = NativeProfileInspector(build_bin)
+        except (OSError, RuntimeError):
+            inspector = None
+
+    inspections = tuple(_inspect(path, inspector) for path in candidates)
+    rows = _rows(supported, inspections)
+    return ModelDiscoveryResult(
+        rows=rows,
+        wall_ms=(time.monotonic() - started) * 1000.0,
+        filesystem_scans=scan_count,
+        metadata_inspections=len(inspections) if inspector is not None else 0,
+    )
+
+
+def format_model_discovery(result: ModelDiscoveryResult) -> str:
+    headings = ("Model", "Local", "Support", "Path / action")
+    widths = [len(value) for value in headings[:3]]
+    for row in result.rows:
+        widths[0] = max(widths[0], len(row.model))
+        widths[1] = max(widths[1], len(row.local))
+        widths[2] = max(widths[2], len(row.support))
+    lines = ["Models:", _format_columns(headings, widths)]
+    lines.extend(
+        _format_columns((row.model, row.local, row.support, row.path_or_action), widths)
+        for row in result.rows
+    )
+    return "\n".join(lines)
+
+
+def _format_columns(values: tuple[str, str, str, str], widths: list[int]) -> str:
+    return f"{values[0]:<{widths[0]}}  {values[1]:<{widths[1]}}  {values[2]:<{widths[2]}}  {values[3]}"
+
+
+def _local_candidates(
+    models_dir: Path,
+    hf_cache: Path,
+    manifests: tuple[ModelManifest, ...],
+    *,
+    explicit_model: Path | None,
+) -> tuple[tuple[Path, ...], int]:
+    auxiliary_names = {
+        spec.file
+        for manifest in manifests
+        for spec in (manifest.mmproj, manifest.mtp)
+        if spec is not None
+    }
+    paths: set[Path] = set()
+    scan_count = 0
+    for pattern in ("*.gguf", "*/*.gguf"):
+        scan_count += 1
+        for path in models_dir.glob(pattern):
+            if path.name not in auxiliary_names and not path.name.startswith(("mmproj-", "mtp-")):
+                confined = _confined_regular_path(path, models_dir)
+                if confined is not None:
+                    paths.add(confined)
+    for manifest in manifests:
+        scan_count += 1
+        for value in glob.glob(str(hf_cache / manifest.target.cache_glob)):
+            confined = _confined_regular_path(Path(value), hf_cache)
+            if confined is not None:
+                paths.add(confined)
+    if explicit_model is not None and explicit_model.exists():
+        try:
+            resolved_explicit = explicit_model.expanduser().resolve(strict=True)
+        except OSError:
+            resolved_explicit = None
+        if resolved_explicit is not None and resolved_explicit.is_file():
+            paths.add(resolved_explicit)
+    unique_files: dict[tuple[int, int], Path] = {}
+    for path in sorted(paths, key=str):
+        try:
+            stat_result = path.stat()
+        except OSError:
+            continue
+        unique_files.setdefault((stat_result.st_dev, stat_result.st_ino), path)
+    return tuple(unique_files.values()), scan_count
+
+
+def _confined_regular_path(path: Path, root: Path) -> Path | None:
+    try:
+        resolved_root = root.expanduser().resolve()
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, ValueError):
+        return None
+    return resolved if resolved.is_file() else None
+
+
+def _inspect(path: Path, inspector: ProfileInspector | None) -> _Inspection:
+    if inspector is None:
+        return _Inspection(path=path, profile=None)
+    try:
+        return _Inspection(path=path, profile=inspector(path))
+    except (OSError, RuntimeError, ValueError):
+        return _Inspection(path=path, profile=None)
+
+
+def _rows(
+    manifests: tuple[ModelManifest, ...],
+    inspections: tuple[_Inspection, ...],
+) -> tuple[ModelDiscoveryRow, ...]:
+    rows: list[ModelDiscoveryRow] = []
+    consumed: set[Path] = set()
+    manifests_by_profile: dict[str, ModelManifest] = {}
+    for manifest in manifests:
+        identity = verified_native_model_identity(manifest.profile_id)
+        if identity is None or identity.architecture != manifest.architecture:
+            raise ValueError("model registry profile mapping is not supported")
+        if manifest.profile_id in manifests_by_profile:
+            raise ValueError(f"duplicate model registry profile: {manifest.profile_id}")
+        manifests_by_profile[manifest.profile_id] = manifest
+
+    for identity in VERIFIED_NATIVE_MODEL_IDENTITIES:
+        manifest = manifests_by_profile.get(identity.profile_id)
+        matches = [
+            item
+            for item in inspections
+            if item.profile is not None
+            and item.profile.verified
+            and item.profile.profile_id == identity.profile_id
+            and item.profile.model_name == identity.model_name
+        ]
+        if not matches:
+            if manifest is None:
+                continue
+            rows.append(
+                ModelDiscoveryRow(
+                    model=manifest.display_name,
+                    local="MISSING",
+                    support="VERIFIED",
+                    path_or_action=f"orbit download {manifest.target.repo}/{manifest.target.file}",
+                )
+            )
+            continue
+        for item in matches:
+            consumed.add(item.path)
+            rows.append(
+                ModelDiscoveryRow(
+                    model=manifest.display_name if manifest is not None else identity.model_name,
+                    local="AVAILABLE",
+                    support="VERIFIED",
+                    path_or_action=str(item.path),
+                )
+            )
+
+    for item in inspections:
+        if item.path in consumed:
+            continue
+        support = "UNVERIFIED" if item.profile is None else "UNSUPPORTED"
+        rows.append(
+            ModelDiscoveryRow(
+                model=item.path.name,
+                local="AVAILABLE",
+                support=support,
+                path_or_action=str(item.path),
+            )
+        )
+    return tuple(rows)

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -6,11 +6,14 @@ from typing import Mapping
 
 
 GEMMA4_PROFILE_ID = "orbit-gemma4-native-v1"
+GEMMA4_VERIFIED_MODEL_NAME = "gemma-4-26B-A4B-it"
 QWEN36_PROFILE_ID = "orbit-qwen36-native-v1"
+QWEN36_VERIFIED_MODEL_NAME = "Qwen3.6-35B-A3B"
 QWEN36_OFFICIAL_TEMPLATE_SHA256 = "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259"
 QWEN36_VERIFIED_FILE_TYPE = "15"
 QWEN36_VERIFIED_QUANTIZATION = "Q4_K_M"
 QWEN3_CODER_PROFILE_ID = "orbit-qwen3-coder-native-v1"
+QWEN3_CODER_VERIFIED_MODEL_NAME = "Qwen3-Coder-30B-A3B-Instruct"
 QWEN3_CODER_OFFICIAL_TEMPLATE_SHA256 = "87710339d25b4e789c1d723f93c91ee861a86d305bb3d20a845536f251d6ea8a"
 QWEN3_CODER_VERIFIED_FILE_TYPE = "15"
 QWEN3_CODER_VERIFIED_QUANTIZATION = "Q4_K_M"
@@ -77,6 +80,31 @@ class NativeModelProfile:
         }
 
 
+@dataclass(frozen=True)
+class VerifiedNativeModelIdentity:
+    profile_id: str
+    model_name: str
+    architecture: str
+
+
+VERIFIED_NATIVE_MODEL_IDENTITIES = (
+    VerifiedNativeModelIdentity(GEMMA4_PROFILE_ID, GEMMA4_VERIFIED_MODEL_NAME, "gemma4"),
+    VerifiedNativeModelIdentity(QWEN36_PROFILE_ID, QWEN36_VERIFIED_MODEL_NAME, "qwen35moe"),
+    VerifiedNativeModelIdentity(
+        QWEN3_CODER_PROFILE_ID,
+        QWEN3_CODER_VERIFIED_MODEL_NAME,
+        "qwen3moe",
+    ),
+)
+
+
+def verified_native_model_identity(profile_id: str) -> VerifiedNativeModelIdentity | None:
+    return next(
+        (identity for identity in VERIFIED_NATIVE_MODEL_IDENTITIES if identity.profile_id == profile_id),
+        None,
+    )
+
+
 def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> NativeModelProfile:
     architecture = metadata.get("general.architecture", "").strip().lower()
     tokenizer_model = metadata.get("tokenizer.ggml.model", "").strip().lower()
@@ -108,7 +136,7 @@ def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> N
 
     qwen_identity = (
         architecture == "qwen35moe"
-        and model_name == "Qwen3.6-35B-A3B"
+        and model_name == QWEN36_VERIFIED_MODEL_NAME
         and tokenizer_model == "gpt2"
         and tokenizer_pre == "qwen35"
         and file_type == QWEN36_VERIFIED_FILE_TYPE
@@ -137,7 +165,7 @@ def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> N
 
     qwen3_coder_identity = (
         architecture == "qwen3moe"
-        and model_name == "Qwen3-Coder-30B-A3B-Instruct"
+        and model_name == QWEN3_CODER_VERIFIED_MODEL_NAME
         and tokenizer_model == "gpt2"
         and tokenizer_pre == "qwen2"
         and file_type == QWEN3_CODER_VERIFIED_FILE_TYPE
@@ -209,7 +237,7 @@ def _unverified_reason(
     template_hash: str,
 ) -> str:
     if architecture == "qwen35moe":
-        if model_name != "Qwen3.6-35B-A3B":
+        if model_name != QWEN36_VERIFIED_MODEL_NAME:
             return "qwen36_model_identity_mismatch"
         if tokenizer_model != "gpt2" or tokenizer_pre != "qwen35":
             return "qwen36_tokenizer_identity_mismatch"
@@ -218,7 +246,7 @@ def _unverified_reason(
         if template_hash != QWEN36_OFFICIAL_TEMPLATE_SHA256:
             return "qwen36_template_identity_mismatch"
     if architecture == "qwen3moe":
-        if model_name != "Qwen3-Coder-30B-A3B-Instruct":
+        if model_name != QWEN3_CODER_VERIFIED_MODEL_NAME:
             return "qwen3_coder_model_identity_mismatch"
         if tokenizer_model != "gpt2" or tokenizer_pre != "qwen2":
             return "qwen3_coder_tokenizer_identity_mismatch"

--- a/src/orbit/native_llama/model_registry.json
+++ b/src/orbit/native_llama/model_registry.json
@@ -3,6 +3,8 @@
   "models": [
     {
       "id": "gemma4-26b-a4b-it-q40",
+      "display_name": "Gemma 4 26B-A4B",
+      "profile_id": "orbit-gemma4-native-v1",
       "backend": "native-llama",
       "architecture": "gemma4",
       "target": {
@@ -22,6 +24,30 @@
         "repo": "ggml-org/gemma-4-26B-A4B-it-GGUF",
         "file": "mtp-gemma-4-26B-A4B-it-Q4_0.gguf",
         "cache_glob": "models--ggml-org--gemma-4-26B-A4B-it-GGUF/snapshots/*/mtp-gemma-4-26B-A4B-it-Q4_0.gguf"
+      }
+    },
+    {
+      "id": "qwen36-35b-a3b-q4-k-m",
+      "display_name": "Qwen 3.6 35B-A3B",
+      "profile_id": "orbit-qwen36-native-v1",
+      "backend": "native-llama",
+      "architecture": "qwen35moe",
+      "target": {
+        "repo": "ggml-org/Qwen3.6-35B-A3B-GGUF",
+        "file": "Qwen3.6-35B-A3B-Q4_K_M.gguf",
+        "cache_glob": "models--ggml-org--Qwen3.6-35B-A3B-GGUF/snapshots/*/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+      }
+    },
+    {
+      "id": "qwen3-coder-30b-a3b-instruct-q4-k-m",
+      "display_name": "Qwen3-Coder 30B-A3B",
+      "profile_id": "orbit-qwen3-coder-native-v1",
+      "backend": "native-llama",
+      "architecture": "qwen3moe",
+      "target": {
+        "repo": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+        "file": "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        "cache_glob": "models--unsloth--Qwen3-Coder-30B-A3B-Instruct-GGUF/snapshots/*/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
       }
     }
   ]

--- a/src/orbit/native_llama/model_registry.py
+++ b/src/orbit/native_llama/model_registry.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib import resources
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import glob
 import json
 from typing import Any
+
+from orbit.native_llama.model_profiles import verified_native_model_identity
 
 
 REGISTRY_RESOURCE = "model_registry.json"
@@ -28,6 +30,8 @@ class MtpSpec(ModelFileSpec):
 @dataclass(frozen=True)
 class ModelManifest:
     id: str
+    display_name: str
+    profile_id: str
     backend: str
     architecture: str
     target: ModelFileSpec
@@ -105,6 +109,8 @@ def _manifest(data: dict[str, Any]) -> ModelManifest:
     mtp_data = data.get("mtp")
     return ModelManifest(
         id=str(data["id"]),
+        display_name=str(data["display_name"]),
+        profile_id=str(data["profile_id"]),
         backend=str(data["backend"]),
         architecture=str(data["architecture"]),
         target=_file_spec(data["target"]),
@@ -116,10 +122,150 @@ def _manifest(data: dict[str, Any]) -> ModelManifest:
 def load_registry(path: Path | None = None) -> list[ModelManifest]:
     if path is None:
         text = resources.files(__package__).joinpath(REGISTRY_RESOURCE).read_text(encoding="utf-8")
-        data = json.loads(text)
+        data = _load_json(text)
     else:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    return [_manifest(item) for item in data.get("models", [])]
+        data = _load_json(path.read_text(encoding="utf-8"))
+    model_data = _validate_registry(data)
+    return [_manifest(item) for item in model_data]
+
+
+def _load_json(text: str) -> Any:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate model registry key: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite model registry value: {value}")
+
+    return json.loads(text, object_pairs_hook=object_pairs, parse_constant=reject_constant)
+
+
+def _validate_registry(data: Any) -> list[dict[str, Any]]:
+    root = _require_mapping(data, "registry")
+    _require_keys(root, required={"version", "models"}, optional=set(), label="registry")
+    if type(root["version"]) is not int or root["version"] != 1:
+        raise ValueError("unsupported model registry version")
+    if not isinstance(root["models"], list):
+        raise ValueError("model registry models must be a list")
+
+    models: list[dict[str, Any]] = []
+    ids: set[str] = set()
+    names: set[str] = set()
+    profiles: set[str] = set()
+    downloads: set[tuple[str, str]] = set()
+    for index, value in enumerate(root["models"]):
+        label = f"models[{index}]"
+        model = _require_mapping(value, label)
+        _require_keys(
+            model,
+            required={"id", "display_name", "profile_id", "backend", "architecture", "target"},
+            optional={"mmproj", "mtp"},
+            label=label,
+        )
+        model_id = _require_string(model, "id", label)
+        display_name = _require_string(model, "display_name", label)
+        profile_id = _require_string(model, "profile_id", label)
+        backend = _require_string(model, "backend", label)
+        architecture = _require_string(model, "architecture", label)
+        if backend != "native-llama":
+            raise ValueError(f"{label}.backend must be native-llama")
+        identity = verified_native_model_identity(profile_id)
+        if identity is None or identity.architecture != architecture:
+            raise ValueError(f"{label} has an invalid profile/architecture mapping")
+        _add_unique(ids, model_id, "model id")
+        _add_unique(names, display_name, "model display name")
+        _add_unique(profiles, profile_id, "model profile")
+
+        specs = [("target", _validate_file_spec(model["target"], f"{label}.target"))]
+        if "mmproj" in model:
+            specs.append(("mmproj", _validate_file_spec(model["mmproj"], f"{label}.mmproj")))
+        if "mtp" in model:
+            specs.append(("mtp", _validate_mtp_spec(model["mtp"], f"{label}.mtp")))
+        for kind, spec in specs:
+            download = (str(spec["repo"]), str(spec["file"]))
+            if download in downloads:
+                raise ValueError(f"duplicate model registry download: {download[0]}/{download[1]}")
+            downloads.add(download)
+            if kind == "target" and not str(spec["file"]).lower().endswith(".gguf"):
+                raise ValueError(f"{label}.target.file must be a GGUF")
+        models.append(model)
+    return models
+
+
+def _validate_file_spec(value: Any, label: str) -> dict[str, Any]:
+    spec = _require_mapping(value, label)
+    _require_keys(spec, required={"repo", "file", "cache_glob"}, optional=set(), label=label)
+    repo = _require_string(spec, "repo", label)
+    file_name = _require_string(spec, "file", label)
+    cache_glob = _require_string(spec, "cache_glob", label)
+    repo_parts = repo.split("/")
+    if len(repo_parts) != 2 or any(part in {"", ".", ".."} for part in repo_parts):
+        raise ValueError(f"{label}.repo must be owner/repository")
+    _validate_relative_path(file_name, f"{label}.file", allow_wildcard=False)
+    _validate_relative_path(cache_glob, f"{label}.cache_glob", allow_wildcard=True)
+    return spec
+
+
+def _validate_mtp_spec(value: Any, label: str) -> dict[str, Any]:
+    spec = _require_mapping(value, label)
+    _require_keys(
+        spec,
+        required={"repo", "file", "cache_glob", "enabled_by_default", "required", "spec_type"},
+        optional=set(),
+        label=label,
+    )
+    _validate_file_spec(
+        {key: spec[key] for key in ("repo", "file", "cache_glob")},
+        label,
+    )
+    if type(spec["enabled_by_default"]) is not bool or type(spec["required"]) is not bool:
+        raise ValueError(f"{label} enablement fields must be booleans")
+    _require_string(spec, "spec_type", label)
+    return spec
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_keys(data: dict[str, Any], *, required: set[str], optional: set[str], label: str) -> None:
+    missing = required - data.keys()
+    unknown = data.keys() - required - optional
+    if missing:
+        raise ValueError(f"{label} missing keys: {', '.join(sorted(missing))}")
+    if unknown:
+        raise ValueError(f"{label} unknown keys: {', '.join(sorted(unknown))}")
+
+
+def _require_string(data: dict[str, Any], key: str, label: str) -> str:
+    value = data[key]
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise ValueError(f"{label}.{key} must be a non-empty string")
+    return value
+
+
+def _validate_relative_path(value: str, label: str, *, allow_wildcard: bool) -> None:
+    if "\\" in value or PurePosixPath(value).is_absolute():
+        raise ValueError(f"{label} must be a relative POSIX path")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"{label} contains an unsafe path component")
+    wildcard_count = sum(part == "*" for part in parts)
+    has_other_wildcard = any(any(char in part for char in "*?[") and part != "*" for part in parts)
+    if has_other_wildcard or (wildcard_count and not allow_wildcard) or wildcard_count > 1:
+        raise ValueError(f"{label} contains an unsupported wildcard")
+
+
+def _add_unique(seen: set[str], value: str, label: str) -> None:
+    if value in seen:
+        raise ValueError(f"duplicate {label}: {value}")
+    seen.add(value)
 
 
 def get_manifest(model_id: str, *, registry_path: Path | None = None) -> ModelManifest:

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -24,8 +24,17 @@ from orbit.native_llama.client import (
     _has_open_thought_channel,
 )
 from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_context as native_kv_request_context
+from orbit.native_llama.model_discovery import discover_models, format_model_discovery
 from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
-from orbit.native_llama.paths import DEFAULT_LLAMA_ROOT, DEFAULT_MODEL_ID, NativeLlamaPaths, resolve_legacy_paths, resolve_paths
+from orbit.native_llama.model_registry import default_hf_cache, default_models_dir
+from orbit.native_llama.paths import (
+    DEFAULT_LLAMA_ROOT,
+    DEFAULT_MODEL_ID,
+    NativeLlamaPaths,
+    _resolve_native_runtime,
+    resolve_legacy_paths,
+    resolve_paths,
+)
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.native_llama.qwen_route_prefix import resolve_qwen_route_prefix_reuse
 from orbit.native_llama.qwen36_shell_tool_prefix import (
@@ -704,6 +713,7 @@ def run_server(argv: list[str] | None = None) -> int:
     qwen36_shell_tool_prefix_config = resolve_qwen36_shell_tool_prefix_reuse()
     qwen3_coder_route_prefix_config = resolve_qwen3_coder_route_prefix_reuse()
 
+    paths: NativeLlamaPaths | None = None
     try:
         paths = resolve_bootstrap_paths(args)
         client = NativeLlamaClient(
@@ -757,10 +767,13 @@ def run_server(argv: list[str] | None = None) -> int:
             if prewarm_interrupted:
                 client.close()
                 return 130
-    except (FileNotFoundError, RuntimeError) as exc:
+    except (FileNotFoundError, KeyError, RuntimeError) as exc:
         print(_format_native_bootstrap_error(exc), file=sys.stderr)
+        if _is_model_bootstrap_failure(exc):
+            _print_model_discovery(args, paths)
         return 1
 
+    assert paths is not None
     model_alias = resolve_model_alias(args.alias, paths)
     httpd = ThreadingHTTPServer((args.host, args.port), OrbitNativeHandler)
     httpd.orbit_state = OrbitNativeServer(client=client, model_alias=model_alias)  # type: ignore[attr-defined]
@@ -999,6 +1012,40 @@ def _format_native_bootstrap_error(exc: Exception) -> str:
             "the required shim, or package the shim under src/orbit/native_llama/vendor/shim."
         )
     return f"error: failed to start native backend: {detail}"
+
+
+def _is_model_bootstrap_failure(exc: Exception) -> bool:
+    detail = str(exc).lower()
+    return any(
+        marker in detail
+        for marker in (
+            "model not found:",
+            "target model not found:",
+            "failed to load model:",
+            "unsupported or unverified native model compatibility",
+            "unknown native model manifest",
+        )
+    )
+
+
+def _print_model_discovery(args: argparse.Namespace, paths: NativeLlamaPaths | None) -> None:
+    build_bin = paths.build_bin if paths is not None else None
+    if build_bin is None:
+        try:
+            build_bin = _resolve_native_runtime(args.llama_root)[1]
+        except FileNotFoundError:
+            build_bin = None
+    try:
+        result = discover_models(
+            models_dir=args.models_dir or default_models_dir(),
+            hf_cache=args.hf_cache or default_hf_cache(),
+            explicit_model=args.model,
+            build_bin=build_bin,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"model discovery unavailable: {str(exc).strip() or exc.__class__.__name__}", file=sys.stderr)
+        return
+    print(format_model_discovery(result), file=sys.stderr)
 
 
 def _session_id_from_payload(payload: dict[str, Any]) -> str:

--- a/tests/test_native_model_discovery.py
+++ b/tests/test_native_model_discovery.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+from unittest import mock
+
+from orbit.native_llama.model_discovery import NativeProfileInspector, discover_models, format_model_discovery
+from orbit.native_llama.model_profiles import (
+    GEMMA4_PROFILE_ID,
+    QWEN36_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+    detect_native_model_profile,
+)
+from orbit.native_llama.model_registry import load_registry, local_model_path
+
+
+def _profile(profile_id: str, model_name: str):
+    return SimpleNamespace(profile_id=profile_id, model_name=model_name, verified=True)
+
+
+class NativeModelDiscoveryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifests = tuple(load_registry())
+
+    def test_no_local_models_lists_all_supported_downloads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: self.fail("no file should be inspected"),
+            )
+
+        self.assertEqual(len(result.rows), 3)
+        self.assertTrue(all(row.local == "MISSING" for row in result.rows))
+        self.assertTrue(all(row.support == "VERIFIED" for row in result.rows))
+        self.assertEqual(
+            {row.path_or_action for row in result.rows},
+            {
+                "orbit download ggml-org/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-Q4_0.gguf",
+                "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                "orbit download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+            },
+        )
+
+    def test_one_verified_local_model_is_available(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = self.manifests[1]
+            model = local_model_path(manifest.target, models_dir=root / "models")
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"GGUF")
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: _profile(QWEN36_PROFILE_ID, "Qwen3.6-35B-A3B"),
+            )
+
+        row = next(row for row in result.rows if row.model == "Qwen 3.6 35B-A3B")
+        self.assertEqual((row.local, row.support), ("AVAILABLE", "VERIFIED"))
+        self.assertEqual(row.path_or_action, str(model.absolute()))
+        self.assertEqual(result.metadata_inspections, 1)
+
+    def test_multiple_verified_models_are_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profiles = {
+                self.manifests[0].target.file: _profile(GEMMA4_PROFILE_ID, "gemma-4-26B-A4B-it"),
+                self.manifests[2].target.file: _profile(
+                    QWEN3_CODER_PROFILE_ID,
+                    "Qwen3-Coder-30B-A3B-Instruct",
+                ),
+            }
+            for manifest in (self.manifests[0], self.manifests[2]):
+                path = local_model_path(manifest.target, models_dir=root / "models")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"GGUF")
+
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda path: profiles[path.name],
+            )
+
+        available = [row.model for row in result.rows if row.local == "AVAILABLE"]
+        self.assertEqual(available, ["Gemma 4 26B-A4B", "Qwen3-Coder 30B-A3B"])
+
+    def test_unsupported_gguf_is_never_presented_as_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            model = root / "models/other/foo.gguf"
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"GGUF")
+            unsupported = detect_native_model_profile(
+                {"general.architecture": "unknown", "general.name": "foo"},
+                "",
+            )
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: unsupported,
+            )
+
+        row = next(row for row in result.rows if row.model == "foo.gguf")
+        self.assertEqual((row.local, row.support), ("AVAILABLE", "UNSUPPORTED"))
+
+    def test_filename_spoof_with_wrong_metadata_remains_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = self.manifests[2]
+            model = local_model_path(manifest.target, models_dir=root / "models")
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"not the expected model")
+            wrong = detect_native_model_profile(
+                {
+                    "general.architecture": "qwen3moe",
+                    "general.name": "different-model",
+                    "tokenizer.ggml.model": "gpt2",
+                    "tokenizer.ggml.pre": "qwen2",
+                    "general.file_type": "15",
+                },
+                "",
+            )
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: wrong,
+            )
+
+        supported = next(row for row in result.rows if row.model == "Qwen3-Coder 30B-A3B")
+        spoof = next(row for row in result.rows if row.model == manifest.target.file)
+        self.assertEqual((supported.local, supported.support), ("MISSING", "VERIFIED"))
+        self.assertEqual((spoof.local, spoof.support), ("AVAILABLE", "UNSUPPORTED"))
+
+    def test_verified_profile_with_different_model_identity_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            model = root / "models/other/gemma-4-12b.gguf"
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"GGUF")
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: _profile(GEMMA4_PROFILE_ID, "gemma-4-12b-it"),
+            )
+
+        row = next(row for row in result.rows if row.model == "gemma-4-12b.gguf")
+        self.assertEqual(row.support, "UNSUPPORTED")
+
+    def test_missing_registry_entry_does_not_weaken_detected_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            model = root / "models/local/qwen.gguf"
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"GGUF")
+            manifests = tuple(item for item in self.manifests if item.profile_id != QWEN36_PROFILE_ID)
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                manifests=manifests,
+                inspector=lambda _path: _profile(QWEN36_PROFILE_ID, "Qwen3.6-35B-A3B"),
+            )
+
+        row = next(row for row in result.rows if row.path_or_action == str(model.resolve()))
+        self.assertEqual((row.local, row.support), ("AVAILABLE", "VERIFIED"))
+
+    def test_incorrect_injected_registry_mapping_fails_closed(self) -> None:
+        bad_manifest = replace(self.manifests[0], architecture="qwen35moe")
+
+        with self.assertRaisesRegex(ValueError, "profile mapping is not supported"):
+            discover_models(manifests=(bad_manifest,), inspector=lambda _path: self.fail("no model"))
+
+    def test_malformed_or_unreadable_gguf_is_unverified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            model = root / "models/broken.gguf"
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"broken")
+
+            def fail(_path: Path):
+                raise RuntimeError("vocab-only GGUF inspection failed")
+
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=fail,
+            )
+
+        row = next(row for row in result.rows if row.model == "broken.gguf")
+        self.assertEqual((row.local, row.support), ("AVAILABLE", "UNVERIFIED"))
+
+    def test_hf_cache_uses_only_exact_registered_globs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = self.manifests[1]
+            model = root / "hf" / manifest.target.cache_glob.replace("*", "snapshot-a")
+            model.parent.mkdir(parents=True)
+            model.write_bytes(b"GGUF")
+            unrelated = root / "hf/models--other--repo/snapshots/a/other.gguf"
+            unrelated.parent.mkdir(parents=True)
+            unrelated.write_bytes(b"GGUF")
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: _profile(QWEN36_PROFILE_ID, "Qwen3.6-35B-A3B"),
+            )
+
+        self.assertEqual(result.metadata_inspections, 1)
+        self.assertFalse(any(row.model == "other.gguf" for row in result.rows))
+        self.assertEqual(result.filesystem_scans, 5)
+
+    def test_symlink_escape_is_not_inspected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            outside = root / "outside.gguf"
+            outside.write_bytes(b"GGUF")
+            models = root / "models"
+            models.mkdir()
+            (models / "escape.gguf").symlink_to(outside)
+            result = discover_models(
+                models_dir=models,
+                hf_cache=root / "hf",
+                inspector=lambda _path: self.fail("escaping symlink must not be inspected"),
+            )
+
+        self.assertFalse(any(row.model == "escape.gguf" for row in result.rows))
+        self.assertEqual(result.metadata_inspections, 0)
+
+    def test_internal_symlink_alias_is_inspected_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            models = root / "models"
+            model = models / "model.gguf"
+            models.mkdir()
+            model.write_bytes(b"GGUF")
+            (models / "alias.gguf").symlink_to(model)
+            inspected: list[Path] = []
+            unsupported = detect_native_model_profile({"general.architecture": "unknown"}, "")
+            result = discover_models(
+                models_dir=models,
+                hf_cache=root / "hf",
+                inspector=lambda path: inspected.append(path) or unsupported,
+            )
+
+        self.assertEqual(inspected, [model.resolve()])
+        self.assertEqual(result.metadata_inspections, 1)
+
+    def test_hard_link_alias_is_inspected_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            models = root / "models"
+            model = models / "model.gguf"
+            models.mkdir()
+            model.write_bytes(b"GGUF")
+            os.link(model, models / "alias.gguf")
+            inspected: list[Path] = []
+            unsupported = detect_native_model_profile({"general.architecture": "unknown"}, "")
+            result = discover_models(
+                models_dir=models,
+                hf_cache=root / "hf",
+                inspector=lambda path: inspected.append(path) or unsupported,
+            )
+
+        self.assertEqual(len(inspected), 1)
+        self.assertEqual(result.metadata_inspections, 1)
+
+    def test_output_is_compact_and_includes_path_or_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = discover_models(
+                models_dir=root / "models",
+                hf_cache=root / "hf",
+                inspector=lambda _path: self.fail("no file should be inspected"),
+            )
+
+        output = format_model_discovery(result)
+        self.assertIn("Model", output)
+        self.assertIn("Local", output)
+        self.assertIn("Support", output)
+        self.assertIn("Path / action", output)
+        self.assertIn("MISSING", output)
+        self.assertNotIn("wall_ms", output)
+
+    def test_native_inspection_is_vocab_only_and_releases_model(self) -> None:
+        params = SimpleNamespace(vocab_only=False, use_mmap=False, check_tensors=False)
+        native_model = object()
+        lib = mock.Mock()
+        lib.llama_model_default_params.return_value = params
+        lib.llama_model_load_from_file.return_value = native_model
+        lib.llama_model_meta_count.return_value = 0
+        lib.llama_model_chat_template.return_value = None
+        binding = SimpleNamespace(lib=lib)
+
+        with mock.patch("orbit.native_llama.model_discovery.LlamaLibrary", return_value=binding):
+            inspector = NativeProfileInspector(Path("/native"))
+            profile = inspector(Path("/models/model.gguf"))
+
+        self.assertTrue(params.vocab_only)
+        self.assertTrue(params.use_mmap)
+        self.assertTrue(params.check_tensors)
+        self.assertFalse(profile.verified)
+        lib.ggml_backend_load_all.assert_called_once_with()
+        lib.llama_model_free.assert_called_once_with(native_model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_model_download.py
+++ b/tests/test_native_model_download.py
@@ -38,6 +38,13 @@ class NativeModelDownloadTests(unittest.TestCase):
         self.assertEqual(request.repo, "ggml-org/gemma-4-26B-A4B-it-GGUF")
         self.assertEqual(request.file, "gemma-4-26B-A4B-it-Q4_0.gguf")
 
+    def test_parse_qwen_repos_use_verified_manifest_files(self) -> None:
+        qwen36 = parse_huggingface_spec("ggml-org/Qwen3.6-35B-A3B-GGUF")
+        coder = parse_huggingface_spec("unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF")
+
+        self.assertEqual(qwen36.file, "Qwen3.6-35B-A3B-Q4_K_M.gguf")
+        self.assertEqual(coder.file, "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf")
+
     def test_parse_repo_with_mmproj_preference_uses_manifest_projector(self) -> None:
         request = parse_huggingface_spec("ggml-org/gemma-4-26B-A4B-it-GGUF", prefer="mmproj")
 

--- a/tests/test_native_model_registry.py
+++ b/tests/test_native_model_registry.py
@@ -14,43 +14,76 @@ from orbit.native_llama.model_registry import (
 )
 
 
-def _write_registry(path: Path) -> None:
-    path.write_text(
-        json.dumps(
+def _registry_data() -> dict:
+    return {
+        "version": 1,
+        "models": [
             {
-                "version": 1,
-                "models": [
-                    {
-                        "id": "test-gemma",
-                        "backend": "native-llama",
-                        "architecture": "gemma4",
-                        "target": {
-                            "repo": "target/repo",
-                            "file": "target.gguf",
-                            "cache_glob": "target/snapshots/*/target.gguf",
-                        },
-                        "mmproj": {
-                            "repo": "target/repo",
-                            "file": "mmproj.gguf",
-                            "cache_glob": "target/snapshots/*/mmproj.gguf",
-                        },
-                        "mtp": {
-                            "enabled_by_default": True,
-                            "required": False,
-                            "spec_type": "draft-mtp",
-                            "repo": "draft/repo",
-                            "file": "MTP/draft.gguf",
-                            "cache_glob": "draft/snapshots/*/MTP/draft.gguf",
-                        },
-                    }
-                ],
+                "id": "test-gemma",
+                "display_name": "Test Gemma",
+                "profile_id": "orbit-gemma4-native-v1",
+                "backend": "native-llama",
+                "architecture": "gemma4",
+                "target": {
+                    "repo": "target/repo",
+                    "file": "target.gguf",
+                    "cache_glob": "target/snapshots/*/target.gguf",
+                },
+                "mmproj": {
+                    "repo": "target/repo",
+                    "file": "mmproj.gguf",
+                    "cache_glob": "target/snapshots/*/mmproj.gguf",
+                },
+                "mtp": {
+                    "enabled_by_default": True,
+                    "required": False,
+                    "spec_type": "draft-mtp",
+                    "repo": "draft/repo",
+                    "file": "MTP/draft.gguf",
+                    "cache_glob": "draft/snapshots/*/MTP/draft.gguf",
+                },
             }
-        ),
-        encoding="utf-8",
-    )
+        ],
+    }
+
+
+def _write_registry(path: Path, data: dict | None = None) -> None:
+    path.write_text(json.dumps(data or _registry_data()), encoding="utf-8")
 
 
 class NativeModelRegistryTests(unittest.TestCase):
+    def test_packaged_registry_contains_only_current_verified_models(self) -> None:
+        manifests = load_registry()
+
+        self.assertEqual(
+            [(item.display_name, item.profile_id) for item in manifests],
+            [
+                ("Gemma 4 26B-A4B", "orbit-gemma4-native-v1"),
+                ("Qwen 3.6 35B-A3B", "orbit-qwen36-native-v1"),
+                ("Qwen3-Coder 30B-A3B", "orbit-qwen3-coder-native-v1"),
+            ],
+        )
+        self.assertEqual(
+            [(item.profile_id, item.target.repo, item.target.file) for item in manifests],
+            [
+                (
+                    "orbit-gemma4-native-v1",
+                    "ggml-org/gemma-4-26B-A4B-it-GGUF",
+                    "gemma-4-26B-A4B-it-Q4_0.gguf",
+                ),
+                (
+                    "orbit-qwen36-native-v1",
+                    "ggml-org/Qwen3.6-35B-A3B-GGUF",
+                    "Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                ),
+                (
+                    "orbit-qwen3-coder-native-v1",
+                    "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+                    "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+                ),
+            ],
+        )
+
     def test_loads_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             registry_path = Path(tmp) / "registry.json"
@@ -60,9 +93,93 @@ class NativeModelRegistryTests(unittest.TestCase):
 
         self.assertEqual(len(manifests), 1)
         self.assertEqual(manifests[0].id, "test-gemma")
+        self.assertEqual(manifests[0].display_name, "Test Gemma")
+        self.assertEqual(manifests[0].profile_id, "orbit-gemma4-native-v1")
         self.assertEqual(manifests[0].backend, "native-llama")
         self.assertEqual(manifests[0].architecture, "gemma4")
         self.assertIsNotNone(manifests[0].mtp)
+
+    def test_duplicate_json_key_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "registry.json"
+            registry_path.write_text('{"version":1,"version":1,"models":[]}', encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "duplicate model registry key"):
+                load_registry(registry_path)
+
+    def test_unknown_registry_key_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "registry.json"
+            data = _registry_data()
+            data["models"][0]["unexpected"] = True
+            _write_registry(registry_path, data)
+
+            with self.assertRaisesRegex(ValueError, "unknown keys"):
+                load_registry(registry_path)
+
+    def test_bad_version_missing_fields_and_wrong_types_are_rejected(self) -> None:
+        cases = []
+        bad_version = _registry_data()
+        bad_version["version"] = True
+        cases.append(bad_version)
+        missing_field = _registry_data()
+        del missing_field["models"][0]["target"]
+        cases.append(missing_field)
+        wrong_type = _registry_data()
+        wrong_type["models"] = {}
+        cases.append(wrong_type)
+        for data in cases:
+            with self.subTest(data=data), tempfile.TemporaryDirectory() as tmp:
+                registry_path = Path(tmp) / "registry.json"
+                _write_registry(registry_path, data)
+
+                with self.assertRaises(ValueError):
+                    load_registry(registry_path)
+
+    def test_duplicate_ids_names_profiles_and_downloads_are_rejected(self) -> None:
+        mutations = {
+            "model id": {},
+            "model display name": {"id": "other"},
+            "model profile": {"id": "other", "display_name": "Other"},
+            "download": {
+                "id": "other",
+                "display_name": "Other",
+                "profile_id": "orbit-qwen36-native-v1",
+                "architecture": "qwen35moe",
+            },
+        }
+        for reason, changes in mutations.items():
+            with self.subTest(reason=reason), tempfile.TemporaryDirectory() as tmp:
+                registry_path = Path(tmp) / "registry.json"
+                data = _registry_data()
+                duplicate = json.loads(json.dumps(data["models"][0]))
+                duplicate.update(changes)
+                data["models"].append(duplicate)
+                _write_registry(registry_path, data)
+
+                with self.assertRaisesRegex(ValueError, f"duplicate (model registry )?{reason}"):
+                    load_registry(registry_path)
+
+    def test_incorrect_profile_architecture_mapping_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "registry.json"
+            data = _registry_data()
+            data["models"][0]["architecture"] = "qwen35moe"
+            _write_registry(registry_path, data)
+
+            with self.assertRaisesRegex(ValueError, "invalid profile/architecture mapping"):
+                load_registry(registry_path)
+
+    def test_unsafe_download_paths_and_globs_are_rejected(self) -> None:
+        for key, value in (("file", "../model.gguf"), ("cache_glob", "../../**/model.gguf")):
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as tmp:
+                registry_path = Path(tmp) / "registry.json"
+                data = _registry_data()
+                data["models"][0]["target"][key] = value
+                _write_registry(registry_path, data)
+
+                with self.assertRaises(ValueError):
+                    load_registry(registry_path)
 
     def test_falls_back_to_no_mtp_when_optional_draft_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from orbit.native_llama.client import NativeRoutePrefixPrefillResult
+from orbit.native_llama.model_discovery import ModelDiscoveryResult, ModelDiscoveryRow
 from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.native_names import runtime_library_filename
 from orbit.native_server.app import (
@@ -131,6 +132,25 @@ class _FakeHTTPServer:
 
 
 class NativeServerBootstrapTests(unittest.TestCase):
+    @staticmethod
+    def _missing_discovery() -> ModelDiscoveryResult:
+        return ModelDiscoveryResult(
+            rows=(
+                ModelDiscoveryRow(
+                    model="Qwen 3.6 35B-A3B",
+                    local="MISSING",
+                    support="VERIFIED",
+                    path_or_action=(
+                        "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/"
+                        "Qwen3.6-35B-A3B-Q4_K_M.gguf"
+                    ),
+                ),
+            ),
+            wall_ms=1.0,
+            filesystem_scans=5,
+            metadata_inspections=0,
+        )
+
     def test_bootstrap_can_use_packaged_vendor_lib_without_llama_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -450,6 +470,88 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertIn("error: native backend libraries are missing.", output)
         self.assertIn("--llama-root", output)
         self.assertIn("ORBIT_LLAMA_ROOT", output)
+
+    def test_run_server_missing_explicit_model_prints_discovery(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                side_effect=FileNotFoundError("model not found: /missing/model.gguf"),
+            ),
+            mock.patch(
+                "orbit.native_server.app.discover_models",
+                return_value=self._missing_discovery(),
+            ) as discovery,
+            redirect_stderr(stderr),
+        ):
+            code = run_server(["--model", "/missing/model.gguf"])
+
+        self.assertEqual(code, 1)
+        output = stderr.getvalue()
+        self.assertIn("model not found", output)
+        self.assertIn("Qwen 3.6 35B-A3B", output)
+        self.assertIn(
+            "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+            output,
+        )
+        discovery.assert_called_once()
+
+    def test_run_server_missing_default_model_prints_supported_choices(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                side_effect=FileNotFoundError("target model not found: repo:model.gguf"),
+            ),
+            mock.patch(
+                "orbit.native_server.app.discover_models",
+                return_value=self._missing_discovery(),
+            ) as discovery,
+            redirect_stderr(stderr),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 1)
+        self.assertIn("Models:", stderr.getvalue())
+        discovery.assert_called_once()
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_run_server_valid_explicit_model_does_not_run_discovery(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=Path("/models/valid.gguf")),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("orbit.native_server.app.discover_models") as discovery,
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+        ):
+            code = run_server(["--model", "/models/valid.gguf"])
+
+        self.assertEqual(code, 0)
+        discovery.assert_not_called()
+
+    def test_unknown_model_id_fails_clearly_with_discovery(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                side_effect=KeyError("unknown native model manifest: made-up"),
+            ),
+            mock.patch(
+                "orbit.native_server.app.discover_models",
+                return_value=self._missing_discovery(),
+            ),
+            redirect_stderr(stderr),
+        ):
+            code = run_server(["--model-id", "made-up"])
+
+        self.assertEqual(code, 1)
+        self.assertIn("unknown native model manifest", stderr.getvalue())
+        self.assertIn("Models:", stderr.getvalue())
 
     def test_run_server_reports_clear_error_when_mtp_shim_inputs_are_missing(self) -> None:
         stderr = io.StringIO()


### PR DESCRIPTION
Summary:
- lists local verified, unsupported, and unverified models after model startup failure
- keeps exact native profile detection as the support authority
- suggests canonical downloads only for missing verified models
- uses bounded, symlink-confined discovery and deduplicates aliases
- leaves an explicit valid --model path unchanged
- makes no inference behavior change

Validation:
- focused discovery/registry/server/profile tests: 92/92 PASS
- native tests: 343/343 PASS, 3 expected skips
- CLI tests: 8/8 PASS
- registry JSON validation PASS
- compileall PASS
- cached diff check PASS

Scope:
- no interactive selector
- no filename-only authorization
- no version or release changes