### PR TITLE
Preserve Qwen3-Coder route cache across tool transitions

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -448,6 +448,10 @@ class NativeLlamaClient:
         self.cancel_event.clear()
 
     def load(self, on_progress=None) -> None:
+        if self._model or self._session.ctx_tgt:
+            self._invalidate_qwen_route_prefix(
+                "model_reload", profile_id=QWEN3_CODER_PROFILE_ID
+            )
         self._invalidate_qwen36_shell_tool_prefix("model_reload")
         lib = self.lib.lib
         lib.ggml_backend_load_all()
@@ -652,7 +656,9 @@ class NativeLlamaClient:
         self._session.mtp_enabled = True
         self._session.mtp_failed = False
 
-    def reset_session_state(self) -> None:
+    def reset_session_state(
+        self, *, preserve_qwen3_coder_route_checkpoint: bool = False
+    ) -> None:
         if not self._session.ctx_tgt:
             raise RuntimeError("native client not loaded")
         lib = self.lib.lib
@@ -668,7 +674,13 @@ class NativeLlamaClient:
         self._profile_last_raw_output = ""
         self._profile_last_parsed_content = ""
         self._invalidate_final_prefix("session_reset")
-        self._invalidate_qwen_route_prefix("session_reset")
+        self._invalidate_qwen_route_prefix(
+            "session_reset", profile_id=QWEN36_PROFILE_ID
+        )
+        if not preserve_qwen3_coder_route_checkpoint:
+            self._invalidate_qwen_route_prefix(
+                "session_reset", profile_id=QWEN3_CODER_PROFILE_ID
+            )
         self._invalidate_qwen36_shell_tool_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
@@ -701,8 +713,31 @@ class NativeLlamaClient:
             return
         if current == mode:
             return
-        self.reset_session_state()
+        profile = getattr(self, "model_profile", None)
+        profile_id = getattr(profile, "profile_id", None)
+        qualified_transition = (current, mode) in (
+            ("chat:thinking=off", "tools:thinking=off"),
+            ("tools:thinking=off", "chat:thinking=off"),
+        )
+        preserve_qwen3_coder_route_checkpoint = (
+            getattr(profile, "verified", False)
+            and profile_id == QWEN3_CODER_PROFILE_ID
+            and qualified_transition
+        )
+        self.reset_session_state(
+            preserve_qwen3_coder_route_checkpoint=preserve_qwen3_coder_route_checkpoint
+        )
         self._session.prompt_cache_mode = mode
+
+    def _invalidate_coder_route_prefix_after_failed_completion(self, reason: str) -> None:
+        profile = getattr(self, "model_profile", None)
+        if (
+            getattr(profile, "verified", False)
+            and getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID
+        ):
+            self._invalidate_qwen_route_prefix(
+                reason, profile_id=QWEN3_CODER_PROFILE_ID
+            )
 
     def _initialize_multimodal_context(self) -> None:
         self.supports_vision = False
@@ -1052,7 +1087,13 @@ class NativeLlamaClient:
                 return timings
             finally:
                 self._session.in_flight = False
