### PR TITLE
Add exact TTFT instrumentation

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -19,6 +19,8 @@ class ChatResult:
     prompt_tokens_per_second: float | None
     generation_tokens_per_second: float | None
     reasoning_content: str = ""
+    backend_ttft_ms: float | None = None
+    stream_ttft_ms: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import re
+import time
 from dataclasses import replace
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
@@ -374,9 +375,14 @@ class LlamaServerBackend:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
+        request_started_ns = time.monotonic_ns()
         try:
             with urlopen(request, timeout=self.timeout) as response:
-                return _parse_chat_stream(response, on_delta=on_delta)
+                return _parse_chat_stream(
+                    response,
+                    on_delta=on_delta,
+                    request_started_ns=request_started_ns,
+                )
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise LlamaServerError(f"backend server HTTP {exc.code}: {detail}") from exc
@@ -401,6 +407,7 @@ class LlamaServerBackend:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
+        request_started_ns = time.monotonic_ns()
         try:
             with urlopen(request, timeout=self.timeout) as response:
                 return _parse_native_stream(
@@ -408,6 +415,7 @@ class LlamaServerBackend:
                     on_delta=on_delta,
                     on_progress=on_progress,
                     literal_content=literal_content,
+                    request_started_ns=request_started_ns,
                 )
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
@@ -474,10 +482,16 @@ def _parse_chat_result(data: dict[str, Any]) -> ChatResult:
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
         reasoning_content=reasoning_content,
+        backend_ttft_ms=_finite_nonnegative_float_or_none(timings.get("backend_ttft_ms")),
     )
 
 
-def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> ChatResult:
+def _parse_chat_stream(
+    response: Any,
+    *,
+    on_delta: Callable[[str], None],
+    request_started_ns: int | None = None,
+) -> ChatResult:
     content_parts: list[str] = []
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
     content_filter = _ContentStreamFilter(on_delta)
@@ -486,6 +500,7 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
     usage: dict[str, Any] = {}
     timings: dict[str, Any] = {}
     reasoning_parts: list[str] = []
+    first_output_ns: int | None = None
 
     for raw_line in response:
         line = raw_line.decode("utf-8", errors="replace").strip()
@@ -515,6 +530,16 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
         delta = first.get("delta")
         if not isinstance(delta, dict):
             continue
+        has_output = any(
+            (
+                isinstance(delta.get(key), str) and bool(delta.get(key))
+                if key != "tool_calls"
+                else isinstance(delta.get(key), list) and bool(delta.get(key))
+            )
+            for key in ("content", "reasoning_content", "tool_calls")
+        )
+        if has_output and first_output_ns is None:
+            first_output_ns = time.monotonic_ns()
         text = delta.get("content")
         if isinstance(text, str) and text:
             content_parts.append(text)
@@ -544,6 +569,8 @@ def _parse_chat_stream(response: Any, *, on_delta: Callable[[str], None]) -> Cha
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
         reasoning_content="".join(reasoning_parts),
+        backend_ttft_ms=_finite_nonnegative_float_or_none(timings.get("backend_ttft_ms")),
+        stream_ttft_ms=_elapsed_ms(request_started_ns, first_output_ns),
     )
 
 
