### PR TITLE
fix(runtime): correlate idless Qwen tool calls

### DIFF
--- a/src/orbit/runtime/tool_message.py
+++ b/src/orbit/runtime/tool_message.py
@@ -12,7 +12,7 @@ from orbit.runtime.tools import ToolResult
 def assistant_tool_call_message(content: str, tool_calls: list[dict[str, object]]) -> Message:
     message: Message = {"role": "assistant", "content": content}
     if tool_calls:
-        message["tool_calls"] = [_safe_tool_call_for_history(tool_call) for tool_call in tool_calls]
+        message["tool_calls"] = _safe_tool_calls_for_history(tool_calls)
     return message
 
 
@@ -43,8 +43,23 @@ def tool_result_message(
     }
 
 
-def _safe_tool_call_for_history(tool_call: dict[str, object]) -> dict[str, Any]:
+def _safe_tool_calls_for_history(tool_calls: list[dict[str, object]]) -> list[dict[str, Any]]:
+    correlation_ids = [tool_call_id(tool_call) for tool_call in tool_calls]
+    if len(tool_calls) > 1:
+        explicit_ids = [tool_call.get("id") for tool_call in tool_calls]
+        if any(not isinstance(value, str) or not value for value in explicit_ids):
+            raise ValueError("multiple tool calls require explicit identifiers")
+        if len(set(correlation_ids)) != len(correlation_ids):
+            raise ValueError("multiple tool calls require unique identifiers")
+    return [
+        _safe_tool_call_for_history(tool_call, correlation_id=correlation_id)
+        for tool_call, correlation_id in zip(tool_calls, correlation_ids, strict=True)
+    ]
+
+
+def _safe_tool_call_for_history(tool_call: dict[str, object], *, correlation_id: str) -> dict[str, Any]:
     sanitized = dict(tool_call)
+    sanitized["id"] = correlation_id
     function = sanitized.get("function")
     if not isinstance(function, dict):
         return sanitized

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -19,6 +19,8 @@ from orbit.runtime.context_manager import ContextAdmissionError, ContextBudget, 
 from orbit.runtime.evidence import EvidenceStore, tool_evidence_ref
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.session_memory import estimate_message_tokens
+from orbit.runtime.tool_message import assistant_tool_call_message, tool_result_message
+from orbit.runtime.tools import ToolResult
 
 
 def _tool_turn(number: int, *, payload_chars: int = 1200) -> list[dict[str, object]]:
@@ -306,6 +308,65 @@ class ContextManagerTests(unittest.TestCase):
         self.assertEqual(plan.status, "blocked")
         self.assertTrue(plan.reason.startswith("invalid-message-structure:"))
 
