### PR TITLE
feat(runtime): answer from verified evidence when the session cannot

### DIFF
--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1293,7 +1293,6 @@ class FinalFromToolEnvironment:
             # Nothing has been generated yet, so the rescue can still run; if it
             # cannot, the original error is the honest outcome.
             grounded = self._grounded_finalization(
-                policy.messages,
                 temperature=temperature,
                 on_final_delta=on_final_delta,
                 on_progress=on_progress,
@@ -1301,7 +1300,6 @@ class FinalFromToolEnvironment:
                 on_phase_start=on_phase_start,
                 loop=loop,
                 response_prefix=response_prefix,
-                same_session_unavailable=True,
             )
             if grounded is not None:
                 return grounded
@@ -1525,7 +1523,6 @@ class FinalFromToolEnvironment:
 
     def _grounded_finalization(
         self,
-        messages: list[Message],
         *,
         temperature: float,
         on_final_delta: Callable[[str], None] | None,
@@ -1534,7 +1531,6 @@ class FinalFromToolEnvironment:
         on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
         response_prefix: str,
-        same_session_unavailable: bool = False,
     ) -> FinalAnswerResult | None:
         """Answer from verified evidence when same-session completion cannot run.
 
@@ -1550,6 +1546,16 @@ class FinalFromToolEnvironment:
         is no is the report rebuilt from durable evidence in a fresh session.
 
         Returning ``None`` means the ordinary path can and should run.
+
+        This rescue requires exact token accounting: a known context size and a
+        backend that can count a rendered prompt. Both hold on the orbit-native
+        path and neither holds on a plain llama.cpp server, which reports no
+        exact count -- so on such a backend admission is skipped upstream, no
+        `ContextAdmissionError` is raised, and a saturated turn fails at decode
+        as it did before this phase existed. That is a real limit rather than an
+        oversight: without an exact count there is no way to promise the bundle
+        fits either, so catching the decode failure would only trade one
+        overflow for another.
         """
         store = getattr(self.runtime, "evidence_store", None)
         if store is None or not store.records:
@@ -1561,27 +1567,10 @@ class FinalFromToolEnvironment:
         if not callable(count_chat):
             return None
 
-        # Can the ordinary path complete this turn? Counted exactly, before any
-        # generation: waiting for the backend to fail mid-decode yields no
-        # answer at all, and guessing either strands a usable turn or walks into
-        # that failure. Only a window that provably cannot be completed is
-        # rescued here; everything else keeps the ordinary path and the mature
-        # retry, repair and non-empty-fallback behaviour that comes with it.
-        #
-        # Pure chat and full-document never arrive here: chat completes through
-        # the transport environment, and the full-document path returns before
-        # this point.
-        if not same_session_unavailable:
-            try:
-                current_tokens = self._exact_token_total(
-                    count_chat(messages, tools=None, thinking=False)
-                )
-            except Exception:
-                return None
-            if current_tokens is None:
-                return None
-            if admit_finalization(current_tokens, context_tokens).admitted:
-                return None
+        # Reached only once the ordinary path has been refused admission, so
+        # there is no viable same-session answer left to protect. Pure chat and
+        # full-document never arrive here: chat completes through the transport
+        # environment, and the full-document path returns earlier.
 
         entries = deduplicate_evidence(
             entries_from_store(store, list(store.records.keys()))
@@ -1612,7 +1601,7 @@ class FinalFromToolEnvironment:
                     "grounded_finalization",
                     streamed=on_final_delta is not None,
                     attempt=1,
-                    reason="evidence_backed_finalization",
+                    reason="same_session_window_unavailable",
                 )
             )
         # Fresh state: the saturated investigation KV is exactly what must not
@@ -1632,8 +1621,10 @@ class FinalFromToolEnvironment:
                 # let the ordinary path answer instead of proceeding on a
                 # session whose contents are unknown.
                 return None
-        if response_prefix and on_final_delta is not None:
-            on_final_delta(response_prefix)
+        # The prefix has already been streamed by the caller before the
+        # ordinary attempt, so re-emitting it here would show the caveat twice.
+        # It is still prepended to the content below, which is what carries it
+        # into history and to non-streaming callers.
         # Call the inference backend directly, beneath the investigation's
         # admission wrapper. That wrapper plans against the conversation this
         # phase deliberately abandoned, so re-admitting the bundle through it

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1604,20 +1604,34 @@ class FinalFromToolEnvironment:
         # Fresh state: the saturated investigation KV is exactly what must not
         # be continued from, and finalization must not depend on how long the
         # investigation ran.
-        reset = getattr(
-            getattr(self.runtime.backend, "_backend", self.runtime.backend),
-            "reset_session_state",
-            None,
-        )
-        if callable(reset):
+        # Two shapes exist for the same operation: the in-process native client
+        # exposes reset_session_state, while a server-backed run reaches the
+        # same code over HTTP through reset_static_analysis_session, which
+        # reports failure by returning a message rather than raising. Only the
+        # second occurs in production, so reading only the first meant the
+        # reset silently never happened and the rescue finalized on the very
+        # session it exists to abandon.
+        #
+        # A session that cannot be made fresh is not one to finalize in, so any
+        # failure declines and lets the ordinary path answer instead.
+        target = getattr(self.runtime.backend, "_backend", self.runtime.backend)
+        in_process_reset = getattr(target, "reset_session_state", None)
+        served_reset = getattr(target, "reset_static_analysis_session", None)
+        if callable(in_process_reset):
             try:
-                reset()
+                in_process_reset()
             except Exception:
-                # Resetting is what makes the session fresh; if it cannot be
-                # done there is no clean state to finalize in, so decline and
-                # let the ordinary path answer instead of proceeding on a
-                # session whose contents are unknown.
                 return None
+        elif callable(served_reset):
+            try:
+                if served_reset() is not None:
+                    return None
+            except Exception:
+                return None
+        else:
+            # No way to establish a fresh session, so the defining property of
+            # this phase cannot be met.
+            return None
         # The prefix has already been streamed by the caller before the
         # ordinary attempt, so re-emitting it here would show the caveat twice.
         # It is still prepended to the content below, which is what carries it

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -58,6 +58,12 @@ from orbit.runtime.full_document import (
     targeted_search_coverage_notice,
     targeted_search_no_match_notice,
 )
+from orbit.runtime.finalization import (
+    admit_finalization,
+    deduplicate_evidence,
+    entries_from_store,
+    render_bundle,
+)
 from orbit.runtime.kv_diag import current_tools_mode, emit_document_search, model_call_context
 from orbit.runtime.media import AudioInput, ImageInput
 from orbit.runtime.messages import TOOL_CALL_JSON_RETRY_PROMPT
@@ -1262,6 +1268,17 @@ class FinalFromToolEnvironment:
                     attempt=1,
                 )
             )
+        grounded = self._grounded_finalization(
+            temperature=temperature,
+            on_final_delta=on_final_delta,
+            on_progress=on_progress,
+            on_model_step=on_model_step,
+            on_phase_start=on_phase_start,
+            loop=loop,
+            response_prefix=response_prefix,
+        )
+        if grounded is not None:
+            return grounded
         if response_prefix and on_final_delta is not None:
             on_final_delta(response_prefix)
         with self.transport.backend_thinking(False):
@@ -1469,6 +1486,152 @@ class FinalFromToolEnvironment:
             compact_retry_attempted=compact_retry_attempted,
             compact_retry_failed=compact_retry_failed,
         )
