### PR TITLE
Add live CLI progress telemetry

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -27,6 +27,11 @@ class StreamProgress:
     current: int
     total: int
     percent: int
+    evaluated_current: int | None = None
+    evaluated_total: int | None = None
+    cached_tokens: int | None = None
+    elapsed_seconds: float | None = None
+    tokens_per_second: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from dataclasses import replace
 from typing import Any, Callable
@@ -602,6 +603,11 @@ def _parse_native_stream(
                 current=_int_or_none(data.get("current")) or 0,
                 total=_int_or_none(data.get("total")) or 0,
                 percent=_int_or_none(data.get("percent")) or 0,
+                evaluated_current=_nonnegative_int_or_none(data.get("evaluated_current")),
+                evaluated_total=_nonnegative_int_or_none(data.get("evaluated_total")),
+                cached_tokens=_nonnegative_int_or_none(data.get("cached_tokens")),
+                elapsed_seconds=_finite_nonnegative_float_or_none(data.get("elapsed_seconds")),
+                tokens_per_second=_finite_nonnegative_float_or_none(data.get("tokens_per_second")),
             )
             on_progress(progress)
         elif current_event == "tool_calls":
@@ -894,6 +900,17 @@ def _int_or_none(value: object) -> int | None:
 
 def _float_or_none(value: object) -> float | None:
     return float(value) if isinstance(value, int | float) else None
