### PR TITLE
fix(runtime): honor explicit full-document output budget

### DIFF
--- a/src/orbit/runtime/completion_budget.py
+++ b/src/orbit/runtime/completion_budget.py
@@ -67,7 +67,13 @@ def resolve_max_tokens(
     if kind == "final_from_tool":
         return _final_from_tool_tokens(requested, evidence, evidence_chars)
     if kind == "full_document":
-        return _internal(requested, FULL_DOCUMENT_FINAL_MAX_TOKENS)
+        # Full-document output is user-visible: an explicit CLI/REPL limit stays
+        # authoritative and is never silently reduced. Exact full-document
+        # admission fails closed when the requested budget does not fit the
+        # active context, so the cap here is only the unspecified default.
+        if requested is None:
+            return FULL_DOCUMENT_FINAL_MAX_TOKENS
+        return requested
     if kind == "chat_final_retry":
         target = CHAT_FINAL_RETRY_AFTER_LENGTH_MAX_TOKENS if previous == "length" else CHAT_FINAL_RETRY_MAX_TOKENS
         return _floor_and_cap(requested, target, target)

--- a/tests/test_completion_budget.py
+++ b/tests/test_completion_budget.py
@@ -41,12 +41,15 @@ class CompletionBudgetPolicyTests(unittest.TestCase):
         self.assertEqual(resolve_max_tokens("final_from_tool", 32, evidence_kind="read", evidence_chars=8000), 256)
         self.assertEqual(resolve_max_tokens("final_from_tool", 1024, evidence_kind="fetch", evidence_chars=8000), 256)
 
-    def test_full_document_budget_respects_user_limit_up_to_dedicated_cap(self) -> None:
+    def test_full_document_budget_defaults_to_dedicated_cap_and_honors_explicit_limit(self) -> None:
         self.assertEqual(resolve_max_tokens("full_document"), 1024)
         self.assertEqual(resolve_max_tokens("full_document", 256), 256)
         self.assertEqual(resolve_max_tokens("full_document", 512), 512)
         self.assertEqual(resolve_max_tokens("full_document", 1024), 1024)
-        self.assertEqual(resolve_max_tokens("full_document", 2048), 1024)
+        # An explicit budget above the default is honored verbatim. Exact
+        # full-document admission, not this budget, decides whether it fits.
+        self.assertEqual(resolve_max_tokens("full_document", 2048), 2048)
+        self.assertEqual(resolve_max_tokens("full_document", 8192), 8192)
 
     def test_retry_and_repair_budgets(self) -> None:
         self.assertEqual(resolve_max_tokens("chat_final_retry", 32), 128)

--- a/tests/test_full_document.py
+++ b/tests/test_full_document.py
@@ -22,7 +22,10 @@ from orbit.runtime.document_tool import (
 from orbit.runtime.file_tools import read_full_document_snapshot
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.tools import tool_definitions
+from orbit.runtime.completion_budget import FULL_DOCUMENT_FINAL_MAX_TOKENS
 from orbit.runtime.full_document import (
+    FULL_DOCUMENT_SAFETY_MARGIN_TOKENS,
+    assess_full_document_admission,
     attest_full_document_snapshot,
     exact_coverage_notice,
     file_display_coverage_notice,
@@ -479,6 +482,67 @@ class FullDocumentTests(unittest.TestCase):
         self.assertIn("Document coverage: none for the current file", result.content)
         self.assertNotIn("complete analysis", result.content)
         self.assertNotIn("complete analysis", "".join(deltas))
+
+    def test_admission_honors_explicit_budget_and_fails_closed_when_it_does_not_fit(self) -> None:
+        workdir, snapshot = self._snapshot("original\n")
+        prompt = "Read note.txt completely."
+        margin = FULL_DOCUMENT_SAFETY_MARGIN_TOKENS
+
+        # Real Qwen3.6 shape: 6702 prompt tokens inside an 11264 context.
+        backend = PreflightBackend(prompt_tokens=6702, context_tokens=11264)
+        for requested, expected_reserve in ((256, 256), (1024, 1024), (2048, 2048)):
+            with self.subTest(requested=requested):
+                admission = assess_full_document_admission(
+                    backend, prompt, snapshot, max_tokens=requested, workdir=workdir
+                )
+                self.assertTrue(admission.compatible)
+                self.assertIsNone(admission.reason)
+                self.assertEqual(admission.output_reserve, expected_reserve)
+                self.assertEqual(admission.required_context, 6702 + expected_reserve + margin)
+                self.assertLessEqual(admission.required_context, admission.active_context)
+
+        # An unspecified budget keeps the dedicated full-document default.
+        default_admission = assess_full_document_admission(
+            backend, prompt, snapshot, max_tokens=None, workdir=workdir
+        )
+        self.assertTrue(default_admission.compatible)
+        self.assertEqual(default_admission.output_reserve, FULL_DOCUMENT_FINAL_MAX_TOKENS)
+
+        # An oversized explicit budget fails closed. It is never clamped down to
+        # the available headroom.
+        oversized = 11264 - 6702 - margin + 1
+        blocked = assess_full_document_admission(
+            backend, prompt, snapshot, max_tokens=oversized, workdir=workdir
+        )
+        self.assertFalse(blocked.compatible)
+        self.assertEqual(blocked.reason, "context_too_small")
+        self.assertEqual(blocked.output_reserve, oversized)
+        self.assertGreater(blocked.required_context, blocked.active_context)
+
+    def test_admitted_reserve_is_the_backend_max_tokens(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            (workdir / "note.txt").write_text("original\n", encoding="utf-8")
+            backend = PreflightBackend(prompt_tokens=6702, context_tokens=11264)
+            observed: list[int] = []
+            original_chat = backend.chat
+
+            def recording_chat(messages, *, temperature, max_tokens, tools=None):
+                observed.append(max_tokens)
+                return original_chat(messages, temperature=temperature, max_tokens=max_tokens, tools=tools)
+
+            backend.chat = recording_chat
+            runtime = ChatRuntime(backend=backend, system_prompt=None)
+            runtime.ask_auto(
+                "Read note.txt completely.",
+                temperature=0,
+                max_tokens=2048,
+                workdir=workdir,
+            )
+
+        self.assertEqual(backend.calls, 2)
+        # The full-document call receives exactly the admitted reserve.
+        self.assertEqual(observed[-1], 2048)
 
     def test_preflight_rejects_tokenizer_template_identity_change(self) -> None:
         class ChangingIdentityBackend(PreflightBackend):


### PR DESCRIPTION
## Problem

The full-document final answer clamped every output budget to `FULL_DOCUMENT_FINAL_MAX_TOKENS = 1024`:

```
CLI --max-tokens 2048
  -> full_document.py:188  resolve_max_tokens("full_document", 2048)
  -> completion_budget.py  min(2048, 1024) -> 1024
  -> backend max_tokens = 1024  ->  finish_reason=length
```

The answer was truncated mid-sentence even though the context had ample room. For a 6702-token prompt at ctx 11264, a 2048 budget needs `6702 + 2048 + 256 = 9006` tokens, leaving **2258 tokens of headroom**. The static cap was never a context-safety requirement.

## Fix

Make the dedicated cap the default rather than a hard ceiling. An explicit caller budget is used unchanged, and exact full-document admission decides whether it fits.

- `resolve_max_tokens("full_document", N)` returns `N` unchanged, falling back to `FULL_DOCUMENT_FINAL_MAX_TOKENS` only when no budget is given
- exact admission keeps checking `prompt_tokens + reserve + safety_margin <= active_context`, so an oversized explicit budget **fails closed** with `context_too_small` instead of being reduced to the available headroom
- the admitted reserve remains the value passed to the backend, so the attempted budget and the blocked diagnostic always agree

This mirrors the existing `chat` branch, where an explicit CLI/REPL limit is already authoritative.

## Behavior change

A request that previously fit only because the budget was silently clamped now reports `context_too_small`. Example: prompt 6000, ctx 8192, `N=2048` — previously admitted at a clamped reserve of 1024, now rejected at 2048.

This is the intended direction: a visible, actionable error instead of a silently truncated answer. The blocked notice reports the reserve, required, and active context, so the user can lower `--max-tokens` or raise ctx.

## Scope

`resolve_max_tokens("full_document", ...)` has exactly one caller (`full_document.py:188`), and the budget is bounded upstream at `MAX_MAX_TOKENS = 4096`, so no unbounded value can reach a backend. Every full-document call is now admission-checked against the real active context, so context-overflow risk decreases.

Unchanged: safety margin (256), default ctx, Context Manager, guardrails/structured reads, backend/KV/model profiles.

## Validation

### Semantics

| Case | Result |
|---|---|
| explicit 256 | 256 |
| explicit 1024 | 1024 |
| explicit 2048 (fits) | 2048 |
| explicit oversized | `context_too_small`, reserve never clamped |
| unspecified | 1024 default |
| admitted reserve | == backend `max_tokens` |

Requirement "reserve == backend max_tokens" is structurally guaranteed: both `assess_full_document_admission` call sites (`environments.py:595`, `:956`) converge on the single model call in `answer_admitted_snapshot`, which passes `admission.output_reserve` with no re-resolution in between.

### Real Qwen3.6 smoke

Qwen3.6-35B-A3B-Q4_K_M, ctx 11264, `--max-tokens 2048`, fresh session:

```
[admission] requested=2048 reserve=2048 prompt_tokens=6702
            required=9006 active_ctx=11264 reason=None compatible=True
[backend]   max_tokens_sent=2048 finish=length completion_tokens=2048
```

Backend received **2048**. One `cat`, `coverage: complete`, `route=full_document`, zero errors. Output grew from 2542 to 4769 chars.

### Test suites

- focused (`test_completion_budget` + `test_full_document`): 41/41 PASS
- affected: 437/437 PASS
- Qualification Harness: 83/83 PASS
- full discovery: **1908/1908 PASS**
- `compileall` clean, `git diff --check` clean
- independent adversarial review: PASS