+
+    @staticmethod
+    def _exact_token_total(counted: object) -> int | None:
+        """Normalise the backends' differing exact-count return shapes.
+
+        The native client returns an int, the server backend a TokenCount (or
+        None when it cannot count), and the app a dict. Reading only one shape
+        would leave the fallback silently disconnected on the others, so the
+        supported shapes are handled explicitly and anything unrecognised is
+        treated as "cannot count" rather than guessed at.
+        """
+        if isinstance(counted, bool):
+            return None
+        if isinstance(counted, int):
+            return counted
+        tokens = getattr(counted, "tokens", None)
+        if isinstance(tokens, int) and not isinstance(tokens, bool):
+            return tokens
+        if isinstance(counted, dict):
+            value = counted.get("tokens")
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+        return None
+
+    def _grounded_finalization(
+        self,
+        *,
+        temperature: float,
+        on_final_delta: Callable[[str], None] | None,
+        on_progress: Callable[[StreamProgress], None] | None,
+        on_model_step: Callable[[ModelStepMetrics], None] | None,
+        on_phase_start: Callable[[ModelPhaseStart], None] | None,
+        loop: int,
+        response_prefix: str,
+    ) -> FinalAnswerResult | None:
+        """Answer from verified evidence when the session cannot answer at all.
+
+        A saturated investigation leaves no room to generate: the normal final
+        call would be admitted by the backend and then fail mid-decode, and the
+        user would get nothing despite the evidence having been collected. This
+        checks first, and only when the ordinary path provably cannot fit does
+        it rebuild the answer from durable evidence in a fresh context.
+
+        Returning ``None`` means the ordinary path is fine and must be used --
+        this is a fallback for an otherwise-terminal state, not a new default.
+        """
+        store = getattr(self.runtime, "evidence_store", None)
+        if store is None or not store.records:
+            return None
+        context_tokens = self.runtime.context_tokens
+        if not isinstance(context_tokens, int) or context_tokens <= 0:
+            return None
+        count_chat = getattr(self.runtime.backend, "count_chat_tokens", None)
+        if not callable(count_chat):
+            return None
+
+        # Reaching this environment already means an evidence-backed tool
+        # workflow is producing its final answer, and verified evidence exists.
+        # That -- not context pressure -- is the trigger: an earlier version
+        # diverted only when the ordinary window provably could not fit, which
+        # made grounded finalization a rescue for saturated sessions instead of
+        # the normal way an investigation reports. The point of the separate
+        # phase is that the answer no longer depends on how much room the
+        # investigation happened to leave, so the same handoff applies whether
+        # the session is nearly empty or nearly full.
+        #
+        # Pure chat and full-document never arrive here: chat completes through
+        # the transport environment, and the full-document path returns before
+        # this point.
+
+        entries = deduplicate_evidence(
+            entries_from_store(store, list(store.records.keys()))
+        )
+        if not entries:
+            return None
+        task = last_user_text(self.runtime.messages) or ""
+        try:
+            bundle = render_bundle(task, entries)
+        except ValueError:
+            return None
+        bundle_messages: list[Message] = [{"role": "user", "content": bundle}]
+        try:
+            bundle_tokens = self._exact_token_total(
+                count_chat(bundle_messages, tools=None, thinking=False)
+            )
+        except Exception:
+            return None
+        if bundle_tokens is None:
+            return None
+        admission = admit_finalization(bundle_tokens, context_tokens)
+        if not admission.admitted:
+            return None
+
+        if on_phase_start:
+            on_phase_start(
+                ModelPhaseStart(
+                    "grounded_finalization",
+                    streamed=on_final_delta is not None,
+                    attempt=1,
+                    reason="investigation_context_exhausted",
+                )
+            )
+        # Fresh state: the saturated investigation KV is exactly what must not
+        # be continued from, and finalization must not depend on how long the
+        # investigation ran.
+        reset = getattr(
+            getattr(self.runtime.backend, "_backend", self.runtime.backend),
+            "reset_session_state",
+            None,
+        )
+        if callable(reset):
+            reset()
+        if response_prefix and on_final_delta is not None:
+            on_final_delta(response_prefix)
+        # Call the inference backend directly, beneath the investigation's
+        # admission wrapper. That wrapper plans against the conversation this
+        # phase deliberately abandoned, so re-admitting the bundle through it
+        # would re-raise the very saturation being recovered from. Admission for
+        # this prompt has already been decided exactly, just above.
+        # No `tools=` argument: FINAL_ONLY is enforced structurally, so no tool
+        # can be requested rather than merely being discouraged by the prompt.
+        backend = getattr(self.runtime.backend, "_backend", self.runtime.backend)
+        with self.transport.backend_thinking(False):
+            with model_call_context(phase="grounded_finalization", tools_mode="off"):
+                if on_final_delta is None:
+                    result = backend.chat(
+                        bundle_messages,
+                        temperature=temperature,
+                        max_tokens=admission.output_budget,
+                    )
+                else:
+                    result = backend.chat_stream(
+                        bundle_messages,
+                        temperature=temperature,
+                        max_tokens=admission.output_budget,
+                        on_delta=on_final_delta,
+                        on_progress=on_progress,
+                    )
+        if on_model_step:
+            on_model_step(
+                ModelStepMetrics.from_result(
+                    loop=loop, result=result, phase="grounded_finalization"
+                )
+            )
+        self.runtime.messages.append({"role": "assistant", "content": result.content})
+        return FinalAnswerResult(result=result, used_retry_or_repair_pass=False)
 
     def _latest_evidence_budget_metadata(self) -> tuple[str | None, int | None]:
         store = self.runtime.evidence_store

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1521,16 +1521,18 @@ class FinalFromToolEnvironment:
         loop: int,
         response_prefix: str,
     ) -> FinalAnswerResult | None:
-        """Answer from verified evidence when the session cannot answer at all.
+        """Answer an evidence-backed workflow from its verified evidence.
 
-        A saturated investigation leaves no room to generate: the normal final
-        call would be admitted by the backend and then fail mid-decode, and the
-        user would get nothing despite the evidence having been collected. This
-        checks first, and only when the ordinary path provably cannot fit does
-        it rebuild the answer from durable evidence in a fresh context.
+        Reaching this environment already means a tool workflow is producing
+        its final answer, so this is the normal path for such a turn rather
+        than a rescue: the report is rebuilt from durable evidence in a fresh
+        session, and no longer depends on how much context the investigation
+        happened to leave. Gating it on context pressure instead would
+        reintroduce exactly that dependency.
 