@@ -553,6 +580,7 @@ def _parse_native_stream(
     on_delta: Callable[[str], None],
     on_progress: Callable[[StreamProgress], None] | None,
     literal_content: bool = False,
+    request_started_ns: int | None = None,
 ) -> ChatResult:
     content_parts: list[str] = []
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
@@ -565,9 +593,10 @@ def _parse_native_stream(
     current_event: str | None = None
     current_data_lines: list[str] = []
     stream_done = False
+    first_output_ns: int | None = None
 
     def flush_event() -> None:
-        nonlocal current_event, current_data_lines, model, finish_reason, usage, timings, stream_done
+        nonlocal current_event, current_data_lines, model, finish_reason, usage, timings, stream_done, first_output_ns
         if not current_event:
             current_data_lines = []
             return
@@ -587,6 +616,8 @@ def _parse_native_stream(
         if current_event == "delta":
             text = data.get("text")
             if isinstance(text, str) and text:
+                if first_output_ns is None:
+                    first_output_ns = time.monotonic_ns()
                 content_parts.append(text)
                 if content_filter is None:
                     on_delta(text)
@@ -595,6 +626,8 @@ def _parse_native_stream(
         elif current_event == "reasoning":
             text = data.get("text")
             if isinstance(text, str) and text:
+                if first_output_ns is None:
+                    first_output_ns = time.monotonic_ns()
                 reasoning_parts.append(text)
         elif current_event.startswith("progress.") and on_progress:
             phase = current_event.split(".", maxsplit=1)[1]
@@ -611,6 +644,8 @@ def _parse_native_stream(
             )
             on_progress(progress)
         elif current_event == "tool_calls":
+            if isinstance(data.get("tool_calls"), list) and data["tool_calls"] and first_output_ns is None:
+                first_output_ns = time.monotonic_ns()
             _merge_stream_tool_calls(tool_calls_by_index, data.get("tool_calls"))
         elif current_event == "metrics":
             if isinstance(data.get("usage"), dict):
@@ -662,7 +697,15 @@ def _parse_native_stream(
         prompt_tokens_per_second=_float_or_none(timings.get("prompt_per_second")),
         generation_tokens_per_second=_float_or_none(timings.get("predicted_per_second")),
         reasoning_content="".join(reasoning_parts),
+        backend_ttft_ms=_finite_nonnegative_float_or_none(timings.get("backend_ttft_ms")),
+        stream_ttft_ms=_elapsed_ms(request_started_ns, first_output_ns),
     )
+
+
+def _elapsed_ms(started_ns: int | None, ended_ns: int | None) -> float | None:
+    if started_ns is None or ended_ns is None:
+        return None
+    return max(0.0, (ended_ns - started_ns) / 1_000_000.0)
 
 
 def _merge_stream_tool_calls(tool_calls_by_index: dict[int, dict[str, Any]], raw_tool_calls: object) -> None:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 import os
 from pathlib import Path
 import threading
+import time
 
 from orbit.final_prefix_config import FINAL_PREFIX_TOKEN_COUNT
 
@@ -99,6 +100,25 @@ class _ProfileParsedOutput:
     content: str
     reasoning_content: str
     tool_calls: tuple[dict[str, object], ...]
+
+
+@dataclass
+class _RequestTiming:
+    started_ns: int
+    first_generated_ns: int | None = None
+
+    @classmethod
+    def start(cls) -> _RequestTiming:
+        return cls(started_ns=time.monotonic_ns())
+
+    def mark_first_generated(self) -> None:
+        if self.first_generated_ns is None:
+            self.first_generated_ns = time.monotonic_ns()
+
+    def backend_ttft_ms(self) -> float | None:
+        if self.first_generated_ns is None:
+            return None
+        return max(0.0, (self.first_generated_ns - self.started_ns) / 1_000_000.0)
 
 
 @dataclass(frozen=True)
@@ -1171,6 +1191,7 @@ class NativeLlamaClient:
         on_token=None,
         should_cancel=None,
     ) -> NativeTimings:
+        request_timing = _RequestTiming.start()
         self._final_prefix_status.last_used = False
         thinking = self._thinking_enabled(thinking)
         prepared_multimodal = prepare_multimodal_messages(messages, media_marker=self._media_marker)
@@ -1197,6 +1218,7 @@ class NativeLlamaClient:
                     on_progress=on_progress,
                     on_token=on_token,
                     should_cancel=should_cancel,
+                    request_timing=request_timing,
                 )
                 self._session.last_metrics = timings
                 self._session.continuation_ready = _can_continue_from_timings(timings)
@@ -1259,6 +1281,7 @@ class NativeLlamaClient:
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
+            request_timing=request_timing,
         )
 
     def complete_chat_text(
@@ -1381,6 +1404,7 @@ class NativeLlamaClient:
         on_token=None,
         should_cancel=None,
     ) -> NativeCompletion:
+        request_timing = _RequestTiming.start()
         if stop:
             raise RuntimeError("Qwen3-Coder artifact generation does not accept stop sequences")
         framed_messages = qwen3_coder_artifact_messages(messages)
