### PR TITLE
Add interactive low-memory selection

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -29,7 +29,13 @@ from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
-from .model_profiles import QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID, NativeModelProfile, detect_native_model_profile
+from .model_profiles import (
+    QWEN36_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+    NativeModelProfile,
+    detect_native_model_profile,
+    supports_low_memory_mode,
+)
 from .model_discovery import inspect_native_model_profile
 from .mtp_completion import MtpCompletionResult
 from .mtp_decode_probe import MtpDecodeProbeResult, run_mtp_decode_probe
@@ -589,7 +595,7 @@ class NativeLlamaClient:
                 raise RuntimeError(
                     f"--low-memory model verification failed: {str(exc).strip() or exc.__class__.__name__}"
                 ) from exc
-            if not profile.verified or profile.profile_id != QWEN3_CODER_PROFILE_ID:
+            if not supports_low_memory_mode(profile):
                 raise RuntimeError(
                     "--low-memory requires verified native profile "
                     f"{QWEN3_CODER_PROFILE_ID}; detected={profile.profile_id}"
@@ -607,7 +613,7 @@ class NativeLlamaClient:
         if not self.config.low_memory:
             return
         profile = self.model_profile
-        if profile is None or not profile.verified or profile.profile_id != QWEN3_CODER_PROFILE_ID:
+        if not supports_low_memory_mode(profile):
             detected = profile.profile_id if profile is not None else "uninitialized"
             raise RuntimeError(
                 "--low-memory model identity changed during load; "

--- a/src/orbit/native_llama/model_discovery.py
+++ b/src/orbit/native_llama/model_discovery.py
@@ -12,6 +12,7 @@ from orbit.native_llama.model_profiles import (
     VERIFIED_NATIVE_MODEL_IDENTITIES,
     NativeModelProfile,
     detect_native_model_profile,
+    supports_low_memory_mode,
     verified_native_model_identity,
 )
 from orbit.native_llama.model_registry import (
@@ -56,6 +57,7 @@ class ModelDiscoveryRow:
     support: str
     path_or_action: str
     model_id: str | None = None
+    low_memory_supported: bool = False
 
 
 @dataclass(frozen=True)
@@ -301,6 +303,7 @@ def _rows(
                     support="VERIFIED",
                     path_or_action=str(item.path),
                     model_id=None if manifest is None else manifest.id,
+                    low_memory_supported=supports_low_memory_mode(item.profile),
                 )
             )
 

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -80,6 +80,14 @@ class NativeModelProfile:
         }
 
 
+def supports_low_memory_mode(profile: NativeModelProfile | None) -> bool:
+    return bool(
+        profile is not None
+        and profile.verified
+        and profile.profile_id == QWEN3_CODER_PROFILE_ID
+    )
+
+
 @dataclass(frozen=True)
 class VerifiedNativeModelIdentity:
     profile_id: str

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -1017,7 +1017,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--low-memory",
         action="store_true",
-        help="Disable CPU weight repacking for the verified Qwen3-Coder profile.",
+        help="Use a qualified low-memory profile when supported by the selected model.",
     )
     return parser
 
@@ -1149,8 +1149,33 @@ def _select_startup_model(args: argparse.Namespace) -> int | None:
         return _download_selected_model(args, selected, build_bin=build_bin)
     args.model = Path(selected.path_or_action)
     args.model_id = selected.model_id
+    memory_exit = _select_memory_mode(args, selected)
+    if memory_exit is not None:
+        return memory_exit
     print(f"Starting {selected.model}...", file=sys.stderr)
     return None