+
+
+def _nonnegative_int_or_none(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _finite_nonnegative_float_or_none(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    parsed = _float_or_none(value)
+    return parsed if parsed is not None and math.isfinite(parsed) and parsed >= 0 else None
 
 
 def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -25,7 +25,7 @@ from .bindings import (
 )
 from .chat_bridge import chat_bridge_filename
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
-from .events import NativeCompletion, NativeProgress, NativeTimings
+from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .model_profiles import QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID, NativeModelProfile, detect_native_model_profile
@@ -196,6 +196,31 @@ class NativeRoutePrefixPrefillResult:
             "session_history_touched": self.session_history_touched,
             "restore_ready": self.restore_ready,
         }
+
+
+def _measured_progress(
+    phase: NativePhase,
+    current: int,
+    total: int,
+    *,
+    elapsed_us: int,
+    evaluated_current: int | None = None,
+    evaluated_total: int | None = None,
+    cached_tokens: int | None = None,
+) -> NativeProgress:
+    elapsed_seconds = max(0.0, elapsed_us / 1_000_000.0)
+    rate_tokens = evaluated_current if evaluated_current is not None else current
+    rate = rate_tokens / elapsed_seconds if rate_tokens > 0 and elapsed_seconds > 0 else None
+    return NativeProgress(
+        phase=phase,
+        current=current,
+        total=total,
+        evaluated_current=evaluated_current,
+        evaluated_total=evaluated_total,
+        cached_tokens=cached_tokens,
+        elapsed_seconds=elapsed_seconds,
+        tokens_per_second=rate,
+    )
 
 
 def _resolve_mtmd_bridge_path(paths: NativeLlamaPaths) -> Path | None:
@@ -1697,9 +1722,19 @@ class NativeLlamaClient:
             processed_tokens = 0
             n_chunks = int(mtmd.orbit_mtmd_chunks_size(chunks))
             n_past = llama_pos(0)
-            if on_progress:
-                on_progress(NativeProgress("prefill", 0, max(1, total_tokens)))
             pf_start = lib.llama_time_us()
+            if on_progress:
+                on_progress(
+                    _measured_progress(
+                        "prefill",
+                        0,
+                        total_tokens,
+                        elapsed_us=0,
+                        evaluated_current=0,
+                        evaluated_total=total_tokens,
+                        cached_tokens=0,
+                    )
+                )
             for idx in range(n_chunks):
                 if should_cancel and should_cancel():
                     self.cancel()
@@ -1721,7 +1756,18 @@ class NativeLlamaClient:
                 n_past = new_n_past
                 processed_tokens += int(mtmd.orbit_mtmd_chunk_token_count(chunk))
                 if on_progress:
-                    on_progress(NativeProgress("prefill", min(processed_tokens, total_tokens), max(1, total_tokens)))
+                    current = min(processed_tokens, total_tokens)
+                    on_progress(
+                        _measured_progress(
+                            "prefill",
+                            current,
+                            total_tokens,
+                            elapsed_us=lib.llama_time_us() - pf_start,
+                            evaluated_current=current,
+                            evaluated_total=total_tokens,
+                            cached_tokens=0,
+                        )
+                    )
             pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
             if self.cancel_event.is_set():
                 return NativeTimings(
@@ -2063,7 +2109,18 @@ class NativeLlamaClient:
             else reused
         )
         if on_progress:
-            on_progress(NativeProgress("prefill", processed, n_prompt))
+            evaluated_current = max(0, processed - reused)
+            on_progress(
+                _measured_progress(
+                    "prefill",
+                    processed,
+                    n_prompt,
+                    elapsed_us=0,
+                    evaluated_current=evaluated_current,
+                    evaluated_total=max(0, n_prompt - reused),
+                    cached_tokens=reused,
+                )
+            )
         token_array = (llama_token * n_prompt)(*prompt_tokens)
         while processed < n_prompt and not self.cancel_event.is_set():
             processed = self._decode_prompt_range(
@@ -2074,6 +2131,8 @@ class NativeLlamaClient:
                 total=n_prompt,
                 on_progress=on_progress,
                 should_cancel=should_cancel,
+                reused=reused,
+                started_us=pf_start,
             )
         pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
         generated, gen_ms, cancelled = self._generate_from_current_context(
@@ -2125,6 +2184,8 @@ class NativeLlamaClient:
         total: int,
         on_progress=None,
         should_cancel=None,
+        reused: int = 0,
+        started_us: int | None = None,
     ) -> int:
         if not self._session.ctx_tgt:
             raise RuntimeError("native client not loaded")
@@ -2140,7 +2201,19 @@ class NativeLlamaClient:
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
             processed += n
             if on_progress:
-                on_progress(NativeProgress("prefill", processed, total))
+                evaluated_current = max(0, processed - reused)
+                elapsed_us = max(0, lib.llama_time_us() - started_us) if started_us is not None else 0
+                on_progress(
+                    _measured_progress(
+                        "prefill",
+                        processed,
+                        total,
+                        elapsed_us=elapsed_us,
+                        evaluated_current=evaluated_current,
+                        evaluated_total=max(0, total - reused),
+                        cached_tokens=reused,
+                    )
+                )
             if decode_rc != 0:
                 if decode_rc == 2 and self.cancel_event.is_set():
                     break
@@ -3197,7 +3270,14 @@ class NativeLlamaClient:
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
             generated += 1
             if on_progress:
-                on_progress(NativeProgress("generation", generated, max_tokens))
+                on_progress(
+                    _measured_progress(
+                        "generation",
+                        generated,
+                        max_tokens,
+                        elapsed_us=lib.llama_time_us() - gen_start,
+                    )
+                )
             if decode_rc != 0:
                 if decode_rc == 2 and self.cancel_event.is_set():
                     break

--- a/src/orbit/native_llama/events.py
+++ b/src/orbit/native_llama/events.py
@@ -12,6 +12,11 @@ class NativeProgress:
     phase: NativePhase
     current: int
     total: int
+    evaluated_current: int | None = None
+    evaluated_total: int | None = None
+    cached_tokens: int | None = None
+    elapsed_seconds: float | None = None
+    tokens_per_second: float | None = None
 
     @property
     def percent(self) -> int:

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -69,6 +69,26 @@ PREFIX_PREWARM_STARTUP = "startup"
 TOOLS_ENV = "ORBIT_TOOLS"
 
 
+def _progress_payload(progress: Any, *, session_id: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "current": progress.current,
+        "total": progress.total,
+        "percent": progress.percent,
+        "session_id": session_id,
+    }
+    for field in (
+        "evaluated_current",
+        "evaluated_total",
+        "cached_tokens",
+        "elapsed_seconds",
+        "tokens_per_second",
+    ):
+        value = getattr(progress, field, None)
+        if value is not None:
+            payload[field] = value
+    return payload
+
+
 class OrbitNativeServer:
     def __init__(self, *, client: NativeLlamaClient, model_alias: str) -> None:
         self.client = client
@@ -590,12 +610,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
         def on_progress(progress) -> None:
             emit(
                 f"progress.{progress.phase}",
-                {
-                    "current": progress.current,
-                    "total": progress.total,
-                    "percent": progress.percent,
-                    "session_id": request.session_id,
-                },
+                _progress_payload(progress, session_id=request.session_id),
             )
 
         try:
@@ -655,12 +670,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
         def on_progress(progress) -> None:
             emit(
                 f"progress.{progress.phase}",
-                {
-                    "current": progress.current,
-                    "total": progress.total,
-                    "percent": progress.percent,
-                    "session_id": DEFAULT_SESSION_ID,
-                },
+                _progress_payload(progress, session_id=DEFAULT_SESSION_ID),
             )
 
         try:

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -28,7 +28,7 @@ from orbit.terminal.session_selection import select_interactive_session
 from orbit.terminal.status import TokenUsageAccumulator, estimate_context_status_tokens, format_turn_status, summarize_turn_token_usage
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.theme import dim, runtime_error_text, warning_text
-from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
+from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import allowed_tool_names_for_spec, tools_are_enabled
 
 
@@ -303,7 +303,7 @@ def _run_one_shot(
                 on_model_step=record_model_step,
                 on_tool_call=lambda name, args: renderer.event(
                     format_tool_call_event(name, args),
-                    next_activity=("tool", name),
+                    next_activity=("tool", format_tool_activity_label(name, args)),
                 ),
                 on_tool_result=lambda name, chars, source, content: _show_tool_result(
                     renderer,

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -31,7 +31,7 @@ from orbit.terminal.status import (
     summarize_turn_token_usage,
 )
 from orbit.terminal.streaming import StreamRenderer
-from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
+from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
 from orbit.terminal.theme import dim, runtime_error_text
 from orbit.runtime.thinking_mode import ThinkingMode
@@ -172,7 +172,7 @@ class Repl:
                     on_progress=renderer.progress,
                     on_tool_call=lambda name, args: renderer.event(
                         format_tool_call_event(name, args),
-                        next_activity=("tool", name),
+                        next_activity=("tool", format_tool_activity_label(name, args)),
                     ),
                     on_tool_result=lambda name, chars, source, content: self._show_tool_result(renderer, name, chars, source, content),
                     on_model_step=self._record_model_step,

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import math
 import re
 import sys
 import threading
 import time
+from dataclasses import dataclass
 
 from orbit.backend.base import StreamProgress
 from orbit.terminal.theme import CYAN, DIM, RESET, dim, is_tty, supports_ansi
@@ -15,6 +17,14 @@ MARKDOWN_BOLD = "\033[1m"
 MARKDOWN_BOLD_OFF = "\033[22m"
 MARKDOWN_ITALIC = "\033[3m"
 MARKDOWN_ITALIC_OFF = "\033[23m"
+
+
+@dataclass(frozen=True)
+class WorkProgress:
+    phase: str
+    current: int
+    total: int
+    unit: str
 
 
 class StreamRenderer:
@@ -42,9 +52,7 @@ class StreamRenderer:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._start_time = 0.0
-        self._progress: StreamProgress | None = None
-        self._generation_completed = 0
-        self._generation_budget_completed = 0
+        self._progress: StreamProgress | WorkProgress | None = None
         self._thinking_started = False
         self._thinking_final_started = False
         self._thinking_dim_open = False
@@ -98,16 +106,14 @@ class StreamRenderer:
         self._start_time = time.monotonic()
         self._first_delta = False
         self._progress = None
-        self._generation_completed = 0
-        self._generation_budget_completed = 0
         if not self._interactive or not self._started:
             return
         self._timer_active = True
         self._thread = threading.Thread(target=self._run_wait_timer, daemon=True)
         self._thread.start()
 
-    def progress(self, update: StreamProgress) -> None:
-        self._progress = self._normalize_progress(update)
+    def progress(self, update: StreamProgress | WorkProgress) -> None:
+        self._progress = update
         if self._interactive and self._started and not self._first_delta:
             self._render_wait_line()
 
@@ -180,8 +186,14 @@ class StreamRenderer:
 
     def _render_wait_line(self) -> None:
         elapsed = time.monotonic() - self._start_time
-        detail = self._phase_label or self._progress_phase_label() or "working"
-        line = dim(_fit_activity_line(self._activity_kind, detail, format_elapsed(elapsed)))
+        detail = self._progress_activity_detail() or self._phase_label or "working"
+        progress_elapsed = getattr(self._progress, "elapsed_seconds", None)
+        shown_elapsed = (
+            progress_elapsed
+            if self._progress is not None and self._progress.phase == "generation" and _valid_metric(progress_elapsed)
+            else elapsed
+        )
+        line = dim(_fit_activity_line(self._activity_kind, detail, format_elapsed(shown_elapsed)))
         print(f"\r{_pad_to_terminal_width(line)}", end="", flush=True)
 
     @staticmethod
@@ -196,6 +208,7 @@ class StreamRenderer:
     def set_phase_label(self, label: str | None) -> None:
         self._activity_kind = "model"
         self._phase_label = label.strip() if label else None
+        self._progress = None
 
     def set_activity(self, kind: str, label: str | None = None) -> None:
         self._activity_kind = kind.strip() or "model"
@@ -206,29 +219,11 @@ class StreamRenderer:
             return
         self._thinking_filter.start_final_output()
 
-    def _normalize_progress(self, update: StreamProgress) -> StreamProgress:
-        if update.phase != "generation":
-            return update
-        if self._progress is not None and self._progress.phase == "generation":
-            previous_current = self._progress.current - self._generation_completed
-            previous_total = self._progress.total - self._generation_budget_completed
-            if update.current < previous_current:
-                self._generation_completed += max(0, previous_current)
-                self._generation_budget_completed += max(0, previous_total)
-        current = self._generation_completed + update.current
-        total = self._generation_budget_completed + update.total
-        percent = int((current / total) * 100) if total > 0 else 0
-        return StreamProgress(phase=update.phase, current=current, total=total, percent=percent)
-
     def _working_status(self, elapsed: float) -> str:
         parts = [format_elapsed(elapsed)]
-        if self._progress is not None:
-            if self._progress.phase == "prefill":
-                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
-            elif self._progress.phase == "generation":
-                parts.append(f"{self._progress.current}/{self._progress.total} tk ({self._progress.percent}%)")
-            else:
-                parts.append(f"{self._progress.current}/{self._progress.total} ({self._progress.percent}%)")
+        detail = self._progress_activity_detail()
+        if detail is not None:
+            parts.append(detail)
             return ", ".join(parts)
         if self._prefill_estimate_seconds and self._prefill_estimate_seconds >= 1:
             progress = max(1, int((elapsed / self._prefill_estimate_seconds) * 100))
@@ -262,14 +257,63 @@ class StreamRenderer:
             return "prefill estimate"
         return None
 
-    def _progress_phase_label(self) -> str | None:
+    def _progress_activity_detail(self) -> str | None:
         if self._progress is None:
             return None
-        if self._progress.phase == "prefill":
-            return "prefill"
-        if self._progress.phase == "generation":
-            return "generation"
-        return self._progress.phase
+        progress = self._progress
+        if isinstance(progress, WorkProgress):
+            current = _valid_count(progress.current)
+            total = _valid_count(progress.total)
+            if current is None or total is None or total <= 0 or current > total:
+                return progress.phase
+            quantity = _format_progress_quantity(current, total, progress.unit)
+            return f"{progress.phase} · {_percent(current, total)}% · {quantity}"
+        if progress.phase == "prefill":
+            current = _valid_count(progress.evaluated_current)
+            total = _valid_count(progress.evaluated_total)
+            if current is None or total is None or total <= 0 or current > total:
+                return "prefill"
+            parts = ["prefill", f"{_percent(current, total)}%", f"{current}/{total} eval"]
+            cached = _valid_count(progress.cached_tokens)
+            if cached is not None:
+                parts.append(f"{cached} cached")
+            rate = _format_rate(progress.tokens_per_second)
+            if rate is not None:
+                parts.append(f"{rate} tok/s")
+            return " · ".join(parts)
+        if progress.phase == "generation":
+            current = _valid_count(progress.current)
+            parts = ["generating", f"{current} tok"] if current is not None else ["generating"]
+            rate = _format_rate(progress.tokens_per_second)
+            if rate is not None:
+                parts.append(f"{rate} tok/s")
+            return " · ".join(parts)
+        return progress.phase
+
+
+def _valid_count(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _valid_metric(value: object) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(float(value)) and value >= 0
+
+
+def _format_rate(value: object) -> str | None:
+    return f"{float(value):.1f}" if _valid_metric(value) else None
+
+
+def _percent(current: int, total: int) -> int:
+    return min(100, max(0, int(round((current / total) * 100)))) if total > 0 else 0
+
+
+def _format_progress_quantity(current: int, total: int, unit: str | None) -> str:
+    if unit == "bytes":
+        divisor, label = (1024 * 1024, "MB") if total >= 1024 * 1024 else (1024, "KB")
+        return f"{current / divisor:.1f}/{total / divisor:.1f} {label}"
+    if unit:
+        return f"{current}/{total} {unit}"
+    return f"{current}/{total}"
 
 
 def _terminal_columns() -> int:

--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -59,6 +59,17 @@ def format_tool_call_event(name: str, args: str) -> str:
     return f"› {display_tool_name(name)}{detail}"
 
 
+def format_tool_activity_label(name: str, args: str) -> str:
+    if name == "exec_shell_full_command":
+        return _command_from_args(args) or name
+    if name == "fetch_url":
+        return _url_from_args(args) or name
+    if name == "list_directory":
+        path, _recursive = _list_directory_from_args(args)
+        return path or name
+    return display_tool_name(name)
+
+
 def format_tool_result_event(name: str, chars: int, source: str | None = None, content: str | None = None) -> str:
     del source
     preview = _tool_result_preview(content)

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -1292,13 +1292,13 @@ class LlamaServerBackendTests(unittest.TestCase):
             FakeStream(
                 [
                     'event: progress.prefill\n',
-                    'data: {"current":243,"total":935,"percent":25}\n',
+                    'data: {"current":1011,"total":1703,"percent":59,"evaluated_current":243,"evaluated_total":935,"cached_tokens":768,"elapsed_seconds":7.75,"tokens_per_second":31.4}\n',
                     '\n',
                     'event: delta\n',
                     'data: {"text":"hel"}\n',
                     '\n',
                     'event: progress.generation\n',
-                    'data: {"current":1,"total":32,"percent":3}\n',
+                    'data: {"current":1,"total":32,"percent":3,"elapsed_seconds":0.2,"tokens_per_second":5.0}\n',
                     '\n',
                     'event: delta\n',
                     'data: {"text":"lo"}\n',
@@ -1312,11 +1312,16 @@ class LlamaServerBackendTests(unittest.TestCase):
                 ]
             ),
             on_delta=emitted.append,
-            on_progress=lambda item: progress.append((item.phase, item.current, item.total, item.percent)),
+            on_progress=progress.append,
         )
 
         self.assertEqual(emitted, ["hel", "lo"])
-        self.assertEqual(progress, [("prefill", 243, 935, 25), ("generation", 1, 32, 3)])
+        self.assertEqual((progress[0].evaluated_current, progress[0].evaluated_total), (243, 935))
+        self.assertEqual(progress[0].cached_tokens, 768)
+        self.assertEqual(progress[0].tokens_per_second, 31.4)
+        self.assertEqual(progress[1].current, 1)
+        self.assertEqual(progress[1].elapsed_seconds, 0.2)
+        self.assertEqual(progress[1].tokens_per_second, 5.0)
         self.assertEqual(result.content, "hello")
         self.assertEqual(result.finish_reason, "stop")
         self.assertEqual(result.prompt_tokens, 935)
@@ -1324,6 +1329,30 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertEqual(result.cached_tokens, 12)
         self.assertEqual(result.prompt_tokens_per_second, 14.7)
         self.assertEqual(result.generation_tokens_per_second, 3.2)
+
+    def test_parse_native_stream_drops_nonfinite_or_invalid_live_metrics(self) -> None:
+        progress = []
+
+        _parse_native_stream(
+            FakeStream(
+                [
+                    'event: progress.prefill\n',
+                    'data: {"current":1,"total":2,"percent":50,"evaluated_current":true,"evaluated_total":2,"cached_tokens":-1,"elapsed_seconds":NaN,"tokens_per_second":true}\n',
+                    '\n',
+                    'event: done\n',
+                    'data: {"finish_reason":"stop"}\n',
+                    '\n',
+                ]
+            ),
+            on_delta=lambda _text: None,
+            on_progress=progress.append,
+        )
+
+        self.assertIsNone(progress[0].evaluated_current)
+        self.assertEqual(progress[0].evaluated_total, 2)
+        self.assertIsNone(progress[0].cached_tokens)
+        self.assertIsNone(progress[0].elapsed_seconds)
+        self.assertIsNone(progress[0].tokens_per_second)
 
     def test_parse_native_stream_converts_raw_tool_call_and_suppresses_delta(self) -> None:
         emitted: list[str] = []

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from types import SimpleNamespace
 
+from orbit.native_llama.events import NativeProgress
 from orbit.native_server.protocol import (
     DEFAULT_SESSION_ID,
     native_chat_response,
@@ -12,10 +13,30 @@ from orbit.native_server.protocol import (
     trim_at_stop,
     validate_session_id,
 )
-from orbit.native_server.app import _final_prefix_reuse_props, _tool_call_healing_props
+from orbit.native_server.app import _final_prefix_reuse_props, _progress_payload, _tool_call_healing_props
 
 
 class NativeServerProtocolTests(unittest.TestCase):
+    def test_progress_payload_preserves_authoritative_live_metrics(self) -> None:
+        progress = NativeProgress(
+            "prefill",
+            1280,
+            1581,
+            evaluated_current=512,
+            evaluated_total=813,
+            cached_tokens=768,
+            elapsed_seconds=16.3,
+            tokens_per_second=31.4,
+        )
+
+        payload = _progress_payload(progress, session_id="default")
+
+        self.assertEqual(payload["evaluated_current"], 512)
+        self.assertEqual(payload["evaluated_total"], 813)
+        self.assertEqual(payload["cached_tokens"], 768)
+        self.assertEqual(payload["elapsed_seconds"], 16.3)
+        self.assertEqual(payload["tokens_per_second"], 31.4)
+
     def test_tool_call_healing_props_are_bounded_and_default_enabled(self) -> None:
         props = _tool_call_healing_props()
 

--- a/tests/test_native_session_state.py
+++ b/tests/test_native_session_state.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _measured_progress
 from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.paths import NativeLlamaPaths
 from orbit.native_llama.session_state import DEFAULT_NATIVE_SESSION_ID
@@ -12,6 +12,14 @@ from orbit.native_server.app import OrbitNativeServer
 
 
 class NativeSessionStateTests(unittest.TestCase):
+    def test_measured_generation_progress_uses_generated_tokens_and_elapsed_time(self) -> None:
+        progress = _measured_progress("generation", 127, 512, elapsed_us=10_000_000)
+
+        self.assertEqual(progress.current, 127)
+        self.assertEqual(progress.total, 512)
+        self.assertEqual(progress.elapsed_seconds, 10.0)
+        self.assertEqual(progress.tokens_per_second, 12.7)
+
     def _paths(self) -> NativeLlamaPaths:
         return NativeLlamaPaths(
             llama_root=Path("/llama"),
@@ -115,7 +123,7 @@ class NativeSessionStateTests(unittest.TestCase):
     def test_complete_prompt_emits_initial_prefill_progress_from_reused_tokens(self, mocked_lib_class) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig())
         mocked_lib = mocked_lib_class.return_value.lib
-        mocked_lib.llama_time_us.side_effect = [0, 1000, 1000, 2000]
+        mocked_lib.llama_time_us.side_effect = [0, 1000, 1000, 2000, 3000]
         mocked_lib.llama_batch_get_one.return_value = object()
         mocked_lib.llama_decode.return_value = 0
 
@@ -124,16 +132,20 @@ class NativeSessionStateTests(unittest.TestCase):
         client._session.sampler = object()
         client.tokenize = mock.Mock(return_value=[1, 2, 3, 4])
         client._prepare_memory_for_prompt = mock.Mock(return_value=3)
-        progress: list[tuple[str, int, int, int]] = []
+        progress = []
 
         timings = client._complete_prompt_standard(
             "hello",
             max_tokens=0,
-            on_progress=lambda item: progress.append((item.phase, item.current, item.total, item.percent)),
+            on_progress=progress.append,
         )
 
-        self.assertEqual(progress[0], ("prefill", 3, 4, 75))
-        self.assertEqual(progress[1], ("prefill", 4, 4, 100))
+        self.assertEqual((progress[0].current, progress[0].total), (3, 4))
+        self.assertEqual((progress[0].evaluated_current, progress[0].evaluated_total), (0, 1))
+        self.assertEqual(progress[0].cached_tokens, 3)
+        self.assertEqual((progress[1].evaluated_current, progress[1].evaluated_total), (1, 1))
+        self.assertEqual(progress[1].cached_tokens, 3)
+        self.assertEqual(progress[1].tokens_per_second, 1000.0)
         self.assertEqual(timings.reused_prompt_tokens, 3)
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -36,7 +36,7 @@ from orbit.terminal.repl import Repl
 from orbit.terminal.repl import _phase_progress_label, _phase_starts_final_output, _prefill_profile_for_turn
 from orbit.terminal.session_preview import format_recent_session_messages
 from orbit.terminal.streaming import StreamRenderer
-from orbit.terminal.tool_events import format_tool_call_event, format_tool_result_event
+from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.prefill_estimator import CHAT_PREFILL_PROFILE, FINAL_FROM_TOOL_PREFILL_PROFILE, TOOL_PREFILL_PROFILE
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
@@ -328,6 +328,7 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(format_tool_result_event("read_file", 10000), "└ 10000 chars · large context")
         self.assertEqual(format_tool_result_event("read_file", 5, "orbit"), "└ 5 chars")
         self.assertEqual(format_tool_call_event("exec_shell_full_command", '{"command":"ls"}'), "› Read  ls")
+        self.assertEqual(format_tool_activity_label("exec_shell_full_command", '{"command":"pytest -q"}'), "pytest -q")
         self.assertEqual(format_tool_result_event("exec_shell_full_command", 45), "└ 45 chars")
         chunk_content = "\n".join(
             [

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -12,7 +12,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from orbit.terminal.streaming import StreamRenderer, _pad_to_terminal_width, _visible_len, format_elapsed
+from orbit.terminal.streaming import StreamRenderer, WorkProgress, _pad_to_terminal_width, _visible_len, format_elapsed
 from orbit.backend.base import StreamProgress
 
 
@@ -590,17 +590,28 @@ class StreamingRendererTests(unittest.TestCase):
     def test_wait_timer_includes_phase_label_in_real_progress_status(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.set_phase_label("forced final")
-        renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
+        renderer.progress(
+            StreamProgress(
+                phase="prefill",
+                current=1011,
+                total=1703,
+                percent=59,
+                evaluated_current=243,
+                evaluated_total=935,
+                cached_tokens=768,
+                tokens_per_second=31.4,
+            )
+        )
 
         self.assertEqual(renderer._working_phase_prefix(), " [forced final prefill]")
-        self.assertEqual(renderer._working_status(5), "5s, 243/935 tk (25%)")
+        self.assertEqual(renderer._working_status(5), "5s, prefill · 26% · 243/935 eval · 768 cached · 31.4 tok/s")
 
     def test_wait_timer_omits_repeated_generation_label_from_status(self) -> None:
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=51, total=256, percent=19))
 
         self.assertEqual(renderer._working_phase_prefix(), " [generation]")
-        self.assertEqual(renderer._working_status(30), "30s, 51/256 tk (19%)")
+        self.assertEqual(renderer._working_status(30), "30s, generating · 51 tok")
 
     def test_wait_timer_includes_generation_detail_in_phase_label(self) -> None:
         renderer = StreamRenderer()
@@ -611,9 +622,21 @@ class StreamingRendererTests(unittest.TestCase):
 
     def test_wait_timer_names_generation_progress_explicitly(self) -> None:
         renderer = StreamRenderer()
-        renderer.progress(StreamProgress(phase="generation", current=7, total=512, percent=1))
+        renderer.progress(
+            StreamProgress(
+                phase="generation",
+                current=7,
+                total=512,
+                percent=1,
+                elapsed_seconds=1.25,
+                tokens_per_second=5.6,
+            )
+        )
 
-        self.assertIn("7/512 tk (1%)", renderer._working_status(1))
+        status = renderer._working_status(1)
+        self.assertIn("generating · 7 tok · 5.6 tok/s", status)
+        self.assertNotIn("%", status)
+        self.assertNotIn("/512", status)
 
     def test_wait_timer_prints_prefill_finalizing_after_estimate(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10)
@@ -622,22 +645,78 @@ class StreamingRendererTests(unittest.TestCase):
 
     def test_wait_timer_prefers_real_prefill_progress_when_available(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
-        renderer.progress(StreamProgress(phase="prefill", current=243, total=935, percent=25))
+        renderer.progress(
+            StreamProgress(
+                phase="prefill",
+                current=1011,
+                total=1703,
+                percent=59,
+                evaluated_current=243,
+                evaluated_total=935,
+                cached_tokens=768,
+            )
+        )
 
-        self.assertIn("243/935 tk (25%)", renderer._working_status(5))
+        self.assertIn("prefill · 26% · 243/935 eval · 768 cached", renderer._working_status(5))
+
+    def test_prefill_progress_uses_authoritative_evaluated_work_from_zero_to_complete(self) -> None:
+        renderer = StreamRenderer()
+        for current, expected in ((0, "0%"), (512, "63%"), (813, "100%")):
+            renderer.progress(
+                StreamProgress(
+                    phase="prefill",
+                    current=768 + current,
+                    total=1581,
+                    percent=0,
+                    evaluated_current=current,
+                    evaluated_total=813,
+                    cached_tokens=768,
+                )
+            )
+            status = renderer._working_status(0)
+            self.assertIn(expected, status)
+            self.assertIn(f"{current}/813 eval", status)
+            self.assertIn("768 cached", status)
+
+    def test_prefill_progress_does_not_render_contradictory_work_as_percentage(self) -> None:
+        renderer = StreamRenderer()
+        renderer.progress(
+            StreamProgress(
+                phase="prefill",
+                current=20,
+                total=10,
+                percent=200,
+                evaluated_current=20,
+                evaluated_total=10,
+                cached_tokens=0,
+            )
+        )
+
+        self.assertEqual(renderer._working_status(0), "0s, prefill")
 
     def test_wait_timer_shows_real_generation_progress_when_available(self) -> None:
         renderer = StreamRenderer(prefill_estimate_seconds=10, prefill_estimate_tokens=1000)
         renderer.progress(StreamProgress(phase="generation", current=7, total=32, percent=21))
 
-        self.assertIn("7/32 tk (21%)", renderer._working_status(5))
+        status = renderer._working_status(5)
+        self.assertIn("generating · 7 tok", status)
+        self.assertNotIn("21%", status)
 
-    def test_wait_timer_accumulates_generation_across_continuation_passes(self) -> None:
+    def test_wait_timer_reports_current_generation_pass_without_budget_percentage(self) -> None:
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=32, total=32, percent=100))
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("33/160 tk (20%)", renderer._working_status(5))
+        self.assertEqual(renderer._working_status(5), "5s, generating · 1 tok")
+
+    def test_known_tool_progress_formats_bytes_and_lines_without_estimation(self) -> None:
+        renderer = StreamRenderer()
+        renderer.set_activity("tool", "read")
+        renderer.progress(WorkProgress(phase="reading", current=7_130_317, total=10_485_760, unit="bytes"))
+        self.assertEqual(renderer._working_status(0), "0s, reading · 68% · 6.8/10.0 MB")
+
+        renderer.progress(WorkProgress(phase="scanning", current=10_770, total=14_753, unit="lines"))
+        self.assertEqual(renderer._working_status(0), "0s, scanning · 73% · 10770/14753 lines")
 
     def test_first_progress_renders_immediately_before_timer_tick(self) -> None:
         stream = io.StringIO()
@@ -732,6 +811,35 @@ class StreamingRendererTests(unittest.TestCase):
             self.assertLessEqual(_visible_len(line), columns)
             self.assertIn("exec_shell_full_command", line)
 
+    def test_progress_line_fits_40_and_60_columns(self) -> None:
+        for columns in (40, 60):
+            stream = io.StringIO()
+            original = sys.stdout
+            try:
+                sys.stdout = stream
+                renderer = StreamRenderer(interactive=True)
+                renderer.progress(
+                    StreamProgress(
+                        phase="prefill",
+                        current=1280,
+                        total=1581,
+                        percent=80,
+                        evaluated_current=512,
+                        evaluated_total=813,
+                        cached_tokens=768,
+                        tokens_per_second=31.4,
+                    )
+                )
+                renderer._start_time = time.monotonic()
+                with mock.patch("orbit.terminal.streaming._terminal_columns", return_value=columns):
+                    renderer._render_wait_line()
+            finally:
+                sys.stdout = original
+
+            line = stream.getvalue().rsplit("\r", 1)[-1]
+            self.assertLessEqual(_visible_len(line), columns)
+            self.assertIn("prefill", line)
+
     def test_non_tty_is_plain_linear_and_keeps_markdown_literal(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
@@ -756,15 +864,68 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertNotIn("\033", output)
         self.assertNotIn("\r", output)
 
+    def test_non_tty_progress_is_byte_identical_across_repeated_runs(self) -> None:
+        def render_once() -> str:
+            stream = io.StringIO()
+            original = sys.stdout
+            try:
+                sys.stdout = stream
+                renderer = StreamRenderer(interactive=False)
+                renderer.start()
+                renderer.progress(
+                    StreamProgress(
+                        phase="prefill",
+                        current=1280,
+                        total=1581,
+                        percent=80,
+                        evaluated_current=512,
+                        evaluated_total=813,
+                        cached_tokens=768,
+                        elapsed_seconds=16.3,
+                        tokens_per_second=31.4,
+                    )
+                )
+                renderer.progress(
+                    StreamProgress(
+                        phase="generation",
+                        current=12,
+                        total=128,
+                        percent=9,
+                        elapsed_seconds=1.0,
+                        tokens_per_second=12.0,
+                    )
+                )
+                renderer.write("answer\n")
+                renderer.finish()
+            finally:
+                sys.stdout = original
+            return stream.getvalue()
+
+        first = render_once()
+        second = render_once()
+        self.assertEqual(first, second)
+        self.assertEqual(first, "answer\n")
+        self.assertNotIn("\033", first)
+        self.assertNotIn("\r", first)
+
     def test_restart_timer_clears_previous_progress_state(self) -> None:
         renderer = StreamRenderer()
         renderer.progress(StreamProgress(phase="generation", current=6, total=32, percent=18))
 
-        self.assertIn("6/32 tk (18%)", renderer._working_status(5))
+        self.assertIn("generating · 6 tok", renderer._working_status(5))
 
         renderer._restart_timer()
 
-        self.assertNotIn("6/32 tk (18%)", renderer._working_status(0))
+        self.assertNotIn("generating · 6 tok", renderer._working_status(0))
+
+    def test_new_model_phase_clears_previous_call_progress(self) -> None:
+        renderer = StreamRenderer()
+        renderer.progress(StreamProgress(phase="generation", current=6, total=32, percent=18))
+
+        renderer.set_phase_label("final answer")
+
+        self.assertNotIn("generating", renderer._working_status(0))
+        self.assertEqual(renderer._working_phase_detail(), None)
 
     def test_restart_timer_clears_generation_accumulator(self) -> None:
         renderer = StreamRenderer()
@@ -774,7 +935,7 @@ class StreamingRendererTests(unittest.TestCase):
         renderer._restart_timer()
         renderer.progress(StreamProgress(phase="generation", current=1, total=128, percent=0))
 
-        self.assertIn("1/128 tk (0%)", renderer._working_status(0))
+        self.assertIn("generating · 1 tok", renderer._working_status(0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- adds authoritative live prefill progress with evaluated and cached token accounting
- adds generated-token, measured decode-rate and elapsed telemetry without a completion percentage
- reuses the single ephemeral TTY activity line for model and tool work
- keeps non-TTY output deterministic and free of ANSI/carriage-return progress
- preserves slash commands and Qwen3-Coder route-cache lifecycle behavior
- adds no model calls, prompt tokens, polling loops, locks or dependencies

Validation:
- focused telemetry/CLI/slash: 254/254 PASS
- native/profile: 364 PASS, 3 expected skips
- affected backend/route/terminal/tool/slash: 301 PASS, 2 expected skips
- full discovery: 1801 PASS, 6 expected skips
- compileall PASS
- diff check PASS
- real Qwen3-Coder TTY smoke PASS; post-tool simple chat restored 768 route tokens (834 input, 63 evaluated, 771 cached)
- real non-TTY smoke contained no ANSI or carriage returns

Scope:
- telemetry is observational only; runtime, routing, tools, prompts and inference semantics are unchanged.