@@ -1402,6 +1426,7 @@ class NativeLlamaClient:
                 should_cancel=should_cancel,
                 sampler_override=sampler,
                 utf8_errors="strict",
+                request_timing=request_timing,
             )
         finally:
             self.lib.lib.llama_sampler_free(sampler)
@@ -1765,7 +1790,9 @@ class NativeLlamaClient:
         on_progress=None,
         on_token=None,
         should_cancel=None,
+        request_timing: _RequestTiming | None = None,
     ) -> NativeTimings:
+        request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
         if not self._session.ctx_tgt or not self._session.sampler or not self._mtmd_ctx or self.mtmd is None:
             raise RuntimeError("native multimodal client not loaded")
@@ -1876,6 +1903,7 @@ class NativeLlamaClient:
                 on_progress=on_progress,
                 on_token=on_token,
                 should_cancel=should_cancel,
+                request_timing=request_timing,
             )
             return NativeTimings(
                 prompt_tokens=total_tokens,
@@ -1885,6 +1913,7 @@ class NativeLlamaClient:
                 prefill_ms=pf_ms,
                 generation_ms=gen_ms,
                 cancelled=cancelled,
+                backend_ttft_ms=request_timing.backend_ttft_ms(),
             )
         finally:
             mtmd.orbit_mtmd_chunks_free(chunks)
@@ -1936,7 +1965,9 @@ class NativeLlamaClient:
         should_cancel=None,
         sampler_override=None,
         utf8_errors: str = "replace",
+        request_timing: _RequestTiming | None = None,
     ) -> NativeTimings:
+        request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
         self.reset_cancel()
         self._session.in_flight = True
@@ -1958,6 +1989,7 @@ class NativeLlamaClient:
                         thinking=thinking,
                         on_progress=on_progress,
                         on_token=on_token,
+                        request_timing=request_timing,
                     )
                     if mtp_result is not None:
                         self._last_completion_used_mtp = True
@@ -1979,6 +2011,7 @@ class NativeLlamaClient:
                 should_cancel=should_cancel,
                 sampler_override=sampler_override,
                 utf8_errors=utf8_errors,
+                request_timing=request_timing,
             )
             self._session.last_metrics = timings
             self._session.continuation_ready = _can_continue_from_timings(timings)
@@ -2012,7 +2045,9 @@ class NativeLlamaClient:
         thinking: bool | None = None,
         on_progress=None,
         on_token=None,
+        request_timing: _RequestTiming | None = None,
     ) -> NativeTimings | None:
+        request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
         profile = getattr(self, "model_profile", None)
         if profile is not None and not profile.mtp_supported:
@@ -2063,6 +2098,14 @@ class NativeLlamaClient:
         streamed_parts: list[str] = []
         generation_cap = max(1, max_tokens)
         self._last_completion_generation_cap = generation_cap
+
+        def collect_mtp_token(text: str) -> None:
+            if request_timing.first_generated_ns is None:
+                request_timing.mark_first_generated()
+            streamed_parts.append(text)
+            if on_token is not None:
+                on_token(text)
+
         result = run_persistent_mtp_completion(
             llama_root=self.paths.llama_root,
             paths=self.paths,
@@ -2070,12 +2113,14 @@ class NativeLlamaClient:
             ctx_tgt=self._session.ctx_tgt,
             prompt=mtp_prompt,
             max_tokens=generation_cap,
-            on_token=(lambda text: (streamed_parts.append(text), on_token(text))[1]) if on_token else None,
-            on_progress=(
-                lambda phase, current, total: on_progress(
-                    NativeProgress("prefill" if phase == 0 else "generation", current, total)
-                )
-            ) if on_progress else None,
+            on_token=collect_mtp_token if on_token is not None else None,
+            on_progress=lambda phase, current, total: self._handle_mtp_progress(
+                phase,
+                current,
+                total,
+                request_timing=request_timing,
+                on_progress=on_progress,
+            ),
         )
         if result.success and result.content and not thinking:
             result = replace(result, content=_strip_control_channels(result.content))
