### PR TITLE
feat(native): qualify Ornith-1.5-35B-A3B as a verified native model

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -694,6 +694,7 @@ class NativeLlamaClient:
                 "qwen3moe.expert_used_count",
                 "qwen35.context_length",
                 "qwen35.block_count",
+                "qwen35moe.context_length",
                 "qwen35moe.block_count",
                 "qwen35moe.expert_count",
                 "qwen35moe.expert_used_count",

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -17,6 +17,11 @@ QWEN38_VERIFIED_MODEL_NAME = "Qwen3.8-27B"
 QWEN38_OFFICIAL_TEMPLATE_SHA256 = "12827f24b742ea4e80cdc12dbcf9622227056b9f797252a3149263d4f9aaadce"
 QWEN38_VERIFIED_FILE_TYPE = "15"
 QWEN38_VERIFIED_QUANTIZATION = "Q4_K_M"
+ORNITH15_PROFILE_ID = "orbit-ornith15-native-v1"
+ORNITH15_VERIFIED_MODEL_NAME = "Ornith-1.5-35B"
+ORNITH15_OFFICIAL_TEMPLATE_SHA256 = "f55f52930aa8bf44ab5cb85f99370fcc3c56e9a85640b812086d5330bce5d86b"
+ORNITH15_VERIFIED_FILE_TYPE = "15"
+ORNITH15_VERIFIED_QUANTIZATION = "Q4_K_M"
 QWEN3_CODER_PROFILE_ID = "orbit-qwen3-coder-native-v1"
 QWEN3_CODER_VERIFIED_MODEL_NAME = "Qwen3-Coder-30B-A3B-Instruct"
 QWEN3_CODER_OFFICIAL_TEMPLATE_SHA256 = "87710339d25b4e789c1d723f93c91ee861a86d305bb3d20a845536f251d6ea8a"
@@ -96,6 +101,7 @@ def supports_low_memory_mode(profile: NativeModelProfile | None) -> bool:
 _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION = {
     QWEN36_OFFICIAL_TEMPLATE_SHA256: "qwen-leading-system-only",
     QWEN38_OFFICIAL_TEMPLATE_SHA256: "qwen-leading-system-only",
+    ORNITH15_OFFICIAL_TEMPLATE_SHA256: "qwen-leading-system-only",
 }
 
 