-        prompt = self.apply_chat_template(messages, tools=tools, thinking=thinking)
+        try:
+            prompt = self.apply_chat_template(messages, tools=tools, thinking=thinking)
+        except Exception:
+            self._invalidate_coder_route_prefix_after_failed_completion(
+                "completion_error"
+            )
+            raise
         qwen_route_anchor_plan = self._qwen_route_anchor_plan_for_prompt(
             messages,
             tools=tools,
@@ -1808,12 +1849,18 @@ class NativeLlamaClient:
                 self._invalidate_final_prefix("cancelled")
             if qwen_route_anchor_plan is not None and timings.cancelled:
                 self._invalidate_qwen_route_prefix("cancelled", profile_id=qwen_route_anchor_plan.profile_id)
+            if qwen_route_anchor_plan is None and timings.cancelled:
+                self._invalidate_coder_route_prefix_after_failed_completion("cancelled")
             return timings
         except Exception:
             if final_prefix_segments is not None:
                 self._invalidate_final_prefix("completion_error")
             if qwen_route_anchor_plan is not None:
                 self._invalidate_qwen_route_prefix("completion_error", profile_id=qwen_route_anchor_plan.profile_id)
+            else:
+                self._invalidate_coder_route_prefix_after_failed_completion(
+                    "completion_error"
+                )
             if qwen36_shell_tool_anchor_plan is not None:
                 self._invalidate_qwen36_shell_tool_prefix("completion_error")
             raise

--- a/tests/test_native_session_state.py
+++ b/tests/test_native_session_state.py
@@ -145,7 +145,9 @@ class NativeSessionStateTests(unittest.TestCase):
 
         client._ensure_prompt_cache_mode("chat:thinking=on")
 
-        client.reset_session_state.assert_called_once()
+        client.reset_session_state.assert_called_once_with(
+            preserve_qwen3_coder_route_checkpoint=False
+        )
         self.assertEqual(client._session.prompt_cache_mode, "chat:thinking=on")
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")

--- a/tests/test_qwen3_coder_route_prefix.py
+++ b/tests/test_qwen3_coder_route_prefix.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _QwenRouteAnchorRuntimePlan
+from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.model_profiles import NativeModelProfile, QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.paths import NativeLlamaPaths
 from orbit.native_llama.prefix_anchor import PrefixAnchorState
@@ -488,6 +489,257 @@ class Qwen3CoderRoutePrefixClientTests(unittest.TestCase):
                 f"{QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION}:{'b' * 64}:"
                 f"{QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY}:ctx=8192"
             ),
