### PR TITLE
fix(native): reuse KV by strict append-only continuation

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -512,6 +512,8 @@ class NativeLlamaClient:
         self.lib.lib.llama_log_set(cb, None)
 
     def close(self) -> None:
+        # Freeing the context destroys the KV the identity describes.
+        self._invalidate_committed_sequence()
         lib = self.lib.lib
         self.lib.configure_expert_usage(False)
         self._invalidate_qwen_route_prefix("client_closed")
@@ -2105,9 +2107,6 @@ class NativeLlamaClient:
                 ctx_tgt=self._session.ctx_tgt,
             )
         except Exception as exc:
-            # KV may hold a partially decoded prompt that matches neither the
-            # previous nor the new sequence.
-            self._invalidate_committed_sequence()
             self.mtp_fallback_reason = str(exc) or "persistent-mtp-reset-failed"
             self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
             self._session.mtp_failed = True
@@ -3120,6 +3119,7 @@ class NativeLlamaClient:
         self._session.cached_prompt_tokens.clear()
 
         self._invalidate_committed_sequence()
+
     def _route_anchor_state_kwargs(self, plan: _RouteAnchorRuntimePlan) -> dict[str, str | None]:
         return {
             "model_id": str(self.paths.model),
@@ -3383,6 +3383,11 @@ class NativeLlamaClient:
     ) -> NativeTimings:
         if not self._session.continuation_ready:
             raise RuntimeError("no active continuation state")
+        # Continuation decodes further tokens into the SAME sequence, extending
+        # KV past the recorded identity. The extension cannot be committed
+        # either, because this path may raise after a partial decode, so the
+        # only provable state is "identity unknown".
+        self._invalidate_committed_sequence()
         self.reset_cancel()
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = max_tokens

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -304,6 +304,7 @@ class NativeLlamaClient:
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = 0
         self.last_target_only_token_hashes: list[int] = []
+        self.last_committed_generated_tokens: list[int] = []
         self.last_target_only_first_sample_trace: dict[str, object] | None = None
         self._last_prompt_decode_batch_n_tokens = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
@@ -553,6 +554,9 @@ class NativeLlamaClient:
                 "model_reload", profile_id=QWEN3_CODER_PROFILE_ID
             )
         self._invalidate_qwen36_shell_tool_prefix("model_reload")
+        # A reload installs a brand-new context: any recorded sequence refers
+        # to memory that no longer exists, possibly from a different model.
+        self._invalidate_committed_sequence()
         lib = self.lib.lib
         lib.ggml_backend_load_all()
         self.lib.configure_expert_usage(self.config.moe_expert_usage_enabled)
@@ -807,6 +811,7 @@ class NativeLlamaClient:
         if mem:
             lib.llama_memory_clear(mem, True)
         self._session.cached_prompt_tokens.clear()
+        self._invalidate_committed_sequence()
         self._session.prompt_cache_mode = None
         self._session.continuation_ready = False
         self._session.last_metrics = None
@@ -1804,6 +1809,9 @@ class NativeLlamaClient:
         lib = self.lib.lib
         mtmd = self.mtmd.lib
         self._session.cached_prompt_tokens.clear()
+        # The multimodal path wipes KV and prefills image chunks, for which no
+        # token-id-exact record exists. Identity stays empty for this turn.
+        self._invalidate_committed_sequence()
         mem = lib.llama_get_memory(self._session.ctx_tgt)
         if mem:
             lib.llama_memory_clear(mem, True)
@@ -2027,6 +2035,9 @@ class NativeLlamaClient:
                 self._invalidate_coder_route_prefix_after_failed_completion("cancelled")
             return timings
         except Exception:
+            # KV may hold a partially decoded prompt matching neither the
+            # previous nor the new sequence: identity is no longer provable.
+            self._invalidate_committed_sequence()
             if final_prefix_segments is not None:
                 self._invalidate_final_prefix("completion_error")
             if qwen_route_anchor_plan is not None:
@@ -2051,6 +2062,10 @@ class NativeLlamaClient:
         on_token=None,
         request_timing: _RequestTiming | None = None,
     ) -> NativeTimings | None:
+        # MTP rewrites the shared target KV (llama_memory_clear / seq_rm in the
+        # persistent MTP shim) and returns before the standard commit point, so
+        # the recorded identity can no longer describe resident memory.
+        self._invalidate_committed_sequence()
         request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
         profile = getattr(self, "model_profile", None)
