### PR TITLE
Add Qwen3-Coder low-memory mode

### DIFF
--- a/qualification/fixtures/workflows-v1.json
+++ b/qualification/fixtures/workflows-v1.json
@@ -45,7 +45,7 @@
         ]
       },
       "request": {
-        "prompt": "Inspect settings.ini, then change mode to production and retries to 5. Limit the change scope to those two values in settings.ini while preserving its section, ordering, newline, and every other byte. notes.txt is a reference input whose hash is checked by qualification. Verify the resulting file before answering.",
+        "prompt": "Inspect settings.ini, then change mode to production and retries to 5. Limit the change scope to those two values in settings.ini while preserving its section, ordering, newline, and every other byte. notes.txt is a reference input whose hash is checked by qualification. Verify the resulting file before answering. No backup file may remain when you answer.",
         "tools": true
       },
       "expect": {
@@ -56,7 +56,7 @@
             {"path": "settings.ini", "content": "[service]\nmode=production\nretries=5\n"}
           ],
           "unchanged_files": ["notes.txt"],
-          "max_tool_calls": 7,
+          "max_tool_calls": 8,
           "timeout_seconds": 900
         }
       },

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -30,6 +30,7 @@ from .expert_usage import summarize_expert_usage
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .model_profiles import QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID, NativeModelProfile, detect_native_model_profile
+from .model_discovery import inspect_native_model_profile
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
 from .mtp_accept_probe import MtpAcceptProbeResult, run_mtp_accept_probe
@@ -123,6 +124,7 @@ class NativeClientConfig:
     qwen3_coder_route_prefix_reuse_source: str = "default"
     qwen3_coder_route_prefix_reuse_config_error: str | None = None
     moe_expert_usage_enabled: bool = False
+    low_memory: bool = False
 
 
 @dataclass
@@ -249,6 +251,7 @@ class NativeLlamaClient:
         self.cancel_event = threading.Event()
         self._callbacks: list[object] = []
         self._model: c_void_p | None = None
+        self._cpu_repack_enabled: bool | None = None
         self._vocab: c_void_p | None = None
         self.model_profile: NativeModelProfile | None = None
         self.chat_bridge: ChatBridgeLibrary | None = None
@@ -421,6 +424,12 @@ class NativeLlamaClient:
         )
         return diagnostics
 
+    def model_load_status(self) -> dict[str, bool | None]:
+        return {
+            "low_memory": self.config.low_memory,
+            "cpu_repack": self._cpu_repack_enabled,
+        }
+
     def moe_expert_usage_status(self) -> dict[str, object]:
         base = {
             "enabled": self.config.moe_expert_usage_enabled,
@@ -530,10 +539,8 @@ class NativeLlamaClient:
         abort_cb = GgmlAbortCallback(lambda _data: self.cancel_event.is_set())
         self._callbacks.extend([progress_cb, abort_cb])
 
-        model_params = lib.llama_model_default_params()
+        model_params = self._model_load_params(progress_cb)
         model_params.n_gpu_layers = self.config.gpu_layers
-        model_params.progress_callback = progress_cb
-        model_params.progress_callback_user_data = None
 
         self._model = lib.llama_model_load_from_file(str(self.paths.model).encode(), model_params)
         if not self._model:
@@ -541,6 +548,7 @@ class NativeLlamaClient:
 
         try:
             self._initialize_model_profile()
+            self._validate_loaded_low_memory_profile()
         except Exception:
             lib.llama_model_free(self._model)
             self._model = None
@@ -572,6 +580,39 @@ class NativeLlamaClient:
         self._initialize_mtp_accept_probe()
         self._initialize_mtp_decode_probe()
         self._initialize_persistent_mtp_session()
+
+    def _model_load_params(self, progress_cb):
+        if self.config.low_memory:
+            try:
+                profile = inspect_native_model_profile(self.lib, self.paths.model)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"--low-memory model verification failed: {str(exc).strip() or exc.__class__.__name__}"
+                ) from exc
+            if not profile.verified or profile.profile_id != QWEN3_CODER_PROFILE_ID:
+                raise RuntimeError(
+                    "--low-memory requires verified native profile "
+                    f"{QWEN3_CODER_PROFILE_ID}; detected={profile.profile_id}"
+                )
+        params = self.lib.lib.llama_model_default_params()
+        self._cpu_repack_enabled = bool(params.use_extra_bufts)
+        if self.config.low_memory:
+            params.use_extra_bufts = False
+            self._cpu_repack_enabled = False
+        params.progress_callback = progress_cb
+        params.progress_callback_user_data = None
+        return params
+
+    def _validate_loaded_low_memory_profile(self) -> None:
+        if not self.config.low_memory:
+            return
+        profile = self.model_profile
+        if profile is None or not profile.verified or profile.profile_id != QWEN3_CODER_PROFILE_ID:
+            detected = profile.profile_id if profile is not None else "uninitialized"
+            raise RuntimeError(
+                "--low-memory model identity changed during load; "
+                f"required={QWEN3_CODER_PROFILE_ID}; detected={detected}"
+            )
 
     def _initialize_model_profile(self) -> None:
         if not self._model:

