### PR TITLE
fix(runtime): keep the user turn ahead of the assistant in rebuilt windows

### DIFF
--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -1424,11 +1424,12 @@ class ChatRuntime:
             return self._with_final_evidence_context(with_chat_system_prompt(self.messages))
         messages: list[Message] = []
         assistant = _latest_operational_assistant_message(self.messages)
-        if assistant is not None:
-            messages.append(assistant)
         latest_user = _latest_user_message(self.messages)
+        # User before assistant: see _chat_final_retry_messages.
         if latest_user is not None:
             messages.append(latest_user)
+        if assistant is not None:
+            messages.append(assistant)
         visible_messages = self._covered_visible_chat_messages()
         if visible_messages is not None:
             candidate = with_visible_chat_system_prompt(visible_messages)
@@ -1543,10 +1544,13 @@ class ChatRuntime:
             assistant = _latest_operational_assistant_message(self.messages)
         else:
             assistant = _latest_short_assistant_message(self.messages)
-        if assistant is not None:
-            messages.append(assistant)
+        # The user turn comes first: a rebuilt window that opens with the
+        # assistant is not a conversation the admission validator can parse,
+        # and the turn fails before inference with no answer at all.
         if latest_user is not None:
             messages.append(latest_user)
+        if assistant is not None:
+            messages.append(assistant)
         return self._with_chat_final_retry_evidence_context(with_chat_system_prompt(messages), consumer_phase="chat_final_retry")
 
     def chat_final_completion_repair_messages(self, repair_instruction: str) -> list[Message] | None:
@@ -1557,9 +1561,10 @@ class ChatRuntime:
             return None
         window: list[Message] = []
         assistant = _latest_assistant_excerpt_message(self.messages)
+        # User before assistant: see _chat_final_retry_messages.
+        window.append(latest_user)
         if assistant is not None:
             window.append(assistant)
-        window.append(latest_user)
         messages = with_chat_system_prompt(window)
         context = build_compact_final_evidence_context(self.evidence_store)
         if context:

--- a/tests/test_chat_final_message_order.py
+++ b/tests/test_chat_final_message_order.py
@@ -1,0 +1,172 @@
+"""Rebuilt final/retry windows must remain parseable conversations.
+
+A compacted window that opens with the assistant is not a conversation the
+admission validator can parse: the turn fails before inference and the user
+gets nothing. This was reached on the second turn of an ordinary chat, where
+the retry rebuild placed the retained assistant excerpt ahead of the user
+message it was answering.
+
+These drive the real builders and validate their output with the production
+parser rather than comparing against a hand-written list, so the tests fail for
+the same reason the runtime did.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.backend.base import TokenCount
+from orbit.runtime.chat import ChatRuntime
+from orbit.runtime.context_manager import _parse_turns
+from orbit.runtime.evidence import EvidenceStore
+
+
+class _CountingBackend:
+    context_tokens = 16384
+    thinking = False
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        digest = hashlib.sha256(b"stable").hexdigest()
+        return TokenCount(
+            tokens=50, context_tokens=16384, rendered_hash=digest, token_hash=digest
+        )
+
+
+TWO_TURN_HISTORY = [
+    {"role": "system", "content": "You are Orbit."},
+    {"role": "user", "content": "hi, how are you?"},
+    {"role": "assistant", "content": "Hi! I'm doing well, thanks for asking!"},
+    {"role": "user", "content": "who designed you?"},
+]
+
+
+def _runtime(store=None, history=None):
+    return ChatRuntime(
+        backend=_CountingBackend(),
+        system_prompt="You are Orbit.",
+        messages=[dict(m) for m in (history or TWO_TURN_HISTORY)],
+        context_tokens=16384,
+        evidence_store=store,
+    )
+
+
+def _seeded_store(tmp: str) -> EvidenceStore:
+    store = EvidenceStore(Path(tmp) / "evidence")
+    store.add(
+        "exec_shell_full_command",
+        "recorded output " + "p" * 120,
+        metadata={
+            "tool_call_id": "call-1",
+            "user_turn_id": "turn-1",
+            "produced_by_phase": "tool_call",
+        },
+    )
+    return store
+
+
+class RebuiltWindowsParseTests(unittest.TestCase):
+    """Every rebuilt window must survive the admission parser."""
+
+    def _assert_parses(self, messages, label: str) -> None:
+        try:
+            _parse_turns(messages)
+        except ValueError as exc:
+            roles = [m.get("role") for m in messages]
+            self.fail(f"{label} produced an unparseable window {roles}: {exc}")
+
+    def test_retry_window_parses_without_evidence(self) -> None:
+        built = _runtime()._chat_final_retry_messages()
+        self._assert_parses(built, "_chat_final_retry_messages")
+
+    def test_retry_window_parses_with_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_retry_messages()
+            self._assert_parses(built, "_chat_final_retry_messages")
+
+    def test_final_window_parses_with_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_messages()
+            self._assert_parses(built, "_chat_final_messages")
+
+    def test_completion_repair_window_parses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp)).chat_final_completion_repair_messages(
+                "Answer the user directly now."
+            )
+            self.assertIsNotNone(built, "repair window unexpectedly unavailable")
+            assert built is not None
+            self._assert_parses(built, "chat_final_completion_repair_messages")
+
+
+class OrderingTests(unittest.TestCase):
+    """The user turn must precede the assistant reply it prompted."""
+
+    def _first_roles(self, messages):
+        return [m.get("role") for m in messages if m.get("role") in {"user", "assistant"}]
+
+    def test_retry_puts_user_before_assistant(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_retry_messages()
+            roles = self._first_roles(built)
+            self.assertEqual(roles[:2], ["user", "assistant"], f"got {roles}")
+
+    def test_final_puts_user_before_assistant(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_messages()
+            roles = self._first_roles(built)
+            self.assertEqual(roles[:2], ["user", "assistant"], f"got {roles}")
+
+    def test_repair_puts_user_before_assistant(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp)).chat_final_completion_repair_messages(
+                "Answer now."
+            )
+            assert built is not None
+            roles = self._first_roles(built)
+            self.assertEqual(roles[:2], ["user", "assistant"], f"got {roles}")
+
+
+class SelectionUnchangedTests(unittest.TestCase):
+    """Reordering must not change which messages are selected or their content."""
+
+    def test_same_messages_are_retained(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_retry_messages()
+            contents = {str(m.get("content")) for m in built}
+            self.assertIn("who designed you?", contents, "latest user turn dropped")
+            self.assertTrue(
+                any("doing well" in c for c in contents), "assistant reply dropped"
+            )
+
+    def test_no_message_is_duplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp))._chat_final_retry_messages()
+            user_turns = [m for m in built if m.get("role") == "user"]
+            self.assertEqual(len(user_turns), 1, "user turn duplicated")
+
+    def test_input_history_is_not_mutated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = _runtime(_seeded_store(tmp))
+            before = copy.deepcopy(runtime.messages)
+            runtime._chat_final_retry_messages()
+            runtime._chat_final_messages()
+            runtime.chat_final_completion_repair_messages("Answer now.")
+            self.assertEqual(runtime.messages, before, "builder mutated history")
+
+    def test_first_turn_history_still_parses(self) -> None:
+        """A single-turn history must remain valid after the reorder."""
+        history = [
+            {"role": "system", "content": "You are Orbit."},
+            {"role": "user", "content": "hi, how are you?"},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            built = _runtime(_seeded_store(tmp), history)._chat_final_retry_messages()
+            _parse_turns(built)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The second turn of an ordinary chat failed before inference with `invalid-message-structure:history-does-not-start-with-user`. Turn one answered normally and left a valid session on disk, so nothing about the persisted state looked wrong.

## Root cause

When a final answer needs a retry, a repair, or an evidence-backed rebuild, the window is reconstructed from the latest user turn plus a retained excerpt of the previous assistant reply. Three builders appended those two in the wrong order, so the rebuilt window opened with the assistant:

- `_chat_final_retry_messages`
- the evidence branch of `_chat_final_messages`
- `chat_final_completion_repair_messages`

Admission parses a window as a conversation, and a conversation cannot begin with a reply to nothing. It refused the turn and the user got an error instead of an answer. Turn one never reaches a retry, which is why the defect only surfaced from the second turn onward.

Independent review confirmed the enumeration is complete: every other window builder either appends only the user turn or is structurally gated against this shape. It also found that the old order violated the `qwen-leading-system-only` contract — run through `serialize_profile_messages`, it produced `system,assistant,user,user`, which does not parse. The fixed order is the one that contract requires.

## Fix

Append the user turn first in each of the three builders. Nothing else changes: the same messages are selected by the same conditions, with identical content and count, so this only restores the order a conversation is required to have. Routing, retry policy, evidence selection, session persistence and admission semantics are untouched.

## Validation

- 11 deterministic tests driving the real builders and validating with the real parser, not hand-written expected lists
- mutation testing: reverting each builder individually fails the corresponding test
- 316 affected tests, full suite 2127 passed
- independent review PASS, zero BLOCKER/MAJOR
- real-user 3-turn Ornith smoke: all turns `finish_reason=stop`, no admission error, persisted history valid