### PR TITLE
fix(native): reset independent static sessions

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -309,6 +309,21 @@ class LlamaServerBackend:
             return None
         return _parse_token_count(data)
 
+    def reset_static_analysis_session(self) -> str | None:
+        if not self._is_orbit_native_backend():
+            return "error: static analysis requires native session reset support"
+        try:
+            data = self._post_json("/session/reset", {})
+        except LlamaServerError:
+            return "error: static analysis native session reset failed"
+        if not (
+            data.get("status") == "reset"
+            and data.get("cached_tokens") == 0
+            and data.get("in_flight") is False
+        ):
+            return "error: static analysis native session reset was not confirmed"
+        return None
+
     def _get_json(self, path: str) -> Any:
         request = Request(f"{self.base_url}{path}", method="GET")
         return self._send(request)

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -112,6 +112,25 @@ class OrbitNativeServer:
         with self.lock:
             return self.client.reset_moe_expert_usage()
 
+    def reset_session(self) -> dict[str, object]:
+        with self.lock:
+            profile = getattr(self.client, "model_profile", None)
+            preserve_coder_checkpoint = bool(
+                getattr(profile, "verified", False)
+                and getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID
+            )
+            self.client.reset_session_state(
+                preserve_qwen3_coder_route_checkpoint=preserve_coder_checkpoint
+            )
+            snapshot = self.client.session_snapshot(DEFAULT_SESSION_ID)
+            return {
+                "status": "reset",
+                "session_id": snapshot.session_id,
+                "cached_tokens": snapshot.cached_tokens,
+                "in_flight": snapshot.in_flight,
+                "qwen3_coder_checkpoint_preserved": preserve_coder_checkpoint,
+            }
+
     def validate_request(self, request: ChatRequest) -> None:
         thinking = self.client.config.thinking if request.thinking is None else request.thinking
         if request.artifact_content and (request.tools or thinking or request.stop):
@@ -451,6 +470,9 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                     self._json(self._state().reset_moe_expert_usage())
                 except RuntimeError as exc:
                     self._json({"error": str(exc)}, status=409)
+                return
+            if self.path == "/session/reset":
+                self._json(self._state().reset_session())
                 return
             payload = self._read_json()
         except ValueError as exc:

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -62,6 +62,42 @@ class FakeNativeStreamWithTrailingNoise:
 
 
 class LlamaServerBackendTests(unittest.TestCase):
+    def test_static_analysis_session_reset_requires_confirmed_empty_native_state(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", model="fake", timeout=1)
+        backend._props_cache = {"backend": "orbit-native"}
+        with mock.patch.object(
+            backend,
+            "_post_json",
+            return_value={"status": "reset", "cached_tokens": 0, "in_flight": False},
+        ) as post:
+            error = backend.reset_static_analysis_session()
+
+        self.assertIsNone(error)
+        post.assert_called_once_with("/session/reset", {})
+
+        for response in (
+            {"status": "reset", "cached_tokens": 1, "in_flight": False},
+            {"status": "reset", "cached_tokens": 0, "in_flight": True},
+            {"status": "not-reset", "cached_tokens": 0, "in_flight": False},
+        ):
+            with self.subTest(response=response), mock.patch.object(
+                backend, "_post_json", return_value=response
+            ):
+                self.assertIn(
+                    "was not confirmed", backend.reset_static_analysis_session() or ""
+                )
+
+    def test_static_analysis_session_reset_fails_closed_without_native_support(self) -> None:
+        backend = LlamaServerBackend(base_url="http://localhost", model="fake", timeout=1)
+        backend._props_cache = {"backend": "other"}
+        self.assertIn("requires native", backend.reset_static_analysis_session() or "")
+
+        backend._props_cache = {"backend": "orbit-native"}
+        with mock.patch.object(
+            backend, "_post_json", side_effect=LlamaServerError("offline")
+        ):
+            self.assertIn("reset failed", backend.reset_static_analysis_session() or "")
+
     def test_artifact_content_stream_is_native_content_only(self) -> None:
         class Backend(LlamaServerBackend):
             def __init__(self) -> None:

--- a/tests/test_native_session_state.py
+++ b/tests/test_native_session_state.py
@@ -12,6 +12,48 @@ from orbit.native_server.app import OrbitNativeServer
 
 
 class NativeSessionStateTests(unittest.TestCase):
+    def test_server_reset_clears_session_and_preserves_verified_coder_checkpoint(self) -> None:
+        client = mock.Mock()
+        client.model_profile = mock.Mock(
+            verified=True, profile_id="orbit-qwen3-coder-native-v1"
+        )
+        client.session_snapshot.return_value = mock.Mock(
+            session_id="default", cached_tokens=0, in_flight=False
+        )
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.reset_session()
+
+        client.reset_session_state.assert_called_once_with(
+            preserve_qwen3_coder_route_checkpoint=True
+        )
+        self.assertEqual(result["status"], "reset")
+        self.assertEqual(result["cached_tokens"], 0)
+        self.assertFalse(result["in_flight"])
+        self.assertTrue(result["qwen3_coder_checkpoint_preserved"])
+
+    def test_server_reset_does_not_preserve_unverified_or_other_profile_checkpoint(self) -> None:
+        for verified, profile_id in (
+            (False, "orbit-qwen3-coder-native-v1"),
+            (True, "orbit-qwen36-native-v1"),
+        ):
+            with self.subTest(verified=verified, profile_id=profile_id):
+                client = mock.Mock()
+                client.model_profile = mock.Mock(
+                    verified=verified, profile_id=profile_id
+                )
+                client.session_snapshot.return_value = mock.Mock(
+                    session_id="default", cached_tokens=0, in_flight=False
+                )
+                server = OrbitNativeServer(client=client, model_alias="m")
+
+                result = server.reset_session()
+
+                client.reset_session_state.assert_called_once_with(
+                    preserve_qwen3_coder_route_checkpoint=False
+                )
+                self.assertFalse(result["qwen3_coder_checkpoint_preserved"])
+
     @mock.patch("orbit.native_llama.client.time.monotonic_ns", side_effect=[1_000_000_000, 1_250_000_000])
     def test_request_timing_latches_first_generated_token_once(self, monotonic_ns) -> None:
         timing = _RequestTiming.start()


### PR DESCRIPTION
Adds an explicit native session reset boundary for independent static-analysis sessions. The backend accepts success only after confirming zero cached tokens and no in-flight request. The native server clears live session/KV state under the inference lock and preserves the dedicated Qwen3-Coder route checkpoint only for the exact verified profile. Normal chat lifecycle is unchanged unless the endpoint is explicitly called.\n\nValidation:\n- focused/affected: 158/158 PASS\n- independent review: 183/183 PASS\n- full discovery: 1864/1864 PASS (6 expected skips)\n- compileall PASS\n- git diff --check PASS