--- a/src/orbit/native_llama/model_discovery.py
+++ b/src/orbit/native_llama/model_discovery.py
@@ -82,43 +82,51 @@ class NativeProfileInspector:
         self._lib.ggml_backend_load_all()
 
     def __call__(self, path: Path) -> NativeModelProfile:
-        params = self._lib.llama_model_default_params()
-        params.vocab_only = True
-        params.use_mmap = True
-        params.check_tensors = True
-        model = self._lib.llama_model_load_from_file(str(path).encode(), params)
-        if not model:
-            raise RuntimeError("vocab-only GGUF inspection failed")
-        try:
-            metadata = self._read_metadata(model)
-            template_ptr = self._lib.llama_model_chat_template(model, None)
-            template = template_ptr.decode("utf-8", errors="replace") if template_ptr else ""
-            return detect_native_model_profile(metadata, template)
-        finally:
-            self._lib.llama_model_free(model)
+        return inspect_native_model_profile(self._binding, path)
 
     def close(self) -> None:
         self._lib.llama_log_set(GgmlLogCallback(), None)
 
-    def _read_metadata(self, model) -> dict[str, str]:
-        metadata: dict[str, str] = {}
-        count = max(0, int(self._lib.llama_model_meta_count(model)))
-        for index in range(count):
-            key = self._metadata_text(self._lib.llama_model_meta_key_by_index, model, index)
-            if key in PROFILE_METADATA_KEYS:
-                metadata[key] = self._metadata_text(self._lib.llama_model_meta_val_str_by_index, model, index)
-        return metadata
 
-    @staticmethod
-    def _metadata_text(function, model, index: int) -> str:
-        needed = int(function(model, index, None, 0))
-        if needed < 0:
-            return ""
-        buffer = create_string_buffer(needed + 1)
-        written = int(function(model, index, buffer, len(buffer)))
-        if written < 0:
-            return ""
-        return bytes(buffer[:written]).decode("utf-8", errors="replace")
+
+def inspect_native_model_profile(binding: LlamaLibrary, path: Path) -> NativeModelProfile:
+    """Verify one GGUF profile without allocating its weight tensors."""
+    lib = binding.lib
+    params = lib.llama_model_default_params()
+    params.vocab_only = True
+    params.use_mmap = True
+    params.check_tensors = True
+    model = lib.llama_model_load_from_file(str(path).encode(), params)
+    if not model:
+        raise RuntimeError("vocab-only GGUF inspection failed")
+    try:
+        metadata = _read_profile_metadata(lib, model)
+        template_ptr = lib.llama_model_chat_template(model, None)
+        template = template_ptr.decode("utf-8", errors="replace") if template_ptr else ""
+        return detect_native_model_profile(metadata, template)
+    finally:
+        lib.llama_model_free(model)
+
+
+def _read_profile_metadata(lib, model) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    count = max(0, int(lib.llama_model_meta_count(model)))
+    for index in range(count):
+        key = _metadata_text(lib.llama_model_meta_key_by_index, model, index)
+        if key in PROFILE_METADATA_KEYS:
+            metadata[key] = _metadata_text(lib.llama_model_meta_val_str_by_index, model, index)
+    return metadata
+
+
+def _metadata_text(function, model, index: int) -> str:
+    needed = int(function(model, index, None, 0))
+    if needed < 0:
+        return ""
+    buffer = create_string_buffer(needed + 1)
+    written = int(function(model, index, buffer, len(buffer)))
+    if written < 0:
+        return ""
+    return bytes(buffer[:written]).decode("utf-8", errors="replace")
 
 
 def discover_models(

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -428,6 +428,7 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     "qwen_route_prefix_reuse": qwen_route_prefix,
                     "qwen36_shell_tool_prefix_reuse": qwen36_shell_tool_prefix,
                     "qwen3_coder_route_prefix_reuse": qwen3_coder_route_prefix,
+                    **_model_load_props(state.client),
                     **final_prefix_config,
                     **_tool_call_healing_props(),
                 }
