### PR TITLE
Add compact inline CLI UX

### DIFF
--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -25,7 +25,7 @@ from orbit.terminal.commands import health_text, help_text, runtime_status, set_
 from orbit.terminal.session_selection import select_interactive_session
 from orbit.terminal.status import TokenUsageAccumulator, estimate_context_status_tokens, format_turn_status, summarize_turn_token_usage
 from orbit.terminal.streaming import StreamRenderer
-from orbit.terminal.theme import dim
+from orbit.terminal.theme import dim, runtime_error_text, warning_text
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import allowed_tool_names_for_spec, tools_are_enabled
 
@@ -110,7 +110,7 @@ def main(argv: list[str] | None = None) -> int:
     session = select_interactive_session(config.workdir)
     session_messages, session_warning = session.load_with_warning()
     if session_warning:
-        print(dim(session_warning), file=sys.stderr)
+        print(dim(warning_text(session_warning)), file=sys.stderr)
     runtime = ChatRuntime(
         backend=backend,
         system_prompt=None if config.no_system else config.system,
@@ -236,7 +236,10 @@ def _run_one_shot(
                 on_final_delta=renderer.write,
                 on_progress=renderer.progress,
                 on_model_step=record_model_step,
-                on_tool_call=lambda name, args: renderer.event(format_tool_call_event(name, args), restart_timer=False),
+                on_tool_call=lambda name, args: renderer.event(
+                    format_tool_call_event(name, args),
+                    next_activity=("tool", name),
+                ),
                 on_tool_result=lambda name, chars, source, content: _show_tool_result(
                     renderer,
                     runtime,
@@ -249,16 +252,19 @@ def _run_one_shot(
             )
     except KeyboardInterrupt:
         renderer.finish(interrupted=True)
-        print(dim("interrupted"), flush=True)
+        print(dim("cancelled"), flush=True)
         return 130
-    except ValueError as exc:
+    except (ValueError, TimeoutError) as exc:
         renderer.finish()
-        print(f"error: {exc}", file=sys.stderr)
+        print(runtime_error_text(exc), file=sys.stderr)
         return 1
     except LlamaServerError as exc:
         renderer.finish()
-        print(f"error: {exc}", file=sys.stderr)
+        print(runtime_error_text(exc), file=sys.stderr)
         return 1
+    except Exception:
+        renderer.finish()
+        raise
     renderer.finish()
     if not model_steps:
         prefill_estimator.update(
@@ -306,7 +312,11 @@ def _show_tool_result(renderer, runtime, prefill_estimator, name: str, chars: in
         tokens = estimate_prefill_tokens_after_tool_result(runtime.messages, content)
         seconds = prefill_estimator.estimate_seconds(tokens, profile=prefill_profile_for_phase("final_from_tool"))
         renderer.set_prefill_estimate(_visible_prefill_seconds(seconds), tokens)
-    renderer.event(format_tool_result_event(name, chars, source, content), trailing_blank_line=True)
+    renderer.event(
+        format_tool_result_event(name, chars, source, content),
+        trailing_blank_line=True,
+        next_activity=("model", "working"),
+    )
 
 
 if __name__ == "__main__":

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -31,7 +31,7 @@ from orbit.terminal.status import (
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
-from orbit.terminal.theme import dim
+from orbit.terminal.theme import dim, runtime_error_text
 from orbit.runtime.thinking_mode import ThinkingMode
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
@@ -51,6 +51,7 @@ class Repl:
     turn_backend_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
     session_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
     backend_usage_observer_installed: bool = field(default=False, init=False, repr=False)
+    prompt_gap_pending: bool = field(default=True, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.tools_mode is None:
@@ -86,12 +87,14 @@ class Repl:
             if prompt.startswith("/"):
                 clear_input_echo(prompt)
                 if self._handle_command(prompt):
+                    self.prompt_gap_pending = True
                     continue
                 return self._finish_interactive_session(0)
             if self.history:
                 resolution = self.history.resolve_prompt(prompt)
                 if resolution.missing_full_text:
                     print("error: full pasted text is unavailable for this history entry", file=sys.stderr)
+                    self.prompt_gap_pending = True
                     continue
                 if resolution.prompt != prompt:
                     prompt = resolution.prompt
@@ -103,10 +106,14 @@ class Repl:
                 self.history.add(prompt)
                 self.history.save()
             self._ask(prompt)
+            self.prompt_gap_pending = True
 
     def _read_next_prompt(self) -> str:
         if self.queued_prompts:
             return self.queued_prompts.pop(0)
+        if self.prompt_gap_pending:
+            print()
+            self.prompt_gap_pending = False
         return read_prompt_input()
 
     def _ask(self, prompt: str) -> None:
@@ -137,7 +144,10 @@ class Repl:
                     allowed_tool_names=allowed_tool_names_for_spec(self.tools_mode or "off"),
                     on_final_delta=renderer.write,
                     on_progress=renderer.progress,
-                    on_tool_call=lambda name, args: renderer.event(format_tool_call_event(name, args), restart_timer=False),
+                    on_tool_call=lambda name, args: renderer.event(
+                        format_tool_call_event(name, args),
+                        next_activity=("tool", name),
+                    ),
                     on_tool_result=lambda name, chars, source, content: self._show_tool_result(renderer, name, chars, source, content),
                     on_model_step=self._record_model_step,
                     on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
@@ -155,13 +165,16 @@ class Repl:
         except KeyboardInterrupt:
             renderer.finish(interrupted=True)
             self.runtime.restore_message_count(checkpoint)
-            print(dim("interrupted"), flush=True)
+            print(dim("cancelled"), flush=True)
             return
-        except LlamaServerError as exc:
+        except (LlamaServerError, TimeoutError) as exc:
             renderer.finish()
             self.runtime.restore_message_count(checkpoint)
-            print(f"error: {exc}", file=sys.stderr)
+            print(runtime_error_text(exc), file=sys.stderr)
             return
+        except Exception:
+            renderer.finish()
+            raise
         renderer.finish()
         self._save_session()
         elapsed = time.monotonic() - started
@@ -232,7 +245,11 @@ class Repl:
             tokens = estimate_prefill_tokens_after_tool_result(self.runtime.messages, content)
             seconds = self.prefill_estimator.estimate_seconds(tokens, profile=FINAL_FROM_TOOL_PREFILL_PROFILE)
             renderer.set_prefill_estimate(_visible_prefill_seconds(seconds), tokens)
-        renderer.event(format_tool_result_event(name, chars, source, content), trailing_blank_line=True)
+        renderer.event(
+            format_tool_result_event(name, chars, source, content),
+            trailing_blank_line=True,
+            next_activity=("model", "working"),
+        )
 
     def _handle_command(self, command: str) -> bool:
         if command == "/exit":
@@ -381,13 +398,16 @@ class Repl:
         except KeyboardInterrupt:
             renderer.finish(interrupted=True)
             self.runtime.restore_message_count(checkpoint)
-            print(dim("interrupted"), flush=True)
+            print(dim("cancelled"), flush=True)
             return
-        except LlamaServerError as exc:
+        except (LlamaServerError, TimeoutError) as exc:
             renderer.finish()
             self.runtime.restore_message_count(checkpoint)
-            print(f"error: {exc}", file=sys.stderr)
+            print(runtime_error_text(exc), file=sys.stderr)
             return
+        except Exception:
+            renderer.finish()
+            raise
         renderer.finish()
         self._save_session()
         elapsed = time.monotonic() - started

--- a/src/orbit/terminal/runtime_status.py
+++ b/src/orbit/terminal/runtime_status.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Protocol
 
 from orbit import __version__
+from orbit.native_llama.model_registry import load_registry
 from orbit.runtime.session_memory import DEFAULT_CONTEXT_TOKENS, SOFT_MEMORY_RATIO, estimate_message_tokens
 from orbit.runtime.tools import tool_names
 from orbit.terminal.config import AppConfig
@@ -79,6 +80,7 @@ class RuntimeStatus:
     mutation_failures: str
     host: HostInfo
     acceleration: AccelerationInfo
+    banner_model: str | None = None
 
 
 def collect_host_info() -> HostInfo:
@@ -130,46 +132,20 @@ def collect_runtime_status(
         mutation_failures=str(runtime.mutation_verification_failures),
         host=host_info or collect_host_info(),
         acceleration=_acceleration_info(props),
+        banner_model=_verified_model_display_name(props),
     )
 
 
 def format_startup_banner(status: RuntimeStatus) -> str:
-    cpu = _cores_short(status.host.physical_cores, status.host.logical_cores)
-    rows = [
-        ("header", "Orbit Runtime"),
-        ("Version", status.version),
-        ("Model", status.model),
-        ("Backend", status.backend),
-        ("MTP", f"{status.mtp}, mmproj {status.mmproj}"),
-        ("Tools", status.tools),
-        ("Think", status.think),
-        ("Max tokens", status.max_tokens),
-        ("Workdir", status.workdir),
-        ("separator", "Host"),
-        ("Machine", status.host.machine),
-        ("OS", status.host.os_name),
-        ("CPU", cpu),
-        ("Cores", f"{status.host.physical_cores} physical / {status.host.logical_cores} logical"),
-        ("RAM", f"{status.host.ram_total} total, {status.host.ram_available} free"),
-        ("Accel", _startup_accel_value(status.acceleration)),
-    ]
+    version = status.version if status.version.startswith("v") else f"v{status.version}"
+    backend = "native" if status.backend in {"native llama.cpp", "orbit-native"} else status.backend
     return "\n".join(
         [
-            _box(rows, width=58),
-            "Type /help for commands, /status for runtime details.",
+            f"Orbit {version} · {status.banner_model or status.model} · {backend}",
+            f"workdir {status.workdir} · tools {status.tools} · think {status.think} · ctx {status.context_window}",
+            "/help for commands · /status for details",
         ]
     )
-
-
-def _startup_accel_value(accel: AccelerationInfo) -> str:
-    parts = [accel.mode]
-    if accel.gpu != UNKNOWN:
-        parts.append(f"GPU {accel.gpu}")
-    if accel.vram_total != UNKNOWN:
-        parts.append(accel.vram_total)
-    if accel.offload != UNKNOWN:
-        parts.append(f"offload {accel.offload}")
-    return ", ".join(parts)
 
 
 def format_status_panel(status: RuntimeStatus) -> str:
@@ -419,6 +395,23 @@ def _model_name(info: object, backend: BackendLike) -> str:
     if isinstance(display, str) and display:
         return _strip_long_path(display)
     return UNKNOWN
+
+
+def _verified_model_display_name(props: dict[str, object]) -> str | None:
+    compatibility = props.get("model_compatibility")
+    if not isinstance(compatibility, dict) or compatibility.get("verified") is not True:
+        return None
+    profile_id = compatibility.get("compatibility_profile")
+    if not isinstance(profile_id, str) or not profile_id:
+        return None
+    try:
+        manifests = load_registry()
+    except (OSError, ValueError):
+        return None
+    return next(
+        (manifest.display_name for manifest in manifests if manifest.profile_id == profile_id),
+        None,
+    )
 
 
 def _model_context(info: object) -> int | None:

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -135,41 +135,46 @@ def format_turn_status(
         estimated_context_tokens=estimated_context_tokens,
         context_tokens=context_tokens,
     )
-    parts = []
-    if estimated_context_tokens is not None and context_tokens is not None and context_tokens > 0:
-        pressure = _context_pressure(estimated_context_tokens, context_tokens)
-        parts.append(f"ctx: {estimated_context_tokens}/{context_tokens} ({(estimated_context_tokens / context_tokens) * 100:.0f}%)")
-        if pressure:
-            parts.append(f"pressure: {pressure}")
-    prompt_tokens = result.prompt_tokens
-    completion_tokens = result.completion_tokens
-    cached_tokens = result.cached_tokens
-    if turn_token_usage is not None:
-        prompt_tokens = turn_token_usage.prompt_tokens
-        completion_tokens = turn_token_usage.completion_tokens
-        cached_tokens = turn_token_usage.cached_tokens
-        parts.extend(_token_usage_parts(turn_token_usage, prefix="tks"))
-    elif prompt_tokens is not None or completion_tokens is not None:
-        cached = f", cached {cached_tokens}" if cached_tokens is not None else ""
-        parts.append(f"tks: {prompt_tokens}->{completion_tokens}{cached}")
-    if turn_token_usage is None and prompt_tokens and cached_tokens is not None:
-        parts.append(f"cache: {(cached_tokens / prompt_tokens) * 100:.0f}%")
-    header = []
+    usage = turn_token_usage or _single_call_usage(result)
+    columns = max(20, terminal_columns or get_terminal_size((80, 20)).columns)
+    summary = []
     if elapsed_seconds is not None:
-        header.append(f"time elapsed: {format_elapsed(elapsed_seconds)}")
-    if result.prompt_tokens_per_second is not None:
-        header.append(f"pf {result.prompt_tokens_per_second:.1f}/s")
-    if result.generation_tokens_per_second is not None:
-        header.append(f"gen {result.generation_tokens_per_second:.1f}/s")
+        summary.append(format_elapsed(elapsed_seconds))
+    if usage is not None:
+        summary.append(f"{usage.model_calls} calls")
     if result.finish_reason:
-        parts.append(f"stop: {result.finish_reason}")
-    details = " | ".join(parts) if parts else "no metrics"
-    if not header:
-        return details
-    columns = terminal_columns or get_terminal_size((80, 20)).columns
-    heading = f"__ {' | '.join(header)} "
-    separator = heading + ("_" * max(0, columns - len(heading)))
-    return f"{separator}\n{details}"
+        summary.append(result.finish_reason)
+
+    lines = _pack_metric_parts(summary or ["no turn metrics"], columns=columns)
+    lines.extend(_token_metric_lines(usage, columns=columns))
+
+    rates = []
+    if result.prompt_tokens_per_second is not None:
+        rates.append(f"{result.prompt_tokens_per_second:.1f} tok/s prefill")
+    if result.generation_tokens_per_second is not None:
+        rates.append(f"{result.generation_tokens_per_second:.1f} tok/s decode")
+    if rates:
+        lines.extend(_pack_metric_parts(rates, columns=columns, prefix="last call: "))
+
+    if estimated_context_tokens is not None and context_tokens is not None and context_tokens > 0:
+        context = f"{estimated_context_tokens}/{context_tokens} ({_context_percentage(estimated_context_tokens, context_tokens)})"
+        pressure = _context_pressure(estimated_context_tokens, context_tokens)
+        context_parts = [context]
+        if pressure:
+            context_parts.append(f"pressure {pressure}")
+        lines.extend(_pack_metric_parts(context_parts, columns=columns, prefix="context: "))
+    if usage is not None and usage.failed_calls:
+        lines.append(f"warning: {usage.failed_calls} failed model call(s); token usage unavailable")
+    return "\n".join(lines)
+
+
+def _context_percentage(used: int, total: int) -> str:
+    if used == 0:
+        return "0%"
+    percentage = (used / total) * 100
+    if 0 < percentage < 1:
+        return "<1%"
+    return f"{percentage:.0f}%"
 
 
 def estimate_context_status_tokens(messages: list[dict[str, object]]) -> int:
@@ -199,6 +204,56 @@ def _add_optional_metric(total: int | None, value: int | None) -> int | None:
     if total is None or value is None:
         return None
     return total + value
+
+
+def _single_call_usage(result: ChatResult) -> TurnTokenUsage:
+    evaluated = None
+    cached = result.cached_tokens
+    if (
+        result.prompt_tokens is not None
+        and cached is not None
+        and 0 <= cached <= result.prompt_tokens
+    ):
+        evaluated = result.prompt_tokens - cached
+    else:
+        cached = None
+    return TurnTokenUsage(
+        model_calls=1,
+        prompt_tokens=result.prompt_tokens,
+        evaluated_tokens=evaluated,
+        cached_tokens=cached,
+        completion_tokens=result.completion_tokens,
+    )
+
+
+def _token_metric_lines(usage: TurnTokenUsage | None, *, columns: int) -> list[str]:
+    if usage is None:
+        return []
+    parts = []
+    for value, label in (
+        (usage.prompt_tokens, "in"),
+        (usage.evaluated_tokens, "eval"),
+        (usage.cached_tokens, "cache"),
+        (usage.completion_tokens, "out"),
+    ):
+        if value is not None:
+            parts.append(f"{value:,} {label}")
+    return _pack_metric_parts(parts or ["unavailable"], columns=columns, prefix="tokens: ")
+
+
+def _pack_metric_parts(parts: list[str], *, columns: int, prefix: str = "") -> list[str]:
+    lines: list[str] = []
+    current = prefix
+    for part in parts:
+        candidate = f"{current} · {part}" if current and current != prefix else f"{current}{part}"
+        if current and current != prefix and len(candidate) > columns:
+            lines.append(current)
+            current = part
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
 
 
 def _token_usage_parts(usage: TurnTokenUsage, *, prefix: str) -> list[str]:

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import re
+import sys
 import threading
 import time
 
 from orbit.backend.base import StreamProgress
-from orbit.terminal.theme import CYAN, DIM, RESET, dim
+from orbit.terminal.theme import CYAN, DIM, RESET, dim, is_tty, supports_ansi
 
 
-SPINNER_FRAMES = ("◐", "◓", "◑", "◒")
 PREFILL_COMPLETION_LABEL = "waiting for model..."
 MARKDOWN_HEADING = "\033[1m" + CYAN
 MARKDOWN_BOLD = "\033[1m"
@@ -26,20 +26,22 @@ class StreamRenderer:
         prefill_estimate_tokens: int | None = None,
         thinking: bool = False,
         render_markdown_mode: str = "plain",
+        interactive: bool | None = None,
     ) -> None:
         self.interval = interval
         self._prefill_estimate_seconds = prefill_estimate_seconds
         self._prefill_estimate_tokens = prefill_estimate_tokens
         self._thinking_filter = _ThinkingDisplayFilter() if thinking else None
-        self._markdown_mode = render_markdown_mode
-        self._markdown_live = _LiveMarkdownRenderer(enabled=render_markdown_mode == "live")
+        self._interactive = is_tty(sys.stdout) if interactive is None else interactive
+        self._ansi = supports_ansi(sys.stdout) if interactive is None else interactive
+        self._markdown_mode = render_markdown_mode if self._ansi else "plain"
+        self._markdown_live = _LiveMarkdownRenderer(enabled=self._markdown_mode == "live")
         self._started = False
         self._first_delta = False
         self._timer_active = False
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._start_time = 0.0
-        self._frame_index = 0
         self._progress: StreamProgress | None = None
         self._generation_completed = 0
         self._generation_budget_completed = 0
@@ -47,11 +49,13 @@ class StreamRenderer:
         self._thinking_final_started = False
         self._thinking_dim_open = False
         self._phase_label: str | None = None
+        self._activity_kind = "model"
 
     def start(self) -> None:
         self._started = True
         self._start_time = time.monotonic()
-        self._frame_index = 0
+        if not self._interactive:
+            return
         self._timer_active = True
         self._thread = threading.Thread(target=self._run_wait_timer, daemon=True)
         self._thread.start()
@@ -70,31 +74,41 @@ class StreamRenderer:
                 continue
             self._print_thinking_fragment(fragment, dimmed=dimmed)
 
-    def event(self, text: str, *, restart_timer: bool = True, trailing_blank_line: bool = False) -> None:
+    def event(
+        self,
+        text: str,
+        *,
+        restart_timer: bool = True,
+        trailing_blank_line: bool = False,
+        next_activity: tuple[str, str | None] | None = None,
+    ) -> None:
         self._flush_markdown_buffer(interrupted=False)
         self._stop_timer(clear=True)
         print(dim(text), flush=True)
         if trailing_blank_line:
             print(flush=True)
-        if not restart_timer:
+        if next_activity is not None:
+            self.set_activity(*next_activity)
+        if not restart_timer and next_activity is None:
             return
         self._restart_timer()
 
     def _restart_timer(self) -> None:
         self._stop.clear()
         self._start_time = time.monotonic()
-        self._frame_index = 0
         self._first_delta = False
         self._progress = None
         self._generation_completed = 0
         self._generation_budget_completed = 0
+        if not self._interactive or not self._started:
+            return
         self._timer_active = True
         self._thread = threading.Thread(target=self._run_wait_timer, daemon=True)
         self._thread.start()
 
     def progress(self, update: StreamProgress) -> None:
         self._progress = self._normalize_progress(update)
-        if self._started and not self._first_delta:
+        if self._interactive and self._started and not self._first_delta:
             self._render_wait_line()
 
     def finish(self, *, interrupted: bool = False) -> None:
@@ -102,7 +116,7 @@ class StreamRenderer:
             for fragment, dimmed in self._thinking_filter.finish():
                 if fragment:
                     self._print_thinking_fragment(fragment, dimmed=dimmed)
-            if self._thinking_dim_open:
+            if self._thinking_dim_open and self._ansi:
                 print(RESET, end="", flush=True)
                 self._thinking_dim_open = False
         self._flush_markdown_buffer(interrupted=interrupted)
@@ -115,14 +129,14 @@ class StreamRenderer:
             print(dim("Thinking...\n"), end="", flush=True)
             self._thinking_started = True
         if not dimmed and self._thinking_started and not self._thinking_final_started:
-            if self._thinking_dim_open:
+            if self._thinking_dim_open and self._ansi:
                 print(RESET, end="", flush=True)
                 self._thinking_dim_open = False
             if not fragment.startswith("\n"):
                 print("\n\n", end="", flush=True)
             self._thinking_final_started = True
         if dimmed:
-            if not self._thinking_dim_open:
+            if self._ansi and not self._thinking_dim_open:
                 print(DIM, end="", flush=True)
                 self._thinking_dim_open = True
             print(fragment, end="", flush=True)
@@ -148,6 +162,9 @@ class StreamRenderer:
                 pass
 
     def _stop_timer(self, *, clear: bool) -> None:
+        if not self._interactive:
+            self._timer_active = False
+            return
         self._stop.set()
         if self._thread and self._thread is not threading.current_thread():
             self._thread.join(timeout=1)
@@ -163,9 +180,8 @@ class StreamRenderer:
 
     def _render_wait_line(self) -> None:
         elapsed = time.monotonic() - self._start_time
-        frame = SPINNER_FRAMES[self._frame_index % len(SPINNER_FRAMES)]
-        self._frame_index += 1
-        line = dim(f"{frame} Working{self._working_phase_prefix()} ({self._working_status(elapsed)} - Ctrl+C to interrupt)")
+        detail = self._phase_label or self._progress_phase_label() or "working"
+        line = dim(_fit_activity_line(self._activity_kind, detail, format_elapsed(elapsed)))
         print(f"\r{_pad_to_terminal_width(line)}", end="", flush=True)
 
     @staticmethod
@@ -178,6 +194,11 @@ class StreamRenderer:
         self._prefill_estimate_tokens = tokens
 
     def set_phase_label(self, label: str | None) -> None:
+        self._activity_kind = "model"
+        self._phase_label = label.strip() if label else None
+
+    def set_activity(self, kind: str, label: str | None = None) -> None:
+        self._activity_kind = kind.strip() or "model"
         self._phase_label = label.strip() if label else None
 
     def set_final_output_mode(self, enabled: bool) -> None:
@@ -241,12 +262,31 @@ class StreamRenderer:
             return "prefill estimate"
         return None
 
+    def _progress_phase_label(self) -> str | None:
+        if self._progress is None:
+            return None
+        if self._progress.phase == "prefill":
+            return "prefill"
+        if self._progress.phase == "generation":
+            return "generation"
+        return self._progress.phase
+
 
 def _terminal_columns() -> int:
     try:
         return max(20, int(__import__("shutil").get_terminal_size((80, 20)).columns))
     except Exception:
         return 80
+
+
+def _fit_activity_line(kind: str, detail: str, elapsed: str) -> str:
+    columns = _terminal_columns()
+    prefix = f"{kind} · "
+    suffix = f" · {elapsed}"
+    available = max(1, columns - len(prefix) - len(suffix) - 1)
+    if len(detail) > available:
+        detail = detail[: max(0, available - 1)].rstrip() + "…"
+    return f"{prefix}{detail}{suffix}"
 
 
 def _pad_to_terminal_width(text: str) -> str:

--- a/src/orbit/terminal/theme.py
+++ b/src/orbit/terminal/theme.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import sys
+from typing import TextIO
+
 
 DIM = "\033[2m"
 CYAN = "\033[36m"
@@ -8,17 +12,57 @@ YELLOW = "\033[33m"
 RESET = "\033[0m"
 
 
+def supports_ansi(stream: TextIO | None = None) -> bool:
+    if os.environ.get("NO_COLOR") is not None or os.environ.get("TERM") == "dumb":
+        return False
+    return is_tty(stream)
+
+
+def is_tty(stream: TextIO | None = None) -> bool:
+    target = stream or sys.stdout
+    try:
+        return bool(target.isatty())
+    except (AttributeError, OSError):
+        return False
+
+
 def accent(text: str) -> str:
-    return f"{CYAN}{text}{RESET}"
+    return _styled(text, CYAN)
 
 
 def dim(text: str) -> str:
-    return f"{DIM}{text}{RESET}"
+    return _styled(text, DIM)
 
 
 def yellow_dim(text: str) -> str:
-    return f"{DIM}{YELLOW}{text}{RESET}"
+    return _styled(text, DIM + YELLOW)
 
 
 def danger(text: str) -> str:
-    return f"{RED}{text}{RESET}"
+    return _styled(text, RED)
+
+
+def warning_text(value: object) -> str:
+    return _prefixed_message("warning", value)
+
+
+def runtime_error_text(value: object) -> str:
+    detail = str(value).strip() or value.__class__.__name__
+    lowered = detail.lower()
+    prefix = "timeout" if "timeout" in lowered or "timed out" in lowered else "error"
+    return _prefixed_message(prefix, detail)
+
+
+def _prefixed_message(prefix: str, value: object) -> str:
+    detail = str(value).strip()
+    for existing in ("error:", "warning:", "timeout:"):
+        if detail.lower().startswith(existing):
+            detail = detail[len(existing) :].strip()
+            break
+    return f"{prefix}: {detail}" if detail else f"{prefix}: unknown"
+
+
+def _styled(text: str, prefix: str) -> str:
+    if not supports_ansi():
+        return text
+    return f"{prefix}{text}{RESET}"

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -9,14 +9,13 @@ LARGE_TOOL_RESULT_CHARS = 10_000
 SHELL_FULL_CONTRACT_ERROR_PREFIX = "error: shell-full analysis requests require content/source/string evidence"
 PREVIEW_LINE_LIMIT = 3
 PREVIEW_INLINE_LIMIT = 120
-COMMAND_PREVIEW_LIMIT = 96
 DISPLAY_TOOL_NAMES = {
-    "exec_shell_full_command": "exec",
-    "fetch_url": "fetch_url",
-    "list_directory": "list_directory",
-    "system_info": "system_info",
-    "write_artifact": "write_artifact",
-    "verify_artifact": "verify_artifact",
+    "exec_shell_full_command": "Exec",
+    "fetch_url": "Web",
+    "list_directory": "Read",
+    "system_info": "Read",
+    "write_artifact": "Artifact",
+    "verify_artifact": "Artifact",
 }
 
 
@@ -32,14 +31,14 @@ def format_tool_call_event(name: str, args: str) -> str:
     if name == "fetch_url":
         url = _url_from_args(args)
         if url:
-            return f"Fetch: {_truncate_inline(url, limit=COMMAND_PREVIEW_LIMIT)}"
+            return f"› Web  {_normalize_inline(url)}"
     if name == "list_directory":
         path, recursive = _list_directory_from_args(args)
         if path:
-            suffix = " recursive" if recursive else ""
-            return f"ListDir{suffix}: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
+            suffix = " · recursive" if recursive else ""
+            return f"› Read  {_normalize_inline(path)}{suffix}"
     if name == "system_info":
-        return "SystemInfo"
+        return "› Read  system information"
     if name == "write_artifact":
         try:
             parsed = json.loads(args)
@@ -47,7 +46,7 @@ def format_tool_call_event(name: str, args: str) -> str:
             parsed = {}
         path = parsed.get("path") if isinstance(parsed, dict) else None
         if isinstance(path, str) and path:
-            return f"Artifact: {_truncate_inline(path, limit=COMMAND_PREVIEW_LIMIT)}"
+            return f"› Artifact  {_normalize_inline(path)}"
     if name == "verify_artifact":
         try:
             parsed = json.loads(args)
@@ -55,8 +54,9 @@ def format_tool_call_event(name: str, args: str) -> str:
             parsed = {}
         check = parsed.get("check") if isinstance(parsed, dict) else None
         if isinstance(check, str):
-            return f"Verify: published artifact ({check})"
-    return f"{display_tool_name(name)} {args}"
+            return f"› Artifact  verify published artifact · {check}"
+    detail = f"  {args}" if args else ""
+    return f"› {display_tool_name(name)}{detail}"
 
 
 def format_tool_result_event(name: str, chars: int, source: str | None = None, content: str | None = None) -> str:
@@ -65,13 +65,17 @@ def format_tool_result_event(name: str, chars: int, source: str | None = None, c
     suffix_parts: list[str] = []
     if _is_rejected_contract_result(content):
         suffix_parts.append("rejected")
+    if _is_truncated_result(content):
+        suffix_parts.append("truncated")
     if chars >= LARGE_TOOL_RESULT_CHARS:
         suffix_parts.append("large context")
-    suffix = f" | {' | '.join(suffix_parts)}" if suffix_parts else ""
+    suffix = f" · {' · '.join(suffix_parts)}" if suffix_parts else ""
     chunk = _chunk_label(content)
     prefix = f"{chunk} " if chunk else ""
-    preview_text = f"{_truncate_inline(preview, limit=PREVIEW_INLINE_LIMIT)} | " if preview else ""
-    return f" └ {prefix}{preview_text}{chars} chars -> model{suffix}"
+    preview_text = _truncate_inline(preview, limit=PREVIEW_INLINE_LIMIT) if preview else None
+    if preview_text:
+        return f"└ {prefix}{preview_text}{suffix}"
+    return f"└ {prefix}{chars} chars{suffix}"
 
 
 def _command_from_args(args: str) -> str | None:
@@ -112,7 +116,7 @@ def _list_directory_from_args(args: str) -> tuple[str | None, bool]:
 
 def _format_shell_command_call(command: str) -> str:
     category = _shell_command_category(command)
-    return f"{category}: {_truncate_inline(command, limit=COMMAND_PREVIEW_LIMIT)}"
+    return f"› {category}  {_normalize_inline(command)}"
 
 
 def _shell_command_category(command: str) -> str:
@@ -121,25 +125,25 @@ def _shell_command_category(command: str) -> str:
     if primary in {"curl", "wget", "lynx", "links"} or "orbit-web-search" in lowered or "http://" in lowered or "https://" in lowered:
         return "Web"
     if primary in {"rg", "grep", "ag", "ack"}:
-        return "Search"
+        return "Read"
     if primary == "find":
         if any(flag in tokens for flag in ("-name", "-iname", "-path", "-ipath", "-regex", "-iregex")):
-            return "Search"
-        return "List"
+            return "Read"
+        return "Read"
     if primary in {"ls", "tree", "du"}:
-        return "List"
+        return "Read"
     if primary in {"cat", "head", "tail", "sed", "awk", "python", "python3", "perl", "strings", "pdftotext"}:
         if primary in {"sed", "perl"} and "-i" in tokens:
-            return "Edit"
+            return "Exec"
         if primary in {"python", "python3", "perl"} and any(operator in command for operator in (">", ">>", ".write(", "write_text(", "write_bytes(")):
-            return "Write"
+            return "Exec"
         return "Read"
     if primary in {"tee", "cp", "mv", "mkdir", "touch", "install", "ln", "truncate"}:
-        return "Write"
+        return "Exec"
     if primary in {"rm", "rmdir"}:
-        return "Edit"
+        return "Exec"
     if any(operator in command for operator in (">", ">>")):
-        return "Write"
+        return "Exec"
     return "Exec"
 
 
@@ -217,6 +221,21 @@ def _is_rejected_contract_result(content: str | None) -> bool:
     return bool(content and content.startswith(SHELL_FULL_CONTRACT_ERROR_PREFIX))
 
 
+def _is_truncated_result(content: str | None) -> bool:
+    return bool(
+        content
+        and (
+            content.strip() == "[truncated]"
+            or "\n[truncated]" in content
+            or "text_truncated: true" in content
+            or "result_truncated: true" in content
+            or "results_truncated: true" in content
+            or "truncated=true" in content
+            or "large_file_excerpt: true" in content
+        )
+    )
+
+
 def _metadata_value(content: str, key: str) -> str | None:
     match = re.search(rf"^{re.escape(key)}:\s*(.+)$", content, flags=re.MULTILINE)
     if not match:
@@ -269,3 +288,7 @@ def _truncate_inline(text: str | None, *, limit: int) -> str:
     if len(normalized) <= limit:
         return normalized
     return normalized[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _normalize_inline(text: str) -> str:
+    return " ".join(text.split())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,10 +85,9 @@ class CliTests(unittest.TestCase):
             )
 
         self.assertEqual(code, 0)
-        self.assertIn(
-            "tks: 420 total (400 in + 20 out) | work: 400 (380 prefill + 20 decode) | cache: 20 (5%) | calls: 2",
-            stream.getvalue(),
-        )
+        self.assertIn("2 calls · stop", stream.getvalue())
+        self.assertIn("tokens: 400 in · 380 eval · 20 cache · 20 out", stream.getvalue())
+        self.assertIn("last call: 10.0 tok/s prefill · 2.0 tok/s decode", stream.getvalue())
 
     def test_one_shot_think_on_does_not_crash(self) -> None:
         completed = _run_cli("", "--think", "on", "/think")
@@ -164,7 +163,7 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("/status\n/exit\n")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("Type /help for commands, /status for runtime details.", completed.stdout)
+        self.assertIn("/help for commands · /status for details", completed.stdout)
         self.assertIn("┌─ Orbit Runtime", completed.stdout)
         self.assertIn("Messages     1", completed.stdout)
 
@@ -172,7 +171,7 @@ class CliTests(unittest.TestCase):
         completed = _run_cli("/status ctx\n/exit\n")
 
         self.assertEqual(completed.returncode, 0)
-        self.assertIn("Type /help for commands, /status for runtime details.", completed.stdout)
+        self.assertIn("/help for commands · /status for details", completed.stdout)
         self.assertIn("Context\n-------", completed.stdout)
         self.assertIn("tool_result:", completed.stdout)
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -251,7 +251,8 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         output = stdout.getvalue()
-        self.assertIn("Orbit v0.0.1-rc32 · unknown · unknown", output)
+        self.assertIn("Orbit v0.0.1-rc32", output)
+        self.assertIn("· unknown · unknown", output)
         self.assertIn("workdir ", output)
         self.assertIn("tools on · think off · ctx 8192", output)
         self.assertIn("/help for commands · /status for details", output)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -233,7 +233,7 @@ class ReplTests(unittest.TestCase):
         self.assertIs(loaded, fake_readline)
         fake_readline.parse_and_bind.assert_called_with("set enable-bracketed-paste on")
 
-    def test_run_banner_is_dim_and_existing_session_preview_is_shown(self) -> None:
+    def test_run_banner_is_compact_and_existing_session_preview_is_shown(self) -> None:
         runtime = CountingRuntime()
         runtime.messages = [
             {"role": "system", "content": "system"},
@@ -251,11 +251,11 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         output = stdout.getvalue()
-        self.assertIn("\033[2m┌─ Orbit Runtime", output)
-        self.assertIn("Version", output)
-        self.assertIn("Tools        on", output)
-        self.assertIn("Workdir", output)
-        self.assertIn("Type /help for commands, /status for runtime details.", output)
+        self.assertIn("Orbit v0.0.1-rc32 · unknown · unknown", output)
+        self.assertIn("workdir ", output)
+        self.assertIn("tools on · think off · ctx 8192", output)
+        self.assertIn("/help for commands · /status for details", output)
+        self.assertNotIn("Machine", output)
         self.assertNotIn("warning: tools on", output)
         self.assertIn("recent session context:", output)
         self.assertIn("user: first question", output)
@@ -294,14 +294,40 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(runtime.messages, before)
         self.assertIn("partial", stdout.getvalue())
-        self.assertIn("interrupted", stdout.getvalue())
+        self.assertIn("cancelled", stdout.getvalue())
+
+    def test_timeout_uses_consistent_prefix_and_clears_renderer(self) -> None:
+        runtime = CountingRuntime()
+        runtime.ask_chat = mock.Mock(side_effect=TimeoutError("request timed out"))
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path("."), tools="off"))
+        stderr = io.StringIO()
+
+        with (
+            mock.patch("orbit.terminal.repl.StreamRenderer") as renderer_class,
+            contextlib.redirect_stderr(stderr),
+        ):
+            repl._ask("hello")
+
+        renderer_class.return_value.finish.assert_called_once_with()
+        self.assertEqual(stderr.getvalue(), "timeout: request timed out\n")
+
+    def test_unexpected_exception_clears_renderer_before_propagating(self) -> None:
+        runtime = CountingRuntime()
+        runtime.ask_chat = mock.Mock(side_effect=RuntimeError("boom"))
+        repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path("."), tools="off"))
+
+        with mock.patch("orbit.terminal.repl.StreamRenderer") as renderer_class:
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                repl._ask("hello")
+
+        renderer_class.return_value.finish.assert_called_once_with()
 
     def test_tool_result_event_marks_large_context(self) -> None:
-        self.assertEqual(format_tool_result_event("read_file", 9999), " └ 9999 chars -> model")
-        self.assertEqual(format_tool_result_event("read_file", 10000), " └ 10000 chars -> model | large context")
-        self.assertEqual(format_tool_result_event("read_file", 5, "orbit"), " └ 5 chars -> model")
-        self.assertEqual(format_tool_call_event("exec_shell_full_command", '{"command":"ls"}'), "List: ls")
-        self.assertEqual(format_tool_result_event("exec_shell_full_command", 45), " └ 45 chars -> model")
+        self.assertEqual(format_tool_result_event("read_file", 9999), "└ 9999 chars")
+        self.assertEqual(format_tool_result_event("read_file", 10000), "└ 10000 chars · large context")
+        self.assertEqual(format_tool_result_event("read_file", 5, "orbit"), "└ 5 chars")
+        self.assertEqual(format_tool_call_event("exec_shell_full_command", '{"command":"ls"}'), "› Read  ls")
+        self.assertEqual(format_tool_result_event("exec_shell_full_command", 45), "└ 45 chars")
         chunk_content = "\n".join(
             [
                 "shell_output_read_file: true",
@@ -314,8 +340,17 @@ class ReplTests(unittest.TestCase):
         )
         self.assertEqual(
             format_tool_result_event("exec_shell_full_command", 200, content=chunk_content),
-            " └ chunk 1/3 build_native.py: #!/usr/bin/env python3 | 200 chars -> model",
+            "└ chunk 1/3 build_native.py: #!/usr/bin/env python3",
         )
+
+    def test_routine_tool_result_shows_preview_without_internal_transport_suffix(self) -> None:
+        rendered = format_tool_result_event(
+            "exec_shell_full_command",
+            8,
+            content="10:15:01",
+        )
+
+        self.assertEqual(rendered, "└ 10:15:01")
 
     def test_tool_result_event_marks_contract_rejection(self) -> None:
         content = (
@@ -325,38 +360,76 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(
             format_tool_result_event("exec_shell_full_command", len(content), content=content),
-            f" └ rejected metadata-only output | {len(content)} chars -> model | rejected",
+            "└ rejected metadata-only output · rejected",
         )
 
     def test_tool_call_event_classifies_shell_commands(self) -> None:
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": 'rg -n "build_native" src tests'})),
-            'Search: rg -n "build_native" src tests',
+            '› Read  rg -n "build_native" src tests',
         )
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "cat README.md"})),
-            "Read: cat README.md",
+            "› Read  cat README.md",
         )
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "sed -i 's/12120/12121/' README.md"})),
-            "Edit: sed -i 's/12120/12121/' README.md",
+            "› Exec  sed -i 's/12120/12121/' README.md",
         )
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "tee notes.txt >/dev/null"})),
-            "Write: tee notes.txt >/dev/null",
+            "› Exec  tee notes.txt >/dev/null",
         )
         self.assertEqual(
             format_tool_call_event("exec_shell_full_command", json.dumps({"command": "curl -L https://example.com"})),
-            "Web: curl -L https://example.com",
+            "› Web  curl -L https://example.com",
         )
         self.assertEqual(
             format_tool_call_event("fetch_url", json.dumps({"url": "https://example.com"})),
-            "Fetch: https://example.com",
+            "› Web  https://example.com",
         )
         self.assertEqual(
             format_tool_call_event("verify_artifact", json.dumps({"check": "text_integrity"})),
-            "Verify: published artifact (text_integrity)",
+            "› Artifact  verify published artifact · text_integrity",
         )