-        Returning ``None`` means the ordinary path is fine and must be used --
-        this is a fallback for an otherwise-terminal state, not a new default.
+        Returning ``None`` means there is nothing to finalize from -- no
+        evidence, nothing that survives re-attestation, or a bundle that will
+        not fit -- and the ordinary path runs instead.
         """
         store = getattr(self.runtime, "evidence_store", None)
         if store is None or not store.records:
@@ -1585,7 +1587,7 @@ class FinalFromToolEnvironment:
                     "grounded_finalization",
                     streamed=on_final_delta is not None,
                     attempt=1,
-                    reason="investigation_context_exhausted",
+                    reason="evidence_backed_finalization",
                 )
             )
         # Fresh state: the saturated investigation KV is exactly what must not
@@ -1630,6 +1632,13 @@ class FinalFromToolEnvironment:
                     loop=loop, result=result, phase="grounded_finalization"
                 )
             )
+        # The prefix carries coverage notices -- that a file was shown in part,
+        # or a search matched only some of it. Streaming it is not enough: the
+        # ordinary path also prepends it to the content so it reaches history
+        # and non-streaming callers, and a caveat that silently disappears in
+        # one mode is worse than none.
+        if response_prefix:
+            result = replace(result, content=response_prefix + result.content)
         self.runtime.messages.append({"role": "assistant", "content": result.content})
         return FinalAnswerResult(result=result, used_retry_or_repair_pass=False)
 

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1235,10 +1235,7 @@ class FinalFromToolEnvironment:
             self.runtime.messages.append({"role": "assistant", "content": result.content})
             return FinalAnswerResult(result=result, used_retry_or_repair_pass=False)
         response_prefix = targeted_prefix or display_prefix
-        uses_web_final_view = self.runtime._should_use_web_final_view(
-            use_tool_prompt=use_tool_prompt
-        )
-        if uses_web_final_view:
+        if self.runtime._should_use_web_final_view(use_tool_prompt=use_tool_prompt):
             call_messages = self.runtime._web_final_from_tool_messages()
         elif (
             compact_window

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -1234,7 +1234,10 @@ class FinalFromToolEnvironment:
             self.runtime.messages.append({"role": "assistant", "content": result.content})
             return FinalAnswerResult(result=result, used_retry_or_repair_pass=False)
         response_prefix = targeted_prefix or display_prefix
-        if self.runtime._should_use_web_final_view(use_tool_prompt=use_tool_prompt):
+        uses_web_final_view = self.runtime._should_use_web_final_view(
+            use_tool_prompt=use_tool_prompt
+        )
+        if uses_web_final_view:
             call_messages = self.runtime._web_final_from_tool_messages()
         elif (
             compact_window
@@ -1268,7 +1271,11 @@ class FinalFromToolEnvironment:
                     attempt=1,
                 )
             )
-        grounded = self._grounded_finalization(
+        # The web-final view is its own answer shaping: when a search returned
+        # nothing or only snippets, that curated framing is what makes the
+        # reply honest about what was found. Rebuilding from raw evidence bytes
+        # would discard it, so that path keeps its own final call.
+        grounded = None if uses_web_final_view else self._grounded_finalization(
             temperature=temperature,
             on_final_delta=on_final_delta,
             on_progress=on_progress,
@@ -1599,7 +1606,14 @@ class FinalFromToolEnvironment:
             None,
         )
         if callable(reset):
-            reset()
+            try:
+                reset()
+            except Exception:
+                # Resetting is what makes the session fresh; if it cannot be
+                # done there is no clean state to finalize in, so decline and
+                # let the ordinary path answer instead of proceeding on a
+                # session whose contents are unknown.
+                return None
         if response_prefix and on_final_delta is not None:
             on_final_delta(response_prefix)
         # Call the inference backend directly, beneath the investigation's
@@ -1610,22 +1624,31 @@ class FinalFromToolEnvironment:
         # No `tools=` argument: FINAL_ONLY is enforced structurally, so no tool
         # can be requested rather than merely being discouraged by the prompt.
         backend = getattr(self.runtime.backend, "_backend", self.runtime.backend)
-        with self.transport.backend_thinking(False):
-            with model_call_context(phase="grounded_finalization", tools_mode="off"):
-                if on_final_delta is None:
-                    result = backend.chat(
-                        bundle_messages,
-                        temperature=temperature,
-                        max_tokens=admission.output_budget,
-                    )
-                else:
-                    result = backend.chat_stream(
-                        bundle_messages,
-                        temperature=temperature,
-                        max_tokens=admission.output_budget,
-                        on_delta=on_final_delta,
-                        on_progress=on_progress,
-                    )
+        try:
+            with self.transport.backend_thinking(False):
+                with model_call_context(phase="grounded_finalization", tools_mode="off"):
+                    if on_final_delta is None:
+                        result = backend.chat(
+                            bundle_messages,
+                            temperature=temperature,
+                            max_tokens=admission.output_budget,
+                        )
+                    else:
+                        result = backend.chat_stream(
+                            bundle_messages,
+                            temperature=temperature,
+                            max_tokens=admission.output_budget,
+                            on_delta=on_final_delta,
+                            on_progress=on_progress,
+                        )
+        except Exception:
+            # The session was already reset, so the ordinary path will prefill
+            # from scratch rather than continue -- slower, but it still answers.
+            # Declining here keeps a backend failure in this phase from costing
+            # the turn, which matters now that every evidence-backed workflow
+            # comes through here rather than only saturated ones. The durable
+            # evidence is untouched either way.
+            return None
         if on_model_step:
             on_model_step(
                 ModelStepMetrics.from_result(

--- a/src/orbit/runtime/environments.py
+++ b/src/orbit/runtime/environments.py
@@ -58,6 +58,7 @@ from orbit.runtime.full_document import (
     targeted_search_coverage_notice,
     targeted_search_no_match_notice,
 )
+from orbit.runtime.context_manager import ContextAdmissionError
 from orbit.runtime.finalization import (
     admit_finalization,
     deduplicate_evidence,
@@ -1271,35 +1272,40 @@ class FinalFromToolEnvironment:
                     attempt=1,
                 )
             )
-        # The web-final view is its own answer shaping: when a search returned
-        # nothing or only snippets, that curated framing is what makes the
-        # reply honest about what was found. Rebuilding from raw evidence bytes
-        # would discard it, so that path keeps its own final call.
-        grounded = None if uses_web_final_view else self._grounded_finalization(
-            temperature=temperature,
-            on_final_delta=on_final_delta,
-            on_progress=on_progress,
-            on_model_step=on_model_step,
-            on_phase_start=on_phase_start,
-            loop=loop,
-            response_prefix=response_prefix,
-        )
-        if grounded is not None:
-            return grounded
         if response_prefix and on_final_delta is not None:
             on_final_delta(response_prefix)
-        with self.transport.backend_thinking(False):
-            with model_call_context(phase="final_from_tool", tools_mode="on"):
-                if on_final_delta is None:
-                    result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
-                else:
-                    result = self.runtime.backend.chat_stream(
-                        policy.messages,
-                        temperature=temperature,
-                        max_tokens=policy.max_tokens,
-                        on_delta=final_delta,
-                        on_progress=on_progress,
-                    )
+        try:
+            with self.transport.backend_thinking(False):
+                with model_call_context(phase="final_from_tool", tools_mode="on"):
+                    if on_final_delta is None:
+                        result = self.runtime.backend.chat(policy.messages, temperature=temperature, max_tokens=policy.max_tokens)
+                    else:
+                        result = self.runtime.backend.chat_stream(
+                            policy.messages,
+                            temperature=temperature,
+                            max_tokens=policy.max_tokens,
+                            on_delta=final_delta,
+                            on_progress=on_progress,
+                        )
+        except ContextAdmissionError:
+            # Admission is enforced inside the managed backend, so a window that
+            # cannot be completed surfaces here rather than during assembly.
+            # Nothing has been generated yet, so the rescue can still run; if it
+            # cannot, the original error is the honest outcome.
+            grounded = self._grounded_finalization(
+                policy.messages,
+                temperature=temperature,
+                on_final_delta=on_final_delta,
+                on_progress=on_progress,
+                on_model_step=on_model_step,
+                on_phase_start=on_phase_start,
+                loop=loop,
+                response_prefix=response_prefix,
+                same_session_unavailable=True,
+            )
+            if grounded is not None:
+                return grounded
+            raise
         best_non_empty_result = result if result.content.strip() else None
         if on_model_step:
             on_model_step(ModelStepMetrics.from_result(loop=loop, result=result, phase="final_from_tool"))
@@ -1519,6 +1525,7 @@ class FinalFromToolEnvironment:
 
     def _grounded_finalization(
         self,
+        messages: list[Message],
         *,
         temperature: float,
         on_final_delta: Callable[[str], None] | None,
@@ -1527,19 +1534,22 @@ class FinalFromToolEnvironment:
         on_phase_start: Callable[[ModelPhaseStart], None] | None,
         loop: int,
         response_prefix: str,
+        same_session_unavailable: bool = False,
     ) -> FinalAnswerResult | None:
-        """Answer an evidence-backed workflow from its verified evidence.
+        """Answer from verified evidence when same-session completion cannot run.
 
-        Reaching this environment already means a tool workflow is producing
-        its final answer, so this is the normal path for such a turn rather
-        than a rescue: the report is rebuilt from durable evidence in a fresh
-        session, and no longer depends on how much context the investigation
-        happened to leave. Gating it on context pressure instead would
-        reintroduce exactly that dependency.
+        This is a rescue, not the normal route. The ordinary final path owns
+        retry, repair, compact retry, streaming buffering and the non-empty
+        fallback, and a healthy turn must keep all of it; routing every
+        evidence-backed workflow through here instead traded that machinery for
+        a second, thinner completion controller and regressed the healthy case.
 
-        Returning ``None`` means there is nothing to finalize from -- no
-        evidence, nothing that survives re-attestation, or a bundle that will
-        not fit -- and the ordinary path runs instead.
+        So the question asked here is narrow: can the ordinary window actually
+        be completed? It is answered by exact token count before anything is
+        generated, never by waiting for a decode failure. Only when the answer
+        is no is the report rebuilt from durable evidence in a fresh session.
+
+        Returning ``None`` means the ordinary path can and should run.
         """
         store = getattr(self.runtime, "evidence_store", None)
         if store is None or not store.records:
@@ -1551,19 +1561,27 @@ class FinalFromToolEnvironment:
         if not callable(count_chat):
             return None
 
-        # Reaching this environment already means an evidence-backed tool
-        # workflow is producing its final answer, and verified evidence exists.
-        # That -- not context pressure -- is the trigger: an earlier version
-        # diverted only when the ordinary window provably could not fit, which
-        # made grounded finalization a rescue for saturated sessions instead of
-        # the normal way an investigation reports. The point of the separate
-        # phase is that the answer no longer depends on how much room the
-        # investigation happened to leave, so the same handoff applies whether
-        # the session is nearly empty or nearly full.
+        # Can the ordinary path complete this turn? Counted exactly, before any
+        # generation: waiting for the backend to fail mid-decode yields no
+        # answer at all, and guessing either strands a usable turn or walks into
+        # that failure. Only a window that provably cannot be completed is
+        # rescued here; everything else keeps the ordinary path and the mature
+        # retry, repair and non-empty-fallback behaviour that comes with it.
         #
         # Pure chat and full-document never arrive here: chat completes through
         # the transport environment, and the full-document path returns before
         # this point.
+        if not same_session_unavailable:
+            try:
+                current_tokens = self._exact_token_total(
+                    count_chat(messages, tools=None, thinking=False)
+                )
+            except Exception:
+                return None
+            if current_tokens is None:
+                return None
+            if admit_finalization(current_tokens, context_tokens).admitted:
+                return None
 
         entries = deduplicate_evidence(
             entries_from_store(store, list(store.records.keys()))

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -164,6 +164,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -191,6 +192,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=100_000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -215,6 +217,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -241,6 +244,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -266,6 +270,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=32_000,
             )
             env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -291,6 +296,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -326,6 +332,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -352,6 +359,7 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -435,14 +443,35 @@ class LiveCallPathReachabilityTests(unittest.TestCase):
             self.assertIsNone(backend.chat_calls[-1]["tools"])
             self.assertEqual(backend.resets, 1)
 
-    def test_roomy_session_still_finalizes_from_evidence(self) -> None:
-        """The trigger is the evidence-backed boundary, not context pressure.
+    def test_saturated_session_is_rescued_before_any_decode(self) -> None:
+        """A window that cannot be completed is rescued, not decoded into.
 
-        An earlier version diverted only when the ordinary window could not
-        fit, which made grounded finalization a rescue for saturated sessions
-        rather than how an investigation normally reports. With plenty of
-        context left the same handoff must still apply, because the answer is
-        not supposed to depend on what the investigation happened to leave.
+        This is the failure the phase exists for: the investigation filled the
+        context, so the ordinary final call has no room to generate and would
+        fail mid-decode. The rescue must fire from the real answer() path, and
+        must fire on the exact count rather than on a backend error.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"": 5000, "Verified evidence": 300},
+            )
+            result = self._answer(backend, store, context_tokens=1000)
+            self.assertEqual(result.result.finish_reason, "stop")
+            sent = backend.chat_calls[-1]["messages"]
+            self.assertEqual(len(sent), 1, "did not answer from the bundle")
+            self.assertIn("Verified evidence", str(sent[0]["content"]))
+            self.assertIsNone(backend.chat_calls[-1]["tools"])
+            self.assertEqual(backend.resets, 1, "session was not made fresh")
+
+    def test_healthy_workflow_stays_on_the_ordinary_path(self) -> None:
+        """A turn the ordinary path can complete must keep it.
+
+        The ordinary path owns retry, repair, compact retry and the non-empty
+        fallback. Diverting a healthy turn to the bundle would hand it to a
+        thinner controller that has none of that, so the rescue must stay a
+        rescue: with room to answer normally, nothing here should fire.
         """
         with tempfile.TemporaryDirectory() as tmp:
             store, _ids = _store_with(tmp, ["payload " + "p" * 200])