@@ -2131,7 +2176,22 @@ class NativeLlamaClient:
             prefill_ms=0.0,
             generation_ms=result.elapsed_ms or 0.0,
             cancelled=False,
+            backend_ttft_ms=request_timing.backend_ttft_ms(),
         )
+
+    @staticmethod
+    def _handle_mtp_progress(
+        phase: int,
+        current: int,
+        total: int,
+        *,
+        request_timing: _RequestTiming,
+        on_progress=None,
+    ) -> None:
+        if phase == 1 and current > 0 and request_timing.first_generated_ns is None:
+            request_timing.mark_first_generated()
+        if on_progress is not None:
+            on_progress(NativeProgress("prefill" if phase == 0 else "generation", current, total))
 
     def _complete_prompt_standard(
         self,
@@ -2148,7 +2208,9 @@ class NativeLlamaClient:
         should_cancel=None,
         sampler_override=None,
         utf8_errors: str = "replace",
+        request_timing: _RequestTiming | None = None,
     ) -> NativeTimings:
+        request_timing = request_timing or _RequestTiming.start()
         if not self._session.ctx_tgt or not self._vocab or not self._session.sampler:
             raise RuntimeError("native client not loaded")
 
@@ -2233,6 +2295,7 @@ class NativeLlamaClient:
             should_cancel=should_cancel,
             sampler_override=sampler_override,
             utf8_errors=utf8_errors,
+            request_timing=request_timing,
         )
         component_tokens = None
         if kv_diag_enabled() and kv_diag_messages is not None:
@@ -2263,6 +2326,7 @@ class NativeLlamaClient:
             prefill_ms=pf_ms,
             generation_ms=gen_ms,
             cancelled=cancelled,
+            backend_ttft_ms=request_timing.backend_ttft_ms(),
         )
 
     def _decode_prompt_range(
@@ -3289,11 +3353,13 @@ class NativeLlamaClient:
         self.reset_cancel()
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = max_tokens
+        request_timing = _RequestTiming.start()
         generated, gen_ms, cancelled = self._generate_from_current_context(
             max_tokens=max_tokens,
             on_progress=on_progress,
             on_token=on_token,
             should_cancel=should_cancel,
+            request_timing=request_timing,
         )
         timings = NativeTimings(
             prompt_tokens=0,
@@ -3303,6 +3369,7 @@ class NativeLlamaClient:
             prefill_ms=0.0,
             generation_ms=gen_ms,
             cancelled=cancelled,
+            backend_ttft_ms=request_timing.backend_ttft_ms(),
         )
         self._session.last_metrics = timings
         self._session.continuation_ready = _can_continue_from_timings(timings)
@@ -3317,6 +3384,7 @@ class NativeLlamaClient:
         should_cancel=None,
         sampler_override=None,
         utf8_errors: str = "replace",
+        request_timing: _RequestTiming | None = None,
     ) -> tuple[int, float, bool]:
         if not self._session.ctx_tgt or not self._session.sampler or not self._vocab:
             raise RuntimeError("native client not loaded")
@@ -3345,6 +3413,8 @@ class NativeLlamaClient:
                 lib.llama_sampler_accept(sampler, token)
             if lib.llama_vocab_is_eog(self._vocab, token):
                 break
+            if request_timing is not None and request_timing.first_generated_ns is None:
+                request_timing.mark_first_generated()
             self.last_target_only_token_hashes.append(_stable_token_hash(int(token)))
             if first_sample_before is not None:
                 first_sample_after = self._target_only_first_sample_metadata(path_name="target_only", generated_count=generated + 1)
@@ -3816,6 +3886,7 @@ def _merge_completions(first: NativeCompletion, second: NativeCompletion) -> Nat
             prefill_ms=first.timings.prefill_ms,
             generation_ms=first.timings.generation_ms + second.timings.generation_ms,
             cancelled=first.timings.cancelled or second.timings.cancelled,
+            backend_ttft_ms=first.timings.backend_ttft_ms,
         ),
         stopped_by_stop=first.stopped_by_stop or second.stopped_by_stop,
         completed_after_thought=_has_closed_thought_with_final(merged_content),