+
+
+def _select_memory_mode(args: argparse.Namespace, selected: ModelDiscoveryRow) -> int | None:
+    if args.low_memory or not selected.low_memory_supported:
+        return None
+    print("\nMemory mode:", file=sys.stderr)
+    print("  1. Standard (~31.3 GiB peak RSS)", file=sys.stderr)
+    print("  2. Low memory (~18.3 GiB peak RSS)", file=sys.stderr)
+    print("Low memory is recommended for hosts with >=24 GB RAM.", file=sys.stderr)
+    print("Select memory mode [1-2] (default 1): ", end="", file=sys.stderr, flush=True)
+    response = sys.stdin.readline()
+    if not response:
+        print("memory mode selection cancelled", file=sys.stderr)
+        return 1
+    answer = response.strip()
+    if answer in {"", "1"}:
+        return None
+    if answer == "2":
+        args.low_memory = True
+        return None
+    print("error: invalid memory mode selection", file=sys.stderr)
+    return 1
 
 
 def _download_selected_model(
@@ -1231,6 +1256,9 @@ def _download_selected_model(
     args.model = downloaded_path
     args.model_id = selected.model_id
     print(f"Verified: {manifest.display_name}", file=sys.stderr)
+    memory_exit = _select_memory_mode(args, verified_row)
+    if memory_exit is not None:
+        return memory_exit
     print(f"Starting {manifest.display_name}...", file=sys.stderr)
     return None
 

--- a/tests/test_native_model_discovery.py
+++ b/tests/test_native_model_discovery.py
@@ -64,6 +64,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
         self.assertEqual((row.local, row.support), ("AVAILABLE", "VERIFIED"))
         self.assertEqual(row.path_or_action, str(model.absolute()))
         self.assertEqual(row.model_id, manifest.id)
+        self.assertFalse(row.low_memory_supported)
         self.assertEqual(result.metadata_inspections, 1)
 
     def test_multiple_verified_models_are_reported(self) -> None:
@@ -89,6 +90,9 @@ class NativeModelDiscoveryTests(unittest.TestCase):
 
         available = [row.model for row in result.rows if row.local == "AVAILABLE"]
         self.assertEqual(available, ["Gemma 4 26B-A4B", "Qwen3-Coder 30B-A3B"])
+        by_model = {row.model: row for row in result.rows if row.local == "AVAILABLE"}
+        self.assertFalse(by_model["Gemma 4 26B-A4B"].low_memory_supported)
+        self.assertTrue(by_model["Qwen3-Coder 30B-A3B"].low_memory_supported)
 
     def test_unsupported_gguf_is_never_presented_as_supported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -136,6 +140,8 @@ class NativeModelDiscoveryTests(unittest.TestCase):
         spoof = next(row for row in result.rows if row.model == manifest.target.file)
         self.assertEqual((supported.local, supported.support), ("MISSING", "VERIFIED"))
         self.assertEqual((spoof.local, spoof.support), ("AVAILABLE", "UNSUPPORTED"))
+        self.assertFalse(supported.low_memory_supported)
+        self.assertFalse(spoof.low_memory_supported)
 
     def test_verified_profile_with_different_model_identity_is_unsupported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -172,8 +178,15 @@ class NativeModelDiscoveryTests(unittest.TestCase):
     def test_incorrect_injected_registry_mapping_fails_closed(self) -> None:
         bad_manifest = replace(self.manifests[0], architecture="qwen35moe")
 
-        with self.assertRaisesRegex(ValueError, "profile mapping is not supported"):
-            discover_models(manifests=(bad_manifest,), inspector=lambda _path: self.fail("no model"))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaisesRegex(ValueError, "profile mapping is not supported"):
+                discover_models(
+                    models_dir=root / "models",
+                    hf_cache=root / "hf",
+                    manifests=(bad_manifest,),
+                    inspector=lambda _path: self.fail("no model"),
+                )
 
     def test_malformed_or_unreadable_gguf_is_unverified(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_model_profiles.py
+++ b/tests/test_native_model_profiles.py
@@ -12,6 +12,7 @@ from orbit.native_llama.model_profiles import (
     QWEN3_CODER_PROFILE_ID,
     NativeModelProfile,
     detect_native_model_profile,
+    supports_low_memory_mode,
 )
 from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT
 
@@ -55,6 +56,7 @@ class NativeModelProfileTests(unittest.TestCase):
         self.assertFalse(profile.mtp_supported)
         self.assertFalse(profile.gemma_prefix_reuse_supported)
         self.assertEqual(profile.verified_quantization, "Q4_K_M")
+        self.assertFalse(supports_low_memory_mode(profile))
         self.assertTrue(profile.diagnostics(thinking_enabled=False)["capabilities"]["full_document_analysis"])
 
     def test_qwen_template_drift_fails_closed(self) -> None:
@@ -97,6 +99,7 @@ class NativeModelProfileTests(unittest.TestCase):
         self.assertEqual(profile.renderer, "orbit-gemma4")
         self.assertTrue(profile.mtp_supported)
         self.assertTrue(profile.gemma_prefix_reuse_supported)
+        self.assertFalse(supports_low_memory_mode(profile))
         self.assertTrue(profile.diagnostics(thinking_enabled=False)["capabilities"]["full_document_analysis"])
 
     def test_detects_verified_qwen3_coder_only_from_complete_identity(self) -> None:
@@ -118,6 +121,7 @@ class NativeModelProfileTests(unittest.TestCase):
         self.assertTrue(profile.route_prefix_reuse_supported)
         self.assertFalse(profile.multimodal_supported)
         self.assertEqual(profile.verified_quantization, "Q4_K_M")
+        self.assertTrue(supports_low_memory_mode(profile))
         self.assertTrue(profile.diagnostics(thinking_enabled=False)["capabilities"]["full_document_analysis"])
 
     def test_qwen3_coder_template_drift_fails_closed(self) -> None:
@@ -125,6 +129,7 @@ class NativeModelProfileTests(unittest.TestCase):
 
         self.assertFalse(profile.verified)
         self.assertEqual(profile.failure_reason, "qwen3_coder_template_identity_mismatch")
+        self.assertFalse(supports_low_memory_mode(profile))
 
     def test_qwen3_coder_architecture_drift_fails_closed(self) -> None:
         metadata = {**QWEN3_CODER_METADATA, "general.architecture": "qwen3"}

--- a/tests/test_native_server_bootstrap.py
+++ b/tests/test_native_server_bootstrap.py
@@ -618,6 +618,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
                     support="VERIFIED",
                     path_or_action=str(selected_path),
                     model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+                    low_memory_supported=True,
                 ),
                 ModelDiscoveryRow(
                     model="other.gguf",
@@ -649,7 +650,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
             mock.patch("orbit.native_server.app.resolve_bootstrap_paths", side_effect=resolve),
             mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
             mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
-            mock.patch("sys.stdin", _InteractiveInput("3\n")),
+            mock.patch("sys.stdin", _InteractiveInput("3\n\n")),
             mock.patch("sys.stdout", new_callable=io.StringIO),
             redirect_stderr(stderr),
         ):
@@ -660,16 +661,106 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(len(captured_args), 1)
         self.assertEqual(captured_args[0].model, selected_path)
         self.assertEqual(captured_args[0].model_id, "qwen3-coder-30b-a3b-instruct-q4-k-m")
+        self.assertFalse(captured_args[0].low_memory)
         output = stderr.getvalue()
         self.assertIn("Models:", output)
         self.assertIn("Verified models:", output)
         self.assertIn("1. Gemma 4 26B-A4B [MISSING]", output)
         self.assertIn("2. Qwen 3.6 35B-A3B [AVAILABLE]", output)
         self.assertIn("3. Qwen3-Coder 30B-A3B [AVAILABLE]", output)
+        self.assertIn("Memory mode:", output)
+        self.assertIn("1. Standard (~31.3 GiB peak RSS)", output)
+        self.assertIn("2. Low memory (~18.3 GiB peak RSS)", output)
+        self.assertIn("recommended for hosts with >=24 GB RAM", output)
         self.assertIn("Starting Qwen3-Coder 30B-A3B...", output)
         selectable_output = output.split("Verified models:", 1)[1]
         self.assertNotIn("other.gguf", selectable_output)
         self.assertNotIn("broken.gguf", selectable_output)
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_interactive_qwen3_coder_low_memory_selection_reaches_backend_config(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        selected_path = Path("/models/qwen3-coder.gguf")
+        available = ModelDiscoveryResult(
+            rows=(
+                ModelDiscoveryRow(
+                    model="Qwen3-Coder 30B-A3B",
+                    local="AVAILABLE",
+                    support="VERIFIED",
+                    path_or_action=str(selected_path),
+                    model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+                    low_memory_supported=True,
+                ),
+            ),
+            wall_ms=1.0,
+            filesystem_scans=5,
+            metadata_inspections=1,
+        )
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app._resolve_native_runtime",
+                return_value=(None, Path("/native"), Path("/native/libllama.so")),
+            ),
+            mock.patch("orbit.native_server.app.discover_models", return_value=available),
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=selected_path),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdin", _InteractiveInput("1\n2\n")),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+            redirect_stderr(stderr),
+        ):
+            code = run_server([])
+
+        self.assertEqual(code, 0)
+        self.assertTrue(_FakeNativeClient.instances[-1].config.low_memory)
+        self.assertIn("Memory mode:", stderr.getvalue())
+
+    @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
+    def test_explicit_low_memory_skips_interactive_memory_prompt(self) -> None:
+        _FakeNativeClient.instances.clear()
+        _FakeHTTPServer.instances.clear()
+        available = ModelDiscoveryResult(
+            rows=(
+                ModelDiscoveryRow(
+                    model="Qwen3-Coder 30B-A3B",
+                    local="AVAILABLE",
+                    support="VERIFIED",
+                    path_or_action="/models/qwen3-coder.gguf",
+                    model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+                    low_memory_supported=True,
+                ),
+            ),
+            wall_ms=1.0,
+            filesystem_scans=5,
+            metadata_inspections=1,
+        )
+        stderr = io.StringIO()
+        with (
+            mock.patch(
+                "orbit.native_server.app._resolve_native_runtime",
+                return_value=(None, Path("/native"), Path("/native/libllama.so")),
+            ),
+            mock.patch("orbit.native_server.app.discover_models", return_value=available),
+            mock.patch(
+                "orbit.native_server.app.resolve_bootstrap_paths",
+                return_value=SimpleNamespace(model=Path("/models/qwen3-coder.gguf")),
+            ),
+            mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
+            mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
+            mock.patch("sys.stdin", _InteractiveInput("1\n")),
+            mock.patch("sys.stdout", new_callable=io.StringIO),
+            redirect_stderr(stderr),
+        ):
+            code = run_server(["--low-memory"])
+
+        self.assertEqual(code, 0)
+        self.assertTrue(_FakeNativeClient.instances[-1].config.low_memory)
+        self.assertNotIn("Memory mode:", stderr.getvalue())
 
     @mock.patch.dict("os.environ", {"ORBIT_KV_PREFIX_PREWARM": "off"}, clear=True)
     def test_run_server_explicit_model_id_bypasses_interactive_selection(self) -> None:
@@ -1140,6 +1231,43 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(code, 1)
         discovery.assert_called_once()
         self.assertEqual(stderr.getvalue().count("Models:"), 1)
+        self.assertNotIn("Memory mode:", stderr.getvalue())
+
+    def test_qwen3_coder_memory_mode_rejects_eof_and_invalid_input(self) -> None:
+        available = ModelDiscoveryResult(
+            rows=(
+                ModelDiscoveryRow(
+                    model="Qwen3-Coder 30B-A3B",
+                    local="AVAILABLE",
+                    support="VERIFIED",
+                    path_or_action="/models/qwen3-coder.gguf",
+                    model_id="qwen3-coder-30b-a3b-instruct-q4-k-m",
+                    low_memory_supported=True,
+                ),
+            ),
+            wall_ms=1.0,
+            filesystem_scans=5,
+            metadata_inspections=1,
+        )
+        cases = (("1\n", "memory mode selection cancelled"), ("1\n3\n", "invalid memory mode selection"))
+        for input_text, expected_message in cases:
+            with self.subTest(input_text=input_text):
+                stderr = io.StringIO()
+                with (
+                    mock.patch(
+                        "orbit.native_server.app._resolve_native_runtime",
+                        return_value=(None, Path("/native"), Path("/native/libllama.so")),
+                    ),
+                    mock.patch("orbit.native_server.app.discover_models", return_value=available),
+                    mock.patch("orbit.native_server.app.resolve_bootstrap_paths") as bootstrap,
+                    mock.patch("sys.stdin", _InteractiveInput(input_text)),
+                    redirect_stderr(stderr),
+                ):
+                    code = run_server([])
+
+                self.assertEqual(code, 1)
+                bootstrap.assert_not_called()
+                self.assertIn(expected_message, stderr.getvalue())
 
     def test_interactive_model_selection_handles_eof_and_keyboard_interrupt(self) -> None:
         available = self._available_discovery()
