### PR TITLE
Add dedicated full-document output budget

### DIFF
--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -17,6 +17,7 @@ FINAL_SYSTEM_INFO_MAX_TOKENS = 160
 FINAL_MEDIUM_MAX_TOKENS = 192
 FINAL_WEB_SEARCH_MAX_TOKENS = 192
 FINAL_READ_MAX_TOKENS = 256
+FULL_DOCUMENT_FINAL_MAX_TOKENS = 1024
 
 CHAT_FINAL_RETRY_MAX_TOKENS = 128
 CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS = 192
@@ -65,6 +66,8 @@ def resolve_max_tokens(
         return _floor_and_cap(requested, 64, CHAT_USER_MAX_TOKENS)
     if kind == "final_from_tool":
         return _final_from_tool_tokens(requested, evidence, evidence_chars)
+    if kind == "full_document":
+        return _internal(requested, FULL_DOCUMENT_FINAL_MAX_TOKENS)
     if kind == "chat_final_retry":
         target = CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS if previous == "length" else CHAT_FINAL_RETRY_MAX_TOKENS
         return _floor_and_cap(requested, target, target)

--- a/src/orbit/runtime/full_document.py
+++ b/src/orbit/runtime/full_document.py
@@ -186,10 +186,8 @@ def assess_full_document_admission(
     workdir: Path,
 ) -> FullDocumentAdmission:
     output_reserve = resolve_max_tokens(
-        "final_from_tool",
+        "full_document",
         max_tokens,
-        evidence_kind="read",
-        evidence_chars=snapshot.char_count,
     )
     reason = full_document_control_marker(snapshot)
     reason = f"unsafe_model_control_markup:{reason}" if reason is not None else None

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -39,6 +39,14 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="directory_listing", evidence_chars=501), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 512, evidence_kind="web_search", evidence_chars=1200), 192)
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="read", evidence_chars=8000), 256)
+        self.assertEqual(resolve_max_tokens("final_from_tool", 1024, evidence_kind="fetch", evidence_chars=8000), 256)
+
+    def test_full_document_budget_respects_user_limit_up_to_dedicated_cap(self) -> None:
+        self.assertEqual(resolve_max_tokens("full_document"), 1024)
+        self.assertEqual(resolve_max_tokens("full_document", 256), 256)
+        self.assertEqual(resolve_max_tokens("full_document", 512), 512)
+        self.assertEqual(resolve_max_tokens("full_document", 1024), 1024)
+        self.assertEqual(resolve_max_tokens("full_document", 2048), 1024)
 
     def test_retry_and_repair_budgets(self) -> None:
         self.assertEqual(resolve_max_tokens("chat_final_retry", 32), 128)

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -345,7 +345,7 @@ class FullDocumentTests(unittest.TestCase):
             workdir = Path(tmp)
             content = "begin\nmiddle\nend\n"
             (workdir / "note.txt").write_text(content, encoding="utf-8")
-            backend = PreflightBackend(prompt_tokens=7680, context_tokens=8192)
+            backend = PreflightBackend(prompt_tokens=7424, context_tokens=8192)
             runtime = ChatRuntime(
                 backend=backend,
                 system_prompt=None,
@@ -374,7 +374,7 @@ class FullDocumentTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             workdir = Path(tmp)
             (workdir / "note.txt").write_text("complete evidence\n", encoding="utf-8")
-            backend = PreflightBackend(prompt_tokens=7681, context_tokens=8192)
+            backend = PreflightBackend(prompt_tokens=7425, context_tokens=8192)
             runtime = ChatRuntime(
                 backend=backend,
                 system_prompt=None,
@@ -399,7 +399,7 @@ class FullDocumentTests(unittest.TestCase):
             workdir = Path(tmp)
             target = workdir / "note.txt"
             target.write_text("beginning\nmiddle\nend\n", encoding="utf-8")
-            backend = PreflightBackend(prompt_tokens=7681, context_tokens=8192)
+            backend = PreflightBackend(prompt_tokens=7425, context_tokens=8192)
             runtime = ChatRuntime(backend=backend, system_prompt=None)
 
             result = runtime.ask_auto(
@@ -415,6 +415,26 @@ class FullDocumentTests(unittest.TestCase):
         self.assertIn("requires at least 8,193 tokens", result.content)
         self.assertNotIn("beginning", result.content)
         self.assertNotIn("central thesis", result.content.lower())
+
+    def test_full_document_1024_budget_is_used_for_context_admission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("complete evidence\n", encoding="utf-8")
+            backend = PreflightBackend(prompt_tokens=6913, context_tokens=8192)
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+
+            result = runtime.ask_auto(
+                "Analyze note.txt completely.",
+                temperature=0,
+                max_tokens=1024,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 1)
+        self.assertIn("Document coverage: none", result.content)
+        self.assertIn("requires at least 8,193 tokens", result.content)
+        self.assertIn("1024-token output reserve", result.content)
+        self.assertNotIn("complete evidence", result.content)
 
     def test_preflight_rejects_changed_file_before_inference(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
- adds a dedicated 1024-token maximum for full-document final answers
- honors the requested response limit up to that maximum
- keeps generic read/fetch final answers capped at 256
- uses the effective reserve in fail-closed context admission
- leaves backend, evidence handoff, and tool-loop behavior unchanged

Validation:
- focused budget/document tests 39/39 PASS on committed tree
- validated focused/affected/full suites 250/250, 267/267, 1860/1860 PASS
- real Qwen3-Coder ctx=11264 full-document result stopped naturally
- compileall and diff check PASS