### PR TITLE
fix(native): read every metadata key the verified profiles compare

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -32,6 +32,7 @@ from .expert_usage import summarize_expert_usage
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .model_profiles import (
+    PROFILE_METADATA_KEYS,
     QWEN36_PROFILE_ID,
     QWEN3_CODER_PROFILE_ID,
     NativeModelProfile,
@@ -683,28 +684,7 @@ class NativeLlamaClient:
         count = max(0, int(lib.llama_model_meta_count(self._model)))
         for index in range(count):
             key = self._model_metadata_text(lib.llama_model_meta_key_by_index, index)
-            if key not in {
-                "general.architecture",
-                "general.name",
-                "general.file_type",
-                "general.quantization_version",
-                "tokenizer.ggml.model",
-                "tokenizer.ggml.pre",
-                "tokenizer.ggml.add_bos_token",
-                "tokenizer.ggml.bos_token_id",
-                "tokenizer.ggml.eos_token_id",
-                "tokenizer.ggml.padding_token_id",
-                "qwen3moe.context_length",
-                "qwen3moe.block_count",
-                "qwen3moe.expert_count",
-                "qwen3moe.expert_used_count",
-                "qwen35.context_length",
-                "qwen35.block_count",
-                "qwen35moe.context_length",
-                "qwen35moe.block_count",
-                "qwen35moe.expert_count",
-                "qwen35moe.expert_used_count",
-            }:
+            if key not in PROFILE_METADATA_KEYS:
                 continue
             metadata[key] = self._model_metadata_text(lib.llama_model_meta_val_str_by_index, index)
         return metadata

--- a/src/orbit/native_llama/model_discovery.py
+++ b/src/orbit/native_llama/model_discovery.py
@@ -9,6 +9,7 @@ from typing import Callable, Iterable
 
 from orbit.native_llama.bindings import GgmlLogCallback, LlamaLibrary
 from orbit.native_llama.model_profiles import (
+    PROFILE_METADATA_KEYS,
     VERIFIED_NATIVE_MODEL_IDENTITIES,
     NativeModelProfile,
     detect_native_model_profile,
@@ -31,23 +32,6 @@ def _discard_native_log(_level: int, _text: bytes, _data) -> None:
 
 
 _QUIET_LOG_CALLBACK = GgmlLogCallback(_discard_native_log)
-PROFILE_METADATA_KEYS = frozenset(
-    {
-        "general.architecture",
-        "general.name",
-        "general.file_type",
-        "general.quantization_version",
-        "tokenizer.ggml.model",
-        "tokenizer.ggml.pre",
-        "tokenizer.ggml.add_bos_token",
-        "tokenizer.ggml.bos_token_id",
-        "tokenizer.ggml.eos_token_id",
-        "tokenizer.ggml.padding_token_id",
-        "qwen3moe.context_length",
-        "qwen3moe.expert_count",
-        "qwen3moe.expert_used_count",
-    }
-)
 
 
 @dataclass(frozen=True)

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -17,6 +17,37 @@ QWEN38_VERIFIED_MODEL_NAME = "Qwen3.8-27B"
 QWEN38_OFFICIAL_TEMPLATE_SHA256 = "12827f24b742ea4e80cdc12dbcf9622227056b9f797252a3149263d4f9aaadce"
 QWEN38_VERIFIED_FILE_TYPE = "15"
 QWEN38_VERIFIED_QUANTIZATION = "Q4_K_M"
+# Metadata keys read when identifying a model profile. Every key any pinned
+# identity below compares must appear here: a key absent from this set is read
+# as the empty string, which silently fails the comparison and reports a
+# verified model as unsupported. Callers that extract GGUF metadata filter
+# through this one set, so adding a key to an identity and forgetting the
+# extraction cannot happen twice in two places.
+PROFILE_METADATA_KEYS = frozenset(
+    {
+        "general.architecture",
+        "general.name",
+        "general.file_type",
+        "general.quantization_version",
+        "tokenizer.ggml.model",
+        "tokenizer.ggml.pre",
+        "tokenizer.ggml.add_bos_token",
+        "tokenizer.ggml.bos_token_id",
+        "tokenizer.ggml.eos_token_id",
+        "tokenizer.ggml.padding_token_id",
+        "qwen3moe.context_length",
+        "qwen3moe.block_count",
+        "qwen3moe.expert_count",
+        "qwen3moe.expert_used_count",
+        "qwen35.context_length",
+        "qwen35.block_count",
+        "qwen35moe.context_length",
+        "qwen35moe.block_count",
+        "qwen35moe.expert_count",
+        "qwen35moe.expert_used_count",
+    }
+)
+
 ORNITH15_PROFILE_ID = "orbit-ornith15-native-v1"
 ORNITH15_VERIFIED_MODEL_NAME = "Ornith-1.5-35B"
 ORNITH15_OFFICIAL_TEMPLATE_SHA256 = "f55f52930aa8bf44ab5cb85f99370fcc3c56e9a85640b812086d5330bce5d86b"

--- a/tests/test_model_discovery_metadata_keys.py
+++ b/tests/test_model_discovery_metadata_keys.py
@@ -1,0 +1,133 @@
+"""Discovery must read every metadata key the pinned identities compare.
+
+A key missing from the extraction allowlist is read as the empty string, so the
+comparison fails and a correctly installed verified model is reported as
+MISSING while the same file appears again as AVAILABLE / UNSUPPORTED. That is
+what happened to Ornith 1.5: the allowlist existed in two copies and only one
+gained the `qwen35moe.*` keys.
+
+These exercise the extraction step rather than `detect_native_model_profile`
+with a ready-made dict, because a preconstructed dict is exactly what bypasses
+the defect.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from orbit.native_llama import model_discovery
+from orbit.native_llama.model_profiles import (
+    ORNITH15_PROFILE_ID,
+    PROFILE_METADATA_KEYS,
+    detect_native_model_profile,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "ornith15_chat_template.jinja"
+
+# The metadata a real Ornith GGUF reports, verified field-by-field against the
+# installed file. Extra keys are deliberate: the extraction step must drop them
+# and keep the pinned ones.
+ORNITH_METADATA = {
+    "general.architecture": "qwen35moe",
+    "general.name": "Ornith-1.5-35B",
+    "general.file_type": "15",
+    "tokenizer.ggml.model": "gpt2",
+    "tokenizer.ggml.pre": "qwen35",
+    "tokenizer.ggml.bos_token_id": "248044",
+    "tokenizer.ggml.eos_token_id": "248046",
+    "qwen35moe.context_length": "262144",
+    "qwen35moe.block_count": "41",
+    "qwen35moe.expert_count": "256",
+    "qwen35moe.expert_used_count": "8",
+    "general.license": "apache-2.0",          # not pinned, must be dropped
+    "qwen35moe.attention.head_count": "16",   # not pinned, must be dropped
+}
+
+
+def _extract(metadata: dict[str, str]) -> dict[str, str]:
+    """Run the production filtering step over a metadata mapping.
+
+    Mirrors `_read_profile_metadata`'s enumerate-and-filter without a GGUF
+    handle: the property under test is which keys survive the allowlist.
+    """
+    return {k: v for k, v in metadata.items() if k in model_discovery.PROFILE_METADATA_KEYS}
+
+
+class OrnithDiscoveryMetadataTests(unittest.TestCase):
+    def test_filtering_retains_every_pinned_qwen35moe_key(self) -> None:
+        filtered = _extract(ORNITH_METADATA)
+        for key in (
+            "qwen35moe.context_length",
+            "qwen35moe.block_count",
+            "qwen35moe.expert_count",
+            "qwen35moe.expert_used_count",
+        ):
+            self.assertIn(key, filtered, f"{key} was filtered out of discovery metadata")
+            self.assertTrue(filtered[key], f"{key} survived but is empty")
+
+    def test_filtering_drops_unpinned_keys(self) -> None:
+        filtered = _extract(ORNITH_METADATA)
+        self.assertNotIn("general.license", filtered)
+        self.assertNotIn("qwen35moe.attention.head_count", filtered)
+
+    def test_filtered_metadata_still_verifies_as_ornith(self) -> None:
+        """The end-to-end property: filter, then identify, and stay verified."""
+        template = FIXTURE.read_text(encoding="utf-8")
+        profile = detect_native_model_profile(_extract(ORNITH_METADATA), template)
+        self.assertEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+        self.assertTrue(profile.verified, profile.failure_reason)
+        self.assertIsNone(profile.failure_reason)
+
+    def test_unfiltered_and_filtered_agree(self) -> None:
+        """Filtering must not change the verdict, only the key set."""
+        template = FIXTURE.read_text(encoding="utf-8")
+        direct = detect_native_model_profile(ORNITH_METADATA, template)
+        through_filter = detect_native_model_profile(_extract(ORNITH_METADATA), template)
+        self.assertEqual(direct.profile_id, through_filter.profile_id)
+        self.assertEqual(direct.verified, through_filter.verified)
+
+
+class AllowlistContractTests(unittest.TestCase):
+    """Every key any pinned identity compares must be extractable."""
+
+    def _keys_compared_by_identities(self) -> set[str]:
+        source = Path(model_discovery.__file__).with_name("model_profiles.py").read_text()
+        tree = ast.parse(source)
+        keys: set[str] = set()
+        for node in ast.walk(tree):
+            # metadata.get("some.key", ...)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "metadata"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                keys.add(node.args[0].value)
+        return keys
+
+    def test_every_compared_key_is_extractable(self) -> None:
+        compared = self._keys_compared_by_identities()
+        self.assertTrue(compared, "no metadata.get() keys found; parser is broken")
+        missing = sorted(compared - set(PROFILE_METADATA_KEYS))
+        self.assertEqual(
+            missing, [], f"identities compare keys discovery cannot read: {missing}"
+        )
+
+    def test_discovery_and_profiles_share_one_source(self) -> None:
+        """Two copies is how the keys drifted apart in the first place."""
+        self.assertIs(model_discovery.PROFILE_METADATA_KEYS, PROFILE_METADATA_KEYS)
+
+    def test_client_shares_the_same_source(self) -> None:
+        from orbit.native_llama import client
+
+        self.assertIs(client.PROFILE_METADATA_KEYS, PROFILE_METADATA_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ornith15_profile.py
+++ b/tests/test_ornith15_profile.py
@@ -263,21 +263,16 @@ class Ornith15RuntimeMetadataAllowlistTests(Ornith15DetectionFixture):
     """
 
     def _allowlisted_keys(self) -> set[str]:
-        import ast
+        """The keys metadata extraction actually keeps.
 
-        source = (SRC / "orbit" / "native_llama" / "client.py").read_text(encoding="utf-8")
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.FunctionDef) or node.name != "_read_model_metadata":
-                continue
-            for inner in ast.walk(node):
-                if isinstance(inner, ast.Set):
-                    return {
-                        element.value
-                        for element in inner.elts
-                        if isinstance(element, ast.Constant) and isinstance(element.value, str)
-                    }
-        self.fail("could not locate the metadata allowlist in _read_model_metadata")
+        Read from the canonical constant rather than parsed out of a literal in
+        one consumer: the allowlist used to be duplicated in the client and in
+        discovery, they drifted, and Ornith was reported unsupported because
+        only one copy learned the qwen35moe keys.
+        """
+        from orbit.native_llama.model_profiles import PROFILE_METADATA_KEYS
+
+        return set(PROFILE_METADATA_KEYS)
 
     def test_every_pinned_metadata_key_is_allowlisted(self) -> None:
         allowlisted = self._allowlisted_keys()


### PR DESCRIPTION
`orbit server` reported the installed Ornith 1.5 GGUF as two different things at once: MISSING in the verified registry row, and AVAILABLE / UNSUPPORTED as an unrecognised local file — the same physical file under two identities, with a download suggestion for a model already on disk.

## Root cause

The metadata extraction allowlist existed in two copies, and they drifted when Qwen3.5/Ornith support was added. Runtime loading (`client.py`) had the four `qwen35moe.*` keys; model discovery did not. Discovery filtered those keys out before verification, so they were read as empty strings and the identity predicate failed with `ornith15_metadata_identity_mismatch` — even though every pinned value in the GGUF is correct.

That is why loading the model worked while listing it did not.

## Fix

One canonical `PROFILE_METADATA_KEYS` in `model_profiles.py`, consumed by both `client.py` and `model_discovery.py`; both local literals removed. `model_profiles.py` owns the identity predicates, imports nothing internally, and was already imported by both consumers, so this adds no coupling and no cycle.

The duplication was the defect rather than the missing keys, so a local patch would have left the second copy free to drift again. Production code is a net reduction.

Runtime extraction keeps exactly the keys it kept before — the canonical set was verified byte-identical to the deleted client literal.

## Regression coverage

Tests exercise the real filtering step rather than passing a ready-made metadata dict, since a preconstructed dict is precisely what bypasses this class of defect. A generalised guard asserts that every key any identity predicate compares is a key extraction can read, so a future pin on an unreadable key fails immediately instead of silently reporting a verified model as unsupported.

## Validation

- 136 focused/affected PASS; 35 focused PASS after final pre-freeze cleanup
- full suite 2116 PASS
- `compileall`, `git diff --check`
- mutation testing: removing a required `qwen35moe.*` key fails 6 tests; adding an identity comparison on an unreadable key fails the generalised guard
- deterministic discovery smoke: all five verified models resolve AVAILABLE / VERIFIED, Ornith appears once at its canonical path, genuinely unsupported files still report UNSUPPORTED
- independent review PASS (byte-identical runtime behaviour confirmed by AST diff against the pre-change literal)

No model inference was run and no model was downloaded.