+        )
+
+    def test_cache_mode_transitions_preserve_only_coder_route_checkpoint(self) -> None:
+        for current, requested in (
+            ("chat:thinking=off", "tools:thinking=off"),
+            ("tools:thinking=off", "chat:thinking=off"),
+        ):
+            with self.subTest(current=current, requested=requested):
+                client = self._client()
+                client._session.ctx_tgt = 1  # type: ignore[assignment]
+                client.lib.lib.llama_get_memory.return_value = 2
+                client._session.prompt_cache_mode = current
+                client._session.cached_prompt_tokens = [1, 2, 3]
+                client._session.continuation_ready = True
+                client._session.last_metrics = object()  # type: ignore[assignment]
+                coder_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"coder",
+                    checkpoint_size=5,
+                    token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+                )
+                client._qwen3_coder_route_prefix_anchor_state = coder_state
+                client._qwen_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"qwen36",
+                    checkpoint_size=6,
+                )
+                coder_spec = QwenRoutePrefixSpec(tuple(), "coder", "text", "system", 0, 0)
+                client._qwen3_coder_route_prefix_spec = coder_spec
+                client._qwen_route_prefix_spec = QwenRoutePrefixSpec(
+                    tuple(), "qwen36", "text", "system", 0, 0
+                )
+
+                with (
+                    mock.patch.object(client, "_invalidate_final_prefix") as final_prefix,
+                    mock.patch.object(
+                        client, "_invalidate_qwen36_shell_tool_prefix"
+                    ) as shell_prefix,
+                ):
+                    client._ensure_prompt_cache_mode(requested)
+
+                self.assertIs(client._qwen3_coder_route_prefix_anchor_state, coder_state)
+                self.assertIs(client._qwen3_coder_route_prefix_spec, coder_spec)
+                self.assertFalse(client._qwen_route_prefix_anchor_state.valid)
+                self.assertIsNone(client._qwen_route_prefix_spec)
+                self.assertEqual(client._session.cached_prompt_tokens, [])
+                self.assertFalse(client._session.continuation_ready)
+                self.assertIsNone(client._session.last_metrics)
+                self.assertEqual(client._session.prompt_cache_mode, requested)
+                client.lib.lib.llama_memory_clear.assert_called_once_with(2, True)
+                final_prefix.assert_called_once_with("session_reset")
+                shell_prefix.assert_called_once_with("session_reset")
+                self.assertEqual(
+                    client.qwen3_coder_route_prefix_reuse_status()["invalidation_count"],
+                    0,
+                )
+
+    def test_unqualified_cache_mode_transition_invalidates_coder_checkpoint(self) -> None:
+        for profile_id, verified, current, requested in (
+            (QWEN3_CODER_PROFILE_ID, True, "chat:thinking=off", "chat:thinking=on"),
+            (
+                QWEN3_CODER_PROFILE_ID,
+                True,
+                "chat:thinking=off",
+                "artifact:qwen3-coder-json-string-v1",
+            ),
+            (QWEN3_CODER_PROFILE_ID, False, "chat:thinking=off", "tools:thinking=off"),
+            ("orbit-qwen36-native-v1", True, "chat:thinking=off", "tools:thinking=off"),
+        ):
+            with self.subTest(
+                profile_id=profile_id,
+                verified=verified,
+                current=current,
+                requested=requested,
+            ):
+                client = self._client()
+                if profile_id != QWEN3_CODER_PROFILE_ID or not verified:
+                    client.model_profile = NativeModelProfile(
+                        **{
+                            **_profile().__dict__,
+                            "profile_id": profile_id,
+                            "verified": verified,
+                        }
+                    )
+                client._session.ctx_tgt = 1  # type: ignore[assignment]
+                client.lib.lib.llama_get_memory.return_value = 2
+                client._session.prompt_cache_mode = current
+                client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"coder",
+                    checkpoint_size=5,
+                    token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+                )
+
+                client._ensure_prompt_cache_mode(requested)
+
+                self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+                self.assertEqual(
+                    client.qwen3_coder_route_prefix_reuse_status()["failure_reason"],
+                    "session_reset",
+                )
+
+    def test_cancel_after_cache_mode_transition_invalidates_preserved_checkpoint(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client.lib.lib.llama_get_memory.return_value = 2
+        client._session.prompt_cache_mode = "chat:thinking=off"
+        client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"coder",
+            checkpoint_size=5,
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+        )
+
+        client._ensure_prompt_cache_mode("tools:thinking=off")
+        self.assertTrue(client._qwen3_coder_route_prefix_anchor_state.valid)
+
+        client.cancel()
+
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(
+            client.qwen3_coder_route_prefix_reuse_status()["failure_reason"],
+            "cancelled",
+        )
+
+    def test_failed_tool_completion_invalidates_preserved_checkpoint(self) -> None:
+        for outcome in ("cancelled", "exception", "render_error"):
+            with self.subTest(outcome=outcome):
+                client = self._client()
+                client._session.ctx_tgt = 1  # type: ignore[assignment]
+                client.lib.lib.llama_get_memory.return_value = 2
+                client._session.prompt_cache_mode = "chat:thinking=off"
+                client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"coder",
+                    checkpoint_size=5,
+                    token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+                )
+                client._ensure_prompt_cache_mode("tools:thinking=off")
+
+                if outcome == "render_error":
+                    client.apply_chat_template = mock.Mock(
+                        side_effect=RuntimeError("synthetic render failure")
+                    )  # type: ignore[method-assign]
+                    with self.assertRaisesRegex(RuntimeError, "render failure"):
+                        client.complete_chat(
+                            [{"role": "user", "content": "run pwd"}],
+                            tools=[{"type": "function"}],
+                            thinking=False,
+                        )
+                    expected_reason = "completion_error"
+                else:
+                    if outcome == "exception":
+                        client._complete_prompt_standard = mock.Mock(
+                            side_effect=RuntimeError("synthetic completion failure")
+                        )  # type: ignore[method-assign]
+                        with self.assertRaisesRegex(RuntimeError, "completion failure"):
+                            client.complete_prompt(
+                                "tool prompt", allow_mtp_experimental=False
+                            )
+                        expected_reason = "completion_error"
+                    else:
+                        client._complete_prompt_standard = mock.Mock(
+                            return_value=NativeTimings(
+                                prompt_tokens=10,
+                                output_tokens=0,
+                                reused_prompt_tokens=0,
+                                evaluated_prompt_tokens=10,
+                                prefill_ms=1.0,
+                                generation_ms=1.0,
+                                cancelled=True,
+                            )
+                        )  # type: ignore[method-assign]
+                        client.complete_prompt(
+                            "tool prompt", allow_mtp_experimental=False
+                        )
+                        expected_reason = "cancelled"
+
+                self.assertFalse(
+                    client._qwen3_coder_route_prefix_anchor_state.valid
+                )
+                status = client.qwen3_coder_route_prefix_reuse_status()
+                self.assertEqual(status["invalidation_count"], 1)
+                self.assertEqual(status["failure_reason"], expected_reason)
+
+    def test_identity_mismatch_falls_back_before_native_restore(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._clear_target_memory = mock.Mock()  # type: ignore[method-assign]
+        client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+            prefix_hash="stale",
+            token_count=QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
+            model_id="model",
+            template_id="template",
+            tool_schema_hash="schema",
+            capability_summary_hash="capabilities",
+            runtime_policy_hash="policy",
+            route_contract_hash="route",
+            backend_version="backend",
+            native_version="native",
+            tools_mode="mode",
+            checkpoint_data=b"checkpoint",
+            checkpoint_size=10,
+            valid=True,
+        )
+        plan = _QwenRouteAnchorRuntimePlan(
+            prefix_tokens=list(range(QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT)),
+            prefix_hash="current",
+            state_kwargs={
+                "model_id": "model",
+                "template_id": "template",
+                "tool_schema_hash": "schema",
+                "capability_summary_hash": "capabilities",
+                "runtime_policy_hash": "policy",
+                "route_contract_hash": "route",
+                "backend_version": "backend",
+                "native_version": "native",
+                "tools_mode": "mode",
+            },
+            spec=QwenRoutePrefixSpec(tuple(), "token", "text", "system", 0, 0),
+            metadata={},
+            profile_id=QWEN3_CODER_PROFILE_ID,
+        )
+
+        processed, reused = client._prepare_memory_with_qwen_route_anchor(plan)
+
+        self.assertEqual((processed, reused), (0, 0))
+        self.assertEqual(client._clear_target_memory.call_count, 2)
+        client.lib.lib.llama_state_seq_set_data.assert_not_called()
+        status = client.qwen3_coder_route_prefix_reuse_status()
+        self.assertEqual(status["fallback_count"], 1)
+        self.assertEqual(status["invalidation_count"], 1)
+        self.assertEqual(status["failure_reason"], "prefix_hash_changed")
+
+    def test_model_reload_invalidates_coder_checkpoint_before_loading(self) -> None:
+        client = self._client()
+        client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+            valid=True,
+            checkpoint_data=b"coder",
+            checkpoint_size=5,
+        )
+        client._model = 1  # type: ignore[assignment]
+        client.lib.lib.llama_model_default_params.side_effect = RuntimeError("stop load")
+
+        with self.assertRaisesRegex(RuntimeError, "stop load"):
+            client.load()
+
+        self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+        self.assertEqual(
+            client.qwen3_coder_route_prefix_reuse_status()["failure_reason"],
+            "model_reload",
         )
 
     def test_cancel_reset_and_close_release_only_profile_specific_checkpoint(self) -> None:


### PR DESCRIPTION
## Summary
- preserves only the immutable `qwen3-coder-route-prefix-v1` checkpoint across qualified internal `chat:thinking=off` / `tools:thinking=off` cache-mode transitions
- continues to clear live KV, prompt-cache, continuation, final-prefix, shell-prefix, and profile projection state
- keeps explicit reset, cancel, close, reload, identity mismatch, restore failure, and completion failure fail-closed
- leaves Qwen3.6 and Gemma checkpoint behavior unchanged

## Review fix
Independent review reproduced a completion-error path that could retain the preserved checkpoint when no route-anchor plan existed. The final change invalidates the Coder checkpoint on render errors, backend completion exceptions, and cancellation.

## Validation
- focused checkpoint/profile/session tests: 100/100 PASS
- affected native tests: 362/362 PASS, 3 expected skips
- full discovery: 1768/1768 PASS, 6 expected skips
- compileall PASS
- cached diff check PASS
- three isolated real workflow cycles retained 771 cached / 63 evaluated tokens after tool-mode transitions, with zero fallback or invalidation
