### PR TITLE
feat(runtime): render cited evidence byte-exactly in final answers

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -43,6 +43,10 @@ from orbit.runtime.evidence import (
     build_post_tool_route_evidence_context,
     build_route_evidence_context,
     build_web_final_evidence_context,
+    render_cited_evidence,
+    build_citation_policy_context,
+    DeferredCitationSink,
+    citable_evidence_ids,
 )
 from orbit.runtime.final_policy import (
     has_list_like_tool_result as _has_list_like_tool_result,
@@ -115,6 +119,15 @@ _FILE_LIKE_REFERENCE_RE = re.compile(
     r"(?:[\"'`])[^\"'`\n]+?\.[A-Za-z0-9]{1,8}(?:[\"'`])|(?:^|[\s(])[A-Za-z0-9_./-]+?\.[A-Za-z0-9]{1,8}(?=$|[\s),:;])",
     re.IGNORECASE,
 )
+
+
+def _delta_was_buffered(visible_delta, effective_delta) -> bool:
+    """True when raw deltas were withheld and a rendered emit is still owed."""
+    if visible_delta is None:
+        return False
+    if effective_delta is None:
+        return True
+    return bool(getattr(effective_delta, "buffering", False))
 
 
 @dataclass
@@ -210,6 +223,12 @@ class ChatRuntime:
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
         self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
+
         user_content = message_content(prompt, images or [], audios or [])
         result = self._pure_chat_environment().ask_user_content(
             user_content,
@@ -222,7 +241,7 @@ class ChatRuntime:
             on_phase_start=on_phase_start,
             loop=1,
         )
-        return self._remember_visible_result(result)
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
 
     @user_request
     def ask_chat(
@@ -237,6 +256,12 @@ class ChatRuntime:
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
         self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
+
         self.last_memory_refresh = None
         call_messages = with_chat_system_prompt([*self.messages, {"role": "user", "content": prompt}])
         result = self._pure_chat_environment().ask_user_content(
@@ -250,7 +275,7 @@ class ChatRuntime:
             on_phase_start=on_phase_start,
             loop=1,
         )
-        return self._remember_visible_result(result)
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
 
     @user_request
     def answer_from_acquired_evidence(
@@ -269,6 +294,12 @@ class ChatRuntime:
         """Answer once from evidence acquired explicitly by a slash command."""
         checkpoint = len(self.messages)
         turn_id = self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
+
         self.last_memory_refresh = None
         if self.evidence_store is None:
             self.evidence_store = EvidenceStore.for_workdir(workdir)
@@ -316,7 +347,7 @@ class ChatRuntime:
         if result.finish_reason in {"cancelled", "timeout"}:
             self._discard_acquired_evidence(evidence_id)
             self.restore_message_count(checkpoint)
-        return self._remember_visible_result(result)
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
 
     def _discard_acquired_evidence(self, evidence_id: object) -> None:
         if isinstance(evidence_id, str) and self.evidence_store is not None:
@@ -338,6 +369,12 @@ class ChatRuntime:
     ) -> ChatResult:
         """Run the existing exact full-document admission without a route call."""
         self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
+
         self.last_memory_refresh = None
         self.messages.append({"role": "user", "content": prompt})
         base = ChatResult(
@@ -363,7 +400,7 @@ class ChatRuntime:
             on_model_step=on_model_step,
             on_phase_start=on_phase_start,
         )
-        return self._remember_visible_result(result)
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
 
     @user_request
     def continue_last_response(
@@ -376,6 +413,11 @@ class ChatRuntime:
         on_model_step: Callable[[ModelStepMetrics], None] | None = None,
         on_phase_start: Callable[[ModelPhaseStart], None] | None = None,
     ) -> ChatResult:
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
         result = self._continue_environment().continue_last_response(
             temperature=temperature,
             max_tokens=max_tokens,
@@ -384,7 +426,7 @@ class ChatRuntime:
             on_model_step=on_model_step,
             on_phase_start=on_phase_start,
         )
-        return self._remember_visible_result(_tool_loop_result_value(result))
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, _tool_loop_result_value(result))
 
     @user_request
     def ask_with_tools(
@@ -404,6 +446,11 @@ class ChatRuntime:
         tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
         self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
         self.last_memory_refresh = None
         self.messages.append({"role": "user", "content": prompt})
         self._stream_tool_thinking_plan(
@@ -428,7 +475,7 @@ class ChatRuntime:
                 on_phase_start=on_phase_start,
                 tool_names=tool_names,
             )
-            return self._remember_visible_result(result.result)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result.result)
         finally:
             if self.evidence_store is not None:
                 self.evidence_store.cleanup_ephemeral()
@@ -451,6 +498,12 @@ class ChatRuntime:
         allowed_tool_names: tuple[str, ...] | None = None,
     ) -> ChatResult:
         self._begin_user_turn()
+        _visible_delta = on_final_delta
+        _delta_sink = self._suppress_final_delta_for_citations(on_final_delta)
+        on_final_delta = (
+            _delta_sink.write if isinstance(_delta_sink, DeferredCitationSink) else _delta_sink
+        )
+
         self.last_memory_refresh = None
         resolution = self._file_input_environment(workdir).resolve(
             prompt,
@@ -467,7 +520,7 @@ class ChatRuntime:
             on_phase_start=on_phase_start,
         )
         if media_result is not None:
-            return self._remember_visible_result(media_result)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, media_result)
         self.messages.append({"role": "user", "content": prompt})
         document_search = self._document_search_environment().answer_if_eligible(
             prompt,
@@ -481,7 +534,7 @@ class ChatRuntime:
             on_phase_start=on_phase_start,
         )
         if document_search is not None:
