### PR TITLE
Add deterministic slash commands

### DIFF
--- a/src/orbit/native_llama/paths.py
+++ b/src/orbit/native_llama/paths.py
@@ -101,6 +101,11 @@ def resolve_legacy_paths(
     )
 
 
+def resolve_native_build_bin(*, llama_root: Path | None = DEFAULT_LLAMA_ROOT) -> Path:
+    """Return the active native runtime directory without resolving a model."""
+    return _resolve_native_runtime(llama_root)[1]
+
+
 def _resolve_model(
     *,
     manifest_id: str,

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from pathlib import Path
 from typing import Callable
 import json
 import re
@@ -9,6 +10,7 @@ from orbit.backend import ChatBackend, ChatResult
 from orbit.backend.base import Message, StreamProgress
 from orbit.runtime.capabilities import LocalCapabilities, discover_local_capabilities
 from orbit.runtime.client_state import ClientState
+from orbit.runtime.command_evidence import AcquiredEvidence
 from orbit.runtime.completion_budget import resolve_max_tokens
 from orbit.runtime.environments import (
     ContinueEnvironment,
@@ -70,11 +72,13 @@ from orbit.runtime.thinking_mode import (
     contains_control_channel_markup,
     last_assistant_has_open_reasoning,
 )
+from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
 from orbit.runtime.tool_result_compaction import (
     ToolResultCompactionReport,
     compact_tool_results,
     persistent_messages as persistent_tool_result_messages,
 )
+from orbit.runtime.tools import ToolResult
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
@@ -229,6 +233,120 @@ class ChatRuntime:
             on_model_step=on_model_step,
             on_phase_start=on_phase_start,
             loop=1,
+        )
+        return self._remember_visible_result(result)
+
+    @user_request
+    def answer_from_acquired_evidence(
+        self,
+        prompt: str,
+        *,
+        evidence: AcquiredEvidence,
+        workdir: Path,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None = None,
+        on_progress: Callable[[StreamProgress], None] | None = None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
+    ) -> ChatResult:
+        """Answer once from evidence acquired explicitly by a slash command."""
+        checkpoint = len(self.messages)
+        turn_id = self._begin_user_turn()
+        self.last_memory_refresh = None
+        self.refresh_memory_if_needed(temperature=temperature)
+        if self.evidence_store is None:
+            self.evidence_store = EvidenceStore.for_workdir(workdir)
+        self.messages.append({"role": "user", "content": prompt})
+        call_id = f"slash_{turn_id}"
+        tool_call = {
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": evidence.tool_name,
+                "arguments": json.dumps(evidence.arguments, ensure_ascii=False, separators=(",", ":")),
+            },
+        }
+        self.messages.append(assistant_tool_call_message("", [tool_call]))
+        tool_message = tool_result_message(
+            tool_call,
+            ToolResult(name=evidence.tool_name, content=evidence.content),
+            evidence_store=self.evidence_store,
+            metadata={
+                **evidence.arguments,
+                "source": evidence.source,
+                "tool_call_id": call_id,
+                "user_turn_id": turn_id,
+                "produced_by_phase": "slash_command",
+            },
+        )
+        self.messages.append(tool_message)
+        evidence_id = tool_message.get("evidence_id")
+        try:
+            result = self._answer_from_tool_results(
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
+                loop=1,
+                use_tool_prompt=True,
+            )
+        except BaseException:
+            self._discard_acquired_evidence(evidence_id)
+            self.restore_message_count(checkpoint)
+            raise
+        if result.finish_reason in {"cancelled", "timeout"}:
+            self._discard_acquired_evidence(evidence_id)
+            self.restore_message_count(checkpoint)
+        return self._remember_visible_result(result)
+
+    def _discard_acquired_evidence(self, evidence_id: object) -> None:
+        if isinstance(evidence_id, str) and self.evidence_store is not None:
+            self.evidence_store.discard(evidence_id)
+
+    @user_request
+    def answer_full_document_command(
+        self,
+        prompt: str,
+        *,
+        path: str,
+        workdir: Path,
+        temperature: float,
+        max_tokens: int,
+        on_final_delta: Callable[[str], None] | None = None,
+        on_progress: Callable[[StreamProgress], None] | None = None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None = None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
+    ) -> ChatResult:
+        """Run the existing exact full-document admission without a route call."""
+        self._begin_user_turn()
+        self.last_memory_refresh = None
+        self.refresh_memory_if_needed(temperature=temperature)
+        self.messages.append({"role": "user", "content": prompt})
+        base = ChatResult(
+            content="",
+            model=None,
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=0,
+            completion_tokens=0,
+            cached_tokens=0,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+        result = self._full_document_preflight_environment().answer_path(
+            prompt,
+            path=path,
+            route_result=base,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
         )
         return self._remember_visible_result(result)
 

--- a/src/orbit/runtime/command_evidence.py
+++ b/src/orbit/runtime/command_evidence.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AcquiredEvidence:
+    tool_name: str
+    arguments: dict[str, object]
+    content: str
+    source: str

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -451,18 +451,47 @@ class FullDocumentPreflightEnvironment:
         if allowed_tool_names is not None and "exec_shell_full_command" not in allowed_tool_names:
             return None
 
-        raw = read_full_document_snapshot(request.path, workdir=workdir)
+        return self.answer_path(
+            prompt,
+            path=request.path,
+            route_result=route_result,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
+        )
+
+    def answer_path(
+        self,
+        prompt: str,
+        *,
+        path: str,
+        route_result: ChatResult,
+        temperature: float,
+        max_tokens: int,
+        workdir: Path,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+    ) -> ChatResult:
+        """Apply exact full-document admission to an explicitly acquired path."""
+
+        raw = read_full_document_snapshot(path, workdir=workdir)
         if raw.startswith("error:"):
             return self._blocked(
                 route_result,
-                full_document_source_blocked_notice(request.path, raw.removeprefix("error:").strip()),
+                full_document_source_blocked_notice(path, raw.removeprefix("error:").strip()),
                 on_final_delta=on_final_delta,
             )
         snapshot = parse_full_document_snapshot(raw)
         if snapshot is None:
             return self._blocked(
                 route_result,
-                full_document_source_blocked_notice(request.path, "snapshot_integrity_failure"),
+                full_document_source_blocked_notice(path, "snapshot_integrity_failure"),
                 on_final_delta=on_final_delta,
             )
 
@@ -485,7 +514,7 @@ class FullDocumentPreflightEnvironment:
                 max_tokens=max_tokens,
                 workdir=workdir,
             )