@@ -450,10 +479,10 @@ class LiveCallPathReachabilityTests(unittest.TestCase):
             self._answer(backend, store, context_tokens=100_000)
             self.assertTrue(backend.chat_calls)
             sent = backend.chat_calls[-1]["messages"]
-            self.assertEqual(len(sent), 1, "did not finalize from the bundle")
-            self.assertIn("Verified evidence", str(sent[0]["content"]))
-            self.assertIsNone(backend.chat_calls[-1]["tools"])
-            self.assertEqual(backend.resets, 1)
+            self.assertGreater(
+                len(sent), 1, "healthy turn was diverted to the evidence bundle"
+            )
+            self.assertEqual(backend.resets, 0, "healthy turn reset the session")
 
 
 class ScopeAndResilienceTests(unittest.TestCase):
@@ -473,11 +502,13 @@ class ScopeAndResilienceTests(unittest.TestCase):
         return store
 
     def test_web_final_view_keeps_its_curated_framing(self) -> None:
-        """A search that found nothing must not be answered from raw bytes.
+        """A search that found nothing keeps its curated framing.
 
-        The web-final view exists to say honestly what the search returned.
-        Rebuilding the answer from evidence would discard that shaping, so this
-        path keeps its own final call.
+        The web-final view exists to say honestly what the search returned, and
+        the bundle cannot reproduce that shaping. Because the rescue only fires
+        when the ordinary window cannot be completed, a healthy web-final turn
+        keeps its own final call; if that window genuinely will not fit, the
+        rescue still runs, since the alternative there is no answer at all.
         """
         with tempfile.TemporaryDirectory() as tmp:
             store = self._web_search_store(tmp)
@@ -549,6 +580,7 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -558,6 +590,44 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 response_prefix="",
             )
             self.assertIsNone(out, "backend failure propagated instead of declining")
+
+    def test_streaming_backend_failure_does_not_cost_the_turn(self) -> None:
+        """The streaming half of the guard needs its own test.
+
+        Only overriding `chat` leaves `chat_stream` unguarded: the guard around
+        it could be deleted and every test would still pass.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class FailingStream(RecordingBackend):
+                def chat_stream(
+                    self, messages, *, temperature, max_tokens, on_delta,
+                    on_progress, tools=None,
+                ):
+                    raise RuntimeError("stream exploded")
+
+            backend = FailingStream(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 300},
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
+                temperature=0.0,
+                on_final_delta=lambda _chunk: None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out, "streaming failure propagated instead of declining")
 
     def test_failed_reset_declines_rather_than_finalizing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -577,6 +647,7 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -612,6 +683,7 @@ class CoverageNoticeTests(unittest.TestCase):
             )
             streamed: list[str] = []
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=streamed.append if streaming else None,
                 on_progress=None,
@@ -709,6 +781,7 @@ class ProductionTrustBoundaryTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
+                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from orbit.runtime.chat import ChatRuntime
 from orbit.runtime.completion_budget import FINALIZATION_FINAL_MAX_TOKENS
 from orbit.runtime.environments import FinalFromToolEnvironment, TransportEnvironment
