### PR TITLE
feat(runtime): add deterministic context manager

### DIFF
--- a/scripts/compare_context_manager.py
+++ b/scripts/compare_context_manager.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult, Message
+from orbit.runtime.context_manager import ContextBudget, plan_context
+from orbit.runtime.full_document import required_full_document_context
+from orbit.runtime.session_memory import estimate_message_tokens, maybe_refresh_memory
+
+
+CONTEXT_TOKENS = 8192
+OUTPUT_RESERVE = 256
+
+
+class _SummaryBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.prompt_tokens = 0
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        self.calls += 1
+        self.prompt_tokens += estimate_message_tokens(messages)
+        return ChatResult(
+            content="Deterministic benchmark placeholder for a model-generated memory summary.",
+            model="benchmark-double",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+
+def _tool_turn(number: int) -> list[Message]:
+    call_id = f"call-{number}"
+    evidence_id = f"ev-{number}"
+    return [
+        {"role": "user", "content": f"Inspect artifact {number} and report the exact result."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": json.dumps({"path": f"item-{number}.txt"})},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": "read_file",
+            "evidence_id": evidence_id,
+            "content": (
+                "tool_evidence_ref: true\n"
+                f"evidence_id: {evidence_id}\n"
+                "raw_ref: evidence:stored\n"
+                "size: 1200 chars, 20 lines\n"
+                "compat_excerpt:\n"
+                + (f"result-{number} " * 90)
+            ),
+        },
+        {"role": "assistant", "content": f"Verified visible result {number}."},
+    ]
+
+
+def _plain_turn(number: int, *, chars: int = 500) -> list[Message]:
+    return [
+        {"role": "user", "content": f"Question {number}: " + ("q" * chars)},
+        {"role": "assistant", "content": f"Answer {number}: " + ("a" * chars)},
+    ]
+
+
+def _workloads() -> dict[str, tuple[list[Message], set[str]]]:
+    tools = [{"role": "system", "content": "stable system"}]
+    for number in range(30):
+        tools.extend(_tool_turn(number))
+    tools.append({"role": "user", "content": "Give a concise follow-up using the verified results."})
+
+    mixed = [{"role": "system", "content": "stable system"}]
+    for number in range(8):
+        mixed.extend(_plain_turn(number, chars=180))
+    for number in range(16):
+        mixed.extend(_tool_turn(number))
+    mixed.append({"role": "user", "content": "Continue from the established results."})
+
+    long_chat = [{"role": "system", "content": "stable system"}]
+    for number in range(34):
+        long_chat.extend(_plain_turn(number, chars=420))
+    long_chat.append({"role": "user", "content": "What constraint did I state first?"})
+
+    near_limit = [{"role": "system", "content": "stable system"}]
+    for number in range(19):
+        near_limit.extend(_plain_turn(number, chars=760))
+    near_limit.append({"role": "user", "content": "Continue without losing any prior requirement."})
+
+    return {
+        "long_normal_conversation": (long_chat, set()),
+        "repeated_large_tool_observations": (tools, {f"ev-{number}" for number in range(30)}),
+        "mixed_assistant_tool_history": (mixed, {f"ev-{number}" for number in range(16)}),
+        "near_context_limit": (near_limit, set()),
+    }
+
+
+def _sha(messages: list[Message] | tuple[Message, ...]) -> str:
+    raw = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _visible_dialogue(messages: list[Message] | tuple[Message, ...]) -> list[tuple[str, object]]:
+    return [
+        (str(message.get("role")), message.get("content"))
+        for message in messages
+        if message.get("role") == "user"
+        or (message.get("role") == "assistant" and not message.get("tool_calls"))
+    ]
+
+
+def _measure(name: str, messages: list[Message], evidence_ids: set[str]) -> dict[str, object]:
+    original_tokens = estimate_message_tokens(messages)
+    baseline_messages = [dict(message) for message in messages]
+    baseline_backend = _SummaryBackend()
+    baseline_refresh = maybe_refresh_memory(
+        baseline_messages,
+        backend=baseline_backend,
+        context_tokens=CONTEXT_TOKENS,
+        temperature=0,
+    )
+    plan = plan_context(
+        messages,
+        budget=ContextBudget(
+            context_tokens=CONTEXT_TOKENS,
+            output_reserve=OUTPUT_RESERVE,
+        ),
+        available_evidence_ids=evidence_ids,
+        covered_evidence_ids=evidence_ids,
+        count_tokens=estimate_message_tokens,
+    )
+    repeated = plan_context(
+        messages,
+        budget=ContextBudget(
+            context_tokens=CONTEXT_TOKENS,
+            output_reserve=OUTPUT_RESERVE,
+        ),
+        available_evidence_ids=evidence_ids,
+        covered_evidence_ids=evidence_ids,
+        count_tokens=estimate_message_tokens,
+    )
+    return {
+        "workload": name,
+        "baseline": {
+            "prompt_tokens_before": original_tokens,
+            "prompt_tokens_after": estimate_message_tokens(baseline_messages),
+            "peak_context_occupancy": round(original_tokens / CONTEXT_TOKENS, 4),
+            "context_management_model_calls": baseline_backend.calls,
+            "context_management_evaluated_tokens": baseline_backend.prompt_tokens,
+            "cached_tokens": None,
+            "ttft_ms": None,
+            "status": baseline_refresh.reason,
+            "semantic_output_parity": "not provable: history is replaced by a model-generated summary",
+        },
+        "candidate": {
+            "prompt_tokens_before": plan.tokens_before,
+            "prompt_tokens_after": plan.tokens_after,
+            "peak_context_occupancy": round(plan.tokens_after / CONTEXT_TOKENS, 4),
+            "context_management_model_calls": 0,
+            "context_management_evaluated_tokens": 0,
+            "cached_tokens": None,
+            "ttft_ms": None,
+            "status": plan.status,
+            "reason": plan.reason,
+            "compacted_turns": plan.compacted_turns,
+            "externalized_evidence": len(plan.externalized_evidence_ids),
+            "visible_dialogue_preserved": _visible_dialogue(messages) == _visible_dialogue(plan.messages),
+            "stable_projection": _sha(plan.messages) == _sha(repeated.messages),
+        },
+    }
+
+
+def main() -> int:
+    measurements = [_measure(name, messages, evidence) for name, (messages, evidence) in _workloads().items()]
+    full_document_prompt_tokens = 6900
+    measurements.append(
+        {
+            "workload": "full_document_request",
+            "baseline": {
+                "prompt_tokens": full_document_prompt_tokens,
+                "required_context": required_full_document_context(full_document_prompt_tokens, 1024),
+                "context_management_model_calls": 0,
+                "status": "existing exact full-document admission",
+            },
+            "candidate": {
+                "prompt_tokens": full_document_prompt_tokens,
+                "required_context": required_full_document_context(full_document_prompt_tokens, 1024),
+                "context_management_model_calls": 0,
+                "status": "delegated unchanged to exact full-document admission",
+            },
+        }
+    )
+    cache_messages = [{"role": "system", "content": "stable system"}, *_tool_turn(1)]
+    cache_budget = ContextBudget(8192, 256)
+    cache_plan = plan_context(
+        cache_messages,
+        budget=cache_budget,
+        available_evidence_ids={"ev-1"},
+        covered_evidence_ids={"ev-1"},
+        count_tokens=estimate_message_tokens,
+    )
+    measurements.append(
+        {
+            "workload": "qwen3_coder_cache_sensitive",
+            "baseline": {"prompt_sha256": _sha(cache_messages), "ordinary_arbitrary_lcp": "disabled by profile"},
+            "candidate": {
+                "prompt_sha256": _sha(cache_plan.messages),
+                "byte_identical_under_budget": list(cache_plan.messages) == cache_messages,
+                "ordinary_arbitrary_lcp": "unchanged/disabled by profile",
+                "dedicated_checkpoint_policy": "not touched",
+            },
+        }
+    )
+    print(json.dumps({"policy": "deterministic-first-v0", "measurements": measurements}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -43,6 +43,7 @@ class LlamaServerBackend:
         self._display_model_name: str | None = None
         self._server_tools_cache: list[dict[str, Any]] | None = None
         self._props_cache: dict[str, Any] | None = None
+        self._props_discovery_status: str | None = None
         self._result_observer: Callable[[ChatResult], None] | None = None
         self._failure_observer: Callable[[], None] | None = None
 
@@ -300,6 +301,32 @@ class LlamaServerBackend:
             return None
         return _parse_token_count(data)
 
+    def supports_exact_context_admission(self) -> bool | None:
+        """Report whether this endpoint exposes Orbit's attested render/token count."""
+        backend = _str_or_none(self._props_or_empty().get("backend"))
+        if backend == "orbit-native":
+            return True
+        if backend is not None or self._props_discovery_status == "confirmed_non_native":
+            return False
+        return None
+
+    def count_artifact_content_tokens(self, messages: list[Message], *, tools=None, thinking=False) -> TokenCount | None:
+        if not self._is_orbit_native_backend() or tools or thinking:
+            return None
+        try:
+            data = self._post_json(
+                "/tokens/count",
+                {
+                    "mode": "artifact_content",
+                    "messages": messages,
+                    "tools": [],
+                    "thinking": False,
+                },
+            )
+        except LlamaServerError:
+            return None
+        return _parse_token_count(data)
+
     def count_text_tokens(self, text: str) -> TokenCount | None:
         if not self._is_orbit_native_backend():
             return None
@@ -341,10 +368,24 @@ class LlamaServerBackend:
                 or (isinstance(cause, HTTPError) and 500 <= cause.code < 600)
             )
             if transient:
+                self._props_discovery_status = "unknown"
                 return {}
+            self._props_discovery_status = (
+                "confirmed_non_native"
+                if isinstance(cause, HTTPError) and cause.code == 404
+                else "unknown"
+            )
             self._props_cache = {}
             return self._props_cache
         self._props_cache = data if isinstance(data, dict) else {}
+        backend = _str_or_none(self._props_cache.get("backend"))
+        self._props_discovery_status = (
+            "native"
+            if backend == "orbit-native"
+            else "confirmed_non_native"
+            if backend is not None
+            else "unknown"
+        )
         return self._props_cache
 
     def _is_orbit_native_backend(self) -> bool:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -3545,6 +3545,27 @@ class NativeLlamaClient:
             token_digest.hexdigest(),
         )
 
+    def inspect_artifact_content_tokens(
+        self,
+        messages: list[NativeMessage],
+    ) -> tuple[int, str, str]:
+        profile = getattr(self, "model_profile", None)
+        if getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID:
+            framed_messages = qwen3_coder_artifact_messages(messages)
+            rendered = self.apply_chat_template(framed_messages, tools=None, thinking=False)
+            prompt = qwen3_coder_artifact_prompt(rendered)
+        else:
+            prompt = self.apply_chat_template(messages, tools=None, thinking=False)
+        token_ids = self.tokenize(prompt)
+        token_digest = hashlib.sha256()
+        for token in token_ids:
+            token_digest.update(int(token).to_bytes(4, byteorder="little", signed=True))
+        return (
+            len(token_ids),
+            hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+            token_digest.hexdigest(),
+        )
+
     def _content_token_count(self, text: str) -> int:
         if not text:
             return 0

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -325,6 +325,16 @@ class OrbitNativeServer:
             "token_hash": token_hash,
         }
 
