### PR TITLE
feat(runtime): add isolated analysis sandbox foundation

### DIFF
--- a/src/orbit/runtime/analysis_sandbox.py
+++ b/src/orbit/runtime/analysis_sandbox.py
@@ -1,0 +1,465 @@
+"""Run one bounded Python program against a read-only input, in isolation.
+
+This is the execution primitive behind analyst-guided investigation: a caller
+supplies an input file and a Python program, and gets back what that program
+printed plus hashes of anything it wrote. The program runs under bubblewrap
+with no network, no host filesystem, dropped capabilities, and hard resource
+limits, so an investigation can transform data without the transforming code
+reaching anything that matters.
+
+Ported from the research harness that proved the approach, minus everything
+specific to that experiment. This module knows nothing about what is being
+analysed -- no file formats, no indicators, no notion of "malware". It runs a
+program and reports facts about the run.
+
+What isolation actually buys, stated precisely: the program cannot reach the
+network or the host filesystem, cannot modify its input, and cannot exceed its
+CPU/memory/output budget. It is arbitrary Python, so it *can* interpret the
+bytes it reads however it likes -- including running them through an
+interpreter it writes itself. Preventing that would require deciding what a
+program means, which is not decidable and not attempted here. The guarantee is
+containment of effects, not restriction of intent.
+
+Nothing here is registered as a model-facing tool. Reaching this module is a
+deliberate act by a caller that already decided code execution is warranted.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import os
+import selectors
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BWRAP = "/usr/bin/bwrap"
+SOURCE_MOUNT = "/workspace/input"
+WORK_MOUNT = "/workspace/work"
+
+# Bounds carried over unchanged from the proven research configuration.
+ACTION_TIMEOUT_SECONDS = 15.0
+CPU_SECONDS = 14
+ADDRESS_SPACE_BYTES = 768 * 1024 * 1024
+FILE_SIZE_BYTES = 64 * 1024
+OPEN_FILES = 96
+EXTRA_PROCESSES = 32
+MAX_CODE_CHARS = 32 * 1024
+MAX_OUTPUT_BYTES = 64 * 1024
+HARD_OUTPUT_BYTES = 2 * 1024 * 1024
+MAX_SCRATCH_BYTES = 8 * 1024 * 1024
+MAX_SCRATCH_FILES = 32
+MAX_SCRATCH_DEPTH = 4
+
+# The recorded successful trajectory used one helper -- reading the input --
+# and never invoked an external binary. Nothing else is mounted: an executable
+# that no proven workflow needs is attack surface with no upside. Adding one
+# back is a deliberate change with its own evidence, not a default.
+ALLOWED_COMMANDS: frozenset[str] = frozenset()
+
+
+class SandboxUnavailable(RuntimeError):
+    """The isolation prerequisite is missing, so nothing was executed.
+
+    Raised instead of degrading to a weaker sandbox. Running the program
+    without isolation would be the one outcome worse than not running it.
+    """
+
+
+@dataclass(frozen=True)
+class DerivedArtifact:
+    """A file the program wrote, identified by content."""
+
+    name: str
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    """Facts about one execution. No interpretation of what was analysed."""
+
+    status: str  # "ok" | "error" | "timeout" | "bounded"
+    code_sha256: str
+    input_sha256: str
+    stdout: str
+    stderr: str
+    exit_status: int | None
+    duration_seconds: float
+    truncated: bool = False
+    bound_exceeded: str | None = None
+    artifacts: tuple[DerivedArtifact, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+
+def sandbox_preflight(bwrap_path: str = BWRAP) -> None:
+    """Fail closed unless real isolation is available.
+
+    Checks that bubblewrap exists and that the exact flag set below actually
+    works on this host, rather than assuming a version implies behaviour: a
+    namespace the kernel refuses is a silent hole if nobody looks.
+    """
+    resolved = shutil.which(bwrap_path) or (bwrap_path if Path(bwrap_path).exists() else None)
+    if resolved is None:
+        raise SandboxUnavailable(
+            "bubblewrap (bwrap) is required for sandboxed analysis and was not found"
+        )
+    probe = [
+        resolved,
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--assert-userns-disabled",
+        "--die-with-parent",
+        "--new-session",
+        "--clearenv",
+        "--cap-drop",
+        "ALL",
+        "--tmpfs",
+        "/",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "/bin/true",
+    ]
+    for root in ("/usr/lib", "/lib", "/lib64", "/bin", "/usr/bin"):
+        if Path(root).exists():
+            probe[-1:-1] = ["--ro-bind", root, root]
+    try:
+        completed = subprocess.run(
+            probe, stdin=subprocess.DEVNULL, capture_output=True, timeout=20
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SandboxUnavailable(f"bubblewrap could not start: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip()[-240:]
+        raise SandboxUnavailable(f"bubblewrap rejected the required isolation: {detail}")
+
+
+def validate_code(code: object) -> str:
+    """Accept only bounded, parseable UTF-8 Python. Returns the code."""
+    if not isinstance(code, str):
+        raise ValueError("code must be a string")
+    try:
+        raw = code.encode("utf-8", "strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError("code is not valid UTF-8") from exc
+    if not code.strip():
+        raise ValueError("code is empty")
+    if len(code) > MAX_CODE_CHARS or len(raw) > MAX_CODE_CHARS * 4:
+        raise ValueError("code exceeds bounds")
+    if "\x00" in code:
+        raise ValueError("code contains a NUL byte")
+    try:
+        ast.parse(code, mode="exec")
+    except SyntaxError as exc:
+        # Keep the interpreter's own wording: a caller repairing the program
+        # needs the real diagnostic, not a paraphrase.
+        location = f" (line {exc.lineno}, offset {exc.offset})" if exc.lineno else ""
+        raise ValueError(f"Python syntax is malformed: {type(exc).__name__}: {exc.msg}{location}") from exc
+    return code
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _preexec_limits() -> None:
+    import resource as _resource
+
+    for kind, value in (
+        (_resource.RLIMIT_CORE, 0),
+        (_resource.RLIMIT_CPU, CPU_SECONDS),
+        (_resource.RLIMIT_AS, ADDRESS_SPACE_BYTES),
+        (_resource.RLIMIT_FSIZE, FILE_SIZE_BYTES),
+        (_resource.RLIMIT_NOFILE, OPEN_FILES),
+        (_resource.RLIMIT_STACK, 16 * 1024 * 1024),
+    ):
+        _resource.setrlimit(kind, (value, value))
+    # NPROC is per-UID, not per-process: the ceiling has to clear every task
+    # this user already owns, or bubblewrap cannot even fork to build the
+    # namespaces and the sandbox fails before the program runs.
+    _resource.setrlimit(
+        _resource.RLIMIT_NPROC, (_uid_task_count() + EXTRA_PROCESSES,) * 2
+    )
+
+
+def _uid_task_count() -> int:
+    uid = os.getuid()
+    count = 0
+    for status in Path("/proc").glob("[0-9]*/status"):
+        try:
+            lines = status.read_text(encoding="ascii", errors="ignore").splitlines()
+        except OSError:
+            continue
+        owner = next((line for line in lines if line.startswith("Uid:")), "")
+        if owner.split()[1:2] != [str(uid)]:
+            continue
+        try:
+            count += sum(1 for _task in (status.parent / "task").iterdir())
+        except OSError:
+            count += 1
+    return max(count, 1)
+
+
+def _sandbox_command(source: Path, scratch: Path, program: Path, python: str) -> list[str]:
+    args = [
+        BWRAP,
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--assert-userns-disabled",
+        "--die-with-parent",
+        "--new-session",
+        "--clearenv",
+        "--cap-drop",
+        "ALL",
+        "--hostname",
+        "orbit-analysis",
+        "--tmpfs",
+        "/",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--dir",
+        "/usr",
+        "--dir",
+        "/usr/bin",
+        "--ro-bind",
+        python,
+        python,
+    ]
+    for root in ("/usr/lib", "/lib", "/lib64"):
+        if Path(root).exists():
+            args.extend(("--ro-bind", root, root))
+    args.extend(("--dir", "/program", "--ro-bind", str(program), "/program/main.py"))
+    args.extend(
+        (
+            "--dir",
+            "/workspace",
+            "--ro-bind",
+            str(source),
+            SOURCE_MOUNT,
+            "--bind",
+            str(scratch),
+            WORK_MOUNT,
+            "--dir",
+            f"{WORK_MOUNT}/tmp",
+            "--symlink",
+            f"{WORK_MOUNT}/tmp",
+            "/tmp",
+            "--chdir",
+            WORK_MOUNT,
+            "--setenv",
+            "PATH",
+            "/nonexistent",
+            "--setenv",
+            "HOME",
+            WORK_MOUNT,
+            "--setenv",
+            "LANG",
+            "C.UTF-8",
+            "--setenv",
+            "PYTHONHASHSEED",
+            "0",
+            python,
+            "-I",
+            "-S",
+            "/program/main.py",
+        )
+    )
+    return args
+
+
+def _scratch_bound_error(root: Path) -> str | None:
+    """Reject anything the capture step could not read safely."""
+    total = 0
+    count = 0
+    try:
+        for base, dirs, files in os.walk(root, followlinks=False):
+            if len(Path(base).relative_to(root).parts) > MAX_SCRATCH_DEPTH:
+                return "scratch depth exceeded"
+            for name in dirs + files:
+                info = (Path(base) / name).lstat()
+                if stat.S_ISLNK(info.st_mode):
+                    return "scratch contains a symlink"
+                if not (stat.S_ISDIR(info.st_mode) or stat.S_ISREG(info.st_mode)):
+                    return "scratch contains an unsupported entry"
+                count += 1
+                if stat.S_ISREG(info.st_mode):
+                    total += info.st_size
+                if count > MAX_SCRATCH_FILES or total > MAX_SCRATCH_BYTES:
+                    return "scratch bound exceeded"
+    except OSError:
+        return "scratch inspection failed"
+    return None
+
+
+def _capture_artifacts(root: Path) -> tuple[DerivedArtifact, ...]:
+    captured: list[DerivedArtifact] = []
+    for path in sorted(root.rglob("*")):
+        info = path.lstat()
+        if stat.S_ISDIR(info.st_mode):
+            continue
+        # Opened with O_NOFOLLOW and re-checked: a symlink or extra hard link
+        # would mean the bytes hashed are not the bytes that were written.
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise RuntimeError("unsafe scratch entry")
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            data = b""
+            while len(data) <= MAX_SCRATCH_BYTES:
+                chunk = os.read(descriptor, min(64 * 1024, MAX_SCRATCH_BYTES - len(data) + 1))
+                if not chunk:
+                    break
+                data += chunk
+        finally:
+            os.close(descriptor)
+        captured.append(
+            DerivedArtifact(
+                name=str(path.relative_to(root)),
+                size_bytes=len(data),
+                sha256=_sha256_bytes(data),
+            )
+        )
+    return tuple(captured)
+
+
+def execute_analysis(
+    *,
+    source_path: Path | str,
+    code: str,
+    scratch_dir: Path | str | None = None,
+    python_executable: str | None = None,
+) -> AnalysisResult:
+    """Run `code` with `source_path` mounted read-only, and report what happened.
+
+    The input is hashed before and after: if the bytes differ, the run is
+    rejected rather than reported, because every later claim about the input
+    would be describing something that no longer exists.
+    """
+    source = Path(source_path).resolve()
+    if not source.is_file():
+        raise ValueError(f"source is not a file: {source}")
+    validated = validate_code(code)
+    sandbox_preflight()
+
+    python = python_executable or f"/usr/bin/python{'.'.join(map(str, __import__('sys').version_info[:2]))}"
+    if not Path(python).exists():
+        raise SandboxUnavailable(f"sandbox interpreter not found: {python}")
+
+    source_before = source.read_bytes()
+    input_sha = _sha256_bytes(source_before)
+    code_sha = _sha256_bytes(validated.encode("utf-8"))
+
+    program_owner = tempfile.TemporaryDirectory(prefix="orbit-analysis-program-")
+    scratch_owner = None
+    if scratch_dir is None:
+        scratch_owner = tempfile.TemporaryDirectory(prefix="orbit-analysis-work-")
+        scratch = Path(scratch_owner.name)
+    else:
+        scratch = Path(scratch_dir)
+        scratch.mkdir(parents=True, exist_ok=True)
+
+    program = Path(program_owner.name) / "main.py"
+    program.write_text(validated, encoding="utf-8")
+    os.chmod(program, 0o400)
+
+    started = time.monotonic()
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    bound_error: str | None = None
+    timed_out = False
+    exit_status: int | None = None
+
+    try:
+        process = subprocess.Popen(
+            _sandbox_command(source, scratch, program, python),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            preexec_fn=_preexec_limits,
+        )
+    except OSError as exc:
+        program_owner.cleanup()
+        if scratch_owner is not None:
+            scratch_owner.cleanup()
+        raise SandboxUnavailable(f"sandbox failed to start: {exc}") from exc
+
+    try:
+        assert process.stdout is not None and process.stderr is not None
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        while selector.get_map():
+            if time.monotonic() - started > ACTION_TIMEOUT_SECONDS:
+                timed_out = True
+                bound_error = bound_error or "analysis timeout"
+            if sum(len(value) for value in buffers.values()) > HARD_OUTPUT_BYTES:
+                bound_error = bound_error or "output hard limit exceeded"
+            if bound_error is not None:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+            for key, _mask in selector.select(timeout=0.05):
+                chunk = os.read(key.fileobj.fileno(), 8192)  # type: ignore[union-attr]
+                if chunk:
+                    buffers[key.data].extend(chunk)
+                else:
+                    selector.unregister(key.fileobj)
+        exit_status = process.wait(timeout=5)
+        process.stdout.close()
+        process.stderr.close()
+
+        if source.read_bytes() != source_before:
+            raise RuntimeError("read-only input changed during analysis")
+
+        scratch_error = _scratch_bound_error(scratch)
+        bound_error = bound_error or scratch_error
+        artifacts: tuple[DerivedArtifact, ...] = ()
+        if scratch_error is None:
+            artifacts = _capture_artifacts(scratch)
+
+        stdout_raw = bytes(buffers["stdout"])
+        stderr_raw = bytes(buffers["stderr"])
+        truncated = len(stdout_raw) + len(stderr_raw) > MAX_OUTPUT_BYTES
+        stdout = stdout_raw[:MAX_OUTPUT_BYTES].decode("utf-8", "replace")
+        stderr = stderr_raw[:MAX_OUTPUT_BYTES].decode("utf-8", "replace")
+
+        if timed_out:
+            status = "timeout"
+        elif bound_error is not None:
+            status = "bounded"
+        elif exit_status == 0:
+            status = "ok"
+        else:
+            status = "error"
+
+        return AnalysisResult(
+            status=status,
+            code_sha256=code_sha,
+            input_sha256=input_sha,
+            stdout=stdout,
+            stderr=stderr,
+            exit_status=exit_status,
+            duration_seconds=time.monotonic() - started,
+            truncated=truncated,
+            bound_exceeded=bound_error,
+            artifacts=artifacts,
+        )
+    finally:
+        program_owner.cleanup()
+        if scratch_owner is not None:
+            scratch_owner.cleanup()

--- a/tests/test_analysis_sandbox.py
+++ b/tests/test_analysis_sandbox.py
@@ -1,0 +1,452 @@
+"""The analysis sandbox has to hold against the program it is running.
+
+These cross the real bubblewrap boundary rather than mocking it: a mocked
+sandbox proves the call shape and nothing about isolation, and isolation is
+the entire point of the module. Every fixture is benign -- the adversarial
+cases are ordinary Python doing things the sandbox must refuse.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.analysis_sandbox import (
+    ALLOWED_COMMANDS,
+    MAX_CODE_CHARS,
+    SandboxUnavailable,
+    execute_analysis,
+    sandbox_preflight,
+    validate_code,
+)
+
+BWRAP_AVAILABLE = shutil.which("/usr/bin/bwrap") is not None
+FIXTURE_TEXT = "alpha\nbeta\ngamma\nSECRET-MARKER-7\n"
+
+
+def requires_bwrap(test):
+    return unittest.skipUnless(BWRAP_AVAILABLE, "bubblewrap not installed")(test)
+
+
+class SandboxTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-sandbox-test-")
+        self.tmp = Path(self._dir.name)
+        self.fixture = self.tmp / "input.txt"
+        self.fixture.write_text(FIXTURE_TEXT, encoding="utf-8")
+        self.addCleanup(self._dir.cleanup)
+
+    def run_code(self, code: str, **kwargs):
+        return execute_analysis(source_path=self.fixture, code=code, **kwargs)
+
+
+class CodeValidationTest(unittest.TestCase):
+    """Rejections that happen before anything is executed."""
+
+    def test_valid_code_is_returned(self) -> None:
+        self.assertEqual(validate_code("print(1)"), "print(1)")
+
+    def test_oversized_code_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_code("#" * (MAX_CODE_CHARS + 1))
+
+    def test_malformed_syntax_keeps_the_interpreter_diagnostic(self) -> None:
+        with self.assertRaises(ValueError) as raised:
+            validate_code("def (:")
+        self.assertIn("SyntaxError", str(raised.exception))
+
+    def test_empty_and_nul_and_non_string_rejected(self) -> None:
+        for bad in ("", "   ", "print(1)\x00"):
+            with self.subTest(code=repr(bad)):
+                with self.assertRaises(ValueError):
+                    validate_code(bad)
+        with self.assertRaises(ValueError):
+            validate_code(b"print(1)")  # type: ignore[arg-type]
+
+
+class PreflightTest(unittest.TestCase):
+    def test_missing_bwrap_executes_nothing(self) -> None:
+        with self.assertRaises(SandboxUnavailable):
+            sandbox_preflight(bwrap_path="/nonexistent/bwrap-does-not-exist")
+
+    @requires_bwrap
+    def test_preflight_passes_on_this_host(self) -> None:
+        sandbox_preflight()
+
+    def test_execute_refuses_when_sandbox_is_unavailable(self) -> None:
+        import tempfile
+
+        from orbit.runtime import analysis_sandbox
+
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "in.txt"
+            src.write_text("x", encoding="utf-8")
+            original = analysis_sandbox.BWRAP
+            analysis_sandbox.BWRAP = "/nonexistent/bwrap-does-not-exist"
+            try:
+                with self.assertRaises(SandboxUnavailable):
+                    analysis_sandbox.execute_analysis(source_path=src, code="print(1)")
+            finally:
+                analysis_sandbox.BWRAP = original
+
+
+@requires_bwrap
+class SandboxBehaviourTest(SandboxTestBase):
+    def test_normal_transformation_succeeds(self) -> None:
+        result = self.run_code(
+            "data = open('/workspace/input').read()\n"
+            "print('LINES:', len(data.splitlines()))\n"
+        )
+        self.assertEqual(result.status, "ok", result.stderr)
+        self.assertIn("LINES: 4", result.stdout)
+        self.assertEqual(result.exit_status, 0)
+
+    def test_input_bytes_are_exact_and_hashed(self) -> None:
+        import hashlib
+
+        result = self.run_code("print(open('/workspace/input').read(), end='')")
+        self.assertEqual(result.stdout, FIXTURE_TEXT)
+        self.assertEqual(
+            result.input_sha256, hashlib.sha256(FIXTURE_TEXT.encode()).hexdigest()
+        )
+
+    def test_input_is_read_only(self) -> None:
+        result = self.run_code(
+            "try:\n"
+            "    open('/workspace/input', 'w').write('tampered')\n"
+            "    print('WROTE')\n"
+            "except OSError as exc:\n"
+            "    print('DENIED', type(exc).__name__)\n"
+        )
+        self.assertIn("DENIED", result.stdout)
+        self.assertNotIn("WROTE", result.stdout)
+        # And the real file on the host is untouched.
+        self.assertEqual(self.fixture.read_text(encoding="utf-8"), FIXTURE_TEXT)
+
+    def test_workspace_is_writable_and_artifacts_are_hashed(self) -> None:
+        import hashlib
+
+        payload = "derived-content"
+        result = self.run_code(
+            f"open('/workspace/work/out.txt','w').write({payload!r})\nprint('OK')\n"
+        )
+        self.assertEqual(result.status, "ok", result.stderr)
+        self.assertEqual(len(result.artifacts), 1)
+        artifact = result.artifacts[0]
+        self.assertEqual(artifact.name, "out.txt")
+        self.assertEqual(artifact.sha256, hashlib.sha256(payload.encode()).hexdigest())
+
+    def test_host_files_are_unreachable(self) -> None:
+        result = self.run_code(
+            "import os\n"
+            "for probe in ('/etc/passwd', '/home', '/root'):\n"
+            "    print(probe, os.path.exists(probe))\n"
+        )
+        self.assertIn("/etc/passwd False", result.stdout)
+        self.assertIn("/home False", result.stdout)
+
+    def test_project_files_are_unreachable(self) -> None:
+        result = self.run_code(
+            f"import os\nprint('PROJECT', os.path.exists({str(ROOT)!r}))\n"
+        )
+        self.assertIn("PROJECT False", result.stdout)
+
+    def test_network_is_denied(self) -> None:
+        result = self.run_code(
+            "import socket\n"
+            "try:\n"
+            "    s = socket.socket()\n"
+            "    s.settimeout(2)\n"
+            "    s.connect(('1.1.1.1', 80))\n"
+            "    print('CONNECTED')\n"
+            "except OSError as exc:\n"
+            "    print('DENIED', type(exc).__name__)\n"
+        )
+        self.assertIn("DENIED", result.stdout)
+        self.assertNotIn("CONNECTED", result.stdout)
+
+    def test_no_external_binaries_are_mounted(self) -> None:
+        self.assertEqual(ALLOWED_COMMANDS, frozenset())
+        result = self.run_code(
+            "import subprocess\n"
+            "try:\n"
+            "    subprocess.run(['grep', '--version'], capture_output=True)\n"
+            "    print('RAN')\n"
+            "except Exception as exc:\n"
+            "    print('DENIED', type(exc).__name__)\n"
+        )
+        self.assertIn("DENIED", result.stdout)
+
+    def test_shell_escape_fails(self) -> None:
+        result = self.run_code(
+            "import os\nprint('RC', os.system('echo escaped > /tmp/escape.txt'))\n"
+        )
+        self.assertNotIn("RC 0", result.stdout)
+
+    def test_writes_outside_workspace_never_reach_the_host(self) -> None:
+        # The sandbox root is a tmpfs, so a write to "/" succeeds inside and is
+        # then discarded. What must hold is that nothing lands on the host and
+        # nothing becomes a captured artifact -- not that every write errors.
+        result = self.run_code(
+            "import os\n"
+            "for target in ('/etc/x', '/usr/x', '/out.txt'):\n"
+            "    try:\n"
+            "        open(target, 'w').write('x')\n"
+            "        print('WROTE', target)\n"
+            "    except OSError:\n"
+            "        print('DENIED', target)\n"
+        )
+        for target in (Path("/etc/x"), Path("/usr/x"), Path("/out.txt")):
+            self.assertFalse(target.exists(), f"{target} escaped to the host")
+        self.assertEqual(result.artifacts, (), "only /workspace/work may yield artifacts")
+
+    def test_symlink_escape_is_rejected(self) -> None:
+        result = self.run_code(
+            "import os\nos.symlink('/etc/passwd', '/workspace/work/link')\nprint('LINKED')\n"
+        )
+        # Either the link cannot resolve to anything useful, or the scratch
+        # scan refuses it -- but it must never be captured as an artifact.
+        self.assertTrue(
+            result.bound_exceeded is not None or not result.artifacts,
+            f"symlink must not become an artifact: {result.artifacts}",
+        )
+
+    def test_timeout_is_enforced(self) -> None:
+        result = self.run_code("import time\nwhile True:\n    time.sleep(0.1)\n")
+        self.assertEqual(result.status, "timeout")
+        self.assertLess(result.duration_seconds, 40)
+
+    def test_cpu_spin_is_bounded(self) -> None:
+        result = self.run_code("x = 0\nwhile True:\n    x += 1\n")
+        self.assertIn(result.status, {"timeout", "bounded", "error"})
+
+    def test_memory_is_bounded(self) -> None:
+        result = self.run_code(
+            "try:\n"
+            "    blob = bytearray(4 * 1024 * 1024 * 1024)\n"
+            "    print('ALLOCATED')\n"
+            "except MemoryError:\n"
+            "    print('DENIED MemoryError')\n"
+        )
+        self.assertNotIn("ALLOCATED", result.stdout)
+
+    def test_excessive_file_creation_is_bounded(self) -> None:
+        result = self.run_code(
+            "for i in range(200):\n"
+            "    open(f'/workspace/work/f{i}.txt','w').write('x')\n"
+            "print('DONE')\n"
+        )
+        self.assertIsNotNone(result.bound_exceeded)
+
+    def test_large_stdout_is_truncated_not_unbounded(self) -> None:
+        result = self.run_code("print('A' * (200 * 1024))")
+        self.assertTrue(result.truncated or result.bound_exceeded)
+        self.assertLessEqual(len(result.stdout.encode()), 64 * 1024)
+
+    def test_environment_is_cleared(self) -> None:
+        result = self.run_code(
+            "import os\nprint('KEYS', sorted(os.environ))\n"
+        )
+        self.assertNotIn("SSH_AUTH_SOCK", result.stdout)
+        self.assertNotIn("AWS_", result.stdout)
+
+    def test_scratch_does_not_leak_between_actions(self) -> None:
+        first = self.run_code("open('/workspace/work/left.txt','w').write('x')\nprint('one')\n")
+        self.assertEqual(first.status, "ok", first.stderr)
+        second = self.run_code(
+            "import os\nprint('LEFTOVER', os.path.exists('/workspace/work/left.txt'))\n"
+        )
+        self.assertIn("LEFTOVER False", second.stdout)
+
+    def test_temporary_directories_do_not_accumulate(self) -> None:
+        # Explicit cleanup is defence in depth: TemporaryDirectory also removes
+        # itself via a GC finalizer, so removing the explicit call is not
+        # observable from outside. What is worth pinning is the property that
+        # matters -- actions leave nothing behind on the host.
+        import tempfile
+
+        root = Path(tempfile.gettempdir())
+        pattern = "orbit-analysis-*"
+        before = {p.name for p in root.glob(pattern)}
+        for _ in range(3):
+            self.run_code("print('tick')")
+        after = {p.name for p in root.glob(pattern)}
+        self.assertEqual(
+            after - before, set(), "each action must remove its temporary directories"
+        )
+
+    def test_nonzero_exit_is_classified_as_error(self) -> None:
+        result = self.run_code("raise SystemExit(3)")
+        self.assertEqual(result.status, "error")
+        self.assertEqual(result.exit_status, 3)
+
+    def test_code_hash_is_recorded(self) -> None:
+        import hashlib
+
+        code = "print('hash me')"
+        result = self.run_code(code)
+        self.assertEqual(result.code_sha256, hashlib.sha256(code.encode()).hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class SandboxConfigurationContractTest(unittest.TestCase):
+    """The security contract, asserted on the invocation Orbit builds.
+
+    Behavioural tests prove the sandbox holds on *this* host. These prove the
+    policy is still being requested at all -- a flag can be dropped while some
+    unrelated protection masks the loss locally, and that must fail loudly
+    here rather than survive until a host where nothing masks it.
+    """
+
+    REQUIRED_FLAGS = (
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--assert-userns-disabled",
+        "--die-with-parent",
+        "--new-session",
+        "--clearenv",
+    )
+
+    def build(self):
+        from orbit.runtime.analysis_sandbox import (
+            SOURCE_MOUNT,
+            WORK_MOUNT,
+            _sandbox_command,
+        )
+
+        argv = _sandbox_command(
+            Path("/srv/input.bin"),
+            Path("/srv/scratch"),
+            Path("/srv/program/main.py"),
+            "/usr/bin/python3.12",
+        )
+        return argv, SOURCE_MOUNT, WORK_MOUNT
+
+    def test_required_isolation_flags_are_all_requested(self) -> None:
+        argv, _src, _work = self.build()
+        missing = [flag for flag in self.REQUIRED_FLAGS if flag not in argv]
+        self.assertEqual(missing, [], f"missing mandatory isolation flags: {missing}")
+
+    def test_capabilities_are_dropped(self) -> None:
+        argv, _src, _work = self.build()
+        self.assertIn("--cap-drop", argv, "capability dropping is mandatory")
+        self.assertEqual(
+            argv[argv.index("--cap-drop") + 1],
+            "ALL",
+            "capabilities must be dropped wholesale, not selectively",
+        )
+
+    def test_source_is_mounted_read_only(self) -> None:
+        argv, source_mount, _work = self.build()
+        self.assertIn(source_mount, argv)
+        index = argv.index(source_mount)
+        # bwrap takes `<kind> <host> <sandbox>`, so the kind sits two back.
+        self.assertEqual(
+            argv[index - 2],
+            "--ro-bind",
+            "the analysed input must never be host-writable",
+        )
+
+    def test_only_scratch_is_host_writable(self) -> None:
+        argv, _src, work_mount = self.build()
+        writable = [
+            argv[i + 2] for i, token in enumerate(argv) if token == "--bind"
+        ]
+        self.assertEqual(
+            writable,
+            [work_mount],
+            f"exactly one host-backed writable mount is permitted, got {writable}",
+        )
+
+    def test_host_root_is_never_bound(self) -> None:
+        argv, _src, _work = self.build()
+        for i, token in enumerate(argv):
+            if token in {"--bind", "--ro-bind"}:
+                self.assertNotEqual(argv[i + 1], "/", "the host root must never be bound")
+        self.assertIn("--tmpfs", argv)
+        self.assertEqual(argv[argv.index("--tmpfs") + 1], "/", "root must be a tmpfs")
+
+    def test_path_cannot_reach_host_executables(self) -> None:
+        argv, _src, _work = self.build()
+        path_value = argv[argv.index("PATH") + 1]
+        self.assertNotIn("/usr/bin", path_value)
+        self.assertNotIn("/bin", path_value)
+
+    def test_command_allowlist_stays_empty(self) -> None:
+        # No proven workflow needed an external binary; each one added back is
+        # attack surface and must arrive with its own evidence.
+        self.assertEqual(ALLOWED_COMMANDS, frozenset())
+
+    def test_python_runs_isolated(self) -> None:
+        argv, _src, _work = self.build()
+        self.assertIn("-I", argv)
+        self.assertIn("-S", argv)
+
+    def test_no_unsandboxed_fallback_exists(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        source = inspect.getsource(analysis_sandbox)
+        self.assertIn("sandbox_preflight()", source, "preflight must gate execution")
+        self.assertIn("raise SandboxUnavailable", source)
+
+    def test_source_integrity_is_verified_after_the_run(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        source = inspect.getsource(analysis_sandbox.execute_analysis)
+        self.assertIn("source_before", source)
+        self.assertIn("read-only input changed", source)
+
+    def test_resource_limits_are_all_applied(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        source = inspect.getsource(analysis_sandbox._preexec_limits)
+        for limit in ("RLIMIT_CPU", "RLIMIT_AS", "RLIMIT_FSIZE", "RLIMIT_NOFILE", "RLIMIT_NPROC"):
+            self.assertIn(limit, source, f"{limit} must be enforced")
+
+    def test_bounds_remain_finite(self) -> None:
+        from orbit.runtime import analysis_sandbox as s
+
+        self.assertLessEqual(s.ACTION_TIMEOUT_SECONDS, 60)
+        self.assertLessEqual(s.CPU_SECONDS, 60)
+        self.assertLessEqual(s.ADDRESS_SPACE_BYTES, 2 * 1024 * 1024 * 1024)
+        self.assertLessEqual(s.HARD_OUTPUT_BYTES, 8 * 1024 * 1024)
+        self.assertLessEqual(s.MAX_CODE_CHARS, 128 * 1024)
+
+    def test_scratch_cleanup_is_wired(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        source = inspect.getsource(analysis_sandbox.execute_analysis)
+        self.assertIn("finally:", source)
+        self.assertIn("cleanup()", source)
+
+    def test_symlinks_and_extra_links_are_refused_when_capturing(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        capture = inspect.getsource(analysis_sandbox._capture_artifacts)
+        self.assertIn("O_NOFOLLOW", capture)
+        self.assertIn("st_nlink", capture)
+        scan = inspect.getsource(analysis_sandbox._scratch_bound_error)
+        self.assertIn("S_ISLNK", scan)


### PR DESCRIPTION
## Scope

Adds a **dormant**, fail-closed bubblewrap analysis sandbox: one bounded Python program, one read-only input, one bounded writable scratch directory.

It is **not** exposed through ChatRuntime, the CLI, the model tool surface, or any ANALYSIS mode. Nothing in production imports it; `TOOL_NAMES` is unchanged (`exec_shell_full_command`, `fetch_url`, `list_directory`, `system_info`, `write_artifact`).

Two new files, 917 insertions, zero modifications to existing code.

## Why

An investigation that needs to decode an artifact has to run code, and the code that decodes an untrusted artifact is the last thing that should be able to reach the host. This is the execution primitive, ported from a research harness that proved the approach, with everything experiment-specific removed.

The module is generic: it takes a file and a program, and reports what the program printed plus hashes of what it wrote. It knows nothing about file formats, indicators, or any particular threat.

## Security properties

- network isolated (`--unshare-all`, verified against raw `libc.connect` → `EAFNOSUPPORT`)
- user namespaces disabled and asserted (`libc.unshare(CLONE_NEWUSER)` → `ENOSPC`)
- capabilities dropped wholesale
- tmpfs root; host filesystem limited to the interpreter and its shared libraries
- analysed input mounted **read-only**, hashed before and after
- exactly one host-writable mount (`/workspace/work`)
- **empty external-command allowlist**; `PATH` cannot reach host executables
- bounded CPU (14s), wall (15s), address space (768 MiB), file size, open files, processes, scratch (8 MiB/32 files), code (32 KiB), output (64 KiB soft / 2 MiB hard kill)
- rlimits verified applied **inside** the sandboxed child, not just the launcher
- artifacts captured `O_NOFOLLOW` with an `st_nlink == 1` check; FIFOs and symlinks fail the capture closed
- **no unsandboxed fallback** — missing bubblewrap or a refused namespace means no execution at all

The allowlist is empty because the proven trajectory used a fixed toolbox of eleven binaries and called none of them. Each one added back needs its own evidence; `node` in particular is not mounted.

## What this does not claim

The program is arbitrary Python, so it can interpret the bytes it reads however it likes — including through an interpreter it writes itself. Restricting that would require deciding what a program means. **The guarantee is containment of effects, not restriction of intent**, and the module documents this where a reader will find it.

This is not "safe malware execution" and not "static-analysis-only execution". It is host containment for code whose behaviour is unknown.

## Validation

- focused suite: **42/42 PASS** against real bubblewrap (not mocked)
- security mutation campaign: **17 CAUGHT, 0 SURVIVED, 0 NOT RUN**
- one cleanup mutation proven **unobservable** rather than force-caught: `TemporaryDirectory` removes itself via its finalizer, so the explicit call is defence-in-depth
- historical zero-inference replay: **PASS** — recorded model-authored code reproduced XOR key 34, the exact URL/GUID, and the `iex`/`irm` evidence, with no model involved
- full Orbit suite: **2257 PASS**
- `compileall`, `git diff --check`: PASS
- independent security review: **PASS, 0 BLOCKER / 0 MAJOR**

## Residuals for the integration mission

Deliberately out of scope here, and required before this becomes reachable:

1. a minimal pure-Python `orbit_tools.read_file` shim — the recorded trajectory imported `orbit_tools` in all 9 actions and called `read_file` 7 times, never `search_file` or `run_command`
2. the caller must guarantee a **stable, caller-owned `source_path`**: the post-run hash catches a mid-run change, not a pre-mount swap
3. EvidenceStore ingestion must impose its **own payload cap**, independent of the sandbox's 8 MiB scratch allowance