### PR TITLE
Preserve complete document evidence handoff

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -292,6 +292,7 @@ class ChatRuntime:
                 on_phase_start=on_phase_start,
                 loop=1,
                 use_tool_prompt=True,
+                workdir=workdir,
             )
         except BaseException:
             self._discard_acquired_evidence(evidence_id)
@@ -983,6 +984,7 @@ class ChatRuntime:
         loop: int,
         use_tool_prompt: bool,
         compact_window: bool = False,
+        workdir: Path | None = None,
     ) -> ChatResult:
         return self._final_from_tool_environment().answer(
             temperature=temperature,
@@ -994,6 +996,7 @@ class ChatRuntime:
             loop=loop,
             use_tool_prompt=use_tool_prompt,
             compact_window=compact_window,
+            workdir=workdir,
         ).result
 
     def _chat_final(

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -41,6 +41,7 @@ from orbit.runtime.final_policy import (
 )
 from orbit.runtime.full_document import (
     FullDocumentAdmission,
+    FullDocumentSnapshot,
     assess_full_document_admission,
     attest_full_document_snapshot,
     exact_coverage_notice,
@@ -51,6 +52,7 @@ from orbit.runtime.full_document import (
     full_document_messages,
     full_document_source_blocked_notice,
     identify_full_document_request,
+    parse_complete_file_display,
     parse_full_document_snapshot,
     required_full_document_context,
     targeted_search_coverage_notice,
@@ -495,6 +497,89 @@ class FullDocumentPreflightEnvironment:
                 on_final_delta=on_final_delta,
             )
 
+        return self._answer_snapshot(
+            prompt,
+            snapshot=snapshot,
+            raw=raw,
+            route_result=route_result,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
+        )
+
+    def answer_complete_display(
+        self,
+        prompt: str,
+        *,
+        raw: str,
+        route_result: ChatResult,
+        temperature: float,
+        max_tokens: int,
+        workdir: Path,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+    ) -> ChatResult | None:
+        display = parse_complete_file_display(raw)
+        if display is None:
+            return None
+        snapshot_raw = read_full_document_snapshot(display.path, workdir=workdir)
+        if snapshot_raw.startswith("error:"):
+            return self._blocked(
+                route_result,
+                full_document_source_blocked_notice(
+                    display.path,
+                    snapshot_raw.removeprefix("error:").strip(),
+                ),
+                on_final_delta=on_final_delta,
+            )
+        snapshot = parse_full_document_snapshot(snapshot_raw)
+        if snapshot is None or (
+            snapshot.path != display.path
+            or snapshot.byte_count != display.byte_count
+            or snapshot.line_count != display.line_count
+            or snapshot.sha256 != display.sha256
+            or snapshot.content != display.content
+        ):
+            return self._blocked(
+                route_result,
+                full_document_source_blocked_notice(display.path, "display_snapshot_mismatch"),
+                on_final_delta=on_final_delta,
+            )
+        return self._answer_snapshot(
+            prompt,
+            snapshot=snapshot,
+            raw=snapshot_raw,
+            route_result=route_result,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            workdir=workdir,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
+        )
+
+    def _answer_snapshot(
+        self,
+        prompt: str,
+        *,
+        snapshot: FullDocumentSnapshot,
+        raw: str,
+        route_result: ChatResult,
+        temperature: float,
+        max_tokens: int,
+        workdir: Path,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+    ) -> ChatResult:
         record = None
         if self.runtime.evidence_store is not None:
             record = self.runtime.evidence_store.add(
@@ -1100,10 +1185,31 @@ class FinalFromToolEnvironment:
         loop: int,
         use_tool_prompt: bool,
         compact_window: bool = False,
+        workdir: Path | None = None,
     ) -> FinalAnswerResult:
         evidence_kind, evidence_chars = self._latest_evidence_budget_metadata()
         targeted_prefix = self._targeted_search_prefix()
-        display_prefix = self._file_display_prefix()
+        complete_display_raw = self._complete_file_display_raw()
+        if complete_display_raw is not None and workdir is not None:
+            prompt = last_user_text(self.runtime.messages) or ""
+            complete_result = FullDocumentPreflightEnvironment(
+                runtime=self.runtime,
+                transport=self.transport,
+            ).answer_complete_display(
+                prompt,
+                raw=complete_display_raw,
+                route_result=_runtime_result(""),
+                temperature=temperature,
+                max_tokens=max_tokens,
+                workdir=workdir,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
+            )
+            if complete_result is not None:
+                return FinalAnswerResult(result=complete_result, used_retry_or_repair_pass=False)
+        display_prefix = "" if complete_display_raw is not None else self._file_display_prefix()
         targeted_no_match = self._targeted_search_no_match()
         if targeted_no_match is not None:
             result = ChatResult(
@@ -1411,6 +1517,17 @@ class FinalFromToolEnvironment:
         except (FileNotFoundError, OSError, UnicodeDecodeError):
             return ""
         return file_display_coverage_notice(raw) or ""
+
+    def _complete_file_display_raw(self) -> str | None:
+        store = self.runtime.evidence_store
+        record = next(iter(store.recent_records(1)), None) if store is not None else None
+        if record is None or record.kind != "read":
+            return None
+        try:
+            raw = store.load_raw(record.evidence_id) if store is not None else ""
+        except (FileNotFoundError, OSError, UnicodeDecodeError):
+            return None
+        return raw if parse_complete_file_display(raw) is not None else None
 
 @dataclass(frozen=True)
 class ContinueEnvironment:

--- a/src/orbit/runtime/full_document.py
+++ b/src/orbit/runtime/full_document.py
@@ -97,6 +97,15 @@ class FullDocumentAdmission:
         return self.reason is None and self.messages is not None
 
 
+@dataclass(frozen=True)
+class CompleteFileDisplay:
+    path: str
+    byte_count: int
+    line_count: int
+    sha256: str
+    content: str
+
+
 def identify_full_document_request(prompt: str) -> FullDocumentRequest | None:
     """Recognize only explicit full-read forms with one syntactic local path."""
     if not isinstance(prompt, str) or not prompt or len(prompt) > FULL_DOCUMENT_REQUEST_MAX_CHARS:
@@ -393,6 +402,8 @@ def file_display_coverage_notice(raw: str) -> str | None:
         or not line_range
     ):
         return None
+    if coverage == "complete" and parse_complete_file_display(raw) is None:
+        return None
     suffix = (
         "The entire verified file was returned."
         if coverage == "complete"
@@ -401,6 +412,53 @@ def file_display_coverage_notice(raw: str) -> str | None:
     return (
         f"Document coverage: {coverage} exact display; `{path}`; bytes 0-{byte_count}; "
         f"lines 1-{line_count}; returned lines {line_range}; SHA-256 {digest}. {suffix}\n\n"
+    )
+
+
+def parse_complete_file_display(raw: str) -> CompleteFileDisplay | None:
+    """Parse only a self-consistent exact display of an entire UTF-8 file."""
+    marker_start = raw.find(f"{FILE_DISPLAY_MARKER}\n")
+    if marker_start < 0:
+        return None
+    display = raw[marker_start:]
+    if _CONTENT_SEPARATOR not in display:
+        return None
+    header, content = display.split(_CONTENT_SEPARATOR, 1)
+    values: dict[str, str] = {}
+    for line in header.splitlines()[1:]:
+        key, separator, value = line.partition(":")
+        key = key.strip()
+        if not separator or not key or key in values:
+            return None
+        values[key] = value.strip()
+    try:
+        path = values["path"]
+        byte_count = int(values["bytes"])
+        line_count = int(values["lines"])
+        digest = values["sha256"]
+        coverage = values["coverage"]
+        line_range = values["line_range"]
+        next_cursor = values["next_cursor"]
+    except (KeyError, ValueError):
+        return None
+    expected_range = "none" if line_count == 0 else f"1-{line_count}"
+    encoded = content.encode("utf-8")
+    if (
+        not path
+        or byte_count != len(encoded)
+        or line_count != len(content.splitlines())
+        or hashlib.sha256(encoded).hexdigest() != digest
+        or coverage != "complete"
+        or line_range != expected_range
+        or next_cursor != "none"
+    ):
+        return None
+    return CompleteFileDisplay(
+        path=path,
+        byte_count=byte_count,
+        line_count=line_count,
+        sha256=digest,
+        content=content,
     )
 
 

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -167,7 +167,7 @@ def run_tool_loop(
     # The state objects only store turn-local facts; they do not decide tasks.
 
     def answer_from_tool_results(**kwargs) -> ChatResult:
-        return runtime._answer_from_tool_results(**kwargs)
+        return runtime._answer_from_tool_results(workdir=Path(workdir), **kwargs)
 
     def write_artifact(arguments: dict[str, object]) -> ToolExecution:
         nonlocal artifact_path_pending_verification, artifact_pending_verification

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -30,6 +30,7 @@ from orbit.runtime.full_document import (
     full_document_control_marker,
     full_document_messages,
     identify_full_document_request,
+    parse_complete_file_display,
     parse_full_document_snapshot,
     required_full_document_context,
     round_context_requirement,
@@ -237,6 +238,19 @@ class FullDocumentTests(unittest.TestCase):
         self.assertIn("Document coverage: partial exact display", notice or "")
         self.assertIn("returned lines 1-100", notice or "")
         self.assertIn("does not represent the complete file", notice or "")
+
+    def test_complete_display_parser_requires_exact_content_identity(self) -> None:
+        workdir, _ = self._snapshot("alpha\nbeta\n")
+        raw = execute_read_file({"path": "note.txt"}, workdir=workdir)
+
+        display = parse_complete_file_display(raw)
+
+        self.assertIsNotNone(display)
+        assert display is not None
+        self.assertEqual(display.content, "alpha\nbeta\n")
+        self.assertEqual(display.byte_count, 11)
+        self.assertIsNone(parse_complete_file_display(raw.replace("beta", "zeta")))
+        self.assertIsNone(file_display_coverage_notice(raw.replace("beta", "zeta")))
 
     def test_zero_match_notice_refuses_definitive_negative(self) -> None:
         raw = "\n".join(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -14,7 +14,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from orbit.backend.base import ChatResult, Message
+from orbit.backend.base import ChatResult, Message, TokenCount
 from orbit.runtime import ChatRuntime
 from orbit.runtime.evidence import (
     EvidenceStore,
@@ -83,6 +83,29 @@ class SequenceBackend:
         if not self.results:
             raise AssertionError("unexpected model call")
         return self.results.pop(0)
+
+
+class ExactTokenCountingBackend:
+    context_tokens = 8192
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        rendered = json.dumps(messages, ensure_ascii=False, sort_keys=True)
+        digest = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+        return TokenCount(
+            tokens=max(1, len(rendered.encode("utf-8")) // 4),
+            context_tokens=self.context_tokens,
+            rendered_hash=digest,
+            token_hash=digest,
+        )
+
+    def count_text_tokens(self, text):
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return TokenCount(
+            tokens=max(1, len(text.encode("utf-8")) // 4),
+            context_tokens=self.context_tokens,
+            rendered_hash=digest,
+            token_hash=digest,
+        )
 
 
 class RuntimeTests(unittest.TestCase):
@@ -2594,6 +2617,178 @@ def _last_tool_message(runtime: ChatRuntime) -> Message:
 
 
 class ToolRuntimeTests(unittest.TestCase):
+    def test_complete_file_display_handoff_sends_one_exact_twenty_kb_document(self) -> None:
+        class CompleteDisplayBackend(ExactTokenCountingBackend):
+            def __init__(self) -> None:
+                self.calls = 0
+                self.messages_by_call: list[list[Message]] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.messages_by_call.append(messages)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat sample.js"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=789,
+                        completion_tokens=8,
+                        cached_tokens=768,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="The complete source includes END_OF_VERIFIED_SAMPLE.",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=self.count_chat_tokens(messages).tokens,
+                    completion_tokens=8,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        lines = [f"const benign_{index:03d} = '{index:03d}-" + ("x" * 185) + "';\n" for index in range(90)]
+        lines.append("// END_OF_VERIFIED_SAMPLE\n")
+        content = "".join(lines)
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "sample.js").write_text(content, encoding="utf-8")
+            backend = CompleteDisplayBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+            phases: list[str] = []
+
+            result = runtime.ask_with_tools(
+                "analyze and decode sample.js and report its indicators",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+                on_phase_start=lambda event: phases.append(event.phase),
+            )
+
+        self.assertGreater(len(content.encode("utf-8")), 19_000)
+        self.assertEqual(len(content.splitlines()), 91)
+        self.assertEqual(backend.calls, 2)
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[1])
+        self.assertIn("full_document_evidence: true", rendered)
+        self.assertEqual(rendered.count(content), 1)
+        self.assertIn("END_OF_VERIFIED_SAMPLE", rendered)
+        self.assertIn("Document coverage: complete; mode exact single context", result.content)
+        self.assertIn("full_document", phases)
+
+    def test_complete_file_display_handoff_fails_closed_when_document_does_not_fit(self) -> None:
+        class OversizedDisplayBackend(ExactTokenCountingBackend):
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls > 1:
+                    raise AssertionError("oversized document reached the answering model")
+                return ChatResult(
+                    content="",
+                    model="fake",
+                    finish_reason="tool_calls",
+                    tool_calls=[
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "exec_shell_full_command",
+                                "arguments": json.dumps({"command": "sed -n '1,200p' oversized.txt"}),
+                            },
+                        }
+                    ],
+                    prompt_tokens=789,
+                    completion_tokens=8,
+                    cached_tokens=768,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        content = "".join(f"line {index:03d} " + ("z" * 290) + "\n" for index in range(180))
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "oversized.txt").write_text(content, encoding="utf-8")
+            backend = OversizedDisplayBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                "analyze oversized.txt",
+                temperature=0,
+                max_tokens=512,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("Document coverage: none", result.content)
+        self.assertIn("requires at least", result.content)
+        self.assertNotIn("line 179", result.content)
+
+    def test_complete_file_display_handoff_rejects_source_change_before_model_call(self) -> None:
+        class ChangedDisplayBackend(ExactTokenCountingBackend):
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                if self.calls > 1:
+                    raise AssertionError("changed document reached the answering model")
+                return ChatResult(
+                    content="",
+                    model="fake",
+                    finish_reason="tool_calls",
+                    tool_calls=[
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "exec_shell_full_command",
+                                "arguments": json.dumps({"command": "cat sample.js"}),
+                            },
+                        }
+                    ],
+                    prompt_tokens=789,
+                    completion_tokens=8,
+                    cached_tokens=768,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        content = "const verified = true;\n" + (("// filler " + "x" * 110 + "\n") * 80)
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            target = workdir / "sample.js"
+            target.write_text(content, encoding="utf-8")
+            backend = ChangedDisplayBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                "analyze sample.js",
+                temperature=0,
+                max_tokens=256,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+                on_tool_result=lambda *_args: target.write_text("changed\n", encoding="utf-8"),
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("Document coverage: none", result.content)
+        self.assertIn("display_snapshot_mismatch", result.content)
+
     def setUp(self) -> None:
         # Keep legacy-path fixtures explicit; default-on behavior is covered by
         # the dedicated post-tool final reuse tests and live matrix.
@@ -3877,7 +4072,7 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn("ignore older tool results", backend.retry_messages[-1]["content"])
 
     def test_shell_full_analysis_metadata_observation_gets_one_model_continuation(self) -> None:
-        class ShellFullAnalysisBackend:
+        class ShellFullAnalysisBackend(ExactTokenCountingBackend):
             def __init__(self) -> None:
                 self.calls = 0
                 self.tools_seen: list[object] = []
@@ -3962,7 +4157,7 @@ class ToolRuntimeTests(unittest.TestCase):
                 allowed_tool_names=("exec_shell_full_command",),
             )
 
-        self.assertIn("Document coverage: complete exact display", result.content)
+        self.assertIn("Document coverage: complete; mode exact single context", result.content)
         self.assertTrue(result.content.endswith("vulnerability found from source evidence"))
         self.assertEqual(backend.calls, 3)
         self.assertEqual(backend.tools_seen[0], None)
@@ -4043,7 +4238,10 @@ class ToolRuntimeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             workdir = Path(tmp)
-            (workdir / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            (workdir / "vulnerable_service.py").write_text(
+                "subprocess.run(cmd, shell=True)\n" + "safe filler\n" * 100,
+                encoding="utf-8",
+            )
             backend = AnalysisCompletionBackend()
             runtime = ChatRuntime(backend=backend, system_prompt="route system")
 
@@ -4059,7 +4257,8 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertIn(backend.calls, {3, 4})
         tool_messages = [message for message in runtime.messages if message.get("role") == "tool"]
         self.assertEqual(len(tool_messages), 1)
-        self.assertIn("shell=True", tool_messages[0]["content"])
+        assert runtime.evidence_store is not None
+        self.assertIn("shell=True", runtime.evidence_store.load_raw(tool_messages[0]["evidence_id"]))
 
     def test_analysis_completion_guard_does_not_block_followup_content_read(self) -> None:
         class FollowupContentBackend:
@@ -4207,7 +4406,10 @@ class ToolRuntimeTests(unittest.TestCase):
             workdir = Path(tmp)
             samples = workdir / "samples"
             samples.mkdir()
-            (samples / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            (samples / "vulnerable_service.py").write_text(
+                "subprocess.run(cmd, shell=True)\n" + "safe filler\n" * 100,
+                encoding="utf-8",
+            )
             backend = FileRecoveryBackend()
             runtime = ChatRuntime(backend=backend, system_prompt="route system")
 
@@ -4224,7 +4426,8 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(len(tool_messages), 3)
         self.assertIn("No such file or directory", tool_messages[0]["content"])
         self.assertIn("./samples/vulnerable_service.py", tool_messages[1]["content"])
-        self.assertIn("shell=True", tool_messages[2]["content"])
+        assert runtime.evidence_store is not None
+        self.assertIn("shell=True", runtime.evidence_store.load_raw(tool_messages[2]["evidence_id"]))
         self.assertIsNotNone(backend.guard_messages)
         self.assertEqual(backend.guard_max_tokens, 64)
         self.assertIn("Requested file not read yet.", backend.guard_messages[-1]["content"])
@@ -4442,7 +4645,7 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(len(tool_messages), 1)
 
     def test_direct_content_read_handoffs_immediately_to_final_from_tool(self) -> None:
-        class DirectContentHandoffBackend:
+        class DirectContentHandoffBackend(ExactTokenCountingBackend):
             def __init__(self) -> None:
                 self.calls = 0
                 self.final_messages: list[Message] | None = None
@@ -4472,7 +4675,8 @@ class ToolRuntimeTests(unittest.TestCase):
                     )
                 self.final_messages = messages
                 assert tools is None
-                assert "shell-full output" in str(messages[-1].get("content"))
+                assert "full_document_evidence: true" in str(messages[-1].get("content"))
+                assert "subprocess.run(cmd, shell=True)" in str(messages[-1].get("content"))
                 return ChatResult(
                     content="The file is vulnerable because it uses shell=True in subprocess.run.",
                     model="fake",
@@ -4578,7 +4782,9 @@ class ToolRuntimeTests(unittest.TestCase):
                         generation_tokens_per_second=None,
                     )
                 assert tools is None
-                assert "shell-full output" in str(messages[-1].get("content"))
+                assert "tool_evidence_card: true" in "\n".join(
+                    str(message.get("content", "")) for message in messages
+                )
                 return ChatResult(
                     content="The file is vulnerable because it uses shell=True in subprocess.run.",
                     model="fake",
@@ -4595,7 +4801,10 @@ class ToolRuntimeTests(unittest.TestCase):
             workdir = Path(tmp)
             samples = workdir / "samples"
             samples.mkdir()
-            (samples / "vulnerable_service.py").write_text("subprocess.run(cmd, shell=True)\n", encoding="utf-8")
+            (samples / "vulnerable_service.py").write_text(
+                "subprocess.run(cmd, shell=True)\n" + "safe filler\n" * 100,
+                encoding="utf-8",
+            )
             backend = CandidatePathBackend()
             runtime = ChatRuntime(backend=backend, system_prompt="route system")
 

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -399,6 +399,8 @@ class SlashCommandTests(unittest.TestCase):
         self.assertEqual(backend.calls, 1)
         self.assertIn("Document coverage: complete", result.content)
         self.assertIn("complete answer", result.content)
+        rendered = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[0])
+        self.assertEqual(rendered.count("alpha\nbeta\n"), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- routes verified complete file displays through exact full-document admission
- ensures complete coverage means the final model receives the full attested content
- fails closed when context is insufficient or the source changes
- preserves partial display, search, cache, and tool-loop behavior

Validation:
- focused full-document/runtime/slash tests PASS (242 tests)
- compileall PASS
- diff check PASS
- real Qwen3-Coder ctx=10240 validation PASS