--- a/src/orbit/native_llama/events.py
+++ b/src/orbit/native_llama/events.py
@@ -34,6 +34,7 @@ class NativeTimings:
     prefill_ms: float
     generation_ms: float
     cancelled: bool = False
+    backend_ttft_ms: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -200,6 +200,7 @@ class OrbitNativeServer:
             prefill_ms=timings.prefill_ms,
             generation_ms=timings.generation_ms,
             cancelled=timings.cancelled and not stopped,
+            backend_ttft_ms=getattr(timings, "backend_ttft_ms", None),
             reasoning_content=getattr(completion, "reasoning_content", ""),
             reasoning_tokens=getattr(completion, "reasoning_tokens", 0),
             tool_calls=tool_calls,
@@ -241,6 +242,7 @@ class OrbitNativeServer:
             prefill_ms=timings.prefill_ms,
             generation_ms=timings.generation_ms,
             cancelled=timings.cancelled and not stopped,
+            backend_ttft_ms=getattr(timings, "backend_ttft_ms", None),
         )
 
     def cancel(self, session_id: str = DEFAULT_SESSION_ID) -> dict[str, Any]:

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -75,6 +75,7 @@ def native_chat_response(
     prefill_ms: float,
     generation_ms: float,
     cancelled: bool,
+    backend_ttft_ms: float | None = None,
     reasoning_content: str = "",
     reasoning_tokens: int = 0,
     tool_calls: tuple[dict[str, Any], ...] = (),
@@ -100,6 +101,7 @@ def native_chat_response(
             "predicted_ms": generation_ms,
             "prompt_per_second": _rate(evaluated_prompt_tokens, prefill_ms),
             "predicted_per_second": _rate(completion_tokens, generation_ms),
+            "backend_ttft_ms": backend_ttft_ms,
         },
         "native": {
             "prompt_tokens": prompt_tokens,
@@ -109,6 +111,7 @@ def native_chat_response(
             "prefill_ms": prefill_ms,
             "generation_ms": generation_ms,
             "cancelled": cancelled,
+            "backend_ttft_ms": backend_ttft_ms,
             "reasoning_tokens": reasoning_tokens,
         },
     }

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -1231,6 +1231,41 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertEqual(result.finish_reason, "stop")
         self.assertEqual(result.prompt_tokens, 2)
 
+    @mock.patch("orbit.backend.llama_server.time.monotonic_ns", return_value=1_250_000_000)
+    def test_parse_chat_stream_records_first_output_event_once(self, monotonic_ns) -> None:
+        result = _parse_chat_stream(
+            FakeStream(
+                [
+                    'data: {"choices":[{"delta":{"content":"first"},"finish_reason":null}]}\n',
+                    'data: {"choices":[{"delta":{"content":"second"},"finish_reason":"stop"}],"timings":{"backend_ttft_ms":200.0}}\n',
+                    "data: [DONE]\n",
+                ]
+            ),
+            on_delta=lambda _text: None,
+            request_started_ns=1_000_000_000,
+        )
+
+        self.assertEqual(result.backend_ttft_ms, 200.0)
+        self.assertEqual(result.stream_ttft_ms, 250.0)
+        monotonic_ns.assert_called_once_with()
+
+    @mock.patch("orbit.backend.llama_server.time.monotonic_ns")
+    def test_parse_chat_stream_keeps_ttft_null_without_output(self, monotonic_ns) -> None:
+        result = _parse_chat_stream(
+            FakeStream(
+                [
+                    'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"backend_ttft_ms":null}}\n',
+                    "data: [DONE]\n",
+                ]
+            ),
+            on_delta=lambda _text: None,
+            request_started_ns=1_000_000_000,
+        )
+
+        self.assertIsNone(result.backend_ttft_ms)
+        self.assertIsNone(result.stream_ttft_ms)
+        monotonic_ns.assert_not_called()
+
     def test_parse_chat_stream_accumulates_tool_call_deltas(self) -> None:
         result = _parse_chat_stream(
             FakeStream(
@@ -1329,6 +1364,47 @@ class LlamaServerBackendTests(unittest.TestCase):
         self.assertEqual(result.cached_tokens, 12)
         self.assertEqual(result.prompt_tokens_per_second, 14.7)
         self.assertEqual(result.generation_tokens_per_second, 3.2)
+
+    @mock.patch("orbit.backend.llama_server.time.monotonic_ns", return_value=1_400_000_000)
+    def test_parse_native_stream_keeps_backend_and_stream_ttft_distinct(self, monotonic_ns) -> None:
+        result = _parse_native_stream(
+            FakeStream(
+                [
+                    'event: progress.prefill\n',
+                    'data: {"current":1,"total":2,"percent":50}\n',
+                    '\n',
+                    'event: delta\n',
+                    'data: {"text":"first"}\n',
+                    '\n',
+                    'event: delta\n',
+                    'data: {"text":"second"}\n',
+                    '\n',
+                    'event: metrics\n',
+                    'data: {"usage":{},"timings":{"backend_ttft_ms":350.0}}\n',
+                    '\n',
+                    'event: done\n',
+                    'data: {"finish_reason":"stop"}\n',
+                    '\n',
+                ]
+            ),
+            on_delta=lambda _text: None,
+            on_progress=lambda _progress: None,
+            request_started_ns=1_000_000_000,
+        )
+
+        self.assertEqual(result.backend_ttft_ms, 350.0)
+        self.assertEqual(result.stream_ttft_ms, 400.0)
+        monotonic_ns.assert_called_once_with()
+
+    def test_parse_chat_result_rejects_invalid_ttft_metrics(self) -> None:
+        result = _parse_chat_result(
+            {
+                "choices": [{"finish_reason": "stop", "message": {"content": "ok"}}],
+                "timings": {"backend_ttft_ms": float("nan")},
+            }
+        )
+
+        self.assertIsNone(result.backend_ttft_ms)
 
     def test_parse_native_stream_drops_nonfinite_or_invalid_live_metrics(self) -> None:
         progress = []

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -404,6 +404,42 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         self.assertTrue(client.last_mtp_completion.success)
         self.assertIsNone(client.mtp_fallback_reason)
 
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns", side_effect=[1_000_000_000, 1_200_000_000])
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_mtp_ttft_is_latched_without_external_progress_subscriber(
+        self,
+        _mocked_lib,
+        mocked_reset,
+        mocked_run,
+        monotonic_ns,
+    ) -> None:
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        self._enable_mock_persistent_mtp(client, mocked_reset)
+        client.tokenize = lambda prompt: [1, 2, 3]
+
+        def complete(**kwargs):
+            kwargs["on_progress"](0, 3, 3)
+            kwargs["on_progress"](1, 1, 8)
+            kwargs["on_progress"](1, 2, 8)
+            return MtpCompletionResult(
+                enabled=True,
+                success=True,
+                error=None,
+                content="ok",
+                output_tokens=2,
+                elapsed_ms=12.5,
+            )
+
+        mocked_run.side_effect = complete
+
+        timings = client.complete_prompt("hello", max_tokens=8)
+
+        self.assertEqual(timings.backend_ttft_ms, 200.0)
+        self.assertEqual(monotonic_ns.call_count, 2)
+
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_complete_chat_keeps_mtp_enabled_for_final_from_tool_history(self, _mocked_lib) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))

--- a/tests/test_native_qwen3_coder_profile.py
+++ b/tests/test_native_qwen3_coder_profile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import unittest
 from unittest import mock
 
-from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _RequestTiming
 from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.model_profiles import NativeModelProfile, QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.paths import NativeLlamaPaths
@@ -313,6 +313,93 @@ class NativeQwen3CoderProfileTests(unittest.TestCase):
         self.assertEqual(generated, 1)
         self.assertFalse(cancelled)
         self.assertEqual(emitted, ["\ufffd"])
+
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns", return_value=1_300_000_000)
+    def test_generation_marks_exact_first_non_eog_token(self, monotonic_ns) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1
+        client._session.sampler = 11
+        client._token_to_bytes = mock.Mock(return_value=b"x")  # type: ignore[method-assign]
+        lib = client.lib.lib
+        lib.llama_sampler_sample.return_value = 94
+        lib.llama_vocab_is_eog.return_value = False
+        lib.llama_decode.return_value = 0
+        lib.llama_time_us.side_effect = [0, 1000]
+        timing = _RequestTiming(started_ns=1_000_000_000)
+
+        generated, _elapsed, cancelled = client._generate_from_current_context(
+            max_tokens=1,
+            request_timing=timing,
+        )
+
+        self.assertEqual(generated, 1)
+        self.assertFalse(cancelled)
+        self.assertEqual(timing.backend_ttft_ms(), 300.0)
+        monotonic_ns.assert_called_once_with()
+
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns")
+    def test_generation_does_not_mark_eog_as_first_output(self, monotonic_ns) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1
+        client._session.sampler = 11
+        lib = client.lib.lib
+        lib.llama_sampler_sample.return_value = 151645
+        lib.llama_vocab_is_eog.return_value = True
+        lib.llama_time_us.side_effect = [0, 1000]
+        timing = _RequestTiming(started_ns=1_000_000_000)
+
+        generated, _elapsed, cancelled = client._generate_from_current_context(
+            max_tokens=1,
+            request_timing=timing,
+        )
+
+        self.assertEqual(generated, 0)
+        self.assertFalse(cancelled)
+        self.assertIsNone(timing.backend_ttft_ms())
+        monotonic_ns.assert_not_called()
+
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns")
+    def test_cancellation_before_first_token_keeps_ttft_null(self, monotonic_ns) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1
+        client._session.sampler = 11
+        client.cancel()
+        lib = client.lib.lib
+        lib.llama_time_us.side_effect = [0, 1000]
+        timing = _RequestTiming(started_ns=1_000_000_000)
+
+        generated, _elapsed, cancelled = client._generate_from_current_context(
+            max_tokens=1,
+            request_timing=timing,
+        )
+
+        self.assertEqual(generated, 0)
+        self.assertTrue(cancelled)
+        self.assertIsNone(timing.backend_ttft_ms())
+        monotonic_ns.assert_not_called()
+
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns", return_value=1_200_000_000)
+    def test_cancellation_after_first_token_keeps_latched_ttft(self, _monotonic_ns) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1
+        client._session.sampler = 11
+        client._token_to_bytes = mock.Mock(return_value=b"x")  # type: ignore[method-assign]
+        lib = client.lib.lib
+        lib.llama_sampler_sample.return_value = 94
+        lib.llama_vocab_is_eog.return_value = False
+        lib.llama_decode.return_value = 0
+        lib.llama_time_us.side_effect = [0, 1000]
+        timing = _RequestTiming(started_ns=1_000_000_000)
+
+        generated, _elapsed, cancelled = client._generate_from_current_context(
+            max_tokens=2,
+            on_token=lambda _text: client.cancel(),
+            request_timing=timing,
+        )
+
+        self.assertEqual(generated, 1)
+        self.assertTrue(cancelled)
+        self.assertEqual(timing.backend_ttft_ms(), 200.0)
 
     def test_unexpected_message_sequence_fails_closed(self) -> None:
         client = self._client()

--- a/tests/test_native_server_protocol.py
+++ b/tests/test_native_server_protocol.py
@@ -208,6 +208,7 @@ class NativeServerProtocolTests(unittest.TestCase):
             prefill_ms=300.0,
             generation_ms=100.0,
             cancelled=False,
+            backend_ttft_ms=325.5,
         )
 
         details = response["usage"]["prompt_tokens_details"]