@@ -783,6 +784,7 @@ def run_server(argv: list[str] | None = None) -> int:
                 qwen3_coder_route_prefix_reuse_source=qwen3_coder_route_prefix_config.source,
                 qwen3_coder_route_prefix_reuse_config_error=qwen3_coder_route_prefix_config.validation_error,
                 moe_expert_usage_enabled=args.moe_expert_usage,
+                low_memory=args.low_memory,
             ),
         )
         if not args.verbose_llama_log:
@@ -856,6 +858,10 @@ def _final_prefix_reuse_props(client: NativeLlamaClient) -> dict[str, object]:
         "final_prefix_reuse_config_error": client.config.final_prefix_reuse_config_error,
         "final_prefix_reuse_legacy_detected": client.config.final_prefix_reuse_legacy_detected,
     }
+
+
+def _model_load_props(client: NativeLlamaClient) -> dict[str, object]:
+    return client.model_load_status()
 
 
 def _tool_call_healing_props() -> dict[str, object]:
@@ -1008,6 +1014,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--verbose-llama-log", action="store_true")
     parser.add_argument("--moe-expert-usage", action="store_true", help="Enable opt-in CPU MoE expert-selection counters.")
+    parser.add_argument(
+        "--low-memory",
+        action="store_true",
+        help="Disable CPU weight repacking for the verified Qwen3-Coder profile.",
+    )
     return parser
 
 

--- a/src/orbit/terminal/runtime_status.py
+++ b/src/orbit/terminal/runtime_status.py
@@ -63,6 +63,8 @@ class RuntimeStatus:
     model: str
     backend: str
     server: str
+    low_memory: str
+    cpu_repack: str
     mtp: str
     mmproj: str
     tools: str
