### PR TITLE
fix(cli): keep measured token usage when an attempt fails and is retried

### DIFF
--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -19,6 +19,11 @@ class TurnTokenUsage:
     cached_tokens: int | None
     completion_tokens: int | None
     failed_calls: int = 0
+    # True when an attempt was made whose token metrics never reached us, so
+    # the sums below are real but not the whole story. Kept separate from the
+    # counters themselves: a number we do know stays knowable even when the
+    # total it belongs to is incomplete.
+    usage_incomplete: bool = False
 
 
 @dataclass
@@ -29,6 +34,7 @@ class TokenUsageAccumulator:
     evaluated_tokens: int | None = 0
     cached_tokens: int | None = 0
     completion_tokens: int | None = 0
+    usage_incomplete: bool = False
 
     def add(self, step: ModelStepMetrics) -> None:
         self._add_metrics(
@@ -45,12 +51,18 @@ class TokenUsageAccumulator:
         )
 
     def add_failed_call(self) -> None:
+        """Record an attempt that raised, without discarding what is known.
+
+        The attempt reached the backend, so it counts; but its token metrics
+        never arrived, so the running totals are now short by an unknown
+        amount. Zeroing them would invent a number, and clearing them threw
+        away figures that had already been measured -- a recovered failure
+        used to erase an entire session's accounting. The totals are kept and
+        marked incomplete instead, which is the only honest description.
+        """
         self.model_calls += 1
         self.failed_calls += 1
-        self.prompt_tokens = None
-        self.evaluated_tokens = None
-        self.cached_tokens = None
-        self.completion_tokens = None
+        self.usage_incomplete = True
 
     def _add_metrics(
         self,
@@ -83,6 +95,7 @@ class TokenUsageAccumulator:
             cached_tokens=self.cached_tokens,
             completion_tokens=self.completion_tokens,
             failed_calls=self.failed_calls,
+            usage_incomplete=self.usage_incomplete,
         )
 
 