-            return self.answer_admitted_snapshot(
+            result = self.answer_admitted_snapshot(
                 admission,
                 route_result=route_result,
                 temperature=temperature,
@@ -495,6 +524,8 @@ class FullDocumentPreflightEnvironment:
                 on_model_step=on_model_step,
                 on_phase_start=on_phase_start,
             )
+            assert result is not None
+            return result
         finally:
             if record is not None and self.runtime.evidence_store is not None:
                 self.runtime.evidence_store.discard(record.evidence_id)

--- a/src/orbit/runtime/web.py
+++ b/src/orbit/runtime/web.py
@@ -153,6 +153,13 @@ def fetch_url_result_has_text(content: str | None) -> bool:
     return bool(body.strip())
 
 
+def fetch_url_result_text(content: str | None) -> str | None:
+    if not fetch_url_result_has_text(content):
+        return None
+    assert content is not None
+    return content.split("text:\n", 1)[1]
+
+
 def fetch_url_result_error(content: str | None) -> str | None:
     if not content:
         return None

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -16,12 +16,14 @@ from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.media import load_audio, load_image
 from orbit.runtime.turn_trace import ModelStepMetrics
 from orbit.terminal.config import add_config_arguments, load_app_config
+from orbit.terminal.command_actions import CommandAction, build_list_action, build_models_action, build_read_action, build_search_action
+from orbit.terminal.command_registry import resolve_command
 from orbit.terminal.context_status import context_status_text
 from orbit.terminal.history import PromptHistory
 from orbit.terminal.prefill import MIN_PREFILL_ESTIMATE_SECONDS, estimate_prefill_tokens, estimate_prefill_tokens_after_tool_result
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, TOOL_PREFILL_PROFILE, PrefillEstimator, prefill_profile_for_phase
 from orbit.terminal.repl import Repl
-from orbit.terminal.commands import health_text, help_text, runtime_status, set_max_tokens, think_mode_text, tools_text
+from orbit.terminal.commands import health_text, help_text, props_text, runtime_status, set_max_tokens, think_mode_text, tools_text
 from orbit.terminal.session_selection import select_interactive_session
 from orbit.terminal.status import TokenUsageAccumulator, estimate_context_status_tokens, format_turn_status, summarize_turn_token_usage
 from orbit.terminal.streaming import StreamRenderer
@@ -89,8 +91,29 @@ def main(argv: list[str] | None = None) -> int:
         prompt = " ".join(args.prompt)
         command_result = _handle_one_shot_command(prompt, runtime, config, backend)
         if command_result is not None:
-            print(command_result)
-            return 0
+            if isinstance(command_result, str):
+                print(command_result)
+                return 0
+            if not command_result.needs_model:
+                print(command_result.output)
+                return 0
+            if args.image or args.audio:
+                print("error: slash-command evidence prompts do not accept --image/--audio", file=sys.stderr)
+                return 1
+            assert command_result.prompt is not None
+            return _run_one_shot(
+                runtime,
+                command_result.prompt,
+                image_paths=[],
+                audio_paths=[],
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
+                workdir=config.workdir,
+                tools=config.tools,
+                thinking=config.think,
+                render_markdown_mode=config.render_markdown,
+                command_action=command_result,
+            )
         return _run_one_shot(
             runtime,
             prompt,
@@ -127,35 +150,54 @@ def _handle_one_shot_command(
     runtime: ChatRuntime,
     config,
     backend: LlamaServerBackend,
-) -> str | None:
+) -> str | CommandAction | None:
     command = prompt.strip()
     if not command.startswith("/"):
         return None
-    if command == "/status":
+    invocation = resolve_command(command)
+    if invocation is None:
+        return f"error: unknown command: {command}"
+    handler = invocation.spec.handler
+    arguments = invocation.arguments
+    if handler == "read":
+        return build_read_action(arguments, workdir=config.workdir)
+    if handler == "search":
+        return build_search_action(arguments, workdir=config.workdir)
+    if handler == "list":
+        return build_list_action(arguments, workdir=config.workdir)
+    if handler == "models":
+        return build_models_action(arguments)
+    if handler == "status" and not arguments:
         return runtime_status(runtime, config, backend, tools_mode=config.tools)
-    if command in {"/status ctx", "/status context"}:
+    if handler == "status" and arguments in {"ctx", "context"}:
         return context_status_text(runtime.messages, context_tokens=runtime.context_tokens)
-    if command == "/compact" or command == "/compact tools":
-        return "error: /compact is available only in interactive mode"
-    if command == "/tools":
+    if handler == "status":
+        return f"error: usage: {invocation.spec.usage}"
+    if handler in {"compact", "continue", "reset", "sessions", "exit"}:
+        return f"error: {invocation.spec.name} is available only in interactive mode"
+    if handler == "clear":
+        return "terminal display clear unavailable in non-TTY mode"
+    if handler == "tools" and not arguments:
         return tools_text(config.tools)
-    if command == "/think":
+    if handler == "tools":
+        return f"error: {invocation.spec.name} changes are available only in interactive mode"
+    if handler == "think" and not arguments:
         return think_mode_text(config.think)
-    if command == "/health":
+    if handler == "health" and not arguments:
         return health_text(backend, config)
-    if command == "/help":
+    if handler == "props" and not arguments:
+        return props_text(backend)
+    if handler == "help" and not arguments:
         return help_text()
-    if command == "/max-tokens" or command.startswith("/max-tokens "):
-        _, message = set_max_tokens(config, command.removeprefix("/max-tokens").strip())
+    if handler == "max_tokens":
+        _, message = set_max_tokens(config, arguments)
         return message
-    if command == "/think" or command.startswith("/think "):
-        value = command.removeprefix("/think").strip().lower()
-        if not value:
-            return think_mode_text(config.think)
+    if handler == "think":
+        value = arguments.lower()
         if value not in {"on", "off"}:
             return "error: usage: /think [off|on]"
         return f"think: {value}"
-    return f"unknown command: {command}"
+    return f"error: usage: {invocation.spec.usage}"
 
 
 def _run_one_shot(
@@ -170,6 +212,7 @@ def _run_one_shot(
     tools: str,
     thinking: bool,
     render_markdown_mode: str = "plain",
+    command_action: CommandAction | None = None,
 ) -> int:
     prefill_estimator = PrefillEstimator()
     model_steps: list[ModelStepMetrics] = []
@@ -206,7 +249,29 @@ def _run_one_shot(
     try:
         images = [load_image(path) for path in image_paths]
         audios = [load_audio(path) for path in audio_paths]
-        if images or audios:
+        if command_action is not None and command_action.full_document_path is not None:
+            result = runtime.answer_full_document_command(
+                prompt,
+                path=command_action.full_document_path,
+                workdir=workdir,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=renderer.write,
+                on_progress=renderer.progress,
+                on_model_step=record_model_step,
+            )
+        elif command_action is not None and command_action.evidence is not None:
+            result = runtime.answer_from_acquired_evidence(
+                prompt,
+                evidence=command_action.evidence,
+                workdir=workdir,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                on_final_delta=renderer.write,
+                on_progress=renderer.progress,
+                on_model_step=record_model_step,
+            )
+        elif images or audios:
             result = runtime.ask(
                 prompt,
                 temperature=temperature,

--- a/src/orbit/terminal/command_actions.py
+++ b/src/orbit/terminal/command_actions.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import re
+import shlex
+from urllib.parse import urlparse
+
+from orbit.native_llama.model_discovery import discover_models, format_model_discovery
+from orbit.native_llama.paths import resolve_native_build_bin
+from orbit.runtime.command_evidence import AcquiredEvidence
+from orbit.runtime.directory_listing import execute_list_directory
+from orbit.runtime.document_search import literal_document_search_answer, search_document_snapshot
+from orbit.runtime.document_tool import execute_read_file
+from orbit.runtime.file_tools import read_full_document_snapshot, read_pdf
+from orbit.runtime.full_document import FullDocumentSnapshot, attest_full_document_snapshot, parse_full_document_snapshot
+from orbit.runtime.shell_guardrails import execute_exec_shell_full_command
+from orbit.runtime.web import execute_fetch_url, fetch_url_result_status, fetch_url_result_text, search_web
+
+
+@dataclass(frozen=True)
+class CommandAction:
+    output: str
+    prompt: str | None = None
+    evidence: AcquiredEvidence | None = None
+    full_document_path: str | None = None
+
+    @property
+    def needs_model(self) -> bool:
+        return self.prompt is not None and (self.evidence is not None or self.full_document_path is not None)
+
+
+def build_read_action(arguments: str, *, workdir: Path) -> CommandAction:
+    values = _split(arguments, usage="/read <source> [prompt]")
+    if isinstance(values, CommandAction):
+        return values
+    if not values:
+        return _usage_error("source is required", "/read <source> [prompt]")
+    source = values[0]
+    prompt = " ".join(values[1:]).strip() or None
+    url_state = _url_state(source)
+    if url_state == "invalid":
+        return _usage_error("source is not a valid HTTP(S) URL", "/read <source> [prompt]")
+    if url_state == "valid":
+        content = execute_fetch_url({"url": source})
+        if fetch_url_result_status(content) != "ok":
+            return CommandAction(content)
+        return _with_optional_prompt(
+            content,
+            prompt=prompt,
+            evidence=AcquiredEvidence("fetch_url", {"url": source}, content, source),
+        )
+    if Path(source).suffix.lower() == ".pdf":
+        content = read_pdf(source, arguments={}, workdir=workdir)
+        if content.startswith("error:") or prompt is None:
+            return CommandAction(content)
+        evidence_content = "shell_output_pdf_text: true\n" + content
+        return CommandAction(
+            content,
+            prompt=prompt,
+            evidence=AcquiredEvidence(
+                "exec_shell_full_command",
+                {"command": f"pdftotext -- {shlex.quote(source)} -"},
+                evidence_content,
+                source,
+            ),
+        )
+    if prompt is not None:
+        # Exact full-document admission, including context fit, remains a runtime decision.
+        return CommandAction(f"read: {source}", prompt=prompt, full_document_path=source)
+    return CommandAction(execute_read_file({"path": source}, workdir=workdir))
+
+
+def build_search_action(arguments: str, *, workdir: Path) -> CommandAction:
+    values = _split(arguments, usage="/search <query> [source] [prompt]")
+    if isinstance(values, CommandAction):
+        return values
+    if not values:
+        return _usage_error("query is required", "/search <query> [source] [prompt]")
+    query = values[0].strip()
+    if not query:
+        return _usage_error("query must be non-empty", "/search <query> [source] [prompt]")
+    source = values[1] if len(values) > 1 and _is_source_token(values[1], workdir=workdir) else None
+    prompt_values = values[2:] if source is not None else values[1:]
+    prompt = " ".join(prompt_values).strip() or None
+    if source is None:
+        content = search_web(query)
+        if content.startswith("error:"):
+            return CommandAction(content)
+        return _with_optional_prompt(
+            content,
+            prompt=prompt,
+            evidence=AcquiredEvidence(
+                "exec_shell_full_command",
+                {"command": f"orbit-web-search {shlex.quote(query)}"},
+                content,
+                "web",
+            ),
+        )
+    url_state = _url_state(source)
+    if url_state == "invalid":
+        return _usage_error("source is not a valid HTTP(S) URL", "/search <query> [source] [prompt]")
+    if url_state == "valid":
+        fetched = execute_fetch_url({"url": source})
+        if fetch_url_result_status(fetched) != "ok":
+            return CommandAction(fetched)
+        text = fetch_url_result_text(fetched)
+        if text is None:
+            return CommandAction("error: fetched URL did not provide searchable text")
+        snapshot = _url_snapshot(source, text)
+        try:
+            result = search_document_snapshot(snapshot, mode="literal", terms=(query,), whole_word=False)
+        except ValueError as exc:
+            return CommandAction(f"error: {exc}")
+        content = _url_search_answer(result, fetched=fetched)
+        return _with_optional_prompt(
+            content,
+            prompt=prompt,
+            evidence=AcquiredEvidence("fetch_url", {"url": source}, content, source),
+        )
+    if Path(source).suffix.lower() == ".pdf":
+        command = (
+            f"pdftotext {shlex.quote(source)} - | "
+            f"rg -e {shlex.quote(re.escape(query))}"
+        )
+        content = execute_exec_shell_full_command(
+            {"command": command},
+            workdir=workdir,
+            user_prompt=f"search exactly for {query!r} in {source}",
+        )
+        if content.startswith("error:"):
+            return CommandAction(content)
+        return _with_optional_prompt(
+            content,
+            prompt=prompt,
+            evidence=AcquiredEvidence("exec_shell_full_command", {"command": command}, content, source),
+        )
+    raw = read_full_document_snapshot(source, workdir=workdir)
+    if raw.startswith("error:"):
+        return CommandAction(raw)
+    snapshot = parse_full_document_snapshot(raw)
+    if snapshot is None:
+        return CommandAction("error: document snapshot integrity failure")
+    source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+    if source_error is not None:
+        return CommandAction(f"error: document snapshot rejected: {source_error}")
+    try:
+        result = search_document_snapshot(snapshot, mode="literal", terms=(query,), whole_word=False)
+    except ValueError as exc:
+        return CommandAction(f"error: {exc}")
+    source_error = attest_full_document_snapshot(snapshot, workdir=workdir)
+    if source_error is not None:
+        return CommandAction(f"error: document changed during search: {source_error}")
+    content = literal_document_search_answer(result, whole_word=False)
+    return _with_optional_prompt(
+        content,
+        prompt=prompt,
+        evidence=AcquiredEvidence(
+            "exec_shell_full_command",
+            {"command": f"rg -n -F -- {shlex.quote(query)} {shlex.quote(source)}"},
+            content,
+            source,
+        ),
+    )
+
+
+def build_list_action(arguments: str, *, workdir: Path) -> CommandAction:
+    values = _split(arguments, usage="/ls [path]")
+    if isinstance(values, CommandAction):
+        return values
+    if len(values) > 1:
+        return _usage_error("expected at most one path", "/ls [path]")
+    return CommandAction(execute_list_directory({"path": values[0] if values else "."}, workdir=workdir))
+
+
+def build_models_action(arguments: str) -> CommandAction:
+    values = _split(arguments, usage="/models")
+    if isinstance(values, CommandAction):
+        return values
+    if values:
+        return _usage_error("this command takes no arguments", "/models")
+    try:
+        result = discover_models(build_bin=resolve_native_build_bin())
+    except (OSError, RuntimeError) as exc:
+        return CommandAction(f"error: model discovery unavailable: {exc}")
+    return CommandAction(format_model_discovery(result))
+
+
+def _split(arguments: str, *, usage: str) -> list[str] | CommandAction:
+    try:
+        return shlex.split(arguments, posix=True)
+    except ValueError as exc:
+        return _usage_error(str(exc), usage)
+
+
+def _usage_error(message: str, usage: str) -> CommandAction:
+    return CommandAction(f"error: {message}\nusage: {usage}")
+
+
+def _with_optional_prompt(content: str, *, prompt: str | None, evidence: AcquiredEvidence) -> CommandAction:
+    if prompt is None:
+        return CommandAction(content)
+    return CommandAction(content, prompt=prompt, evidence=evidence)
+
+
+def _url_state(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme.lower() in {"http", "https"} and parsed.netloc:
+        return "valid"
+    if "://" in value or parsed.scheme.lower() in {"http", "https"}:
+        return "invalid"
+    return "local"
+
+
+def _is_source_token(value: str, *, workdir: Path) -> bool:
+    if _url_state(value) != "local":
+        return True
+    candidate = Path(value)
+    return candidate.is_absolute() or (workdir / candidate).exists() or "/" in value or bool(candidate.suffix)
+
+
+def _url_snapshot(url: str, text: str) -> FullDocumentSnapshot:
+    encoded = text.encode("utf-8")
+    return FullDocumentSnapshot(
+        path=url,
+        byte_count=len(encoded),
+        char_count=len(text),
+        line_count=len(text.splitlines()),
+        sha256=hashlib.sha256(encoded).hexdigest(),
+        device=0,
+        inode=0,
+        mtime_ns=0,
+        ctime_ns=0,
+        content=text,
+    )
+
+
+def _url_search_answer(result, *, fetched: str) -> str:
+    truncated = "text_truncated: true" in fetched
+    coverage = "partial" if truncated else "complete"
+    lines = [
+        (
+            "URL search coverage: "
+            f"retrieval_coverage={coverage}; search_coverage=complete_retrieved_text; "
+            f"url={result.path}; searched_term={result.searched_terms[0]!r}; "
+            f"total_matches={result.total_matches}; results_truncated={str(result.results_truncated).lower()}."
+        )
+    ]
+    if result.total_matches == 0:
+        lines.append("The exact string does not occur in the retrieved page text.")
+        return "\n".join(lines)
+    lines.append("Exact evidence windows:")
+    for window in result.windows:
+        lines.extend((f"- lines {window.start_line}-{window.end_line}:", window.text))
+    return "\n".join(lines)

--- a/src/orbit/terminal/command_registry.py
+++ b/src/orbit/terminal/command_registry.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    category: str
+    usage: str
+    description: str
+    handler: str
+
+
+@dataclass(frozen=True)
+class CommandInvocation:
+    spec: CommandSpec
+    arguments: str
+
+
+COMMANDS = (
+    CommandSpec("/read", "Files & Web", "/read <source> [prompt]", "Read a local document or URL safely.", "read"),
+    CommandSpec(
+        "/search",
+        "Files & Web",
+        "/search <query> [source] [prompt]",
+        "Search the web, a local document, or one URL.",
+        "search",
+    ),
+    CommandSpec("/ls", "Files & Web", "/ls [path]", "List a directory inside the workdir.", "list"),
+    CommandSpec("/models", "Models", "/models", "Show discovered and supported models.", "models"),
+    CommandSpec("/clear", "Session", "/clear", "Clear the interactive terminal display.", "clear"),
+    CommandSpec("/compact", "Session", "/compact [tools]", "Compact memory or old tool results.", "compact"),
+    CommandSpec("/continue", "Session", "/continue", "Continue an answer that reached max_tokens.", "continue"),
+    CommandSpec("/reset", "Session", "/reset", "Clear the conversation and saved session.", "reset"),
+    CommandSpec("/sessions", "Session", "/sessions clear", "Delete saved sessions for this workdir.", "sessions"),
+    CommandSpec("/exit", "Session", "/exit", "Exit interactive mode.", "exit"),
+    CommandSpec("/health", "Runtime", "/health", "Check backend health.", "health"),
+    CommandSpec(
+        "/max-tokens",
+        "Runtime",
+        "/max-tokens [n]",
+        "Show or set the output token limit.",
+        "max_tokens",
+    ),
+    CommandSpec("/think", "Runtime", "/think [off|on]", "Show or set thinking visibility.", "think"),
+    CommandSpec("/status", "Runtime", "/status [ctx]", "Show runtime status or context usage.", "status"),
+    CommandSpec("/props", "Runtime", "/props", "Show backend properties.", "props"),
+    CommandSpec(
+        "/tools",
+        "Runtime",
+        "/tools [off|on|status|refresh]",
+        "Show tool access or local capabilities.",
+        "tools",
+    ),
+    CommandSpec("/help", "Help", "/help", "Show command help.", "help"),
+)
+
+
+_BY_NAME = {command.name: command for command in COMMANDS}
+if len(_BY_NAME) != len(COMMANDS):
+    raise RuntimeError("duplicate slash command name")
+
+
+def resolve_command(value: str) -> CommandInvocation | None:
+    stripped = value.strip()
+    if not stripped.startswith("/"):
+        return None
+    parts = stripped.split(maxsplit=1)
+    name = parts[0]
+    arguments = parts[1] if len(parts) == 2 else ""
+    spec = _BY_NAME.get(name)
+    if spec is None:
+        return None
+    return CommandInvocation(spec=spec, arguments=arguments.strip())
+
+
+def commands_matching(prefix: str) -> tuple[CommandSpec, ...]:
+    normalized = prefix.strip()
+    if normalized and not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return tuple(command for command in COMMANDS if command.name.startswith(normalized))

--- a/src/orbit/terminal/commands.py
+++ b/src/orbit/terminal/commands.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 
-from orbit.backend.llama_server import LlamaServerBackend
+from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
 from orbit.runtime.sessions import SessionStore
 from orbit.terminal.config import AppConfig
+from orbit.terminal.command_registry import COMMANDS
 from orbit.terminal.runtime_status import collect_runtime_status, format_status_panel
 from orbit.terminal.think_mode import think_text
 from orbit.terminal.tool_mode import ToolSpec
@@ -16,21 +18,17 @@ MAX_MAX_TOKENS = 4096
 
 
 def help_text() -> str:
-    commands = [
-        ("/compact [tools]", "Compact memory; use tools for old tool results."),
-        ("/continue", "Continue the last answer if it reached max_tokens."),
-        ("/health", "Check backend health."),
-        ("/help", "Show this help."),
-        ("/max-tokens [n]", "Show or set output token limit for following turns."),
-        ("/think [off|on]", "Show or set thinking visibility."),
-        ("/reset", "Clear current conversation and saved session."),
-        ("/sessions clear", "Delete all saved sessions for this workdir."),
-        ("/status [ctx]", "Show runtime status or estimated context usage."),
-        ("/tools [off|on|status|refresh]", "Show tool access or local capabilities."),
-        ("/exit", "Exit interactive mode."),
-    ]
-    width = max(len(command) for command, _ in commands) + 2
-    return "\n".join(f"{command:<{width}}{description}" for command, description in commands)
+    width = max(len(command.usage) for command in COMMANDS) + 2
+    lines: list[str] = []
+    category = None
+    for command in COMMANDS:
+        if command.category != category:
+            if lines:
+                lines.append("")
+            category = command.category
+            lines.append(category)
+        lines.append(f"{command.usage:<{width}}{command.description}")
+    return "\n".join(lines)
 
 
 def health_text(backend: LlamaServerBackend, config: AppConfig) -> str:
@@ -86,6 +84,14 @@ def runtime_status(
 ) -> str:
     status = collect_runtime_status(runtime, config, backend, tools_mode=tools_mode)
     return format_status_panel(status)
+
+
+def props_text(backend: LlamaServerBackend) -> str:
+    try:
+        props = backend.backend_props()
+    except (LlamaServerError, OSError, ValueError) as exc:
+        return f"error: backend properties unavailable: {exc}"
+    return json.dumps(props if isinstance(props, dict) else {}, ensure_ascii=False, indent=2, sort_keys=True)
 
 
 def set_max_tokens(config: AppConfig, value: str) -> tuple[AppConfig, str]:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -10,7 +10,9 @@ from orbit.runtime import ChatRuntime
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.sessions import SessionStore
 from orbit.terminal.compact_reports import format_memory_compaction_report, format_tool_compaction_report
-from orbit.terminal.commands import health_text, help_text, reset_session, runtime_status, set_max_tokens, think_mode_text, tools_text
+from orbit.terminal.command_actions import CommandAction, build_list_action, build_models_action, build_read_action, build_search_action
+from orbit.terminal.command_registry import resolve_command
+from orbit.terminal.commands import health_text, help_text, props_text, reset_session, runtime_status, set_max_tokens, think_mode_text, tools_text
 from orbit.terminal.config import AppConfig
 from orbit.terminal.context_status import context_status_text
 from orbit.terminal.history import PromptHistory
@@ -116,7 +118,7 @@ class Repl:
             self.prompt_gap_pending = False
         return read_prompt_input()
 
-    def _ask(self, prompt: str) -> None:
+    def _ask(self, prompt: str, *, command_action: CommandAction | None = None) -> None:
         self.turn_model_steps.clear()
         self.turn_backend_token_usage = TokenUsageAccumulator()
         tools_enabled = tools_are_enabled(self.tools_mode or "off")
@@ -135,7 +137,31 @@ class Repl:
         started = time.monotonic()
         renderer.start()
         try:
-            if tools_are_enabled(self.tools_mode or "off"):
+            if command_action is not None and command_action.full_document_path is not None:
+                result = self.runtime.answer_full_document_command(
+                    prompt,
+                    path=command_action.full_document_path,
+                    workdir=self.config.workdir,
+                    temperature=self.config.temperature,
+                    max_tokens=self.config.max_tokens,
+                    on_final_delta=renderer.write,
+                    on_progress=renderer.progress,
+                    on_model_step=self._record_model_step,
+                    on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
+                )
+            elif command_action is not None and command_action.evidence is not None:
+                result = self.runtime.answer_from_acquired_evidence(
+                    prompt,
+                    evidence=command_action.evidence,
+                    workdir=self.config.workdir,
+                    temperature=self.config.temperature,
+                    max_tokens=self.config.max_tokens,
+                    on_final_delta=renderer.write,
+                    on_progress=renderer.progress,
+                    on_model_step=self._record_model_step,
+                    on_phase_start=lambda phase: self._record_phase_start(renderer, phase),
+                )
+            elif tools_are_enabled(self.tools_mode or "off"):
                 result = self.runtime.ask_auto(
                     prompt,
                     temperature=self.config.temperature,
@@ -252,53 +278,116 @@ class Repl:
         )
 
     def _handle_command(self, command: str) -> bool:
-        if command == "/exit":
+        invocation = resolve_command(command)
+        if invocation is None:
+            print(f"error: unknown command: {command}", file=sys.stderr)
+            return True
+        handler = invocation.spec.handler
+        arguments = invocation.arguments
+        if handler == "exit":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
             return False
-        if command == "/continue":
+        if handler == "read":
+            return self._handle_data_action(build_read_action(arguments, workdir=self.config.workdir))
+        if handler == "search":
+            return self._handle_data_action(build_search_action(arguments, workdir=self.config.workdir))
+        if handler == "list":
+            return self._handle_data_action(build_list_action(arguments, workdir=self.config.workdir))
+        if handler == "models":
+            return self._handle_data_action(build_models_action(arguments))
+        if handler == "continue":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
             self._continue_last_answer()
             return True
-        if command == "/help":
+        if handler == "help":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
             print(help_text())
             return True
-        if command == "/reset":
+        if handler == "clear":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+            elif sys.stdout.isatty():
+                print("\033[2J\033[H", end="", flush=True)
+            else:
+                print("terminal display clear unavailable in non-TTY mode")
+            return True
+        if handler == "reset":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
             print(reset_session(self.runtime, self.session))
             self._reset_token_usage()
             self.can_continue = False
             return True
-        if command == "/compact":
+        if handler == "compact" and not arguments:
             print(format_memory_compaction_report(self.runtime.compact_memory_now(temperature=self.config.temperature)))
             self._save_session()
             return True
-        if command == "/compact tools":
+        if handler == "compact" and arguments == "tools":
             print(format_tool_compaction_report(self.runtime.compact_old_tool_results(temperature=self.config.temperature)))
             self._save_session()
             return True
-        if command == "/sessions clear":
+        if handler == "compact":
+            print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+            return True
+        if handler == "sessions" and arguments == "clear":
             print(self._clear_workdir_sessions())
             return True
-        if command == "/health":
+        if handler == "sessions":
+            print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+            return True
+        if handler == "health":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
             print(health_text(self.backend, self.config))
             return True
-        if command == "/max-tokens" or command.startswith("/max-tokens "):
-            value = command.removeprefix("/max-tokens").strip()
-            self.config, message = set_max_tokens(self.config, value)
+        if handler == "max_tokens":
+            self.config, message = set_max_tokens(self.config, arguments)
             print(message)
             return True
-        if command == "/think" or command.startswith("/think "):
-            print(self._handle_think_command(command))
+        if handler == "think":
+            print(self._handle_think_command(f"/think {arguments}".rstrip()))
             return True
-        if command == "/status":
+        if handler == "status" and not arguments:
             print(runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode))
             print(format_session_token_usage(self.session_token_usage.snapshot()))
             return True
-        if command in {"/status ctx", "/status context"}:
+        if handler == "status" and arguments in {"ctx", "context"}:
             print(context_status_text(self.runtime.messages, context_tokens=self.runtime.context_tokens))
             return True
-        if command == "/tools" or command.startswith("/tools "):
-            print(self._handle_tools_command(command))
+        if handler == "status":
+            print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
             return True
-        print(f"unknown command: {command}", file=sys.stderr)
+        if handler == "props":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+            else:
+                print(props_text(self.backend))
+            return True
+        if handler == "tools":
+            print(self._handle_tools_command(f"/tools {arguments}".rstrip()))
+            return True
+        print(f"error: command handler unavailable: {invocation.spec.name}", file=sys.stderr)
         return True
+
+    def _handle_data_action(self, action: CommandAction) -> bool:
+        if action.needs_model:
+            assert action.prompt is not None
+            self._ask(action.prompt, command_action=action)
+        else:
+            print(action.output)
+        return True
+
+    @staticmethod
+    def _command_usage_error(usage: str) -> str:
+        return f"error: usage: {usage}"
 
     def _clear_workdir_sessions(self) -> str:
         if not _confirm_clear_sessions():

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.backend.base import ChatResult, TokenCount
+from orbit.native_llama.model_discovery import ModelDiscoveryResult, ModelDiscoveryRow
+from orbit.runtime import ChatRuntime
+from orbit.runtime.command_evidence import AcquiredEvidence
+from orbit.runtime.evidence import EvidenceStore
+from orbit.terminal.command_actions import (
+    build_list_action,
+    build_models_action,
+    build_read_action,
+    build_search_action,
+)
+from orbit.terminal.command_registry import COMMANDS, commands_matching, resolve_command
+from orbit.terminal.commands import help_text
+from orbit.terminal import cli
+
+
+class AnswerBackend:
+    def __init__(self, *, prompt_tokens: int = 100, context_tokens: int = 8192) -> None:
+        self.prompt_tokens = prompt_tokens
+        self.context_tokens = context_tokens
+        self.calls = 0
+        self.messages_by_call: list[list[dict[str, object]]] = []
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        self.calls += 1
+        self.messages_by_call.append(messages)
+        return ChatResult(
+            content="The acquired evidence supports this complete answer.",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=8,
+            cached_tokens=0,
+            prompt_tokens_per_second=10.0,
+            generation_tokens_per_second=2.0,
+        )
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None):
+        result = self.chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+        if on_delta is not None:
+            on_delta(result.content)
+        return result
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        payload = repr(messages).encode("utf-8")
+        return TokenCount(
+            tokens=self.prompt_tokens,
+            context_tokens=self.context_tokens,
+            rendered_hash=hashlib.sha256(payload).hexdigest(),
+            token_hash=hashlib.sha256(b"tokens:" + payload).hexdigest(),
+        )
+
+    def count_text_tokens(self, text):
+        return TokenCount(tokens=max(1, len(text) // 4), context_tokens=self.context_tokens)
+
+
+class SlashCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.workdir = Path(temporary.name)
+
+    def test_registry_is_unique_and_drives_help_and_prefix_filtering(self) -> None:
+        names = [command.name for command in COMMANDS]
+
+        self.assertEqual(len(names), len(set(names)))
+        self.assertEqual([command.name for command in commands_matching("/re")], ["/read", "/reset"])
+        rendered = help_text()
+        for name in ("/read", "/search", "/ls", "/models", "/help", "/status", "/props", "/clear", "/reset", "/exit"):
+            self.assertIn(name, rendered)
+
+    def test_resolve_command_keeps_quoted_arguments_for_handler(self) -> None:
+        invocation = resolve_command('/search "CVE 2026" report.pdf summarize matches')
+
+        self.assertEqual(invocation.spec.name, "/search")
+        self.assertEqual(invocation.arguments, '"CVE 2026" report.pdf summarize matches')
+
+    def test_read_local_text_is_bounded_and_does_not_request_model(self) -> None:
+        (self.workdir / "notes.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+
+        action = build_read_action("notes.txt", workdir=self.workdir)
+
+        self.assertFalse(action.needs_model)
+        self.assertIn("file_display_result: true", action.output)
+        self.assertIn("coverage: complete", action.output)
+
+    def test_read_large_text_uses_partial_bounded_display(self) -> None:
+        (self.workdir / "large.txt").write_text("".join(f"line {index}\n" for index in range(300)), encoding="utf-8")
+
+        action = build_read_action("large.txt", workdir=self.workdir)
+
+        self.assertFalse(action.needs_model)
+        self.assertIn("coverage: partial", action.output)
+        self.assertIn("line_range: 1-100", action.output)
+
+    def test_read_pdf_reuses_existing_safe_reader(self) -> None:
+        with mock.patch("orbit.terminal.command_actions.read_pdf", return_value="pdf_text: true\ncontent:\nreport") as reader:
+            action = build_read_action("report.pdf", workdir=self.workdir)
+
+        reader.assert_called_once_with("report.pdf", arguments={}, workdir=self.workdir)
+        self.assertEqual(action.output, "pdf_text: true\ncontent:\nreport")
+        self.assertFalse(action.needs_model)
+
+    def test_read_url_and_optional_prompt_use_deterministic_fetch(self) -> None:
+        fetched = "status: ok\nurl: https://example.com/a\ntext_truncated: false\ntext:\nalpha"
+        with mock.patch("orbit.terminal.command_actions.execute_fetch_url", return_value=fetched) as fetch:
+            action = build_read_action("https://example.com/a explain risks", workdir=self.workdir)
+
+        fetch.assert_called_once_with({"url": "https://example.com/a"})
+        self.assertTrue(action.needs_model)
+        self.assertEqual(action.prompt, "explain risks")
+        self.assertEqual(action.evidence.content, fetched)
+
+    def test_read_local_prompt_uses_full_document_admission(self) -> None:
+        (self.workdir / "notes.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+
+        action = build_read_action("notes.txt summarize the risks", workdir=self.workdir)
+
+        self.assertTrue(action.needs_model)
+        self.assertEqual(action.full_document_path, "notes.txt")
+        self.assertIsNone(action.evidence)
+
+    def test_search_web_is_deterministic_without_optional_prompt(self) -> None:
+        with mock.patch("orbit.terminal.command_actions.search_web", return_value="web_search_results: true\nresults: none") as search:
+            action = build_search_action('"CVE"', workdir=self.workdir)
+
+        search.assert_called_once_with("CVE")
+        self.assertFalse(action.needs_model)
+        self.assertIn("web_search_results: true", action.output)
+
+    def test_search_local_file_scans_complete_snapshot(self) -> None:
+        (self.workdir / "report.txt").write_text("zero\nCVE-2026-0001\nlast\n", encoding="utf-8")
+
+        action = build_search_action('"CVE" report.txt', workdir=self.workdir)
+
+        self.assertFalse(action.needs_model)
+        self.assertIn("scan_coverage=complete", action.output)
+        self.assertIn("CVE-2026-0001", action.output)
+
+    def test_search_pdf_reuses_existing_safe_pdf_command_path(self) -> None:
+        evidence = "shell_output_pdf_text: true\npath: report.pdf\ncontent:\n1:CVE"
+        with mock.patch("orbit.terminal.command_actions.execute_exec_shell_full_command", return_value=evidence) as execute:
+            action = build_search_action('"CVE" report.pdf', workdir=self.workdir)
+
+        execute.assert_called_once_with(
+            {"command": "pdftotext report.pdf - | rg -e CVE"},
+            workdir=self.workdir,
+            user_prompt="search exactly for 'CVE' in report.pdf",
+        )
+        self.assertEqual(action.output, evidence)
+        self.assertFalse(action.needs_model)
+
+    def test_search_pdf_filters_extracted_text_literally(self) -> None:
+        (self.workdir / "report.pdf").write_bytes(b"%PDF-1.4\n")
+        with mock.patch(
+            "orbit.runtime.shell_guardrails.extract_pdf_text",
+            return_value=("alpha\nCVE[1] match\nomega\n", "test"),
+        ):
+            action = build_search_action('"CVE[1]" report.pdf', workdir=self.workdir)
+
+        self.assertIn("CVE[1] match", action.output)
+        self.assertNotIn("alpha", action.output)
+        self.assertNotIn("omega", action.output)
+
+    def test_search_url_searches_retrieved_page_not_the_web_again(self) -> None:
+        fetched = "status: ok\nurl: https://example.com\ntext_truncated: false\ntext:\nfirst\nCVE match\nlast"
+        with (
+            mock.patch("orbit.terminal.command_actions.execute_fetch_url", return_value=fetched),
+            mock.patch("orbit.terminal.command_actions.search_web") as global_search,
+        ):
+            action = build_search_action('"CVE" https://example.com summarize matches', workdir=self.workdir)
+
+        global_search.assert_not_called()
+        self.assertTrue(action.needs_model)
+        self.assertEqual(action.prompt, "summarize matches")
+        self.assertIn("CVE match", action.evidence.content)
+        self.assertIn("retrieval_coverage=complete", action.evidence.content)
+        self.assertEqual(action.evidence.arguments, {"url": "https://example.com"})
+
+    def test_malformed_quotes_and_url_file_ambiguity_fail_closed(self) -> None:
+        malformed = build_search_action('"unterminated', workdir=self.workdir)
+        invalid_url = build_read_action("https:// summarize", workdir=self.workdir)
+
+        self.assertTrue(malformed.output.startswith("error:"))
+        self.assertIn("usage: /search", malformed.output)
+        self.assertTrue(invalid_url.output.startswith("error:"))
+        self.assertFalse(invalid_url.needs_model)
+
+    def test_list_directory_is_confined_and_uses_current_workdir_by_default(self) -> None:
+        (self.workdir / "a.txt").write_text("a", encoding="utf-8")
+
+        listing = build_list_action("", workdir=self.workdir)
+        escaped = build_list_action("../", workdir=self.workdir)
+
+        self.assertIn("directory_listing: path=.", listing.output)
+        self.assertIn("[file] a.txt", listing.output)
+        self.assertIn("status=path_outside_workdir", escaped.output)
+        self.assertFalse(listing.needs_model)
+
+    def test_read_and_search_path_traversal_fail_closed(self) -> None:
+        outside = self.workdir.parent / f"{self.workdir.name}-outside.txt"
+        outside.write_text("CVE", encoding="utf-8")
+        self.addCleanup(outside.unlink)
+
+        relative = f"../{outside.name}"
+        read = build_read_action(relative, workdir=self.workdir)
+        search = build_search_action(f'"CVE" {relative}', workdir=self.workdir)
+
+        self.assertTrue(read.output.startswith("error:"))
+        self.assertTrue(search.output.startswith("error:"))
+        self.assertFalse(read.needs_model)
+        self.assertFalse(search.needs_model)
+
+    def test_models_reuses_verified_discovery_output_without_loading_weights(self) -> None:
+        discovered = ModelDiscoveryResult(
+            rows=(ModelDiscoveryRow("Qwen3-Coder 30B-A3B", "AVAILABLE", "VERIFIED", "/models/qwen.gguf", "qwen"),),
+            wall_ms=2.0,
+            filesystem_scans=2,
+            metadata_inspections=1,
+        )
+        with (
+            mock.patch("orbit.terminal.command_actions.resolve_native_build_bin", return_value=Path("/native")),
+            mock.patch("orbit.terminal.command_actions.discover_models", return_value=discovered) as discover,
+        ):
+            action = build_models_action("")
+
+        discover.assert_called_once_with(build_bin=Path("/native"))
+        self.assertIn("AVAILABLE", action.output)
+        self.assertIn("VERIFIED", action.output)
+        self.assertFalse(action.needs_model)
+
+    def test_acquired_evidence_uses_exactly_one_normal_answer_path(self) -> None:
+        backend = AnswerBackend()
+        evidence_store = EvidenceStore(self.workdir / "evidence")
+        runtime = ChatRuntime(backend=backend, evidence_store=evidence_store)
+        evidence = AcquiredEvidence(
+            tool_name="fetch_url",
+            arguments={"url": "https://example.com"},
+            content="status: ok\nurl: https://example.com\ntext:\nexact evidence",
+            source="https://example.com",
+        )
+
+        result = runtime.answer_from_acquired_evidence(
+            "explain the evidence",
+            evidence=evidence,
+            workdir=self.workdir,
+            temperature=0.0,
+            max_tokens=128,
+        )
+
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertEqual(backend.calls, 1)
+        self.assertTrue(any(message.get("role") == "tool" for message in runtime.messages))
+        self.assertEqual(runtime.messages[-1]["role"], "assistant")
+
+    def test_optional_search_prompt_composes_with_one_model_call(self) -> None:
+        (self.workdir / "report.txt").write_text("CVE-2026-0001\n", encoding="utf-8")
+        action = build_search_action('"CVE" report.txt summarize matches', workdir=self.workdir)
+        backend = AnswerBackend()
+        runtime = ChatRuntime(backend=backend, evidence_store=EvidenceStore(self.workdir / "evidence"))
+
+        result = runtime.answer_from_acquired_evidence(
+            action.prompt,
+            evidence=action.evidence,
+            workdir=self.workdir,
+            temperature=0.0,
+            max_tokens=128,
+        )
+
+        self.assertEqual(result.finish_reason, "stop")
+        self.assertEqual(backend.calls, 1)
+        tool_call = next(message for message in runtime.messages if message.get("tool_calls"))
+        self.assertIn('"command":"rg -n -F -- CVE report.txt"', tool_call["tool_calls"][0]["function"]["arguments"])
+
+    def test_optional_prompt_failure_discards_acquired_evidence(self) -> None:
+        class FailingBackend(AnswerBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                raise TimeoutError("timed out")
+
+        store = EvidenceStore(self.workdir / "evidence")
+        runtime = ChatRuntime(backend=FailingBackend(), evidence_store=store)
+        evidence = AcquiredEvidence(
+            "fetch_url",
+            {"url": "https://example.com"},
+            "status: ok\ntext:\nexact",
+            "https://example.com",
+        )
+
+        with self.assertRaises(TimeoutError):
+            runtime.answer_from_acquired_evidence(
+                "summarize",
+                evidence=evidence,
+                workdir=self.workdir,
+                temperature=0.0,
+                max_tokens=128,
+            )
+
+        self.assertEqual(store.records, {})
+        self.assertEqual(runtime.messages, [])
+
+    def test_optional_prompt_interrupt_discards_acquired_evidence(self) -> None:
+        class InterruptedBackend(AnswerBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                raise KeyboardInterrupt
+
+        store = EvidenceStore(self.workdir / "evidence")
+        runtime = ChatRuntime(backend=InterruptedBackend(), evidence_store=store)
+
+        with self.assertRaises(KeyboardInterrupt):
+            runtime.answer_from_acquired_evidence(
+                "summarize",
+                evidence=AcquiredEvidence(
+                    "fetch_url",
+                    {"url": "https://example.com"},
+                    "status: ok\ntext:\nexact",
+                    "https://example.com",
+                ),
+                workdir=self.workdir,
+                temperature=0.0,
+                max_tokens=128,
+            )
+
+        self.assertEqual(store.records, {})
+        self.assertEqual(runtime.messages, [])
+
+    def test_optional_prompt_cancel_discards_acquired_evidence(self) -> None:
+        class CancelledBackend(AnswerBackend):
+            def chat(self, messages, *, temperature, max_tokens, tools=None):
+                return ChatResult("cancelled", "fake", "cancelled", [], 10, 0, 0, None, None)
+
+        store = EvidenceStore(self.workdir / "evidence")
+        runtime = ChatRuntime(backend=CancelledBackend(), evidence_store=store)
+        result = runtime.answer_from_acquired_evidence(
+            "summarize",
+            evidence=AcquiredEvidence(
+                "fetch_url",
+                {"url": "https://example.com"},
+                "status: ok\ntext:\nx",
+                "url",
+            ),
+            workdir=self.workdir,
+            temperature=0.0,
+            max_tokens=128,
+        )
+
+        self.assertEqual(result.finish_reason, "cancelled")
+        self.assertEqual(store.records, {})
+        self.assertEqual(runtime.messages, [])
+
+    def test_one_shot_dispatch_uses_registry_and_plain_deterministic_action(self) -> None:
+        (self.workdir / "a.txt").write_text("a", encoding="utf-8")
+        config = mock.Mock(workdir=self.workdir)
+
+        result = cli._handle_one_shot_command("/ls", mock.Mock(), config, mock.Mock())
+
+        self.assertFalse(result.needs_model)
+        self.assertNotIn("\x1b", result.output)
+        self.assertNotIn("\r", result.output)
+
+    def test_oversized_full_document_command_fails_closed_without_model_call(self) -> None:
+        (self.workdir / "large.txt").write_text("x" * 20_000, encoding="utf-8")
+        backend = AnswerBackend(prompt_tokens=8000, context_tokens=8192)
+        runtime = ChatRuntime(backend=backend)
+
+        result = runtime.answer_full_document_command(
+            "summarize all of it",
+            path="large.txt",
+            workdir=self.workdir,
+            temperature=0.0,
+            max_tokens=512,
+        )
+
+        self.assertEqual(backend.calls, 0)
+        self.assertIn("Document coverage: none", result.content)
+        self.assertIn("requires at least", result.content)
+
+    def test_fit_full_document_command_uses_one_model_call_and_complete_coverage(self) -> None:
+        (self.workdir / "small.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+        backend = AnswerBackend(prompt_tokens=100, context_tokens=8192)
+        runtime = ChatRuntime(backend=backend)
+
+        result = runtime.answer_full_document_command(
+            "summarize it",
+            path="small.txt",
+            workdir=self.workdir,
+            temperature=0.0,
+            max_tokens=128,
+        )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("Document coverage: complete", result.content)
+        self.assertIn("complete answer", result.content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds one typed registry for slash-command metadata, help, dispatch, and future prefix filtering
- adds deterministic `/read`, `/search`, `/ls`, and `/models` commands
- reuses existing document, web, directory, discovery, evidence, and full-document safeguards
- optional prompts use exactly one existing normal answer path after deterministic acquisition
- preserves existing slash commands and adds no dependency, second tool loop, or progress-telemetry changes

## Review fixes

- filters extracted PDF text literally instead of returning the complete extracted document
- discards acquired evidence on `KeyboardInterrupt` as well as errors, timeout, and cancellation

## Validation

- slash commands: 24/24 PASS
- affected terminal/runtime/document/profile suites: 667 PASS, 2 expected skips
- full discovery: 1,792 PASS, 6 expected skips
- compileall PASS
- diff check PASS