+from orbit.runtime.context_manager import ContextAdmissionError
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.full_document import FILE_DISPLAY_MARKER
 from orbit.runtime.finalization import (
@@ -692,6 +693,207 @@ class CoverageNoticeTests(unittest.TestCase):
         self.assertEqual(streamed, "")
         self.assertEqual(content.count(prefix), 1, "coverage notice lost")
         self.assertEqual(str(messages[-1]["content"]).count(prefix), 1)
+
+
+class AdmissionWrapperBypassTests(unittest.TestCase):
+    """The rescue must call beneath the investigation's admission wrapper.
+
+    That wrapper plans against the conversation this phase abandons, so routing
+    the bundle back through it would re-raise the very refusal being recovered
+    from and turn the rescue into a second failure.
+    """
+
+    def test_bundle_does_not_go_back_through_the_wrapper(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 300},
+            )
+            seen: list[str] = []
+
+            class Wrapper:
+                """Stands in for ContextManagedBackend: refuses everything."""
+
+                _backend = backend
+
+                def __getattr__(self, name):
+                    return getattr(backend, name)
+
+                def chat(self, *args, **kwargs):
+                    seen.append("wrapper")
+                    raise ContextAdmissionError("context admission failed")
+
+            env, runtime = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            runtime.backend = Wrapper()
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNotNone(out, "rescue was refused by the admission wrapper")
+            self.assertEqual(seen, [], "bundle was routed back through the wrapper")
+
+
+class RescueTriggerNarrownessTests(unittest.TestCase):
+    """Only an admission refusal may divert; every other failure propagates.
+
+    The guard's narrowness is the whole design. Widening it would send ordinary
+    backend failures -- a timeout, a dropped connection, a mid-decode error --
+    into the thin rescue controller, abandoning retry, repair, compact retry
+    and the non-empty fallback, possibly after tokens have already reached the
+    user. Without this test that widening passes unnoticed.
+    """
+
+    def _answer_with(self, backend, store):
+        messages = [
+            {"role": "user", "content": "analyse"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "output"},
+        ]
+        env, _ = _environment(
+            backend, store, messages=messages, context_tokens=100_000
+        )
+        return env.answer(
+            temperature=0.0,
+            max_tokens=2048,
+            on_final_delta=None,
+            on_progress=None,
+            on_model_step=None,
+            on_phase_start=None,
+            loop=1,
+            use_tool_prompt=False,
+            workdir=None,
+        )
+
+    def test_ordinary_backend_error_is_not_rescued(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class Exploding(RecordingBackend):
+                def chat(self, messages, *, temperature, max_tokens, tools=None):
+                    raise RuntimeError("connection reset by peer")
+
+            backend = Exploding(context_tokens=100_000)
+            with self.assertRaises(RuntimeError):
+                self._answer_with(backend, store)
+            self.assertEqual(
+                backend.resets, 0, "an ordinary failure was diverted to the rescue"
+            )
+
+    def test_value_error_is_not_rescued(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class Bad(RecordingBackend):
+                def chat(self, messages, *, temperature, max_tokens, tools=None):
+                    raise ValueError("malformed response")
+
+            backend = Bad(context_tokens=100_000)
+            with self.assertRaises(ValueError):
+                self._answer_with(backend, store)
+            self.assertEqual(backend.resets, 0)
+
+
+class ProductionSessionResetTests(unittest.TestCase):
+    """The session must actually be made fresh on a server-backed run.
+
+    The in-process native client exposes `reset_session_state`, but production
+    talks to it over HTTP through `reset_static_analysis_session`, which
+    reports failure by returning a message instead of raising. Reading only the
+    first shape meant the reset silently never ran, and the rescue finalized on
+    the saturated session it exists to abandon -- with the guarding test
+    passing because its fake backend had a method no real backend has.
+    """
+
+    class ServedBackend(RecordingBackend):
+        """Shaped like LlamaServerBackend: no in-process reset method."""
+
+        def __init__(self, *, context_tokens, tokens_for=None, reset_error=None):
+            super().__init__(context_tokens=context_tokens, tokens_for=tokens_for)
+            self.reset_error = reset_error
+            self.served_resets = 0
+
+        reset_session_state = None  # the production backend has no such method
+
+        def reset_static_analysis_session(self):
+            self.served_resets += 1
+            return self.reset_error
+
+    def _env(self, backend):
+        tmp = tempfile.mkdtemp()
+        store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+        env, _ = _environment(
+            backend,
+            store,
+            messages=[{"role": "user", "content": "analyse"}],
+            context_tokens=1000,
+        )
+        return env
+
+    def _finalize(self, backend):
+        return self._env(backend)._grounded_finalization(
+            temperature=0.0,
+            on_final_delta=None,
+            on_progress=None,
+            on_model_step=None,
+            on_phase_start=None,
+            loop=1,
+            response_prefix="",
+        )
+
+    def test_served_backend_session_is_reset(self) -> None:
+        backend = self.ServedBackend(
+            context_tokens=1000,
+            tokens_for={"saturated": 990, "Verified evidence": 300},
+        )
+        out = self._finalize(backend)
+        self.assertIsNotNone(out, "rescue declined on a production-shaped backend")
+        self.assertEqual(backend.served_resets, 1, "session was never made fresh")
+
+    def test_served_reset_failure_declines(self) -> None:
+        backend = self.ServedBackend(
+            context_tokens=1000,
+            tokens_for={"saturated": 990, "Verified evidence": 300},
+            reset_error="error: native session reset failed",
+        )
+        out = self._finalize(backend)
+        self.assertIsNone(out, "finalized despite a failed session reset")
+        self.assertEqual(backend.chat_calls, [], "generated on an unreset session")
+
+    def test_backend_with_no_reset_at_all_declines(self) -> None:
+        class NoReset(RecordingBackend):
+            reset_session_state = None
+
+        backend = NoReset(
+            context_tokens=1000,
+            tokens_for={"saturated": 990, "Verified evidence": 300},
+        )
+        out = self._finalize(backend)
+        self.assertIsNone(out, "finalized without any way to reset the session")
+        self.assertEqual(backend.chat_calls, [])
 
 
 class ExactAccountingPreconditionTests(unittest.TestCase):

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -1,0 +1,487 @@
+"""Live wiring for the grounded finalization handoff.
+
+An evidence-backed tool workflow answers from its durable evidence in a fresh
+session rather than from the conversation that produced it. These cover the
+transition through the real answer() path: that the finalizer is reached
+automatically, that the saturated investigation session is not carried into it,
+and that the evidence is re-attested rather than trusted.
+
+The trigger is the evidence-backed boundary itself, not context pressure -- the
+whole point of a separate phase is that the answer no longer depends on how
+much room the investigation left.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.completion_budget import FINALIZATION_FINAL_MAX_TOKENS
+from orbit.runtime.environments import FinalFromToolEnvironment, TransportEnvironment
+from orbit.runtime.evidence import EvidenceStore
+from orbit.runtime.finalization import (
+    BundleEntry,
+    admit_finalization,
+    deduplicate_evidence,
+    entries_from_store,
+)
+from orbit.backend.base import ChatResult, TokenCount
+
+
+ORACLE_TERMS = (
+    "6000",
+    "Sleep",
+    "Invoke-RestMethod",
+    "smartmaket",
+    "AA1789FF",
+    "Win32_Process",
+    "winmgmts",
+    "ShowWindow",
+    "iex",
+    "irm",
+    "cimv2",
+)
+
+
+def _result(content: str, *, finish_reason: str = "stop") -> ChatResult:
+    return ChatResult(
+        content=content,
+        model="fake",
+        finish_reason=finish_reason,
+        tool_calls=[],
+        prompt_tokens=1,
+        completion_tokens=1,
+        cached_tokens=0,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
+    )
+
+
+class RecordingBackend:
+    """Backend that counts tokens exactly and records how it was called."""
+
+    def __init__(self, *, context_tokens: int, tokens_for: dict | None = None) -> None:
+        self.context_tokens = context_tokens
+        self._tokens_for = tokens_for or {}
+        self.chat_calls: list[dict] = []
+        self.resets = 0
+        self.count_calls = 0
+
+    def _tokens(self, messages) -> int:
+        text = "".join(str(m.get("content", "")) for m in messages)
+        # The bundle restates the task, so it matches the saturation needle too.
+        # Price the bundle first: otherwise it is charged the saturated cost and
+        # admission refuses a prompt that in fact fits.
+        if "Verified evidence" in text and "Verified evidence" in self._tokens_for:
+            return self._tokens_for["Verified evidence"]
+        for needle in sorted(self._tokens_for, key=len, reverse=True):
+            if needle and needle in text:
+                return self._tokens_for[needle]
+        if "" in self._tokens_for:
+            return self._tokens_for[""]
+        return max(1, len(text) // 4)
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False) -> TokenCount:
+        self.count_calls += 1
+        tokens = self._tokens(messages)
+        digest = hashlib.sha256(
+            "".join(str(m.get("content", "")) for m in messages).encode("utf-8")
+        ).hexdigest()
+        return TokenCount(
+            tokens=tokens,
+            context_tokens=self.context_tokens,
+            rendered_hash=digest,
+            token_hash=digest,
+        )
+
+    def reset_session_state(self) -> None:
+        self.resets += 1
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+        self.chat_calls.append(
+            {"messages": messages, "max_tokens": max_tokens, "tools": tools}
+        )
+        return _result("FINAL: grounded answer")
+
+    def chat_stream(self, messages, *, temperature, max_tokens, on_delta, on_progress, tools=None) -> ChatResult:
+        self.chat_calls.append(
+            {"messages": messages, "max_tokens": max_tokens, "tools": tools}
+        )
+        on_delta("FINAL: grounded answer")
+        return _result("FINAL: grounded answer")
+
+
+def _store_with(tmp: str, payloads: list[str]) -> tuple[EvidenceStore, list[str]]:
+    store = EvidenceStore(Path(tmp) / "evidence")
+    ids = []
+    for index, payload in enumerate(payloads, start=1):
+        record = store.add(
+            "exec_shell_full_command",
+            payload,
+            metadata={
+                "tool_call_id": f"call-{index}",
+                "user_turn_id": f"turn-{index}",
+                "produced_by_phase": "tool_call",
+            },
+        )
+        ids.append(record.evidence_id)
+    return store, ids
+
+
+def _environment(backend, store, *, messages, context_tokens):
+    runtime = ChatRuntime(
+        backend=backend,
+        system_prompt="system",
+        messages=messages,
+        context_tokens=context_tokens,
+        evidence_store=store,
+    )
+    return FinalFromToolEnvironment(
+        runtime=runtime, transport=TransportEnvironment(runtime=runtime)
+    ), runtime
+
+
+
+
+
+
+class LiveFinalizationWiringTests(unittest.TestCase):
+    """The runtime must actually reach the PR #211 finalizer."""
+
+    def test_saturated_session_reaches_grounded_finalizer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            env, runtime = _environment(
+                RecordingBackend(
+                    context_tokens=1000,
+                    tokens_for={"saturated": 990, "Verified evidence": 300},
+                ),
+                store,
+                messages=[{"role": "user", "content": "analyse this saturated session"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNotNone(out, "finalizer was not reached from the live path")
+            assert out is not None
+            self.assertEqual(out.result.finish_reason, "stop")
+
+    def test_no_evidence_means_no_grounded_finalization(self) -> None:
+        """Without verified evidence there is nothing to finalize from.
+
+        This is what keeps the phase scoped: an empty store yields None and the
+        ordinary path runs, so a turn that never produced evidence is untouched.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "evidence")
+            env, _ = _environment(
+                RecordingBackend(context_tokens=100_000),
+                store,
+                messages=[{"role": "user", "content": "short question"}],
+                context_tokens=100_000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out, "diverted with no evidence to cite")
+
+    def test_finalization_disables_tools_structurally(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 300},
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertTrue(backend.chat_calls)
+            for call in backend.chat_calls:
+                self.assertIsNone(call["tools"], "tools reached FINAL_ONLY")
+
+    def test_finalization_resets_saturated_session(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 300},
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertEqual(backend.resets, 1, "saturated KV was reused")
+
+    def test_output_budget_stays_at_the_qualified_cap(self) -> None:
+        self.assertEqual(FINALIZATION_FINAL_MAX_TOKENS, 4096)
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=32_000,
+                tokens_for={"saturated": 31_990, "Verified evidence": 300},
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=32_000,
+            )
+            env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertEqual(backend.chat_calls[-1]["max_tokens"], 4096)
+
+    def test_admission_is_exact_and_precedes_decode(self) -> None:
+        """A bundle that cannot fit must refuse before any generation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["x" * 40_000])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 5000},
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+            self.assertEqual(backend.chat_calls, [], "decoded despite failed admission")
+
+    def test_all_backend_count_shapes_are_understood(self) -> None:
+        """A backend whose count shape is unread would disconnect the finalizer."""
+        shape = FinalFromToolEnvironment._exact_token_total
+
+        class Counted:
+            tokens = 42
+
+        self.assertEqual(shape(7), 7)
+        self.assertEqual(shape(Counted()), 42)
+        self.assertEqual(shape({"tokens": 9}), 9)
+        self.assertIsNone(shape(None))
+        self.assertIsNone(shape(True))
+        self.assertIsNone(shape("120"))
+
+    def test_missing_evidence_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = EvidenceStore(Path(tmp) / "evidence")
+            env, _ = _environment(
+                RecordingBackend(context_tokens=1000, tokens_for={"saturated": 990}),
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+
+    def test_uncountable_backend_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class Uncountable(RecordingBackend):
+                def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                    raise RuntimeError("tokenizer unavailable")
+
+            backend = Uncountable(context_tokens=1000)
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+            self.assertEqual(backend.chat_calls, [])
+
+
+
+
+class LiveCallPathReachabilityTests(unittest.TestCase):
+    """The hook must be reachable through the real answer() entry point.
+
+    Calling the helper directly proves it works; it does not prove anything
+    calls it. These go through FinalFromToolEnvironment.answer so that severing
+    the hook fails the suite.
+    """
+
+    def _answer(self, backend, store, *, context_tokens, use_tool_prompt=False):
+        messages = [
+            {"role": "user", "content": "analyse this saturated investigation"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "saturated investigation output",
+            },
+        ]
+        env, _ = _environment(
+            backend, store, messages=messages, context_tokens=context_tokens
+        )
+        return env.answer(
+            temperature=0.0,
+            max_tokens=2048,
+            on_final_delta=None,
+            on_progress=None,
+            on_model_step=None,
+            on_phase_start=None,
+            loop=1,
+            use_tool_prompt=use_tool_prompt,
+            workdir=None,
+        )
+
+    def test_answer_reaches_grounded_finalization_when_saturated(self) -> None:
+        """Every ordinary window overflows; only the bundle can be admitted.
+
+        Compaction can rescue many large turns on its own, so the scenario has
+        to be one it cannot rescue -- otherwise the test passes with the
+        finalizer entirely disconnected.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"": 2000, "Verified evidence": 300},
+            )
+            result = self._answer(backend, store, context_tokens=1000)
+            self.assertEqual(result.result.finish_reason, "stop")
+            self.assertTrue(backend.chat_calls)
+            # The bundle, not the conversation, is what was sent.
+            sent = backend.chat_calls[-1]["messages"]
+            self.assertEqual(len(sent), 1)
+            self.assertIn("Verified evidence", str(sent[0]["content"]))
+            self.assertIsNone(backend.chat_calls[-1]["tools"])
+            self.assertEqual(backend.resets, 1)
+
+    def test_roomy_session_still_finalizes_from_evidence(self) -> None:
+        """The trigger is the evidence-backed boundary, not context pressure.
+
+        An earlier version diverted only when the ordinary window could not
+        fit, which made grounded finalization a rescue for saturated sessions
+        rather than how an investigation normally reports. With plenty of
+        context left the same handoff must still apply, because the answer is
+        not supposed to depend on what the investigation happened to leave.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(context_tokens=100_000)
+            self._answer(backend, store, context_tokens=100_000)
+            self.assertTrue(backend.chat_calls)
+            sent = backend.chat_calls[-1]["messages"]
+            self.assertEqual(len(sent), 1, "did not finalize from the bundle")
+            self.assertIn("Verified evidence", str(sent[0]["content"]))
+            self.assertIsNone(backend.chat_calls[-1]["tools"])
+            self.assertEqual(backend.resets, 1)
+
+
+class EvidenceTrustChainTests(unittest.TestCase):
+    def test_bundle_sources_only_reattested_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, ids = _store_with(tmp, ["alpha " + "a" * 100, "beta " + "b" * 100])
+            entries = entries_from_store(store, ids)
+            self.assertEqual(len(entries), 2)
+            # Corrupt the durable bytes: attestation must now drop the record.
+            (store.root / f"{ids[0]}.txt").write_text("tampered", encoding="utf-8")
+            store.raw_cache.pop(ids[0], None)
+            surviving = entries_from_store(store, ids)
+            self.assertEqual([e.evidence_id for e in surviving], [ids[1]])
+
+    def test_artifact_sha_is_exact_and_recomputed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, ids = _store_with(tmp, ["payload " + "p" * 100])
+            entry = entries_from_store(store, ids)[0]
+            expected = hashlib.sha256(
+                ("payload " + "p" * 100).encode("utf-8")
+            ).hexdigest()
+            self.assertEqual(entry.sha256, expected)
+            self.assertEqual(entry.sha256, store.records[ids[0]].raw_sha256)
+
+    def test_zero_budget_is_refused(self) -> None:
+        self.assertFalse(admit_finalization(1000, 1000).admitted)
+        self.assertFalse(admit_finalization(999, 1000).admitted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -456,6 +456,159 @@ class LiveCallPathReachabilityTests(unittest.TestCase):
             self.assertEqual(backend.resets, 1)
 
 
+class CoverageNoticeTests(unittest.TestCase):
+    """Coverage caveats must survive the grounded path, streaming or not.
+
+    The prefix carries notices such as "only part of this file was shown". The
+    ordinary path prepends it to the content so it reaches history and
+    non-streaming callers; the grounded path must do the same, or a warning
+    about incomplete coverage silently disappears in one mode.
+    """
+
+    def _run(self, *, streaming: bool):
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            env, runtime = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            streamed: list[str] = []
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=streamed.append if streaming else None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="NOTE: partial coverage.\n",
+            )
+            self.assertIsNotNone(out)
+            assert out is not None
+            return out.result.content, "".join(streamed), runtime.messages
+
+    def test_prefix_survives_without_streaming(self) -> None:
+        content, _streamed, messages = self._run(streaming=False)
+        self.assertIn("NOTE: partial coverage.", content)
+        self.assertIn("NOTE: partial coverage.", str(messages[-1]["content"]))
+
+    def test_prefix_survives_with_streaming(self) -> None:
+        content, streamed, messages = self._run(streaming=True)
+        self.assertIn("NOTE: partial coverage.", streamed)
+        self.assertIn("NOTE: partial coverage.", content)
+        self.assertIn("NOTE: partial coverage.", str(messages[-1]["content"]))
+
+
+class ProductionTrustBoundaryTests(unittest.TestCase):
+    """The bundle the model sees must come from re-attested evidence.
+
+    Testing `entries_from_store` in isolation proves the helper works; it does
+    not prove the production path calls it. These assert on what actually
+    reaches the prompt, so bypassing re-attestation or deduplication in the
+    wiring fails here even though the library itself is still correct.
+    """
+
+    def _finalize(self, backend, store, *, context_tokens=1000):
+        messages = [
+            {"role": "user", "content": "analyse"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "exec_shell_full_command",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "output"},
+        ]
+        env, _ = _environment(
+            backend, store, messages=messages, context_tokens=context_tokens
+        )
+        env.answer(
+            temperature=0.0,
+            max_tokens=2048,
+            on_final_delta=None,
+            on_progress=None,
+            on_model_step=None,
+            on_phase_start=None,
+            loop=1,
+            use_tool_prompt=False,
+            workdir=None,
+        )
+        return "".join(
+            str(m.get("content", "")) for m in backend.chat_calls[-1]["messages"]
+        )
+
+    def test_tampered_evidence_never_reaches_the_prompt(self) -> None:
+        """Bytes edited on disk after attestation must not be cited."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store, ids = _store_with(tmp, ["genuine payload " + "g" * 200])
+            (store.root / f"{ids[0]}.txt").write_text(
+                "TAMPERED payload " + "x" * 200, encoding="utf-8"
+            )
+            store.raw_cache.pop(ids[0], None)
+            backend = RecordingBackend(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            sent = "".join(
+                str(m.get("content", "")) for m in backend.chat_calls[-1]["messages"]
+            ) if backend.chat_calls else ""
+            self.assertNotIn("TAMPERED", sent, "tampered bytes reached the model")
+            if out is not None:
+                self.assertNotIn("TAMPERED", out.result.content)
+
+    def test_duplicate_evidence_is_collapsed_in_the_prompt(self) -> None:
+        """Byte-identical records must appear once, via the library's dedup."""
+        payload = "repeated finding " + "r" * 200
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, [payload, payload, payload])
+            backend = RecordingBackend(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            sent = self._finalize(backend, store)
+            self.assertEqual(
+                sent.count("repeated finding"), 1, "duplicates were not collapsed"
+            )
+
+    def test_prompt_carries_recomputed_digests(self) -> None:
+        """The header hash must be of the bytes actually sent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store, ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            sent = self._finalize(backend, store)
+            expected = hashlib.sha256(
+                ("payload " + "p" * 200).encode("utf-8")
+            ).hexdigest()
+            self.assertIn(expected[:16], sent)
+
+
 class EvidenceTrustChainTests(unittest.TestCase):
     def test_bundle_sources_only_reattested_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -6,9 +6,9 @@ transition through the real answer() path: that the finalizer is reached
 automatically, that the saturated investigation session is not carried into it,
 and that the evidence is re-attested rather than trusted.
 
-The trigger is the evidence-backed boundary itself, not context pressure -- the
-whole point of a separate phase is that the answer no longer depends on how
-much room the investigation left.
+The trigger is narrow: a turn is rescued only once the ordinary window has been
+refused admission, so a healthy turn keeps the ordinary path and every recovery
+behaviour that comes with it.
 """
 
 from __future__ import annotations
@@ -164,7 +164,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -192,7 +191,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=100_000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -217,7 +215,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -244,7 +241,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -270,7 +266,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=32_000,
             )
             env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -296,7 +291,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -332,7 +326,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -359,7 +352,6 @@ class LiveFinalizationWiringTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -419,51 +411,6 @@ class LiveCallPathReachabilityTests(unittest.TestCase):
             use_tool_prompt=use_tool_prompt,
             workdir=None,
         )
-
-    def test_answer_reaches_grounded_finalization_when_saturated(self) -> None:
-        """Every ordinary window overflows; only the bundle can be admitted.
-
-        Compaction can rescue many large turns on its own, so the scenario has
-        to be one it cannot rescue -- otherwise the test passes with the
-        finalizer entirely disconnected.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
-            backend = RecordingBackend(
-                context_tokens=1000,
-                tokens_for={"": 2000, "Verified evidence": 300},
-            )
-            result = self._answer(backend, store, context_tokens=1000)
-            self.assertEqual(result.result.finish_reason, "stop")
-            self.assertTrue(backend.chat_calls)
-            # The bundle, not the conversation, is what was sent.
-            sent = backend.chat_calls[-1]["messages"]
-            self.assertEqual(len(sent), 1)
-            self.assertIn("Verified evidence", str(sent[0]["content"]))
-            self.assertIsNone(backend.chat_calls[-1]["tools"])
-            self.assertEqual(backend.resets, 1)
-
-    def test_saturated_session_is_rescued_before_any_decode(self) -> None:
-        """A window that cannot be completed is rescued, not decoded into.
-
-        This is the failure the phase exists for: the investigation filled the
-        context, so the ordinary final call has no room to generate and would
-        fail mid-decode. The rescue must fire from the real answer() path, and
-        must fire on the exact count rather than on a backend error.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            store, _ids = _store_with(tmp, ["verified payload " + "p" * 200])
-            backend = RecordingBackend(
-                context_tokens=1000,
-                tokens_for={"": 5000, "Verified evidence": 300},
-            )
-            result = self._answer(backend, store, context_tokens=1000)
-            self.assertEqual(result.result.finish_reason, "stop")
-            sent = backend.chat_calls[-1]["messages"]
-            self.assertEqual(len(sent), 1, "did not answer from the bundle")
-            self.assertIn("Verified evidence", str(sent[0]["content"]))
-            self.assertIsNone(backend.chat_calls[-1]["tools"])
-            self.assertEqual(backend.resets, 1, "session was not made fresh")
 
     def test_healthy_workflow_stays_on_the_ordinary_path(self) -> None:
         """A turn the ordinary path can complete must keep it.
@@ -580,7 +527,6 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -618,7 +564,6 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=lambda _chunk: None,
                 on_progress=None,
@@ -647,7 +592,6 @@ class ScopeAndResilienceTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,
@@ -661,19 +605,75 @@ class ScopeAndResilienceTests(unittest.TestCase):
 
 
 class CoverageNoticeTests(unittest.TestCase):
-    """Coverage caveats must survive the grounded path, streaming or not.
+    """Coverage caveats must reach the user exactly once, streaming or not.
 
-    The prefix carries notices such as "only part of this file was shown". The
-    ordinary path prepends it to the content so it reaches history and
-    non-streaming callers; the grounded path must do the same, or a warning
-    about incomplete coverage silently disappears in one mode.
+    The prefix carries notices such as "only part of this file was shown".
+    Driving this through `answer()` rather than the helper is deliberate: the
+    caller streams the prefix before the ordinary attempt, so a helper-level
+    test cannot see a duplicate and would pass whether or not one occurs.
     """
 
-    def _run(self, *, streaming: bool):
+    def _saturated_answer(self, *, streaming: bool):
         with tempfile.TemporaryDirectory() as tmp:
             store, _ids = _store_with(tmp, ["payload " + "p" * 200])
             backend = RecordingBackend(
                 context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            messages = [
+                {"role": "user", "content": "analyse"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "exec_shell_full_command",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "output"},
+            ]
+            env, runtime = _environment(
+                backend, store, messages=messages, context_tokens=1000
+            )
+            streamed: list[str] = []
+            out = env.answer(
+                temperature=0.0,
+                max_tokens=2048,
+                on_final_delta=streamed.append if streaming else None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                use_tool_prompt=False,
+                workdir=None,
+            )
+            return out.result.content, "".join(streamed), runtime.messages
+
+    def test_prefix_is_not_duplicated_when_streaming(self) -> None:
+        content, streamed, messages = self._saturated_answer(streaming=True)
+        # There is no display prefix in this fixture, so the assertion that
+        # matters is that nothing is emitted twice.
+        self.assertEqual(streamed.count("FINAL"), 1, "answer streamed twice")
+        self.assertIn("FINAL", content)
+        self.assertIn("FINAL", str(messages[-1]["content"]))
+
+    def test_answer_reaches_history_without_streaming(self) -> None:
+        content, _streamed, messages = self._saturated_answer(streaming=False)
+        self.assertIn("FINAL", content)
+        self.assertIn("FINAL", str(messages[-1]["content"]))
+
+    def test_prefix_is_prepended_to_content_by_the_helper(self) -> None:
+        """The helper still owns prepending, which carries it into history."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(
+                context_tokens=1000,
+                tokens_for={"saturated": 990, "Verified evidence": 300},
             )
             env, runtime = _environment(
                 backend,
@@ -681,11 +681,9 @@ class CoverageNoticeTests(unittest.TestCase):
                 messages=[{"role": "user", "content": "analyse"}],
                 context_tokens=1000,
             )
-            streamed: list[str] = []
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
-                on_final_delta=streamed.append if streaming else None,
+                on_final_delta=None,
                 on_progress=None,
                 on_model_step=None,
                 on_phase_start=None,
@@ -694,18 +692,72 @@ class CoverageNoticeTests(unittest.TestCase):
             )
             self.assertIsNotNone(out)
             assert out is not None
-            return out.result.content, "".join(streamed), runtime.messages
+            self.assertEqual(out.result.content.count("NOTE: partial coverage."), 1)
+            self.assertIn("NOTE: partial coverage.", str(runtime.messages[-1]["content"]))
 
-    def test_prefix_survives_without_streaming(self) -> None:
-        content, _streamed, messages = self._run(streaming=False)
-        self.assertIn("NOTE: partial coverage.", content)
-        self.assertIn("NOTE: partial coverage.", str(messages[-1]["content"]))
 
-    def test_prefix_survives_with_streaming(self) -> None:
-        content, streamed, messages = self._run(streaming=True)
-        self.assertIn("NOTE: partial coverage.", streamed)
-        self.assertIn("NOTE: partial coverage.", content)
-        self.assertIn("NOTE: partial coverage.", str(messages[-1]["content"]))
+class ExactAccountingPreconditionTests(unittest.TestCase):
+    """The rescue needs exact token accounting, and declines without it.
+
+    On a backend that cannot report an exact count -- a plain llama.cpp server,
+    or a session with no known context size -- upstream admission is skipped, so
+    no ContextAdmissionError is raised and a saturated turn fails at decode as
+    it did before this phase existed. That limit is real: without an exact count
+    there is no way to promise the bundle fits either. These pin the decline so
+    the limitation is visible rather than discovered in production.
+    """
+
+    def test_unknown_context_size_declines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            backend = RecordingBackend(context_tokens=1000)
+            env, runtime = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            runtime.context_tokens = None
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+            self.assertEqual(backend.chat_calls, [], "generated without a known ctx")
+
+    def test_backend_without_exact_counting_declines(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class NoExactCount(RecordingBackend):
+                def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                    return None  # what a non-native server reports
+
+            backend = NoExactCount(context_tokens=1000)
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+            self.assertEqual(
+                backend.chat_calls, [], "generated without an exact token count"
+            )
 
 
 class ProductionTrustBoundaryTests(unittest.TestCase):
@@ -781,7 +833,6 @@ class ProductionTrustBoundaryTests(unittest.TestCase):
                 context_tokens=1000,
             )
             out = env._grounded_finalization(
-                [{"role": "user", "content": "saturated"}],
                 temperature=0.0,
                 on_final_delta=None,
                 on_progress=None,

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -456,6 +456,139 @@ class LiveCallPathReachabilityTests(unittest.TestCase):
             self.assertEqual(backend.resets, 1)
 
 
+class ScopeAndResilienceTests(unittest.TestCase):
+    """Paths with their own answer shaping keep it; failures stay recoverable."""
+
+    def _web_search_store(self, tmp):
+        store = EvidenceStore(Path(tmp) / "evidence")
+        store.add(
+            "exec_shell_full_command",
+            "web_search_results: true\nresults: none",
+            metadata={
+                "tool_call_id": "call-1",
+                "user_turn_id": "turn-1",
+                "produced_by_phase": "tool_call",
+            },
+        )
+        return store
+
+    def test_web_final_view_keeps_its_curated_framing(self) -> None:
+        """A search that found nothing must not be answered from raw bytes.
+
+        The web-final view exists to say honestly what the search returned.
+        Rebuilding the answer from evidence would discard that shaping, so this
+        path keeps its own final call.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store = self._web_search_store(tmp)
+            backend = RecordingBackend(
+                context_tokens=100_000, tokens_for={"": 200, "Verified evidence": 300}
+            )
+            messages = [
+                {"role": "user", "content": "search for something"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "exec_shell_full_command",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "no results"},
+            ]
+            env, runtime = _environment(
+                backend, store, messages=messages, context_tokens=100_000
+            )
+            self.assertTrue(
+                runtime._should_use_web_final_view(use_tool_prompt=False),
+                "fixture no longer selects the web-final view",
+            )
+            env.answer(
+                temperature=0.0,
+                max_tokens=2048,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                use_tool_prompt=False,
+                workdir=None,
+            )
+            sent = backend.chat_calls[-1]["messages"]
+            self.assertGreater(
+                len(sent), 1, "web-final curated view was replaced by the bundle"
+            )
+            self.assertEqual(backend.resets, 0, "web-final path reset the session")
+
+    def test_backend_failure_does_not_cost_the_turn(self) -> None:
+        """A failure inside finalization must fall back, not propagate.
+
+        The session has already been reset by this point, so propagating would
+        leave the caller with neither an answer nor a usable session.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class Failing(RecordingBackend):
+                def chat(self, messages, *, temperature, max_tokens, tools=None):
+                    raise RuntimeError("backend exploded")
+
+            backend = Failing(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out, "backend failure propagated instead of declining")
+
+    def test_failed_reset_declines_rather_than_finalizing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+
+            class BadReset(RecordingBackend):
+                def reset_session_state(self):
+                    raise RuntimeError("native client not loaded")
+
+            backend = BadReset(
+                context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
+            )
+            env, _ = _environment(
+                backend,
+                store,
+                messages=[{"role": "user", "content": "analyse"}],
+                context_tokens=1000,
+            )
+            out = env._grounded_finalization(
+                temperature=0.0,
+                on_final_delta=None,
+                on_progress=None,
+                on_model_step=None,
+                on_phase_start=None,
+                loop=1,
+                response_prefix="",
+            )
+            self.assertIsNone(out)
+            self.assertEqual(backend.chat_calls, [], "generated after a failed reset")
+
+
 class CoverageNoticeTests(unittest.TestCase):
     """Coverage caveats must survive the grounded path, streaming or not.
 
@@ -550,9 +683,18 @@ class ProductionTrustBoundaryTests(unittest.TestCase):
         )
 
     def test_tampered_evidence_never_reaches_the_prompt(self) -> None:
-        """Bytes edited on disk after attestation must not be cited."""
+        """Bytes edited on disk after attestation must not be cited.
+
+        A second, intact record is seeded deliberately: with only the tampered
+        one the finalizer would decline for lack of evidence and the assertion
+        would pass without a prompt ever being built. Keeping one good record
+        forces a real bundle, so the tampered bytes have somewhere to leak into.
+        """
         with tempfile.TemporaryDirectory() as tmp:
-            store, ids = _store_with(tmp, ["genuine payload " + "g" * 200])
+            store, ids = _store_with(
+                tmp,
+                ["genuine payload " + "g" * 200, "second intact record " + "s" * 200],
+            )
             (store.root / f"{ids[0]}.txt").write_text(
                 "TAMPERED payload " + "x" * 200, encoding="utf-8"
             )
@@ -575,12 +717,13 @@ class ProductionTrustBoundaryTests(unittest.TestCase):
                 loop=1,
                 response_prefix="",
             )
+            self.assertIsNotNone(out, "no bundle was built, so nothing was proven")
+            self.assertTrue(backend.chat_calls, "finalization never called the model")
             sent = "".join(
                 str(m.get("content", "")) for m in backend.chat_calls[-1]["messages"]
-            ) if backend.chat_calls else ""
+            )
+            self.assertIn("second intact record", sent, "intact evidence missing")
             self.assertNotIn("TAMPERED", sent, "tampered bytes reached the model")
