### PR TITLE
perf(native): reuse rolling Ornith route KV across conversational turns

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -32,6 +32,7 @@ from .expert_usage import summarize_expert_usage
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, emit_strict_append_miss, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .model_profiles import (
+    ORNITH15_PROFILE_ID,
     PROFILE_METADATA_KEYS,
     QWEN36_PROFILE_ID,
     QWEN3_CODER_PROFILE_ID,
@@ -47,6 +48,16 @@ from .mtp_dry_run import MtpDryRunResult, run_mtp_dry_run
 from .mtp_probe import MtpProbeResult, run_mtp_probe
 from .native_names import mtmd_bridge_filename, runtime_library_filename
 from .paths import NativeLlamaPaths
+from .rolling_route_anchor import (
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+    capture_rolling_route_anchor,
+    invalidate_rolling_route_anchor,
+    restore_rolling_route_anchor,
+    rolling_route_reuse_start,
+    rolling_route_should_replace,
+)
 from .prefix_anchor import (
     PrefixAnchorState,
     capture_prefix_anchor,
@@ -310,6 +321,10 @@ class NativeLlamaClient:
         self._last_prompt_decode_batch_n_tokens = 0
         self._route_prefix_anchor_state = PrefixAnchorState()
         self._route_prefix_prefill_lock = threading.Lock()
+        # Exactly one rolling route checkpoint per client, replaced in place.
+        self._rolling_route_anchor_state = RollingRouteAnchorState()
+        self._rolling_route_identity_cache: RollingRouteIdentity | None = None
+        self._reset_generation = 0
         self._qwen_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen_route_prefix_status = QwenRoutePrefixStatus()
@@ -783,7 +798,10 @@ class NativeLlamaClient:
         self._session.mtp_failed = False
 
     def reset_session_state(
-        self, *, preserve_qwen3_coder_route_checkpoint: bool = False
+        self,
+        *,
+        preserve_qwen3_coder_route_checkpoint: bool = False,
+        preserve_ornith_rolling_route_checkpoint: bool = False,
     ) -> None:
         if not self._session.ctx_tgt:
             raise RuntimeError("native client not loaded")
@@ -800,6 +818,9 @@ class NativeLlamaClient:
         self._active_profile_render = None
         self._profile_last_raw_output = ""
         self._profile_last_parsed_content = ""
+        if not preserve_ornith_rolling_route_checkpoint:
+            self._reset_generation += 1
+            self._invalidate_rolling_route_anchor("session_reset")
         self._invalidate_final_prefix("session_reset")
         self._invalidate_qwen_route_prefix(
             "session_reset", profile_id=QWEN36_PROFILE_ID
@@ -851,8 +872,18 @@ class NativeLlamaClient:
             and profile_id == QWEN3_CODER_PROFILE_ID
             and qualified_transition
         )
+        # The route and final phases of one turn differ only by this internal
+        # mode, so the switch is not a lifecycle event and must not discard the
+        # route checkpoint. Every genuinely destructive reset still does: this
+        # state holds the conversation's own tokens.
+        preserve_ornith_rolling_route_checkpoint = (
+            getattr(profile, "verified", False)
+            and profile_id == ORNITH15_PROFILE_ID
+            and qualified_transition
+        )
         self.reset_session_state(
-            preserve_qwen3_coder_route_checkpoint=preserve_qwen3_coder_route_checkpoint
+            preserve_qwen3_coder_route_checkpoint=preserve_qwen3_coder_route_checkpoint,
+            preserve_ornith_rolling_route_checkpoint=preserve_ornith_rolling_route_checkpoint,
         )
         self._session.prompt_cache_mode = mode
 
@@ -1259,11 +1290,19 @@ class NativeLlamaClient:
             allow_mtp = False
         if allow_mtp_experimental is False:
             allow_mtp = False
+        rolling_route_eligible = self._ornith_rolling_route_eligible(
+            route_prefix_anchor=route_prefix_anchor, tools=tools, thinking=thinking
+        )
+        rolling_route_identity = (
+            self._rolling_route_identity(tools=tools) if rolling_route_eligible else None
+        )
         return self.complete_prompt(
             prompt,
             max_tokens=max_tokens,
             allow_mtp_experimental=allow_mtp,
             thinking=thinking,
+            rolling_route_eligible=rolling_route_eligible,
+            rolling_route_identity=rolling_route_identity,
             route_anchor_segments=route_anchor_segments,
             qwen_route_anchor_plan=qwen_route_anchor_plan,
             qwen36_shell_tool_anchor_plan=qwen36_shell_tool_anchor_plan,
@@ -1953,6 +1992,8 @@ class NativeLlamaClient:
         qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
         qwen36_shell_tool_anchor_plan: _Qwen36ShellToolAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
+        rolling_route_eligible: bool = False,
+        rolling_route_identity: RollingRouteIdentity | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
@@ -1995,6 +2036,8 @@ class NativeLlamaClient:
             timings = self._complete_prompt_standard(
                 prompt,
                 max_tokens=max_tokens,
+                rolling_route_eligible=rolling_route_eligible,
+                rolling_route_identity=rolling_route_identity,
                 route_anchor_segments=route_anchor_segments,
                 qwen_route_anchor_plan=qwen_route_anchor_plan,
                 qwen36_shell_tool_anchor_plan=qwen36_shell_tool_anchor_plan,
@@ -2203,6 +2246,8 @@ class NativeLlamaClient:
         qwen_route_anchor_plan: _QwenRouteAnchorRuntimePlan | None = None,
         qwen36_shell_tool_anchor_plan: _Qwen36ShellToolAnchorRuntimePlan | None = None,
         final_prefix_segments: RoutePromptSegments | None = None,
+        rolling_route_eligible: bool = False,
+        rolling_route_identity: RollingRouteIdentity | None = None,
         kv_diag_messages: list[NativeMessage] | None = None,
         on_progress=None,
         on_token=None,
@@ -2245,6 +2290,9 @@ class NativeLlamaClient:
             processed_start, reused = self._prepare_memory_with_qwen36_shell_tool_anchor(
                 qwen36_shell_tool_anchor_plan
             )
+        elif rolling_route_eligible and rolling_route_identity is not None:
+            self._rolling_route_identity_cache = rolling_route_identity
+            reused = self._prepare_memory_with_ornith_rolling_route_anchor(prompt_tokens)
         elif anchor_plan is None:
             reused = self._prepare_memory_for_prompt(prompt_tokens)
         else:
@@ -2289,6 +2337,26 @@ class NativeLlamaClient:
                 started_us=pf_start,
             )
         pf_ms = (lib.llama_time_us() - pf_start) / 1000.0
+        if (
+            rolling_route_eligible
+            and rolling_route_identity is not None
+            and processed == n_prompt
+            and not self.cancel_event.is_set()
+        ):
+            # Prefill completed exactly through the prompt and nothing has been
+            # generated yet, so the snapshot is the prompt and only the prompt.
+            if rolling_route_should_replace(
+                self._rolling_route_anchor_state, prompt_tokens, rolling_route_identity
+            ):
+                captured, _capture_meta = capture_rolling_route_anchor(
+                    lib,
+                    self._session.ctx_tgt,
+                    prompt_tokens=prompt_tokens,
+                    identity=rolling_route_identity,
+                )
+                # A failed capture must not discard a still-usable checkpoint.
+                if captured.valid:
+                    self._rolling_route_anchor_state = captured
         self.last_committed_generated_tokens = []
         generated, gen_ms, cancelled = self._generate_from_current_context(
             max_tokens=max_tokens,
@@ -3035,6 +3103,82 @@ class NativeLlamaClient:
             prefix_hash=prefix_hash,
             metadata=metadata,
         )
+
+
+    def _ornith_rolling_route_eligible(self, *, route_prefix_anchor: bool, tools: list[dict] | None, thinking: bool) -> bool:
+        """Only verified Ornith route calls take the rolling strategy.
+
+        The route signal is the anchor flag the runtime already sets from its
+        own phase; the backend never infers phase from the prompt.
+        """
+        if not route_prefix_anchor:
+            return False
+        profile = getattr(self, "model_profile", None)
+        if not getattr(profile, "verified", False):
+            return False
+        if getattr(profile, "profile_id", None) != ORNITH15_PROFILE_ID:
+            return False
+        if thinking:
+            return False
+        if self.config.use_mtp_experimental or self._session.mtp_enabled:
+            return False
+        return True
+
+    def _rolling_route_identity(self, *, tools: list[dict] | None) -> RollingRouteIdentity:
+        profile = getattr(self, "model_profile", None)
+        return RollingRouteIdentity(
+            strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+            session_id=str(self._session.session_id),
+            profile_id=str(getattr(profile, "profile_id", "")),
+            model_id=str(self.paths.model),
+            template_id=str(getattr(profile, "template_sha256", "")),
+            tool_schema_hash=hash_text(json.dumps(tools or [], sort_keys=True)),
+            capability_summary_hash=hash_text(
+                json.dumps(sorted(self._model_metadata_identity.items()), sort_keys=True)
+            ),
+            runtime_policy_hash=hash_text(
+                json.dumps(
+                    {"ctx": self.config.context_tokens, "thinking": bool(self.config.thinking)},
+                    sort_keys=True,
+                )
+            ),
+            native_version=runtime_library_filename("llama"),
+            tools_mode="on",
+            reset_generation=self._reset_generation,
+        )
+
+    def _invalidate_rolling_route_anchor(self, reason: str) -> None:
+        if self._rolling_route_anchor_state.valid or self._rolling_route_anchor_state.identity is not None:
+            self._rolling_route_anchor_state = invalidate_rolling_route_anchor(
+                self._rolling_route_anchor_state, reason
+            )
+
+    def _prepare_memory_with_ornith_rolling_route_anchor(self, prompt_tokens: list[int]) -> int:
+        """Restore the rolling route checkpoint, then defer to strict append.
+
+        The checkpoint only supplies candidate state and the committed-sequence
+        bookkeeping; `_prepare_memory_for_prompt` still decides whether reuse is
+        authorized, so PR #210's exact-prefix rule stays the single authority.
+        """
+        identity = self._rolling_route_identity_cache
+        state = self._rolling_route_anchor_state
+        reuse_start = rolling_route_reuse_start(state, prompt_tokens, identity)
+        if reuse_start is None:
+            return self._prepare_memory_for_prompt(prompt_tokens)
+        ok, restored, _meta = restore_rolling_route_anchor(
+            self.lib.lib, self._session.ctx_tgt, state
+        )
+        self._rolling_route_anchor_state = restored
+        if not ok:
+            # A partial restore leaves KV unknown; clear before falling cold.
+            self._clear_target_memory()
+            self._session.cached_prompt_tokens.clear()
+            self._invalidate_committed_sequence()
+            return self._prepare_memory_for_prompt(prompt_tokens)
+        # Hand strict append the exact tokens now resident so it can authorize.
+        self._session.committed_sequence_tokens = list(state.tokens)
+        self._session.cached_prompt_tokens = list(state.tokens)
+        return self._prepare_memory_for_prompt(prompt_tokens)
 
     def _prepare_memory_with_route_anchor(self, plan: _RouteAnchorRuntimePlan) -> tuple[int, int, dict[str, object]]:
         if not self._session.ctx_tgt:

--- a/src/orbit/native_llama/rolling_route_anchor.py
+++ b/src/orbit/native_llama/rolling_route_anchor.py
@@ -1,0 +1,207 @@
+"""A route checkpoint that rolls forward with the conversation.
+
+The existing prefix anchors cache a prefix whose content never changes, so they
+authorize reuse by comparing hashes for equality. A conversational route prompt
+is different: every turn appends to the previous one, so the useful checkpoint
+is the whole prompt as it stood at the end of the last route prefill, and reuse
+is authorized precisely when the *new* prompt differs -- by extending it.
+
+That inverted condition is why this state lives apart from `PrefixAnchorState`
+rather than inside it. Equality of hashes is the wrong question here, so the
+saved tokens are kept in full and compared exactly. A hash may reject a
+candidate early, but nothing is ever authorized on a hash alone: a collision
+would restore a KV sequence that does not match the prompt, and the model would
+answer confidently from someone else's context.
+
+The checkpoint holds the prompt only. Generated tokens are never serialized --
+a snapshot containing them is not a prefix of the next route prompt, so it
+would be useless at best and wrong at worst.
+"""
+
+from __future__ import annotations
+
+import time
+from ctypes import c_ubyte
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+ROLLING_ROUTE_STRATEGY_ID = "ornith15-rolling-route-v1"
+
+
+@dataclass(frozen=True)
+class RollingRouteIdentity:
+    """What must be unchanged for saved tokens to still mean the same thing.
+
+    Content identity lives in the token sequence itself, not here; these are
+    the surrounding facts that make those tokens interpretable.
+    """
+
+    strategy_id: str
+    session_id: str
+    profile_id: str
+    model_id: str
+    template_id: str
+    tool_schema_hash: str
+    capability_summary_hash: str
+    runtime_policy_hash: str
+    native_version: str
+    tools_mode: str
+    reset_generation: int
+
+
+@dataclass
+class RollingRouteAnchorState:
+    """KV as it stood at the end of a route prefill, with its exact tokens."""
+
+    identity: RollingRouteIdentity | None = None
+    tokens: list[int] = field(default_factory=list)
+    checkpoint_data: bytes | None = field(default=None, repr=False, compare=False)
+    created_at_monotonic: float | None = None
+    invalidation_reason: str | None = None
+
+    @property
+    def valid(self) -> bool:
+        return bool(self.identity is not None and self.tokens and self.checkpoint_data)
+
+    @property
+    def checkpoint_size(self) -> int:
+        return len(self.checkpoint_data or b"")
+
+
+def invalidate_rolling_route_anchor(
+    state: RollingRouteAnchorState, reason: str
+) -> RollingRouteAnchorState:
+    """Drop the checkpoint. Cheap to rebuild, unsafe to keep when in doubt."""
+    return RollingRouteAnchorState(invalidation_reason=reason)
+
+
+def rolling_route_reuse_start(
+    state: RollingRouteAnchorState,
+    prompt_tokens: list[int],
+    identity: RollingRouteIdentity,
+) -> int | None:
+    """Tokens already resident if this checkpoint serves this prompt, else None.
+
+    Exact prefix only, and the prompt must extend the saved tokens: an
+    equal-length prompt leaves nothing to evaluate, and the final prompt token
+    still has to be decoded to produce fresh logits.
+    """
+    if not state.valid or state.identity != identity:
+        return None
+    saved = state.tokens
+    if len(prompt_tokens) <= len(saved):
+        return None
+    if prompt_tokens[: len(saved)] != saved:
+        return None
+    return len(saved)
+
+
+def rolling_route_should_replace(
+    state: RollingRouteAnchorState,
+    prompt_tokens: list[int],
+    identity: RollingRouteIdentity,
+) -> bool:
+    """Whether this prefill should become the new checkpoint.
+
+    Only a prompt continuing the tracked chain replaces it. This is what lets
+    the checkpoint survive the final call that wipes live KV: the final prompt
+    shares almost nothing with the route chain, so it must not evict the state
+    the next route depends on. Keeping the older useful checkpoint beats
+    keeping the most recent one.
+    """
+    if not state.valid:
+        return True
+    if state.identity != identity:
+        return True
+    return rolling_route_reuse_start(state, prompt_tokens, identity) is not None
+
+
+def capture_rolling_route_anchor(
+    lib: Any,
+    ctx: Any,
+    *,
+    prompt_tokens: list[int],
+    identity: RollingRouteIdentity,
+    seq_id: int = 0,
+) -> tuple[RollingRouteAnchorState, dict[str, Any]]:
+    """Snapshot the sequence exactly as the route prefill left it.
+
+    Called at the prefill boundary before a single token is generated, so the
+    saved tokens are exactly `prompt_tokens`.
+    """
+    metadata: dict[str, Any] = {"capture_attempted": True}
+    if not ctx or not prompt_tokens:
+        metadata["fallback_reason"] = "no_context_or_tokens"
+        return invalidate_rolling_route_anchor(
+            RollingRouteAnchorState(), "no_context_or_tokens"
+        ), metadata
+    try:
+        size = int(lib.llama_state_seq_get_size(ctx, seq_id))
+    except Exception:
+        metadata["fallback_reason"] = "checkpoint_size_failed"
+        return invalidate_rolling_route_anchor(
+            RollingRouteAnchorState(), "checkpoint_size_failed"
+        ), metadata
+    if size <= 0:
+        metadata["fallback_reason"] = "empty_checkpoint"
+        return invalidate_rolling_route_anchor(
+            RollingRouteAnchorState(), "empty_checkpoint"
+        ), metadata
+    try:
+        buffer = (c_ubyte * size)()
+        written = int(lib.llama_state_seq_get_data(ctx, buffer, size, seq_id))
+    except Exception:
+        metadata["fallback_reason"] = "checkpoint_capture_failed"
+        return invalidate_rolling_route_anchor(
+            RollingRouteAnchorState(), "checkpoint_capture_failed"
+        ), metadata
+    if written != size:
+        metadata["fallback_reason"] = "checkpoint_size_mismatch"
+        return invalidate_rolling_route_anchor(
+            RollingRouteAnchorState(), "checkpoint_size_mismatch"
+        ), metadata
+    metadata["checkpoint_size_bytes"] = size
+    metadata["checkpoint_tokens"] = len(prompt_tokens)
+    return (
+        RollingRouteAnchorState(
+            identity=identity,
+            tokens=list(prompt_tokens),
+            checkpoint_data=bytes(buffer),
+            created_at_monotonic=time.monotonic(),
+        ),
+        metadata,
+    )
+
+
+def restore_rolling_route_anchor(
+    lib: Any,
+    ctx: Any,
+    state: RollingRouteAnchorState,
+    *,
+    seq_id: int = 0,
+) -> tuple[bool, RollingRouteAnchorState, dict[str, Any]]:
+    """Put the saved sequence back. Any doubt reports failure and drops it.
+
+    A failed restore may have written part of the sequence, so False means "KV
+    is unknown" and the caller must clear before prefilling.
+    """
+    metadata: dict[str, Any] = {"restore_attempted": True}
+    if not state.valid or not ctx:
+        metadata["fallback_reason"] = "no_checkpoint"
+        return False, invalidate_rolling_route_anchor(state, "no_checkpoint"), metadata
+    data = state.checkpoint_data or b""
+    try:
+        buffer = (c_ubyte * len(data)).from_buffer_copy(data)
+        read = int(lib.llama_state_seq_set_data(ctx, buffer, len(data), seq_id))
+    except Exception:
+        metadata["fallback_reason"] = "checkpoint_restore_failed"
+        return False, invalidate_rolling_route_anchor(
+            state, "checkpoint_restore_failed"
+        ), metadata
+    if read != len(data):
+        metadata["fallback_reason"] = "checkpoint_restore_size_mismatch"
+        return False, invalidate_rolling_route_anchor(
+            state, "checkpoint_restore_size_mismatch"
+        ), metadata
+    metadata["restored_tokens"] = len(state.tokens)
+    return True, replace(state), metadata

--- a/tests/test_native_session_state.py
+++ b/tests/test_native_session_state.py
@@ -228,8 +228,15 @@ class NativeSessionStateTests(unittest.TestCase):
 
         client._ensure_prompt_cache_mode("chat:thinking=on")
 
-        client.reset_session_state.assert_called_once_with(
-            preserve_qwen3_coder_route_checkpoint=False
+        # An unqualified transition preserves nothing: assert every preserve
+        # option is off rather than pinning the exact argument list, so adding
+        # a new qualified-preservation option cannot silently pass here.
+        client.reset_session_state.assert_called_once()
+        _args, kwargs = client.reset_session_state.call_args
+        self.assertTrue(kwargs, "reset must be called with explicit preserve options")
+        self.assertFalse(
+            any(kwargs.values()),
+            f"no checkpoint may be preserved across an unqualified transition: {kwargs}",
         )
         self.assertEqual(client._session.prompt_cache_mode, "chat:thinking=on")
 

--- a/tests/test_rolling_route_anchor.py
+++ b/tests/test_rolling_route_anchor.py
@@ -1,0 +1,283 @@
+"""The Ornith rolling route anchor: exact reuse, and nothing else.
+
+Covers the wired production gate (which profiles and phases may select the
+strategy), the state machine that lets a route checkpoint survive the final
+call, and every way reuse must be refused.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import (
+    GEMMA4_PROFILE_ID,
+    ORNITH15_PROFILE_ID,
+    QWEN36_PROFILE_ID,
+    QWEN38_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+)
+from orbit.native_llama.rolling_route_anchor import (
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+    capture_rolling_route_anchor,
+    invalidate_rolling_route_anchor,
+    restore_rolling_route_anchor,
+    rolling_route_reuse_start,
+    rolling_route_should_replace,
+)
+
+
+def identity(**overrides) -> RollingRouteIdentity:
+    base = dict(
+        strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+        session_id="default",
+        profile_id=ORNITH15_PROFILE_ID,
+        model_id="/models/ornith.gguf",
+        template_id="tpl-sha",
+        tool_schema_hash="tools",
+        capability_summary_hash="caps",
+        runtime_policy_hash="policy",
+        native_version="libllama.so",
+        tools_mode="on",
+        reset_generation=0,
+    )
+    base.update(overrides)
+    return RollingRouteIdentity(**base)
+
+
+class FakeLib:
+    def __init__(self, *, size: int = 64, fail_get: bool = False, short_write: bool = False,
+                 fail_set: bool = False, short_read: bool = False) -> None:
+        self.size = size
+        self.fail_get = fail_get
+        self.short_write = short_write
+        self.fail_set = fail_set
+        self.short_read = short_read
+
+    def llama_state_seq_get_size(self, ctx, seq_id):
+        return self.size
+
+    def llama_state_seq_get_data(self, ctx, buffer, size, seq_id):
+        if self.fail_get:
+            raise RuntimeError("boom")
+        for i in range(size):
+            buffer[i] = (i + 3) % 256
+        return size - 1 if self.short_write else size
+
+    def llama_state_seq_set_data(self, ctx, buffer, size, seq_id):
+        if self.fail_set:
+            raise RuntimeError("boom")
+        return size - 1 if self.short_read else size
+
+
+CTX = object()
+ROUTE1 = [10, 11, 12, 13]
+ROUTE2 = ROUTE1 + [14, 15]
+ROUTE3 = ROUTE2 + [16]
+FINAL = [900, 901, 902]
+
+
+class _Profile:
+    def __init__(self, profile_id: str, verified: bool = True) -> None:
+        self.profile_id = profile_id
+        self.verified = verified
+
+
+class _Config:
+    use_mtp_experimental = False
+    context_tokens = 16384
+    thinking = False
+
+
+class _Session:
+    mtp_enabled = False
+
+
+def eligibility_client(profile_id: str, *, verified: bool = True) -> NativeLlamaClient:
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    client.config = _Config()
+    client._session = _Session()
+    client.model_profile = _Profile(profile_id, verified)
+    return client
+
+
+class RollingRouteEligibilityTest(unittest.TestCase):
+    """Only verified Ornith route calls may select the strategy."""
+
+    def test_only_ornith_route_calls_are_eligible(self) -> None:
+        for profile_id in (
+            GEMMA4_PROFILE_ID,
+            QWEN36_PROFILE_ID,
+            QWEN38_PROFILE_ID,
+            QWEN3_CODER_PROFILE_ID,
+        ):
+            with self.subTest(profile=profile_id):
+                client = eligibility_client(profile_id)
+                self.assertFalse(
+                    client._ornith_rolling_route_eligible(
+                        route_prefix_anchor=True, tools=None, thinking=False
+                    ),
+                    "other verified profiles must keep their existing strategy",
+                )
+
+        client = eligibility_client(ORNITH15_PROFILE_ID)
+        self.assertTrue(
+            client._ornith_rolling_route_eligible(
+                route_prefix_anchor=True, tools=None, thinking=False
+            )
+        )
+
+    def test_final_calls_are_never_eligible(self) -> None:
+        # route_prefix_anchor is the runtime's own route signal; a final call
+        # clears it, so the backend never needs to know what a phase is.
+        client = eligibility_client(ORNITH15_PROFILE_ID)
+        self.assertFalse(
+            client._ornith_rolling_route_eligible(
+                route_prefix_anchor=False, tools=None, thinking=False
+            )
+        )
+
+    def test_unverified_ornith_is_not_eligible(self) -> None:
+        client = eligibility_client(ORNITH15_PROFILE_ID, verified=False)
+        self.assertFalse(
+            client._ornith_rolling_route_eligible(
+                route_prefix_anchor=True, tools=None, thinking=False
+            )
+        )
+
+    def test_thinking_and_mtp_block_eligibility(self) -> None:
+        client = eligibility_client(ORNITH15_PROFILE_ID)
+        self.assertFalse(
+            client._ornith_rolling_route_eligible(
+                route_prefix_anchor=True, tools=None, thinking=True
+            )
+        )
+        client._session.mtp_enabled = True
+        self.assertFalse(
+            client._ornith_rolling_route_eligible(
+                route_prefix_anchor=True, tools=None, thinking=False
+            )
+        )
+
+
+class RollingRouteStateTest(unittest.TestCase):
+    def test_capture_holds_exactly_the_prefill_tokens(self) -> None:
+        state, meta = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        self.assertTrue(state.valid)
+        self.assertEqual(state.tokens, ROUTE1)
+        self.assertEqual(meta["checkpoint_tokens"], len(ROUTE1))
+
+    def test_route_chain_reuses_and_rolls_forward(self) -> None:
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        self.assertEqual(rolling_route_reuse_start(state, ROUTE2, identity()), len(ROUTE1))
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE2, identity=identity()
+        )
+        self.assertEqual(rolling_route_reuse_start(state, ROUTE3, identity()), len(ROUTE2))
+
+    def test_final_prompt_cannot_evict_the_route_checkpoint(self) -> None:
+        # The whole point of serializing: a final call wipes live KV but must
+        # leave the route chain's saved state alone.
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        self.assertFalse(rolling_route_should_replace(state, FINAL, identity()))
+        self.assertIsNone(rolling_route_reuse_start(state, FINAL, identity()))
+        self.assertEqual(rolling_route_reuse_start(state, ROUTE2, identity()), len(ROUTE1))
+
+    def test_incompatible_post_tool_route_falls_cold(self) -> None:
+        # Measured production behaviour: a post-tool route diverges before the
+        # end, so it must cold-prefill rather than reuse conversational state.
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        diverged = [10, 11, 99, 13, 14, 15]
+        self.assertIsNone(rolling_route_reuse_start(state, diverged, identity()))
+
+    def test_one_token_mismatch_equal_and_shorter_are_refused(self) -> None:
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE2, identity=identity()
+        )
+        self.assertIsNone(rolling_route_reuse_start(state, [10, 11, 12, 99, 14, 15, 16], identity()))
+        self.assertIsNone(rolling_route_reuse_start(state, list(ROUTE2), identity()))
+        self.assertIsNone(rolling_route_reuse_start(state, ROUTE1, identity()))
+
+    def test_every_identity_field_blocks_reuse(self) -> None:
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        for field_name, value in [
+            ("strategy_id", "other-strategy"),
+            ("session_id", "other-session"),
+            ("profile_id", GEMMA4_PROFILE_ID),
+            ("model_id", "/models/other.gguf"),
+            ("template_id", "other-template"),
+            ("tool_schema_hash", "other-tools"),
+            ("capability_summary_hash", "other-caps"),
+            ("runtime_policy_hash", "other-policy"),
+            ("native_version", "other-lib"),
+            ("tools_mode", "off"),
+            ("reset_generation", 1),
+        ]:
+            with self.subTest(field=field_name):
+                self.assertIsNone(
+                    rolling_route_reuse_start(state, ROUTE2, identity(**{field_name: value})),
+                    f"{field_name} change must block reuse",
+                )
+
+    def test_invalidated_state_cannot_be_reused_or_restored(self) -> None:
+        state, _ = capture_rolling_route_anchor(
+            FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+        )
+        dead = invalidate_rolling_route_anchor(state, "session_reset")
+        self.assertFalse(dead.valid)
+        self.assertIsNone(rolling_route_reuse_start(dead, ROUTE2, identity()))
+        ok, _, _ = restore_rolling_route_anchor(FakeLib(), CTX, dead)
+        self.assertFalse(ok)
+
+    def test_capture_failures_produce_no_usable_state(self) -> None:
+        for kwargs, reason in [
+            ({"fail_get": True}, "checkpoint_capture_failed"),
+            ({"short_write": True}, "checkpoint_size_mismatch"),
+            ({"size": 0}, "empty_checkpoint"),
+        ]:
+            with self.subTest(reason=reason):
+                state, meta = capture_rolling_route_anchor(
+                    FakeLib(**kwargs), CTX, prompt_tokens=ROUTE1, identity=identity()
+                )
+                self.assertFalse(state.valid)
+                self.assertEqual(meta["fallback_reason"], reason)
+
+    def test_restore_failure_is_reported_and_drops_state(self) -> None:
+        for kwargs, reason in [
+            ({"fail_set": True}, "checkpoint_restore_failed"),
+            ({"short_read": True}, "checkpoint_restore_size_mismatch"),
+        ]:
+            with self.subTest(reason=reason):
+                state, _ = capture_rolling_route_anchor(
+                    FakeLib(), CTX, prompt_tokens=ROUTE1, identity=identity()
+                )
+                ok, after, meta = restore_rolling_route_anchor(FakeLib(**kwargs), CTX, state)
+                self.assertFalse(ok, "a partial restore must never read as success")
+                self.assertFalse(after.valid)
+                self.assertEqual(meta["fallback_reason"], reason)
+
+    def test_empty_state_is_never_reusable(self) -> None:
+        self.assertIsNone(rolling_route_reuse_start(RollingRouteAnchorState(), ROUTE2, identity()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rolling_route_anchor_integration.py
+++ b/tests/test_rolling_route_anchor_integration.py
@@ -1,0 +1,341 @@
+"""The wired rolling route anchor, driven through the real client methods.
+
+The companion module tests cover `RollingRouteAnchorState` in isolation. These
+drive `NativeLlamaClient` itself, because the safety properties that matter
+live in the wiring: that a restored checkpoint still has to satisfy strict
+append, that a reset destroys the checkpoint, that an incomplete prefill never
+captures, and that a failed capture leaves a good checkpoint alone.
+
+Each test asserts the production method was actually entered and that the hook
+it depends on was actually called -- a test that only checks a return value
+would pass just as happily if the wiring were deleted.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.native_llama.client as client_module
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID
+from orbit.native_llama.rolling_route_anchor import (
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+)
+
+ROUTE1 = [10, 11, 12, 13]
+ROUTE2 = ROUTE1 + [14, 15]
+CHECKPOINT = b"checkpoint-a"
+
+
+def identity(**overrides) -> RollingRouteIdentity:
+    base = dict(
+        strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+        session_id="default",
+        profile_id=ORNITH15_PROFILE_ID,
+        model_id="/models/ornith.gguf",
+        template_id="tpl",
+        tool_schema_hash="tools",
+        capability_summary_hash="caps",
+        runtime_policy_hash="policy",
+        native_version="libllama.so",
+        tools_mode="on",
+        reset_generation=0,
+    )
+    base.update(overrides)
+    return RollingRouteIdentity(**base)
+
+
+class _Lib:
+    """The handful of C entry points these paths touch."""
+
+    def __init__(self, *, fail_set: bool = False) -> None:
+        self.fail_set = fail_set
+        self.cleared = 0
+        self.set_data_calls = 0
+
+    def llama_state_seq_set_data(self, ctx, buffer, size, seq_id):
+        self.set_data_calls += 1
+        if self.fail_set:
+            raise RuntimeError("restore exploded")
+        return size
+
+    def llama_get_memory(self, ctx):
+        return object()
+
+    def llama_memory_clear(self, mem, flag):
+        self.cleared += 1
+
+
+class _LibHolder:
+    def __init__(self, lib: _Lib) -> None:
+        self.lib = lib
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.ctx_tgt = object()
+        self.session_id = "default"
+        self.cached_prompt_tokens: list[int] = []
+        self.committed_sequence_tokens: list[int] = []
+        self.mtp_enabled = False
+
+
+def strategy_client(state: RollingRouteAnchorState, *, fail_set: bool = False):
+    """A client with only what the rolling strategy path reaches."""
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    lib = _Lib(fail_set=fail_set)
+    client.lib = _LibHolder(lib)
+    client._session = _Session()
+    client._rolling_route_anchor_state = state
+    client._rolling_route_identity_cache = None
+    calls: list[list[int]] = []
+
+    def fake_prepare(prompt_tokens):
+        # Stand in for the real strict-append gate and record that the
+        # strategy actually deferred to it.
+        calls.append(list(prompt_tokens))
+        return 99
+
+    client._prepare_memory_for_prompt = fake_prepare  # type: ignore[method-assign]
+    client._invalidate_committed_sequence = lambda: client._session.committed_sequence_tokens.clear()  # type: ignore[method-assign]
+    return client, lib, calls
+
+
+def valid_state(tokens=ROUTE1, ident=None) -> RollingRouteAnchorState:
+    return RollingRouteAnchorState(
+        identity=ident or identity(),
+        tokens=list(tokens),
+        checkpoint_data=CHECKPOINT,
+        created_at_monotonic=1.0,
+    )
+
+
+class StrictAppendRemainsAuthorityTest(unittest.TestCase):
+    """Test A: the rolling strategy may restore, but never authorize."""
+
+    def test_restore_defers_to_prepare_memory_for_prompt(self) -> None:
+        client, lib, calls = strategy_client(valid_state())
+        client._rolling_route_identity_cache = identity()
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(ROUTE2)
+
+        # The restore really happened...
+        self.assertEqual(lib.set_data_calls, 1, "the checkpoint must actually be restored")
+        # ...bookkeeping was handed over so strict append can judge it...
+        self.assertEqual(client._session.committed_sequence_tokens, ROUTE1)
+        self.assertEqual(client._session.cached_prompt_tokens, ROUTE1)
+        # ...and the decision was delegated, not made here.
+        self.assertEqual(calls, [ROUTE2], "_prepare_memory_for_prompt must decide reuse")
+        self.assertEqual(
+            result, 99, "the strategy must return strict append's verdict, not its own prefix length"
+        )
+        self.assertNotEqual(
+            result, len(ROUTE1), "returning the restored prefix length would bypass PR #210"
+        )
+
+    def test_incompatible_prompt_skips_restore_and_still_defers(self) -> None:
+        client, lib, calls = strategy_client(valid_state())
+        client._rolling_route_identity_cache = identity()
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor([10, 11, 99, 13, 14])
+
+        self.assertEqual(lib.set_data_calls, 0, "a mismatched prompt must not restore")
+        self.assertEqual(calls, [[10, 11, 99, 13, 14]])
+        self.assertEqual(result, 99)
+
+    def test_failed_restore_clears_then_defers(self) -> None:
+        client, lib, calls = strategy_client(valid_state(), fail_set=True)
+        client._rolling_route_identity_cache = identity()
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(ROUTE2)
+
+        self.assertEqual(lib.set_data_calls, 1)
+        self.assertGreaterEqual(lib.cleared, 1, "a partial restore leaves KV unknown; clear it")
+        self.assertFalse(
+            client._rolling_route_anchor_state.valid, "a failed restore must drop the checkpoint"
+        )
+        self.assertEqual(calls, [ROUTE2], "the cold path still runs through strict append")
+        self.assertEqual(result, 99)
+
+
+class DirectCallFailsClosedTest(unittest.TestCase):
+    """Phase 3: without a staged identity the strategy must not reuse."""
+
+    def test_missing_staged_identity_rejects_reuse(self) -> None:
+        client, lib, calls = strategy_client(valid_state())
+        # Dispatcher never ran, so no identity was staged.
+        self.assertIsNone(client._rolling_route_identity_cache)
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(ROUTE2)
+
+        self.assertEqual(lib.set_data_calls, 0, "no identity means no restore")
+        self.assertEqual(calls, [ROUTE2])
+        self.assertEqual(result, 99)
+
+    def test_stale_identity_from_another_session_rejects_reuse(self) -> None:
+        client, lib, calls = strategy_client(valid_state())
+        client._rolling_route_identity_cache = identity(session_id="a-different-session")
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(ROUTE2)
+
+        self.assertEqual(lib.set_data_calls, 0)
+        self.assertEqual(result, 99)
+
+
+class CaptureGuardTest(unittest.TestCase):
+    """Tests C and D: what may and may not become a checkpoint."""
+
+    def _capture_harness(self, *, processed, n_prompt, cancelled, existing, capture_result):
+        """Re-execute the production capture guard against recorded inputs.
+
+        The guard is a block inside `_complete_prompt_standard`; driving the
+        whole method would need a live model, so the guard's exact condition
+        and body are exercised here with the same client state.
+        """
+        client = NativeLlamaClient.__new__(NativeLlamaClient)
+        client._rolling_route_anchor_state = existing
+        import threading
+
+        client.cancel_event = threading.Event()
+        if cancelled:
+            client.cancel_event.set()
+        client._session = _Session()
+
+        captured_calls: list[list[int]] = []
+
+        def fake_capture(lib, ctx, *, prompt_tokens, identity):
+            captured_calls.append(list(prompt_tokens))
+            return capture_result, {}
+
+        original = client_module.capture_rolling_route_anchor
+        client_module.capture_rolling_route_anchor = fake_capture
+        try:
+            source = _capture_guard_source()
+            exec_globals = {
+                "rolling_route_eligible": True,
+                "rolling_route_identity": identity(),
+                "processed": processed,
+                "n_prompt": n_prompt,
+                "self": client,
+                "lib": object(),
+                "prompt_tokens": ROUTE2,
+                "rolling_route_should_replace": client_module.rolling_route_should_replace,
+                "capture_rolling_route_anchor": fake_capture,
+            }
+            exec(source, exec_globals)
+        finally:
+            client_module.capture_rolling_route_anchor = original
+        return client, captured_calls
+
+    def test_partial_prefill_never_captures(self) -> None:
+        existing = valid_state()
+        client, captured = self._capture_harness(
+            processed=5, n_prompt=6, cancelled=False, existing=existing,
+            capture_result=valid_state(ROUTE2),
+        )
+        self.assertEqual(captured, [], "an incomplete prefill must not be snapshotted")
+        self.assertEqual(client._rolling_route_anchor_state.tokens, ROUTE1)
+
+    def test_cancelled_prefill_never_captures(self) -> None:
+        existing = valid_state()
+        client, captured = self._capture_harness(
+            processed=6, n_prompt=6, cancelled=True, existing=existing,
+            capture_result=valid_state(ROUTE2),
+        )
+        self.assertEqual(captured, [], "a cancelled prefill must not be snapshotted")
+        self.assertEqual(client._rolling_route_anchor_state.tokens, ROUTE1)
+
+    def test_complete_prefill_captures_and_rolls_forward(self) -> None:
+        existing = valid_state()
+        client, captured = self._capture_harness(
+            processed=6, n_prompt=6, cancelled=False, existing=existing,
+            capture_result=valid_state(ROUTE2),
+        )
+        self.assertEqual(captured, [ROUTE2], "a complete prefill is the capture point")
+        self.assertEqual(client._rolling_route_anchor_state.tokens, ROUTE2)
+
+    def test_failed_capture_preserves_previous_checkpoint(self) -> None:
+        existing = valid_state()
+        failed = RollingRouteAnchorState(invalidation_reason="checkpoint_capture_failed")
+        client, captured = self._capture_harness(
+            processed=6, n_prompt=6, cancelled=False, existing=existing,
+            capture_result=failed,
+        )
+        self.assertEqual(captured, [ROUTE2], "capture was attempted")
+        state = client._rolling_route_anchor_state
+        self.assertTrue(state.valid, "a failed capture must not destroy a good checkpoint")
+        self.assertEqual(state.tokens, ROUTE1)
+        self.assertEqual(state.checkpoint_data, CHECKPOINT)
+
+
+def _capture_guard_source() -> str:
+    """The capture guard, lifted verbatim from the production method.
+
+    Read from the installed source so the test cannot drift away from the
+    code it is protecting: if the guard changes, this text changes with it.
+    """
+    import inspect
+    import textwrap
+
+    source = inspect.getsource(NativeLlamaClient._complete_prompt_standard)
+    marker = "        if (\n            rolling_route_eligible"
+    start = source.index(marker)
+    end = source.index("        self.last_committed_generated_tokens = []", start)
+    return textwrap.dedent(source[start:end])
+
+
+class ResetInvalidatesRollingStateTest(unittest.TestCase):
+    """Test B: a reset must destroy conversation-derived KV state."""
+
+    def test_reset_session_state_invalidates_and_bumps_generation(self) -> None:
+        client = NativeLlamaClient.__new__(NativeLlamaClient)
+        client._rolling_route_anchor_state = valid_state()
+        client._reset_generation = 0
+
+        before = client._rolling_route_anchor_state
+        self.assertTrue(before.valid)
+
+        # Exercise the two production effects reset relies on.
+        client._reset_generation += 1
+        client._invalidate_rolling_route_anchor("session_reset")
+
+        self.assertFalse(
+            client._rolling_route_anchor_state.valid,
+            "a reset must destroy the rolling checkpoint",
+        )
+        self.assertEqual(client._rolling_route_anchor_state.invalidation_reason, "session_reset")
+        self.assertEqual(client._reset_generation, 1)
+
+    def test_reset_session_state_source_invalidates_rolling_state(self) -> None:
+        # The invalidation must live in reset_session_state itself: removing it
+        # there would otherwise leave a conversation checkpoint alive across
+        # /reset, which the unit above cannot see.
+        import inspect
+
+        source = inspect.getsource(NativeLlamaClient.reset_session_state)
+        self.assertIn("_invalidate_rolling_route_anchor", source)
+        self.assertIn("_reset_generation", source)
+
+    def test_bumped_generation_blocks_reuse_of_an_old_checkpoint(self) -> None:
+        client, lib, calls = strategy_client(valid_state())
+        # Checkpoint was built at generation 0; the client has since reset.
+        client._rolling_route_identity_cache = identity(reset_generation=1)
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(ROUTE2)
+
+        self.assertEqual(lib.set_data_calls, 0, "a pre-reset checkpoint must not be restored")
+        self.assertEqual(calls, [ROUTE2])
+        self.assertEqual(result, 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rolling_route_mode_transition.py
+++ b/tests/test_rolling_route_mode_transition.py
@@ -1,0 +1,242 @@
+"""The rolling route checkpoint and the internal prompt-cache mode switch.
+
+A conversational turn alternates between two internal cache modes: the route
+call runs with tools attached (`tools:thinking=off`), the final call without
+(`chat:thinking=off`). Every switch calls `reset_session_state()`, which is
+where conversation-derived KV state goes to die -- correctly, for a user reset,
+and catastrophically for an optimisation that only pays off across turns.
+
+So the checkpoint has to survive exactly one thing: that internal switch, for
+the one profile qualified for it. It must still die on a real reset, a new
+session, a profile change, or any identity drift. These tests pin both halves,
+because a preservation rule that leaks into `/reset` would keep one
+conversation's tokens resident into the next.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import (
+    GEMMA4_PROFILE_ID,
+    ORNITH15_PROFILE_ID,
+    QWEN36_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+)
+from orbit.native_llama.rolling_route_anchor import (
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+)
+
+TOOLS_MODE = "tools:thinking=off"
+CHAT_MODE = "chat:thinking=off"
+MULTIMODAL_MODE = "multimodal:thinking=off"
+THINKING_MODE = "tools:thinking=on"
+
+ROUTE_A = [10, 11, 12, 13]
+
+
+def identity(**overrides) -> RollingRouteIdentity:
+    base = dict(
+        strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+        session_id="default",
+        profile_id=ORNITH15_PROFILE_ID,
+        model_id="/models/ornith.gguf",
+        template_id="tpl",
+        tool_schema_hash="tools",
+        capability_summary_hash="caps",
+        runtime_policy_hash="policy",
+        native_version="libllama.so",
+        tools_mode="on",
+        reset_generation=0,
+    )
+    base.update(overrides)
+    return RollingRouteIdentity(**base)
+
+
+def checkpoint_a() -> RollingRouteAnchorState:
+    return RollingRouteAnchorState(
+        identity=identity(),
+        tokens=list(ROUTE_A),
+        checkpoint_data=b"checkpoint-a",
+        created_at_monotonic=1.0,
+    )
+
+
+class _Profile:
+    def __init__(self, profile_id: str, verified: bool = True) -> None:
+        self.profile_id = profile_id
+        self.verified = verified
+
+
+class _Session:
+    def __init__(self, mode: str | None) -> None:
+        self.prompt_cache_mode = mode
+
+
+def mode_client(profile_id: str = ORNITH15_PROFILE_ID, *, mode: str | None = TOOLS_MODE,
+                verified: bool = True):
+    """A client whose only live behaviour is the mode-transition decision."""
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    client.model_profile = _Profile(profile_id, verified)
+    client._session = _Session(mode)
+    client._rolling_route_anchor_state = checkpoint_a()
+    client._reset_generation = 0
+    recorded: list[dict] = []
+
+    def fake_reset(**kwargs):
+        recorded.append(dict(kwargs))
+        # Mirror the production reset's effect on rolling state so the test
+        # observes what a real reset would actually do.
+        if not kwargs.get("preserve_ornith_rolling_route_checkpoint"):
+            client._reset_generation += 1
+            client._rolling_route_anchor_state = RollingRouteAnchorState(
+                invalidation_reason="session_reset"
+            )
+
+    client.reset_session_state = fake_reset  # type: ignore[method-assign]
+    return client, recorded
+
+
+class QualifiedTransitionPreservesTest(unittest.TestCase):
+    """The defect this mission exists to fix."""
+
+    def test_tools_to_chat_preserves_the_rolling_checkpoint(self) -> None:
+        client, recorded = mode_client(mode=TOOLS_MODE)
+        client._ensure_prompt_cache_mode(CHAT_MODE)
+
+        self.assertEqual(len(recorded), 1, "the mode switch still resets the session")
+        self.assertTrue(
+            client._rolling_route_anchor_state.valid,
+            "the final call's mode switch must not destroy the route checkpoint",
+        )
+        self.assertEqual(client._rolling_route_anchor_state.tokens, ROUTE_A)
+
+    def test_chat_to_tools_preserves_the_rolling_checkpoint(self) -> None:
+        client, _ = mode_client(mode=CHAT_MODE)
+        client._ensure_prompt_cache_mode(TOOLS_MODE)
+        self.assertTrue(
+            client._rolling_route_anchor_state.valid,
+            "returning to the route mode must find the checkpoint intact",
+        )
+
+    def test_full_turn_cycle_keeps_the_checkpoint_alive(self) -> None:
+        # route (tools) -> final (chat) -> next route (tools)
+        client, _ = mode_client(mode=TOOLS_MODE)
+        client._ensure_prompt_cache_mode(CHAT_MODE)
+        client._ensure_prompt_cache_mode(TOOLS_MODE)
+        self.assertTrue(client._rolling_route_anchor_state.valid)
+        self.assertEqual(client._rolling_route_anchor_state.tokens, ROUTE_A)
+        self.assertEqual(
+            client._reset_generation, 0, "an internal switch is not a lifecycle reset"
+        )
+
+
+class UnqualifiedTransitionsStillDestroyTest(unittest.TestCase):
+    def test_thinking_mode_change_is_not_qualified(self) -> None:
+        client, _ = mode_client(mode=TOOLS_MODE)
+        client._ensure_prompt_cache_mode(THINKING_MODE)
+        self.assertFalse(
+            client._rolling_route_anchor_state.valid,
+            "only the exact tools<->chat pair is qualified",
+        )
+
+    def test_multimodal_transition_is_not_qualified(self) -> None:
+        client, _ = mode_client(mode=TOOLS_MODE)
+        client._ensure_prompt_cache_mode(MULTIMODAL_MODE)
+        self.assertFalse(client._rolling_route_anchor_state.valid)
+
+    def test_other_profiles_do_not_get_ornith_preservation(self) -> None:
+        for profile_id in (GEMMA4_PROFILE_ID, QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            with self.subTest(profile=profile_id):
+                client, recorded = mode_client(profile_id, mode=TOOLS_MODE)
+                client._ensure_prompt_cache_mode(CHAT_MODE)
+                self.assertFalse(
+                    recorded[0].get("preserve_ornith_rolling_route_checkpoint", False),
+                    "rolling preservation is Ornith-only",
+                )
+
+    def test_unverified_ornith_does_not_get_preservation(self) -> None:
+        client, recorded = mode_client(mode=TOOLS_MODE, verified=False)
+        client._ensure_prompt_cache_mode(CHAT_MODE)
+        self.assertFalse(recorded[0].get("preserve_ornith_rolling_route_checkpoint", False))
+
+
+class DestructiveResetStillDestroysTest(unittest.TestCase):
+    """The preservation flag must not leak into real resets."""
+
+    def test_reset_session_state_without_the_flag_invalidates(self) -> None:
+        client = NativeLlamaClient.__new__(NativeLlamaClient)
+        client._rolling_route_anchor_state = checkpoint_a()
+        client._reset_generation = 0
+        client._invalidate_rolling_route_anchor("session_reset")
+        self.assertFalse(client._rolling_route_anchor_state.valid)
+
+    def test_reset_default_does_not_preserve_rolling_state(self) -> None:
+        # A caller that says nothing must get the destructive behaviour.
+        import inspect
+
+        signature = inspect.signature(NativeLlamaClient.reset_session_state)
+        param = signature.parameters.get("preserve_ornith_rolling_route_checkpoint")
+        self.assertIsNotNone(param, "the preserve option must exist")
+        self.assertIs(param.default, False, "preservation must be opt-in, never the default")
+
+    def test_real_reset_body_honours_the_preserve_flag(self) -> None:
+        """Drive the real reset body, not a stub, in both directions.
+
+        The transition tests stub `reset_session_state`, so only this can see
+        whether the flag is actually consulted inside it.
+        """
+        import inspect
+        import textwrap
+
+        source = inspect.getsource(NativeLlamaClient.reset_session_state)
+        start = source.index("        if not preserve_ornith_rolling_route_checkpoint:")
+        end = source.index("        self._invalidate_final_prefix(", start)
+        block = textwrap.dedent(source[start:end])
+
+        for preserve, expect_valid in ((True, True), (False, False)):
+            with self.subTest(preserve=preserve):
+                client = NativeLlamaClient.__new__(NativeLlamaClient)
+                client._rolling_route_anchor_state = checkpoint_a()
+                client._reset_generation = 0
+                exec(
+                    block,
+                    {
+                        "self": client,
+                        "preserve_ornith_rolling_route_checkpoint": preserve,
+                    },
+                )
+                self.assertEqual(
+                    client._rolling_route_anchor_state.valid,
+                    expect_valid,
+                    "the reset body must consult the preserve flag",
+                )
+                self.assertEqual(client._reset_generation, 0 if preserve else 1)
+
+    def test_server_reset_endpoint_never_preserves_rolling_state(self) -> None:
+        # /reset must clear conversation-derived KV: unlike the fixed
+        # Qwen3-Coder prefix, this checkpoint holds the user's own tokens.
+        import inspect
+
+        from orbit.native_server.app import OrbitNativeServer
+
+        source = inspect.getsource(OrbitNativeServer.reset_session)
+        self.assertNotIn(
+            "preserve_ornith_rolling_route_checkpoint",
+            source,
+            "/reset must not preserve conversation-derived rolling state",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Ordinary Ornith conversational routing produces a rolling exact-prefix route chain: turn two's route prompt opens with turn one's, token for token. But each turn interleaves a small final call that runs in a different internal prompt-cache mode, and the mode switch clears active KV.

Later route calls therefore cold-prefill even though their prompts exactly extend prior route prompts — re-evaluating hundreds of tokens that were resident moments earlier.

## Fix

One isolated Ornith-only rolling route-anchor strategy:

- exact verified profile only: `orbit-ornith15-native-v1`;
- route calls only;
- one rolling checkpoint per native client/session, replaced in place;
- captures the full route KV exactly after prompt prefill and **before** decode, so generated route tokens are excluded by construction;
- final calls may mutate or clear active KV but cannot evict the serialized rolling checkpoint — that is why it is serialized rather than left resident;
- the next compatible route restores it;
- exact saved-token prefix identity is required (`new[:len(saved)] == saved`, and the new prompt must be strictly longer);
- the existing PR #210 strict-append logic remains the **final reuse authority** — the checkpoint supplies candidate state, strict append decides;
- incompatible post-tool agentic routes fail closed and cold-prefill;
- no prompt, routing, or tool semantics changed;
- genuine resets and session changes invalidate the rolling state.

### Internal mode-transition handling

The rolling checkpoint survives only the qualified Ornith internal transition:

```
tools:thinking=off  <->  chat:thinking=off
```

This does **not** weaken `/reset` or destructive lifecycle invalidation. Unlike the fixed Qwen3-Coder route prefix, this checkpoint holds the conversation's own tokens, so a real reset, a new session, or any identity drift destroys it.

### Profile isolation

- Gemma stable route-anchor behavior unchanged
- Qwen3-Coder behavior unchanged
- Qwen 3.6 unchanged
- Qwen 3.8 unchanged

## Performance evidence

Deterministic topology, measured with the real tokenizer through `ChatRuntime.ask_auto`:

- route1 → route2: exact prefix
- route2 → route3: exact prefix
- evaluated-token reduction: approximately 61–62%

Real follow-up route reuse was demonstrated, and a combined production smoke showed:

- turn 1: `0 cache` (cold, as expected)
- turn 2: `843 cache`
- turn 3: `898 cache`
- session: `1741 cache (~60%)`
- no false failed attempts, truthful partial accounting

Conversational wall times improved materially in prior controlled runs. Those runs were not fully isolated from page-cache warmth, so the reuse figures above — not the wall times — are the load-bearing evidence.

## Memory

Stated transparently:

- serialized rolling checkpoint: ~79 MiB
- observed transient RSS increase during capture: ~176 MiB (a `bytes()` copy alongside the live buffer)
- bounded to one checkpoint per session, replaced in place, no turn-over-turn accumulation

Worth budgeting against `--ctx` on memory-constrained hosts.

## Validation

- exact-SHA independent review: **PASS**
- **0 BLOCKER / 0 MAJOR / 0 MINOR**
- **8/8 critical mutation tests CAUGHT** (PR #210 bypass, reset invalidation, prefill-boundary guard, failed-capture overwrite, final eviction, weakened prefix check, `/reset` preservation, wrong-profile preservation)
- production integration, mode-transition, and reset tests PASS
- agentic filesystem canary PASS
- combined telemetry + rolling suite: **2215 PASS**
- `compileall`: PASS
- `git diff --check`: PASS
- no agentic correctness regression

Agentic route reuse is **not** guaranteed: post-tool route prompts generally diverge from the conversational chain, so they fail the exact-prefix check and remain cold. Agentic behavior is preserved, not improved.