+        self.assertEqual(
+            format_tool_call_event("write_artifact", json.dumps({"path": "output/result.json"})),
+            "› Artifact  output/result.json",
+        )
+
+    def test_tool_call_does_not_truncate_essential_arguments(self) -> None:
+        command = "printf '%s' " + ("x" * 140) + " END-MARKER"
+
+        rendered = format_tool_call_event("exec_shell_full_command", json.dumps({"command": command}))
+
+        self.assertTrue(rendered.startswith("› Exec  printf"))
+        self.assertTrue(rendered.endswith("END-MARKER"))
+
+    def test_tool_failure_keeps_error_prefix_and_bounded_preview(self) -> None:
+        content = "error: exit 1\nFAILED test_example.py::test_value\nmore details"
+
+        rendered = format_tool_result_event("exec_shell_full_command", len(content), content=content)
+
+        self.assertTrue(rendered.startswith("└ error: exit 1"))
+        self.assertNotIn("chars -> model", rendered)
+
+    def test_tool_result_keeps_truncation_visible_without_internal_transport_suffix(self) -> None:
+        cases = (
+            ("first line\n[truncated]", "└ first line · truncated"),
+            ("[truncated]", "└ 11 chars · truncated"),
+            (
+                "directory_listing: path=. total_seen=500 truncated=true\na\nb",
+                "└ a | b · truncated",
+            ),
+        )
+        for content, expected in cases:
+            with self.subTest(content=content):
+                rendered = format_tool_result_event(
+                    "exec_shell_full_command",
+                    len(content),
+                    content=content,
+                )
+                self.assertEqual(rendered, expected)
 
     def test_tool_result_event_previews_pdf_and_list_output(self) -> None:
         pdf_content = "\n".join(
@@ -370,13 +443,13 @@ class ReplTests(unittest.TestCase):
         )
         self.assertEqual(
             format_tool_result_event("exec_shell_full_command", len(pdf_content), content=pdf_content),
-            " └ pdf/grande.pdf: This document discusses eIDAS 2.0 and the EUDI… | 133 chars -> model",
+            "└ pdf/grande.pdf: This document discusses eIDAS 2.0 and the EUDI…",
         )
 
         list_content = ".\n./pdf\n./text\n./samples\n"
         self.assertEqual(
             format_tool_result_event("exec_shell_full_command", len(list_content), content=list_content),
-            " └ . | ./pdf | ./text | 25 chars -> model",
+            "└ . | ./pdf | ./text",
         )
 
     def test_phase_progress_label_maps_buffered_and_streamed_phases(self) -> None:
