### PR TITLE
Render Markdown inline code in the terminal

### DIFF
--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -17,6 +17,8 @@ MARKDOWN_BOLD = "\033[1m"
 MARKDOWN_BOLD_OFF = "\033[22m"
 MARKDOWN_ITALIC = "\033[3m"
 MARKDOWN_ITALIC_OFF = "\033[23m"
+MARKDOWN_INLINE_CODE = CYAN
+MARKDOWN_INLINE_CODE_OFF = "\033[39m"
 
 
 @dataclass(frozen=True)
@@ -518,6 +520,7 @@ class _LiveMarkdownRenderer:
         self._inline_buffer = ""
         self._discard_fence_line = False
         self._last_visible_char = ""
+        self._trailing_backslashes = 0
 
     def write(self, text: str) -> list[str]:
         if not text:
@@ -542,6 +545,8 @@ class _LiveMarkdownRenderer:
         if self._style_open:
             tail.append(RESET)
             self._style_open = False
+        self._last_visible_char = ""
+        self._trailing_backslashes = 0
         return tail
 
     def _write_char(self, ch: str) -> list[str]:
@@ -583,7 +588,7 @@ class _LiveMarkdownRenderer:
         self._start_of_line = keep_start
         if visible_prefix is None:
             visible_prefix = prefix
-        if visible_prefix.startswith("**"):
+        if visible_prefix.startswith(("**", "`")):
             return self._write_inline_text(visible_prefix)
         if not visible_prefix:
             return []
@@ -658,7 +663,7 @@ class _LiveMarkdownRenderer:
                 emitted.append(self._emit(self._inline_buffer[:start]))
                 self._inline_buffer = self._inline_buffer[start:]
                 continue
-            end = self._inline_buffer.find(marker, len(marker))
+            end = self._find_closing_inline_marker(marker)
             if end < 0:
                 if len(self._inline_buffer) > self._INLINE_BUFFER_LIMIT:
                     emitted.append(self._emit(self._inline_buffer))
@@ -679,7 +684,7 @@ class _LiveMarkdownRenderer:
 
     def _next_inline_marker(self) -> tuple[int, str]:
         candidates: list[tuple[int, str]] = []
-        for marker in ("**", "*", "_"):
+        for marker in ("**", "*", "_", "`"):
             idx = self._find_inline_marker(marker)
             if idx >= 0:
                 candidates.append((idx, marker))
@@ -694,7 +699,10 @@ class _LiveMarkdownRenderer:
             if idx < 0:
                 return -1
             next_idx = idx + len(marker)
-            if marker != "**" and next_idx < len(self._inline_buffer) and self._inline_buffer[next_idx].isspace():
+            if marker == "`" and self._backtick_is_escaped(idx):
+                start = idx + 1
+                continue
+            if marker in {"*", "_"} and next_idx < len(self._inline_buffer) and self._inline_buffer[next_idx].isspace():
                 start = idx + 1
                 continue
             if marker == "_" and self._marker_inside_word(idx=idx, marker=marker):
@@ -706,12 +714,37 @@ class _LiveMarkdownRenderer:
         if marker == "**":
             open_style = MARKDOWN_BOLD
             close_style = MARKDOWN_BOLD_OFF
+        elif marker == "`":
+            open_style = MARKDOWN_INLINE_CODE
+            close_style = MARKDOWN_INLINE_CODE_OFF
         else:
             open_style = MARKDOWN_ITALIC
             close_style = MARKDOWN_ITALIC_OFF
         if self._line_style and self._style_open:
             close_style = RESET + self._line_style
         return f"{open_style}{text}{close_style}"
+
+    def _find_closing_inline_marker(self, marker: str) -> int:
+        start = len(marker)
+        while True:
+            idx = self._inline_buffer.find(marker, start)
+            if idx < 0:
+                return -1
+            if marker != "`" or not self._backtick_is_escaped(idx):
+                return idx
+            start = idx + 1
+
+    def _backtick_is_escaped(self, idx: int) -> bool:
+        if idx == 0:
+            return self._trailing_backslashes % 2 == 1
+        backslashes = 0
+        cursor = idx - 1
+        while cursor >= 0 and self._inline_buffer[cursor] == "\\":
+            backslashes += 1
+            cursor -= 1
+        if cursor < 0:
+            backslashes += self._trailing_backslashes
+        return backslashes % 2 == 1
 
     def _marker_inside_word(self, *, idx: int, marker: str) -> bool:
         previous = self._inline_buffer[idx - 1] if idx > 0 else self._last_visible_char
