### PR TITLE
fix(telemetry): preserve prompt metrics when a stream is stopped early

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -7,6 +7,15 @@ from typing import Any, Callable, Protocol
 Message = dict[str, Any]
 
 
+@dataclass(frozen=True)
+class StreamPromptMetrics:
+    """What prefill measured, known before any token is generated."""
+
+    prompt_tokens: int | None = None
+    evaluated_tokens: int | None = None
+    cached_tokens: int | None = None
+
+
 class StreamConsumerAbort(Exception):
     """A stream consumer stopped its own call on purpose; the backend is fine.
 
@@ -16,7 +25,15 @@ class StreamConsumerAbort(Exception):
     request reached the model and the model was answering. Backends recognise
     this marker so they do not report a healthy call as a failed attempt. The
     exception still propagates -- only the accounting treats it differently.
+
+    `prompt_metrics` carries whatever prefill had already measured when the
+    consumer stopped. Prefill finishes before the first token, so its token
+    counts are final by then and are simply lost if the terminal metrics event
+    is never read. The streaming layer attaches them on the way out; nothing
+    reads them for control flow.
     """
+
+    prompt_metrics: "StreamPromptMetrics | None" = None
 
 
 @dataclass(frozen=True)

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -9,7 +9,15 @@ from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from .base import ChatResult, Message, ModelInfo, StreamConsumerAbort, StreamProgress, TokenCount
+from .base import (
+    ChatResult,
+    Message,
+    ModelInfo,
+    StreamConsumerAbort,
+    StreamProgress,
+    StreamPromptMetrics,
+    TokenCount,
+)
 from .model_names import resolve_model_display_name
 from .payloads import (
     ARTIFACT_CONTENT_PROTOCOL_ID,
@@ -47,7 +55,7 @@ class LlamaServerBackend:
         self._props_discovery_status: str | None = None
         self._result_observer: Callable[[ChatResult], None] | None = None
         self._failure_observer: Callable[[], None] | None = None
-        self._aborted_observer: Callable[[], None] | None = None
+        self._aborted_observer: Callable[[StreamPromptMetrics | None], None] | None = None
 
     def set_result_observer(self, observer: Callable[[ChatResult], None] | None) -> None:
         self._result_observer = observer
@@ -55,7 +63,9 @@ class LlamaServerBackend:
     def set_failure_observer(self, observer: Callable[[], None] | None) -> None:
         self._failure_observer = observer
 
-    def set_aborted_observer(self, observer: Callable[[], None] | None) -> None:
+    def set_aborted_observer(
+        self, observer: Callable[[StreamPromptMetrics | None], None] | None
+    ) -> None:
         self._aborted_observer = observer
 
     def chat(
@@ -436,14 +446,11 @@ class LlamaServerBackend:
     def _observe_call(self, call: Callable[[], ChatResult]) -> ChatResult:
         try:
             result = call()
-        except StreamConsumerAbort:
+        except StreamConsumerAbort as abort:
             # The consumer stopped this stream deliberately, so nothing failed:
-            # report an attempt whose usage never arrived rather than a failure.
+            # report an attempt, along with whatever prefill already measured.
             if self._aborted_observer is not None:
-                try:
-                    self._aborted_observer()
-                except Exception:
-                    pass
+                self._aborted_observer(abort.prompt_metrics)
             raise
         except BaseException:
             if self._failure_observer is not None:
@@ -682,6 +689,7 @@ def _parse_native_stream(
     content_parts: list[str] = []
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
     content_filter = None if literal_content else _ContentStreamFilter(on_delta)
+    _prefill_holder: list[StreamPromptMetrics | None] = [None]
     model: str | None = None
     finish_reason: str | None = None
     usage: dict[str, Any] = {}
@@ -726,7 +734,7 @@ def _parse_native_stream(
                 if first_output_ns is None:
                     first_output_ns = time.monotonic_ns()
                 reasoning_parts.append(text)
-        elif current_event.startswith("progress.") and on_progress:
+        elif current_event.startswith("progress."):
             phase = current_event.split(".", maxsplit=1)[1]
             progress = StreamProgress(
                 phase=phase,
@@ -739,7 +747,17 @@ def _parse_native_stream(
                 elapsed_seconds=_finite_nonnegative_float_or_none(data.get("elapsed_seconds")),
                 tokens_per_second=_finite_nonnegative_float_or_none(data.get("tokens_per_second")),
             )
-            on_progress(progress)
+            if phase == "prefill":
+                # Prefill totals are final before the first token, so keep the
+                # newest snapshot: it is all that survives an aborted stream.
+                nonlocal_prefill = StreamPromptMetrics(
+                    prompt_tokens=progress.total or None,
+                    evaluated_tokens=progress.evaluated_total,
+                    cached_tokens=progress.cached_tokens,
+                )
+                _prefill_holder[0] = nonlocal_prefill
+            if on_progress:
+                on_progress(progress)
         elif current_event == "tool_calls":
             if isinstance(data.get("tool_calls"), list) and data["tool_calls"] and first_output_ns is None:
                 first_output_ns = time.monotonic_ns()
@@ -758,18 +776,25 @@ def _parse_native_stream(
         model = _str_or_none(data.get("model")) or model
         current_event = None
 
-    for raw_line in response:
-        line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
-        if not line:
-            flush_event()
-            if stream_done:
-                break
-            continue
-        if line.startswith("event:"):
-            current_event = line.removeprefix("event:").strip()
-            continue
-        if line.startswith("data:"):
-            current_data_lines.append(line.removeprefix("data:").strip())
+    try:
+        for raw_line in response:
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                flush_event()
+                if stream_done:
+                    break
+                continue
+            if line.startswith("event:"):
+                current_event = line.removeprefix("event:").strip()
+                continue
+            if line.startswith("data:"):
+                current_data_lines.append(line.removeprefix("data:").strip())
+    except StreamConsumerAbort as abort:
+        # The consumer stopped reading on purpose. Prefill had already finished
+        # and its counts are final, so hand them out rather than lose them.
+        if abort.prompt_metrics is None:
+            abort.prompt_metrics = _prefill_holder[0]
+        raise
 
     if not stream_done:
         flush_event()

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -4,7 +4,7 @@ import sys
 import time
 from dataclasses import dataclass, field, replace
 
-from orbit.backend.base import ChatResult
+from orbit.backend.base import ChatResult, StreamPromptMetrics
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
 from orbit.runtime.context_manager import ContextAdmissionError
@@ -266,9 +266,11 @@ class Repl:
         self.turn_backend_token_usage.add_failed_call()
         self.session_token_usage.add_failed_call()
 
-    def _record_backend_abort(self) -> None:
-        self.turn_backend_token_usage.add_aborted_call()
-        self.session_token_usage.add_aborted_call()
+    def _record_backend_abort(self, prompt_metrics: StreamPromptMetrics | None) -> None:
+        # The same snapshot goes to both ledgers: whatever prefill measured
+        # before the stream was stopped, or nothing at all if it got no further.
+        self.turn_backend_token_usage.add_aborted_call(prompt_metrics)
+        self.session_token_usage.add_aborted_call(prompt_metrics)
 
     def _turn_token_usage(self) -> TurnTokenUsage | None:
         if self.backend_usage_observer_installed:

--- a/src/orbit/terminal/status.py
+++ b/src/orbit/terminal/status.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from shutil import get_terminal_size
 from typing import Sequence
 
-from orbit.backend.base import ChatResult
+from orbit.backend.base import ChatResult, StreamPromptMetrics
 from orbit.runtime.kv_diag import emit_footer_metrics
 from orbit.runtime.session_memory import MemoryRefresh, estimate_message_tokens
 from orbit.runtime.turn_trace import ModelStepMetrics
@@ -64,18 +64,39 @@ class TokenUsageAccumulator:
         self.failed_calls += 1
         self.usage_incomplete = True
 
-    def add_aborted_call(self) -> None:
+    def add_aborted_call(self, prompt_metrics: StreamPromptMetrics | None = None) -> None:
         """Record an attempt the client stopped on purpose.
 
         The request reached the model and real work happened, so it counts as
-        a model call, but the usage event only arrives at the end of a stream
-        that was cut short -- so the totals are short by an unknown amount and
-        must say so. What this must not do is claim a failure: nothing went
+        a model call. What this must not do is claim a failure: nothing went
         wrong, and reporting one sends a reader looking for a fault that does
         not exist.
+
+        Prefill finishes before the first token, so when the stream carried
+        those counts they are final and get accumulated here. Decode never
+        reported, so the totals stay marked incomplete either way -- known
+        numbers are worth keeping even when the whole picture is not.
         """
         self.model_calls += 1
         self.usage_incomplete = True
+        if prompt_metrics is None:
+            return
+        prompt = getattr(prompt_metrics, "prompt_tokens", None)
+        cached = getattr(prompt_metrics, "cached_tokens", None)
+        if prompt is None:
+            return
+        self.prompt_tokens = _add_optional_metric(self.prompt_tokens, prompt)
+        if (
+            self.cached_tokens is None
+            or self.evaluated_tokens is None
+            or cached is None
+            or not 0 <= cached <= prompt
+        ):
+            self.cached_tokens = None
+            self.evaluated_tokens = None
+        else:
+            self.cached_tokens += cached
+            self.evaluated_tokens += prompt - cached
 
     def _add_metrics(
         self,

--- a/tests/test_repl_abort_metrics_seam.py
+++ b/tests/test_repl_abort_metrics_seam.py
@@ -1,0 +1,218 @@
+"""The REPL is the observer the backend actually calls on an aborted stream.
+
+Wiring prompt metrics into the accumulator is only half the job: the value has
+to survive the seam between the backend and the REPL's own observer. A test
+that hands `add_aborted_call` straight to the backend proves the accumulator
+works and nothing about the seam, which is exactly where the metrics were
+being dropped.
+
+These drive the real `Repl._record_backend_abort` and assert both the turn and
+session accumulators receive the same snapshot exactly once.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.backend.llama_server as llama_server
+from orbit.backend.base import StreamConsumerAbort, StreamPromptMetrics
+from orbit.backend.llama_server import LlamaServerBackend
+from orbit.terminal.repl import Repl
+from orbit.terminal.status import TokenUsageAccumulator, format_session_token_usage
+
+PROMPT_TOKENS = 1105
+REUSED_TOKENS = 1085
+EVALUATED_TOKENS = 20
+
+
+def _event(name: str, payload: dict) -> list[bytes]:
+    return [
+        f"event: {name}\n".encode(),
+        b"data: " + json.dumps(payload).encode() + b"\n",
+        b"\n",
+    ]
+
+
+class _Stream:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_Stream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def read(self) -> bytes:
+        return b""
+
+
+def aborted_route_stream() -> _Stream:
+    lines = _event(
+        "progress.prefill",
+        {
+            "current": PROMPT_TOKENS,
+            "total": PROMPT_TOKENS,
+            "percent": 100,
+            "evaluated_current": EVALUATED_TOKENS,
+            "evaluated_total": EVALUATED_TOKENS,
+            "cached_tokens": REUSED_TOKENS,
+        },
+    )
+    lines += _event("delta", {"text": "I'm doing well, thanks!"})
+    return _Stream(lines)
+
+
+class _RouteAbort(StreamConsumerAbort):
+    """Stands in for the runtime's route abort: same marker, same propagation."""
+
+
+class _ReplSeam:
+    """Only the observer surface of Repl, bound to real accumulators.
+
+    `Repl` is a dataclass with a large constructor, so the real method is bound
+    to a minimal holder. The method under test is production code.
+    """
+
+    def __init__(self) -> None:
+        self.turn_backend_token_usage = TokenUsageAccumulator()
+        self.session_token_usage = TokenUsageAccumulator()
+        self.calls = 0
+
+    def record(self, prompt_metrics):
+        self.calls += 1
+        return Repl._record_backend_abort(self, prompt_metrics)
+
+
+def backend_with_seam():
+    backend = LlamaServerBackend(base_url="http://127.0.0.1:1", timeout=5)
+    seam = _ReplSeam()
+    backend.set_aborted_observer(seam.record)
+    patches = mock.patch.multiple(
+        LlamaServerBackend,
+        _is_orbit_native_backend=lambda self: True,
+        request_model_name=lambda self: "m",
+        _props_or_empty=lambda self: {},
+        _serialize_for_profile=lambda self, messages: list(messages),
+    )
+    return backend, seam, patches
+
+
+class ReplSeamReceivesPromptMetricsTest(unittest.TestCase):
+    def test_turn_and_session_both_receive_the_snapshot_once(self) -> None:
+        backend, seam, patches = backend_with_seam()
+
+        def on_delta(_text: str) -> None:
+            raise _RouteAbort("route stream produced non-command prose")
+
+        with patches, mock.patch.object(
+            llama_server, "urlopen", lambda *a, **k: aborted_route_stream()
+        ):
+            with self.assertRaises(_RouteAbort):
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=on_delta,
+                )
+
+        self.assertEqual(seam.calls, 1, "the observer runs exactly once")
+
+        for label, usage in (
+            ("turn", seam.turn_backend_token_usage),
+            ("session", seam.session_token_usage),
+        ):
+            with self.subTest(accumulator=label):
+                snapshot = usage.snapshot()
+                self.assertEqual(snapshot.model_calls, 1)
+                self.assertEqual(snapshot.failed_calls, 0, "a deliberate stop is not a failure")
+                self.assertEqual(
+                    snapshot.cached_tokens,
+                    REUSED_TOKENS,
+                    "metrics must survive the backend -> REPL seam",
+                )
+                self.assertEqual(snapshot.prompt_tokens, PROMPT_TOKENS)
+                self.assertEqual(snapshot.evaluated_tokens, EVALUATED_TOKENS)
+                self.assertTrue(snapshot.usage_incomplete, "decode metrics never arrived")
+
+        line = format_session_token_usage(seam.session_token_usage.snapshot())
+        self.assertNotIn("cache: 0 (0%)", line)
+        self.assertNotIn("failed attempts", line)
+        self.assertIn("partial", line)
+
+    def test_abort_without_metrics_reaches_the_seam_with_none(self) -> None:
+        backend, seam, patches = backend_with_seam()
+        empty = _Stream(_event("delta", {"text": "prose"}))
+
+        def on_delta(_text: str) -> None:
+            raise _RouteAbort("stop")
+
+        with patches, mock.patch.object(llama_server, "urlopen", lambda *a, **k: empty):
+            with self.assertRaises(_RouteAbort):
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=on_delta,
+                )
+
+        self.assertEqual(seam.calls, 1)
+        for usage in (seam.turn_backend_token_usage, seam.session_token_usage):
+            self.assertEqual(usage.model_calls, 1)
+            self.assertEqual(usage.failed_calls, 0)
+            self.assertEqual(usage.prompt_tokens, 0, "nothing measured, nothing recorded")
+            self.assertEqual(usage.cached_tokens, 0)
+
+
+class ObserverExceptionIsNotRetriedTest(unittest.TestCase):
+    """A bug inside the observer must surface, not masquerade as bad arity."""
+
+    def test_internal_type_error_propagates_after_one_call(self) -> None:
+        backend = LlamaServerBackend(base_url="http://127.0.0.1:1", timeout=5)
+        calls: list[object] = []
+
+        def broken_observer(prompt_metrics: StreamPromptMetrics | None) -> None:
+            calls.append(prompt_metrics)
+            raise TypeError("observer bug")
+
+        backend.set_aborted_observer(broken_observer)
+
+        def on_delta(_text: str) -> None:
+            raise _RouteAbort("stop")
+
+        patches = mock.patch.multiple(
+            LlamaServerBackend,
+            _is_orbit_native_backend=lambda self: True,
+            request_model_name=lambda self: "m",
+            _props_or_empty=lambda self: {},
+            _serialize_for_profile=lambda self, messages: list(messages),
+        )
+        with patches, mock.patch.object(
+            llama_server, "urlopen", lambda *a, **k: aborted_route_stream()
+        ):
+            with self.assertRaises(TypeError) as raised:
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=on_delta,
+                )
+
+        self.assertEqual(str(raised.exception), "observer bug")
+        self.assertEqual(len(calls), 1, "a failing observer must not be retried")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stream_prompt_metrics.py
+++ b/tests/test_stream_prompt_metrics.py
@@ -1,0 +1,234 @@
+"""Prompt metrics survive a stream the consumer stops on purpose.
+
+A route stream is cut short as soon as the output is clearly prose, which
+happens on every ordinary conversational turn. The backend has already
+finished prefill by then and knows exactly how many prompt tokens were reused
+and evaluated -- but that knowledge only reaches the client in the terminal
+`metrics` event, which an aborted stream never sees. The turn then reports
+`cache: 0` for a call that reused most of its prompt.
+
+These tests pin the honest outcome: what prefill measured is reported, what
+decode never produced stays unknown, and the deliberate stop is still not a
+failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.backend.llama_server as llama_server
+from orbit.backend.base import StreamConsumerAbort
+from orbit.backend.llama_server import LlamaServerBackend
+from orbit.terminal.status import (
+    TokenUsageAccumulator,
+    format_session_token_usage,
+)
+
+PROMPT_TOKENS = 1105
+REUSED_TOKENS = 1085
+EVALUATED_TOKENS = 20
+
+
+class _Stream:
+    """The native SSE wire format, assembled from explicit events."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_Stream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def read(self) -> bytes:
+        return b""
+
+
+def _event(name: str, payload: dict) -> list[bytes]:
+    return [
+        f"event: {name}\n".encode(),
+        b"data: " + json.dumps(payload).encode() + b"\n",
+        b"\n",
+    ]
+
+
+def prefill_progress_event() -> list[bytes]:
+    """What the server sends once prefill is complete, before any token."""
+    return _event(
+        "progress.prefill",
+        {
+            "current": PROMPT_TOKENS,
+            "total": PROMPT_TOKENS,
+            "percent": 100,
+            "evaluated_current": EVALUATED_TOKENS,
+            "evaluated_total": EVALUATED_TOKENS,
+            "cached_tokens": REUSED_TOKENS,
+        },
+    )
+
+
+def aborted_route_stream() -> _Stream:
+    """Prefill metrics, then prose: the consumer stops before `metrics`."""
+    lines = prefill_progress_event()
+    lines += _event("delta", {"text": "I'm doing well, thanks!"})
+    # No `metrics`, no `done`: the consumer raised and stopped reading.
+    return _Stream(lines)
+
+
+def complete_stream() -> _Stream:
+    """A normal call: prefill metrics, deltas, then the terminal metrics."""
+    lines = prefill_progress_event()
+    lines += _event("delta", {"text": '{"command"'})
+    lines += _event("delta", {"text": ': "pwd"}'})
+    lines += _event(
+        "metrics",
+        {
+            "usage": {
+                "prompt_tokens": PROMPT_TOKENS,
+                "completion_tokens": 8,
+                "prompt_tokens_details": {"cached_tokens": REUSED_TOKENS},
+            },
+            "timings": {},
+        },
+    )
+    lines += _event("done", {"finish_reason": "stop", "model": "m"})
+    return _Stream(lines)
+
+
+class _RouteAbort(StreamConsumerAbort):
+    """Stands in for the runtime's route abort: same marker, same propagation."""
+
+
+def backend_with(stream: _Stream):
+    backend = LlamaServerBackend(base_url="http://127.0.0.1:1", timeout=5)
+    usage = TokenUsageAccumulator()
+    backend.set_result_observer(usage.add_result)
+    backend.set_failure_observer(usage.add_failed_call)
+    aborted = getattr(backend, "set_aborted_observer", None)
+    if callable(aborted):
+        aborted(usage.add_aborted_call)
+    patches = mock.patch.multiple(
+        LlamaServerBackend,
+        _is_orbit_native_backend=lambda self: True,
+        request_model_name=lambda self: "m",
+        _props_or_empty=lambda self: {},
+        _serialize_for_profile=lambda self, messages: list(messages),
+    )
+    return backend, usage, patches
+
+
+class AbortedStreamKeepsPrefillMetricsTest(unittest.TestCase):
+    def test_known_prompt_and_cache_survive_the_abort(self) -> None:
+        backend, usage, patches = backend_with(aborted_route_stream())
+
+        def on_delta(_text: str) -> None:
+            raise _RouteAbort("route stream produced non-command prose")
+
+        with patches, mock.patch.object(
+            llama_server, "urlopen", lambda *a, **k: aborted_route_stream()
+        ):
+            with self.assertRaises(_RouteAbort):
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=on_delta,
+                )
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.model_calls, 1, "the attempt counts exactly once")
+        self.assertEqual(snapshot.failed_calls, 0, "a deliberate stop is not a failure")
+        # The point of the fix: prefill already measured these.
+        self.assertEqual(
+            snapshot.cached_tokens,
+            REUSED_TOKENS,
+            "reuse measured during prefill must not be discarded by the abort",
+        )
+        self.assertEqual(snapshot.prompt_tokens, PROMPT_TOKENS)
+        self.assertEqual(snapshot.evaluated_tokens, EVALUATED_TOKENS)
+        # Decode never reported, so the totals stay honestly incomplete.
+        self.assertTrue(snapshot.usage_incomplete)
+
+        line = format_session_token_usage(snapshot)
+        self.assertNotIn("cache: 0 (0%)", line, "a reusing turn must not read as zero cache")
+        self.assertNotIn("failed attempts", line)
+        self.assertIn("partial", line)
+
+    def test_abort_before_any_prompt_metrics_invents_nothing(self) -> None:
+        empty = _Stream(_event("delta", {"text": "prose"}))
+
+        def on_delta(_text: str) -> None:
+            raise _RouteAbort("stop")
+
+        backend, usage, patches = backend_with(empty)
+        with patches, mock.patch.object(llama_server, "urlopen", lambda *a, **k: empty):
+            with self.assertRaises(_RouteAbort):
+                backend.chat_stream(
+                    [{"role": "user", "content": "hi"}],
+                    temperature=0,
+                    max_tokens=8,
+                    on_delta=on_delta,
+                )
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.model_calls, 1)
+        self.assertEqual(snapshot.failed_calls, 0)
+        self.assertTrue(snapshot.usage_incomplete)
+        # Nothing was measured, so nothing may be written: an accumulator that
+        # stamps zeros looks identical to one that measured zero reuse.
+        self.assertEqual(usage.prompt_tokens, 0, "no prompt tokens may be recorded")
+        self.assertEqual(usage.cached_tokens, 0)
+        self.assertEqual(usage.evaluated_tokens, 0)
+
+        # Prove it by contrast: a prior real call's totals must survive intact.
+        with_history = TokenUsageAccumulator()
+        with_history.prompt_tokens = 500
+        with_history.cached_tokens = 100
+        with_history.evaluated_tokens = 400
+        with_history.add_aborted_call(None)
+        self.assertEqual(with_history.prompt_tokens, 500, "an empty abort must add nothing")
+        self.assertEqual(with_history.cached_tokens, 100)
+        self.assertEqual(with_history.evaluated_tokens, 400)
+
+
+class CompleteStreamCountsOnceTest(unittest.TestCase):
+    def test_prefill_and_final_metrics_are_not_double_counted(self) -> None:
+        backend, usage, patches = backend_with(complete_stream())
+        with patches, mock.patch.object(
+            llama_server, "urlopen", lambda *a, **k: complete_stream()
+        ):
+            backend.chat_stream(
+                [{"role": "user", "content": "hi"}],
+                temperature=0,
+                max_tokens=8,
+                on_delta=lambda _t: None,
+            )
+
+        snapshot = usage.snapshot()
+        self.assertEqual(snapshot.model_calls, 1, "one attempt, one count")
+        self.assertEqual(snapshot.failed_calls, 0)
+        self.assertEqual(
+            snapshot.prompt_tokens,
+            PROMPT_TOKENS,
+            "prefill progress must not be added on top of the final metrics",
+        )
+        self.assertEqual(snapshot.cached_tokens, REUSED_TOKENS)
+        self.assertEqual(snapshot.completion_tokens, 8)
+        self.assertFalse(snapshot.usage_incomplete, "a complete stream is not partial")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

An intentional stream-consumer abort can occur *after* prompt prefill metrics are already authoritative but *before* the terminal stream metrics reach the client.

The route phase does exactly this on every ordinary conversational turn: it stops its own stream as soon as the output is clearly prose. Prefill has finished by then, so the backend already knows how many prompt tokens it reused and evaluated — but those counts only travel in the terminal metrics event, which a stopped stream never reads. Known prompt-side metrics, including evaluated and reused/cache tokens, were therefore lost from REPL and session telemetry, and a turn that reused most of its prompt reported `cache: 0`.

## Fix

- retain the authoritative `progress.prefill` metrics per request;
- attach them to the intentional `StreamConsumerAbort` on its way out;
- forward them through the real REPL abort-observer seam;
- accumulate known prompt / evaluated / reused metrics exactly once;
- keep intentional aborts out of `failed_calls`;
- preserve `usage_incomplete=True` when decode/output metrics remain unavailable;
- keep normal-success and genuine-failure accounting unchanged;
- no stream protocol shape change;
- no global mutable telemetry state — the snapshot is request-local.

Prefill totals are final before the first token is generated: `reused` is assigned before the prefill event is emitted and never reassigned, and across all prefill events `total`, `evaluated_total`, and `cached_tokens` are constant. No timing or output field is captured, because those are not authoritative at that point.

What decode never reported stays unknown. Totals remain marked partial and no completion figures are invented — a known number plus an honest gap beats a zero that reads as "no reuse happened".

## Observer contract

```
aborted_observer(prompt_metrics: StreamPromptMetrics | None) -> None
```

One shape, no `TypeError` compatibility fallback. The previous arity-sniffing fallback both hid the metrics from the real REPL observer (whose signature took no argument) and turned a bug *inside* an observer into a second invocation, with the real error misreported as an arity mismatch.

## Validation

- independent review: **PASS**
- confirmation review of the frozen SHA: **PASS**
- **0 BLOCKER / 0 MAJOR / 0 MINOR**
- **8/8 mutation tests CAUGHT**, each verified on disk and restored with zero residue
- full suite: **2178 PASS**
- `compileall`: PASS
- `git diff --check`: PASS
- request isolation proven — metrics from one call cannot reach the next
- no double counting between the early snapshot and the terminal metrics
- the real production REPL seam is exercised, not a directly-wired accumulator
- a combined rolling+telemetry smoke showed non-zero user-visible cache on follow-up turns and no false failed attempts

## Scope

This telemetry fix is independently correct for any intentional aborted stream where prompt metrics are already known. The rolling route-KV work is **not** part of this PR and remains a separate unmerged candidate.