@@ -109,6 +115,7 @@ class VerifiedNativeModelIdentity:
 VERIFIED_NATIVE_MODEL_IDENTITIES = (
     VerifiedNativeModelIdentity(GEMMA4_PROFILE_ID, GEMMA4_VERIFIED_MODEL_NAME, "gemma4"),
     VerifiedNativeModelIdentity(QWEN36_PROFILE_ID, QWEN36_VERIFIED_MODEL_NAME, "qwen35moe"),
+    VerifiedNativeModelIdentity(ORNITH15_PROFILE_ID, ORNITH15_VERIFIED_MODEL_NAME, "qwen35moe"),
     VerifiedNativeModelIdentity(QWEN38_PROFILE_ID, QWEN38_VERIFIED_MODEL_NAME, "qwen35"),
     VerifiedNativeModelIdentity(
         QWEN3_CODER_PROFILE_ID,
@@ -180,6 +187,47 @@ def detect_native_model_profile(metadata: Mapping[str, str], template: str) -> N
             mtp_supported=False,
             gemma_prefix_reuse_supported=False,
             verified_quantization=QWEN36_VERIFIED_QUANTIZATION,
+            route_prefix_reuse_supported=True,
+        )
+
+    ornith15_identity = (
+        architecture == "qwen35moe"
+        and model_name == ORNITH15_VERIFIED_MODEL_NAME
+        and tokenizer_model == "gpt2"
+        and tokenizer_pre == "qwen35"
+        and file_type == ORNITH15_VERIFIED_FILE_TYPE
+        and metadata.get("tokenizer.ggml.bos_token_id", "").strip() == "248044"
+        and metadata.get("tokenizer.ggml.eos_token_id", "").strip() == "248046"
+        and metadata.get("qwen35moe.context_length", "").strip() == "262144"
+        and metadata.get("qwen35moe.block_count", "").strip() == "41"
+        and metadata.get("qwen35moe.expert_count", "").strip() == "256"
+        and metadata.get("qwen35moe.expert_used_count", "").strip() == "8"
+        and template_hash == ORNITH15_OFFICIAL_TEMPLATE_SHA256
+    )
+    if ornith15_identity:
+        return NativeModelProfile(
+            profile_id=ORNITH15_PROFILE_ID,
+            family="ornith1.5",
+            model_name=model_name,
+            architecture=architecture,
+            renderer="llama.cpp-jinja",
+            reasoning_protocol="qwen-think",
+            # Tool envelope verified byte-identical to the reviewed Qwen3.6
+            # template: same <tool_call>/<function=>/<parameter=> form and
+            # <tool_response> results.
+            tool_call_protocol="qwen3.6-xml",
+            # This template silently DROPS a system message past the leading
+            # run instead of raising, so Orbit evidence and citation cards
+            # would vanish without the leading-system-only contract.
+            history_serialization="qwen-leading-system-only",
+            verified=True,
+            failure_reason=None,
+            template_source="gguf-embedded-official",
+            template_sha256=template_hash,
+            thinking_supported=True,
+            mtp_supported=False,
+            gemma_prefix_reuse_supported=False,
+            verified_quantization=ORNITH15_VERIFIED_QUANTIZATION,
             route_prefix_reuse_supported=True,
         )
 
@@ -294,6 +342,14 @@ def _unverified_reason(
     template_hash: str,
 ) -> str:
     if architecture == "qwen35moe":
+        if model_name == ORNITH15_VERIFIED_MODEL_NAME:
+            if tokenizer_model != "gpt2" or tokenizer_pre != "qwen35":
+                return "ornith15_tokenizer_identity_mismatch"
+            if file_type != ORNITH15_VERIFIED_FILE_TYPE:
+                return "ornith15_quantization_identity_mismatch"
+            if template_hash != ORNITH15_OFFICIAL_TEMPLATE_SHA256:
+                return "ornith15_template_identity_mismatch"
+            return "ornith15_metadata_identity_mismatch"
         if model_name != QWEN36_VERIFIED_MODEL_NAME:
             return "qwen36_model_identity_mismatch"
         if tokenizer_model != "gpt2" or tokenizer_pre != "qwen35":

--- a/src/orbit/native_llama/model_registry.json
+++ b/src/orbit/native_llama/model_registry.json
@@ -51,6 +51,18 @@
       }
     },
     {
+      "id": "ornith15-35b-a3b-q4-k-m",
+      "display_name": "Ornith 1.5 35B-A3B",
+      "profile_id": "orbit-ornith15-native-v1",
+      "backend": "native-llama",
+      "architecture": "qwen35moe",
+      "target": {
+        "repo": "ornith-ai/Ornith-1.5-35B-A3B-GGUF",
+        "file": "Ornith-1.5-35B-Q4_K_M.gguf",
+        "cache_glob": "models--ornith-ai--Ornith-1.5-35B-A3B-GGUF/snapshots/*/Ornith-1.5-35B-Q4_K_M.gguf"
+      }
+    },
+    {
       "id": "qwen3-coder-30b-a3b-instruct-q4-k-m",
       "display_name": "Qwen3-Coder 30B-A3B",
       "profile_id": "orbit-qwen3-coder-native-v1",

--- a/src/orbit/runtime/history_serialization.py
+++ b/src/orbit/runtime/history_serialization.py
@@ -16,6 +16,12 @@ from typing import Any
 
 LEADING_SYSTEM_ONLY = "qwen-leading-system-only"
 
+# Roles the contract confines to the leading position. Orbit's context manager
+# and session memory treat `developer` as a peer of `system`, so a contract
+# that demoted only `system` would let a trailing developer message reach a
+# template that discards it.
+PREFIX_ONLY_ROLES = frozenset({"system", "developer"})
+
 
 def serialize_profile_messages(
     messages: Any,
@@ -35,9 +41,10 @@ def serialize_profile_messages(
         return messages
     items = [dict(message) for message in messages]
     for index, item in enumerate(items):
-        if item.get("role") == "system" and index != 0:
-            # The reviewed template accepts a system role only at the
-            # beginning. Preserve later Orbit evidence cards in place as a
-            # normal input turn instead of reordering or dropping content.
+        if item.get("role") in PREFIX_ONLY_ROLES and index != 0:
+            # The reviewed templates accept these roles only at the beginning:
+            # one raises on a later occurrence, another drops it silently.
+            # Preserve later Orbit evidence cards in place as a normal input
+            # turn instead of reordering or dropping content.
             item["role"] = "user"
     return items

--- a/tests/fixtures/ornith15_chat_template.jinja
+++ b/tests/fixtures/ornith15_chat_template.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set num_sys = 0 %}
+{%- set merged_system = '' %}
+{%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+    {%- set first = render_content(messages[0].content, false, true)|trim %}
+    {%- if messages|length > 1 and (messages[1].role == 'system' or messages[1].role == 'developer') %}
+        {%- set second = render_content(messages[1].content, false, true)|trim %}
+        {%- set merged_system = first + '\n' + second %}
+        {%- set num_sys = 2 %}
+    {%- else %}
+        {%- set merged_system = first %}
+        {%- set num_sys = 1 %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if merged_system %}
+        {{- '\n\n' + merged_system }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if merged_system %}
+        {{- '<|im_start|>system\n' + merged_system + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if loop.index0 >= num_sys and message.role != "system" and message.role != "developer" %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is mapping %}
+                    {%- for args_name in tool_call.arguments %}
+                        {%- set args_value = tool_call.arguments[args_name] %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+{#- Unsloth fixes - developer role, tool calling #}

--- a/tests/test_native_model_discovery.py
+++ b/tests/test_native_model_discovery.py
@@ -35,7 +35,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
                 inspector=lambda _path: self.fail("no file should be inspected"),
             )
 
-        self.assertEqual(len(result.rows), 4)
+        self.assertEqual(len(result.rows), 5)
         self.assertTrue(all(row.local == "MISSING" for row in result.rows))
         self.assertTrue(all(row.support == "VERIFIED" for row in result.rows))
         self.assertEqual(
@@ -43,6 +43,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
             {
                 "orbit download ggml-org/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-Q4_0.gguf",
                 "orbit download ggml-org/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+                "orbit download ornith-ai/Ornith-1.5-35B-A3B-GGUF/Ornith-1.5-35B-Q4_K_M.gguf",
                 "orbit download unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf",
                 "orbit download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
             },
@@ -226,7 +227,7 @@ class NativeModelDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(result.metadata_inspections, 1)
         self.assertFalse(any(row.model == "other.gguf" for row in result.rows))
-        self.assertEqual(result.filesystem_scans, 6)
+        self.assertEqual(result.filesystem_scans, 7)
 
     def test_symlink_escape_is_not_inspected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_native_model_registry.py
+++ b/tests/test_native_model_registry.py
@@ -61,6 +61,7 @@ class NativeModelRegistryTests(unittest.TestCase):
                 ("Gemma 4 26B-A4B", "orbit-gemma4-native-v1"),
                 ("Qwen 3.6 35B-A3B", "orbit-qwen36-native-v1"),
                 ("Qwen 3.8 27B", "orbit-qwen38-native-v1"),
+                ("Ornith 1.5 35B-A3B", "orbit-ornith15-native-v1"),
                 ("Qwen3-Coder 30B-A3B", "orbit-qwen3-coder-native-v1"),
             ],
         )
@@ -81,6 +82,11 @@ class NativeModelRegistryTests(unittest.TestCase):
                     "orbit-qwen38-native-v1",
                     "unsloth/Qwen3.8-27B-GGUF",
                     "Qwen3.8-27B-Q4_K_M.gguf",
+                ),
+                (
+                    "orbit-ornith15-native-v1",
+                    "ornith-ai/Ornith-1.5-35B-A3B-GGUF",
+                    "Ornith-1.5-35B-Q4_K_M.gguf",
                 ),
                 (
                     "orbit-qwen3-coder-native-v1",
@@ -256,6 +262,18 @@ if __name__ == "__main__":
 
 
 class Qwen38RegistryTests(unittest.TestCase):
+    def test_ornith15_entry_resolves_with_isolated_profile(self) -> None:
+        manifest = get_manifest("ornith15-35b-a3b-q4-k-m")
+        self.assertEqual(manifest.profile_id, "orbit-ornith15-native-v1")
+        self.assertEqual(manifest.architecture, "qwen35moe")
+        # Shares Qwen3.6's architecture but must never share its identity.
+        self.assertNotEqual(manifest.profile_id, "orbit-qwen36-native-v1")
+
+    def test_ornith15_entry_declares_no_mtp_or_mmproj(self) -> None:
+        manifest = get_manifest("ornith15-35b-a3b-q4-k-m")
+        self.assertIsNone(manifest.mtp)
+        self.assertIsNone(manifest.mmproj)
+
     def test_qwen38_entry_resolves_with_isolated_profile(self) -> None:
         manifest = get_manifest("qwen38-27b-q4-k-m")
         self.assertEqual(manifest.profile_id, "orbit-qwen38-native-v1")

--- a/tests/test_ornith15_profile.py
+++ b/tests/test_ornith15_profile.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.model_profiles import (
+    _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION,
+    ORNITH15_OFFICIAL_TEMPLATE_SHA256,
+    ORNITH15_PROFILE_ID,
+    ORNITH15_VERIFIED_MODEL_NAME,
+    QWEN36_PROFILE_ID,
+    detect_native_model_profile,
+    history_serialization_for_template,
+)
+from orbit.runtime.history_serialization import serialize_profile_messages
+
+
+# The verified Ornith-1.5-35B metadata, transcribed from the audited GGUF. Any
+# drift in these values must fail closed rather than resolve a near-match.
+ORNITH15_METADATA = {
+    "general.architecture": "qwen35moe",
+    "general.name": ORNITH15_VERIFIED_MODEL_NAME,
+    "general.file_type": "15",
+    "tokenizer.ggml.model": "gpt2",
+    "tokenizer.ggml.pre": "qwen35",
+    "tokenizer.ggml.bos_token_id": "248044",
+    "tokenizer.ggml.eos_token_id": "248046",
+    "qwen35moe.context_length": "262144",
+    "qwen35moe.block_count": "41",
+    "qwen35moe.expert_count": "256",
+    "qwen35moe.expert_used_count": "8",
+}
+
+
+class Ornith15DetectionFixture(unittest.TestCase):
+    """Shared fixture only: carries no assertions of its own.
+
+    Subclasses inherit setUp/_detect. Keeping the identity assertions in a
+    separate leaf class stops them re-running once per subclass.
+    """
+
+    def setUp(self) -> None:
+        self.template = "ornith-official-template-body"
+        self.digest = hashlib.sha256(self.template.encode("utf-8")).hexdigest()
+
+    def _detect(self, metadata=None, template=None):
+        from unittest import mock
+
+        with mock.patch(
+            "orbit.native_llama.model_profiles.ORNITH15_OFFICIAL_TEMPLATE_SHA256",
+            self.digest,
+        ):
+            return detect_native_model_profile(
+                ORNITH15_METADATA if metadata is None else metadata,
+                self.template if template is None else template,
+            )
+
+
+class Ornith15IdentityTests(Ornith15DetectionFixture):
+    def test_exact_identity_is_accepted_with_isolated_profile(self) -> None:
+        profile = self._detect()
+
+        self.assertTrue(profile.verified)
+        self.assertEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+        self.assertEqual(profile.family, "ornith1.5")
+        self.assertEqual(profile.architecture, "qwen35moe")
+        self.assertEqual(profile.verified_quantization, "Q4_K_M")
+        self.assertIsNone(profile.failure_reason)
+
+    def test_does_not_resolve_to_the_qwen36_identity(self) -> None:
+        profile = self._detect()
+
+        # Ornith shares Qwen3.6's architecture, tokenizer, block count, and
+        # expert layout. Only the template digest and model name separate them,
+        # so this must never collapse into the Qwen3.6 profile.
+        self.assertNotEqual(profile.profile_id, QWEN36_PROFILE_ID)
+        self.assertNotEqual(profile.family, "qwen3.6")
+
+    def test_mtp_and_prefix_reuse_acceleration_stay_off(self) -> None:
+        profile = self._detect()
+
+        self.assertFalse(profile.mtp_supported)
+        self.assertFalse(profile.gemma_prefix_reuse_supported)
+
+    def test_reasoning_and_tool_protocols_match_the_verified_envelope(self) -> None:
+        profile = self._detect()
+
+        self.assertEqual(profile.reasoning_protocol, "qwen-think")
+        self.assertEqual(profile.tool_call_protocol, "qwen3.6-xml")
+        self.assertTrue(profile.thinking_supported)
+        self.assertEqual(profile.renderer, "llama.cpp-jinja")
+        self.assertEqual(profile.template_source, "gguf-embedded-official")
+        self.assertEqual(profile.template_sha256, self.digest)
+
+
+class Ornith15FailClosedTests(Ornith15DetectionFixture):
+    def test_wrong_template_is_rejected(self) -> None:
+        profile = self._detect(template="not-the-official-template")
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "ornith15_template_identity_mismatch")
+
+    def test_wrong_tokenizer_is_rejected(self) -> None:
+        for key, value in (
+            ("tokenizer.ggml.model", "llama"),
+            ("tokenizer.ggml.pre", "qwen2"),
+        ):
+            with self.subTest(key=key):
+                profile = self._detect({**ORNITH15_METADATA, key: value})
+
+                self.assertFalse(profile.verified)
+                self.assertEqual(
+                    profile.failure_reason, "ornith15_tokenizer_identity_mismatch"
+                )
+
+    def test_wrong_quantization_is_rejected(self) -> None:
+        profile = self._detect({**ORNITH15_METADATA, "general.file_type": "7"})
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(
+            profile.failure_reason, "ornith15_quantization_identity_mismatch"
+        )
+
+    def test_critical_metadata_drift_is_rejected(self) -> None:
+        for key, value in (
+            ("tokenizer.ggml.bos_token_id", "1"),
+            ("tokenizer.ggml.eos_token_id", "2"),
+            ("qwen35moe.context_length", "32768"),
+            ("qwen35moe.block_count", "40"),
+            ("qwen35moe.expert_count", "128"),
+            ("qwen35moe.expert_used_count", "4"),
+        ):
+            with self.subTest(key=key):
+                profile = self._detect({**ORNITH15_METADATA, key: value})
+
+                self.assertFalse(profile.verified)
+                self.assertEqual(
+                    profile.failure_reason, "ornith15_metadata_identity_mismatch"
+                )
+
+    def test_near_match_model_name_is_rejected(self) -> None:
+        for name in ("Ornith-1.5-35B-A3B", "ornith-1.5-35b", "Ornith-1.5-30B"):
+            with self.subTest(name=name):
+                profile = self._detect({**ORNITH15_METADATA, "general.name": name})
+
+                self.assertFalse(profile.verified)
+                # A name that is not the exact pin must not fall through to the
+                # Ornith branch, and must not be adopted by Qwen3.6 either.
+                self.assertNotEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+                self.assertNotEqual(profile.profile_id, QWEN36_PROFILE_ID)
+
+    def test_ornith_template_does_not_verify_a_qwen36_named_model(self) -> None:
+        profile = self._detect(
+            {**ORNITH15_METADATA, "general.name": "Qwen3.6-35B-A3B"}
+        )
+
+        self.assertFalse(profile.verified)
+        self.assertEqual(profile.failure_reason, "qwen36_template_identity_mismatch")
+
+
+class Ornith15SystemMessageContractTests(Ornith15DetectionFixture):
+    def test_profile_declares_the_leading_system_only_contract(self) -> None:
+        profile = self._detect()
+
+        # The Ornith template merges only the leading system run and silently
+        # drops any later system message instead of raising. Orbit appends
+        # trailing system messages for evidence, citation policy, and
+        # full-document analysis, so the contract is mandatory here.
+        self.assertEqual(profile.history_serialization, "qwen-leading-system-only")
+
+    def test_trailing_system_evidence_survives_serialization(self) -> None:
+        profile = self._detect()
+        messages = [
+            {"role": "system", "content": "orbit policy"},
+            {"role": "user", "content": "analyze"},
+            {"role": "system", "content": "evidence:e1 payload"},
+        ]
+
+        serialized = serialize_profile_messages(
+            messages, history_serialization=profile.history_serialization
+        )
+
+        self.assertEqual(serialized[0]["role"], "system")
+        # Demoted to user rather than dropped: the evidence still reaches the
+        # model instead of vanishing inside the template loop.
+        self.assertEqual(serialized[2]["role"], "user")
+        self.assertEqual(serialized[2]["content"], "evidence:e1 payload")
+
+    def test_utf8_and_json_argument_payloads_are_preserved_verbatim(self) -> None:
+        profile = self._detect()
+        payload = '{"path": "/tmp/fattura — é\\u00e8.js", "flags": ["--dry-run"]}'
+        messages = [
+            {"role": "system", "content": "policy"},
+            {"role": "user", "content": "试探 — прове́рка"},
+            {"role": "system", "content": payload},
+        ]
+
+        serialized = serialize_profile_messages(
+            messages, history_serialization=profile.history_serialization
+        )
+
+        self.assertEqual(serialized[1]["content"], "试探 — прове́рка")
+        self.assertEqual(serialized[2]["content"], payload)
+
+    def test_trailing_developer_message_is_also_demoted(self) -> None:
+        # Orbit's context manager and session memory treat `developer` as a
+        # peer of `system`. The Ornith template drops both silently past the
+        # leading run, so the contract must cover the developer role too.
+        profile = self._detect()
+        messages = [
+            {"role": "system", "content": "policy"},
+            {"role": "user", "content": "analyze"},
+            {"role": "developer", "content": "evidence:e2 payload"},
+        ]
+
+        serialized = serialize_profile_messages(
+            messages, history_serialization=profile.history_serialization
+        )
+
+        self.assertEqual(serialized[2]["role"], "user")
+        self.assertEqual(serialized[2]["content"], "evidence:e2 payload")
+
+    def test_leading_developer_message_is_preserved(self) -> None:
+        profile = self._detect()
+        messages = [
+            {"role": "developer", "content": "policy"},
+            {"role": "user", "content": "analyze"},
+        ]
+
+        serialized = serialize_profile_messages(
+            messages, history_serialization=profile.history_serialization
+        )
+
+        self.assertEqual(serialized[0]["role"], "developer")
+
+    def test_serialization_does_not_mutate_the_caller_messages(self) -> None:
+        profile = self._detect()
+        messages = [
+            {"role": "system", "content": "policy"},
+            {"role": "system", "content": "trailing"},
+        ]
+
+        serialize_profile_messages(
+            messages, history_serialization=profile.history_serialization
+        )
+
+        self.assertEqual(messages[1]["role"], "system")
+
+
+class Ornith15RuntimeMetadataAllowlistTests(Ornith15DetectionFixture):
+    """The pinned keys must survive the native client's metadata allowlist.
+
+    detect_native_model_profile only ever sees keys that _read_model_metadata
+    kept. A pin on a key missing from that allowlist verifies in tests and is
+    then rejected at load time, which is how the Qwen3.8 profile first failed.
+    """
+
+    def _allowlisted_keys(self) -> set[str]:
+        import ast
+
+        source = (SRC / "orbit" / "native_llama" / "client.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name != "_read_model_metadata":
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Set):
+                    return {
+                        element.value
+                        for element in inner.elts
+                        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+                    }
+        self.fail("could not locate the metadata allowlist in _read_model_metadata")
+
+    def test_every_pinned_metadata_key_is_allowlisted(self) -> None:
+        allowlisted = self._allowlisted_keys()
+
+        missing = sorted(set(ORNITH15_METADATA) - allowlisted)
+
+        self.assertEqual(missing, [], f"pinned keys stripped before detection: {missing}")
+
+    def test_profile_still_verifies_after_allowlist_filtering(self) -> None:
+        allowlisted = self._allowlisted_keys()
+        filtered = {k: v for k, v in ORNITH15_METADATA.items() if k in allowlisted}
+
+        profile = self._detect(filtered)
+
+        self.assertTrue(profile.verified, profile.failure_reason)
+        self.assertEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+
+
+class Ornith15RealTemplateTests(unittest.TestCase):
+    """Validates the pins against the real audited template, unmocked.
+
+    Every other class patches ORNITH15_OFFICIAL_TEMPLATE_SHA256, so a typo in
+    the 64-character constant would otherwise ship green and then reject the
+    real GGUF at load time.
+    """
+
+    def setUp(self) -> None:
+        self.template = (
+            Path(__file__).resolve().parent
+            / "fixtures"
+            / "ornith15_chat_template.jinja"
+        ).read_text(encoding="utf-8")
+
+    def test_fixture_is_the_audited_template(self) -> None:
+        self.assertEqual(len(self.template), 7828)
+
+    def test_pinned_digest_matches_the_real_template(self) -> None:
+        self.assertEqual(
+            hashlib.sha256(self.template.encode("utf-8")).hexdigest(),
+            ORNITH15_OFFICIAL_TEMPLATE_SHA256,
+        )
+
+    def test_real_template_and_metadata_verify_without_any_patching(self) -> None:
+        profile = detect_native_model_profile(ORNITH15_METADATA, self.template)
+
+        self.assertTrue(profile.verified, profile.failure_reason)
+        self.assertEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+        self.assertEqual(profile.history_serialization, "qwen-leading-system-only")
+        self.assertFalse(profile.mtp_supported)
+
+    def test_real_template_lookup_returns_the_contract(self) -> None:
+        self.assertEqual(
+            history_serialization_for_template(self.template),
+            "qwen-leading-system-only",
+        )
+
+    def test_pinned_model_name_matches_the_audited_gguf_string(self) -> None:
+        self.assertEqual(ORNITH15_VERIFIED_MODEL_NAME, "Ornith-1.5-35B")
+
+    def test_real_template_has_no_leading_system_guard(self) -> None:
+        # Qwen3.6 raises on a non-leading system message; Ornith does not. The
+        # absence of this guard is precisely why the contract is mandatory.
+        self.assertNotIn("System message must be at the beginning", self.template)
+
+    def test_real_template_drops_trailing_system_and_developer_roles(self) -> None:
+        self.assertIn(
+            'message.role != "system" and message.role != "developer"',
+            self.template,
+        )
+
+
+class Ornith15PinnedDigestTests(unittest.TestCase):
+    """Exercises the real pinned digest, with no constant patched."""
+
+    def test_pinned_template_digest_maps_to_the_leading_system_only_contract(self) -> None:
+        # history_serialization_for_template takes template TEXT and hashes it.
+        # The real 7828-character Ornith template is not vendored here, so the
+        # digest map is asserted directly against the pinned constant: an
+        # external backend seeing that template must get the same contract the
+        # native profile declares.
+        self.assertEqual(
+            _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION.get(ORNITH15_OFFICIAL_TEMPLATE_SHA256),
+            "qwen-leading-system-only",
+        )
+
+    def test_lookup_hashes_template_text_and_honors_the_ornith_pin(self) -> None:
+        from unittest import mock
+
+        template = "ornith-official-template-body"
+        digest = hashlib.sha256(template.encode("utf-8")).hexdigest()
+
+        with mock.patch.dict(
+            _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION,
+            {digest: "qwen-leading-system-only"},
+        ):
+            self.assertEqual(
+                history_serialization_for_template(template),
+                "qwen-leading-system-only",
+            )
+        self.assertIsNone(history_serialization_for_template("unreviewed-template"))
+
+    def test_pinned_digest_is_distinct_from_every_other_verified_template(self) -> None:
+        from orbit.native_llama.model_profiles import (
+            QWEN36_OFFICIAL_TEMPLATE_SHA256,
+            QWEN38_OFFICIAL_TEMPLATE_SHA256,
+        )
+
+        self.assertNotEqual(ORNITH15_OFFICIAL_TEMPLATE_SHA256, QWEN36_OFFICIAL_TEMPLATE_SHA256)
+        self.assertNotEqual(ORNITH15_OFFICIAL_TEMPLATE_SHA256, QWEN38_OFFICIAL_TEMPLATE_SHA256)
+        self.assertEqual(len(ORNITH15_OFFICIAL_TEMPLATE_SHA256), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an isolated verified native identity for Ornith-1.5-35B Q4_K_M.

## Why a separate profile

Ornith is architecturally identical to Qwen 3.6: `qwen35moe`, 41 blocks, 256 experts / 8 used, embedding 2048, same tokenizer (`gpt2`/`qwen35`), same BOS 248044 / EOS 248046, same 262144 context. Only the model name and the embedded template digest distinguish them. It therefore gets its own identity rather than reusing the Qwen 3.6 profile: no family-name heuristics, no shared identity.

Detection pins architecture, exact model name, tokenizer model and pre-tokenizer, quantization, BOS/EOS, context length, block count, expert count and used count, and the template SHA-256. Near-matches fail closed with a distinct reason.

## Protocol reuse is evidence-backed

The tool envelope and reasoning markers were compared against the reviewed Qwen 3.6 template and are byte-identical across all 13 markers (`<tool_call>`, `<function=`, `<parameter=`, `<tools>`, `<tool_response>`, `<|im_start|>`, `<|im_end|>`, `<think>`, `</think>` and their closers). `qwen3.6-xml` and `qwen-think` therefore apply unchanged — reuse justified from the actual template, not from the family name.

## The template difference that matters

Qwen 3.6 raises `System message must be at the beginning` on a misplaced system message. Ornith has no such guard: it merges only the leading system run (up to two messages) and its loop filters every later `system` or `developer` message, **discarding it silently**. Orbit appends trailing system messages for evidence cards, citation policy, and full-document analysis, so those would vanish with no error. The profile declares the `qwen-leading-system-only` contract, which demotes them to `user` so the content still reaches the model.

## Two defects fixed along the way

The shared contract previously demoted only the `system` role, while `context_manager` and `session_memory` treat `developer` as a peer. A trailing developer message therefore reached a template that drops it. Confirmed by rendering the real template: the payload was absent before, present after. The fix keys on the contract string only and is a proven no-op for profiles that do not declare it (Gemma 4, Qwen3-Coder return the caller's own list unchanged).

`qwen35moe.context_length` was missing from the native metadata reader's allowlist. The profile pins that key, so detection saw an empty value and rejected the model at load time even though every test passed. A test now AST-parses the allowlist and guards every pinned key against this class of defect.

## Verification

28 focused tests plus updated enumeration tests; 2002 total pass. The pins are validated unmocked against a vendored template fixture that is byte-identical to the GGUF's embedded template, so a typo in the digest or model name fails the suite rather than shipping green.

One real smoke on the actual model, stock config (ctx 8192, 6 threads, MTP off, no sampler/KV/backend changes): profile verified at load, one chat turn and one tool round-trip both correct, tool call well-formed, UTF-8 tool result preserved into the final answer, no reasoning or control-token leakage. Measured decode 9.62 / 10.19 / 10.07 tok/s against a matched-config Qwen 3.6 baseline of 7.89 tok/s.

MTP stays off; the registry entry declares no draft or projector model. No sampler, default-context, backend, or KV changes.