### PR TITLE
Add interactive verified model downloads

### DIFF
--- a/src/orbit/native_llama/model_download.py
+++ b/src/orbit/native_llama/model_download.py
@@ -86,7 +86,7 @@ def download_model(
         else:
             retrieve(url, str(tmp_path), _progress_hook(progress))
         tmp_path.replace(destination)
-    except Exception:
+    except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
     return DownloadResult(path=destination, downloaded=True, url=url)

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -24,9 +24,11 @@ from orbit.native_llama.client import (
     _has_open_thought_channel,
 )
 from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_context as native_kv_request_context
-from orbit.native_llama.model_discovery import discover_models, format_model_discovery
+from orbit.native_llama.download_cli import _DownloadProgress as DownloadProgress
+from orbit.native_llama.model_discovery import ModelDiscoveryRow, discover_models, format_model_discovery
+from orbit.native_llama.model_download import download_model
 from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
-from orbit.native_llama.model_registry import default_hf_cache, default_models_dir
+from orbit.native_llama.model_registry import default_hf_cache, default_models_dir, get_manifest, local_model_path
 from orbit.native_llama.paths import (
     DEFAULT_LLAMA_ROOT,
     DEFAULT_MODEL_ID,
@@ -711,8 +713,9 @@ def run_server(argv: list[str] | None = None) -> int:
     selected_interactively = False
     if _interactive_model_selection_requested(args):
         try:
-            if not _select_startup_model(args):
-                return 1
+            selection_exit = _select_startup_model(args)
+            if selection_exit is not None:
+                return selection_exit
             selected_interactively = True
         except KeyboardInterrupt:
             print("\nmodel selection cancelled", file=sys.stderr)
@@ -1062,7 +1065,7 @@ def _interactive_model_selection_requested(args: argparse.Namespace) -> bool:
     return args.model is None and args.model_id is None and callable(isatty) and bool(isatty())
 
 
-def _select_startup_model(args: argparse.Namespace) -> bool:
+def _select_startup_model(args: argparse.Namespace) -> int | None:
     try:
         build_bin = _resolve_native_runtime(args.llama_root)[1]
         result = discover_models(
@@ -1072,40 +1075,124 @@ def _select_startup_model(args: argparse.Namespace) -> bool:
         )
     except (OSError, RuntimeError, ValueError) as exc:
         print(_format_native_bootstrap_error(exc), file=sys.stderr)
-        return False
+        return 1
 
     print(format_model_discovery(result), file=sys.stderr)
     choices = tuple(
         row
         for row in result.rows
-        if row.local == "AVAILABLE" and row.support == "VERIFIED"
+        if row.local in {"AVAILABLE", "MISSING"} and row.support == "VERIFIED"
     )
     if not choices:
-        print("error: no verified local model is available", file=sys.stderr)
-        return False
+        print("error: no verified model is available or downloadable", file=sys.stderr)
+        return 1
 
-    print("\nAvailable verified models:", file=sys.stderr)
+    print("\nVerified models:", file=sys.stderr)
     for index, row in enumerate(choices, start=1):
-        print(f"  {index}. {row.model}", file=sys.stderr)
+        print(f"  {index}. {row.model} [{row.local}]", file=sys.stderr)
     print(f"Select model [1-{len(choices)}]: ", end="", file=sys.stderr, flush=True)
     response = sys.stdin.readline()
     if not response:
         print("model selection cancelled", file=sys.stderr)
-        return False
+        return 1
     try:
         selection = int(response.strip())
     except ValueError:
         print("error: invalid model selection", file=sys.stderr)
-        return False
+        return 1
     if not 1 <= selection <= len(choices):
         print("error: invalid model selection", file=sys.stderr)
-        return False
+        return 1
     selected = choices[selection - 1]
 
+    if selected.local == "MISSING":
+        return _download_selected_model(args, selected, build_bin=build_bin)
     args.model = Path(selected.path_or_action)
     args.model_id = selected.model_id
     print(f"Starting {selected.model}...", file=sys.stderr)
-    return True
+    return None
+
+
+def _download_selected_model(
+    args: argparse.Namespace,
+    selected: ModelDiscoveryRow,
+    *,
+    build_bin: Path,
+) -> int | None:
+    if selected.model_id is None:
+        print("error: selected model has no canonical download identity", file=sys.stderr)
+        return 1
+    try:
+        manifest = get_manifest(selected.model_id)
+    except KeyError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    target = f"{manifest.target.repo}/{manifest.target.file}"
+    print(f"\nSelected: {manifest.display_name}", file=sys.stderr)
+    print(f"Download: orbit download {target}", file=sys.stderr)
+    print("Download now? [Y/n] ", end="", file=sys.stderr, flush=True)
+    response = sys.stdin.readline()
+    if not response:
+        print("download cancelled", file=sys.stderr)
+        return 0
+    answer = response.strip().lower()
+    if answer in {"n", "no"}:
+        print("download cancelled", file=sys.stderr)
+        return 0
+    if answer not in {"", "y", "yes"}:
+        print("error: invalid download confirmation", file=sys.stderr)
+        return 1
+
+    models_dir = args.models_dir or default_models_dir()
+    progress = DownloadProgress()
+    try:
+        try:
+            downloaded = download_model(target, models_dir=models_dir, progress=progress)
+        finally:
+            progress.finish()
+    except Exception as exc:
+        print(f"error: download failed: {str(exc).strip() or exc.__class__.__name__}", file=sys.stderr)
+        return 1
+
+    expected_path = local_model_path(manifest.target, models_dir=models_dir).expanduser().resolve()
+    downloaded_path = downloaded.path.expanduser().resolve()
+    if downloaded_path != expected_path:
+        print("error: downloader returned an unexpected model destination", file=sys.stderr)
+        return 1
+
+    action = "downloaded" if downloaded.downloaded else "already present"
+    print(f"{action}: {downloaded.path}", file=sys.stderr)
+    try:
+        verified = discover_models(
+            models_dir=models_dir,
+            hf_cache=args.hf_cache or default_hf_cache(),
+            build_bin=build_bin,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: downloaded model verification failed: {str(exc).strip() or exc.__class__.__name__}", file=sys.stderr)
+        return 1
+
+    verified_row = next(
+        (
+            row
+            for row in verified.rows
+            if row.local == "AVAILABLE"
+            and row.support == "VERIFIED"
+            and row.model_id == selected.model_id
+            and Path(row.path_or_action).expanduser().resolve() == downloaded_path
+        ),
+        None,
+    )
+    if verified_row is None:
+        print("error: downloaded model is not the selected verified profile", file=sys.stderr)
+        return 1
+
+    args.model = downloaded_path
+    args.model_id = selected.model_id
+    print(f"Verified: {manifest.display_name}", file=sys.stderr)
+    print(f"Starting {manifest.display_name}...", file=sys.stderr)
+    return None
 
 
 def _session_id_from_payload(payload: dict[str, Any]) -> str:

--- a/tests/test_native_model_download.py
+++ b/tests/test_native_model_download.py
@@ -93,6 +93,21 @@ class NativeModelDownloadTests(unittest.TestCase):
             self.assertEqual(result.path, models_dir / "owner--repo" / "path/model.gguf")
             self.assertIn("downloaded from https://huggingface.co/owner/repo/resolve/main/path/model.gguf", result.path.read_text(encoding="utf-8"))
 
+    def test_interrupted_download_removes_temporary_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            models_dir = Path(tmp) / "models"
+
+            def retrieve(_url: str, dest: str) -> None:
+                Path(dest).write_text("partial", encoding="utf-8")
+                raise KeyboardInterrupt
+
+            with self.assertRaises(KeyboardInterrupt):
+                download_model("owner/repo/model.gguf", models_dir=models_dir, retrieve=retrieve)
+
+            destination = models_dir / "owner--repo" / "model.gguf"
+            self.assertFalse(destination.exists())
+            self.assertEqual(list(destination.parent.glob(".*.tmp")), [])
+
     def test_download_reports_bounded_percentage_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             progress: list[tuple[int, int]] = []

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 from orbit.native_llama.client import NativeRoutePrefixPrefillResult
 from orbit.native_llama.model_discovery import ModelDiscoveryResult, ModelDiscoveryRow
+from orbit.native_llama.model_download import DownloadResult
 from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.native_names import runtime_library_filename
 from orbit.native_server.app import (
@@ -155,6 +156,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
                         "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/"
                         "Qwen3.6-35B-A3B-Q4_K_M.gguf"
                     ),
+                    model_id="qwen36-35b-a3b-q4-k-m",
                 ),
             ),
             wall_ms=1.0,
@@ -621,7 +623,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
             mock.patch("orbit.native_server.app.resolve_bootstrap_paths", side_effect=resolve),
             mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
             mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
-            mock.patch("sys.stdin", _InteractiveInput("2\n")),
+            mock.patch("sys.stdin", _InteractiveInput("3\n")),
             mock.patch("sys.stdout", new_callable=io.StringIO),
             redirect_stderr(stderr),
         ):