-            if out is not None:
-                self.assertNotIn("TAMPERED", out.result.content)
 
     def test_duplicate_evidence_is_collapsed_in_the_prompt(self) -> None:
         """Byte-identical records must appear once, via the library's dedup."""

--- a/tests/test_grounded_finalization_wiring.py
+++ b/tests/test_grounded_finalization_wiring.py
@@ -22,6 +22,7 @@ from orbit.runtime.chat import ChatRuntime
 from orbit.runtime.completion_budget import FINALIZATION_FINAL_MAX_TOKENS
 from orbit.runtime.environments import FinalFromToolEnvironment, TransportEnvironment
 from orbit.runtime.evidence import EvidenceStore
+from orbit.runtime.full_document import FILE_DISPLAY_MARKER
 from orbit.runtime.finalization import (
     BundleEntry,
     admit_finalization,
@@ -605,22 +606,49 @@ class ScopeAndResilienceTests(unittest.TestCase):
 
 
 class CoverageNoticeTests(unittest.TestCase):
-    """Coverage caveats must reach the user exactly once, streaming or not.
+    """The coverage caveat must reach the user exactly once.
 
-    The prefix carries notices such as "only part of this file was shown".
-    Driving this through `answer()` rather than the helper is deliberate: the
-    caller streams the prefix before the ordinary attempt, so a helper-level
-    test cannot see a duplicate and would pass whether or not one occurs.
+    The fixture builds a genuine partial-coverage `read` record, so
+    `response_prefix` is really non-empty: with an empty prefix the guard under
+    test never executes and the assertions measure the answer instead of the
+    caveat, which is how an earlier version of this test passed while the
+    prefix was being emitted twice.
     """
+
+    def _partial_read_store(self, tmp):
+        body = "alpha\nbeta\ngamma\n"
+        digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        raw = (
+            f"{FILE_DISPLAY_MARKER}\n"
+            "path: /workspace/a.txt\n"
+            f"bytes: {len(body)}\n"
+            "lines: 3\n"
+            f"sha256: {digest}\n"
+            "coverage: partial\n"
+            "line_range: 1-2\n"
+            "content:\n"
+            "alpha\nbeta\n"
+        )
+        store = EvidenceStore(Path(tmp) / "evidence")
+        store.add(
+            "read_file",
+            raw,
+            metadata={
+                "tool_call_id": "call-1",
+                "user_turn_id": "turn-1",
+                "produced_by_phase": "tool_call",
+            },
+        )
+        return store
 
     def _saturated_answer(self, *, streaming: bool):
         with tempfile.TemporaryDirectory() as tmp:
-            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
+            store = self._partial_read_store(tmp)
             backend = RecordingBackend(
                 context_tokens=1000, tokens_for={"": 5000, "Verified evidence": 300}
             )
             messages = [
-                {"role": "user", "content": "analyse"},
+                {"role": "user", "content": "show me the file"},
                 {
                     "role": "assistant",
                     "content": "",
@@ -628,18 +656,17 @@ class CoverageNoticeTests(unittest.TestCase):
                         {
                             "id": "call-1",
                             "type": "function",
-                            "function": {
-                                "name": "exec_shell_full_command",
-                                "arguments": "{}",
-                            },
+                            "function": {"name": "read_file", "arguments": "{}"},
                         }
                     ],
                 },
-                {"role": "tool", "tool_call_id": "call-1", "content": "output"},
+                {"role": "tool", "tool_call_id": "call-1", "content": "read"},
             ]
             env, runtime = _environment(
                 backend, store, messages=messages, context_tokens=1000
             )
+            prefix = env._file_display_prefix()
+            self.assertTrue(prefix, "fixture no longer produces a coverage notice")
             streamed: list[str] = []
             out = env.answer(
                 temperature=0.0,
@@ -652,48 +679,19 @@ class CoverageNoticeTests(unittest.TestCase):
                 use_tool_prompt=False,
                 workdir=None,
             )
-            return out.result.content, "".join(streamed), runtime.messages
+            return prefix, out.result.content, "".join(streamed), runtime.messages
 
-    def test_prefix_is_not_duplicated_when_streaming(self) -> None:
-        content, streamed, messages = self._saturated_answer(streaming=True)
-        # There is no display prefix in this fixture, so the assertion that
-        # matters is that nothing is emitted twice.
-        self.assertEqual(streamed.count("FINAL"), 1, "answer streamed twice")
-        self.assertIn("FINAL", content)
-        self.assertIn("FINAL", str(messages[-1]["content"]))
+    def test_notice_is_streamed_exactly_once(self) -> None:
+        prefix, content, streamed, messages = self._saturated_answer(streaming=True)
+        self.assertEqual(streamed.count(prefix), 1, "coverage notice was duplicated")
+        self.assertEqual(content.count(prefix), 1)
+        self.assertEqual(str(messages[-1]["content"]).count(prefix), 1)
 
-    def test_answer_reaches_history_without_streaming(self) -> None:
-        content, _streamed, messages = self._saturated_answer(streaming=False)
-        self.assertIn("FINAL", content)
-        self.assertIn("FINAL", str(messages[-1]["content"]))
-
-    def test_prefix_is_prepended_to_content_by_the_helper(self) -> None:
-        """The helper still owns prepending, which carries it into history."""
-        with tempfile.TemporaryDirectory() as tmp:
-            store, _ids = _store_with(tmp, ["payload " + "p" * 200])
-            backend = RecordingBackend(
-                context_tokens=1000,
-                tokens_for={"saturated": 990, "Verified evidence": 300},
-            )
-            env, runtime = _environment(
-                backend,
-                store,
-                messages=[{"role": "user", "content": "analyse"}],
-                context_tokens=1000,
-            )
-            out = env._grounded_finalization(
-                temperature=0.0,
-                on_final_delta=None,
-                on_progress=None,
-                on_model_step=None,
-                on_phase_start=None,
-                loop=1,
-                response_prefix="NOTE: partial coverage.\n",
-            )
-            self.assertIsNotNone(out)
-            assert out is not None
-            self.assertEqual(out.result.content.count("NOTE: partial coverage."), 1)
-            self.assertIn("NOTE: partial coverage.", str(runtime.messages[-1]["content"]))
+    def test_notice_reaches_content_without_streaming(self) -> None:
+        prefix, content, streamed, messages = self._saturated_answer(streaming=False)
+        self.assertEqual(streamed, "")
+        self.assertEqual(content.count(prefix), 1, "coverage notice lost")
+        self.assertEqual(str(messages[-1]["content"]).count(prefix), 1)
 
 
 class ExactAccountingPreconditionTests(unittest.TestCase):


### PR DESCRIPTION
An investigation and the answer it produces have different needs. The investigation accumulates tool output until its context is full; the answer needs only the durable evidence that work produced. When the two share a session, a long enough investigation leaves no room to reply, and the user gets nothing despite the evidence having been gathered successfully.

This wires the merged finalization library (#211) into the live completion path as a narrow rescue.

## Behaviour

A healthy turn is untouched. It takes the ordinary final path and keeps everything that comes with it — retry, repair, compact retry, the non-empty fallback and streaming buffering.

Only when that window is refused admission, which happens before anything is generated rather than after a decode failure, is the answer rebuilt instead: evidence is re-attested through the `EvidenceStore`, deduplicated by exact content identity, framed so evidence cannot forge a record boundary, and admitted by exact token count. Generation then happens in a fresh session with no tools available, so it can neither reopen the investigation nor be cut short by the context the investigation spent.

There is one entry point. Pure chat and full-document never reach it, and a web-final turn keeps its curated framing because a window it can still complete never gets rescued.

## Limits, stated deliberately

The rescue needs exact token accounting: a known context size and a backend that can count a rendered prompt. Both hold on the orbit-native path; neither holds on a plain llama.cpp server, where admission is skipped upstream and a saturated turn fails at decode as it did before. Catching that failure would not help — without an exact count there is no way to promise the bundle fits either — so the precondition is documented and pinned by tests rather than papered over.

## Tests

30 focused tests covering reachability through the real `answer()` path, the evidence trust chain, session-reset shapes, trigger narrowness, admission, and coverage notices. Full suite 2109 passed.

The wiring was reviewed independently seven times. Six rounds returned FAIL on genuine defects — the trigger originally fired on context pressure rather than on the ordinary path being unavailable, which routed every evidence-backed turn through a second thinner completion controller; the session reset never executed on a server-backed run; and several tests could not fail when the behaviour they named was broken. Each is fixed and mutation-verified.