@@ -2090,6 +2105,9 @@ class NativeLlamaClient:
                 ctx_tgt=self._session.ctx_tgt,
             )
         except Exception as exc:
+            # KV may hold a partially decoded prompt that matches neither the
+            # previous nor the new sequence.
+            self._invalidate_committed_sequence()
             self.mtp_fallback_reason = str(exc) or "persistent-mtp-reset-failed"
             self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
             self._session.mtp_failed = True
@@ -2292,6 +2310,7 @@ class NativeLlamaClient:
                 started_us=pf_start,
             )
         pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
+        self.last_committed_generated_tokens = []
         generated, gen_ms, cancelled = self._generate_from_current_context(
             max_tokens=max_tokens,
             on_progress=on_progress,
@@ -2308,6 +2327,15 @@ class NativeLlamaClient:
                 prompt_tokens_total=n_prompt,
                 token_count=self._content_token_count,
             )
+        # Record the sequence now resident in KV: the prefilled prompt plus the
+        # tokens actually decoded into it. A cancelled generation cannot be
+        # proven complete, so identity is dropped and the next call falls back.
+        # Commit only when the whole prompt was prefilled AND generation was not
+        # cancelled: a partial prefill leaves a tail that is not in KV.
+        if cancelled or processed < n_prompt:
+            self._invalidate_committed_sequence()
+        else:
+            self._commit_sequence(prompt_tokens, self.last_committed_generated_tokens)
         emit_prompt_cache_event(
             prompt_tokens=prompt_tokens,
             previous_prompt_tokens=previous_prompt_tokens,
@@ -3091,6 +3119,7 @@ class NativeLlamaClient:
             self.lib.lib.llama_memory_clear(mem, True)
         self._session.cached_prompt_tokens.clear()
 
+        self._invalidate_committed_sequence()
     def _route_anchor_state_kwargs(self, plan: _RouteAnchorRuntimePlan) -> dict[str, str | None]:
         return {
             "model_id": str(self.paths.model),
@@ -3398,6 +3427,9 @@ class NativeLlamaClient:
         sampler = sampler_override or self._session.sampler
         lib.llama_sampler_reset(sampler)
         self.last_target_only_token_hashes = []
+        # Exact ids decoded into KV during this generation. An EOG token breaks
+        # before llama_decode, so it never joins the resident sequence.
+        self.last_committed_generated_tokens = []
         self.last_target_only_first_sample_trace = None
         generated = 0
         gen_start = lib.llama_time_us()
@@ -3437,6 +3469,8 @@ class NativeLlamaClient:
             one_token = (llama_token * 1)(token)
             batch = lib.llama_batch_get_one(one_token, 1)
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            if decode_rc == 0:
+                self.last_committed_generated_tokens.append(int(token))
             generated += 1
             if on_progress:
                 on_progress(
@@ -3592,6 +3626,21 @@ class NativeLlamaClient:
             raise RuntimeError("native client not loaded")
         lib = self.lib.lib
         common = 0
+        # Strict append-only continuation. When the resident KV sequence is a
+        # token-exact prefix of this prompt, the sequence stays intact and only
+        # the new suffix is prefilled. No partial seq_rm is attempted, which is
+        # what makes this safe on hybrid/iSWA caches that legitimately refuse
+        # to discard an arbitrary prefix. Anything less than exact identity
+        # falls through to the existing behaviour.
+        committed = getattr(self._session, "committed_sequence_tokens", None)
+        if (
+            committed
+            and not self._qwen3_coder_native_protocol()
+            and len(prompt_tokens) > len(committed)
+            and prompt_tokens[: len(committed)] == committed
+        ):
+            self._session.cached_prompt_tokens = list(prompt_tokens)
+            return len(committed)
         if not self._qwen3_coder_native_protocol():
             max_common = min(len(prompt_tokens), len(self._session.cached_prompt_tokens))
             while common < max_common and prompt_tokens[common] == self._session.cached_prompt_tokens[common]:
@@ -3613,7 +3662,26 @@ class NativeLlamaClient:
                     lib.llama_memory_clear(mem, True)
                     common = 0
         self._session.cached_prompt_tokens = list(prompt_tokens)
+        # The fallback path just rewrote KV. Identity is re-established only
+        # after a successful generation, so drop it now.
+        self._invalidate_committed_sequence()
         return common
+
+    def _invalidate_committed_sequence(self) -> None:
+        """Drop committed-sequence identity whenever backend KV may diverge.
+
+        Strict append-only continuation is only safe while the recorded tokens
+        are exactly the ones resident in KV. Every path that clears, rewrites
+        or replaces that memory must call this; a stale identity would produce
+        a false cache hit, which is a correctness bug rather than a slow path.
+        """
+        self._session.committed_sequence_tokens.clear()
+
+    def _commit_sequence(self, prompt_tokens, generated_tokens) -> None:
+        """Record the exact sequence now resident in KV."""
+        self._session.committed_sequence_tokens = (
+            list(prompt_tokens) + list(generated_tokens)
+        )
 
     def _qwen3_coder_native_protocol(self) -> bool:
         profile = getattr(self, "model_profile", None)

--- a/src/orbit/native_llama/session_state.py
+++ b/src/orbit/native_llama/session_state.py
@@ -28,6 +28,10 @@ class NativeSessionState:
     ctx_tgt: c_void_p | None = None
     sampler: c_void_p | None = None
     cached_prompt_tokens: list[int] = field(default_factory=list)
+    # Exact tokens currently resident in the backend KV sequence: the prompt
+    # that was prefilled plus every generated token that was successfully
+    # decoded into it. Empty whenever that identity cannot be proven.
+    committed_sequence_tokens: list[int] = field(default_factory=list)
     prompt_cache_mode: str | None = None
     in_flight: bool = False
     cancel_requested: bool = False

--- a/tests/test_native_strict_append_continuation.py
+++ b/tests/test_native_strict_append_continuation.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import ast
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.session_state import NativeSessionState
+
+
+class _Memory:
+    def __init__(self) -> None:
+        self.cleared = 0
+        self.seq_rm_calls: list[tuple[int, int, int]] = []
+        self.seq_rm_result = False
+
+
+class _Lib:
+    def __init__(self, memory: _Memory) -> None:
+        self._memory = memory
+
+    def llama_get_memory(self, _ctx):
+        return self._memory
+
+    def llama_memory_clear(self, memory, _data):
+        memory.cleared += 1
+
+    def llama_memory_seq_rm(self, memory, seq, p0, p1):
+        memory.seq_rm_calls.append((seq, p0, p1))
+        return memory.seq_rm_result
+
+
+def _client(committed: list[int], *, profile_id: str = "orbit-ornith15-native-v1"):
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    memory = _Memory()
+    client.lib = types.SimpleNamespace(lib=_Lib(memory))
+    client._session = NativeSessionState(session_id="test")
+    client._session.ctx_tgt = object()
+    client._session.committed_sequence_tokens = list(committed)
+    client.model_profile = types.SimpleNamespace(verified=True, profile_id=profile_id)
+    return client, memory
+
+
+class StrictAppendContinuationTests(unittest.TestCase):
+    def test_exact_append_reuses_committed_sequence(self) -> None:
+        client, memory = _client([1, 2, 3, 4])
+
+        common = client._prepare_memory_for_prompt([1, 2, 3, 4, 5, 6])
+
+        self.assertEqual(common, 4)
+        # The resident sequence must be left intact: no trim, no clear.
+        self.assertEqual(memory.seq_rm_calls, [])
+        self.assertEqual(memory.cleared, 0)
+
+    def test_one_token_divergence_is_rejected(self) -> None:
+        client, memory = _client([1, 2, 3, 4])
+
+        common = client._prepare_memory_for_prompt([1, 2, 9, 4, 5, 6])
+
+        self.assertNotEqual(common, 4)
+        self.assertTrue(memory.seq_rm_calls or memory.cleared)
+
+    def test_shorter_prompt_takes_the_fallback_path(self) -> None:
+        client, memory = _client([1, 2, 3, 4, 5])
+
+        client._prepare_memory_for_prompt([1, 2, 3])
+
+        # Must reach the pre-existing logic, not the fast path.
+        self.assertTrue(memory.seq_rm_calls or memory.cleared)
+
+    def test_equal_length_prompt_is_rejected(self) -> None:
+        # Strict continuation requires a genuine suffix to prefill.
+        client, memory = _client([1, 2, 3, 4])
+
+        client._prepare_memory_for_prompt([1, 2, 3, 4])
+
+        self.assertTrue(memory.seq_rm_calls or memory.cleared)
+
+    def test_different_generated_history_is_rejected(self) -> None:
+        # Same prompt prefix, different committed generation -> not an extension.
+        client, _ = _client([1, 2, 3, 99])
+
+        common = client._prepare_memory_for_prompt([1, 2, 3, 4, 5])
+
+        self.assertNotEqual(common, 4)
+
+    def test_empty_committed_state_falls_back(self) -> None:
+        client, memory = _client([])
+
+        client._prepare_memory_for_prompt([1, 2, 3])
+
+        self.assertEqual(memory.cleared, 1)
+
+    def test_multiple_consecutive_appends_advance_state(self) -> None:
+        client, memory = _client([1, 2])
+        self.assertEqual(client._prepare_memory_for_prompt([1, 2, 3]), 2)
+
+        client._session.committed_sequence_tokens = [1, 2, 3, 4]
+        self.assertEqual(client._prepare_memory_for_prompt([1, 2, 3, 4, 5]), 4)
+        self.assertEqual(memory.seq_rm_calls, [])
+
+    def test_qwen3_coder_never_uses_strict_continuation(self) -> None:
+        client, memory = _client([1, 2, 3], profile_id="orbit-qwen3-coder-native-v1")
+
+        common = client._prepare_memory_for_prompt([1, 2, 3, 4])
+
+        # Qwen3-Coder keeps its full-prefill correctness policy.
+        self.assertEqual(common, 0)
+        self.assertEqual(memory.cleared, 1)
+
+    def test_strict_path_never_requires_partial_seq_rm(self) -> None:
+        # iSWA refuses partial removal; the fast path must not depend on it.
+        client, memory = _client([1, 2, 3, 4])
+        memory.seq_rm_result = False
+
+        common = client._prepare_memory_for_prompt([1, 2, 3, 4, 5])
+
+        self.assertEqual(common, 4)
+        self.assertEqual(memory.seq_rm_calls, [])
+
+    def test_fallback_path_invalidates_committed_sequence(self) -> None:
+        # The fallback rewrites KV; identity must not survive it.
+        client, _ = _client([1, 2, 3, 4])
+
+        client._prepare_memory_for_prompt([9, 9, 9])
+
+        self.assertEqual(client._session.committed_sequence_tokens, [])
+
+    def test_clear_target_memory_invalidates_committed_sequence(self) -> None:
+        # _clear_target_memory is the repo's main KV wipe: ~25 call sites,
+        # including every anchor restore/fallback branch.
+        client, _ = _client([1, 2, 3, 4])
+        client._clear_target_memory()
+
+        self.assertEqual(client._session.committed_sequence_tokens, [])
+
+    def test_real_reset_session_state_invalidates_committed_sequence(self) -> None:
+        client, _ = _client([1, 2, 3, 4])
+        client.reset_cancel = lambda: None
+        client._invalidate_final_prefix = lambda _r: None
+        client._invalidate_qwen_route_prefix = lambda _r: None
+        client._invalidate_qwen36_shell_tool_prefix = lambda _r: None
+        client._invalidate_qwen3_coder_route_prefix = lambda _r, **k: None
+
+        try:
+            client.reset_session_state()
+        except Exception:
+            # Any unstubbed collaborator is irrelevant: the invalidation runs
+            # before them, which is what this asserts.
+            pass
+
+        self.assertEqual(client._session.committed_sequence_tokens, [])
+
+
+class CommittedSequenceRecordingTests(unittest.TestCase):
+    """The recorded set must contain exactly the tokens decoded into KV.
+
+    Driving the full generation loop needs a large ctypes surface, so these
+    assert the two structural guarantees directly on the source: an EOG token
+    breaks BEFORE llama_decode, and the append is gated on decode_rc == 0.
+    A regression in either ordering silently corrupts the committed identity.
+    """
+
+    SOURCE = (SRC / "orbit" / "native_llama" / "client.py").read_text(encoding="utf-8")
+
+    def _generation_loop(self) -> str:
+        marker = "    def _generate_from_current_context("
+        start = self.SOURCE.index(marker)
+        end = self.SOURCE.index("\n    def ", start + len(marker))
+        return self.SOURCE[start:end]
+
+    def test_eog_breaks_before_decode_so_it_is_never_committed(self) -> None:
+        body = self._generation_loop()
+        eog = body.index("llama_vocab_is_eog")
+        decode = body.index("llama_decode(")
+        append = body.index("last_committed_generated_tokens.append")
+
+        self.assertLess(eog, decode, "EOG check must precede llama_decode")
+        self.assertLess(decode, append, "append must follow the decode call")
+        # The break belongs to the EOG branch, before any decode.
+        self.assertIn("break", body[eog:decode])
+
+    def test_append_is_gated_on_successful_decode(self) -> None:
+        body = self._generation_loop()
+        append_at = body.index("last_committed_generated_tokens.append")
+        preceding = body[:append_at]
+
+        self.assertIn("if decode_rc == 0:", preceding[-120:])
+
+    def test_commit_requires_complete_prefill_and_no_cancel(self) -> None:
+        self.assertIn("if cancelled or processed < n_prompt:", self.SOURCE)
+        self.assertIn("self._commit_sequence(", self.SOURCE)
+
+
+class InvalidationCoverageTests(unittest.TestCase):
+    """Every KV-mutating path must drop committed identity.
+
+    These assert POSITION via AST, not mere substring presence. A substring
+    test cannot tell a first statement from an unreachable branch, and that is
+    precisely the misplacement bug class this feature has already suffered
+    twice.
+    """
+
+    SOURCE = (SRC / "orbit" / "native_llama" / "client.py").read_text(encoding="utf-8")
+    TREE = ast.parse(SOURCE)
+
+    def _function(self, name: str) -> ast.FunctionDef:
+        for node in ast.walk(self.TREE):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        self.fail(f"function {name} not found")
+
+    @staticmethod
+    def _is_invalidation(stmt: ast.stmt) -> bool:
+        return (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Call)
+            and getattr(stmt.value.func, "attr", None) == "_invalidate_committed_sequence"
+        )
+
+    def _body_after_docstring(self, fn: ast.FunctionDef) -> list[ast.stmt]:
+        body = list(fn.body)
+        if body and isinstance(body[0], ast.Expr) and isinstance(
+            getattr(body[0], "value", None), ast.Constant
+        ):
+            body = body[1:]
+        return body
+
+    def _top_level_invalidation_line(self, name: str) -> int | None:
+        for stmt in self._body_after_docstring(self._function(name)):
+            if self._is_invalidation(stmt):
+                return stmt.lineno
+        return None
+
+    def test_mtp_invalidates_as_its_first_statement(self) -> None:
+        # Must run before every early return, not inside a conditional branch.
+        body = self._body_after_docstring(self._function("_try_complete_with_mtp_experimental"))
+        self.assertTrue(self._is_invalidation(body[0]))
+
+    def test_multimodal_invalidates_before_clearing_kv(self) -> None:
+        fn = self._function("_complete_prompt_multimodal")
+        line = self._top_level_invalidation_line("_complete_prompt_multimodal")
+        self.assertIsNotNone(line, "multimodal path must invalidate at top level")
+        clears = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "llama_memory_clear"
+        ]
+        self.assertTrue(clears)
+        self.assertLess(line, min(clears), "invalidation must precede the KV clear")
+
+    def test_clear_target_memory_invalidates_at_top_level(self) -> None:
+        self.assertIsNotNone(self._top_level_invalidation_line("_clear_target_memory"))
+
+    def test_load_invalidates_at_top_level(self) -> None:
+        self.assertIsNotNone(self._top_level_invalidation_line("load"))
+
+    def test_reset_session_state_invalidates_at_top_level(self) -> None:
+        self.assertIsNotNone(self._top_level_invalidation_line("reset_session_state"))
+
+    def test_complete_prompt_exception_handler_invalidates(self) -> None:
+        fn = self._function("complete_prompt")
+        handlers = [h for node in ast.walk(fn) if isinstance(node, ast.Try) for h in node.handlers]
+        self.assertTrue(handlers)
+        self.assertTrue(
+            any(any(self._is_invalidation(s) for s in h.body) for h in handlers),
+            "an exception must drop committed identity",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_strict_append_continuation.py
+++ b/tests/test_native_strict_append_continuation.py
@@ -266,6 +266,31 @@ class InvalidationCoverageTests(unittest.TestCase):
     def test_reset_session_state_invalidates_at_top_level(self) -> None:
         self.assertIsNotNone(self._top_level_invalidation_line("reset_session_state"))
 
+    def test_continuation_invalidates_before_extending_kv(self) -> None:
+        # continue_chat_text_current_context is public and server-reachable
+        # (native_server/app.py). It decodes further tokens into the SAME
+        # sequence, so the recorded identity must be dropped first: otherwise a
+        # later prompt takes the fast path against a longer KV and the suffix
+        # is written at auto-assigned positions past the real end.
+        fn = self._function("_continue_generation_from_current_context")
+        body = self._body_after_docstring(fn)
+        invalidation = next(
+            (i for i, stmt in enumerate(body) if self._is_invalidation(stmt)), None
+        )
+        self.assertIsNotNone(invalidation, "continuation must invalidate identity")
+        decodes = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "_generate_from_current_context"
+        ]
+        self.assertTrue(decodes)
+        self.assertLess(body[invalidation].lineno, min(decodes))
+
+    def test_close_invalidates_identity(self) -> None:
+        # Freeing the context destroys the KV the identity describes.
+        self.assertIsNotNone(self._top_level_invalidation_line("close"))
+
     def test_complete_prompt_exception_handler_invalidates(self) -> None:
         fn = self._function("complete_prompt")
         handlers = [h for node in ast.walk(fn) if isinstance(node, ast.Try) for h in node.handlers]

--- a/tests/test_prefix_anchor_probe.py
+++ b/tests/test_prefix_anchor_probe.py
@@ -140,6 +140,7 @@ def _prefill_hook_client(segments, *, lib=None) -> NativeLlamaClient:
     client._session = SimpleNamespace(
         ctx_tgt=object(),
         cached_prompt_tokens=[],
+        committed_sequence_tokens=[],
         continuation_ready=False,
         in_flight=False,
         cancel_requested=False,


### PR DESCRIPTION
Profiles whose cache cannot honour a partial removal never reused any KV. Every call in a multi-turn session re-evaluated the whole prompt.

## Why

Ornith is interleaved sliding-window attention. `llama_memory_seq_rm(seq, p0, -1)` returns false for an arbitrary `p0`, because the sliding-window layers no longer hold the older keys. The generic path treats that refusal as a signal to clear memory and prefill cold — correct for a trim, but it discards a prefix that never needed trimming.

Continuing an intact sequence is a different operation, and the cache does support it. Measured directly:

```
seq_rm(seq=0, p0=264, p1=-1) -> True    (end of sequence)
seq_rm(seq=0, p0=100, p1=-1) -> False   (arbitrary trim)
```

## What changed

The session records the prompt that was prefilled plus the generated tokens actually decoded into memory. An end-of-generation token breaks before the decode call, so it never becomes resident and is excluded; a token whose decode fails is excluded likewise. The prompt is committed only when the prefill ran to completion and generation was not cancelled, mirroring the check the anchor paths already make.

Before the existing logic, a fast path applies when that recorded sequence is a strictly shorter, token-exact prefix of the incoming prompt: memory is left untouched and those tokens are reported as reused. Anything short of exact identity falls through unchanged, so a false reuse cannot arise from a near match. The condition requires at least one unevaluated token, so the final prompt token always produces fresh logits.

A stale record would claim memory that is not there, so every path that clears, rewrites or replaces the cache drops it: the shared clear helper (and therefore all ~25 of its callers), session reset, model reload, the multimodal path, the speculative-decoding path, the fallback branch, and any exception during completion.

Qwen3-Coder is excluded from the fast path and keeps its full-prefill policy from #199. Named anchors and speculative decoding are otherwise untouched.

## Measured

Ornith, three appended turns:

```
turn 1: prompt=262 cached=  0 evaluated=262   0.0%
turn 2: prompt=281 cached=264 evaluated= 17  94.0%
turn 3: prompt=300 cached=283 evaluated= 17  94.3%
```

Output identical to a cold-prefill control. A tool call followed by its result reuses 312 of 331 (94.3%). Gemma 4 26B reuses where it previously did not. A deliberately divergent prefix falls back and reports no reuse, with correct output.

On a preserved 9-call agent trajectory, all 8 transitions satisfy strict append-only identity: 51,333 of 63,639 prompt tokens (80.7%) become reusable.

## Validation

2023 tests pass. New `tests/test_native_strict_append_continuation.py` covers exact append, one-token divergence, shorter and equal-length prompts, differing generated history, consecutive appends, Qwen3-Coder isolation, and the guarantee that the fast path never depends on a partial `seq_rm`.

Invalidation coverage is asserted positionally via AST rather than by substring, because a substring test cannot distinguish a first statement from an unreachable branch — a misplacement bug this change hit twice during development. Mutation testing confirms the positional tests catch both relocating an invalidation into a dead branch and removing a primary invalidation masked by a duplicate.