### PR TITLE
Fix README model link and benchmark host

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Linux is the main target environment. macOS may work. Windows is not a target.
 |---|---:|---:|---:|---:|---:|
 | [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
 | [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
-| [Qwen3-Coder 30B-A3B](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
+| [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
 
-Measured on the author's Intel Core i7-10710U (6 cores / 12 threads) with 64 GB RAM, no GPU, Linux, llama.cpp b9551, `ctx=8192`, 6 threads, batch/ubatch 256/128, Flash Attention AUTO, thinking off, and MTP off.
+NUC10 Intel Core i7-10710U (6 cores / 12 threads) with 64 GB RAM, no GPU
+Linux, llama.cpp b9551, ctx=8192, 6 threads, batch/ubatch 256/128, Flash Attention AUTO, thinking off, and MTP off.
 
 Chat and tool latencies are warm steady-state medians after one excluded warm-up. Prefill measures evaluated tokens only and excludes cache benefit. These are not universal performance claims; actual results vary with CPU, memory bandwidth, quantization, backend build, and workload.
 


### PR DESCRIPTION
## Summary
- points Qwen3-Coder to the verified GGUF repository
- identifies the benchmark host as a NUC10 and keeps the exact runtime configuration
- documentation only; benchmark values are unchanged

## Validation
- exact replacements verified
- git diff --check PASS