@@ -634,11 +636,12 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(captured_args[0].model_id, "qwen3-coder-30b-a3b-instruct-q4-k-m")
         output = stderr.getvalue()
         self.assertIn("Models:", output)
-        self.assertIn("Available verified models:", output)
-        self.assertIn("1. Qwen 3.6 35B-A3B", output)
-        self.assertIn("2. Qwen3-Coder 30B-A3B", output)
+        self.assertIn("Verified models:", output)
+        self.assertIn("1. Gemma 4 26B-A4B [MISSING]", output)
+        self.assertIn("2. Qwen 3.6 35B-A3B [AVAILABLE]", output)
+        self.assertIn("3. Qwen3-Coder 30B-A3B [AVAILABLE]", output)
         self.assertIn("Starting Qwen3-Coder 30B-A3B...", output)
-        selectable_output = output.split("Available verified models:", 1)[1]
+        selectable_output = output.split("Verified models:", 1)[1]
         self.assertNotIn("other.gguf", selectable_output)
         self.assertNotIn("broken.gguf", selectable_output)
 
@@ -682,11 +685,76 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(code, 0)
         discovery.assert_not_called()
 
-    def test_run_server_interactive_without_available_verified_model_fails_closed(self) -> None:
+    def test_run_server_missing_verified_model_can_be_declined_without_side_effects(self) -> None:
         stderr = io.StringIO()
         with (
             mock.patch("orbit.native_server.app._resolve_native_runtime", return_value=(None, Path("/native"), Path("/native/libllama.so"))),
-            mock.patch("orbit.native_server.app.discover_models", return_value=self._missing_discovery()),
+            mock.patch("orbit.native_server.app.discover_models", return_value=self._missing_discovery()) as discovery,
+            mock.patch("orbit.native_server.app.download_model") as download,
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+            mock.patch("sys.stdin", _InteractiveInput("1\nn\n")),
+            redirect_stderr(stderr),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        discovery.assert_called_once()
+        download.assert_not_called()
+        bootstrap.assert_not_called()
+        self.assertIn("Download now? [Y/n]", stderr.getvalue())
+        self.assertIn("download cancelled", stderr.getvalue())
+
+    def test_missing_model_confirmation_handles_eof_and_invalid_input(self) -> None:
+        cases = (("1\n", 0, "download cancelled"), ("1\nmaybe\n", 1, "invalid download confirmation"))
+        for input_text, expected_code, expected_message in cases:
+            with self.subTest(input_text=input_text):
+                stderr = io.StringIO()
+                with (
+                    mock.patch(
+                        "orbit.native_server.app._resolve_native_runtime",
+                        return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                    ),
+                    mock.patch("orbit.native_server.app.discover_models", return_value=self._missing_discovery()),
+                    mock.patch("orbit.native_server.app.download_model") as download,
+                    mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+                    mock.patch("sys.stdin", _InteractiveInput(input_text)),
+                    redirect_stderr(stderr),
+                ):
+                    code = run_server([])
+
+                self.assertEqual(code, expected_code)
+                download.assert_not_called()
+                bootstrap.assert_not_called()
+                self.assertIn(expected_message, stderr.getvalue())
+
+    def test_unsupported_and_unverified_models_are_not_selectable(self) -> None:
+        discovery_result = ModelDiscoveryResult(
+            rows=(
+                ModelDiscoveryRow(
+                    model="other.gguf",
+                    local="AVAILABLE",
+                    support="UNSUPPORTED",
+                    path_or_action="/models/other.gguf",
+                ),
+                ModelDiscoveryRow(
+                    model="broken.gguf",
+                    local="AVAILABLE",
+                    support="UNVERIFIED",
+                    path_or_action="/models/broken.gguf",
+                ),
+            ),
+            wall_ms=1.0,
+            filesystem_scans=5,
+            metadata_inspections=2,
+        )
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app._resolve_native_runtime",
+                return_value=(None, Path("/native"), Path("/native/libllama.so")),
+            ),
+            mock.patch("orbit.native_server.app.discover_models", return_value=discovery_result) as discovery,
+            mock.patch("orbit.native_server.app.download_model") as download,
             mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
             mock.patch("sys.stdin", _InteractiveInput("1\n")),
             redirect_stderr(stderr),
