### PR TITLE
fix(native): disable arbitrary LCP reuse for Qwen3-Coder

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -3567,13 +3567,14 @@ class NativeLlamaClient:
             raise RuntimeError("native client not loaded")
         lib = self.lib.lib
         common = 0
-        max_common = min(len(prompt_tokens), len(self._session.cached_prompt_tokens))
-        while common < max_common and prompt_tokens[common] == self._session.cached_prompt_tokens[common]:
-            common += 1
-        if prompt_tokens:
-            # The final prompt token must be evaluated to produce fresh logits
-            # for the next sampled token.
-            common = min(common, len(prompt_tokens) - 1)
+        if not self._qwen3_coder_native_protocol():
+            max_common = min(len(prompt_tokens), len(self._session.cached_prompt_tokens))
+            while common < max_common and prompt_tokens[common] == self._session.cached_prompt_tokens[common]:
+                common += 1
+            if prompt_tokens:
+                # The final prompt token must be evaluated to produce fresh logits
+                # for the next sampled token.
+                common = min(common, len(prompt_tokens) - 1)
 
         mem = lib.llama_get_memory(self._session.ctx_tgt)
         if mem:
@@ -3588,6 +3589,13 @@ class NativeLlamaClient:
                     common = 0
         self._session.cached_prompt_tokens = list(prompt_tokens)
         return common
+
+    def _qwen3_coder_native_protocol(self) -> bool:
+        profile = getattr(self, "model_profile", None)
+        return bool(
+            getattr(profile, "verified", False)
+            and getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID
+        )
 
     def apply_chat_template(
         self,

--- a/tests/test_native_qwen3_coder_profile.py
+++ b/tests/test_native_qwen3_coder_profile.py
@@ -94,6 +94,43 @@ class NativeQwen3CoderProfileTests(unittest.TestCase):
     def _wire(content: str) -> str:
         return json.dumps(content, ensure_ascii=False)[1:]
 
+    def test_regular_prompt_prefix_reuse_falls_back_to_cold_prefill(self) -> None:
+        client = self._client()
+        client._session.ctx_tgt = 1  # type: ignore[assignment]
+        client._session.cached_prompt_tokens = [1, 2, 3, 4]
+        native = client.lib.lib
+        native.llama_get_memory.return_value = 2
+        native.llama_memory_seq_rm.return_value = True
+
+        reused = client._prepare_memory_for_prompt([1, 2, 9])
+
+        self.assertEqual(reused, 0)
+        self.assertEqual(client._session.cached_prompt_tokens, [1, 2, 9])
+        native.llama_memory_seq_rm.assert_not_called()
+        native.llama_memory_clear.assert_called_once_with(2, True)
+
+    def test_arbitrary_lcp_fallback_is_limited_to_exact_verified_profile(self) -> None:
+        for verified, profile_id in (
+            (False, QWEN3_CODER_PROFILE_ID),
+            (True, "orbit-gemma4-native-v1"),
+        ):
+            with self.subTest(verified=verified, profile_id=profile_id):
+                client = self._client()
+                client.model_profile = mock.Mock(
+                    verified=verified, profile_id=profile_id
+                )
+                client._session.ctx_tgt = 1  # type: ignore[assignment]
+                client._session.cached_prompt_tokens = [1, 2, 3, 4]
+                native = client.lib.lib
+                native.llama_get_memory.return_value = 2
+                native.llama_memory_seq_rm.return_value = True
+
+                reused = client._prepare_memory_for_prompt([1, 2, 9])
+
+                self.assertEqual(reused, 2)
+                native.llama_memory_seq_rm.assert_called_once_with(2, 0, 2, -1)
+                native.llama_memory_clear.assert_not_called()
+
     def test_generative_text_formats_preserve_content_without_outer_fence(self) -> None:
         fixtures = (
             "<!doctype html>\n<script>const x = 1;</script>",


### PR DESCRIPTION
Disables ordinary arbitrary longest-common-prefix KV reuse for the exact verified Qwen3-Coder native profile. Those requests now clear ordinary target memory and perform a full prefill, restoring semantic parity with clean evaluation. Dedicated verified route checkpoints remain separate and enabled; Qwen 3.6 and Gemma LCP behavior is unchanged.\n\nCorrectness evidence:\n- pre-fix: 683 cached + 642 evaluated diverged from 1325-token full prefill at output token 4\n- post-fix: cached-path setup and clean runs all evaluate 1325 tokens and produce identical 560-token output\n\nValidation:\n- focused: 109/109 PASS\n- independent review: 171/171 PASS\n- full discovery: 1866/1866 PASS (6 expected skips)\n- compileall PASS\n- git diff --check PASS