@@ -1195,13 +1323,14 @@ class NativeServerBootstrapTests(unittest.TestCase):
                 filesystem_scans=5,
                 metadata_inspections=1,
             )
+            stderr = io.StringIO()
             with (
                 mock.patch("orbit.native_server.app.discover_models", return_value=available),
                 mock.patch("orbit.native_server.app.NativeLlamaClient", _FakeNativeClient),
                 mock.patch("orbit.native_server.app.ThreadingHTTPServer", _FakeHTTPServer),
                 mock.patch("sys.stdin", _InteractiveInput("1\n")),
                 mock.patch("sys.stdout", new_callable=io.StringIO),
-                mock.patch("sys.stderr", new_callable=io.StringIO),
+                redirect_stderr(stderr),
             ):
                 code = run_server(
                     [
@@ -1223,6 +1352,7 @@ class NativeServerBootstrapTests(unittest.TestCase):
         self.assertEqual(paths.draft_mtp_model, draft)
         self.assertTrue(paths.multimodal_available)
         self.assertTrue(paths.mtp_available)
+        self.assertNotIn("Memory mode:", stderr.getvalue())
 
     def test_unknown_model_id_fails_clearly_with_discovery(self) -> None:
         stderr = io.StringIO()

--- a/tests/test_qwen3_coder_low_memory.py
+++ b/tests/test_qwen3_coder_low_memory.py
@@ -40,7 +40,12 @@ class Qwen3CoderLowMemoryTests(unittest.TestCase):
 
         self.assertFalse(parser.parse_args([]).low_memory)
         self.assertTrue(parser.parse_args(["--low-memory"]).low_memory)
-        self.assertIn("--low-memory", parser.format_help())
+        help_text = parser.format_help()
+        self.assertIn("--low-memory", help_text)
+        self.assertIn(
+            "Use a qualified low-memory profile when supported by the selected model.",
+            " ".join(help_text.split()),
+        )
 
     def test_default_preserves_backend_cpu_repack_setting(self) -> None:
         client = self._client(low_memory=False)


### PR DESCRIPTION
- adds a Standard / Low memory choice after interactive verified Qwen3-Coder selection
- defaults to Standard and shows concise qualified RSS guidance
- reuses exact verified-profile gating for low-memory support
- preserves explicit --low-memory, explicit model/model-id, and non-TTY behavior
- no inference or runtime semantic changes

Validation:
- focused 99/99 PASS
- affected 203/203 PASS
- full discovery 1826/1826 PASS
- compileall PASS
- diff check PASS