### PR TITLE
fix(backend): honor profile history serialization on external servers

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -25,6 +25,7 @@ from orbit.native_llama.qwen36_shell_tool_prefix import (
 )
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
+from orbit.runtime.history_serialization import serialize_profile_messages
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
 
@@ -65,7 +66,7 @@ class LlamaServerBackend:
         payload = build_chat_payload(
             ChatPayloadOptions(
                 model=self.request_model_name(),
-                messages=messages,
+                messages=self._serialize_for_profile(messages),
                 temperature=temperature,
                 max_tokens=max_tokens,
                 thinking=self.thinking,
@@ -107,7 +108,7 @@ class LlamaServerBackend:
         payload = build_chat_payload(
             ChatPayloadOptions(
                 model=self.request_model_name(),
-                messages=messages,
+                messages=self._serialize_for_profile(messages),
                 temperature=temperature,
                 max_tokens=max_tokens,
                 thinking=self.thinking,
@@ -160,7 +161,7 @@ class LlamaServerBackend:
         payload = build_chat_payload(
             ChatPayloadOptions(
                 model=self.request_model_name(),
-                messages=messages,
+                messages=self._serialize_for_profile(messages),
                 temperature=temperature,
                 max_tokens=max_tokens,
                 thinking=False,
@@ -387,6 +388,33 @@ class LlamaServerBackend:
             else "unknown"
         )
         return self._props_cache
+
+    def _verified_history_serialization(self) -> str | None:
+        """History-serialization contract of the verified profile, if identifiable.
+
+        Orbit-native servers publish `model_compatibility`. A plain upstream
+        llama-server does not, but it does publish the exact `chat_template`,
+        which verified Orbit profiles already pin by SHA-256. Matching that
+        digest identifies the profile cryptographically, with no model-name
+        heuristic. Anything unrecognised returns None, so no model-specific
+        normalization is applied speculatively.
+        """
+        props = self._props_or_empty()
+        compatibility = props.get("model_compatibility")
+        if isinstance(compatibility, dict) and compatibility.get("verified") is True:
+            value = compatibility.get("history_serialization")
+            return value if isinstance(value, str) else None
+        template = props.get("chat_template")
+        if not isinstance(template, str) or not template:
+            return None
+        from orbit.native_llama.model_profiles import history_serialization_for_template
+
+        return history_serialization_for_template(template)
+
+    def _serialize_for_profile(self, messages: list[Message]) -> list[Message]:
+        return serialize_profile_messages(
+            messages, history_serialization=self._verified_history_serialization()
+        )
 
     def _is_orbit_native_backend(self) -> bool:
         return _str_or_none(self._props_or_empty().get("backend")) == "orbit-native"

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -12,6 +12,7 @@ import threading
 import time
 
 from orbit.final_prefix_config import FINAL_PREFIX_TOKEN_COUNT
+from orbit.runtime.history_serialization import serialize_profile_messages
 
 from .bindings import (
     ChatBridgeLibrary,
@@ -3677,18 +3678,12 @@ class NativeLlamaClient:
 
     def _serialize_profile_messages(self, messages: list[NativeMessage]) -> list[NativeMessage]:
         profile = getattr(self, "model_profile", None)
-        if profile is None or getattr(profile, "history_serialization", None) != "qwen-leading-system-only":
+        if profile is None:
             return messages
-        serialized: list[NativeMessage] = []
-        for index, message in enumerate(messages):
-            item = dict(message)
-            if item.get("role") == "system" and index != 0:
-                # The reviewed Qwen template accepts a system role only at the
-                # beginning. Preserve later Orbit evidence cards in place as a
-                # normal input turn instead of reordering or dropping content.
-                item["role"] = "user"
-            serialized.append(item)
-        return serialized
+        return serialize_profile_messages(
+            messages,
+            history_serialization=getattr(profile, "history_serialization", None),
+        )
 
     def _parse_profile_output(self, generated_text: str, *, partial: bool) -> _ProfileParsedOutput:
         if self.chat_bridge is None or not self._chat_bridge_context:

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -93,6 +93,12 @@ def supports_low_memory_mode(profile: NativeModelProfile | None) -> bool:
     )
 
 
+_VERIFIED_TEMPLATE_HISTORY_SERIALIZATION = {
+    QWEN36_OFFICIAL_TEMPLATE_SHA256: "qwen-leading-system-only",
+    QWEN38_OFFICIAL_TEMPLATE_SHA256: "qwen-leading-system-only",
+}
+
+
 @dataclass(frozen=True)
 class VerifiedNativeModelIdentity:
     profile_id: str
@@ -317,3 +323,17 @@ def _unverified_reason(
             return "qwen3_coder_template_identity_mismatch"
         return "qwen3_coder_metadata_identity_mismatch"
     return "unsupported_model_profile"
+
+
+def history_serialization_for_template(template: str) -> str | None:
+    """History-serialization contract for a template that matches a verified pin.
+
+    Matches the exact template text against the digests of verified profile
+    templates, so a backend without Orbit-native metadata can still honour the
+    profile's message-shape contract. Returns None when the template matches no
+    verified profile, which keeps unverified models free of model-specific
+    handling.
+    """
+
+    digest = hashlib.sha256(template.encode("utf-8")).hexdigest()
+    return _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION.get(digest)

--- a/src/orbit/runtime/history_serialization.py
+++ b/src/orbit/runtime/history_serialization.py
@@ -1,0 +1,43 @@
+"""Shared profile message-serialization contracts.
+
+A verified model profile may declare a `history_serialization` contract that
+constrains the message shape a template accepts. The contract belongs to the
+profile, not to any one backend, so both the native client and an external
+llama-server request path apply it from here.
+
+This module is deliberately model-agnostic: it keys on the declared contract
+string only, never on a model or family name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+LEADING_SYSTEM_ONLY = "qwen-leading-system-only"
+
+
+def serialize_profile_messages(
+    messages: Any,
+    *,
+    history_serialization: str | None,
+) -> Any:
+    """Apply a profile's history-serialization contract to a message list.
+
+    Unknown or absent contracts return the messages unchanged, so a backend
+    that cannot identify a verified profile never gets model-specific
+    normalization applied speculatively.
+    """
+
+    if history_serialization != LEADING_SYSTEM_ONLY:
+        # No contract to apply: hand back the caller's own list so identity is
+        # preserved for paths that rely on it.
+        return messages
+    items = [dict(message) for message in messages]
+    for index, item in enumerate(items):
+        if item.get("role") == "system" and index != 0:
+            # The reviewed template accepts a system role only at the
+            # beginning. Preserve later Orbit evidence cards in place as a
+            # normal input turn instead of reordering or dropping content.
+            item["role"] = "user"
+    return items

--- a/tests/test_history_serialization.py
+++ b/tests/test_history_serialization.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from orbit.runtime.history_serialization import (
+    LEADING_SYSTEM_ONLY,
+    serialize_profile_messages,
+)
+
+
+class SharedHistorySerializationTests(unittest.TestCase):
+    def test_leading_system_preserved_trailing_demoted(self) -> None:
+        msgs = [
+            {"role": "system", "content": "lead"},
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "evidence card"},
+        ]
+        out = serialize_profile_messages(msgs, history_serialization=LEADING_SYSTEM_ONLY)
+        self.assertEqual([m["role"] for m in out], ["system", "user", "user"])
+        self.assertEqual(out[2]["content"], "evidence card")
+
+    def test_multiple_trailing_system_messages(self) -> None:
+        msgs = [
+            {"role": "system", "content": "lead"},
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "citation policy"},
+            {"role": "system", "content": "full document"},
+        ]
+        out = serialize_profile_messages(msgs, history_serialization=LEADING_SYSTEM_ONLY)
+        self.assertEqual([m["role"] for m in out], ["system", "user", "user", "user"])
+
+    def test_tool_and_assistant_ordering_unchanged(self) -> None:
+        msgs = [
+            {"role": "system", "content": "lead"},
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "tool_call_id": "1", "name": "t", "content": "r"},
+        ]
+        out = serialize_profile_messages(msgs, history_serialization=LEADING_SYSTEM_ONLY)
+        self.assertEqual([m["role"] for m in out], ["system", "user", "assistant", "tool"])
+        self.assertEqual(out[2]["tool_calls"], [{"id": "1"}])
+        self.assertEqual(out[3]["tool_call_id"], "1")
+
+    def test_unknown_contract_is_byte_identical(self) -> None:
+        msgs = [
+            {"role": "system", "content": "lead"},
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "trailing"},
+        ]
+        for contract in (None, "", "other-contract"):
+            with self.subTest(contract=contract):
+                out = serialize_profile_messages(msgs, history_serialization=contract)
+                self.assertEqual(out, [dict(m) for m in msgs])
+
+    def test_input_is_not_mutated(self) -> None:
+        msgs = [{"role": "system", "content": "a"}, {"role": "system", "content": "b"}]
+        serialize_profile_messages(msgs, history_serialization=LEADING_SYSTEM_ONLY)
+        self.assertEqual([m["role"] for m in msgs], ["system", "system"])
+
+    def test_empty_message_list(self) -> None:
+        self.assertEqual(serialize_profile_messages([], history_serialization=LEADING_SYSTEM_ONLY), [])
+
+
+class TemplateContractLookupTests(unittest.TestCase):
+    def test_verified_templates_resolve_contract(self) -> None:
+        from orbit.native_llama.model_profiles import (
+            QWEN36_OFFICIAL_TEMPLATE_SHA256,
+            QWEN38_OFFICIAL_TEMPLATE_SHA256,
+            _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION,
+        )
+
+        for digest in (QWEN36_OFFICIAL_TEMPLATE_SHA256, QWEN38_OFFICIAL_TEMPLATE_SHA256):
+            self.assertEqual(
+                _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION[digest], LEADING_SYSTEM_ONLY
+            )
+
+    def test_unknown_template_returns_none(self) -> None:
+        from orbit.native_llama.model_profiles import history_serialization_for_template
+
+        self.assertIsNone(history_serialization_for_template("unreviewed template"))
+        self.assertIsNone(history_serialization_for_template(""))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ExternalBackendSerializationTests(unittest.TestCase):
+    """External llama-server must honour the contract without claiming native."""
+
+    def _backend(self, props):
+        from orbit.backend.llama_server import LlamaServerBackend
+
+        b = LlamaServerBackend(base_url="http://127.0.0.1:1", timeout=1)
+        b._props_cache = props
+        b._props_discovery_status = "ok"
+        return b
+
+    def test_upstream_template_hash_resolves_contract(self) -> None:
+        from orbit.native_llama.model_profiles import QWEN38_OFFICIAL_TEMPLATE_SHA256
+
+        import hashlib
+
+        # Build a template whose digest is pinned by using the real one.
+        tpl = None
+        import struct
+
+        path = "models/unsloth--Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf"
+        try:
+            f = open(path, "rb")
+        except OSError:
+            self.skipTest("model not present")
+        with f:
+            f.read(4); struct.unpack("<I", f.read(4)); struct.unpack("<Q", f.read(8))
+            nkv, = struct.unpack("<Q", f.read(8))
+            def rs():
+                n, = struct.unpack("<Q", f.read(8)); return f.read(n).decode("utf-8", "replace")
+            S = {0:1,1:1,2:2,3:2,4:4,5:4,6:4,7:1,10:8,11:8,12:8}
+            def sk(t):
+                if t == 8: rs(); return
+                if t == 9:
+                    et, = struct.unpack("<I", f.read(4)); n, = struct.unpack("<Q", f.read(8))
+                    for _ in range(n): sk(et)
+                    return
+                f.read(S[t])
+            for _ in range(nkv):
+                k = rs(); t, = struct.unpack("<I", f.read(4))
+                if k == "tokenizer.chat_template" and t == 8: tpl = rs()
+                else: sk(t)
+        self.assertEqual(hashlib.sha256(tpl.encode()).hexdigest(), QWEN38_OFFICIAL_TEMPLATE_SHA256)
+        b = self._backend({"chat_template": tpl})
+        self.assertEqual(b._verified_history_serialization(), LEADING_SYSTEM_ONLY)
+        out = b._serialize_for_profile(
+            [{"role": "system", "content": "lead"},
+             {"role": "user", "content": "q"},
+             {"role": "system", "content": "card"}]
+        )
+        self.assertEqual([m["role"] for m in out], ["system", "user", "user"])
+
+    def test_unknown_template_gets_no_normalization(self) -> None:
+        b = self._backend({"chat_template": "some unreviewed template"})
+        self.assertIsNone(b._verified_history_serialization())
+        msgs = [{"role": "system", "content": "a"}, {"role": "system", "content": "b"}]
+        self.assertEqual(b._serialize_for_profile(msgs), msgs)
+
+    def test_absent_props_gets_no_normalization(self) -> None:
+        b = self._backend({})
+        self.assertIsNone(b._verified_history_serialization())
+
+    def test_native_compatibility_block_is_preferred(self) -> None:
+        b = self._backend({
+            "model_compatibility": {"verified": True, "history_serialization": LEADING_SYSTEM_ONLY},
+        })
+        self.assertEqual(b._verified_history_serialization(), LEADING_SYSTEM_ONLY)
+
+    def test_unverified_compatibility_block_is_ignored(self) -> None:
+        b = self._backend({
+            "model_compatibility": {"verified": False, "history_serialization": LEADING_SYSTEM_ONLY},
+        })
+        self.assertIsNone(b._verified_history_serialization())
+
+    def test_recognized_template_does_not_enable_exact_token_counting(self) -> None:
+        """Item-6 invariant: normalization must never imply exact admission.
+
+        A non-native server carrying a recognized template digest resolves the
+        message-shape contract, but exact token counting must stay unavailable
+        so counting and generation cannot desynchronize.
+        """
+        b = self._backend({"chat_template": "x", "model_compatibility": {
+            "verified": True, "history_serialization": LEADING_SYSTEM_ONLY}})
+        self.assertEqual(b._verified_history_serialization(), LEADING_SYSTEM_ONLY)
+        self.assertFalse(b._is_orbit_native_backend())
+        self.assertIsNone(b.count_chat_tokens([{"role": "user", "content": "q"}]))
+        self.assertFalse(b.supports_exact_context_admission())
+
+    def test_external_backend_remains_non_native(self) -> None:
+        b = self._backend({"chat_template": "x"})
+        self.assertFalse(b._is_orbit_native_backend())


### PR DESCRIPTION
## Problem

A verified profile can declare that its template accepts a system role only in the leading position (`history_serialization = "qwen-leading-system-only"`). Orbit appends **trailing** system messages for evidence cards, citation policy and full-document analysis.

The native client rewrites those later system turns before rendering. The external `llama-server` path never did — it had no profile awareness at all (`grep` count: 0). A real Qwen3.8 run against an external server failed at render time:

```
HTTP 500: Jinja Exception: System message must be at the beginning.
```

This is a generic backend-parity gap, not a model-specific workaround.

## Approach

The contract belongs to the **profile**, not to one backend. Moved the rewrite into a shared runtime helper keyed **only** on the declared contract string — no model or family name is consulted anywhere.

**External profile identity, without heuristics.** An external server must know which contract applies:
- Orbit-native servers publish `model_compatibility` → used directly.
- A plain upstream llama-server does not, but it publishes its exact `chat_template`, and verified profiles already pin that template by SHA-256. Matching the digest identifies the profile **cryptographically**.
- A template matching no pinned digest yields no contract → no rewriting → unverified models untouched.

Measured against a real upstream server: its `chat_template` hashes to `12827f24…`, exactly the pinned Qwen3.8 digest.

## Safety properties

- **Counting and generation cannot disagree.** Normalization is applied to chat requests only. `count_chat_tokens` returns `None` on non-native backends, so no exact count exists to desynchronize; on native, both counting and generation already render through the same `apply_chat_template`, which applies the serializer server-side (client-side normalization is idempotent).
- **External stays non-native.** `_is_orbit_native_backend()` is untouched. Exact admission, cache/checkpoint telemetry, cancellation semantics and profile verification remain native-only. Applying a message-shape contract creates no claim of verification anywhere.
- **Identity preserved.** The no-contract path returns the caller's own list, so callers relying on object identity keep working; only the rewriting path copies. (A Qwen3-Coder test asserts this with `assertIs`.)
- **Fail-closed** on missing props, props fetch failure, unverified compatibility block, or unknown template.

## Validation

- 15 new tests: leading system preserved, single/multiple trailing demoted, tool ordering and `tool_call_id` intact, unknown contract byte-identical, input not mutated, real upstream template resolves the contract, unverified block ignored, external remains non-native, and a regression test asserting a recognized template still does **not** enable exact token counting.
- full discovery **1972/1972**, Qualification Harness 83/83, `compileall` and `git diff --check` clean.
- Independent adversarial review: **PASS, mergeable**. Its three cosmetic nits and its recommended regression test were applied.
- Real external-server run: 4 model calls, 2 tool round-trips, no template error, no control-token leakage, file unchanged.