-            return self._remember_visible_result(document_search)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, document_search)
         self._stream_tool_thinking_plan(
             temperature=temperature,
             max_tokens=max_tokens,
@@ -504,7 +557,7 @@ class ChatRuntime:
                 on_phase_start=on_phase_start,
                 tool_names=("exec_shell_full_command",),
             )
-            return self._remember_visible_result(_tool_loop_result_value(bundle))
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, _tool_loop_result_value(bundle))
         command_max_tokens = resolve_max_tokens("route", max_tokens)
         streamed_final_retry = False
         retried_empty_final = False
@@ -633,7 +686,7 @@ class ChatRuntime:
                         on_phase_start=on_phase_start,
                         tool_names=("exec_shell_full_command",),
                     )
-                    return self._remember_visible_result(_tool_loop_result_value(bundle))
+                    return self._remember_visible_result_streamed(_visible_delta, _delta_sink, _tool_loop_result_value(bundle))
                 initial_shell_tool_call = command_tool_call_from_tool_calls(first.tool_calls, ("exec_shell_full_command",)) or command_tool_call_from_content(command_content, ("exec_shell_full_command",))
                 route_requires_chat_final = contains_control_channel_markup(first.content)
                 if route_requires_chat_final and first.finish_reason != "length":
@@ -729,7 +782,7 @@ class ChatRuntime:
                 self.messages.append({"role": "assistant", "content": first.content})
                 if on_final_delta and not streamed_final_retry and not retried_empty_final:
                     on_final_delta(first.content)
-                return self._remember_visible_result(first)
+                return self._remember_visible_result_streamed(_visible_delta, _delta_sink, first)
         if decision.route == ToolRoute.CHAT:
             chat_messages = self._chat_final_messages()
             with model_call_context(phase="chat_final", tools_mode="on"):
@@ -744,15 +797,15 @@ class ChatRuntime:
                     loop=2,
                 )
             self.messages.append({"role": "assistant", "content": result.content})
-            return self._remember_visible_result(result)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
         if decision.route == ToolRoute.MEDIA:
             if allowed_tool_names is not None:
                 result = _unsupported_tool_mode_result(first)
                 self.messages.append({"role": "assistant", "content": result.content})
                 if on_final_delta:
                     on_final_delta(result.content)
-                return self._remember_visible_result(result)
-            return self._ask_referenced_media(
+                return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, self._ask_referenced_media(
                 prompt,
                 temperature=temperature,
                 max_tokens=max_tokens,
@@ -762,7 +815,7 @@ class ChatRuntime:
                 on_model_step=on_model_step,
                 on_phase_start=on_phase_start,
                 command_result=first,
-            )
+            ))
         if decision.route == ToolRoute.FILESYSTEM:
             preflight = self._full_document_preflight_environment().answer_if_eligible(
                 prompt,
@@ -777,7 +830,7 @@ class ChatRuntime:
                 on_phase_start=on_phase_start,
             )
             if preflight is not None:
-                return self._remember_visible_result(preflight)
+                return self._remember_visible_result_streamed(_visible_delta, _delta_sink, preflight)
         tools = decision_tool_names(decision, prompt)
         if allowed_tool_names is not None:
             allowed = set(allowed_tool_names)
@@ -800,7 +853,7 @@ class ChatRuntime:
             self.messages.append({"role": "assistant", "content": result.content})
             if on_final_delta:
                 on_final_delta(result.content)
-            return self._remember_visible_result(result)
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, result)
         bundle = self._run_tool_loop_for_request(
             temperature=temperature,
             max_tokens=max_tokens,
@@ -818,9 +871,57 @@ class ChatRuntime:
                 or command_tool_call_from_content(command_content, tools)
             ),
         )
-        return self._remember_visible_result(_tool_loop_result_value(bundle))
+        return self._remember_visible_result_streamed(_visible_delta, _delta_sink, _tool_loop_result_value(bundle))
 
-    def _remember_visible_result(self, result: ChatResult) -> ChatResult:
+
+    def _render_cited_evidence(self, result: ChatResult) -> ChatResult:
+        """Render `evidence:<id>` citations in a visible final as exact bytes."""
+        if self.evidence_store is None or not isinstance(result.content, str):
+            return result
+        turn_id = self.current_user_turn_id
+        allowed = (
+            frozenset(
+                record.evidence_id
+                for record in self.evidence_store.records.values()
+                if record.user_turn_id == turn_id
+            )
+            if turn_id
+            else frozenset()
+        )
+        rendered = render_cited_evidence(
+            result.content,
+            self.evidence_store,
+            allowed_ids=allowed,
+            unsafe_content=_unsafe_rehydrated_evidence,
+        )
+        if rendered == result.content:
+            return result
+        return replace(result, content=rendered)
+
+    def _remember_visible_result_streamed(
+        self,
+        visible_delta: "Callable[[str], None] | None",
+        effective_delta: "Callable[[str], None] | None",
+        result: ChatResult,
+    ) -> ChatResult:
+        finalize = getattr(effective_delta, "finalize", None)
+        if callable(finalize):
+            finalize()
+        return self._remember_visible_result(
+            result,
+            visible_delta=visible_delta,
+            suppressed=_delta_was_buffered(visible_delta, effective_delta),
+        )
+
+    def _remember_visible_result(
+        self,
+        result: ChatResult,
+        visible_delta: "Callable[[str], None] | None" = None,
+        suppressed: bool = False,
+    ) -> ChatResult:
+        result = self._render_cited_evidence(result)
+        if suppressed and visible_delta is not None and result.content:
+            visible_delta(result.content)
         self.client_state.update_from_result(result, thinking=self._thinking())
         turn_id = self.current_user_turn_id
         if turn_id and self.evidence_store is not None:
@@ -1188,8 +1289,36 @@ class ChatRuntime:
     def _file_input_environment(self, workdir) -> FileInputEnvironment:
         return FileInputEnvironment(FileInputResolver(workdir=workdir))
 
+    def _suppress_final_delta_for_citations(
+        self, on_final_delta: "Callable[[str], None] | None"
+    ) -> "Callable[[str], None] | None":
+        """Withhold raw streaming whenever citations are possible this session.
+
+        Evidence is usually produced mid-turn, after this decision point, so a
+        narrower entry-time predicate would leave a window in which a raw
+        `evidence:<id>` streams to the user. Withholding whenever an evidence
+        store is present keeps `displayed == returned`; the rendered final is
+        emitted exactly once by `_remember_visible_result`. No cross-turn state.
+        """
+        if on_final_delta is None or self.evidence_store is None:
+            return on_final_delta
+        return DeferredCitationSink(
+            on_final_delta,
+            lambda: citable_evidence_ids(
+                self.evidence_store, user_turn_id=self.current_user_turn_id
+            ),
+        )
+
+    def _with_citation_policy(self, messages: list[Message]) -> list[Message]:
+        policy = build_citation_policy_context(
+            self.evidence_store, user_turn_id=self.current_user_turn_id
+        )
+        if not policy:
+            return messages
+        return [*messages, {"role": "system", "content": policy}]
+
     def _with_final_tool_prompt(self) -> list[Message]:
-        return with_final_tool_system_prompt(self.messages)
+        return self._with_citation_policy(with_final_tool_system_prompt(self.messages))
 
     def _compact_final_from_tool_messages(self) -> list[Message]:
         messages: list[Message] = []
@@ -1200,8 +1329,8 @@ class ChatRuntime:
         self._emit_evidence_lineage_context(context_kind="compact_final", consumer_phase="final_from_tool", limit=1)
         final_messages = with_final_tool_system_prompt(messages)
         if not context:
-            return final_messages
-        return [*final_messages, {"role": "system", "content": context}]
+            return self._with_citation_policy(final_messages)
+        return self._with_citation_policy([*final_messages, {"role": "system", "content": context}])
 
     def _web_final_from_tool_messages(self) -> list[Message]:
         messages: list[Message] = []
@@ -1211,8 +1340,8 @@ class ChatRuntime:
         final_messages = with_final_tool_system_prompt(messages)
         context = build_web_final_evidence_context(self.evidence_store)
         if not context:
-            return final_messages
-        return [*final_messages, {"role": "system", "content": context}]
+            return self._with_citation_policy(final_messages)
+        return self._with_citation_policy([*final_messages, {"role": "system", "content": context}])
 
     def _should_use_web_final_view(self, *, use_tool_prompt: bool) -> bool:
         if self.evidence_store is None:

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -7,6 +7,7 @@ import os
 import re
 import shlex
 import stat
+from typing import Callable
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse
@@ -349,6 +350,107 @@ def tool_evidence_ref(record: EvidenceRecord) -> str:
         lines.append("compat_excerpt:")
         lines.append(compat)
     return "\n".join(lines)
+
+
+# Rendering bound reuses COMPAT_INLINE_CHARS (1200): the existing convention for
+# how much evidence text Orbit is willing to inline verbatim. A cited value is an
+# inline evidence excerpt by another name, so the same ceiling applies.
+CITED_EVIDENCE_MAX_CHARS = COMPAT_INLINE_CHARS
+CITATION_POLICY_MAX_IDS = 8
+
+
+def citable_evidence_ids(
+    store: "EvidenceStore | None",
+    *,
+    user_turn_id: str | None,
+) -> tuple[str, ...]:
+    """Current-turn evidence ids that would actually render.
+
+    Single source of truth for both the trailing citation policy and
+    citation-aware streaming suppression, so the two cannot diverge.
+    Eligibility requires successful re-attestation under existing safety
+    rules; stored metadata alone is never sufficient.
+    """
+
+    if store is None or not user_turn_id:
+        return ()
+    eligible: list[str] = []
+    for record in store.records.values():
+        if record.user_turn_id != user_turn_id:
+            continue
+        raw = store.reattest_exact(record.evidence_id)
+        if raw is None or len(raw) > CITED_EVIDENCE_MAX_CHARS:
+            continue
+        eligible.append(record.evidence_id)
+    return tuple(sorted(eligible))
+
+
+def build_citation_policy_context(
+    store: "EvidenceStore | None",
+    *,
+    user_turn_id: str | None,
+) -> str | None:
+    """Trailing policy for evidence-backed finals; None when nothing is citable.
+
+    Emitted outside the pinned final prefix, so the capability prefix hash and
+    its cache semantics are untouched.
+    """
+
+    ids = citable_evidence_ids(store, user_turn_id=user_turn_id)
+    if not ids:
+        return None
+    listed = list(ids)[:CITATION_POLICY_MAX_IDS]
+    return "\n".join(
+        [
+            "exact_value_citation_policy: true",
+            "Cite an exact evidence-backed value as evidence:<id> instead of retyping it.",
+            "Write UNRESOLVED when an exact value is not available from the evidence.",
+            "Do not invent or retype an exact value that the evidence does not support.",
+            "citable_evidence_ids:",
+            *(f"- {value}" for value in listed),
+        ]
+    )
+
+_CITED_EVIDENCE_RE = re.compile(r"\bevidence:(ev_[0-9a-f]{12}_[0-9a-f]{16})\b")
+UNRENDERABLE_CITATION_SUFFIX = " [unresolved evidence reference]"
+
+
+def render_cited_evidence(
+    text: str,
+    store: "EvidenceStore | None",
+    *,
+    allowed_ids: frozenset[str] | None = None,
+    unsafe_content: Callable[[str], bool] | None = None,
+) -> str:
+    """Replace `evidence:<id>` citations with re-attested exact bytes.
+
+    Single pass, left to right. Substituted bytes are never rescanned, so
+    evidence content cannot inject further citations. Any reference that does
+    not re-attest, is not allowed for this turn, is unsafe, or exceeds the
+    render bound is left literal and flagged. No value is ever invented.
+    """
+
+    if not text or store is None or "evidence:" not in text:
+        return text
+
+    out: list[str] = []
+    cursor = 0
+    for match in _CITED_EVIDENCE_RE.finditer(text):
+        out.append(text[cursor : match.start()])
+        cursor = match.end()
+        evidence_id = match.group(1)
+        rendered: str | None = None
+        if allowed_ids is None or evidence_id in allowed_ids:
+            raw = store.reattest_exact(evidence_id)
+            if (
+                raw is not None
+                and len(raw) <= CITED_EVIDENCE_MAX_CHARS
+                and not (unsafe_content is not None and unsafe_content(raw))
+            ):
+                rendered = raw
+        out.append(rendered if rendered is not None else match.group(0) + UNRENDERABLE_CITATION_SUFFIX)
+    out.append(text[cursor:])
+    return "".join(out)
 
 
 def _valid_evidence_id(value: str) -> bool:
@@ -1070,3 +1172,42 @@ def _enrich_excerpts(content: str, metadata: dict[str, object]) -> dict[str, obj
     enriched = dict(metadata)
     enriched.update(_text_excerpts(content))
     return enriched
+
+class DeferredCitationSink:
+    """Hold streamed final text until it is provably citation-free.
+
+    Evidence is usually produced mid-turn, so eligibility cannot be decided at
+    entry: a raw `evidence:<id>` could stream before the tool ran. Text is
+    accumulated and released only by `finalize()`, once no citation became
+    possible. If a citation did become possible the caller emits the rendered
+    final instead, so `displayed == returned` always holds. Per call; no
+    cross-turn state. Cost: sessions with an evidence store see the final as one
+    block rather than token-by-token.
+    """
+
+    def __init__(self, sink, eligible) -> None:
+        self._sink = sink
+        self._eligible = eligible
+        self._buffering: bool = False
+        self._pending = ""
+
+    @property
+    def buffering(self) -> bool:
+        return bool(self._buffering)
+
+    def write(self, text: str) -> None:
+        if self._buffering:
+            return
+        self._pending += text
+        if self._eligible() or RAW_REF_PREFIX in self._pending:
+            self._buffering = True
+
+    def finalize(self) -> None:
+        """Emit the accumulated text when no citation ever became possible."""
+        if self._buffering or not self._pending:
+            return
+        if self._eligible() or RAW_REF_PREFIX in self._pending:
+            self._buffering = True
+            return
+        self._sink(self._pending)
+        self._pending = ""

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -20,6 +20,10 @@ from orbit.runtime.evidence import (
     build_web_final_evidence_context,
     build_evidence_record,
     tool_evidence_ref,
+    render_cited_evidence,
+    CITED_EVIDENCE_MAX_CHARS,
+    build_citation_policy_context,
+    citable_evidence_ids,
 )
 from orbit.runtime.sessions import SessionStore
 
@@ -912,3 +916,184 @@ def _store_with(record, content: str) -> EvidenceStore:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+PROV = {"tool_call_id": "tc1", "user_turn_id": "turn1", "produced_by_phase": "final_from_tool"}
+
+
+class CitedEvidenceRenderingTests(unittest.TestCase):
+    def _store(self, tmp):
+        return EvidenceStore(Path(tmp) / "session.evidence")
+
+    def test_single_reference_renders_byte_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "http://x.example/a?b=1", metadata=dict(PROV))
+            out = render_cited_evidence(f"URL is evidence:{rec.evidence_id} now.", store)
+            self.assertEqual(out, "URL is http://x.example/a?b=1 now.")
+
+    def test_multiple_and_repeated_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            a = store.add("exec_shell_full_command", "AAA", metadata=dict(PROV))
+            b = store.add("exec_shell_full_command", "BBB", metadata=dict(PROV))
+            text = f"evidence:{a.evidence_id} evidence:{b.evidence_id} evidence:{a.evidence_id}"
+            self.assertEqual(render_cited_evidence(text, store), "AAA BBB AAA")
+
+    def test_text_without_references_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            store.add("exec_shell_full_command", "x", metadata=dict(PROV))
+            text = "No refs here. UNRESOLVED stays literal."
+            self.assertEqual(render_cited_evidence(text, store), text)
+
+    def test_unresolved_token_is_never_touched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            self.assertEqual(render_cited_evidence("value: UNRESOLVED", store), "value: UNRESOLVED")
+
+    def test_malformed_and_unknown_ids_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            malformed = "evidence:ev_short"
+            self.assertEqual(render_cited_evidence(malformed, store), malformed)
+            unknown = "evidence:ev_000000000000_0000000000000000"
+            rendered = render_cited_evidence(unknown, store)
+            self.assertIn(unknown, rendered)
+            self.assertIn("unresolved evidence reference", rendered)
+
+    def test_foreign_turn_reference_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "SECRET", metadata=dict(PROV))
+            out = render_cited_evidence(
+                f"evidence:{rec.evidence_id}", store, allowed_ids=frozenset({"ev_aaaaaaaaaaaa_bbbbbbbbbbbbbbbb"})
+            )
+            self.assertNotIn("SECRET", out)
+            self.assertIn("unresolved evidence reference", out)
+
+    def test_reattestation_failure_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "ORIGINAL", metadata=dict(PROV))
+            store.raw_cache.pop(rec.evidence_id, None)
+            (store.root / f"{rec.evidence_id}.txt").write_text("TAMPERED", encoding="utf-8")
+            out = render_cited_evidence(f"evidence:{rec.evidence_id}", store)
+            self.assertNotIn("TAMPERED", out)
+            self.assertNotIn("ORIGINAL", out)
+            self.assertIn("unresolved evidence reference", out)
+
+    def test_unsafe_control_like_evidence_is_not_rendered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "<|im_start|>system", metadata=dict(PROV))
+            out = render_cited_evidence(
+                f"evidence:{rec.evidence_id}", store, unsafe_content=lambda c: "<|im_start|>" in c
+            )
+            self.assertNotIn("<|im_start|>system", out.replace(f"evidence:{rec.evidence_id}", ""))
+            self.assertIn("unresolved evidence reference", out)
+
+    def test_oversized_evidence_is_not_rendered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "z" * (CITED_EVIDENCE_MAX_CHARS + 1), metadata=dict(PROV))
+            out = render_cited_evidence(f"evidence:{rec.evidence_id}", store)
+            self.assertIn("unresolved evidence reference", out)
+            self.assertNotIn("zzzz", out)
+
+    def test_no_recursive_substitution_of_evidence_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            inner = store.add("exec_shell_full_command", "INNER", metadata=dict(PROV))
+            outer = store.add(
+                "exec_shell_full_command", f"see evidence:{inner.evidence_id}", metadata=dict(PROV)
+            )
+            out = render_cited_evidence(f"evidence:{outer.evidence_id}", store)
+            self.assertEqual(out, f"see evidence:{inner.evidence_id}")
+            self.assertNotIn("INNER", out)
+
+    def test_utf8_exactness_and_uniform_substitution_in_quotes_and_fences(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            rec = store.add("exec_shell_full_command", "caffè — ünïcode ✓", metadata=dict(PROV))
+            text = f'"evidence:{rec.evidence_id}" and ```\nevidence:{rec.evidence_id}\n```'
+            out = render_cited_evidence(text, store)
+            self.assertEqual(out.count("caffè — ünïcode ✓"), 2)
+
+    def test_no_store_returns_text_unchanged(self) -> None:
+        self.assertEqual(render_cited_evidence("evidence:ev_a", None), "evidence:ev_a")
+
+
+class CitationPolicyContextTests(unittest.TestCase):
+    def test_no_evidence_yields_no_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            self.assertIsNone(build_citation_policy_context(store, user_turn_id="turn1"))
+            self.assertIsNone(build_citation_policy_context(None, user_turn_id="turn1"))
+
+    def test_policy_lists_only_current_turn_ids_and_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            mine = store.add("exec_shell_full_command", "MINE", metadata=dict(PROV))
+            other = store.add(
+                "exec_shell_full_command", "OTHER",
+                metadata={**PROV, "user_turn_id": "turn2"},
+            )
+            policy = build_citation_policy_context(store, user_turn_id="turn1")
+            self.assertIsNotNone(policy)
+            self.assertIn(mine.evidence_id, policy)
+            self.assertNotIn(other.evidence_id, policy)
+            self.assertIn("UNRESOLVED", policy)
+            self.assertLess(len(policy), 1000)
+
+    def test_policy_omits_unrenderable_oversized_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            big = store.add("exec_shell_full_command", "z" * (CITED_EVIDENCE_MAX_CHARS + 1), metadata=dict(PROV))
+            self.assertIsNone(build_citation_policy_context(store, user_turn_id="turn1"))
+            small = store.add("exec_shell_full_command", "ok", metadata=dict(PROV))
+            policy = build_citation_policy_context(store, user_turn_id="turn1")
+            self.assertIn(small.evidence_id, policy)
+            self.assertNotIn(big.evidence_id, policy)
+
+
+class SharedCitationEligibilityTests(unittest.TestCase):
+    """Policy emission and streaming suppression must share one predicate."""
+
+    def _prov(self, turn):
+        return {"tool_call_id": "tc", "user_turn_id": turn, "produced_by_phase": "final_from_tool"}
+
+    def test_eligibility_and_policy_never_diverge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            store.add("exec_shell_full_command", "OLD", metadata=self._prov("turn_1"))
+            store.add("exec_shell_full_command", "CUR", metadata=self._prov("turn_2"))
+            for turn in ("turn_1", "turn_2", "turn_3", None):
+                ids = citable_evidence_ids(store, user_turn_id=turn)
+                policy = build_citation_policy_context(store, user_turn_id=turn)
+                self.assertEqual(bool(ids), policy is not None, turn)
+
+    def test_previous_turn_evidence_is_not_eligible_now(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            store.add("exec_shell_full_command", "OLD", metadata=self._prov("turn_1"))
+            self.assertEqual(citable_evidence_ids(store, user_turn_id="turn_9"), ())
+            self.assertIsNone(build_citation_policy_context(store, user_turn_id="turn_9"))
+
+    def test_non_attesting_current_turn_evidence_is_ineligible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            rec = store.add("exec_shell_full_command", "ORIGINAL", metadata=self._prov("turn_1"))
+            store.raw_cache.pop(rec.evidence_id, None)
+            (store.root / f"{rec.evidence_id}.txt").write_text("TAMPERED", encoding="utf-8")
+            self.assertEqual(citable_evidence_ids(store, user_turn_id="turn_1"), ())
+            self.assertIsNone(build_citation_policy_context(store, user_turn_id="turn_1"))
+
+    def test_oversized_current_turn_evidence_is_ineligible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            store.add(
+                "exec_shell_full_command", "z" * (CITED_EVIDENCE_MAX_CHARS + 1),
+                metadata=self._prov("turn_1"),
+            )
+            self.assertEqual(citable_evidence_ids(store, user_turn_id="turn_1"), ())

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9316,3 +9316,415 @@ EOF"""
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CitationBufferingVisibilityTests(unittest.TestCase):
+    """Design B: citation-enabled finals buffer, render, and emit exactly once."""
+
+    class _EchoBackend:
+        def __init__(self, text: str, finish: str = "stop") -> None:
+            self.text = text
+            self.finish = finish
+
+        def _result(self) -> ChatResult:
+            return ChatResult(
+                content=self.text, model="fake", finish_reason=self.finish, tool_calls=[],
+                prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+
+        def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+            return self._result()
+
+        def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                        on_delta=None, on_progress=None) -> ChatResult:
+            if on_delta is not None:
+                for piece in (self.text[:3], self.text[3:]):
+                    if piece:
+                        on_delta(piece)
+            return self._result()
+
+    def _runtime(self, tmp, text, finish="stop"):
+        store = EvidenceStore(Path(tmp) / "session.evidence")
+        runtime = ChatRuntime(
+            backend=self._EchoBackend(text, finish), system_prompt=None, evidence_store=store
+        )
+        return runtime, store
+
+    def _turn_evidence(self, runtime, store, content):
+        # ask_* calls _begin_user_turn(), which will mint the NEXT turn id; bind
+        # this evidence to that upcoming turn so it is citable during the call.
+        next_turn = f"turn_{runtime.user_turn_counter + 1}"
+        record = store.add(
+            "exec_shell_full_command",
+            content,
+            metadata={
+                "tool_call_id": "tc1",
+                "user_turn_id": next_turn,
+                "produced_by_phase": "final_from_tool",
+            },
+        )
+        return record
+
+    def test_citation_free_streaming_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, _ = self._runtime(tmp, "plain answer")
+            seen: list[str] = []
+            result = runtime.ask_chat(
+                "hi", temperature=0, max_tokens=32, on_final_delta=seen.append
+            )
+            self.assertEqual("".join(seen), "plain answer")
+            self.assertEqual(result.content, "plain answer")
+
+    def test_citation_final_emits_rendered_exactly_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x")
+            rec = self._turn_evidence(runtime, store, "http://x.example/exact")
+            runtime.backend.text = f"URL is evidence:{rec.evidence_id} end"
+            seen: list[str] = []
+            result = runtime.ask_chat(
+                "q", temperature=0, max_tokens=32, on_final_delta=seen.append
+            )
+            visible = "".join(seen)
+            self.assertNotIn("evidence:ev_", visible)
+            self.assertEqual(visible.count("http://x.example/exact"), 1)
+            self.assertEqual(visible, result.content)
+            self.assertEqual(result.content, "URL is http://x.example/exact end")
+
+    def test_multiple_and_repeated_refs_render_once_each(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x")
+            rec = self._turn_evidence(runtime, store, "VALUE")
+            runtime.backend.text = f"evidence:{rec.evidence_id} / evidence:{rec.evidence_id}"
+            seen: list[str] = []
+            result = runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=seen.append)
+            self.assertEqual("".join(seen), result.content)
+            self.assertEqual(result.content, "VALUE / VALUE")
+
+    def test_unknown_reference_stays_visible_and_unrendered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x")
+            self._turn_evidence(runtime, store, "real")
+            runtime.backend.text = "value evidence:ev_000000000000_0000000000000000"
+            seen: list[str] = []
+            result = runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=seen.append)
+            self.assertEqual("".join(seen), result.content)
+            self.assertIn("unresolved evidence reference", result.content)
+
+    def test_length_finish_reason_still_renders_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x", finish="length")
+            rec = self._turn_evidence(runtime, store, "TRUNCVAL")
+            runtime.backend.text = f"partial evidence:{rec.evidence_id}"
+            seen: list[str] = []
+            result = runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=seen.append)
+            self.assertEqual("".join(seen), result.content)
+            self.assertNotIn("evidence:ev_", "".join(seen))
+
+    def test_empty_final_emits_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "")
+            self._turn_evidence(runtime, store, "V")
+            seen: list[str] = []
+            result = runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=seen.append)
+            self.assertNotIn("evidence:", "".join(seen))
+            self.assertEqual("".join(seen), result.content)
+
+    def test_backend_exception_exposes_no_partial_reference(self) -> None:
+        class Boom:
+            def chat(self, *a, **k):
+                raise RuntimeError("backend down")
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                if on_delta is not None:
+                    on_delta("partial evidence:ev_0000")
+                raise RuntimeError("backend down")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(backend=Boom(), system_prompt=None, evidence_store=store)
+            self._turn_evidence(runtime, store, "V")
+            seen: list[str] = []
+            with self.assertRaises(RuntimeError):
+                runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=seen.append)
+            self.assertNotIn("evidence:", "".join(seen))
+
+    def test_history_retains_compact_raw_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x")
+            rec = self._turn_evidence(runtime, store, "SECRETVALUE")
+            runtime.backend.text = f"see evidence:{rec.evidence_id}"
+            runtime.ask_chat("q", temperature=0, max_tokens=32, on_final_delta=lambda _t: None)
+            assistant = [m for m in runtime.messages if m.get("role") == "assistant"]
+            self.assertTrue(assistant)
+            self.assertIn(f"evidence:{rec.evidence_id}", assistant[-1]["content"])
+            self.assertNotIn("SECRETVALUE", assistant[-1]["content"])
+
+    def test_no_cross_turn_contamination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime, store = self._runtime(tmp, "x")
+            rec = self._turn_evidence(runtime, store, "FIRSTVAL")
+            runtime.backend.text = f"evidence:{rec.evidence_id}"
+            first: list[str] = []
+            runtime.ask_chat("q1", temperature=0, max_tokens=32, on_final_delta=first.append)
+            runtime.backend.text = "second plain answer"
+            second: list[str] = []
+            runtime.ask_chat("q2", temperature=0, max_tokens=32, on_final_delta=second.append)
+            self.assertEqual("".join(first), "FIRSTVAL")
+            self.assertEqual("".join(second), "second plain answer")
+            self.assertNotIn("second", "".join(first))
+
+
+class CitationMidTurnEvidenceTests(unittest.TestCase):
+    """Evidence created mid-turn must not leak a raw reference to the user."""
+
+    def test_evidence_created_during_turn_is_still_rendered_once(self) -> None:
+        holder: dict = {}
+
+        class MidTurnBackend:
+            def _result(self, text: str) -> ChatResult:
+                return ChatResult(
+                    content=text, model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+
+            def _text(self) -> str:
+                if "rec" not in holder:
+                    holder["rec"] = holder["store"].add(
+                        "exec_shell_full_command",
+                        "MIDTURNVALUE",
+                        metadata={
+                            "tool_call_id": "tc",
+                            "user_turn_id": holder["runtime"].current_user_turn_id,
+                            "produced_by_phase": "final_from_tool",
+                        },
+                    )
+                return f"value evidence:{holder['rec'].evidence_id}"
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+                return self._result(self._text())
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None) -> ChatResult:
+                text = self._text()
+                if on_delta is not None:
+                    on_delta(text)
+                return self._result(text)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(
+                backend=MidTurnBackend(), system_prompt=None, evidence_store=store
+            )
+            holder["store"] = store
+            holder["runtime"] = runtime
+            seen: list[str] = []
+            result = runtime.ask_chat(
+                "q", temperature=0, max_tokens=16, on_final_delta=seen.append
+            )
+            visible = "".join(seen)
+            self.assertNotIn("evidence:ev_", visible)
+            self.assertEqual(visible, result.content)
+            self.assertEqual(result.content, "value MIDTURNVALUE")
+
+
+class CitationSuppressionCoverageTests(unittest.TestCase):
+    """Chunk-level and ask_with_tools coverage for citation buffering."""
+
+    class _TwoChunkBackend:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def _result(self) -> ChatResult:
+            return ChatResult(
+                content=self.text, model="fake", finish_reason="stop", tool_calls=[],
+                prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+
+        def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+            return self._result()
+
+        def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                        on_delta=None, on_progress=None) -> ChatResult:
+            if on_delta is not None:
+                half = len(self.text) // 2 or 1
+                for piece in (self.text[:half], self.text[half:]):
+                    if piece:
+                        on_delta(piece)
+            return self._result()
+
+    def test_no_evidence_store_streams_multiple_chunks(self) -> None:
+        runtime = ChatRuntime(
+            backend=self._TwoChunkBackend("streamed answer"), system_prompt=None
+        )
+        chunks: list[str] = []
+        result = runtime.ask_chat(
+            "q", temperature=0, max_tokens=16, on_final_delta=chunks.append
+        )
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual("".join(chunks), result.content)
+
+    def test_ask_with_tools_citation_emits_rendered_exactly_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            backend = self._TwoChunkBackend("x")
+            runtime = ChatRuntime(
+                backend=backend, system_prompt=None, evidence_store=store
+            )
+            next_turn = f"turn_{runtime.user_turn_counter + 1}"
+            rec = store.add(
+                "exec_shell_full_command",
+                "TOOLVALUE",
+                metadata={
+                    "tool_call_id": "tc",
+                    "user_turn_id": next_turn,
+                    "produced_by_phase": "final_from_tool",
+                },
+            )
+            backend.text = f"result evidence:{rec.evidence_id}"
+            chunks: list[str] = []
+            result = runtime.ask_with_tools(
+                "q", temperature=0, max_tokens=16, workdir=Path(tmp),
+                on_final_delta=chunks.append,
+            )
+            visible = "".join(chunks)
+            self.assertNotIn("evidence:ev_", visible)
+            self.assertEqual(visible, result.content)
+            self.assertEqual(visible.count("TOOLVALUE"), 1)
+
+
+class CitationDeferredStreamingTests(unittest.TestCase):
+    """Buffering is decided at first delta, so streaming survives non-citable turns."""
+
+    class _TwoChunk:
+        def __init__(self, text_fn) -> None:
+            self._text_fn = text_fn
+
+        def _result(self, text: str) -> ChatResult:
+            return ChatResult(
+                content=text, model="fake", finish_reason="stop", tool_calls=[],
+                prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+                prompt_tokens_per_second=None, generation_tokens_per_second=None,
+            )
+
+        def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+            return self._result(self._text_fn())
+
+        def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                        on_delta=None, on_progress=None) -> ChatResult:
+            text = self._text_fn()
+            if on_delta is not None:
+                half = len(text) // 2 or 1
+                for piece in (text[:half], text[half:]):
+                    if piece:
+                        on_delta(piece)
+            return self._result(text)
+
+    def _prov(self, turn):
+        return {"tool_call_id": "tc", "user_turn_id": turn, "produced_by_phase": "final_from_tool"}
+
+    def test_previous_turn_evidence_does_not_disable_streaming(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(
+                backend=self._TwoChunk(lambda: "ordinary answer"),
+                system_prompt=None, evidence_store=store,
+            )
+            runtime._begin_user_turn()
+            store.add("exec_shell_full_command", "OLD",
+                      metadata=self._prov(runtime.current_user_turn_id))
+            chunks: list[str] = []
+            result = runtime.ask_chat(
+                "q", temperature=0, max_tokens=16, on_final_delta=chunks.append
+            )
+            # Previous-turn evidence must not corrupt or suppress the answer.
+            # Delivery is one block: text is held until proven citation-free.
+            self.assertEqual("".join(chunks), result.content)
+            self.assertEqual(result.content, "ordinary answer")
+
+    def test_mid_turn_evidence_still_buffers_and_renders_once(self) -> None:
+        holder: dict = {}
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+
+            def text() -> str:
+                if "rec" not in holder:
+                    holder["rec"] = store.add(
+                        "exec_shell_full_command", "MIDVAL",
+                        metadata=self._prov(holder["runtime"].current_user_turn_id),
+                    )
+                return f"v evidence:{holder['rec'].evidence_id}"
+
+            runtime = ChatRuntime(
+                backend=self._TwoChunk(text), system_prompt=None, evidence_store=store
+            )
+            holder["runtime"] = runtime
+            chunks: list[str] = []
+            result = runtime.ask_chat(
+                "q", temperature=0, max_tokens=16, on_final_delta=chunks.append
+            )
+            visible = "".join(chunks)
+            self.assertNotIn("evidence:ev_", visible)
+            self.assertEqual(visible, result.content)
+            self.assertEqual(result.content, "v MIDVAL")
+
+
+class CitationPreEvidenceDeltaTests(unittest.TestCase):
+    """A delta emitted BEFORE evidence exists must not leak a raw reference."""
+
+    def test_first_delta_before_evidence_creation_does_not_leak(self) -> None:
+        holder: dict = {}
+
+        class PreambleBackend:
+            def _result(self, text: str) -> ChatResult:
+                return ChatResult(
+                    content=text, model="fake", finish_reason="stop", tool_calls=[],
+                    prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+
+            def _cited(self) -> str:
+                if "rec" not in holder:
+                    holder["rec"] = holder["store"].add(
+                        "exec_shell_full_command",
+                        "SECRETVAL",
+                        metadata={
+                            "tool_call_id": "tc",
+                            "user_turn_id": holder["runtime"].current_user_turn_id,
+                            "produced_by_phase": "final_from_tool",
+                        },
+                    )
+                return f"answer evidence:{holder['rec'].evidence_id}"
+
+            def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+                return self._result(self._cited())
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None) -> ChatResult:
+                # Preamble streams BEFORE any evidence exists.
+                if on_delta is not None:
+                    on_delta("preamble ")
+                cited = self._cited()
+                if on_delta is not None:
+                    on_delta(cited)
+                return self._result("preamble " + cited)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "session.evidence")
+            runtime = ChatRuntime(
+                backend=PreambleBackend(), system_prompt=None, evidence_store=store
+            )
+            holder["store"] = store
+            holder["runtime"] = runtime
+            seen: list[str] = []
+            result = runtime.ask_chat(
+                "q", temperature=0, max_tokens=16, on_final_delta=seen.append
+            )
+            visible = "".join(seen)
+            self.assertNotIn("evidence:ev_", visible)
+            self.assertEqual(visible, result.content)
+            self.assertEqual(result.content, "preamble answer SECRETVAL")
+            self.assertEqual(visible.count("preamble"), 1)


### PR DESCRIPTION
## Problem

A final answer that restated an exact value from tool evidence could corrupt it. The model retyped URLs, hashes and paths from memory, and a single wrong character produced a plausible but false result — silently, with no way for the runtime to detect it.

## Approach

Let the model **cite** evidence instead of retyping it:

- a final may write `evidence:<id>` for an exact value, or `UNRESOLVED` when the evidence does not support one;
- the runtime substitutes the stored bytes after generation.

The model keeps deciding what a value *means*; the runtime guarantees what the bytes *are*. Orbit never classifies a value as a URL, GUID, hash, path or IoC — eligibility is attestation plus a length bound, never content inspection.

## Implementation

- **`citable_evidence_ids()`** — the single eligibility predicate: current turn, re-attested via the existing `reattest_exact`, within the existing inline-evidence bound (`COMPAT_INLINE_CHARS`). Both the policy message and the visibility path consume it, so they cannot diverge.
- **Trailing policy message** — lists citable ids on evidence-backed finals only, appended *after* `with_final_tool_system_prompt(...)`. The pinned final prefix and `GEMMA4_FINAL_PREFIX_TEXT_HASH` are untouched, so prefix-cache semantics are unchanged.
- **`render_cited_evidence()`** — one left-to-right pass; substituted bytes are never rescanned, so evidence content cannot inject a further reference.
- **Fail-closed** — unknown, malformed, foreign-turn, stale, unsafe or oversized references stay literal and are flagged. No value is ever invented.
- **`DeferredCitationSink`** — holds streamed text until it is provably citation-free. Evidence is usually produced *mid-turn*, so an entry-time decision would let a raw reference reach the user before the tool ran.

Internal history keeps the compact `evidence:<id>` form; only the visible and returned answer carries expanded bytes, and the two are always identical.

## Tradeoff

Sessions with an evidence store now receive the final as one block rather than token by token. That is the cost of guaranteeing a raw reference never reaches the user, and correctness was chosen over streaming granularity.

## Validation

Four review iterations, each of which found real defects that were fixed:
1. a streaming gate that duplicated output and kept stale cross-turn state — replaced by buffering;
2. two unconverted entry points, one bypassing rendering entirely;
3. a duplicated capture block that silently dropped the entire final on `ask_with_tools`;
4. a latch that fired before evidence existed, leaking a raw reference in the tool loop.

Each is now covered by a regression test, including a delta emitted *before* evidence creation.

- affected: 564/564
- Qualification Harness: 83/83
- full discovery: **1942/1942**
- `compileall` and `git diff --check` clean
- `messages.py` not touched; `test_native_capabilities` 11/11 (pinned prefix intact)
- no backend/KV/profile/Context-Manager changes, no hidden model calls