@@ -115,6 +117,8 @@ def collect_runtime_status(
         model=display_model,
         backend=_backend_name(props),
         server="ok" if bool(_safe_call(getattr(backend, "health", None))) else "unavailable",
+        low_memory=_on_off(props.get("low_memory")),
+        cpu_repack=_on_off(props.get("cpu_repack")),
         mtp=_on_off(props.get("mtp_enabled")),
         mmproj=_loaded_missing(props.get("multimodal_available")),
         tools=_tools_mode(tools_mode if tools_mode is not None else config.tools),
@@ -155,6 +159,8 @@ def format_status_panel(status: RuntimeStatus) -> str:
         *([("Package", status.package_version)] if status.version != status.package_version else []),
         ("Model", status.model),
         ("Backend", f"{status.backend}, server {status.server}"),
+        ("Low memory", status.low_memory),
+        ("CPU repack", status.cpu_repack),
         ("MTP", f"{status.mtp}, mmproj {status.mmproj}"),
         ("Tools", status.tools),
         ("Think", status.think),

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -262,6 +262,11 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
         self.assertEqual(args.think, "on")
 
+    def test_parser_accepts_low_memory_flag(self) -> None:
+        args = build_parser().parse_args(["--low-memory"])
+
+        self.assertTrue(args.low_memory)
+
     def test_parser_defaults_to_new_user_port(self) -> None:
         args = build_parser().parse_args([])
 
@@ -564,6 +569,27 @@ class NativeServerBootstrapTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         discovery.assert_not_called()
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_run_server_passes_low_memory_only_when_requested(self) -> None:
+        for argv, expected in ((["--model", "/models/valid.gguf"], False), (["--model", "/models/valid.gguf", "--low-memory"], True)):
+            with self.subTest(argv=argv):
+                _FakeNativeClient.instances.clear()
+                _FakeHTTPServer.instances.clear()
+                with (
+                    mock.patch(
+                        "orbit.native_server.app.resolve_bootstrap_paths",
+                        return_value=SimpleNamespace(model=Path("/models/valid.gguf")),
+                    ),
+                    mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+                    mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+                    mock.patch("sys.stdout", new_callable=io.StringIO),
+                ):
+                    code = run_server(argv)
+
+                self.assertEqual(code, 0)
+                self.assertEqual(len(_FakeNativeClient.instances), 1)
+                self.assertIs(_FakeNativeClient.instances[0].config.low_memory, expected)
 
     @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
     def test_run_server_without_model_prompts_and_starts_selected_verified_model(self) -> None:

--- a/tests/test_qwen3_coder_low_memory.py
+++ b/tests/test_qwen3_coder_low_memory.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.native_server.app import _model_load_props, build_parser
+
+
+def _profile(profile_id: str, *, verified: bool = True):
+    return SimpleNamespace(profile_id=profile_id, verified=verified)
+
+
+class Qwen3CoderLowMemoryTests(unittest.TestCase):
+    def _client(self, *, low_memory: bool) -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/qwen3-coder.gguf"),
+            model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+        )
+        binding = mock.Mock()
+        binding.lib.llama_model_default_params.return_value = SimpleNamespace(
+            use_extra_bufts=True,
+            progress_callback=None,
+            progress_callback_user_data=None,
+            n_gpu_layers=0,
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary", return_value=binding):
+            return NativeLlamaClient(paths, NativeClientConfig(low_memory=low_memory))
+
+    def test_parser_defaults_off_and_documents_opt_in(self) -> None:
+        parser = build_parser()
+
+        self.assertFalse(parser.parse_args([]).low_memory)
+        self.assertTrue(parser.parse_args(["--low-memory"]).low_memory)
+        self.assertIn("--low-memory", parser.format_help())
+
+    def test_default_preserves_backend_cpu_repack_setting(self) -> None:
+        client = self._client(low_memory=False)
+        with mock.patch("orbit.native_llama.client.inspect_native_model_profile") as inspect:
+            params = client._model_load_params(None)
+
+        self.assertTrue(params.use_extra_bufts)
+        self.assertEqual(client.model_load_status(), {"low_memory": False, "cpu_repack": True})
+        inspect.assert_not_called()
+
+    def test_low_memory_disables_repack_only_for_verified_qwen3_coder(self) -> None:
+        client = self._client(low_memory=True)
+        with mock.patch(
+            "orbit.native_llama.client.inspect_native_model_profile",
+            return_value=_profile(QWEN3_CODER_PROFILE_ID),
+        ) as inspect:
+            params = client._model_load_params(None)
+
+        self.assertFalse(params.use_extra_bufts)
+        self.assertEqual(client.model_load_status(), {"low_memory": True, "cpu_repack": False})
+        inspect.assert_called_once_with(client.lib, client.paths.model)
+
+    def test_unsupported_or_unverified_profiles_fail_before_model_load(self) -> None:
+        cases = (
+            _profile("orbit-qwen36-native-v1"),
+            _profile("orbit-gemma4-native-v1"),
+            _profile(QWEN3_CODER_PROFILE_ID, verified=False),
+        )
+        for profile in cases:
+            with self.subTest(profile=profile.profile_id, verified=profile.verified):
+                client = self._client(low_memory=True)
+                with mock.patch(
+                    "orbit.native_llama.client.inspect_native_model_profile",
+                    return_value=profile,
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "requires verified native profile"):
+                        client._model_load_params(None)
+                client.lib.lib.llama_model_default_params.assert_not_called()
+
+    def test_malformed_preflight_failure_is_clear_and_fail_closed(self) -> None:
+        client = self._client(low_memory=True)
+        with mock.patch(
+            "orbit.native_llama.client.inspect_native_model_profile",
+            side_effect=RuntimeError("vocab-only GGUF inspection failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "--low-memory model verification failed"):
+                client._model_load_params(None)
+        client.lib.lib.llama_model_default_params.assert_not_called()
+
+    def test_loaded_identity_is_checked_again_after_preflight(self) -> None:
+        client = self._client(low_memory=True)
+        client.model_profile = _profile("orbit-qwen36-native-v1")
+
+        with self.assertRaisesRegex(RuntimeError, "identity changed during load"):
+            client._validate_loaded_low_memory_profile()
+
+    def test_startup_and_reload_pass_no_repack_to_native_model_load(self) -> None:
+        for reloading in (False, True):
+            with self.subTest(reloading=reloading):
+                client = self._client(low_memory=True)
+                if reloading:
+                    client._model = 1  # type: ignore[assignment]
+                    client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+                        valid=True,
+                        checkpoint_data=b"route",
+                        checkpoint_size=5,
+                    )
+                client.lib.lib.llama_model_load_from_file.return_value = None
+                with mock.patch(
+                    "orbit.native_llama.client.inspect_native_model_profile",
+                    return_value=_profile(QWEN3_CODER_PROFILE_ID),
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "failed to load model"):
+                        client.load()
+
+                params = client.lib.lib.llama_model_load_from_file.call_args.args[1]
+                self.assertFalse(params.use_extra_bufts)
+                if reloading:
+                    self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+
+    def test_low_memory_mode_survives_lifecycle_cleanup_without_preserving_state(self) -> None:
+        for operation in ("cancel", "reset", "close"):
+            with self.subTest(operation=operation):
+                client = self._client(low_memory=True)
+                client._cpu_repack_enabled = False
+                client.model_profile = _profile(QWEN3_CODER_PROFILE_ID)
+                client._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState(
+                    valid=True,
+                    checkpoint_data=b"route",
+                    checkpoint_size=5,
+                )
+                if operation == "reset":
+                    client._session.ctx_tgt = 1  # type: ignore[assignment]
+                    client.lib.lib.llama_get_memory.return_value = 2
+                    client.reset_session_state()
+                elif operation == "close":
+                    client.close()
+                else:
+                    client.cancel()
+
+                self.assertFalse(client._qwen3_coder_route_prefix_anchor_state.valid)
+                self.assertEqual(
+                    client.model_load_status(),
+                    {"low_memory": True, "cpu_repack": False},
+                )
+
+    def test_diagnostics_expose_only_mode_and_repack_state(self) -> None:
+        client = self._client(low_memory=True)
+        client._cpu_repack_enabled = False
+
+        self.assertEqual(
+            _model_load_props(client),
+            {"low_memory": True, "cpu_repack": False},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -92,12 +92,36 @@ class RuntimeStatusFormattingTests(unittest.TestCase):
         self.assertIn("Version", panel)
         self.assertIn("Model", panel)
         self.assertIn("MTP", panel)
+        self.assertIn("Low memory", panel)
+        self.assertIn("CPU repack", panel)
         self.assertIn("Host", panel)
         self.assertIn("Machine", panel)
         self.assertIn("Linux test", panel)
         self.assertIn("Acceleration", panel)
         self.assertIn("CPU-only", panel)
         self.assertIn("Mutations", panel)
+
+    def test_status_panel_reports_low_memory_and_cpu_repack(self) -> None:
+        class LowMemoryBackend(_Backend):
+            def backend_props(self) -> dict[str, object]:
+                return {
+                    "backend": "orbit-native",
+                    "low_memory": True,
+                    "cpu_repack": False,
+                }
+
+        status = collect_runtime_status(
+            _Runtime(),
+            AppConfig(workdir=ROOT),
+            LowMemoryBackend(),
+            host_info=HostInfo(),
+        )
+        panel = format_status_panel(status)
+
+        self.assertEqual(status.low_memory, "on")
+        self.assertEqual(status.cpu_repack, "off")
+        self.assertIn("│ Low memory   on", panel)
+        self.assertIn("│ CPU repack   off", panel)
 
     def test_status_panel_shows_package_when_git_version_differs(self) -> None:
         panel = format_status_panel(_status(version="v0.0.1-rc11", package_version="0.0.1"))
@@ -229,6 +253,8 @@ def _status(
         model="Gemma 4 12B",
         backend="native",
         server="ok",
+        low_memory="off",
+        cpu_repack="on",
         mtp="on",
         mmproj="loaded",
         tools="on",


### PR DESCRIPTION
Summary:
- adds opt-in `orbit server --low-memory` for the exact verified Qwen3-Coder profile
- maps the mode only to llama.cpp `use_extra_bufts=false`
- leaves default CPU repacking, prompts, routing, tools and lifecycle semantics unchanged
- rejects Gemma, Qwen3.6 and unverified identities before model load
- exposes bounded `low_memory` and `cpu_repack` diagnostics
- stabilizes the existing-file qualification contract without fixing a tool strategy

Measured:
- ready RSS: 31.211 -> 18.203 GiB (-41.7%)
- peak RSS: 31.284 -> 18.276 GiB (-41.6%)
- weighted prefill: -13.9%
- decode: -1.0%
- 24 GiB PASS; 20 GiB diagnostic PASS
- zero major faults, physical reads, swap or OOM
- Qwen3-Coder route restore remains cached=768

Validation:
- focused 164/164 PASS
- affected 348/348 PASS
- full discovery 1823/1823 PASS, 6 expected skips
- compileall PASS
- diff check PASS

Known limit:
- 24 GiB is the recommended minimum complete-host RAM; 20 GiB is only a process-budget diagnostic target