+    def count_artifact_content_tokens(self, messages: list[dict[str, Any]]) -> dict[str, int | str]:
+        with self.lock:
+            tokens, rendered_hash, token_hash = self.client.inspect_artifact_content_tokens(messages)
+        return {
+            "tokens": tokens,
+            "context_tokens": self.client.config.context_tokens,
+            "rendered_hash": rendered_hash,
+            "token_hash": token_hash,
+        }
+
     def error_result(self, message: str, payload: dict[str, Any]) -> dict[str, Any]:
         session_id = DEFAULT_SESSION_ID
         try:
@@ -500,7 +510,13 @@ class OrbitNativeHandler(BaseHTTPRequestHandler):
                         )
                     )
                     return
-                raise ValueError("token count mode must be text or chat")
+                if mode == "artifact_content":
+                    request = parse_chat_request(payload)
+                    if request.tools or request.thinking:
+                        raise ValueError("artifact content token count does not accept tools or thinking")
+                    self._json(self._state().count_artifact_content_tokens(request.messages))
+                    return
+                raise ValueError("token count mode must be text, chat, or artifact_content")
             if self.path == "/chat":
                 try:
                     with native_kv_request_context(endpoint="/chat", payload=payload):

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -12,6 +12,13 @@ from orbit.runtime.capabilities import LocalCapabilities, discover_local_capabil
 from orbit.runtime.client_state import ClientState
 from orbit.runtime.command_evidence import AcquiredEvidence
 from orbit.runtime.completion_budget import resolve_max_tokens
+from orbit.runtime.context_manager import (
+    ContextAdmissionError,
+    ContextManagedBackend,
+    ContextPlan,
+    DEFAULT_NEXT_ACTION_RESERVE,
+    plan_exact_context,
+)
 from orbit.runtime.environments import (
     ContinueEnvironment,
     DocumentSearchEnvironment,
@@ -41,7 +48,14 @@ from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
 )
 from orbit.runtime.file_input_resolver import FileInputResolver
-from orbit.runtime.kv_diag import emit_evidence_lineage, emit_route_outcome, instrument_backend, model_call_context, user_request
+from orbit.runtime.kv_diag import (
+    current_phase,
+    emit_evidence_lineage,
+    emit_route_outcome,
+    instrument_backend,
+    model_call_context,
+    user_request,
+)
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import (
     TOOL_CALL_JSON_RETRY_PROMPT,
@@ -113,7 +127,6 @@ class ChatRuntime:
     context_tokens: int | None = None
     last_memory_refresh: MemoryRefresh | None = None
     last_memory_refresh_message_count: int | None = None
-    memory_refresh_cooldown_messages: int = 4
     memory_refreshes: int = 0
     total_memory_tokens_saved: int = 0
     last_memory_refresh_attempt: MemoryRefresh | None = None
@@ -151,9 +164,13 @@ class ChatRuntime:
     post_tool_final_reuse_fallback_count: int = 0
     post_tool_final_reuse_avoided_model_calls: int = 0
     post_tool_final_reuse_last_reason: str | None = None
+    last_context_plan: ContextPlan | None = field(default=None, repr=False)
+    last_context_rehydrated_ids: tuple[str, ...] = field(default=(), repr=False)
+    context_compactions: int = 0
+    context_tokens_saved: int = 0
 
     def __post_init__(self) -> None:
-        self.backend = instrument_backend(self.backend)
+        self.backend = ContextManagedBackend(instrument_backend(self.backend), self._prepare_model_context)
         if hasattr(self.backend, "thinking"):
             self.thinking_mode = bool(getattr(self.backend, "thinking"))
         if not self.messages and self.system_prompt:
@@ -221,7 +238,6 @@ class ChatRuntime:
     ) -> ChatResult:
         self._begin_user_turn()
         self.last_memory_refresh = None
-        self.refresh_memory_if_needed(temperature=temperature)
         call_messages = with_chat_system_prompt([*self.messages, {"role": "user", "content": prompt}])
         result = self._pure_chat_environment().ask_user_content(
             prompt,
@@ -254,7 +270,6 @@ class ChatRuntime:
         checkpoint = len(self.messages)
         turn_id = self._begin_user_turn()
         self.last_memory_refresh = None
-        self.refresh_memory_if_needed(temperature=temperature)
         if self.evidence_store is None:
             self.evidence_store = EvidenceStore.for_workdir(workdir)
         self.messages.append({"role": "user", "content": prompt})
@@ -324,7 +339,6 @@ class ChatRuntime:
         """Run the existing exact full-document admission without a route call."""
         self._begin_user_turn()
         self.last_memory_refresh = None
-        self.refresh_memory_if_needed(temperature=temperature)
         self.messages.append({"role": "user", "content": prompt})
         base = ChatResult(
             content="",
@@ -391,7 +405,6 @@ class ChatRuntime:
     ) -> ChatResult:
         self._begin_user_turn()
         self.last_memory_refresh = None
-        self.refresh_memory_if_needed(temperature=temperature)
         self.messages.append({"role": "user", "content": prompt})
         self._stream_tool_thinking_plan(
             temperature=temperature,
@@ -439,7 +452,6 @@ class ChatRuntime:
     ) -> ChatResult:
         self._begin_user_turn()
         self.last_memory_refresh = None
-        self.refresh_memory_if_needed(temperature=temperature)
         resolution = self._file_input_environment(workdir).resolve(
             prompt,
             allowed_tool_names=allowed_tool_names,
@@ -1075,6 +1087,10 @@ class ChatRuntime:
         self.post_tool_final_reuse_fallback_count = 0
         self.post_tool_final_reuse_avoided_model_calls = 0
         self.post_tool_final_reuse_last_reason = None
+        self.last_context_plan = None
+        self.last_context_rehydrated_ids = ()
+        self.context_compactions = 0
+        self.context_tokens_saved = 0
         self.last_memory_refresh = None
         self.last_memory_refresh_message_count = None
         self.last_memory_refresh_attempt = None
@@ -1082,17 +1098,19 @@ class ChatRuntime:
             self.messages.append({"role": "system", "content": self.system_prompt})
 
     def compact_old_tool_results(self, *, temperature: float) -> ToolResultCompactionReport:
-        return compact_tool_results(self.messages, backend=self.backend, temperature=temperature)
+        with model_call_context(phase="explicit_tool_compact", tools_mode="off"):
+            return compact_tool_results(self.messages, backend=self.backend, temperature=temperature)
 
     def compact_memory_now(self, *, temperature: float) -> MemoryRefresh:
         before_count = len(self.messages)
-        result = maybe_refresh_memory(
-            self.messages,
-            backend=self.backend,
-            context_tokens=self.context_tokens,
-            temperature=temperature,
-            force=True,
-        )
+        with model_call_context(phase="explicit_memory_compact", tools_mode="off"):
+            result = maybe_refresh_memory(
+                self.messages,
+                backend=self.backend,
+                context_tokens=self.context_tokens,
+                temperature=temperature,
+                force=True,
+            )
         if result.changed:
             self.last_memory_refresh = result
             self.last_memory_refresh_message_count = len(self.messages)
@@ -1429,29 +1447,111 @@ class ChatRuntime:
             )
         return max_tokens
 
-    def refresh_memory_if_needed(self, *, temperature: float, force: bool = False) -> bool:
-        if not force and self._memory_refresh_in_cooldown():
-            return False
-        result = maybe_refresh_memory(
-            self.messages,
+    def _prepare_model_context(
+        self,
+        messages: list[Message],
+        max_tokens: int,
+        tools: list[dict[str, object]] | None,
+        thinking: bool,
+        artifact_content: bool,
+    ) -> list[Message]:
+        if current_phase() in {"full_document", "explicit_memory_compact", "explicit_tool_compact"} or self.context_tokens is None:
+            return messages
+        exact_admission = getattr(self.backend, "supports_exact_context_admission", None)
+        if callable(exact_admission):
+            exact_admission_status = exact_admission()
+            if exact_admission_status is False:
+                return messages
+            if exact_admission_status is not True:
+                raise ContextAdmissionError("context admission failed: exact-token-capability-unavailable")
+        candidate, rehydrated_ids = self._with_explicit_evidence_rehydration(messages)
+        available, covered = self._context_evidence_sets(messages)
+        next_action_reserve = DEFAULT_NEXT_ACTION_RESERVE if _phase_may_require_next_action(current_phase()) else 0
+        artifact_counter = getattr(self.backend, "count_artifact_content_tokens", None) if artifact_content else None
+        if artifact_content and not callable(artifact_counter):
+            raise ContextAdmissionError("context admission failed: exact-artifact-token-count-unavailable")
+        plan = plan_exact_context(
+            candidate,
             backend=self.backend,
-            context_tokens=self.context_tokens,
-            temperature=temperature,
-            force=force,
+            output_reserve=max_tokens,
+            next_action_reserve=next_action_reserve,
+            configured_context_tokens=self.context_tokens,
+            tools=tools,
+            thinking=thinking,
+            available_evidence_ids=available,
+            covered_evidence_ids=covered,
+            count_chat_override=artifact_counter,
         )
-        if result.changed:
-            self.last_memory_refresh = result
-            self.last_memory_refresh_message_count = len(self.messages)
-            self.memory_refreshes += 1
-            self.total_memory_tokens_saved += max(0, result.estimated_tokens_before - result.estimated_tokens_after)
-        self.last_memory_refresh_attempt = result
-        return result.changed
+        self.last_context_plan = plan
+        self.last_context_rehydrated_ids = rehydrated_ids
+        if not plan.admitted:
+            raise ContextAdmissionError(f"context admission failed: {plan.reason or 'required-context-does-not-fit'}")
+        if plan.status == "compacted":
+            self.context_compactions += 1
+            if plan.tokens_before is not None and plan.tokens_after is not None:
+                self.context_tokens_saved += max(0, plan.tokens_before - plan.tokens_after)
+        return [dict(message) for message in plan.messages]
 
-    def _memory_refresh_in_cooldown(self) -> bool:
-        if self.last_memory_refresh_message_count is None:
-            return False
-        return len(self.messages) - self.last_memory_refresh_message_count < self.memory_refresh_cooldown_messages
+    def _context_evidence_sets(self, messages: list[Message]) -> tuple[set[str], set[str]]:
+        if self.evidence_store is None:
+            return set(), set()
+        available: set[str] = set()
+        covered: set[str] = set()
+        for message in messages:
+            if message.get("role") != "tool":
+                continue
+            evidence_id = message.get("evidence_id")
+            reference = message.get("content")
+            if not isinstance(evidence_id, str) or not isinstance(reference, str):
+                continue
+            record = self.evidence_store.records.get(evidence_id)
+            if record is None:
+                continue
+            if (
+                record.tool_call_id != message.get("tool_call_id")
+                or record.tool_name != message.get("name")
+                or record.user_turn_id != message.get("user_turn_id")
+            ):
+                continue
+            if self.evidence_store.reattest_exact(evidence_id, expected_reference=reference) is None:
+                continue
+            available.add(evidence_id)
+            if evidence_id in self.completed_evidence_ids and _evidence_has_visible_final(messages, evidence_id):
+                covered.add(evidence_id)
+        return available, covered
 
+    def _with_explicit_evidence_rehydration(
+        self,
+        messages: list[Message],
+    ) -> tuple[list[Message], tuple[str, ...]]:
+        if self.evidence_store is None:
+            return messages, ()
+        latest_user = _latest_user_message(messages)
+        content = latest_user.get("content") if latest_user is not None else None
+        if not isinstance(content, str):
+            return messages, ()
+        evidence_ids = tuple(dict.fromkeys(re.findall(r"\bevidence:(ev_[0-9a-f]{12}_[0-9a-f]{16})\b", content)))
+        if not evidence_ids:
+            return messages, ()
+        parts = ["deterministic_evidence_rehydration: exact archived tool output"]
+        rehydrated: list[str] = []
+        for evidence_id in evidence_ids:
+            raw = self.evidence_store.reattest_exact(evidence_id)
+            record = self.evidence_store.records.get(evidence_id)
+            if raw is None or record is None or _unsafe_rehydrated_evidence(raw):
+                raise ContextAdmissionError(f"context admission failed: evidence-rehydration-unavailable:{evidence_id}")
+            delimiter = f"orbit-evidence-{record.raw_sha256}"
+            parts.extend(
+                [
+                    f"evidence_id: {evidence_id}",
+                    f"sha256: {record.raw_sha256}",
+                    f"exact_content_begin: {delimiter}",
+                    raw,
+                    f"exact_content_end: {delimiter}",
+                ]
+            )
+            rehydrated.append(evidence_id)
+        return [*messages, {"role": "system", "content": "\n".join(parts)}], tuple(rehydrated)
 
 class _ThoughtOnlyDeltaFilter:
     _THOUGHT_START = "<|channel>thought\n"
@@ -1720,6 +1820,61 @@ def _evidence_has_visible_final(messages: list[Message], evidence_id: str) -> bo
         if isinstance(content, str) and content.strip():
             return True
     return False
+
+
+def _phase_may_require_next_action(phase: str | None) -> bool:
+    return phase in {
+        "route",
+        "route_retry",
+        "tool_plan",
+        "tool_call",
+        "tool_call_json_retry",
+        "tool_call_retry",
+        "chat_thinking",
+        "document_search_plan",
+        "artifact_content",
+    }
+
+
+def _unsafe_rehydrated_evidence(content: str) -> bool:
+    lowered = content.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "<bos>",
+            "<eos>",
+            "<start_of_turn>",
+            "<end_of_turn>",
+            "<|start_header_id|>",
+            "<|end_header_id|>",
+            "<|eot_id|>",
+            "<|im_start|>",
+            "<|im_end|>",
+            "</s>",
+            "<|endoftext|>",
+            "<|fim_pad|>",
+            "<|repo_name|>",
+            "<|file_sep|>",
+            "<|fim_prefix|>",
+            "<|fim_middle|>",
+            "<|fim_suffix|>",
+            "<|turn>",
+            "<turn|>",
+            "<|channel>",
+            "<channel|>",
+            "<|tool_call>",
+            "<tool_call|>",
+            "<tool_call>",
+            "</tool_call>",
+            "<|tool_response>",
+            "<tool_response|>",
+            "<tool_response>",
+            "</tool_response>",
+            "<|think|>",
+            "<think>",
+            "</think>",
+        )
+    )
 
 
 def _tool_has_associated_user(messages: list[Message]) -> bool:

--- a/src/orbit/runtime/context_manager.py
+++ b/src/orbit/runtime/context_manager.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from orbit.backend.base import ChatResult, Message, StreamProgress, TokenCount
+
+
+EVIDENCE_REF_MARKER = "tool_evidence_ref: true"
+DEFAULT_NEXT_ACTION_RESERVE = 256
+DEFAULT_SAFETY_MARGIN = 256
+
+
+class ContextAdmissionError(ValueError):
+    """The exact model input cannot be admitted without losing required context."""
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    context_tokens: int
+    output_reserve: int
+    next_action_reserve: int = DEFAULT_NEXT_ACTION_RESERVE
+    safety_margin: int = DEFAULT_SAFETY_MARGIN
+
+    @property
+    def input_limit(self) -> int:
+        return max(
+            0,
+            self.context_tokens
+            - self.output_reserve
+            - self.next_action_reserve
+            - self.safety_margin,
+        )
+
+
+@dataclass(frozen=True)
+class ContextPlan:
+    status: str
+    messages: tuple[Message, ...]
+    input_limit: int
+    tokens_before: int | None
+    tokens_after: int | None
+    compacted_turns: int = 0
+    externalized_evidence_ids: tuple[str, ...] = ()
+    reason: str | None = None
+
+    @property
+    def admitted(self) -> bool:
+        return self.status in {"unchanged", "compacted"}
+
+
+@dataclass(frozen=True)
+class _Turn:
+    start: int
+    end: int
+    final_index: int | None
+    evidence_ids: tuple[str, ...]
+    contains_embedded_system: bool = False
+
+
+def plan_context(
+    messages: list[Message],
+    *,
+    budget: ContextBudget,
+    available_evidence_ids: Iterable[str] = (),
+    covered_evidence_ids: Iterable[str] = (),
+    count_tokens: Callable[[list[Message]], int],
+) -> ContextPlan:
+    """Build a deterministic prompt view without semantic summarization.
+
+    Only completed tool-bearing turns whose exact evidence is both externally
+    available and covered by a completed visible answer may have tool-result
+    content replaced by a deterministic exact-evidence reference. The complete
+    user/assistant/tool role structure, ordinary conversation, and the active
+    turn remain intact. If those reductions are insufficient, admission fails
+    closed.
+    """
+
+    source = [dict(message) for message in messages]
+    if not _budget_is_valid(budget):
+        return _blocked(source, budget, None, "invalid-context-reserve")
+    try:
+        before = _count(count_tokens, source)
+    except (TypeError, ValueError):
+        return _blocked(source, budget, None, "exact-token-count-unavailable")
+    if budget.input_limit <= 0:
+        return _blocked(source, budget, before, "invalid-or-exhausted-reserve")
+    try:
+        turns = _parse_turns(source)
+    except ValueError as exc:
+        return _blocked(source, budget, before, f"invalid-message-structure:{exc}")
+    if before <= budget.input_limit:
+        return ContextPlan(
+            status="unchanged",
+            messages=tuple(source),
+            input_limit=budget.input_limit,
+            tokens_before=before,
+            tokens_after=before,
+        )
+
+    available = frozenset(available_evidence_ids)
+    covered = frozenset(covered_evidence_ids)
+    selected: set[int] = set()
+    omitted_ids: list[str] = []
+    projected = source
+    after = before
+    for turn_index, turn in enumerate(turns):
+        if not _eligible_tool_turn(turn, available=available, covered=covered):
+            continue
+        selected.add(turn_index)
+        omitted_ids.extend(turn.evidence_ids)
+        projected = _project(source, turns, selected)
+        try:
+            after = _count(count_tokens, projected)
+        except (TypeError, ValueError):
+            return ContextPlan(
+                status="blocked",
+                messages=tuple(projected),
+                input_limit=budget.input_limit,
+                tokens_before=before,
+                tokens_after=None,
+                compacted_turns=len(selected),
+                externalized_evidence_ids=tuple(omitted_ids),
+                reason="exact-token-count-unavailable",
+            )
+        if after <= budget.input_limit:
+            return ContextPlan(
+                status="compacted",
+                messages=tuple(projected),
+                input_limit=budget.input_limit,
+                tokens_before=before,
+                tokens_after=after,
+                compacted_turns=len(selected),
+                externalized_evidence_ids=tuple(omitted_ids),
+            )
+
+    return ContextPlan(
+        status="blocked",
+        messages=tuple(projected),
+        input_limit=budget.input_limit,
+        tokens_before=before,
+        tokens_after=after,
+        compacted_turns=len(selected),
+        externalized_evidence_ids=tuple(omitted_ids),
+        reason="required-context-does-not-fit",
+    )
+
+
+def plan_exact_context(
+    messages: list[Message],
+    *,
+    backend: object,
+    output_reserve: int,
+    next_action_reserve: int,
+    configured_context_tokens: int | None,
+    tools: list[dict[str, Any]] | None,
+    thinking: bool,
+    available_evidence_ids: Iterable[str] = (),
+    covered_evidence_ids: Iterable[str] = (),
+    safety_margin: int = DEFAULT_SAFETY_MARGIN,
+    count_chat_override: Callable[..., object] | None = None,
+) -> ContextPlan:
+    """Plan admission from two attested renders of the actual backend input."""
+
+    source = [dict(message) for message in messages]
+    count_chat = count_chat_override if count_chat_override is not None else getattr(backend, "count_chat_tokens", None)
+    if not callable(count_chat):
+        return _blocked_without_budget(source, "exact-token-count-unavailable")
+    first = _safe_count_chat(count_chat, source, tools=tools, thinking=thinking)
+    second = _safe_count_chat(count_chat, source, tools=tools, thinking=thinking)
+    if not _same_exact_count(first, second):
+        return _blocked_without_budget(source, "tokenizer-template-or-context-changed")
+    assert first is not None and first.context_tokens is not None
+    active_context = first.context_tokens
+    if isinstance(configured_context_tokens, int) and configured_context_tokens > 0:
+        active_context = min(active_context, configured_context_tokens)
+    budget = ContextBudget(
+        context_tokens=active_context,
+        output_reserve=output_reserve,
+        next_action_reserve=next_action_reserve,
+        safety_margin=safety_margin,
+    )
+    source_key = _message_identity(source)
+    exact_cache: dict[str, int] = {source_key: first.tokens}
+
+    def exact_counter(candidate: list[Message]) -> int:
+        key = _message_identity(candidate)
+        cached = exact_cache.get(key)
+        if cached is not None:
+            return cached
+        candidate_first = _safe_count_chat(count_chat, candidate, tools=tools, thinking=thinking)
+        candidate_second = _safe_count_chat(count_chat, candidate, tools=tools, thinking=thinking)
+        if not _same_exact_count(candidate_first, candidate_second):
+            raise ValueError("exact token identity unavailable")
+        assert candidate_first is not None
+        if candidate_first.context_tokens != first.context_tokens:
+            raise ValueError("active context changed")
+        exact_cache[key] = candidate_first.tokens
+        return candidate_first.tokens
+
+    return plan_context(
+        source,
+        budget=budget,
+        available_evidence_ids=available_evidence_ids,
+        covered_evidence_ids=covered_evidence_ids,
+        count_tokens=exact_counter,
+    )
+
+
+class ContextManagedBackend:
+    """Runtime-side admission wrapper; the wrapped backend still owns inference."""
+
+    def __init__(
+        self,
+        backend: object,
+        prepare: Callable[[list[Message], int, list[dict[str, Any]] | None, bool, bool], list[Message]],
+    ) -> None:
+        object.__setattr__(self, "_backend", backend)
+        object.__setattr__(self, "_prepare", prepare)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._backend, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"_backend", "_prepare"}:
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._backend, name, value)
+
+    def _messages(
+        self,
+        messages: list[Message],
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None,
+        *,
+        artifact_content: bool = False,
+    ) -> list[Message]:
+        thinking = False if artifact_content else bool(getattr(self._backend, "thinking", False))
+        return self._prepare(messages, max_tokens, tools, thinking, artifact_content)
+
+    def chat(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> ChatResult:
+        prepared = self._messages(messages, max_tokens, tools)
+        return self._backend.chat(prepared, temperature=temperature, max_tokens=max_tokens, tools=tools)
+
+    def chat_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        prepared = self._messages(messages, max_tokens, tools)
+        return self._backend.chat_stream(
+            prepared,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            on_delta=on_delta,
+            on_progress=on_progress,
+        )
+
+    def artifact_content_stream(
+        self,
+        messages: list[Message],
+        *,
+        temperature: float,
+        max_tokens: int,
+        on_delta: Callable[[str], None],
+        on_progress: Callable[[StreamProgress], None] | None = None,
+    ) -> ChatResult:
+        generate = getattr(self._backend, "artifact_content_stream", None)
+        if not callable(generate):
+            raise RuntimeError("artifact content generation requires the native Orbit backend")
+        prepared = self._messages(messages, max_tokens, None, artifact_content=True)
+        return generate(
+            prepared,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            on_delta=on_delta,
+            on_progress=on_progress,
+        )
+
+
+def _parse_turns(messages: list[Message]) -> list[_Turn]:
+    prefix_done = False
+    starts: list[int] = []
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if role in {"system", "developer"} and not prefix_done:
+            continue
+        prefix_done = True
+        if role == "user":
+            starts.append(index)
+        elif role in {"system", "developer"}:
+            continue
+        elif role not in {"assistant", "tool"}:
+            raise ValueError(f"unsupported-role-{role}")
+        elif not starts:
+            raise ValueError("history-does-not-start-with-user")
+    if not starts:
+        return []
+
+    turns: list[_Turn] = []
+    for number, start in enumerate(starts):
+        end = starts[number + 1] if number + 1 < len(starts) else len(messages)
+        pending: list[str] = []
+        final_index: int | None = None
+        terminal_seen = False
+        evidence_ids: list[str] = []
+        for index in range(start + 1, end):
+            message = messages[index]
+            role = message.get("role")
+            if role in {"system", "developer"}:
+                continue
+            if role == "assistant":
+                if terminal_seen:
+                    raise ValueError("message-after-terminal-assistant")
+                if pending:
+                    raise ValueError("assistant-before-tool-results")
+                calls = message.get("tool_calls")
+                if calls is None:
+                    terminal_seen = True
+                    content = message.get("content")
+                    final_index = index if isinstance(content, str) and content.strip() else None
+                    continue
+                if not isinstance(calls, list) or not calls:
+                    raise ValueError("invalid-tool-call-list")
+                pending = [_tool_call_id(call) for call in calls]
+                final_index = None
+                continue
+            if role != "tool":
+                raise ValueError(f"unsupported-role-{role}")
+            if terminal_seen:
+                raise ValueError("message-after-terminal-assistant")
+            if not pending:
+                raise ValueError("orphan-tool-result")
+            tool_call_id = message.get("tool_call_id")
+            if tool_call_id != pending[0]:
+                raise ValueError("tool-result-order-or-id-mismatch")
+            pending.pop(0)
+            evidence_id = message.get("evidence_id")
+            content = message.get("content")
+            if not isinstance(evidence_id, str) or not evidence_id:
+                evidence_ids.clear()
+            elif _is_externalized_evidence_ref(content, evidence_id):
+                evidence_ids.append(evidence_id)
+            else:
+                evidence_ids.clear()
+        if pending:
+            raise ValueError("missing-tool-result")
+        tool_count = sum(1 for message in messages[start:end] if message.get("role") == "tool")
+        turns.append(
+            _Turn(
+                start=start,
+                end=end,
+                final_index=final_index,
+                evidence_ids=tuple(evidence_ids) if len(evidence_ids) == tool_count else (),
+                contains_embedded_system=any(
+                    message.get("role") in {"system", "developer"}
+                    for message in messages[start + 1 : end]
+                ),
+            )
+        )
+    return turns
+
+
+def _tool_call_id(call: object) -> str:
+    if not isinstance(call, dict):
+        raise ValueError("invalid-tool-call")
+    call_id = call.get("id")
+    if not isinstance(call_id, str) or not call_id:
+        raise ValueError("missing-tool-call-id")
+    return call_id
+
+
+def _count(counter: Callable[[list[Message]], int], messages: list[Message]) -> int:
+    value = counter(messages)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("invalid exact token count")
+    return value
+
+
+def _budget_is_valid(budget: ContextBudget) -> bool:
+    values = (
+        budget.context_tokens,
+        budget.output_reserve,
+        budget.next_action_reserve,
+        budget.safety_margin,
+    )
+    return (
+        all(isinstance(value, int) and not isinstance(value, bool) for value in values)
+        and budget.context_tokens > 0
+        and budget.output_reserve >= 0
+        and budget.next_action_reserve >= 0
+        and budget.safety_margin >= 0
+    )
+
+
+def _is_externalized_evidence_ref(content: object, evidence_id: str) -> bool:
+    if not isinstance(content, str) or not content.startswith(f"{EVIDENCE_REF_MARKER}\n"):
+        return False
+    return f"evidence_id: {evidence_id}" in content.splitlines()[1:]
+
+
+def _eligible_tool_turn(
+    turn: _Turn,
+    *,
+    available: frozenset[str],
+    covered: frozenset[str],
+) -> bool:
+    if turn.final_index is None or not turn.evidence_ids or turn.contains_embedded_system:
+        return False
+    evidence = frozenset(turn.evidence_ids)
+    return evidence.issubset(available) and evidence.issubset(covered)
+
+
+def _project(messages: list[Message], turns: list[_Turn], selected: set[int]) -> list[Message]:
+    first_turn = turns[0].start if turns else len(messages)
+    projected = [dict(message) for message in messages[:first_turn]]
+    for index, turn in enumerate(turns):
+        if index not in selected:
+            projected.extend(dict(message) for message in messages[turn.start : turn.end])
+            continue
+        for message in messages[turn.start : turn.end]:
+            copied = dict(message)
+            if copied.get("role") == "tool":
+                evidence_id = copied.get("evidence_id")
+                assert isinstance(evidence_id, str)
+                copied["content"] = _archive_tool_reference(evidence_id)
+            projected.append(copied)
+    return projected
+
+
+def _blocked(messages: list[Message], budget: ContextBudget, tokens: int | None, reason: str) -> ContextPlan:
+    return ContextPlan(
+        status="blocked",
+        messages=tuple(messages),
+        input_limit=budget.input_limit,
+        tokens_before=tokens,
+        tokens_after=tokens,
+        reason=reason,
+    )
+
+
+def _blocked_without_budget(messages: list[Message], reason: str) -> ContextPlan:
+    return ContextPlan(
+        status="blocked",
+        messages=tuple(messages),
+        input_limit=0,
+        tokens_before=None,
+        tokens_after=None,
+        reason=reason,
+    )
+
+
+def _archive_tool_reference(evidence_id: str) -> str:
+    return "\n".join(
+        (
+            "tool_evidence_ref: true",
+            "archived: true",
+            f"evidence_id: {evidence_id}",
+            f"exact_content_ref: evidence:{evidence_id}",
+        )
+    )
+
+
+def _safe_count_chat(
+    counter: Callable[..., object],
+    messages: list[Message],
+    *,
+    tools: list[dict[str, Any]] | None,
+    thinking: bool,
+) -> TokenCount | None:
+    try:
+        value = counter(messages, tools=tools, thinking=thinking)
+    except Exception:
+        return None
+    return value if isinstance(value, TokenCount) else None
+
+
+def _exact_count(value: TokenCount | None) -> bool:
+    return (
+        value is not None
+        and isinstance(value.tokens, int)
+        and value.tokens >= 0
+        and isinstance(value.context_tokens, int)
+        and value.context_tokens > 0
+        and isinstance(value.rendered_hash, str)
+        and len(value.rendered_hash) == 64
+        and isinstance(value.token_hash, str)
+        and len(value.token_hash) == 64
+    )
+
+
+def _same_exact_count(first: TokenCount | None, second: TokenCount | None) -> bool:
+    return _exact_count(first) and _exact_count(second) and first == second
+
+
+def _message_identity(messages: list[Message]) -> str:
+    import hashlib
+    import json
+
+    rendered = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 import hashlib
 import json
+import os
 import re
 import shlex
+import stat
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse
@@ -114,6 +116,54 @@ class EvidenceStore:
         content = path.read_bytes().decode("utf-8")
         if len(content) <= RAW_MEMORY_CACHE_MAX_CHARS:
             self.raw_cache[evidence_id] = content
+        return content
+
+    def reattest_exact(self, evidence_id: str, *, expected_reference: str | None = None) -> str | None:
+        """Return durable exact evidence only after identity and provenance checks."""
+        record = self.records.get(evidence_id)
+        if record is None or not _valid_evidence_id(evidence_id):
+            return None
+        if record.raw_ref != f"{RAW_REF_PREFIX}{evidence_id}":
+            return None
+        if expected_reference is not None and expected_reference != tool_evidence_ref(record):
+            return None
+        if not record.tool_call_id or not record.user_turn_id or not record.produced_by_phase:
+            return None
+        if record.metadata.get("sidecar_status") is not None:
+            return None
+        if record.metadata.get("ephemeral") == "full_document_snapshot":
+            return None
+        path = self.root / f"{evidence_id}.txt"
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        try:
+            fd = os.open(path, flags)
+        except OSError:
+            return None
+        try:
+            before = os.fstat(fd)
+            if not stat.S_ISREG(before.st_mode):
+                return None
+            raw = bytearray()
+            while True:
+                chunk = os.read(fd, 64 * 1024)
+                if not chunk:
+                    break
+                raw.extend(chunk)
+            after = os.fstat(fd)
+        except OSError:
+            return None
+        finally:
+            os.close(fd)
+        if (before.st_dev, before.st_ino, before.st_size) != (after.st_dev, after.st_ino, after.st_size):
+            return None
+        try:
+            content = bytes(raw).decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        if hashlib.sha256(bytes(raw)).hexdigest() != record.raw_sha256:
+            return None
+        if len(content) != record.raw_chars or len(content.splitlines()) != record.raw_lines:
+            return None
         return content
 
     def discard(self, evidence_id: str) -> bool:
@@ -299,6 +349,10 @@ def tool_evidence_ref(record: EvidenceRecord) -> str:
         lines.append("compat_excerpt:")
         lines.append(compat)
     return "\n".join(lines)
+
+
+def _valid_evidence_id(value: str) -> bool:
+    return re.fullmatch(r"ev_[0-9a-f]{12}_[0-9a-f]{16}", value) is not None
 
 
 def build_route_evidence_context(store: EvidenceStore | None, *, limit: int = RECENT_EVIDENCE_LIMIT) -> str | None:

--- a/src/orbit/runtime/session_memory.py
+++ b/src/orbit/runtime/session_memory.py
@@ -71,12 +71,6 @@ def maybe_refresh_memory(
     )
 
 
-def should_refresh_for_append(messages: list[Message], content: str, *, context_tokens: int | None) -> bool:
-    window = context_tokens or DEFAULT_CONTEXT_TOKENS
-    projected = estimate_message_tokens(messages) + estimate_text_tokens(content)
-    return projected >= int(window * SOFT_MEMORY_RATIO)
-
-
 def rebuild_with_memory(messages: list[Message], *, summary: str, context_tokens: int) -> list[Message]:
     system = _first_system_message(messages)
     tail = _recent_tail(messages, context_tokens=context_tokens)

--- a/src/orbit/runtime/tool_loop.py
+++ b/src/orbit/runtime/tool_loop.py
@@ -28,7 +28,6 @@ from orbit.runtime.messages import (
     with_tool_call_system_prompt,
 )
 from orbit.runtime.post_tool_final_reuse import evaluate_post_tool_final_reuse
-from orbit.runtime.session_memory import should_refresh_for_append
 from orbit.runtime.shell_guardrails import (
     SHELL_FULL_COMPLETION_GUARD_PROMPT,
     SHELL_FULL_ANALYSIS_COMPLETION_GUARD_PROMPT,
@@ -1793,8 +1792,6 @@ def run_tool_loop(
                 state.advance_after_mutation(tool_call)
             if on_tool_result:
                 on_tool_result(tool_result.name, len(tool_result.content), execution.source, tool_result.content)
-            if should_refresh_for_append(runtime.messages, tool_result.content, context_tokens=runtime.context_tokens):
-                runtime.refresh_memory_if_needed(temperature=temperature, force=True)
             history_message = tool_result_message(
                 tool_call,
                 tool_result,

--- a/src/orbit/runtime/tool_message.py
+++ b/src/orbit/runtime/tool_message.py
@@ -25,18 +25,21 @@ def tool_result_message(
 ) -> Message:
     content = tool_result.content
     evidence_id = None
+    evidence_user_turn_id = None
     if evidence_store is not None and tool_result.content:
         evidence_metadata = dict(metadata or _tool_call_metadata(tool_call))
         evidence_metadata.setdefault("tool_call_id", tool_call_id(tool_call))
         record = evidence_store.add(tool_result.name, tool_result.content, metadata=evidence_metadata)
         content = tool_evidence_ref(record)
         evidence_id = record.evidence_id
+        evidence_user_turn_id = record.user_turn_id
     return {
         "role": "tool",
         "tool_call_id": tool_call_id(tool_call),
         "name": tool_result.name,
         "content": content,
         **({"evidence_id": evidence_id} if evidence_id else {}),
+        **({"user_turn_id": evidence_user_turn_id} if evidence_user_turn_id else {}),
     }
 
 

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, replace
 from orbit.backend.base import ChatResult
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
+from orbit.runtime.context_manager import ContextAdmissionError
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.sessions import SessionStore
 from orbit.terminal.compact_reports import format_memory_compaction_report, format_tool_compaction_report
@@ -198,7 +199,7 @@ class Repl:
             self.runtime.restore_message_count(checkpoint)
             print(dim("cancelled"), flush=True)
             return
-        except (LlamaServerError, TimeoutError) as exc:
+        except (ContextAdmissionError, LlamaServerError, TimeoutError) as exc:
             renderer.finish()
             self.runtime.restore_message_count(checkpoint)
             print(runtime_error_text(exc), file=sys.stderr)
@@ -494,7 +495,7 @@ class Repl:
             self.runtime.restore_message_count(checkpoint)
             print(dim("cancelled"), flush=True)
             return
-        except (LlamaServerError, TimeoutError) as exc:
+        except (ContextAdmissionError, LlamaServerError, TimeoutError) as exc:
             renderer.finish()
             self.runtime.restore_message_count(checkpoint)
             print(runtime_error_text(exc), file=sys.stderr)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,637 @@
+from __future__ import annotations
+
+import sys
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult, TokenCount
+from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.context_manager import ContextAdmissionError, ContextBudget, plan_context, plan_exact_context
+from orbit.runtime.evidence import EvidenceStore, tool_evidence_ref
+from orbit.runtime.kv_diag import model_call_context
+from orbit.runtime.session_memory import estimate_message_tokens
+
+
+def _tool_turn(number: int, *, payload_chars: int = 1200) -> list[dict[str, object]]:
+    call_id = f"call-{number}"
+    evidence_id = f"ev-{number}"
+    return [
+        {"role": "user", "content": f"request {number}"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": "read_file",
+            "evidence_id": evidence_id,
+            "content": f"tool_evidence_ref: true\nevidence_id: {evidence_id}\n" + ("x" * payload_chars),
+        },
+        {"role": "assistant", "content": f"grounded final {number}"},
+    ]
+
+
+class _ExactBackend:
+    def __init__(self, *, context_tokens: int = 4096) -> None:
+        self.context_tokens = context_tokens
+        self.thinking = False
+        self.calls = 0
+        self.count_calls = 0
+        self.artifact_count_calls = 0
+        self.messages_by_call: list[list[dict[str, object]]] = []
+        self.tools_by_count: list[object] = []
+        self.thinking_by_count: list[bool] = []
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        self.count_calls += 1
+        self.tools_by_count.append(tools)
+        self.thinking_by_count.append(thinking)
+        rendered = json.dumps(
+            {"messages": messages, "tools": tools or [], "thinking": thinking},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+        return TokenCount(
+            tokens=max(1, len(rendered.encode("utf-8")) // 4),
+            context_tokens=self.context_tokens,
+            rendered_hash=digest,
+            token_hash=digest,
+        )
+
+    def count_artifact_content_tokens(self, messages, *, tools=None, thinking=False):
+        self.artifact_count_calls += 1
+        rendered = json.dumps(
+            {"artifact_messages": messages, "tools": tools or [], "thinking": thinking},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+        return TokenCount(
+            tokens=max(1, len(rendered.encode("utf-8")) // 4),
+            context_tokens=self.context_tokens,
+            rendered_hash=digest,
+            token_hash=digest,
+        )
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        self.calls += 1
+        self.messages_by_call.append([dict(message) for message in messages])
+        exact = "EXACT_VALUE_123" if any(
+            "deterministic_evidence_rehydration" in str(message.get("content", ""))
+            for message in messages
+        ) else ""
+        return ChatResult(
+            content=exact or "done",
+            model="fake",
+            finish_reason="stop",
+            tool_calls=[],
+            prompt_tokens=None,
+            completion_tokens=None,
+            cached_tokens=None,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+
+def _stored_tool_turn(store: EvidenceStore, number: int, raw: str) -> tuple[list[dict[str, object]], str]:
+    call_id = f"call-{number}"
+    turn_id = f"turn-{number}"
+    record = store.add(
+        "read_file",
+        raw,
+        metadata={
+            "tool_call_id": call_id,
+            "user_turn_id": turn_id,
+            "produced_by_phase": "tool_call",
+        },
+    )
+    return (
+        [
+            {"role": "user", "content": f"request {number}"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "name": "read_file",
+                "evidence_id": record.evidence_id,
+                "user_turn_id": turn_id,
+                "content": tool_evidence_ref(record),
+            },
+            {"role": "assistant", "content": f"visible final {number}"},
+        ],
+        record.evidence_id,
+    )
+
+
+class ContextManagerTests(unittest.TestCase):
+    def test_under_budget_is_byte_for_byte_unchanged(self) -> None:
+        messages = [{"role": "system", "content": "system"}, {"role": "user", "content": "hello"}]
+
+        plan = plan_context(messages, budget=ContextBudget(4096, 256), count_tokens=estimate_message_tokens)
+
+        self.assertEqual(plan.status, "unchanged")
+        self.assertEqual(list(plan.messages), messages)
+
+    def test_compacts_oldest_covered_externalized_tool_turn_only_as_needed(self) -> None:
+        messages = [
+            {"role": "system", "content": "system"},
+            *_tool_turn(1),
+            *_tool_turn(2),
+            {"role": "user", "content": "current question"},
+        ]
+        budget = ContextBudget(context_tokens=700, output_reserve=128, next_action_reserve=64, safety_margin=32)
+
+        plan = plan_context(
+            messages,
+            budget=budget,
+            available_evidence_ids={"ev-1", "ev-2"},
+            covered_evidence_ids={"ev-1", "ev-2"},
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertTrue(plan.admitted)
+        self.assertEqual(plan.status, "compacted")
+        self.assertGreaterEqual(plan.compacted_turns, 1)
+        self.assertLess(plan.tokens_after, plan.tokens_before)
+        self.assertEqual(plan.messages[-1], {"role": "user", "content": "current question"})
+        self.assertEqual(
+            [message.get("role") for message in plan.messages],
+            [message.get("role") for message in messages],
+        )
+        self.assertTrue(
+            any(
+                message.get("role") == "tool" and "evidence:ev-1" in str(message.get("content"))
+                for message in plan.messages
+            )
+        )
+        rendered = "\n".join(str(message.get("content", "")) for message in plan.messages)
+        self.assertIn("grounded final 1", rendered)
+
+    def test_multiple_terminal_assistant_messages_fail_closed(self) -> None:
+        messages = [
+            {"role": "system", "content": "system"},
+            *_tool_turn(1, payload_chars=3000),
+            {"role": "assistant", "content": ""},
+        ]
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(600, 128, 64, 32),
+            available_evidence_ids={"ev-1"},
+            covered_evidence_ids={"ev-1"},
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("message-after-terminal-assistant", str(plan.reason))
+
+    def test_never_compacts_uncovered_or_unavailable_evidence(self) -> None:
+        messages = [{"role": "system", "content": "system"}, *_tool_turn(1, payload_chars=3000)]
+        budget = ContextBudget(600, 128, 64, 32)
+
+        unavailable = plan_context(
+            messages,
+            budget=budget,
+            available_evidence_ids=set(),
+            covered_evidence_ids={"ev-1"},
+            count_tokens=estimate_message_tokens,
+        )
+        uncovered = plan_context(
+            messages,
+            budget=budget,
+            available_evidence_ids={"ev-1"},
+            covered_evidence_ids=set(),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(unavailable.status, "blocked")
+        self.assertEqual(uncovered.status, "blocked")
+        self.assertEqual(list(unavailable.messages), messages)
+        self.assertEqual(list(uncovered.messages), messages)
+
+    def test_long_plain_chat_fails_closed_instead_of_semantic_summary(self) -> None:
+        messages: list[dict[str, object]] = [{"role": "system", "content": "system"}]
+        for number in range(12):
+            messages.extend(
+                [
+                    {"role": "user", "content": f"question {number} " + ("q" * 400)},
+                    {"role": "assistant", "content": f"answer {number} " + ("a" * 400)},
+                ]
+            )
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(1200, 256, 128, 64),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.reason, "required-context-does-not-fit")
+        self.assertEqual(plan.compacted_turns, 0)
+        self.assertEqual(list(plan.messages), messages)
+
+    def test_active_tool_group_is_preserved(self) -> None:
+        messages = [
+            {"role": "system", "content": "system"},
+            *_tool_turn(1, payload_chars=2000),
+            {"role": "user", "content": "active"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "active-call", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "active-call",
+                "name": "read_file",
+                "evidence_id": "active-ev",
+                "content": "tool_evidence_ref: true\nevidence_id: active-ev\nactive result",
+            },
+        ]
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(800, 128, 64, 32),
+            available_evidence_ids={"ev-1", "active-ev"},
+            covered_evidence_ids={"ev-1"},
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertTrue(plan.admitted)
+        self.assertEqual(plan.messages[-1]["tool_call_id"], "active-call")
+        self.assertIn("active result", str(plan.messages[-1]["content"]))
+
+    def test_malformed_tool_sequence_fails_closed(self) -> None:
+        messages = [
+            {"role": "user", "content": "request"},
+            {"role": "tool", "tool_call_id": "orphan", "name": "read_file", "content": "result"},
+        ]
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(256, 64, 32, 16),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertTrue(plan.reason.startswith("invalid-message-structure:"))
+
+    def test_parallel_tool_results_keep_declared_order(self) -> None:
+        messages = [
+            {"role": "user", "content": "request"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "a", "type": "function", "function": {"name": "one", "arguments": "{}"}},
+                    {"id": "b", "type": "function", "function": {"name": "two", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "b", "name": "two", "content": "bad order"},
+        ]
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(256, 64, 32, 16),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("tool-result-order-or-id-mismatch", str(plan.reason))
+
+    def test_reserves_are_subtracted_from_admission(self) -> None:
+        plan = plan_context(
+            [{"role": "user", "content": "x" * 600}],
+            budget=ContextBudget(context_tokens=256, output_reserve=64, next_action_reserve=32, safety_margin=16),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.input_limit, 144)
+        self.assertEqual(plan.status, "blocked")
+
+    def test_projection_is_stable_for_cache_sensitive_callers(self) -> None:
+        messages = [{"role": "system", "content": "system"}, *_tool_turn(1, payload_chars=3000)]
+        kwargs = {
+            "budget": ContextBudget(600, 128, 64, 32),
+            "available_evidence_ids": {"ev-1"},
+            "covered_evidence_ids": {"ev-1"},
+            "count_tokens": estimate_message_tokens,
+        }
+
+        first = plan_context(messages, **kwargs)
+        second = plan_context(messages, **kwargs)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.status, "compacted")
+
+    def test_missing_exact_token_identity_fails_closed(self) -> None:
+        plan = plan_context(
+            [{"role": "user", "content": "hello"}],
+            budget=ContextBudget(4096, 256),
+            count_tokens=lambda _messages: None,  # type: ignore[return-value]
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.reason, "exact-token-count-unavailable")
+        self.assertIsNone(plan.tokens_before)
+
+    def test_invalid_reserve_fails_closed(self) -> None:
+        plan = plan_context(
+            [{"role": "user", "content": "hello"}],
+            budget=ContextBudget(4096, -1),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.reason, "invalid-context-reserve")
+
+    def test_changed_render_or_token_identity_fails_closed(self) -> None:
+        class ChangingBackend(_ExactBackend):
+            def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                value = super().count_chat_tokens(messages, tools=tools, thinking=thinking)
+                if self.count_calls == 2:
+                    return TokenCount(
+                        tokens=value.tokens,
+                        context_tokens=value.context_tokens,
+                        rendered_hash=value.rendered_hash,
+                        token_hash="f" * 64,
+                    )
+                return value
+
+        plan = plan_exact_context(
+            [{"role": "user", "content": "hello"}],
+            backend=ChangingBackend(),
+            output_reserve=64,
+            next_action_reserve=0,
+            configured_context_tokens=4096,
+            tools=None,
+            thinking=False,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.reason, "tokenizer-template-or-context-changed")
+
+    def test_marker_text_without_matching_evidence_identity_is_not_compacted(self) -> None:
+        messages = [{"role": "system", "content": "system"}, *_tool_turn(1, payload_chars=3000)]
+        messages[3]["content"] = "prefix " + ("x" * 3000) + "\ntool_evidence_ref: true\nevidence_id: ev-1"
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(600, 128, 64, 32),
+            available_evidence_ids={"ev-1"},
+            covered_evidence_ids={"ev-1"},
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.compacted_turns, 0)
+
+    def test_exact_admission_counts_actual_tools_and_thinking_twice(self) -> None:
+        backend = _ExactBackend()
+        messages = [{"role": "system", "content": "system"}, {"role": "user", "content": "hello"}]
+        tools = [{"type": "function", "function": {"name": "x", "parameters": {"type": "object"}}}]
+
+        plan = plan_exact_context(
+            messages,
+            backend=backend,
+            output_reserve=128,
+            next_action_reserve=256,
+            configured_context_tokens=4096,
+            tools=tools,
+            thinking=True,
+        )
+
+        self.assertEqual(plan.status, "unchanged")
+        self.assertEqual(list(plan.messages), messages)
+        self.assertEqual(backend.count_calls, 2)
+        self.assertEqual(backend.tools_by_count, [tools, tools])
+        self.assertEqual(backend.thinking_by_count, [True, True])
+
+    def test_runtime_compacts_only_reattested_covered_tool_turns_and_rehydrates_exactly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "evidence")
+            turns: list[dict[str, object]] = []
+            evidence_ids: list[str] = []
+            for number in range(1, 5):
+                prefix = "EXACT_VALUE_123\n" if number == 1 else f"value {number}\n"
+                turn, evidence_id = _stored_tool_turn(store, number, prefix + (chr(96 + number) * 700))
+                turns.extend(turn)
+                evidence_ids.append(evidence_id)
+            first_id = evidence_ids[0]
+            backend = _ExactBackend(context_tokens=1300)
+            runtime = ChatRuntime(
+                backend=backend,
+                system_prompt="system",
+                messages=[{"role": "system", "content": "system"}, *turns],
+                context_tokens=1300,
+                evidence_store=store,
+            )
+            runtime.completed_evidence_ids.update(evidence_ids)
+
+            result = runtime.ask_chat("current question", temperature=0, max_tokens=64)
+
+            self.assertEqual(result.content, "done")
+            self.assertIsNotNone(runtime.last_context_plan)
+            assert runtime.last_context_plan is not None
+            self.assertEqual(runtime.last_context_plan.status, "compacted")
+            self.assertGreater(runtime.last_context_plan.tokens_before, runtime.last_context_plan.tokens_after)
+            sent = backend.messages_by_call[-1]
+            self.assertNotIn(tool_evidence_ref(store.records[first_id]), [message.get("content") for message in sent])
+            self.assertTrue(any(f"evidence:{first_id}" in str(message.get("content")) for message in sent))
+
+            followup = runtime.ask_chat(
+                f"Return the exact value from evidence:{first_id}",
+                temperature=0,
+                max_tokens=64,
+            )
+
+            self.assertEqual(followup.content, "EXACT_VALUE_123")
+            self.assertEqual(runtime.last_context_rehydrated_ids, (first_id,))
+            rehydrated = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[-1])
+            self.assertIn("EXACT_VALUE_123", rehydrated)
+            self.assertIn(store.records[first_id].raw_sha256, rehydrated)
+
+    def test_runtime_rejects_protocol_markers_before_exact_rehydration(self) -> None:
+        markers = (
+            "<|im_start|>",
+            "<|im_end|>",
+            "</s>",
+            "<|endoftext|>",
+            "<|fim_pad|>",
+            "<|repo_name|>",
+            "<|file_sep|>",
+            "<|fim_prefix|>",
+            "<|fim_middle|>",
+            "<|fim_suffix|>",
+            "<tool_call>",
+            "</tool_call>",
+            "<|tool_response>",
+            "<tool_response|>",
+            "<start_of_turn>",
+            "<end_of_turn>",
+        )
+        for marker in markers:
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as tmp:
+                store = EvidenceStore(Path(tmp) / "evidence")
+                turn, evidence_id = _stored_tool_turn(store, 1, f"before {marker} after")
+                backend = _ExactBackend(context_tokens=4096)
+                runtime = ChatRuntime(
+                    backend=backend,
+                    messages=[*turn],
+                    context_tokens=4096,
+                    evidence_store=store,
+                )
+                runtime.completed_evidence_ids.add(evidence_id)
+
+                with self.assertRaises(ContextAdmissionError):
+                    runtime.ask_chat(f"Return evidence:{evidence_id}", temperature=0, max_tokens=64)
+
+                self.assertEqual(backend.calls, 0)
+
+    def test_runtime_binds_evidence_to_tool_call_name_and_user_turn(self) -> None:
+        mutations = {
+            "call": lambda turn: (
+                turn[1]["tool_calls"][0].__setitem__("id", "different-call"),
+                turn[2].__setitem__("tool_call_id", "different-call"),
+            ),
+            "name": lambda turn: turn[2].__setitem__("name", "different_tool"),
+            "turn": lambda turn: turn[2].__setitem__("user_turn_id", "different-turn"),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(field=label), tempfile.TemporaryDirectory() as tmp:
+                store = EvidenceStore(Path(tmp) / "evidence")
+                turn, evidence_id = _stored_tool_turn(store, 1, "x" * 1800)
+                mutate(turn)
+                backend = _ExactBackend(context_tokens=470)
+                runtime = ChatRuntime(
+                    backend=backend,
+                    messages=[*turn],
+                    context_tokens=470,
+                    evidence_store=store,
+                )
+                runtime.completed_evidence_ids.add(evidence_id)
+
+                with self.assertRaises(ContextAdmissionError):
+                    runtime.ask_chat("follow up", temperature=0, max_tokens=64)
+
+                self.assertEqual(backend.calls, 0)
+                assert runtime.last_context_plan is not None
+                self.assertEqual(runtime.last_context_plan.compacted_turns, 0)
+
+    def test_declared_non_native_backend_keeps_normal_path_unchanged(self) -> None:
+        class NonNativeBackend(_ExactBackend):
+            def supports_exact_context_admission(self):
+                return False
+
+        backend = NonNativeBackend(context_tokens=128)
+        runtime = ChatRuntime(backend=backend, context_tokens=128)
+        messages = [{"role": "user", "content": "x" * 4000}]
+
+        with model_call_context(phase="chat_final", tools_mode="off"):
+            runtime.backend.chat(messages, temperature=0, max_tokens=64)
+
+        self.assertEqual(backend.count_calls, 0)
+        self.assertEqual(backend.messages_by_call[-1], messages)
+
+    def test_unknown_exact_count_capability_fails_closed(self) -> None:
+        class UnknownBackend(_ExactBackend):
+            def supports_exact_context_admission(self):
+                return None
+
+        backend = UnknownBackend(context_tokens=4096)
+        runtime = ChatRuntime(backend=backend, context_tokens=4096)
+
+        with model_call_context(phase="chat_final", tools_mode="off"):
+            with self.assertRaises(ContextAdmissionError):
+                runtime.backend.chat([{"role": "user", "content": "hello"}], temperature=0, max_tokens=64)
+
+        self.assertEqual(backend.calls, 0)
+
+    def test_chat_thinking_phase_reserves_next_action(self) -> None:
+        backend = _ExactBackend(context_tokens=4096)
+        runtime = ChatRuntime(backend=backend, context_tokens=4096)
+        messages = [{"role": "user", "content": "think"}]
+
+        with model_call_context(phase="chat_thinking", tools_mode="off"):
+            runtime.backend.chat(messages, temperature=0, max_tokens=64)
+
+        assert runtime.last_context_plan is not None
+        self.assertEqual(runtime.last_context_plan.input_limit, 4096 - 64 - 256 - 256)
+
+    def test_stale_evidence_prevents_compaction_and_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "evidence")
+            turn, evidence_id = _stored_tool_turn(store, 1, "x" * 1100)
+            (store.root / f"{evidence_id}.txt").unlink()
+            backend = _ExactBackend(context_tokens=600)
+            runtime = ChatRuntime(
+                backend=backend,
+                messages=[*turn],
+                context_tokens=600,
+                evidence_store=store,
+            )
+            runtime.completed_evidence_ids.add(evidence_id)
+
+            with self.assertRaises(ContextAdmissionError):
+                runtime.ask_chat("follow up", temperature=0, max_tokens=64)
+
+            self.assertEqual(backend.calls, 0)
+            self.assertIsNotNone(runtime.last_context_plan)
+            assert runtime.last_context_plan is not None
+            self.assertEqual(runtime.last_context_plan.compacted_turns, 0)
+
+    def test_full_document_phase_bypasses_generic_manager(self) -> None:
+        backend = _ExactBackend(context_tokens=128)
+        runtime = ChatRuntime(backend=backend, context_tokens=128)
+        messages = [{"role": "user", "content": "x" * 2000}]
+
+        with model_call_context(phase="full_document", tools_mode="on"):
+            runtime.backend.chat(messages, temperature=0, max_tokens=64)
+
+        self.assertEqual(backend.count_calls, 0)
+        self.assertEqual(backend.messages_by_call[-1], messages)
+
+    def test_artifact_content_uses_phase_specific_exact_counter(self) -> None:
+        backend = _ExactBackend(context_tokens=4096)
+        runtime = ChatRuntime(backend=backend, context_tokens=4096)
+        messages = [{"role": "user", "content": "artifact content"}]
+
+        prepared = runtime._prepare_model_context(messages, 512, None, False, True)
+
+        self.assertEqual(prepared, messages)
+        self.assertEqual(backend.artifact_count_calls, 2)
+        self.assertEqual(backend.count_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -186,15 +186,21 @@ class LlamaServerBackendTests(unittest.TestCase):
 
         backend = Backend()
         chat = backend.count_chat_tokens([{"role": "user", "content": "hello"}], thinking=False)
+        artifact = backend.count_artifact_content_tokens([{"role": "user", "content": "artifact"}])
         text_count = backend.count_text_tokens("hello")
 
-        assert chat is not None and text_count is not None
+        assert chat is not None and artifact is not None and text_count is not None
         self.assertEqual((chat.tokens, chat.context_tokens), (123, 8192))
         self.assertEqual((chat.rendered_hash, chat.token_hash), ("a" * 64, "b" * 64))
         self.assertEqual((text_count.tokens, text_count.context_tokens), (123, 8192))
-        self.assertEqual([request[0] for request in backend.requests], ["/tokens/count", "/tokens/count"])
+        self.assertEqual((artifact.tokens, artifact.context_tokens), (123, 8192))
+        self.assertEqual(
+            [request[0] for request in backend.requests],
+            ["/tokens/count", "/tokens/count", "/tokens/count"],
+        )
         self.assertEqual(backend.requests[0][1]["mode"], "chat")
-        self.assertEqual(backend.requests[1][1], {"mode": "text", "text": "hello"})
+        self.assertEqual(backend.requests[1][1]["mode"], "artifact_content")
+        self.assertEqual(backend.requests[2][1], {"mode": "text", "text": "hello"})
 
     def test_external_backend_does_not_attempt_native_token_count(self) -> None:
         class Backend(LlamaServerBackend):
@@ -206,6 +212,7 @@ class LlamaServerBackendTests(unittest.TestCase):
 
         backend = Backend(base_url="http://localhost", timeout=1)
         self.assertIsNone(backend.count_chat_tokens([{"role": "user", "content": "hello"}]))
+        self.assertIsNone(backend.count_artifact_content_tokens([{"role": "user", "content": "artifact"}]))
         self.assertIsNone(backend.count_text_tokens("hello"))
 
     def test_result_observer_receives_every_completed_backend_result(self) -> None:
@@ -377,17 +384,18 @@ class LlamaServerBackendTests(unittest.TestCase):
                 return self.response
 
         cases = (
-            ({"backend": "orbit-native"}, True, {"backend": "orbit-native"}),
-            ({"backend": "external"}, False, {"backend": "external"}),
-            (["malformed"], False, {}),
+            ({"backend": "orbit-native"}, True, {"backend": "orbit-native"}, True),
+            ({"backend": "external"}, False, {"backend": "external"}, False),
+            (["malformed"], False, {}, None),
         )
-        for response, expected_native, expected_cache in cases:
+        for response, expected_native, expected_cache, expected_admission in cases:
             with self.subTest(response=response):
                 backend = Backend(response)
                 self.assertEqual(backend._is_orbit_native_backend(), expected_native)
                 self.assertEqual(backend._is_orbit_native_backend(), expected_native)
                 self.assertEqual(backend.props_calls, 1)
                 self.assertEqual(backend._props_cache, expected_cache)
+                self.assertEqual(backend.supports_exact_context_admission(), expected_admission)
 
     def test_permanent_props_failure_is_cached_and_fails_closed(self) -> None:
         class Backend(LlamaServerBackend):
@@ -416,6 +424,10 @@ class LlamaServerBackendTests(unittest.TestCase):
                 self.assertFalse(backend._is_orbit_native_backend())
                 self.assertEqual(backend.props_calls, 1)
                 self.assertEqual(backend._props_cache, {})
+                self.assertEqual(
+                    backend.supports_exact_context_admission(),
+                    False if isinstance(cause, HTTPError) else None,
+                )
 
     def test_native_separated_reasoning_requires_verified_qwen_profile(self) -> None:
         class Backend(LlamaServerBackend):

--- a/tests/test_native_qwen3_coder_profile.py
+++ b/tests/test_native_qwen3_coder_profile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import unittest
@@ -89,6 +90,26 @@ class NativeQwen3CoderProfileTests(unittest.TestCase):
         self.assertEqual(rendered_messages[0]["content"], QWEN3_CODER_ARTIFACT_SYSTEM_PROMPT)
         self.assertEqual(messages[0]["content"], "generic artifact instruction")
         return result, emitted
+
+    def test_artifact_token_inspection_matches_verified_framing_path(self) -> None:
+        client = self._client()
+        client.apply_chat_template = mock.Mock(return_value="<|im_start|>assistant\n")  # type: ignore[method-assign]
+        client.tokenize = mock.Mock(return_value=[11, 12, 13])  # type: ignore[method-assign]
+        messages = [
+            {"role": "system", "content": "generic artifact instruction"},
+            {"role": "user", "content": "write content"},
+        ]
+
+        count, rendered_hash, token_hash = client.inspect_artifact_content_tokens(messages)
+
+        self.assertEqual(count, 3)
+        framed = client.apply_chat_template.call_args.args[0]
+        self.assertEqual(framed[0]["content"], QWEN3_CODER_ARTIFACT_SYSTEM_PROMPT)
+        prompt = client.tokenize.call_args.args[0]
+        self.assertTrue(prompt.endswith('<|im_start|>assistant\n"'))
+        self.assertEqual(rendered_hash, hashlib.sha256(prompt.encode("utf-8")).hexdigest())
+        expected_tokens = b"".join(value.to_bytes(4, "little", signed=True) for value in [11, 12, 13])
+        self.assertEqual(token_hash, hashlib.sha256(expected_tokens).hexdigest())
 
     @staticmethod
     def _wire(content: str) -> str:

--- a/tests/test_native_runtime_props.py
+++ b/tests/test_native_runtime_props.py
@@ -66,6 +66,7 @@ class NativeRuntimePropsTests(unittest.TestCase):
         client = NativeLlamaClient(self._paths(), NativeClientConfig(context_tokens=16384))
         client.count_text_tokens = mock.Mock(return_value=17)
         client.inspect_chat_tokens = mock.Mock(return_value=(29, "a" * 64, "b" * 64))
+        client.inspect_artifact_content_tokens = mock.Mock(return_value=(31, "c" * 64, "d" * 64))
         server = OrbitNativeServer(client=client, model_alias="m")
 
         text = server.count_text_tokens("hello")
@@ -73,6 +74,9 @@ class NativeRuntimePropsTests(unittest.TestCase):
             [{"role": "user", "content": "hello"}],
             tools=[],
             thinking=False,
+        )
+        artifact = server.count_artifact_content_tokens(
+            [{"role": "user", "content": "artifact"}],
         )
 
         self.assertEqual(text, {"tokens": 17, "context_tokens": 16384})
@@ -85,11 +89,23 @@ class NativeRuntimePropsTests(unittest.TestCase):
                 "token_hash": "b" * 64,
             },
         )
+        self.assertEqual(
+            artifact,
+            {
+                "tokens": 31,
+                "context_tokens": 16384,
+                "rendered_hash": "c" * 64,
+                "token_hash": "d" * 64,
+            },
+        )
         client.count_text_tokens.assert_called_once_with("hello")
         client.inspect_chat_tokens.assert_called_once_with(
             [{"role": "user", "content": "hello"}],
             tools=[],
             thinking=False,
+        )
+        client.inspect_artifact_content_tokens.assert_called_once_with(
+            [{"role": "user", "content": "artifact"}],
         )
 
     @mock.patch("orbit.native_server.app.safe_native_capability_manifest")

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -99,6 +99,10 @@ class _FakeClient:
         del messages, tools, thinking
         return 7, "rendered", "tokens"
 
+    def inspect_artifact_content_tokens(self, messages):
+        del messages
+        return 9, "artifact-rendered", "artifact-tokens"
+
 
 class NativeServerThinkTests(unittest.TestCase):
     def test_artifact_content_uses_literal_path_without_tool_parsing(self) -> None:
@@ -457,6 +461,17 @@ class NativeServerThinkTests(unittest.TestCase):
         )
 
         self.assertEqual(result["tokens"], 7)
+
+    def test_artifact_token_inspection_uses_exact_artifact_renderer(self) -> None:
+        client = _FakeClient(thinking=False)
+        server = OrbitNativeServer(client=client, model_alias="m")
+
+        result = server.count_artifact_content_tokens(
+            [{"role": "user", "content": "content only"}],
+        )
+
+        self.assertEqual(result["tokens"], 9)
+        self.assertEqual(result["rendered_hash"], "artifact-rendered")
 
     def test_error_result_handles_continue_payload_without_messages(self) -> None:
         server = OrbitNativeServer(client=_FakeClient(thinking=False), model_alias="m")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8727,25 +8727,13 @@ EOF"""
         self.assertIn("does not prove", result.content)
         self.assertNotIn("The requested fact is absent", result.content)
 
-    def test_ask_with_tools_records_memory_refresh_event(self) -> None:
-        class MemoryThenAnswerBackend:
+    def test_ask_with_tools_does_not_generate_hidden_memory_refresh(self) -> None:
+        class MemoryThenAnswerBackend(ExactTokenCountingBackend):
             def __init__(self) -> None:
                 self.calls = 0
 
             def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
                 self.calls += 1
-                if tools is None:
-                    return ChatResult(
-                        content="Durable memory.",
-                        model="fake",
-                        finish_reason="stop",
-                        tool_calls=[],
-                        prompt_tokens=None,
-                        completion_tokens=None,
-                        cached_tokens=None,
-                        prompt_tokens_per_second=None,
-                        generation_tokens_per_second=None,
-                    )
                 return ChatResult(
                     content="done",
                     model="fake",
@@ -8759,7 +8747,7 @@ EOF"""
                 )
 
         backend = MemoryThenAnswerBackend()
-        runtime = ChatRuntime(backend=backend, system_prompt="system", context_tokens=100)
+        runtime = ChatRuntime(backend=backend, system_prompt="system", context_tokens=8192)
         for index in range(20):
             runtime.messages.append({"role": "user", "content": f"question {index} " + ("x" * 60)})
             runtime.messages.append({"role": "assistant", "content": f"answer {index} " + ("y" * 60)})
@@ -8767,54 +8755,10 @@ EOF"""
         result = runtime.ask_with_tools("continue", temperature=0, max_tokens=32, workdir=Path("."))
 
         self.assertEqual(result.content, "done")
-        self.assertIsNotNone(runtime.last_memory_refresh)
-        self.assertTrue(runtime.last_memory_refresh.changed)
-        self.assertIs(runtime.last_memory_refresh_attempt, runtime.last_memory_refresh)
-        self.assertEqual(runtime.memory_refreshes, 1)
-        self.assertGreater(runtime.total_memory_tokens_saved, 0)
-
-    def test_memory_refresh_cooldown_avoids_back_to_back_refresh(self) -> None:
-        class MemoryThenAnswerBackend:
-            def __init__(self) -> None:
-                self.memory_calls = 0
-
-            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
-                if tools is None:
-                    self.memory_calls += 1
-                    return ChatResult(
-                        content="Durable memory.",
-                        model="fake",
-                        finish_reason="stop",
-                        tool_calls=[],
-                        prompt_tokens=None,
-                        completion_tokens=None,
-                        cached_tokens=None,
-                        prompt_tokens_per_second=None,
-                        generation_tokens_per_second=None,
-                    )
-                return ChatResult(
-                    content="done",
-                    model="fake",
-                    finish_reason="stop",
-                    tool_calls=[],
-                    prompt_tokens=None,
-                    completion_tokens=None,
-                    cached_tokens=None,
-                    prompt_tokens_per_second=None,
-                    generation_tokens_per_second=None,
-                )
-
-        backend = MemoryThenAnswerBackend()
-        runtime = ChatRuntime(backend=backend, system_prompt="system", context_tokens=100)
-        for index in range(20):
-            runtime.messages.append({"role": "user", "content": f"question {index} " + ("x" * 60)})
-            runtime.messages.append({"role": "assistant", "content": f"answer {index} " + ("y" * 60)})
-
-        runtime.ask_with_tools("continue", temperature=0, max_tokens=32, workdir=Path("."))
-        runtime.ask_with_tools("continue again", temperature=0, max_tokens=32, workdir=Path("."))
-
-        self.assertEqual(backend.memory_calls, 1)
-        self.assertEqual(runtime.memory_refreshes, 1)
+        self.assertEqual(backend.calls, 1)
+        self.assertIsNone(runtime.last_memory_refresh)
+        self.assertEqual(runtime.memory_refreshes, 0)
+        self.assertEqual(runtime.total_memory_tokens_saved, 0)
 
     def test_ask_with_tools_streams_final_text(self) -> None:
         class StreamingBackend:

--- a/tests/test_tool_message.py
+++ b/tests/test_tool_message.py
@@ -80,6 +80,7 @@ class ToolMessageTests(unittest.TestCase):
             self.assertEqual(message["role"], "tool")
             self.assertEqual(message["tool_call_id"], "call-1")
             self.assertEqual(message["name"], "exec_shell_full_command")
+            self.assertEqual(message["user_turn_id"], "turn_1")
             self.assertIn("tool_evidence_ref: true", message["content"])
             self.assertIn("raw_ref:", message["content"])
             self.assertNotIn("evidence_excerpt:", message["content"])


### PR DESCRIPTION
## Summary
- replace automatic model-generated memory refresh with deterministic exact context admission
- compact only completed, re-attested evidence-backed tool turns and support exact evidence rehydration
- preserve full-document behavior and verified native checkpoint/cache policies

## Validation
- Context Manager + Qualification Harness: 107/107 PASS (24 + 83)
- full discovery: 1891/1891 PASS
- compileall PASS
- git diff --check PASS
- independent review PASS

No release, version, model-profile, default-context, or malware-analysis changes.