@@ -723,3 +756,7 @@ class _LiveMarkdownRenderer:
         visible = re.sub(r"\x1b\[[0-9;]*m", "", text)
         if visible:
             self._last_visible_char = visible[-1]
+            trailing = len(visible) - len(visible.rstrip("\\"))
+            self._trailing_backslashes = (
+                self._trailing_backslashes + trailing if trailing == len(visible) else trailing
+            )

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -266,6 +266,138 @@ class StreamingRendererTests(unittest.TestCase):
         self.assertIn("\033[3mitalic\033[23m", output)
         self.assertIn(" word", output)
 
+    def test_live_markdown_rendering_styles_complete_inline_code(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use `text/summary.txt` now")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertEqual(output, "Use \033[36mtext/summary.txt\033[39m now")
+        self.assertNotIn("`", output)
+
+    def test_live_markdown_rendering_handles_split_inline_code(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use `")
+            renderer.write("python")
+            renderer.write("` now")
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "Use \033[36mpython\033[39m now")
+
+    def test_live_markdown_rendering_handles_multiple_mixed_inline_spans(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("**bold** uses `foo bar`, `--low-memory`, and *italic*")
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[1mbold\033[22m", output)
+        self.assertIn("\033[36mfoo bar\033[39m", output)
+        self.assertIn("\033[36m--low-memory\033[39m", output)
+        self.assertIn("\033[3mitalic\033[23m", output)
+        self.assertNotIn("`foo bar`", output)
+
+    def test_live_markdown_rendering_preserves_unmatched_inline_code(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use `python")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "Use `python")
+
+    def test_live_markdown_rendering_preserves_escaped_backticks(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write(r"Use \`python\` literally")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), r"Use \`python\` literally")
+
+    def test_live_markdown_rendering_distinguishes_even_backslash_escape(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use \\\\`python` now")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "Use \\\\" + "\033[36mpython\033[39m now")
+
+    def test_live_markdown_rendering_preserves_code_span_spaces(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use ` foo bar ` now")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        self.assertEqual(stream.getvalue(), "Use \033[36m foo bar \033[39m now")
+
+    def test_live_markdown_rendering_keeps_inline_code_out_of_fences(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("`before`\n```python\nvalue = `literal`\n```\n`after`")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[36mbefore\033[39m", output)
+        self.assertIn("value = `literal`", output)
+        self.assertIn("\033[36mafter\033[39m", output)
+        self.assertNotIn("```python", output)
+
+    def test_live_markdown_rendering_does_not_cross_tool_event_boundaries(self) -> None:
+        stream = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = stream
+            renderer = StreamRenderer(render_markdown_mode="live")
+            renderer.write("Use `python` ending \\")
+            renderer.event("Exec: echo `literal`", restart_timer=False)
+            renderer.write("Then `done`")
+            renderer.finish()
+        finally:
+            sys.stdout = original
+
+        output = stream.getvalue()
+        self.assertIn("\033[36mpython\033[39m", output)
+        self.assertIn("Exec: echo `literal`", output)
+        self.assertIn("\033[36mdone\033[39m", output)
+
     def test_live_markdown_rendering_does_not_style_snake_case_as_italic(self) -> None:
         stream = io.StringIO()
         original = sys.stdout
@@ -854,13 +986,13 @@ class StreamingRendererTests(unittest.TestCase):
                 renderer.start()
                 renderer.progress(StreamProgress(phase="prefill", current=1, total=2, percent=50))
                 renderer.event("› Exec  pwd", next_activity=("tool", "exec_shell_full_command"))
-                renderer.write("**answer**\n")
+                renderer.write("**answer** with `inline code`\n")
                 renderer.finish()
         finally:
             sys.stdout = original
 
         output = stream.getvalue()
-        self.assertEqual(output, "› Exec  pwd\n**answer**\n")
+        self.assertEqual(output, "› Exec  pwd\n**answer** with `inline code`\n")
         self.assertNotIn("\033", output)
         self.assertNotIn("\r", output)
 


### PR DESCRIPTION
- renders closed single-backtick spans in the live terminal Markdown renderer
- preserves split-chunk streaming, unmatched and escaped backticks, fenced code, and tool boundaries
- leaves plain non-TTY output unchanged
- adds no dependency and changes no runtime or inference behavior

Validation:
- streaming 69/69 PASS
- affected terminal/CLI 197/197 PASS
- full discovery 1849/1849 PASS, 6 skips
- compileall and diff check PASS