@@ -569,19 +642,22 @@ class ReplTests(unittest.TestCase):
     def test_colorize_paste_preview_highlights_only_badge(self) -> None:
         preview = "Lorem ipsum...\n[text 5108 chars #a1b2c3d4]"
 
-        colored = colorize_paste_preview(preview)
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=True):
+            colored = colorize_paste_preview(preview)
 
         self.assertIn("Lorem ipsum...\n", colored)
         self.assertIn("\033[2m\033[33m[text 5108 chars #a1b2c3d4]\033[0m", colored)
         self.assertNotIn("\033[2m\033[33mLorem", colored)
 
     def test_colorize_user_prompt_accents_prompt_text(self) -> None:
-        colored = colorize_user_prompt("> hello")
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=True):
+            colored = colorize_user_prompt("> hello")
 
         self.assertEqual(colored, "\033[36m> hello\033[0m")
 
     def test_colorize_user_prompt_keeps_paste_badge_yellow(self) -> None:
-        colored = colorize_user_prompt("> Lorem...\n[text 5108 chars #a1b2c3d4]")
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=True):
+            colored = colorize_user_prompt("> Lorem...\n[text 5108 chars #a1b2c3d4]")
 
         self.assertIn("\033[36m> Lorem...\n\033[0m", colored)
         self.assertIn("\033[2m\033[33m[text 5108 chars #a1b2c3d4]\033[0m", colored)