@@ -164,7 +177,9 @@ def format_turn_status(
             context_parts.append(f"pressure {pressure}")
         lines.extend(_pack_metric_parts(context_parts, columns=columns, prefix="context: "))
     if usage is not None and usage.failed_calls:
-        lines.append(f"warning: {usage.failed_calls} failed model call(s); token usage unavailable")
+        lines.append(
+            f"warning: {usage.failed_calls} failed attempt(s); token totals exclude them"
+        )
     return "\n".join(lines)
 
 
@@ -238,6 +253,9 @@ def _token_metric_lines(usage: TurnTokenUsage | None, *, columns: int) -> list[s
     ):
         if value is not None:
             parts.append(f"{value:,} {label}")
+    if parts and usage.usage_incomplete:
+        # The figures are real; they just are not the whole turn.
+        parts.append("(partial)")
     return _pack_metric_parts(parts or ["unavailable"], columns=columns, prefix="tokens: ")
 
 
@@ -267,6 +285,8 @@ def _token_usage_parts(usage: TurnTokenUsage, *, prefix: str) -> list[str]:
         parts.append(f"{prefix}: output {usage.completion_tokens}")
     else:
         parts.append(f"{prefix}: unavailable")
+    if usage.usage_incomplete:
+        parts.append("totals: partial")
     if usage.evaluated_tokens is not None and usage.completion_tokens is not None:
         work = usage.evaluated_tokens + usage.completion_tokens
         parts.append(f"work: {work} ({usage.evaluated_tokens} prefill + {usage.completion_tokens} decode)")
@@ -275,7 +295,7 @@ def _token_usage_parts(usage: TurnTokenUsage, *, prefix: str) -> list[str]:
         parts.append(f"cache: {usage.cached_tokens} ({ratio:.0f}%)")
     parts.append(f"calls: {usage.model_calls}")
     if usage.failed_calls:
-        parts.append(f"failed: {usage.failed_calls} (token usage unavailable)")
+        parts.append(f"failed attempts: {usage.failed_calls}")
     return parts
 
 

--- a/tests/test_recovered_failure_telemetry.py
+++ b/tests/test_recovered_failure_telemetry.py
@@ -1,0 +1,153 @@
+"""Telemetry must survive a backend attempt that failed and was recovered.
+
+A malformed tool-call JSON makes the backend raise after inference has already
+run. The runtime retries and the user gets a correct answer, but the accounting
+used to treat that attempt as a reason to discard every figure it had: one
+recovered failure erased the whole session's token usage, including tokens that
+had been measured correctly before it.
+
+The attempt is still counted -- it really happened. What changes is that a
+number already known stays known, and the total says plainly that it is
+missing something rather than pretending to be exact.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from orbit.backend.base import ChatResult
+from orbit.terminal.status import TokenUsageAccumulator, TurnTokenUsage
+
+
+def _result(prompt: int, completion: int, cached: int = 0) -> ChatResult:
+    return ChatResult(
+        content="ok",
+        model="m",
+        finish_reason="stop",
+        tool_calls=[],
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cached_tokens=cached,
+        prompt_tokens_per_second=None,
+        generation_tokens_per_second=None,
+    )
+
+
+class CounterSemanticsTests(unittest.TestCase):
+    def test_success_only(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(881, 42))
+        self.assertEqual(usage.prompt_tokens, 881)
+        self.assertEqual(usage.completion_tokens, 42)
+        self.assertEqual(usage.model_calls, 1)
+        self.assertEqual(usage.failed_calls, 0)
+        self.assertFalse(usage.usage_incomplete)
+
+    def test_failure_before_any_metrics(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add_failed_call()
+        self.assertEqual(usage.model_calls, 1)
+        self.assertEqual(usage.failed_calls, 1)
+        self.assertTrue(usage.usage_incomplete)
+        # Nothing was measured, so nothing is claimed -- but zero is a real
+        # answer here, not a fabricated one.
+        self.assertEqual(usage.prompt_tokens, 0)
+
+    def test_known_metrics_survive_a_later_failure(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(881, 42))
+        usage.add_failed_call()
+        self.assertEqual(usage.prompt_tokens, 881, "measured tokens were discarded")
+        self.assertEqual(usage.completion_tokens, 42)
+        self.assertTrue(usage.usage_incomplete)
+
+    def test_retry_after_failure_keeps_accumulating(self) -> None:
+        """The real Ornith path: success, recovered failure, success."""
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(881, 42))
+        usage.add_failed_call()
+        usage.add_result(_result(900, 50))
+        self.assertEqual(usage.prompt_tokens, 1781)
+        self.assertEqual(usage.completion_tokens, 92)
+        self.assertEqual(usage.model_calls, 3)
+        self.assertEqual(usage.failed_calls, 1)
+        self.assertTrue(usage.usage_incomplete)
+
+    def test_multiple_failures_then_success(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(100, 10))
+        usage.add_failed_call()
+        usage.add_failed_call()
+        usage.add_result(_result(200, 20))
+        self.assertEqual(usage.prompt_tokens, 300)
+        self.assertEqual(usage.model_calls, 4)
+        self.assertEqual(usage.failed_calls, 2)
+
+    def test_failure_counted_exactly_once(self) -> None:
+        usage = TokenUsageAccumulator()
+        before_calls, before_failed = usage.model_calls, usage.failed_calls
+        usage.add_failed_call()
+        self.assertEqual(usage.model_calls, before_calls + 1)
+        self.assertEqual(usage.failed_calls, before_failed + 1)
+
+    def test_cache_metrics_are_not_poisoned_by_a_failure(self) -> None:
+        """Unknownness must stay with the unknown quantity."""
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(1000, 10, cached=400))
+        usage.add_failed_call()
+        self.assertEqual(usage.cached_tokens, 400)
+        self.assertEqual(usage.evaluated_tokens, 600)
+
+    def test_snapshot_carries_completeness(self) -> None:
+        usage = TokenUsageAccumulator()
+        usage.add_result(_result(881, 42))
+        usage.add_failed_call()
+        snap = usage.snapshot()
+        self.assertIsInstance(snap, TurnTokenUsage)
+        self.assertEqual(snap.prompt_tokens, 881)
+        self.assertEqual(snap.failed_calls, 1)
+        self.assertTrue(snap.usage_incomplete)
+
+
+class RenderingTests(unittest.TestCase):
+    """Incomplete totals must not be presented as exact."""
+
+    def _turn_line(self, usage: TurnTokenUsage) -> str:
+        from orbit.terminal.status import _token_metric_lines
+
+        return "\n".join(_token_metric_lines(usage, columns=200))
+
+    def test_partial_total_is_marked(self) -> None:
+        usage = TurnTokenUsage(
+            model_calls=3, prompt_tokens=1781, evaluated_tokens=1781,
+            cached_tokens=0, completion_tokens=92, failed_calls=1,
+            usage_incomplete=True,
+        )
+        line = self._turn_line(usage)
+        self.assertIn("1,781 in", line, "known figures must still be shown")
+        self.assertIn("(partial)", line, "incomplete total presented as exact")
+
+    def test_complete_total_is_not_marked(self) -> None:
+        usage = TurnTokenUsage(
+            model_calls=1, prompt_tokens=881, evaluated_tokens=881,
+            cached_tokens=0, completion_tokens=42, failed_calls=0,
+        )
+        line = self._turn_line(usage)
+        self.assertIn("881 in", line)
+        self.assertNotIn("(partial)", line)
+
+    def test_session_wording_says_attempts(self) -> None:
+        from orbit.terminal.status import format_session_token_usage
+
+        usage = TurnTokenUsage(
+            model_calls=3, prompt_tokens=1781, evaluated_tokens=1781,
+            cached_tokens=0, completion_tokens=92, failed_calls=2,
+            usage_incomplete=True,
+        )
+        text = format_session_token_usage(usage)
+        self.assertIn("failed attempts: 2", text)
+        self.assertNotIn("token usage unavailable", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -34,16 +34,24 @@ class StatusTests(unittest.TestCase):
             "session tks: 420 total (400 in + 20 out) | work: 400 (380 prefill + 20 decode) | cache: 20 (5%) | calls: 2",
         )
 
-    def test_failed_call_makes_token_total_unavailable_without_hiding_attempt(self) -> None:
+    def test_failed_attempt_is_reported_without_discarding_known_usage(self) -> None:
+        """A failed attempt is counted; measured tokens are still reported.
+
+        This previously asserted the totals became "unavailable". That was the
+        defect: one recovered failure erased usage that had already been
+        measured. The attempt is still surfaced, and the total now says it is
+        partial rather than claiming to know nothing.
+        """
         usage = TokenUsageAccumulator()
         usage.add(ModelStepMetrics(1, "route", "stop", 100, 5, 20, 10.0, 2.0, 0))
         usage.add_failed_call()
 
         rendered = format_session_token_usage(usage.snapshot())
 
-        self.assertIn("session tks: unavailable", rendered)
+        self.assertIn("105 total (100 in + 5 out)", rendered)
         self.assertIn("calls: 2", rendered)
-        self.assertIn("failed: 1 (token usage unavailable)", rendered)
+        self.assertIn("failed attempts: 1", rendered)
+        self.assertIn("totals: partial", rendered)
 
     def test_turn_token_usage_sums_every_model_call_and_real_evaluated_tokens(self) -> None:
         steps = [


### PR DESCRIPTION
Three successful chat turns reported `failed: 2` and `token usage unavailable`. The answers were correct and the session history was valid — only the accounting was wrong.

## Root cause

A backend attempt that raises after inference has already run — a malformed tool call is the common case — is caught by the runtime, retried, and answered correctly. `failed_calls` counting that attempt is **already right**: a real backend call really did fail.

The defect was what came next. `add_failed_call()` set every token counter to `None`, and because later results are summed onto the cleared value, the figures never came back. One recovered failure erased an entire session of accounting, including tokens that had been measured correctly before it happened.

## Fix

Measuring something and knowing the total are now separate facts. The counters keep what was actually observed; a new `usage_incomplete` flag records that the total is missing an unknown amount. Successful retries continue accumulating normally.

Nothing is estimated to fill the gap. No token value is fabricated for the failed attempt, because none ever reached the client.

Because a total can now be real but partial, it says so instead of presenting itself as exact: `(partial)` on the turn line, `totals: partial` on the session line. The session line reports `failed attempts: N`, which is also what the counter has always measured — attempts that raised, not turns that failed.

## Deliberately unresolved

The native server discards the real metrics of a completed inference when output parsing later raises (`error_result` hard-codes them to zero). Totals therefore still under-count by one completed inference per recovery. That is a **separate server-side mission**; here it is simply marked partial rather than hidden.

## Validation

- 11 deterministic tests plus the historical PR #162 test, rewritten to pin the surviving figures rather than assert their absence — it fails if the old `None` poisoning returns
- 5/5 mutations caught, each verified on disk
- 87 affected tests, full suite 2127 passed
- independent review PASS, zero BLOCKER/MAJOR, covering `usage_incomplete` propagation, both other `TurnTokenUsage` constructors, aggregation/reset semantics and UI completeness