@@ -215,6 +216,26 @@ class NativeServerProtocolTests(unittest.TestCase):
         self.assertEqual(details["reused_tokens"], 7)
         self.assertEqual(details["evaluated_tokens"], 3)
         self.assertEqual(response["timings"]["prompt_per_second"], 10.0)
+        self.assertEqual(response["timings"]["backend_ttft_ms"], 325.5)
+        self.assertEqual(response["native"]["backend_ttft_ms"], 325.5)
+
+    def test_native_response_keeps_ttft_null_without_output(self) -> None:
+        response = native_chat_response(
+            content="",
+            model="m",
+            finish_reason="cancelled",
+            session_id=DEFAULT_SESSION_ID,
+            prompt_tokens=10,
+            completion_tokens=0,
+            reused_prompt_tokens=0,
+            evaluated_prompt_tokens=10,
+            prefill_ms=300.0,
+            generation_ms=0.0,
+            cancelled=True,
+        )
+
+        self.assertIsNone(response["timings"]["backend_ttft_ms"])
+        self.assertIsNone(response["native"]["backend_ttft_ms"])
 
     def test_openai_response_keeps_expected_shape(self) -> None:
         native = native_chat_response(

--- a/tests/test_native_session_state.py
+++ b/tests/test_native_session_state.py
@@ -4,7 +4,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _measured_progress
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient, _RequestTiming, _measured_progress
 from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.paths import NativeLlamaPaths
 from orbit.native_llama.session_state import DEFAULT_NATIVE_SESSION_ID
@@ -12,6 +12,34 @@ from orbit.native_server.app import OrbitNativeServer
 
 
 class NativeSessionStateTests(unittest.TestCase):
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns", side_effect=[1_000_000_000, 1_250_000_000])
+    def test_request_timing_latches_first_generated_token_once(self, monotonic_ns) -> None:
+        timing = _RequestTiming.start()
+
+        timing.mark_first_generated()
+        timing.mark_first_generated()
+
+        self.assertEqual(timing.backend_ttft_ms(), 250.0)
+        self.assertEqual(monotonic_ns.call_count, 2)
+
+    def test_request_timing_is_null_without_generated_token(self) -> None:
+        timing = _RequestTiming(started_ns=1_000_000_000)
+
+        self.assertIsNone(timing.backend_ttft_ms())
+
+    @mock.patch("orbit.native_llama.client.time.monotonic_ns", return_value=1_150_000_000)
+    def test_mtp_generation_progress_latches_exact_first_output(self, monotonic_ns) -> None:
+        timing = _RequestTiming(started_ns=1_000_000_000)
+        progress = []
+
+        NativeLlamaClient._handle_mtp_progress(0, 10, 10, request_timing=timing, on_progress=progress.append)
+        NativeLlamaClient._handle_mtp_progress(1, 1, 8, request_timing=timing, on_progress=progress.append)
+        NativeLlamaClient._handle_mtp_progress(1, 2, 8, request_timing=timing, on_progress=progress.append)
+
+        self.assertEqual(timing.backend_ttft_ms(), 150.0)
+        self.assertEqual([item.phase for item in progress], ["prefill", "generation", "generation"])
+        monotonic_ns.assert_called_once_with()
+
     def test_measured_generation_progress_uses_generated_tokens_and_elapsed_time(self) -> None:
         progress = _measured_progress("generation", 127, 512, elapsed_us=10_000_000)
 
@@ -147,6 +175,7 @@ class NativeSessionStateTests(unittest.TestCase):
         self.assertEqual(progress[1].cached_tokens, 3)
         self.assertEqual(progress[1].tokens_per_second, 1000.0)
         self.assertEqual(timings.reused_prompt_tokens, 3)
+        self.assertIsNone(timings.backend_ttft_ms)
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_prompt_cache_mode_change_resets_session_state(self, _mocked_lib) -> None:


### PR DESCRIPTION
Summary:
- records backend TTFT from native inference entry to the first accepted non-EOG token
- records stream TTFT from HTTP request start to the first nonempty SSE output event
- keeps backend and stream timing explicitly separate and null when no token is generated
- uses monotonic one-shot latches with no prompt, routing, tool, or terminal behavior changes

Validation:
- focused 174/174 PASS
- full discovery 1839/1839 PASS
- compileall PASS
- diff check PASS
- real Qwen3-Coder cold, cached, chat, tool, and final-response qualification PASS

Overhead:
- approximately 0.91 microseconds per successful request latch
- approximately 0.189 microseconds per MTP progress event
- no locks, polling, extra model calls, or tokens