@@ -751,6 +827,33 @@ class ReplTests(unittest.TestCase):
 
         self.assertEqual(prompt, "queued prompt")
         self.assertEqual(repl.queued_prompts, [])
+
+    def test_prompt_gap_is_exactly_one_blank_line_and_does_not_accumulate(self) -> None:
+        for interactive in (False, True):
+            with self.subTest(interactive=interactive):
+                runtime = CountingRuntime()
+                repl = Repl(runtime=runtime, backend=runtime.backend, config=AppConfig(workdir=Path(".")))
+                responses = iter(("", "next"))
+                stdout = io.StringIO()
+
+                def fake_read() -> str:
+                    print("> ")
+                    return next(responses)
+
+                with (
+                    mock.patch.object(stdout, "isatty", return_value=interactive),
+                    mock.patch("orbit.terminal.repl.read_prompt_input", side_effect=fake_read),
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    print("context: 970/189440 (<1%)")
+                    repl.prompt_gap_pending = True
+                    self.assertEqual(repl._read_next_prompt(), "")
+                    self.assertEqual(repl._read_next_prompt(), "next")
+
+                self.assertEqual(
+                    stdout.getvalue(),
+                    "context: 970/189440 (<1%)\n\n> \n> \n",
+                )
 
     def test_tools_command_toggles_interactive_mode(self) -> None:
         runtime = CountingRuntime()

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -31,20 +31,14 @@ class RuntimeStatusFormattingTests(unittest.TestCase):
     def test_startup_banner_cpu_only(self) -> None:
         banner = format_startup_banner(_status())
 
-        self.assertIn("┌─ Orbit Runtime", banner)
-        self.assertIn("│ Version      0.0.1", banner)
-        self.assertIn("Gemma 4 12B", banner)
-        self.assertIn("│ MTP          on, mmproj loaded", banner)
-        self.assertIn("│ Tools        on", banner)
-        self.assertIn("│ Think        off", banner)
-        self.assertIn("│ Workdir      /tmp/orbit", banner)
-        self.assertIn("│ Machine      Test Machine", banner)
-        self.assertIn("│ OS           Linux test", banner)
-        self.assertIn("│ CPU          8C/16T", banner)
-        self.assertIn("│ Cores        8 physical / 16 logical", banner)
-        self.assertIn("│ RAM          32 GB total, 21 GB free", banner)
-        self.assertIn("│ Accel        CPU-only", banner)
-        self.assertIn("Type /help for commands, /status for runtime details.", banner)
+        self.assertEqual(
+            banner,
+            "Orbit v0.0.1 · Gemma 4 12B · native\n"
+            "workdir /tmp/orbit · tools on · think off · ctx 8192\n"
+            "/help for commands · /status for details",
+        )
+        self.assertNotIn("Machine", banner)
+        self.assertNotIn("RAM", banner)
 
     def test_startup_banner_gpu_mock(self) -> None:
         status = _status(
@@ -59,7 +53,37 @@ class RuntimeStatusFormattingTests(unittest.TestCase):
 
         banner = format_startup_banner(status)
 
-        self.assertIn("│ Accel        CUDA, GPU RTX 4090, 24 GB, offload 41 la...", banner)
+        self.assertNotIn("RTX 4090", banner)
+        self.assertIn("RTX 4090", format_status_panel(status))
+
+    def test_verified_registry_name_is_compact_in_banner_and_full_model_remains_in_status(self) -> None:
+        full_name = "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
+
+        class VerifiedBackend(_Backend):
+            def model_info(self):
+                return SimpleNamespace(id=full_name, context_length=8192)
+
+            def backend_props(self) -> dict[str, object]:
+                return {
+                    "backend": "orbit-native",
+                    "model_compatibility": {
+                        "verified": True,
+                        "compatibility_profile": "orbit-qwen3-coder-native-v1",
+                    },
+                }
+
+        manifest = SimpleNamespace(
+            profile_id="orbit-qwen3-coder-native-v1",
+            display_name="Qwen3-Coder 30B-A3B",
+        )
+        with (
+            mock.patch("orbit.terminal.runtime_status.load_registry", return_value=[manifest]),
+            mock.patch("orbit.terminal.runtime_status.subprocess.run", side_effect=OSError),
+        ):
+            status = collect_runtime_status(_Runtime(), AppConfig(workdir=ROOT), VerifiedBackend())
+
+        self.assertIn("· Qwen3-Coder 30B-A3B · native", format_startup_banner(status))
+        self.assertIn(full_name, format_status_panel(status))
 
     def test_status_panel_contains_runtime_host_and_acceleration(self) -> None:
         panel = format_status_panel(_status())
@@ -114,10 +138,12 @@ class RuntimeStatusFormattingTests(unittest.TestCase):
 
         self.assertEqual(fallback.version, "0.0.1")
 
-    def test_startup_banner_truncates_long_workdir(self) -> None:
+    def test_startup_banner_keeps_workdir_without_fixed_width_box(self) -> None:
         banner = format_startup_banner(_status(workdir="/tmp/" + "very-long/" * 12))
 
-        self.assertIn("│ Workdir      /tmp/very-long/very-long/very-long/very-...", banner)
+        self.assertIn("workdir /tmp/very-long/very-long/", banner)
+        self.assertNotIn("┌", banner)
+        self.assertEqual(len(banner.splitlines()), 3)
 
     def test_unknown_values_do_not_fail(self) -> None:
         panel = format_status_panel(_status(host=HostInfo(), acceleration=AccelerationInfo()))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 import sys
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -19,7 +20,7 @@ from orbit.terminal.status import (
     format_turn_status,
     summarize_turn_token_usage,
 )
-from orbit.terminal.theme import dim, yellow_dim
+from orbit.terminal.theme import dim, runtime_error_text, warning_text, yellow_dim
 
 
 class StatusTests(unittest.TestCase):
@@ -83,10 +84,9 @@ class StatusTests(unittest.TestCase):
 
         status = format_turn_status(result, turn_token_usage=usage)
 
-        self.assertIn("tks: 630 total (600 in + 30 out)", status)
-        self.assertIn("work: 560 (530 prefill + 30 decode)", status)
-        self.assertIn("cache: 70 (12%)", status)
-        self.assertIn("calls: 3", status)
+        self.assertIn("3 calls · stop", status)
+        self.assertIn("tokens: 600 in · 530 eval · 70 cache · 30 out", status)
+        self.assertIn("last call: 12.5 tok/s prefill · 3.4 tok/s decode", status)
 
     def test_format_turn_status_includes_stop_tokens_cache_and_speed(self) -> None:
         status = format_turn_status(
@@ -104,10 +104,9 @@ class StatusTests(unittest.TestCase):
         )
 
         self.assertNotIn("model:", status)
-        self.assertIn("stop: stop", status)
-        self.assertIn("tks: 10->3, cached 8", status)
-        self.assertIn("cache: 80%", status)
-        self.assertIn("__ pf 12.5/s | gen 3.4/s", status)
+        self.assertIn("1 calls · stop", status)
+        self.assertIn("tokens: 10 in · 2 eval · 8 cache · 3 out", status)
+        self.assertIn("last call: 12.5 tok/s prefill · 3.4 tok/s decode", status)
 
     def test_format_turn_status_includes_context_window_and_usage_percent(self) -> None:
         status = format_turn_status(
@@ -126,7 +125,35 @@ class StatusTests(unittest.TestCase):
             context_tokens=8192,
         )
 
-        self.assertIn("ctx: 2212/8192 (27%) | stop: stop", status)
+        self.assertIn("context: 2212/8192 (27%)", status)
+
+    def test_context_percentage_distinguishes_zero_sub_one_and_integer_values(self) -> None:
+        result = ChatResult(
+            content="hello",
+            model="gemma4",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+        cases = (
+            (0, 10_000, "0%"),
+            (50, 10_000, "<1%"),
+            (100, 10_000, "1%"),
+            (2_500, 10_000, "25%"),
+        )
+        for used, total, expected in cases:
+            with self.subTest(used=used):
+                status = format_turn_status(
+                    result,
+                    estimated_context_tokens=used,
+                    context_tokens=total,
+                )
+                self.assertIn(f"context: {used}/{total} ({expected})", status)
 
     def test_format_turn_status_includes_context_pressure(self) -> None:
         result = ChatResult(
@@ -145,11 +172,9 @@ class StatusTests(unittest.TestCase):
         high = format_turn_status(result, estimated_context_tokens=5900, context_tokens=8192)
         refresh = format_turn_status(result, estimated_context_tokens=7000, context_tokens=8192)
 
-        self.assertIn("ctx: 4280/8192 (52%)", moderate)
-        self.assertIn("pressure: moderate", moderate)
-        self.assertIn("ctx: 5900/8192 (72%)", high)
-        self.assertIn("pressure: high | consider /compact tools", high)
-        self.assertIn("pressure: memory refresh", refresh)
+        self.assertIn("context: 4280/8192 (52%) · pressure moderate", moderate)
+        self.assertIn("context: 5900/8192 (72%) · pressure high | consider /compact tools", high)
+        self.assertIn("pressure memory refresh", refresh)
 
     def test_format_turn_status_includes_elapsed_time(self) -> None:
         result = ChatResult(
@@ -167,14 +192,54 @@ class StatusTests(unittest.TestCase):
         short = format_turn_status(result, elapsed_seconds=34, terminal_columns=72)
         long = format_turn_status(result, elapsed_seconds=79, terminal_columns=72)
 
-        self.assertIn("time elapsed: 34s", short)
-        self.assertIn("time elapsed: 1m 19s", long)
-        self.assertEqual(len(short.splitlines()[0]), 72)
-        self.assertTrue(short.endswith("stop: stop"))
+        self.assertIn("34s · 1 calls · stop", short)
+        self.assertIn("1m 19s · 1 calls · stop", long)
+        self.assertFalse(short.startswith("__"))
 
     def test_dim_wraps_text_in_ansi_escape(self) -> None:
-        self.assertEqual(dim("model: gemma4"), "\033[2mmodel: gemma4\033[0m")
-        self.assertEqual(yellow_dim("[text 10 chars #12345678]"), "\033[2m\033[33m[text 10 chars #12345678]\033[0m")
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=True):
+            self.assertEqual(dim("model: gemma4"), "\033[2mmodel: gemma4\033[0m")
+            self.assertEqual(yellow_dim("[text 10 chars #12345678]"), "\033[2m\033[33m[text 10 chars #12345678]\033[0m")
+
+    def test_theme_emits_plain_text_when_redirected(self) -> None:
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=False):
+            self.assertEqual(dim("model: gemma4"), "model: gemma4")
+            self.assertEqual(yellow_dim("warning"), "warning")
+
+    def test_runtime_messages_have_stable_prefixes(self) -> None:
+        self.assertEqual(runtime_error_text(RuntimeError("broken")), "error: broken")
+        self.assertEqual(runtime_error_text(TimeoutError("request timed out")), "timeout: request timed out")
+        self.assertEqual(runtime_error_text(RuntimeError("error: broken")), "error: broken")
+        self.assertEqual(warning_text("cache unavailable"), "warning: cache unavailable")
+
+    def test_turn_footer_wraps_by_metric_group_at_narrow_widths(self) -> None:
+        result = ChatResult(
+            content="ok",
+            model="qwen",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=2393,
+            completion_tokens=211,
+            cached_tokens=768,
+            prompt_tokens_per_second=29.6,
+            generation_tokens_per_second=7.3,
+        )
+        usage = TokenUsageAccumulator()
+        usage.add(ModelStepMetrics(1, "route", "stop", 2393, 211, 768, 29.6, 7.3, 0))
+
+        for columns in (40, 60):
+            rendered = format_turn_status(
+                result,
+                elapsed_seconds=30,
+                estimated_context_tokens=1334,
+                context_tokens=8192,
+                turn_token_usage=usage.snapshot(),
+                terminal_columns=columns,
+            )
+            self.assertTrue(all(len(line) <= columns for line in rendered.splitlines()))
+            self.assertIn("2,393 in", rendered)
+            self.assertIn("1,625 eval", rendered)
+            self.assertIn("last call:", rendered)
 
     def test_format_memory_refresh_includes_savings_timing_and_threshold(self) -> None:
         status = format_memory_refresh(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -12,11 +12,24 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from orbit.terminal.streaming import StreamRenderer, _pad_to_terminal_width, format_elapsed
+from orbit.terminal.streaming import StreamRenderer, _pad_to_terminal_width, _visible_len, format_elapsed
 from orbit.backend.base import StreamProgress
 
 
 class StreamingRendererTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tty_patches = [
+            mock.patch("orbit.terminal.streaming.is_tty", return_value=True),
+            mock.patch("orbit.terminal.streaming.supports_ansi", return_value=True),
+            mock.patch("orbit.terminal.theme.supports_ansi", return_value=True),
+        ]
+        for patcher in self._tty_patches:
+            patcher.start()
+
+    def tearDown(self) -> None:
+        for patcher in reversed(self._tty_patches):
+            patcher.stop()
+
     def test_write_prints_delta(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
@@ -521,7 +534,7 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertEqual(format_elapsed(59.9), "59s")
         self.assertEqual(format_elapsed(79), "1m 19s")
 
-    def test_wait_timer_prints_working_message(self) -> None:
+    def test_wait_timer_prints_compact_activity(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
         try:
@@ -534,9 +547,9 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("Working (0s - Ctrl+C to interrupt)", output)
+        self.assertIn("model · working · 0s", output)
 
-    def test_wait_timer_prints_prefill_progress_when_estimated(self) -> None:
+    def test_wait_timer_does_not_print_speculative_prefill_estimate(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
         try:
@@ -549,7 +562,8 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("Working [prefill estimate] (0s, prefill estimate ~1% - Ctrl+C to interrupt)", output)
+        self.assertIn("model · working · 0s", output)
+        self.assertNotIn("estimate", output)
 
     def test_wait_timer_includes_phase_label_when_present(self) -> None:
         stream = io.StringIO()
@@ -565,7 +579,7 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("Working [prefill estimate] (0s, prefill estimate ~1% - Ctrl+C to interrupt)", output)
+        self.assertIn("model · final answer · 0s", output)
 
     def test_wait_timer_prints_prefill_token_progress_when_estimated(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
@@ -638,7 +652,7 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertIn("Working [prefill] (0s, 12/48 tk (25%) - Ctrl+C to interrupt)", output)
+        self.assertIn("model · prefill · 0s", output)
 
     def test_wait_line_is_padded_to_clear_previous_content(self) -> None:
         padded = _pad_to_terminal_width("\033[2mshort\033[0m")
@@ -660,7 +674,7 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         after_delta = stream.getvalue().split("hello", 1)[1]
-        self.assertNotIn("Working", after_delta)
+        self.assertNotIn("model ·", after_delta)
 
     def test_restarted_timer_stops_before_later_delta(self) -> None:
         stream = io.StringIO()
@@ -679,7 +693,68 @@ class StreamingRendererTests(unittest.TestCase):
             sys.stdout = original
 
         after_final = stream.getvalue().split("final answer", 1)[1]
-        self.assertNotIn("Working", after_final)
+        self.assertNotIn("model ·", after_final)
+
+    def test_tool_activity_replaces_model_activity_until_result(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(interval=0.01)
+            renderer.start()
+            renderer.event("› Exec  pwd", next_activity=("tool", "exec_shell_full_command"))
+            time.sleep(0.02)
+            renderer.event("└ /tmp", next_activity=("model", "final answer"))
+            time.sleep(0.02)
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("tool · exec_shell_full_command · 0s", output)
+        self.assertIn("model · final answer · 0s", output)
+
+    def test_activity_line_fits_40_and_60_columns(self) -> None:
+        for columns in (40, 60):
+            stream = io.StringIO()
+            original = sys.stdout
+            try:
+                sys.stdout = stream
+                renderer = StreamRenderer(interactive=True)
+                renderer.set_activity("tool", "exec_shell_full_command")
+                renderer._start_time = time.monotonic()
+                with mock.patch("orbit.terminal.streaming._terminal_columns", return_value=columns):
+                    renderer._render_wait_line()
+            finally:
+                sys.stdout = original
+
+            line = stream.getvalue().rsplit("\r", 1)[-1]
+            self.assertLessEqual(_visible_len(line), columns)
+            self.assertIn("exec_shell_full_command", line)
+
+    def test_non_tty_is_plain_linear_and_keeps_markdown_literal(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            with (
+                mock.patch("orbit.terminal.streaming.is_tty", return_value=False),
+                mock.patch("orbit.terminal.streaming.supports_ansi", return_value=False),
+                mock.patch("orbit.terminal.theme.supports_ansi", return_value=False),
+            ):
+                renderer = StreamRenderer(interval=0.01, render_markdown_mode="live")
+                renderer.start()
+                renderer.progress(StreamProgress(phase="prefill", current=1, total=2, percent=50))
+                renderer.event("› Exec  pwd", next_activity=("tool", "exec_shell_full_command"))
+                renderer.write("**answer**\n")
+                renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertEqual(output, "› Exec  pwd\n**answer**\n")
+        self.assertNotIn("\033", output)
+        self.assertNotIn("\r", output)
 
     def test_restart_timer_clears_previous_progress_state(self) -> None:
         renderer = StreamRenderer()


### PR DESCRIPTION
## Summary

- simplifies the startup banner
- adds one replace-in-place activity line for model/tool waits
- normalizes compact tool and error presentation
- clarifies footer metric scope
- preserves streamed Markdown
- guarantees plain deterministic non-TTY output
- makes no runtime, backend, prompt, or inference changes

## Validation

- terminal/CLI: 162/162 PASS
- affected suites: 412/412 PASS
- full discovery: 1762/1762 PASS, 4 expected skips
- compileall: PASS
- diff check: PASS

## Known limit

The prompt remains turn-based; persistent bottom input requires a separate TUI/async-input design.