+    def test_qwen36_single_call_without_native_id_has_ordered_stable_history(self) -> None:
+        raw_call = {
+            "id": "",
+            "type": "function",
+            "function": {
+                "name": "exec_shell_full_command",
+                "arguments": '{"command":"cat samples/example.js"}',
+            },
+        }
+        messages: list[dict[str, object]] = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "read the file"},
+        ]
+        for number in (1, 2):
+            messages.append(assistant_tool_call_message("", [raw_call]))
+            messages.append(
+                tool_result_message(
+                    raw_call,
+                    ToolResult(name="exec_shell_full_command", content=f"result {number}"),
+                )
+            )
+        messages.append({"role": "assistant", "content": "complete"})
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(4096, 256),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "unchanged")
+        assistant_ids = [
+            message["tool_calls"][0]["id"]
+            for message in messages
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        ]
+        result_ids = [message["tool_call_id"] for message in messages if message.get("role") == "tool"]
+        self.assertEqual(assistant_ids, ["tool-call", "tool-call"])
+        self.assertEqual(result_ids, ["tool-call", "tool-call"])
+
+    def test_missing_assistant_tool_call_id_still_fails_closed(self) -> None:
+        messages = [
+            {"role": "user", "content": "request"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "", "function": {"name": "read_file", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "tool-call", "name": "read_file", "content": "result"},
+        ]
+
+        plan = plan_context(
+            messages,
+            budget=ContextBudget(4096, 256),
+            count_tokens=estimate_message_tokens,
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.reason, "invalid-message-structure:missing-tool-call-id")
+
     def test_parallel_tool_results_keep_declared_order(self) -> None:
         messages = [
             {"role": "user", "content": "request"},
@@ -480,6 +541,62 @@ class ContextManagerTests(unittest.TestCase):
             rehydrated = "\n".join(str(message.get("content", "")) for message in backend.messages_by_call[-1])
             self.assertIn("EXACT_VALUE_123", rehydrated)
             self.assertIn(store.records[first_id].raw_sha256, rehydrated)
+
+    def test_qwen36_repeated_idless_calls_compact_and_rehydrate_exact_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "evidence")
+            raw_call = {
+                "id": "",
+                "type": "function",
+                "function": {
+                    "name": "exec_shell_full_command",
+                    "arguments": '{"command":"cat samples/example.js"}',
+                },
+            }
+            messages: list[dict[str, object]] = [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "read the file twice"},
+            ]
+            evidence_ids: list[str] = []
+            for number in (1, 2):
+                messages.append(assistant_tool_call_message("", [raw_call]))
+                result = tool_result_message(
+                    raw_call,
+                    ToolResult(
+                        name="exec_shell_full_command",
+                        content=("EXACT_VALUE_123\n" if number == 1 else "second result\n") + ("x" * 1400),
+                    ),
+                    evidence_store=store,
+                    metadata={"user_turn_id": "turn-qwen36", "produced_by_phase": "tool_call"},
+                )
+                messages.append(result)
+                evidence_ids.append(str(result["evidence_id"]))
+            messages.append({"role": "assistant", "content": "visible completed answer"})
+            backend = _ExactBackend(context_tokens=650)
+            runtime = ChatRuntime(
+                backend=backend,
+                messages=messages,
+                context_tokens=650,
+                evidence_store=store,
+            )
+            runtime.completed_evidence_ids.update(evidence_ids)
+
+            runtime.ask_chat("continue", temperature=0, max_tokens=64)
+
+            assert runtime.last_context_plan is not None
+            self.assertEqual(runtime.last_context_plan.status, "compacted")
+            self.assertEqual(runtime.last_context_plan.externalized_evidence_ids, tuple(evidence_ids))
+
+            backend.context_tokens = 4096
+            runtime.context_tokens = 4096
+            result = runtime.ask_chat(
+                f"Return the exact value from evidence:{evidence_ids[0]}",
+                temperature=0,
+                max_tokens=64,
+            )
+
+            self.assertEqual(result.content, "EXACT_VALUE_123")
+            self.assertEqual(runtime.last_context_rehydrated_ids, (evidence_ids[0],))
 
     def test_runtime_rejects_protocol_markers_before_exact_rehydration(self) -> None:
         markers = (

--- a/tests/test_native_qwen_profile.py
+++ b/tests/test_native_qwen_profile.py
@@ -204,6 +204,7 @@ class NativeQwenProfileTests(unittest.TestCase):
 
         self.assertEqual(parsed.content, "")
         self.assertEqual(len(parsed.tool_calls), 1)
+        self.assertEqual(parsed.tool_calls[0]["id"], "")
         function = parsed.tool_calls[0]["function"]
         self.assertEqual(function["name"], "exec_shell_full_command")
         self.assertEqual(json.loads(function["arguments"]), {"command": "pwd"})

--- a/tests/test_tool_message.py
+++ b/tests/test_tool_message.py
@@ -39,6 +39,47 @@ class ToolMessageTests(unittest.TestCase):
         self.assertIn("invalid_arguments", arguments)
         self.assertTrue(arguments.startswith("{"))
 
+    def test_single_tool_call_without_protocol_id_uses_existing_stable_correlation(self) -> None:
+        tool_call = {
+            "id": "",
+            "type": "function",
+            "function": {"name": "exec_shell_full_command", "arguments": '{"command":"pwd"}'},
+        }
+
+        assistant = assistant_tool_call_message("", [tool_call])
+        result = tool_result_message(tool_call, ToolResult(name="exec_shell_full_command", content="ok"))
+
+        self.assertEqual(assistant["tool_calls"][0]["id"], "tool-call")  # type: ignore[index]
+        self.assertEqual(result["tool_call_id"], "tool-call")
+
+    def test_multiple_tool_calls_without_protocol_ids_fail_closed(self) -> None:
+        calls = [
+            {"id": "", "function": {"name": "one", "arguments": "{}"}},
+            {"id": "", "function": {"name": "two", "arguments": "{}"}},
+        ]
+
+        with self.assertRaisesRegex(ValueError, "explicit identifiers"):
+            assistant_tool_call_message("", calls)
+
+    def test_multiple_tool_calls_require_unique_protocol_ids(self) -> None:
+        calls = [
+            {"id": "same", "function": {"name": "one", "arguments": "{}"}},
+            {"id": "same", "function": {"name": "two", "arguments": "{}"}},
+        ]
+
+        with self.assertRaisesRegex(ValueError, "unique identifiers"):
+            assistant_tool_call_message("", calls)
+
+    def test_multiple_tool_calls_preserve_unique_protocol_ids(self) -> None:
+        calls = [
+            {"id": "one-id", "function": {"name": "one", "arguments": "{}"}},
+            {"id": "two-id", "function": {"name": "two", "arguments": "{}"}},
+        ]
+
+        message = assistant_tool_call_message("", calls)
+
+        self.assertEqual([call["id"] for call in message["tool_calls"]], ["one-id", "two-id"])
+
     def test_assistant_tool_call_message_omits_empty_tool_calls(self) -> None:
         message = assistant_tool_call_message("done", [])
 


### PR DESCRIPTION
## Summary
- normalize one accepted idless tool call to Orbit's existing stable history correlation
- preserve explicit identifiers unchanged
- reject ambiguous multi-call groups without explicit unique identifiers
- keep Context Manager structural validation unchanged

## Validation
- focused: 48/48 PASS
- affected: 568/568 PASS
- Qualification Harness: 83/83 PASS
- full discovery: 1898/1898 PASS
- compileall PASS
- git diff --check PASS
- real Qwen3.6 smoke PASS: 90 lines / 19948 bytes, 2 model calls, zero hidden summary calls
- independent review PASS

No Context Manager policy, model-profile, backend, KV/checkpoint, default-context, release, or malware-analysis changes.