### PR TITLE
feat(native): add verified Qwen3.8-27B model profile

### DIFF
--- a/src/orbit/native_llama/capabilities.py
+++ b/src/orbit/native_llama/capabilities.py
@@ -10,7 +10,12 @@ from typing import Any, Protocol
 
 from .bindings import load_native_cdll, native_cdll_flags
 from .chat_template import render_gemma4_chat, render_gemma4_route_prompt_segments
-from .model_profiles import GEMMA4_PROFILE_ID, QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID
+from .model_profiles import (
+    GEMMA4_PROFILE_ID,
+    QWEN36_PROFILE_ID,
+    QWEN38_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+)
 from .native_names import runtime_library_filename
 
 
@@ -42,7 +47,7 @@ def safe_native_capability_manifest(client: _TokenizingClient, *, final_system_p
     profile = getattr(client, "model_profile", None)
     if getattr(profile, "profile_id", None) == GEMMA4_PROFILE_ID:
         return safe_gemma4_capability_manifest(client, final_system_prompt=final_system_prompt)
-    if getattr(profile, "profile_id", None) in {QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID}:
+    if getattr(profile, "profile_id", None) in {QWEN36_PROFILE_ID, QWEN38_PROFILE_ID, QWEN3_CODER_PROFILE_ID}:
         build_bin = _client_build_bin(client)
         build = read_llama_cpp_build_info(build_bin) if build_bin is not None else _unavailable_build("build_bin_unavailable")
         return {

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -691,6 +691,8 @@ class NativeLlamaClient:
                 "qwen3moe.block_count",
                 "qwen3moe.expert_count",
                 "qwen3moe.expert_used_count",
+                "qwen35.context_length",
+                "qwen35.block_count",
                 "qwen35moe.block_count",
                 "qwen35moe.expert_count",
                 "qwen35moe.expert_used_count",
@@ -3675,7 +3677,7 @@ class NativeLlamaClient:
 
     def _serialize_profile_messages(self, messages: list[NativeMessage]) -> list[NativeMessage]:
         profile = getattr(self, "model_profile", None)
-        if profile is None or profile.family != "qwen3.6":
+        if profile is None or getattr(profile, "history_serialization", None) != "qwen-leading-system-only":
             return messages
         serialized: list[NativeMessage] = []
         for index, message in enumerate(messages):

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -12,6 +12,11 @@ QWEN36_VERIFIED_MODEL_NAME = "Qwen3.6-35B-A3B"
 QWEN36_OFFICIAL_TEMPLATE_SHA256 = "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259"
 QWEN36_VERIFIED_FILE_TYPE = "15"
 QWEN36_VERIFIED_QUANTIZATION = "Q4_K_M"
+QWEN38_PROFILE_ID = "orbit-qwen38-native-v1"
+QWEN38_VERIFIED_MODEL_NAME = "Qwen3.8-27B"
+QWEN38_OFFICIAL_TEMPLATE_SHA256 = "12827f24b742ea4e80cdc12dbcf9622227056b9f797252a3149263d4f9aaadce"
+QWEN38_VERIFIED_FILE_TYPE = "15"
+QWEN38_VERIFIED_QUANTIZATION = "Q4_K_M"
 QWEN3_CODER_PROFILE_ID = "orbit-qwen3-coder-native-v1"
 QWEN3_CODER_VERIFIED_MODEL_NAME = "Qwen3-Coder-30B-A3B-Instruct"
 QWEN3_CODER_OFFICIAL_TEMPLATE_SHA256 = "87710339d25b4e789c1d723f93c91ee861a86d305bb3d20a845536f251d6ea8a"
@@ -98,6 +103,7 @@ class VerifiedNativeModelIdentity:
 VERIFIED_NATIVE_MODEL_IDENTITIES = (
     VerifiedNativeModelIdentity(GEMMA4_PROFILE_ID, GEMMA4_VERIFIED_MODEL_NAME, "gemma4"),
     VerifiedNativeModelIdentity(QWEN36_PROFILE_ID, QWEN36_VERIFIED_MODEL_NAME, "qwen35moe"),
+    VerifiedNativeModelIdentity(QWEN38_PROFILE_ID, QWEN38_VERIFIED_MODEL_NAME, "qwen35"),
     VerifiedNativeModelIdentity(
         QWEN3_CODER_PROFILE_ID,
         QWEN3_CODER_VERIFIED_MODEL_NAME,
@@ -168,6 +174,43 @@ def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> N
             mtp_supported=False,
             gemma_prefix_reuse_supported=False,
             verified_quantization=QWEN36_VERIFIED_QUANTIZATION,
+            route_prefix_reuse_supported=True,
+        )
+
+    qwen38_identity = (
+        architecture == "qwen35"
+        and model_name == QWEN38_VERIFIED_MODEL_NAME
+        and tokenizer_model == "gpt2"
+        and tokenizer_pre == "qwen35"
+        and file_type == QWEN38_VERIFIED_FILE_TYPE
+        and metadata.get("tokenizer.ggml.bos_token_id", "").strip() == "248044"
+        and metadata.get("tokenizer.ggml.eos_token_id", "").strip() == "248046"
+        and metadata.get("qwen35.context_length", "").strip() == "262144"
+        and metadata.get("qwen35.block_count", "").strip() == "65"
+        and template_hash == QWEN38_OFFICIAL_TEMPLATE_SHA256
+    )
+    if qwen38_identity:
+        return NativeModelProfile(
+            profile_id=QWEN38_PROFILE_ID,
+            family="qwen3.8",
+            model_name=model_name,
+            architecture=architecture,
+            renderer="llama.cpp-jinja",
+            reasoning_protocol="qwen-think",
+            # Wire protocol verified byte-identical to Qwen3.6: same
+            # <tool_call>/<function=>/<parameter=> envelope, same
+            # <tool_response> result form. Qwen3.8 only adds template-side
+            # argument validation, which does not change the emitted format.
+            tool_call_protocol="qwen3.6-xml",
+            history_serialization="qwen-leading-system-only",
+            verified=True,
+            failure_reason=None,
+            template_source="gguf-embedded-official",
+            template_sha256=template_hash,
+            thinking_supported=True,
+            mtp_supported=False,
+            gemma_prefix_reuse_supported=False,
+            verified_quantization=QWEN38_VERIFIED_QUANTIZATION,
             route_prefix_reuse_supported=True,
         )
 
@@ -253,6 +296,16 @@ def _unverified_reason(
             return "qwen36_quantization_identity_mismatch"
         if template_hash != QWEN36_OFFICIAL_TEMPLATE_SHA256:
             return "qwen36_template_identity_mismatch"
+    if architecture == "qwen35":
+        if model_name != QWEN38_VERIFIED_MODEL_NAME:
+            return "qwen38_model_identity_mismatch"
+        if tokenizer_model != "gpt2" or tokenizer_pre != "qwen35":
+            return "qwen38_tokenizer_identity_mismatch"
+        if file_type != QWEN38_VERIFIED_FILE_TYPE:
+            return "qwen38_quantization_identity_mismatch"
+        if template_hash != QWEN38_OFFICIAL_TEMPLATE_SHA256:
+            return "qwen38_template_identity_mismatch"
+        return "qwen38_metadata_identity_mismatch"
     if architecture == "qwen3moe":
         if model_name != QWEN3_CODER_VERIFIED_MODEL_NAME:
             return "qwen3_coder_model_identity_mismatch"

--- a/src/orbit/native_llama/model_registry.json
+++ b/src/orbit/native_llama/model_registry.json
@@ -39,6 +39,18 @@
       }
     },
     {
+      "id": "qwen38-27b-q4-k-m",
+      "display_name": "Qwen 3.8 27B",
+      "profile_id": "orbit-qwen38-native-v1",
+      "backend": "native-llama",
+      "architecture": "qwen35",
+      "target": {
+        "repo": "unsloth/Qwen3.8-27B-GGUF",
+        "file": "Qwen3.8-27B-Q4_K_M.gguf",
+        "cache_glob": "models--unsloth--Qwen3.8-27B-GGUF/snapshots/*/Qwen3.8-27B-Q4_K_M.gguf"
+      }
+    },
+    {
       "id": "qwen3-coder-30b-a3b-instruct-q4-k-m",
       "display_name": "Qwen3-Coder 30B-A3B",
       "profile_id": "orbit-qwen3-coder-native-v1",

--- a/tests/test_native_model_discovery.py
+++ b/tests/test_native_model_discovery.py
@@ -35,7 +35,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
                 inspector=lambda _path: self.fail("no file should be inspected"),
             )
 
-        self.assertEqual(len(result.rows), 3)
+        self.assertEqual(len(result.rows), 4)
         self.assertTrue(all(row.local == "MISSING" for row in result.rows))
         self.assertTrue(all(row.support == "VERIFIED" for row in result.rows))
         self.assertEqual(
@@ -43,6 +43,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
             {
                 "orbit download ggml-org/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-Q4_0.gguf",
                 "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                "orbit download unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
                 "orbit download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
             },
         )
@@ -225,7 +226,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(result.metadata_inspections, 1)
         self.assertFalse(any(row.model == "other.gguf" for row in result.rows))
-        self.assertEqual(result.filesystem_scans, 5)
+        self.assertEqual(result.filesystem_scans, 6)
 
     def test_symlink_escape_is_not_inspected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_model_profiles.py
+++ b/tests/test_native_model_profiles.py
@@ -10,6 +10,7 @@ from orbit.native_llama.model_profiles import (
     GEMMA4_PROFILE_ID,
     QWEN36_PROFILE_ID,
     QWEN3_CODER_PROFILE_ID,
+    QWEN38_PROFILE_ID,
     NativeModelProfile,
     detect_native_model_profile,
     supports_low_memory_mode,
@@ -39,6 +40,117 @@ QWEN3_CODER_METADATA = {
     "qwen3moe.expert_count": "128",
     "qwen3moe.expert_used_count": "8",
 }
+
+
+QWEN38_METADATA = {
+    "general.architecture": "qwen35",
+    "general.name": "Qwen3.8-27B",
+    "general.file_type": "15",
+    "tokenizer.ggml.model": "gpt2",
+    "tokenizer.ggml.pre": "qwen35",
+    "tokenizer.ggml.bos_token_id": "248044",
+    "tokenizer.ggml.eos_token_id": "248046",
+    "qwen35.context_length": "262144",
+    "qwen35.block_count": "65",
+}
+
+
+class Qwen38ProfileTests(unittest.TestCase):
+    """Qwen3.8 is a distinct dense `qwen35` identity, isolated from Qwen3.6."""
+
+    def _detect(self, metadata=None, template="official-qwen38-template"):
+        digest = hashlib.sha256(template.encode()).hexdigest()
+        with mock.patch(
+            "orbit.native_llama.model_profiles.QWEN38_OFFICIAL_TEMPLATE_SHA256", digest
+        ):
+            return detect_native_model_profile(metadata or QWEN38_METADATA, template)
+
+    def test_exact_identity_is_verified_and_isolated(self) -> None:
+        profile = self._detect()
+        self.assertEqual(profile.profile_id, QWEN38_PROFILE_ID)
+        self.assertNotEqual(profile.profile_id, QWEN36_PROFILE_ID)
+        self.assertTrue(profile.verified)
+        self.assertEqual(profile.family, "qwen3.8")
+        self.assertEqual(profile.architecture, "qwen35")
+        self.assertEqual(profile.renderer, "llama.cpp-jinja")
+        self.assertEqual(profile.verified_quantization, "Q4_K_M")
+
+    def test_tool_protocol_matches_verified_wire_format(self) -> None:
+        # Envelope proven byte-identical to Qwen3.6 in the GGUF template.
+        profile = self._detect()
+        self.assertEqual(profile.tool_call_protocol, "qwen3.6-xml")
+        self.assertEqual(profile.history_serialization, "qwen-leading-system-only")
+
+    def test_mtp_and_gemma_prefix_reuse_stay_disabled(self) -> None:
+        profile = self._detect()
+        self.assertFalse(profile.mtp_supported)
+        self.assertFalse(profile.gemma_prefix_reuse_supported)
+
+    def test_thinking_supported(self) -> None:
+        self.assertTrue(self._detect().thinking_supported)
+
+    def test_template_drift_fails_closed(self) -> None:
+        profile = detect_native_model_profile(QWEN38_METADATA, "unreviewed-template")
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen38_template_identity_mismatch")
+
+    def test_model_name_drift_fails_closed(self) -> None:
+        profile = self._detect({**QWEN38_METADATA, "general.name": "Qwen3.8-9B"})
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen38_model_identity_mismatch")
+
+    def test_tokenizer_drift_fails_closed(self) -> None:
+        profile = self._detect({**QWEN38_METADATA, "tokenizer.ggml.pre": "qwen2"})
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen38_tokenizer_identity_mismatch")
+
+    def test_quantization_drift_fails_closed(self) -> None:
+        profile = self._detect({**QWEN38_METADATA, "general.file_type": "7"})
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen38_quantization_identity_mismatch")
+
+    def test_near_match_metadata_fails_closed(self) -> None:
+        for key, value in (
+            ("tokenizer.ggml.bos_token_id", "1"),
+            ("tokenizer.ggml.eos_token_id", "2"),
+            ("qwen35.context_length", "32768"),
+            ("qwen35.block_count", "64"),
+        ):
+            with self.subTest(key=key):
+                profile = self._detect({**QWEN38_METADATA, key: value})
+                self.assertFalse(profile.verified)
+                self.assertEqual(profile.failure_reason, "qwen38_metadata_identity_mismatch")
+
+    def test_trailing_system_messages_are_demoted_like_qwen36(self) -> None:
+        """The Qwen3.8 template rejects a non-leading system role, so the
+        declared history contract must actually be enforced."""
+        from orbit.native_llama.client import NativeLlamaClient
+
+        messages = [
+            {"role": "system", "content": "lead"},
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "evidence card"},
+        ]
+        client = object.__new__(NativeLlamaClient)
+        client.model_profile = self._detect()
+        serialized = NativeLlamaClient._serialize_profile_messages(client, messages)
+        self.assertEqual([m["role"] for m in serialized], ["system", "user", "user"])
+
+    def test_capability_manifest_does_not_report_unsupported(self) -> None:
+        """A verified profile must not self-report as unsupported."""
+        profile = self._detect()
+        client = SimpleNamespace(model_profile=profile)
+        manifest = safe_native_capability_manifest(
+            client, final_system_prompt=FINAL_FROM_TOOL_SYSTEM_PROMPT
+        )
+        self.assertNotEqual(manifest["profile_id"], "unsupported")
+        self.assertEqual(manifest["profile_id"], profile.profile_id)
+
+    def test_qwen36_metadata_does_not_resolve_to_qwen38(self) -> None:
+        digest = hashlib.sha256("official-qwen-template".encode()).hexdigest()
+        with mock.patch("orbit.native_llama.model_profiles.QWEN36_OFFICIAL_TEMPLATE_SHA256", digest):
+            profile = detect_native_model_profile(QWEN_METADATA, "official-qwen-template")
+        self.assertEqual(profile.profile_id, QWEN36_PROFILE_ID)
 
 
 class NativeModelProfileTests(unittest.TestCase):

--- a/tests/test_native_model_registry.py
+++ b/tests/test_native_model_registry.py
@@ -60,6 +60,7 @@ class NativeModelRegistryTests(unittest.TestCase):
             [
                 ("Gemma 4 26B-A4B", "orbit-gemma4-native-v1"),
                 ("Qwen 3.6 35B-A3B", "orbit-qwen36-native-v1"),
+                ("Qwen 3.8 27B", "orbit-qwen38-native-v1"),
                 ("Qwen3-Coder 30B-A3B", "orbit-qwen3-coder-native-v1"),
             ],
         )
@@ -75,6 +76,11 @@ class NativeModelRegistryTests(unittest.TestCase):
                     "orbit-qwen36-native-v1",
                     "ggml-org/Qwen3.6-35B-A3B-GGUF",
                     "Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                ),
+                (
+                    "orbit-qwen38-native-v1",
+                    "unsloth/Qwen3.8-27B-GGUF",
+                    "Qwen3.8-27B-Q4_K_M.gguf",
                 ),
                 (
                     "orbit-qwen3-coder-native-v1",
@@ -247,3 +253,24 @@ class NativeModelRegistryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class Qwen38RegistryTests(unittest.TestCase):
+    def test_qwen38_entry_resolves_with_isolated_profile(self) -> None:
+        manifest = get_manifest("qwen38-27b-q4-k-m")
+        self.assertEqual(manifest.profile_id, "orbit-qwen38-native-v1")
+        self.assertEqual(manifest.architecture, "qwen35")
+
+    def test_qwen38_entry_declares_no_mtp_or_mmproj(self) -> None:
+        manifest = get_manifest("qwen38-27b-q4-k-m")
+        self.assertIsNone(getattr(manifest, "mtp", None))
+        self.assertIsNone(getattr(manifest, "mmproj", None))
+
+    def test_existing_model_ids_still_resolve(self) -> None:
+        for model_id, profile_id in (
+            ("qwen36-35b-a3b-q4-k-m", "orbit-qwen36-native-v1"),
+            ("qwen3-coder-30b-a3b-instruct-q4-k-m", "orbit-qwen3-coder-native-v1"),
+            ("gemma4-26b-a4b-it-q40", "orbit-gemma4-native-v1"),
+        ):
+            with self.subTest(model_id=model_id):
+                self.assertEqual(get_manifest(model_id).profile_id, profile_id)


### PR DESCRIPTION
## Problem

`Qwen3.8-27B-Q4_K_M` loads fine in the vendored llama.cpp (`qwen35` is a recognised architecture), but Orbit refused it at startup:

```
unsupported or unverified native model compatibility: family=qwen35; reason=unsupported_model_profile
```

No verified identity existed for the dense `qwen35` architecture.

## Approach

An **isolated** profile, not a widened Qwen3.6 one. The models are not interchangeable: Qwen3.6 is `qwen35moe`, Qwen3.8 is dense `qwen35`, and their chat templates differ (7764 vs 9993 chars, different digests) — Qwen3.8 adds multi-system merging and a `reasoning_effort` block.

- `orbit-qwen38-native-v1` pins architecture, model name, tokenizer model/pre, quantization, BOS, EOS, context length, block count and the official template digest. Every near miss fails closed with a `qwen38_*` reason.
- **Tool protocol reuse is evidence-backed, not assumed.** The emitted wire format was compared marker-by-marker against Qwen3.6 and is byte-identical (`<tool_call>`, `<function=`, `<parameter=`, `<tools>`, `<tool_response>`). Qwen3.8 only adds template-side `raise_exception` argument validation, which cannot change the emitted format. Nothing in the codebase branches on the protocol string.
- Registry entry `qwen38-27b-q4-k-m`, no `mmproj`, no draft model.
- `mtp_supported=False` despite the architecture advertising `nextn_predict_layers=1` — speculative decoding is unqualified here and stays off.

## Integration fixes

Two runtime points needed adjusting for the model to actually work; both were found by independent review after detection already passed:

1. **Message serialization** was gated on `family == "qwen3.6"` while the leading-system-only contract it implements is a profile *field*. Now gated on `history_serialization`, so any profile declaring that contract gets it. Without this, Qwen3.8's template raises `System message must be at the beginning.` on Orbit's trailing evidence cards and citation-policy messages — breaking mainline chat, artifact and full-document paths.
2. **Capability manifest** listed verified profile ids explicitly and reported Qwen3.8 as `unsupported` despite successful detection.

Reading two `qwen35.*` metadata keys required extending the client allowlist. Traced: those keys feed profile detection only, and no other model or subsystem reads them.

## Measured

Loads in 15s, 26.6 GiB resident, 5.80 tok/s prefill, **1.51 tok/s decode**. A short chat, a tool call (`get_time{"timezone":"Europe/Rome"}`, valid JSON) and the answer built from its result all round-trip correctly, with no protocol drift or backend errors.

The decode rate makes long analysis workloads impractical on this CPU — roughly 3× slower per token than the ~3B-active Qwen3.6 MoE. That is an economics limit, not a correctness one, and no malware qualification is proposed on this hardware.

## Validation

- new profile/registry tests, including both regression tests verified to **fail** against the unfixed code
- full discovery: **1957/1957**
- Qualification Harness: 83/83
- `compileall` and `git diff --check` clean
- Gemma / Qwen3.6 / Qwen3-Coder resolution unchanged; a test asserts Qwen3.6 metadata cannot resolve to Qwen3.8