@@ -694,8 +762,317 @@ class NativeServerBootstrapTests(unittest.TestCase):
             code = run_server([])
 
         self.assertEqual(code, 1)
+        discovery.assert_called_once()
+        download.assert_not_called()
         bootstrap.assert_not_called()
-        self.assertIn("no verified local model is available", stderr.getvalue())
+        self.assertIn("no verified model is available or downloadable", stderr.getvalue())
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_run_server_downloads_verifies_and_starts_missing_verified_model(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            models_dir = root / "models"
+            downloaded_path = models_dir / "ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+            downloaded_path.parent.mkdir(parents=True)
+            downloaded_path.write_bytes(b"GGUF")
+            available = ModelDiscoveryResult(
+                rows=(
+                    ModelDiscoveryRow(
+                        model="Qwen 3.6 35B-A3B",
+                        local="AVAILABLE",
+                        support="VERIFIED",
+                        path_or_action=str(downloaded_path),
+                        model_id="qwen36-35b-a3b-q4-k-m",
+                    ),
+                ),
+                wall_ms=1.0,
+                filesystem_scans=5,
+                metadata_inspections=1,
+            )
+            captured_args = []
+
+            def resolve(args):
+                captured_args.append(args)
+                return SimpleNamespace(model=downloaded_path)
+
+            stderr = io.StringIO()
+            with (
+                mock.patch(
+                    "orbit.native_server.app._resolve_native_runtime",
+                    return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.discover_models",
+                    side_effect=(self._missing_discovery(), available),
+                ) as discovery,
+                mock.patch(
+                    "orbit.native_server.app.download_model",
+                    return_value=DownloadResult(
+                        path=downloaded_path,
+                        downloaded=True,
+                        url="https://example.invalid/qwen.gguf",
+                    ),
+                ) as download,
+                mock.patch("orbit.native_server.app.resolve_bootstrap_paths", side_effect=resolve),
+                mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+                mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+                mock.patch("sys.stdin", _InteractiveInput("1\n\n")),
+                mock.patch("sys.stdout", new_callable=io.StringIO),
+                redirect_stderr(stderr),
+            ):
+                code = run_server(["--models-dir", str(models_dir), "--hf-cache", str(root / "hf")])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(discovery.call_count, 2)
+        download.assert_called_once_with(
+            "ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+            models_dir=models_dir,
+            progress=mock.ANY,
+        )
+        self.assertEqual(len(captured_args), 1)
+        self.assertEqual(captured_args[0].model, downloaded_path.resolve())
+        self.assertEqual(captured_args[0].model_id, "qwen36-35b-a3b-q4-k-m")
+        output = stderr.getvalue()
+        self.assertIn("Download: orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf", output)
+        self.assertIn("Verified: Qwen 3.6 35B-A3B", output)
+
+    def test_missing_model_download_failure_does_not_start_or_repeat(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app._resolve_native_runtime",
+                return_value=(None, Path("/native"), Path("/native/libllama.so")),
+            ),
+            mock.patch("orbit.native_server.app.discover_models", return_value=self._missing_discovery()) as discovery,
+            mock.patch("orbit.native_server.app.download_model", side_effect=RuntimeError("network unavailable")) as download,
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+            mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+            redirect_stderr(stderr),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 1)
+        discovery.assert_called_once()
+        download.assert_called_once()
+        bootstrap.assert_not_called()
+        self.assertIn("download failed: network unavailable", stderr.getvalue())
+
+    def test_interrupted_missing_model_download_exits_130_without_start(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app._resolve_native_runtime",
+                return_value=(None, Path("/native"), Path("/native/libllama.so")),
+            ),
+            mock.patch("orbit.native_server.app.discover_models", return_value=self._missing_discovery()) as discovery,
+            mock.patch("orbit.native_server.app.download_model", side_effect=KeyboardInterrupt) as download,
+            mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+            mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+            redirect_stderr(stderr),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 130)
+        discovery.assert_called_once()
+        download.assert_called_once()
+        bootstrap.assert_not_called()
+        self.assertIn("model selection cancelled", stderr.getvalue())
+
+    def test_downloaded_model_must_match_selected_verified_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloaded_path = root / "models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+            downloaded_path.parent.mkdir(parents=True)
+            downloaded_path.write_bytes(b"wrong model")
+            unverified = ModelDiscoveryResult(
+                rows=(
+                    self._missing_discovery().rows[0],
+                    ModelDiscoveryRow(
+                        model=downloaded_path.name,
+                        local="AVAILABLE",
+                        support="UNVERIFIED",
+                        path_or_action=str(downloaded_path),
+                    ),
+                ),
+                wall_ms=1.0,
+                filesystem_scans=5,
+                metadata_inspections=1,
+            )
+            stderr = io.StringIO()
+            with (
+                mock.patch(
+                    "orbit.native_server.app._resolve_native_runtime",
+                    return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.discover_models",
+                    side_effect=(self._missing_discovery(), unverified),
+                ) as discovery,
+                mock.patch(
+                    "orbit.native_server.app.download_model",
+                    return_value=DownloadResult(
+                        path=downloaded_path,
+                        downloaded=True,
+                        url="https://example.invalid/wrong.gguf",
+                    ),
+                ),
+                mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+                mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+                redirect_stderr(stderr),
+            ):
+                code = run_server(["--models-dir", str(root / "models")])
+
+        self.assertEqual(code, 1)
+        self.assertEqual(discovery.call_count, 2)
+        bootstrap.assert_not_called()
+        self.assertIn("not the selected verified profile", stderr.getvalue())
+
+    def test_downloaded_model_rejects_a_different_verified_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloaded_path = root / "models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+            wrong_profile = ModelDiscoveryResult(
+                rows=(
+                    self._missing_discovery().rows[0],
+                    ModelDiscoveryRow(
+                        model="Qwen3-Coder 30B-A3B",
+                        local="AVAILABLE",
+                        support="VERIFIED",
+                        path_or_action=str(downloaded_path),
+                        model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+                    ),
+                ),
+                wall_ms=1.0,
+                filesystem_scans=5,
+                metadata_inspections=1,
+            )
+            stderr = io.StringIO()
+            with (
+                mock.patch(
+                    "orbit.native_server.app._resolve_native_runtime",
+                    return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.discover_models",
+                    side_effect=(self._missing_discovery(), wrong_profile),
+                ) as discovery,
+                mock.patch(
+                    "orbit.native_server.app.download_model",
+                    return_value=DownloadResult(
+                        path=downloaded_path,
+                        downloaded=True,
+                        url="https://example.invalid/wrong-profile.gguf",
+                    ),
+                ),
+                mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+                mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+                redirect_stderr(stderr),
+            ):
+                code = run_server(["--models-dir", str(root / "models")])
+
+        self.assertEqual(code, 1)
+        self.assertEqual(discovery.call_count, 2)
+        bootstrap.assert_not_called()
+        self.assertIn("not the selected verified profile", stderr.getvalue())
+
+    def test_downloaded_model_rejects_unexpected_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            unexpected_path = root / "elsewhere/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+            verified = ModelDiscoveryResult(
+                rows=(
+                    ModelDiscoveryRow(
+                        model="Qwen 3.6 35B-A3B",
+                        local="AVAILABLE",
+                        support="VERIFIED",
+                        path_or_action=str(unexpected_path),
+                        model_id="qwen36-35b-a3b-q4-k-m",
+                    ),
+                ),
+                wall_ms=1.0,
+                filesystem_scans=5,
+                metadata_inspections=1,
+            )
+            stderr = io.StringIO()
+            with (
+                mock.patch(
+                    "orbit.native_server.app._resolve_native_runtime",
+                    return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.discover_models",
+                    side_effect=(self._missing_discovery(), verified),
+                ) as discovery,
+                mock.patch(
+                    "orbit.native_server.app.download_model",
+                    return_value=DownloadResult(
+                        path=unexpected_path,
+                        downloaded=True,
+                        url="https://example.invalid/unexpected.gguf",
+                    ),
+                ),
+                mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+                mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+                redirect_stderr(stderr),
+            ):
+                code = run_server(["--models-dir", str(root / "models")])
+
+        self.assertEqual(code, 1)
+        discovery.assert_called_once()
+        bootstrap.assert_not_called()
+        self.assertIn("unexpected model destination", stderr.getvalue())
+
+    def test_verified_download_bootstrap_failure_does_not_repeat_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            downloaded_path = root / "models/ggml-org--Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf"
+            available = ModelDiscoveryResult(
+                rows=(
+                    ModelDiscoveryRow(
+                        model="Qwen 3.6 35B-A3B",
+                        local="AVAILABLE",
+                        support="VERIFIED",
+                        path_or_action=str(downloaded_path),
+                        model_id="qwen36-35b-a3b-q4-k-m",
+                    ),
+                ),
+                wall_ms=1.0,
+                filesystem_scans=5,
+                metadata_inspections=1,
+            )
+            stderr = io.StringIO()
+            with (
+                mock.patch(
+                    "orbit.native_server.app._resolve_native_runtime",
+                    return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.discover_models",
+                    side_effect=(self._missing_discovery(), available),
+                ) as discovery,
+                mock.patch(
+                    "orbit.native_server.app.download_model",
+                    return_value=DownloadResult(
+                        path=downloaded_path,
+                        downloaded=True,
+                        url="https://example.invalid/qwen.gguf",
+                    ),
+                ),
+                mock.patch(
+                    "orbit.native_server.app.resolve_bootstrap_paths",
+                    side_effect=RuntimeError("failed to load model: synthetic bootstrap failure"),
+                ),
+                mock.patch("sys.stdin", _InteractiveInput("1\ny\n")),
+                redirect_stderr(stderr),
+            ):
+                code = run_server(["--models-dir", str(root / "models")])
+
+        self.assertEqual(code, 1)
+        self.assertEqual(discovery.call_count, 2)
+        self.assertEqual(stderr.getvalue().count("Models:"), 1)
+        self.assertNotIn("Select model", stderr.getvalue().split("Starting", 1)[-1])
 
     def test_run_server_interactive_rejects_out_of_range_selection(self) -> None:
         available = self._available_discovery()


### PR DESCRIPTION
## Summary

- lets `orbit server` download a selected MISSING + VERIFIED model
- reuses the existing Orbit downloader
- validates canonical destination and exact verified profile before startup
- keeps unsupported/unverified models non-selectable
- preserves explicit/headless/direct-download paths
- no inference or routing changes

## Validation

- focused 105/105 PASS
- native 362/362 PASS, 3 expected skips
- CLI 31/31 PASS
- affected 255/255 PASS
- JSON validation PASS
- compileall PASS
- diff check PASS