### PR TITLE
fix(cli): stop counting a deliberate route stop as a failed call

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -7,6 +7,18 @@ from typing import Any, Callable, Protocol
 Message = dict[str, Any]
 
 
+class StreamConsumerAbort(Exception):
+    """A stream consumer stopped its own call on purpose; the backend is fine.
+
+    A delta callback may decide mid-stream that it has seen enough and raise to
+    stop generating early. That exception travels out through the backend call
+    exactly like a transport error, but it means the opposite thing: the
+    request reached the model and the model was answering. Backends recognise
+    this marker so they do not report a healthy call as a failed attempt. The
+    exception still propagates -- only the accounting treats it differently.
+    """
+
+
 @dataclass(frozen=True)
 class ChatResult:
     content: str

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from .base import ChatResult, Message, ModelInfo, StreamProgress, TokenCount
+from .base import ChatResult, Message, ModelInfo, StreamConsumerAbort, StreamProgress, TokenCount
 from .model_names import resolve_model_display_name
 from .payloads import (
     ARTIFACT_CONTENT_PROTOCOL_ID,
@@ -47,12 +47,16 @@ class LlamaServerBackend:
         self._props_discovery_status: str | None = None
         self._result_observer: Callable[[ChatResult], None] | None = None
         self._failure_observer: Callable[[], None] | None = None
+        self._aborted_observer: Callable[[], None] | None = None
 
     def set_result_observer(self, observer: Callable[[ChatResult], None] | None) -> None:
         self._result_observer = observer
 
     def set_failure_observer(self, observer: Callable[[], None] | None) -> None:
         self._failure_observer = observer
+
+    def set_aborted_observer(self, observer: Callable[[], None] | None) -> None:
+        self._aborted_observer = observer
 
     def chat(
         self,
@@ -432,6 +436,15 @@ class LlamaServerBackend:
     def _observe_call(self, call: Callable[[], ChatResult]) -> ChatResult:
         try:
             result = call()
+        except StreamConsumerAbort:
+            # The consumer stopped this stream deliberately, so nothing failed:
+            # report an attempt whose usage never arrived rather than a failure.
+            if self._aborted_observer is not None:
+                try:
+                    self._aborted_observer()
+                except Exception:
+                    pass
+            raise
         except BaseException:
             if self._failure_observer is not None:
                 try:

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -7,7 +7,7 @@ import json
 import re
 
 from orbit.backend import ChatBackend, ChatResult
-from orbit.backend.base import Message, StreamProgress
+from orbit.backend.base import Message, StreamConsumerAbort, StreamProgress
 from orbit.runtime.capabilities import LocalCapabilities, discover_local_capabilities
 from orbit.runtime.client_state import ClientState
 from orbit.runtime.command_evidence import AcquiredEvidence
@@ -1731,7 +1731,7 @@ class _ThoughtOnlyDeltaFilter:
             self._in_thought = True
 
 
-class _RouteNotCommandAbort(Exception):
+class _RouteNotCommandAbort(StreamConsumerAbort):
     def __init__(self, content: str, *, chunks: int) -> None:
         super().__init__("route stream produced non-command prose")
         self.content = content

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -68,6 +68,9 @@ class Repl:
         set_failure_observer = getattr(self.backend, "set_failure_observer", None)
         if callable(set_failure_observer):
             set_failure_observer(self._record_backend_failure)
+        set_aborted_observer = getattr(self.backend, "set_aborted_observer", None)
+        if callable(set_aborted_observer):
+            set_aborted_observer(self._record_backend_abort)
 
     def run(self) -> int:
         if self.history:
@@ -262,6 +265,10 @@ class Repl:
     def _record_backend_failure(self) -> None:
         self.turn_backend_token_usage.add_failed_call()
         self.session_token_usage.add_failed_call()
+
+    def _record_backend_abort(self) -> None:
+        self.turn_backend_token_usage.add_aborted_call()
+        self.session_token_usage.add_aborted_call()
 
     def _turn_token_usage(self) -> TurnTokenUsage | None:
         if self.backend_usage_observer_installed:

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -64,6 +64,19 @@ class TokenUsageAccumulator:
         self.failed_calls += 1
         self.usage_incomplete = True
 
+    def add_aborted_call(self) -> None:
+        """Record an attempt the client stopped on purpose.
+
+        The request reached the model and real work happened, so it counts as
+        a model call, but the usage event only arrives at the end of a stream
+        that was cut short -- so the totals are short by an unknown amount and
+        must say so. What this must not do is claim a failure: nothing went
+        wrong, and reporting one sends a reader looking for a fault that does
+        not exist.
+        """
+        self.model_calls += 1
+        self.usage_incomplete = True
+
     def _add_metrics(
         self,
         *,

--- a/tests/test_route_abort_telemetry.py
+++ b/tests/test_route_abort_telemetry.py
@@ -1,0 +1,187 @@
+"""An intentionally aborted route stream is an attempt, not a failure.
+
+The route phase stops its own stream as soon as the output cannot become a
+tool decision. That early stop travels out of the backend as an exception, so
+it used to be counted as a failed backend call and every ordinary
+conversational turn reported a failure that never happened. These tests pin
+the distinction end to end, through the real backend and runtime, with only
+the HTTP layer scripted.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.backend.llama_server as llama_server
+from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
+from orbit.runtime.chat import ChatRuntime
+from orbit.terminal.status import (
+    TokenUsageAccumulator,
+    format_session_token_usage,
+    format_turn_status,
+)
+
+PROSE_CHUNKS = ["I'm", " doing", " well", ", thanks!"]
+ROUTE_CHUNKS = ['{"command"', ': "pwd"}']
+
+
+class _ScriptedStream:
+    """The native SSE wire format, replayed from a list of text chunks."""
+
+    def __init__(self, chunks: list[str], *, prompt_tokens: int, completion_tokens: int) -> None:
+        self._lines: list[bytes] = []
+        for chunk in chunks:
+            self._lines.append(b"event: delta\n")
+            self._lines.append(b"data: " + json.dumps({"text": chunk}).encode() + b"\n")
+            self._lines.append(b"\n")
+        self._lines.append(b"event: metrics\n")
+        self._lines.append(
+            b"data: "
+            + json.dumps(
+                {"usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens}}
+            ).encode()
+            + b"\n"
+        )
+        self._lines.append(b"\n")
+        self._lines.append(b"event: done\n")
+        self._lines.append(b"data: " + json.dumps({"finish_reason": "stop", "model": "m"}).encode() + b"\n")
+        self._lines.append(b"\n")
+
+    def __enter__(self) -> "_ScriptedStream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def read(self) -> bytes:
+        return b""
+
+
+class RouteAbortTelemetryTest(unittest.TestCase):
+    def _backend(self) -> tuple[LlamaServerBackend, TokenUsageAccumulator]:
+        backend = LlamaServerBackend(base_url="http://127.0.0.1:1", timeout=5)
+        usage = TokenUsageAccumulator()
+        backend.set_result_observer(usage.add_result)
+        backend.set_failure_observer(usage.add_failed_call)
+        backend.set_aborted_observer(usage.add_aborted_call)
+        return backend, usage
+
+    def _run(self, backend: LlamaServerBackend, phases: list[tuple[str, int, str | None]]):
+        runtime = ChatRuntime(backend=backend, system_prompt="sys")
+        return runtime.ask_auto(
+            "hi, how are you?",
+            temperature=0,
+            max_tokens=64,
+            workdir=Path("."),
+            on_final_delta=lambda _text: None,
+            on_progress=lambda _item: None,
+            on_phase_start=lambda ph: phases.append((ph.phase, ph.attempt, ph.reason)),
+            allowed_tool_names=("exec_shell_full_command",),
+        )
+
+    def _patched(self, responses):
+        """Serve each backend call from `responses`, which may raise instead."""
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            index = min(calls["n"], len(responses) - 1)
+            calls["n"] += 1
+            item = responses[index]
+            if isinstance(item, Exception):
+                raise item
+            return item()
+
+        return mock.patch.object(llama_server, "urlopen", fake_urlopen), calls
+
+    def _stub_profile(self):
+        return mock.patch.multiple(
+            LlamaServerBackend,
+            _is_orbit_native_backend=lambda self: True,
+            request_model_name=lambda self: "test-model",
+            _props_or_empty=lambda self: {},
+            _serialize_for_profile=lambda self, messages: list(messages),
+        )
+
+    def test_prose_route_abort_counts_an_attempt_not_a_failure(self) -> None:
+        backend, usage = self._backend()
+        phases: list[tuple[str, int, str | None]] = []
+        patch, calls = self._patched(
+            [lambda: _ScriptedStream(PROSE_CHUNKS, prompt_tokens=40, completion_tokens=8)]
+        )
+        with self._stub_profile(), patch:
+            result = self._run(backend, phases)
+
+        # The early stop still happens, and the runtime still recovers through
+        # the existing handler: route -> chat_final_retry(route_not_command).
+        self.assertEqual(
+            [(phase, reason) for phase, _attempt, reason in phases],
+            [("route", "tool_decision"), ("chat_final_retry", "route_not_command")],
+        )
+        self.assertEqual(result.content, "I'm doing well, thanks!")
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.model_calls, 2, "route attempt and final call both count")
+        self.assertEqual(snapshot.failed_calls, 0, "an intentional abort is not a failure")
+        # The aborted stream never delivered its metrics event, so the totals
+        # are real but short -- saying otherwise would invent usage.
+        self.assertTrue(snapshot.usage_incomplete)
+
+        # What the user actually reads: no failure warning, but still an honest
+        # "partial" on the totals the abort left short.
+        turn_status = format_turn_status(
+            result, elapsed_seconds=1.0, turn_token_usage=snapshot
+        )
+        self.assertNotIn("failed attempt", turn_status)
+        self.assertIn("(partial)", turn_status)
+        session_line = format_session_token_usage(snapshot)
+        self.assertNotIn("failed attempts", session_line)
+        self.assertIn("partial", session_line)
+
+    def test_genuine_route_decision_is_unaffected(self) -> None:
+        backend, usage = self._backend()
+        phases: list[tuple[str, int, str | None]] = []
+        patch, _calls = self._patched(
+            [lambda: _ScriptedStream(ROUTE_CHUNKS, prompt_tokens=40, completion_tokens=8)]
+        )
+        with self._stub_profile(), patch:
+            self._run(backend, phases)
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.failed_calls, 0)
+        self.assertFalse(snapshot.usage_incomplete, "a completed route reports full usage")
+        self.assertEqual([phase for phase, _a, _r in phases][0], "route")
+
+    def test_genuine_backend_failure_still_counts_as_failed(self) -> None:
+        backend, usage = self._backend()
+        with self._stub_profile(), mock.patch.object(
+            llama_server, "urlopen", side_effect=URLError("connection reset")
+        ):
+            with self.assertRaises(LlamaServerError):
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=lambda _text: None,
+                )
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.model_calls, 1)
+        self.assertEqual(snapshot.failed_calls, 1, "a real transport error is still a failure")
+        self.assertTrue(snapshot.usage_incomplete)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`_RouteNotCommandAbort` is an intentional stream-consumer control-flow signal: the route phase raises it to stop generating once the output is clearly conversational prose and can no longer become a tool decision. The early stop is an optimisation, not an error.

Because `_observe_call()` treated every raised `BaseException` as a backend failure, ordinary REPL conversations reported a failed attempt that never happened — a normal `hi, how are you?` turn showed `failed attempts: 1` alongside a perfectly successful answer.

## Fix

- introduce a narrow shared `StreamConsumerAbort` marker in `backend/base.py` (a stdlib-only leaf module, so no backend → `runtime/chat.py` dependency and no string-based classification);
- classify intentional stream-consumer aborts separately from genuine backend failures in `_observe_call()`;
- keep the route abort propagating unchanged to its existing handler in `chat.py`;
- preserve route early-stop and retry behaviour exactly;
- count the real route inference attempt in `model_calls` — the request reached the model and real work happened;
- do not increment `failed_calls` for the intentional abort;
- preserve authoritative usage when it is available;
- mark usage incomplete only when authoritative metrics for the aborted attempt are unavailable;
- never invent usage values.

Genuine backend failures are unaffected: they still increment `failed_calls`, still mark usage incomplete, and still raise.

## Validation

- independent review: **PASS**, 0 BLOCKER / 0 MAJOR
- **7/7 mutation tests caught**, each verified present on disk, each failing for the intended reason, each restored with zero residue
- focused regression tests: 3 PASS (prose route, genuine route decision, genuine backend failure)
- affected suites: 295 PASS
- full suite: **2172 tests OK**
- `compileall`: PASS
- `git diff --check`: PASS

Real Ornith 1.5 35B-A3B native-stream smoke (one ordinary turn, tools on, think off):

- 2 model calls
- **0 failed attempts**
- finish reason `stop`
- complete authoritative telemetry in the observed real case (`881 in · 42 out`, totals consistent)
- route behaviour unchanged

Note on scope: an intentional route abort does **not** always imply incomplete usage. Whether authoritative metrics are available depends on how far the stream progressed before the abort; the fix reports them faithfully when present and marks accounting incomplete only when they are not.