### PR TITLE
Fix optional analysis helper mutation classification

### DIFF
--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -195,6 +195,14 @@ _MUTATION_PROMPT_RE = re.compile(
     r"\b(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
 )
+_ANALYSIS_HELPER_PERMISSION_RE = re.compile(
+    r"\byou\s+may\s+(?P<helper_verb>write|create)\s+"
+    r"(?:(?:and|then)\s+run\s+)?(?:a\s+)?"
+    r"(?:(?:small|offline|local|temporary|disposable)\s+){0,3}"
+    r"(?:python\s+)?(?:scripts?|scratch\s+files?|temporary\s+files?)\s+"
+    r"(?:to|for)\s+(?:inspect|analy[sz]e|transform|process|decode|verify)\b",
+    re.IGNORECASE,
+)
 _NEGATED_MUTATION_PROMPT_RE = re.compile(
     r"\b(?:do\s+not|don't|without)\s+(?:add|change|create|fix|harden|improve|write|edit|modify|replace|append|delete|remove|rename|refactor|move|copy|install|commit|update|insert|drop|alter|set|enable|disable|configure)\b",
     re.IGNORECASE,
@@ -739,18 +747,26 @@ def is_mutative_user_request(user_prompt: str | None) -> bool:
     if not user_prompt:
         return False
     active_text = without_inert_user_text(user_prompt)
-    intent_text = _without_user_paths_and_urls(active_text)
+    required_intent_text = _without_user_paths_and_urls(_without_analytical_mutation_mentions(active_text))
     if classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
         return False
     if _NEGATED_MUTATION_PROMPT_RE.search(active_text) and not re.search(
         r"\b(?:fix|update|change|create|write|rename|refactor|edit)\b.*\b(?:file|code|implementation|config|test)\b",
-        intent_text,
+        required_intent_text,
         re.IGNORECASE,
     ):
         return False
-    if _READ_ONLY_PROMPT_RE.search(active_text) and not _MUTATION_PROMPT_RE.search(intent_text):
+    if _READ_ONLY_PROMPT_RE.search(active_text) and not _MUTATION_PROMPT_RE.search(required_intent_text):
         return False
-    return _MUTATION_PROMPT_RE.search(intent_text) is not None
+    return _MUTATION_PROMPT_RE.search(required_intent_text) is not None
+
+
+def _without_analytical_mutation_mentions(intent_text: str) -> str:
+    chars = list(intent_text)
+    for match in _ANALYSIS_HELPER_PERMISSION_RE.finditer(intent_text):
+        start, end = match.span("helper_verb")
+        chars[start:end] = " " * (end - start)
+    return "".join(chars)
 
 
 def classify_explicit_no_mutation_constraint(text: str | None) -> str:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4772,6 +4772,94 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(backend.calls, 2)
         self.assertIsNotNone(backend.final_messages)
 
+    def test_analysis_description_does_not_cause_duplicate_content_read(self) -> None:
+        class AnalysisReadBackend(ExactTokenCountingBackend):
+            def __init__(self) -> None:
+                self.calls = 0
+                self.tools_by_call: list[object] = []
+
+            def chat(self, messages: list[Message], *, temperature: float, max_tokens: int, tools=None) -> ChatResult:
+                self.calls += 1
+                self.tools_by_call.append(tools)
+                if self.calls == 1:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat sample.js"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=5,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                if tools is not None:
+                    return ChatResult(
+                        content="",
+                        model="fake",
+                        finish_reason="tool_calls",
+                        tool_calls=[
+                            {
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_shell_full_command",
+                                    "arguments": json.dumps({"command": "cat sample.js"}),
+                                },
+                            }
+                        ],
+                        prompt_tokens=6,
+                        completion_tokens=1,
+                        cached_tokens=0,
+                        prompt_tokens_per_second=None,
+                        generation_tokens_per_second=None,
+                    )
+                return ChatResult(
+                    content="analysis complete",
+                    model="fake",
+                    finish_reason="stop",
+                    tool_calls=[],
+                    prompt_tokens=self.count_chat_tokens(messages).tokens,
+                    completion_tokens=2,
+                    cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        prompt = """Analyze the provided JavaScript file sample.js as a potentially malicious artifact.
+
+Perform a complete static analysis using the available tools when useful. You may write and run small offline Python scripts to inspect or transform data.
+
+Determine which files or artifacts it creates, modifies, executes, downloads, or removes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "sample.js").write_text("const value = 1;\n", encoding="utf-8")
+            backend = AnalysisReadBackend()
+            runtime = ChatRuntime(backend=backend, system_prompt="route system")
+
+            result = runtime.ask_with_tools(
+                prompt,
+                temperature=0,
+                max_tokens=64,
+                workdir=workdir,
+                tool_names=("exec_shell_full_command",),
+            )
+
+        self.assertTrue(result.content.endswith("analysis complete"))
+        self.assertIn("Document coverage: complete; mode exact single context", result.content)
+        self.assertEqual(backend.calls, 2)
+        self.assertIsNotNone(backend.tools_by_call[0])
+        self.assertIsNone(backend.tools_by_call[1])
+
     def test_candidate_paths_without_direct_content_do_not_handoff_to_final_from_tool(self) -> None:
         class CandidatePathBackend:
             def __init__(self) -> None:

--- a/tests/test_shell_guardrails.py
+++ b/tests/test_shell_guardrails.py
@@ -254,6 +254,43 @@ class ShellGuardrailsTests(unittest.TestCase):
         self.assertTrue(is_mutative_user_request("Enable the service in settings.ini."))
         self.assertTrue(is_mutative_user_request("Disable debug mode in service.yaml."))
 
+    def test_analysis_descriptions_and_optional_helpers_are_not_mutative_requests(self) -> None:
+        prompts = (
+            "Identify which files the artifact creates, writes, modifies, or removes.",
+            "Explain what the script writes or removes during execution.",
+            "Analyze sample.js. You may write and run small offline Python scripts to inspect transformed data.",
+        )
+
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertFalse(is_mutative_user_request(prompt))
+
+    def test_analysis_with_requested_or_ambiguous_mutation_remains_mutative(self) -> None:
+        prompts = (
+            "Analyze sample.js and write report.md.",
+            "Inspect config.json, then modify the file.",
+            "Determine what sample.js changes; then remove old.txt.",
+            "Determine which files it creates, then remove old.txt.",
+            "Determine which files it creates, then write report.md.",
+            "Determine which files it creates, and remove old.txt.",
+            "Identify what the script writes, and delete old.txt.",
+            "Report what the artifact changes, then edit config.json.",
+            "Determine which files it creates, modify report.md.",
+            "Determine which files it creates and write a report to report.md.",
+            "Explain which files it modifies, afterwards delete old.txt.",
+            "Analyze what the program creates, but remove old.txt.",
+            "Explain which files the artifact may remove, and write report.md.",
+            "Identify which files the script may create, and remove old.txt.",
+            "Report what the program may modify, and create summary.txt.",
+            "Determine which files the artifact may remove and modify config.json.",
+            "You may write the final report and create temporary files to analyze data.",
+            "You may write a report while using scratch files to analyze data.",
+        )
+
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                self.assertTrue(is_mutative_user_request(prompt))
+
     def test_suggest_fixes_remains_read_only_when_negated(self) -> None:
         self.assertFalse(is_mutative_user_request("Suggest fixes for service.py but do not modify files."))
 


### PR DESCRIPTION
## Summary
- classify tightly bounded optional analysis-helper permissions as read-only
- preserve fail-closed handling for explicit, mixed, and ambiguous mutations
- prevent false mutation classification from bypassing direct full-document handoff

## Validation
- focused: 223/223
- affected: 370/370
- Qualification Harness: 83/83
- full discovery: 1903/1903
- compileall and diff check: PASS
- Qwen3.6 narrow smoke: one cat, complete exact coverage, full_document, stop, zero hidden calls
- independent review: PASS