### PR TITLE
fix(runtime): allow structured reads under negative mutation wording

### DIFF
--- a/src/orbit/runtime/shell_guardrails.py
+++ b/src/orbit/runtime/shell_guardrails.py
@@ -16,6 +16,7 @@ from orbit.runtime.file_tools import (
     extract_pdf_text,
     format_pdf_result,
     load_text_file,
+    load_text_snapshot,
     read_file,
     read_pdf,
 )
@@ -299,6 +300,7 @@ _INERT_USER_TEXT_RE = re.compile(
 )
 _NO_MUTATION_NONE = "none"
 _NO_MUTATION_GLOBAL = "global"
+_NO_MUTATION_NEGATIVE = "negative"
 _NO_MUTATION_MIXED = "mixed"
 
 
@@ -349,6 +351,8 @@ def execute_exec_shell_full_command(arguments: dict[str, Any], *, workdir: Path,
     exact_text_result = _read_exact_cat_target(raw_command, workdir=workdir)
     if exact_text_result is not None:
         return exact_text_result
+    if _requires_attested_single_file_cat(raw_command, user_prompt=user_prompt):
+        return "error: read-only structured cat target could not be re-attested; command rejected"
     exact_range_result = _read_exact_sed_range_target(raw_command, workdir=workdir)
     if exact_range_result is not None:
         return exact_range_result
@@ -468,12 +472,22 @@ def validate_shell_full_contract(arguments: dict[str, Any], *, user_prompt: str 
     return None
 
 
-def validate_read_only_shell_mutation(arguments: dict[str, Any], *, user_prompt: str | None) -> str | None:
+def validate_read_only_shell_mutation(
+    arguments: dict[str, Any],
+    *,
+    user_prompt: str | None,
+    workdir: Path | None = None,
+) -> str | None:
     raw_command = arguments.get("command")
     if not isinstance(raw_command, str) or not raw_command.strip():
         return None
     explicit_mode = classify_explicit_no_mutation_constraint(user_prompt)
     if explicit_mode != _NO_MUTATION_NONE:
+        if explicit_mode in {_NO_MUTATION_GLOBAL, _NO_MUTATION_NEGATIVE} and _is_attested_single_file_cat(
+            raw_command,
+            workdir=workdir,
+        ):
+            return None
         return read_only_mutation_policy_error(user_prompt, action="unrestricted shell command")
     if not is_read_only_user_request(user_prompt):
         return None
@@ -482,14 +496,44 @@ def validate_read_only_shell_mutation(arguments: dict[str, Any], *, user_prompt:
     return read_only_mutation_policy_error(user_prompt, action="mutating shell command")
 
 
+def _literal_single_file_cat_path(command: str) -> str | None:
+    if re.search(r"[\n\r;&|<>$`(){}\[\]*?~]", command):
+        return None
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if len(tokens) != 2 or tokens[0] != "cat" or not tokens[1] or tokens[1].startswith("-"):
+        return None
+    return tokens[1]
+
+
+def _is_attested_single_file_cat(command: str, *, workdir: Path | None) -> bool:
+    path = _literal_single_file_cat_path(command)
+    if path is None or workdir is None:
+        return False
+    return not isinstance(
+        load_text_snapshot(path, workdir=workdir, max_bytes=MAX_FULL_DOCUMENT_BYTES),
+        str,
+    )
+
+
+def _requires_attested_single_file_cat(command: str, *, user_prompt: str | None) -> bool:
+    return (
+        classify_explicit_no_mutation_constraint(user_prompt) in {_NO_MUTATION_GLOBAL, _NO_MUTATION_NEGATIVE}
+        and _literal_single_file_cat_path(command) is not None
+    )
+
+
 def validate_tool_no_mutation_policy(
     name: str,
     arguments: dict[str, Any],
     *,
     user_prompt: str | None,
+    workdir: Path | None = None,
 ) -> str | None:
     if name == "exec_shell_full_command":
-        return validate_read_only_shell_mutation(arguments, user_prompt=user_prompt)
+        return validate_read_only_shell_mutation(arguments, user_prompt=user_prompt, workdir=workdir)
     if name == "write_artifact" and classify_explicit_no_mutation_constraint(user_prompt) != _NO_MUTATION_NONE:
         return read_only_mutation_policy_error(user_prompt, action="artifact creation")
     return None
@@ -793,6 +837,8 @@ def classify_explicit_no_mutation_constraint(text: str | None) -> str:
         return _NO_MUTATION_MIXED
     if constraint is global_match:
         return _NO_MUTATION_GLOBAL
+    if constraint is scoped_match:
+        return _NO_MUTATION_NEGATIVE
     return _NO_MUTATION_MIXED
 
 

--- a/src/orbit/runtime/tool_backends.py
+++ b/src/orbit/runtime/tool_backends.py
@@ -116,7 +116,12 @@ class HybridToolExecutor:
         if isinstance(parsed, str):
             return ToolExecution(ToolResult(name=name, content=parsed), "orbit", "rejected_parse", "invalid_arguments")
         if not canonical_validated:
-            policy_error = validate_tool_no_mutation_policy(name, parsed, user_prompt=self.user_prompt)
+            policy_error = validate_tool_no_mutation_policy(
+                name,
+                parsed,
+                user_prompt=self.user_prompt,
+                workdir=self.workdir,
+            )
             if policy_error:
                 return ToolExecution(
                     ToolResult(name=name, content=policy_error),

--- a/src/orbit/runtime/tool_contract.py
+++ b/src/orbit/runtime/tool_contract.py
@@ -199,7 +199,7 @@ def _policy_and_operational(
             shlex.split(command)
         except ValueError:
             return neutral, ContractStageOutcome(False, "invalid_shell_syntax", "arguments.command")
-        policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
+        policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt, workdir=workdir)
         if policy_error:
             return ContractStageOutcome(
                 False,
@@ -252,7 +252,7 @@ def _policy_and_operational(
                     "arguments.path",
                     path_error,
                 )
-            policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt)
+            policy_error = validate_tool_no_mutation_policy(name, arguments, user_prompt=user_prompt, workdir=workdir)
             if policy_error:
                 return ContractStageOutcome(
                     False,

--- a/src/orbit/runtime/tools.py
+++ b/src/orbit/runtime/tools.py
@@ -73,7 +73,7 @@ def execute_tool(
     parsed = parse_tool_arguments(arguments)
     if isinstance(parsed, str):
         return ToolResult(name=name, content=parsed)
-    policy_error = validate_tool_no_mutation_policy(name, parsed, user_prompt=user_prompt)
+    policy_error = validate_tool_no_mutation_policy(name, parsed, user_prompt=user_prompt, workdir=workdir)
     if policy_error:
         return ToolResult(name=name, content=policy_error)
     if name == "fetch_url":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4772,7 +4772,7 @@ class ToolRuntimeTests(unittest.TestCase):
         self.assertEqual(backend.calls, 2)
         self.assertIsNotNone(backend.final_messages)
 
-    def test_analysis_description_does_not_cause_duplicate_content_read(self) -> None:
+    def test_analysis_safety_constraints_do_not_cause_duplicate_content_read(self) -> None:
         class AnalysisReadBackend(ExactTokenCountingBackend):
             def __init__(self) -> None:
                 self.calls = 0
@@ -4837,9 +4837,11 @@ class ToolRuntimeTests(unittest.TestCase):
 
         prompt = """Analyze the provided JavaScript file sample.js as a potentially malicious artifact.
 
-Perform a complete static analysis using the available tools when useful. You may write and run small offline Python scripts to inspect or transform data.
+Perform a complete static analysis using the available tools when useful. You may write and run small offline Python scripts to inspect or transform data, but do not execute the sample itself and do not access the network.
 
-Determine which files or artifacts it creates, modifies, executes, downloads, or removes."""
+Determine which files or artifacts it creates, modifies, executes, downloads, or removes.
+
+Do not modify the analyzed file."""
         with tempfile.TemporaryDirectory() as tmp:
             workdir = Path(tmp)
             (workdir / "sample.js").write_text("const value = 1;\n", encoding="utf-8")

--- a/tests/test_shell_guardrails.py
+++ b/tests/test_shell_guardrails.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import patch
 import subprocess
 
+from orbit.runtime.file_tools import MAX_FULL_DOCUMENT_BYTES
 from orbit.runtime.shell_guardrails import (
     classify_explicit_no_mutation_constraint,
     execute_exec_shell_full_command,
@@ -329,6 +330,120 @@ class ShellGuardrailsTests(unittest.TestCase):
             user_prompt=prompt,
         )
         self.assertIn("mixed or scoped mutation constraint", error or "")
+
+    def test_negative_safety_clauses_allow_only_attested_single_file_cat(self) -> None:
+        base = "Analyze sample.js. You may write and run small offline Python scripts to inspect transformed data."
+        variants = (
+            (base, "none"),
+            (f"{base} Do not modify the analyzed file.", "negative"),
+            (f"{base} Do not modify any files.", "global"),
+            (f"{base} Do not execute the sample itself.", "none"),
+            (f"{base} Do not access the network.", "none"),
+            (
+                f"{base} Do not execute the sample itself and do not access the network. "
+                "Do not modify the analyzed file.",
+                "negative",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workdir = root / "work"
+            workdir.mkdir()
+            (workdir / "sample.js").write_text("const value = 1;\n", encoding="utf-8")
+            for prompt, expected_constraint in variants:
+                with self.subTest(prompt=prompt):
+                    self.assertFalse(is_mutative_user_request(prompt))
+                    self.assertEqual(classify_explicit_no_mutation_constraint(prompt), expected_constraint)
+                    self.assertIsNone(
+                        validate_read_only_shell_mutation(
+                            {"command": "cat sample.js"},
+                            user_prompt=prompt,
+                            workdir=workdir,
+                        )
+                    )
+
+            constrained = f"{base} Do not modify the analyzed file."
+            rejected_commands = (
+                "cat sample.js > copy.js",
+                "cat sample.js | tee copy.js",
+                "cat $(touch marker.txt)",
+                'cat "$(touch marker.txt)"',
+                "cat sample.js other.js",
+                "env cat sample.js",
+                "sed -i 's/a/b/' sample.js",
+                "rm -f sample.js",
+            )
+            for command in rejected_commands:
+                with self.subTest(command=command):
+                    self.assertIsNotNone(
+                        validate_read_only_shell_mutation(
+                            {"command": command},
+                            user_prompt=constrained,
+                            workdir=workdir,
+                        )
+                    )
+
+            outside = root / "outside.txt"
+            outside.write_text("outside", encoding="utf-8")
+            (workdir / "escape.txt").symlink_to(outside)
+            for command in ("cat ../outside.txt", "cat escape.txt"):
+                with self.subTest(command=command):
+                    self.assertIsNotNone(
+                        validate_read_only_shell_mutation(
+                            {"command": command},
+                            user_prompt=constrained,
+                            workdir=workdir,
+                        )
+                    )
+
+            (workdir / "binary.js").write_bytes(b"\xff\xfe")
+            self.assertIsNotNone(
+                validate_read_only_shell_mutation(
+                    {"command": "cat binary.js"},
+                    user_prompt=constrained,
+                    workdir=workdir,
+                )
+            )
+            (workdir / "oversized.js").write_bytes(b"a" * (MAX_FULL_DOCUMENT_BYTES + 1))
+            self.assertIsNotNone(
+                validate_read_only_shell_mutation(
+                    {"command": "cat oversized.js"},
+                    user_prompt=constrained,
+                    workdir=workdir,
+                )
+            )
+
+    def test_scoped_mutation_constraint_remains_fail_closed(self) -> None:
+        prompt = "Do not modify files except report.txt."
+
+        self.assertEqual(classify_explicit_no_mutation_constraint(prompt), "mixed")
+        self.assertIsNotNone(
+            validate_read_only_shell_mutation(
+                {"command": "touch report.txt"},
+                user_prompt=prompt,
+            )
+        )
+
+    def test_attested_cat_never_falls_back_to_generic_shell_after_revalidation_failure(self) -> None:
+        prompt = "Analyze sample.js. Do not modify the analyzed file."
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "sample.js").write_text("const value = 1;\n", encoding="utf-8")
+            with (
+                patch("orbit.runtime.shell_guardrails._read_exact_cat_target", return_value=None),
+                patch("orbit.runtime.shell_guardrails._run_shell_command") as run_shell,
+            ):
+                result = execute_exec_shell_full_command(
+                    {"command": "cat sample.js"},
+                    workdir=workdir,
+                    user_prompt=prompt,
+                )
+
+        self.assertEqual(
+            result,
+            "error: read-only structured cat target could not be re-attested; command rejected",
+        )
+        run_shell.assert_not_called()
 
     def test_global_no_mutation_constraint_overrides_positive_mutation_verb(self) -> None:
         prompt = "Update config.json, but do so without making any changes."


### PR DESCRIPTION
## Problem

Purely negative mutation wording such as `Do not modify X` was classified as a **mixed** constraint. Mixed rejects every shell command, so a read-only analysis prompt carrying an explicit mutation prohibition could not read its own subject:

- `Analyze X.` -> `cat X` allowed
- `Analyze X. Do not modify X.` -> `cat X` **rejected**
- `do not execute X` alone -> allowed
- `do not access network` alone -> allowed

The rejection was caused solely by the `Do not modify X` clause.

## Fix

Pure negative wording gets its own classification and may serve an attested single-file `cat` through the structured reader, while every mutation stays rejected.

- `classify_explicit_no_mutation_constraint` returns `"negative"` for a scoped negated-mutation match with no exception or transition tail
- `validate_read_only_shell_mutation` admits an attested single-file `cat` under global/negative wording; everything else keeps the existing fail-closed rejection
- `workdir` is threaded through `validate_tool_no_mutation_policy` so the contract, hybrid executor and tools entry points attest identically
- a `cat` whose target cannot be re-attested is rejected and never falls back to a real shell spawn

Mixed and scoped constraints are unchanged and still fail closed.

**No new shell capability**: the admitted `cat` is served by the structured reader, so no shell process is spawned (verified: `_run_shell_command` is never called).

## Validation

Decision matrix against baseline `0b4fbcb` over **138 cells**:

- **2 cells change**, both `REJECT -> ALLOW` for the structured read
- **0 `ALLOW -> REJECT`** regressions

22 adversarial bypass probes all rejected: `cat X; rm X`, `cat X && rm X`, `cat X > out`, `| tee`, `cat $(rm X)`, `env cat`, `/bin/cat`, `cat --`, multi-file, globs, path traversal, symlink escape, binary and oversized targets.

### Real Qwen3.6 integration smoke

Two independent fresh sessions (Qwen3.6-35B-A3B-Q4_K_M, ctx 11264, max_tokens 2048):

- exactly 1 `cat`, 1 successful
- `coverage: complete`, exact single context, `line_range: 1-31`
- `route=full_document` (`reason=exact_complete_preflight`)
- zero guardrail / protocol / admission / backend errors
- zero hidden summary calls
- sample file unchanged (MD5 verified before and after)

### Test suites

- focused `test_shell_guardrails` + `test_runtime`: 226/226 PASS
- affected: 430/430 PASS
- Qualification Harness: 83/83 PASS
- full discovery: **1906/1906 PASS**
- `compileall` clean, `git diff --check` clean

## Out of scope

`finish_reason=length` at 1024 full-document output tokens is a separate pre-existing output-budget issue and is not addressed here. No changes to the Context Manager, structured-read semantics, output-token budgets, model profiles/backend/KV, or global shell policy beyond this patch.
