### PR TITLE
feat(runtime): add analyst-guided analysis foundation

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -1,0 +1,545 @@
+"""One analyst step: one model call, at most one action, then hand back.
+
+The autonomous version of this loop kept going until it decided it was
+finished, and the recorded runs show what that cost -- eight actions deep,
+most of the chain recovered, and the one attestation an analyst would have
+asked for on turn two never produced. So this runtime does the opposite:
+it takes one instruction, makes exactly one model call, runs at most one
+sandboxed action, records the evidence, and stops. Whatever happens next is
+the analyst's decision, not the model's.
+
+The stop is structural rather than advisory. `step()` has no loop and no
+path from a tool result back to another model call: continuing requires
+calling `step()` again with new analyst input. That is the whole design.
+
+Orchestration is all that is new here. The model call goes through the same
+`ChatBackend.chat_stream` that ChatRuntime uses, so profile handling,
+tokenization, streaming, cancellation, metrics, tool-call parsing and KV
+bookkeeping stay in one place and the backend never learns that CHAT and
+ANALYSIS are different things.
+
+History is appended in the order it happened -- request, tool call, tool
+result -- before control returns, so step N's messages are a prefix of step
+N+1's. Nothing is reconstructed or rewritten between steps, which is what a
+later exact-prefix KV strategy will need.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from orbit.backend.base import ChatBackend, Message
+from orbit.runtime.analysis_sandbox import (
+    WORK_MOUNT,
+    AnalysisResult,
+    SandboxUnavailable,
+    execute_analysis,
+    scratch_baseline,
+)
+from orbit.runtime.evidence import EvidenceRecord, EvidenceStore
+from orbit.runtime.tool_calls import tool_call_id
+
+ANALYSIS_TOOL_NAME = "execute_analysis"
+
+# Stable prefix. Everything here is identical for every step of every
+# analysis on a given profile, which is what makes a future exact-prefix
+# prewarm possible. Nothing volatile belongs above this line: no source
+# path, no hash, no session id, no timestamp, no analyst text.
+ANALYSIS_SYSTEM_PROMPT = (
+    "You are performing static analysis of one artifact in an isolated offline workspace.\n"
+    "The artifact is mounted read-only at /workspace/input. There is no network.\n"
+    "Inspect and transform it by writing Python and running it with execute_analysis; "
+    "`import orbit_tools` provides read_file(path, offset, limit).\n"
+    "Write bounded files under /workspace/work to keep a derived artifact.\n"
+    "Perform at most one execute_analysis action per turn, then stop and report what it produced.\n"
+    "Base every claim on the artifact or on output an action actually produced. "
+    "State plainly when something is unresolved rather than filling the gap."
+)
+
+ANALYSIS_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": ANALYSIS_TOOL_NAME,
+        "description": (
+            "Run one bounded Python program in the isolated analysis workspace. "
+            "The artifact is read-only at /workspace/input; write derived files under "
+            "/workspace/work. Print the facts you want recorded as evidence."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": (
+                        "Complete Python source. `import orbit_tools` for "
+                        "read_file(path, offset=0, limit=65536) -> str."
+                    ),
+                }
+            },
+            "required": ["code"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+# What may enter model-visible history from one action. The sandbox permits
+# 8 MiB of scratch; that ceiling governs what a program may write, not what
+# a prompt should carry. Full output stays addressable in EvidenceStore.
+MAX_EVIDENCE_CHARS = 8 * 1024
+
+# The per-action allowance the qualified sandbox enforces is a limit on what
+# ONE action may produce. A persistent workspace also needs a ceiling on what
+# a whole session may retain, or an analyst-guided session has no bound at all.
+#
+# The preserved 20 Aug runs cannot supply this number: those trajectories wrote
+# no derived files whatsoever (`open(` never appears in any recorded action)
+# and ran at most 9 actions, so measured footprint is zero. Rather than
+# multiply the per-action allowance by a made-up action count, these are
+# explicit conservative constants: 64 MiB is eight full per-action allowances,
+# and 256 files is eight times the per-action file count -- enough headroom for
+# a session far longer than any recorded run, small enough to stay a bound.
+# Revisit with real analyst-session telemetry.
+MAX_SESSION_SCRATCH_BYTES = 64 * 1024 * 1024
+MAX_SESSION_SCRATCH_FILES = 256
+SESSION_CAPACITY_EXHAUSTED = "session artifact capacity exhausted"
+
+
+@dataclass(frozen=True)
+class AnalysisSource:
+    """An immutable snapshot of the artifact under analysis.
+
+    The sandbox hashes its input before and after a run, which catches a file
+    changing underneath it -- but not a file swapped before the mount. Taking
+    the bytes once and mounting only this copy removes that window, and makes
+    the analysis identity the content rather than a path someone else can
+    repoint.
+    """
+
+    snapshot_path: Path
+    sha256: str
+    size_bytes: int
+    original_path: str
+
+    @property
+    def analysis_id(self) -> str:
+        return self.sha256[:16]
+
+
+@dataclass
+class AnalysisWorkspace:
+    """Storage owned by one analysis session, for its whole lifetime.
+
+    The sandbox allocates a throwaway scratch directory per action when the
+    caller supplies none, which is right for a one-shot execution and wrong
+    for an investigation: a derived artifact recorded in step one is gone
+    before step two can read it, leaving a hash that names bytes nobody can
+    produce. The session therefore owns one directory and passes it in, so
+    what an action writes is still there for the next action -- and still
+    there to re-hash when someone asks whether the record is honest.
+
+    Removal is explicit. `close()` deletes the workspace; nothing here waits
+    for a finalizer, because a runtime that outlives several turns should not
+    depend on when the collector happens to run. After abnormal process death
+    the residue is an ordinary temporary directory, cleaned by the OS on its
+    own schedule -- stated plainly rather than dressed up as a guarantee.
+    """
+
+    root: Path
+    _closed: bool = False
+
+    @classmethod
+    def create(cls) -> "AnalysisWorkspace":
+        root = Path(tempfile.mkdtemp(prefix="orbit-analysis-session-"))
+        (root / "source").mkdir()
+        (root / "work").mkdir()
+        return cls(root=root)
+
+    @property
+    def source_root(self) -> Path:
+        return self.root / "source"
+
+    @property
+    def scratch_root(self) -> Path:
+        return self.root / "work"
+
+    def close(self) -> None:
+        """Remove the workspace. Safe to call more than once."""
+        if self._closed:
+            return
+        self._closed = True
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def __enter__(self) -> "AnalysisWorkspace":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        self.close()
+        return False
+
+
+@dataclass(frozen=True)
+class AnalysisStepResult:
+    """What one analyst step produced. Control is with the analyst on return."""
+
+    model_calls: int
+    action_attempted: bool
+    action_executed: bool
+    assistant_text: str
+    result: AnalysisResult | None = None
+    evidence: EvidenceRecord | None = None
+    rejection: str | None = None
+    raw_output_evidence_id: str | None = None
+    artifact_handles: tuple[str, ...] = ()
+
+    @property
+    def control_returned(self) -> bool:
+        # Always true by construction: step() has no path that continues past
+        # here. Named so tests assert the property rather than the absence of
+        # a loop.
+        return True
+
+
+def acquire_analysis_source(original: Path | str, workspace: Path | str) -> AnalysisSource:
+    """Copy the artifact into Orbit-owned storage and identify it by content."""
+    source = Path(original)
+    data = source.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    root = Path(workspace)
+    root.mkdir(parents=True, exist_ok=True)
+    snapshot = root / f"analysis-{digest[:16]}.bin"
+    if not snapshot.exists():
+        tmp = root / f".{digest[:16]}.partial"
+        tmp.write_bytes(data)
+        tmp.replace(snapshot)
+    snapshot.chmod(0o400)
+    if hashlib.sha256(snapshot.read_bytes()).hexdigest() != digest:
+        raise RuntimeError("analysis snapshot does not match the acquired bytes")
+    return AnalysisSource(
+        snapshot_path=snapshot,
+        sha256=digest,
+        size_bytes=len(data),
+        original_path=str(source),
+    )
+
+
+def _raw_action_output(result: AnalysisResult) -> str:
+    """The complete output of one action, for durable retention.
+
+    Status and bound lead the record. A bounded action can still print
+    something that reads like success, so a sidecar holding only stdout would
+    later attest to text that misrepresents what happened.
+    """
+    header = f"status: {result.status}"
+    if result.bound_exceeded:
+        header += f"\nbound: {result.bound_exceeded}"
+    return f"{header}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def _bounded_observation(result: AnalysisResult) -> tuple[str, bool, int]:
+    """Model-facing text for one action, plus whether it was shortened."""
+    parts = [f"status: {result.status}"]
+    if result.bound_exceeded:
+        parts.append(f"bound: {result.bound_exceeded}")
+    if result.stdout:
+        parts.append(f"stdout:\n{result.stdout}")
+    if result.stderr:
+        parts.append(f"stderr:\n{result.stderr}")
+    for artifact in result.artifacts:
+        # The name is model-chosen, and the observation is newline-delimited
+        # `key: value` lines, so an unescaped name could forge entries that
+        # read exactly like real ones.
+        parts.append(
+            f"artifact: {artifact.name!r} "
+            f"({artifact.size_bytes} bytes, sha256 {artifact.sha256})"
+        )
+    text = "\n".join(parts)
+    full = len(text)
+    if full <= MAX_EVIDENCE_CHARS:
+        return text, False, full
+    keep = MAX_EVIDENCE_CHARS - 200
+    # Record what was dropped rather than silently shortening: a reader must
+    # be able to tell a small result from a large one that was cut.
+    notice = (
+        f"\n[truncated for prompt: {full} chars produced, {keep} retained; "
+        f"full output stored in evidence]"
+    )
+    return text[:keep] + notice, True, full
+
+
+@dataclass
+class AnalysisRuntime:
+    """Analyst-driven analysis. One model call and one action per step."""
+
+    backend: ChatBackend
+    source: AnalysisSource
+    evidence_store: EvidenceStore
+    workspace: AnalysisWorkspace | None = None
+    messages: list[Message] = field(default_factory=list)
+    temperature: float = 0.0
+    max_tokens: int = 1024
+    model_calls: int = 0
+    actions_executed: int = 0
+    analyst_turns: int = 0
+
+    def __post_init__(self) -> None:
+        if self.workspace is None:
+            self.workspace = AnalysisWorkspace.create()
+        if not self.messages:
+            self.messages.append({"role": "system", "content": ANALYSIS_SYSTEM_PROMPT})
+            # Volatile identity goes after the stable prefix so the prefix can
+            # later be prewarmed without carrying this step's specifics.
+            self.messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Artifact under analysis: /workspace/input "
+                        f"({self.source.size_bytes} bytes, sha256 {self.source.sha256})."
+                    ),
+                }
+            )
+
+    def session_usage(self) -> tuple[int, int]:
+        """Return (bytes, files) currently retained in the session workspace.
+
+        `scratch_baseline` marks directories with size -1 so the per-action
+        bound can tell them from files. Both figures here count files only:
+        summing the sentinel would discount real bytes, and counting it would
+        let empty directories alone exhaust a session that holds no data.
+        """
+        sizes = scratch_baseline(self.workspace.scratch_root)
+        return (
+            sum(size for size in sizes.values() if size >= 0),
+            sum(1 for size in sizes.values() if size >= 0),
+        )
+
+    def _session_capacity_error(self) -> str | None:
+        """Refuse a new action once the workspace is full.
+
+        Checked before the action runs, so capacity is never reported by
+        executing code and then throwing its output away. What is already
+        stored stays readable: nothing is evicted to make room.
+        """
+        used_bytes, used_files = self.session_usage()
+        if used_bytes >= MAX_SESSION_SCRATCH_BYTES or used_files >= MAX_SESSION_SCRATCH_FILES:
+            return (
+                f"{SESSION_CAPACITY_EXHAUSTED}: {used_files} files / {used_bytes} bytes "
+                f"retained (limit {MAX_SESSION_SCRATCH_FILES} files / "
+                f"{MAX_SESSION_SCRATCH_BYTES} bytes)"
+            )
+        return None
+
+    def step(self, analyst_message: str) -> AnalysisStepResult:
+        """Run exactly one analyst-driven step and return control."""
+        self.analyst_turns += 1
+        self.messages.append({"role": "user", "content": analyst_message})
+
+        deltas: list[str] = []
+        response = self.backend.chat_stream(
+            list(self.messages),
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            tools=[ANALYSIS_TOOL_SCHEMA],
+            on_delta=deltas.append,
+        )
+        self.model_calls += 1
+
+        calls = list(response.tool_calls or [])
+        assistant: Message = {"role": "assistant", "content": response.content or ""}
+        if calls:
+            assistant["tool_calls"] = calls
+        self.messages.append(assistant)
+
+        if not calls:
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=False,
+                action_executed=False,
+                assistant_text=response.content or "",
+            )
+
+        rejection = self._structural_rejection(calls)
+        if rejection is not None:
+            # No repair call: repairing would mean a second model invocation
+            # before the analyst has seen anything, which is the boundary this
+            # runtime exists to hold.
+            self._append_tool_result(calls[0], f"rejected: {rejection}")
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=True,
+                action_executed=False,
+                assistant_text=response.content or "",
+                rejection=rejection,
+            )
+
+        capacity_error = self._session_capacity_error()
+        if capacity_error is not None:
+            # Refused before running: an exhausted session must not execute
+            # code whose artifacts it has already decided not to record.
+            self._append_tool_result(calls[0], f"action not executed: {capacity_error}")
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=True,
+                action_executed=False,
+                assistant_text=response.content or "",
+                rejection=capacity_error,
+            )
+
+        code = json.loads(calls[0]["function"]["arguments"])["code"]
+        # Snapshot before the action so the sandbox charges it for its own
+        # delta rather than for everything earlier steps left behind.
+        baseline_sizes = scratch_baseline(self.workspace.scratch_root)
+        baseline_digests = self._scratch_digests()
+        try:
+            result = execute_analysis(
+                source_path=self.source.snapshot_path,
+                code=code,
+                scratch_dir=self.workspace.scratch_root,
+                scratch_baseline_sizes=baseline_sizes,
+                scratch_baseline_digests=baseline_digests,
+            )
+        except (SandboxUnavailable, ValueError) as exc:
+            detail = f"{type(exc).__name__}: {exc}"
+            self._append_tool_result(calls[0], f"action not executed: {detail}")
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=True,
+                action_executed=False,
+                assistant_text=response.content or "",
+                rejection=detail,
+            )
+
+        self.actions_executed += 1
+        observation, truncated, full_chars = _bounded_observation(result)
+
+        # The full output goes to the evidence sidecar, which lives on disk and
+        # is only ever surfaced to a prompt through bounded excerpts. Recording
+        # the truncated text here instead would leave `observation_full_chars`
+        # describing bytes that no longer exist anywhere.
+        # Provenance is what `reattest_exact` checks before it will hand back
+        # durable evidence: without all three fields a record is stored but
+        # can never be re-attested. The identity is the model's own call id
+        # and this analyst turn -- nothing synthesised to satisfy the check.
+        provenance = self._provenance(calls[0])
+        raw_record = self.evidence_store.add(
+            f"{ANALYSIS_TOOL_NAME}_raw",
+            _raw_action_output(result),
+            metadata={
+                **provenance,
+                "analysis_source_sha256": self.source.sha256,
+                "code_sha256": result.code_sha256,
+                "kind": "raw_action_output",
+                "full_chars": full_chars,
+                "produced_by_phase": "analysis_action_raw",
+            },
+        )
+        record = self.evidence_store.add(
+            ANALYSIS_TOOL_NAME,
+            observation,
+            metadata={
+                **provenance,
+                "analysis_source_sha256": self.source.sha256,
+                "analysis_source_bytes": self.source.size_bytes,
+                "original_path": self.source.original_path,
+                "code_sha256": result.code_sha256,
+                "input_sha256": result.input_sha256,
+                "status": result.status,
+                "exit_status": result.exit_status,
+                "bound_exceeded": result.bound_exceeded,
+                "observation_truncated": truncated,
+                "observation_full_chars": full_chars,
+                "raw_output_evidence_id": raw_record.evidence_id,
+                "artifacts": [
+                    {
+                        "name": a.name,
+                        "size_bytes": a.size_bytes,
+                        "sha256": a.sha256,
+                        # Stable virtual handle: the host path stays an
+                        # implementation detail and never reaches the model.
+                        "handle": f"{WORK_MOUNT}/{a.name}",
+                    }
+                    for a in result.artifacts
+                ],
+            },
+        )
+        # Appended before returning: step N+1 must find this already in place
+        # rather than have it reconstructed later.
+        self._append_tool_result(calls[0], observation)
+        return AnalysisStepResult(
+            model_calls=1,
+            action_attempted=True,
+            action_executed=True,
+            assistant_text=response.content or "",
+            result=result,
+            evidence=record,
+            raw_output_evidence_id=raw_record.evidence_id,
+            artifact_handles=tuple(f"{WORK_MOUNT}/{a.name}" for a in result.artifacts),
+        )
+
+    def close(self) -> None:
+        """Release the session workspace. Idempotent."""
+        if self.workspace is not None:
+            self.workspace.close()
+
+    def __enter__(self) -> "AnalysisRuntime":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        self.close()
+        return False
+
+    def _provenance(self, call: dict[str, Any]) -> dict[str, object]:
+        """Canonical provenance for evidence produced by one executed action."""
+        return {
+            "tool_call_id": tool_call_id(call),
+            "user_turn_id": f"turn_{self.analyst_turns}",
+            "produced_by_phase": "analysis_action",
+        }
+
+    def _scratch_digests(self) -> dict[str, str]:
+        """Hash each retained file so a rewrite is distinguishable from a keep."""
+        digests: dict[str, str] = {}
+        root = self.workspace.scratch_root
+        for path in sorted(root.rglob("*")):
+            try:
+                info = path.lstat()
+                if not stat.S_ISREG(info.st_mode):
+                    continue
+                digests[str(path.relative_to(root))] = hashlib.sha256(
+                    path.read_bytes()
+                ).hexdigest()
+            except OSError:
+                continue
+        return digests
+
+    def _structural_rejection(self, calls: list[dict[str, Any]]) -> str | None:
+        if len(calls) > 1:
+            return f"{len(calls)} tool calls in one response; at most one action per step"
+        call = calls[0]
+        function = call.get("function") or {}
+        name = function.get("name")
+        if name != ANALYSIS_TOOL_NAME:
+            return f"unsupported tool: {name!r}"
+        try:
+            arguments = json.loads(function.get("arguments") or "")
+        except (TypeError, json.JSONDecodeError):
+            return "tool arguments are not valid JSON"
+        if not isinstance(arguments, dict) or not isinstance(arguments.get("code"), str):
+            return "tool arguments must supply a 'code' string"
+        return None
+
+    def _append_tool_result(self, call: dict[str, Any], content: str) -> None:
+        self.messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call.get("id") or "",
+                "name": ANALYSIS_TOOL_NAME,
+                "content": content,
+            }
+        )

--- a/src/orbit/runtime/analysis_sandbox.py
+++ b/src/orbit/runtime/analysis_sandbox.py
@@ -39,6 +39,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from orbit.runtime.analysis_tools_shim import ORBIT_TOOLS_SOURCE
+
 BWRAP = "/usr/bin/bwrap"
 SOURCE_MOUNT = "/workspace/input"
 WORK_MOUNT = "/workspace/work"
@@ -170,6 +172,25 @@ def validate_code(code: object) -> str:
     return code
 
 
+def _program_with_tools(code: str) -> str:
+    """Make `orbit_tools` importable without relaxing interpreter isolation.
+
+    The sandbox runs Python with `-I`, which keeps the script's directory off
+    `sys.path`; a mounted `orbit_tools.py` therefore would not import, and
+    dropping `-I` to fix that would trade real isolation for convenience. So
+    the module is registered in `sys.modules` ahead of the analysis code,
+    which runs afterwards byte-for-byte as written.
+    """
+    prelude = (
+        "import sys as _orbit_sys, types as _orbit_types\n"
+        "_orbit_mod = _orbit_types.ModuleType('orbit_tools')\n"
+        "exec(compile(_ORBIT_TOOLS_SRC, 'orbit_tools.py', 'exec'), _orbit_mod.__dict__)\n"
+        "_orbit_sys.modules['orbit_tools'] = _orbit_mod\n"
+        "del _orbit_sys, _orbit_types, _orbit_mod, _ORBIT_TOOLS_SRC\n"
+    )
+    return f"_ORBIT_TOOLS_SRC = {ORBIT_TOOLS_SOURCE!r}\n{prelude}\n{code}"
+
+
 def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -282,8 +303,48 @@ def _sandbox_command(source: Path, scratch: Path, program: Path, python: str) ->
     return args
 
 
-def _scratch_bound_error(root: Path) -> str | None:
-    """Reject anything the capture step could not read safely."""
+def scratch_baseline(root: Path) -> dict[str, int]:
+    """Record every entry already in `root`, keyed by relative path.
+
+    A persistent workspace carries earlier steps' output into the next action.
+    Charging an action for those is what wedges a session, so the caller
+    snapshots first and the bound below is measured against the difference.
+    An empty mapping (the default) reproduces the original whole-directory
+    accounting, which is correct for a scratch directory that starts empty.
+
+    Directories are recorded too, with size -1 to mark them as non-files.
+    Counting them here but not there would recharge every directory an earlier
+    step created to every later action, which is the same wedge one level up:
+    the sandbox itself creates `work/tmp`, so it would start on the first run.
+    """
+    baseline: dict[str, int] = {}
+    try:
+        for base, dirs, files in os.walk(root, followlinks=False):
+            for name in dirs:
+                path = Path(base) / name
+                if stat.S_ISDIR(path.lstat().st_mode):
+                    baseline[str(path.relative_to(root))] = -1
+            for name in files:
+                path = Path(base) / name
+                info = path.lstat()
+                if stat.S_ISREG(info.st_mode):
+                    baseline[str(path.relative_to(root))] = info.st_size
+    except OSError:
+        return {}
+    return baseline
+
+
+def _scratch_bound_error(root: Path, baseline: dict[str, int] | None = None) -> str | None:
+    """Reject anything the capture step could not read safely.
+
+    `total` and `count` measure THIS action's footprint: bytes it added and
+    files it created. Growth of an existing file counts, because appending is
+    writing; shrinking counts as zero rather than a credit, so deleting an old
+    file cannot buy room for a new one. Unsafe entries are rejected wherever
+    they sit -- a symlink left behind by an earlier step is still a symlink,
+    and the capture step must never follow it.
+    """
+    prior = baseline or {}
     total = 0
     count = 0
     try:
@@ -291,14 +352,44 @@ def _scratch_bound_error(root: Path) -> str | None:
             if len(Path(base).relative_to(root).parts) > MAX_SCRATCH_DEPTH:
                 return "scratch depth exceeded"
             for name in dirs + files:
-                info = (Path(base) / name).lstat()
+                path = Path(base) / name
+                info = path.lstat()
                 if stat.S_ISLNK(info.st_mode):
                     return "scratch contains a symlink"
                 if not (stat.S_ISDIR(info.st_mode) or stat.S_ISREG(info.st_mode)):
                     return "scratch contains an unsupported entry"
-                count += 1
+                # Rejected here rather than at capture: an extra hard link means
+                # the bytes hashed need not be the bytes written, and a session
+                # workspace keeps the file, so raising during capture would
+                # brick every later step instead of bounding this one.
+                if stat.S_ISREG(info.st_mode) and info.st_nlink != 1:
+                    return "scratch contains a hard link"
+                # Checked while bounding, for the same reason as the hard link:
+                # a file the capture step cannot open would otherwise raise out
+                # of `step()` and, because the workspace persists, keep raising.
+                # Directories are checked too: os.walk cannot descend into an
+                # unreadable one, so its contents would go uncharged and
+                # uncaptured, then be attributed to whichever later action
+                # happens to unlock it.
+                readable = os.R_OK | (os.X_OK if stat.S_ISDIR(info.st_mode) else 0)
+                if not os.access(path, readable):
+                    return "scratch contains an unreadable entry"
+                # A name the filesystem accepts but UTF-8 cannot represent
+                # arrives as surrogates, which cannot be encoded again. It
+                # would fail later while being written to evidence, by which
+                # point the file is in the persistent workspace and every
+                # later step would fail the same way.
+                relative = str(path.relative_to(root))
+                if any("\ud800" <= ch <= "\udfff" for ch in relative):
+                    return "scratch contains an undecodable name"
                 if stat.S_ISREG(info.st_mode):
-                    total += info.st_size
+                    if relative in prior and prior[relative] >= 0:
+                        total += max(0, info.st_size - prior[relative])
+                    else:
+                        count += 1
+                        total += info.st_size
+                elif relative not in prior:
+                    count += 1
                 if count > MAX_SCRATCH_FILES or total > MAX_SCRATCH_BYTES:
                     return "scratch bound exceeded"
     except OSError:
@@ -306,7 +397,18 @@ def _scratch_bound_error(root: Path) -> str | None:
     return None
 
 
-def _capture_artifacts(root: Path) -> tuple[DerivedArtifact, ...]:
+def _capture_artifacts(
+    root: Path, baseline: dict[str, str] | None = None
+) -> tuple[DerivedArtifact, ...]:
+    """Hash the files this action produced.
+
+    `baseline` maps relative path to the SHA the file had before the action.
+    A file whose bytes are unchanged belongs to the step that made it and is
+    not re-reported here; a file whose bytes differ is a new version and is
+    reported with its new hash. Reporting the whole directory instead would
+    credit every action with every artifact ever written.
+    """
+    prior = baseline or {}
     captured: list[DerivedArtifact] = []
     for path in sorted(root.rglob("*")):
         info = path.lstat()
@@ -316,7 +418,13 @@ def _capture_artifacts(root: Path) -> tuple[DerivedArtifact, ...]:
         # would mean the bytes hashed are not the bytes that were written.
         if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
             raise RuntimeError("unsafe scratch entry")
-        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            # The bound check already rejects unreadable entries, so reaching
+            # here means the state changed underneath us. Fail the capture
+            # loudly rather than reporting a partial artifact set.
+            raise RuntimeError("unsafe scratch entry") from exc
         try:
             data = b""
             while len(data) <= MAX_SCRATCH_BYTES:
@@ -326,12 +434,12 @@ def _capture_artifacts(root: Path) -> tuple[DerivedArtifact, ...]:
                 data += chunk
         finally:
             os.close(descriptor)
+        relative = str(path.relative_to(root))
+        digest = _sha256_bytes(data)
+        if prior.get(relative) == digest:
+            continue
         captured.append(
-            DerivedArtifact(
-                name=str(path.relative_to(root)),
-                size_bytes=len(data),
-                sha256=_sha256_bytes(data),
-            )
+            DerivedArtifact(name=relative, size_bytes=len(data), sha256=digest)
         )
     return tuple(captured)
 
@@ -342,6 +450,8 @@ def execute_analysis(
     code: str,
     scratch_dir: Path | str | None = None,
     python_executable: str | None = None,
+    scratch_baseline_sizes: dict[str, int] | None = None,
+    scratch_baseline_digests: dict[str, str] | None = None,
 ) -> AnalysisResult:
     """Run `code` with `source_path` mounted read-only, and report what happened.
 
@@ -373,8 +483,9 @@ def execute_analysis(
         scratch.mkdir(parents=True, exist_ok=True)
 
     program = Path(program_owner.name) / "main.py"
-    program.write_text(validated, encoding="utf-8")
+    program.write_text(_program_with_tools(validated), encoding="utf-8")
     os.chmod(program, 0o400)
+
 
     started = time.monotonic()
     buffers = {"stdout": bytearray(), "stderr": bytearray()}
@@ -426,11 +537,11 @@ def execute_analysis(
         if source.read_bytes() != source_before:
             raise RuntimeError("read-only input changed during analysis")
 
-        scratch_error = _scratch_bound_error(scratch)
+        scratch_error = _scratch_bound_error(scratch, scratch_baseline_sizes)
         bound_error = bound_error or scratch_error
         artifacts: tuple[DerivedArtifact, ...] = ()
         if scratch_error is None:
-            artifacts = _capture_artifacts(scratch)
+            artifacts = _capture_artifacts(scratch, scratch_baseline_digests)
 
         stdout_raw = bytes(buffers["stdout"])
         stderr_raw = bytes(buffers["stderr"])

--- a/src/orbit/runtime/analysis_tools_shim.py
+++ b/src/orbit/runtime/analysis_tools_shim.py
@@ -1,0 +1,81 @@
+"""The `orbit_tools` module analysis programs import, generated as source.
+
+Recorded model-authored analysis code opens with `import orbit_tools` and
+reads the artifact through `orbit_tools.read_file(...)`. That module has to
+exist inside the sandbox or the program dies on line one, so this emits it
+as a small file mounted alongside the program.
+
+It is deliberately not the research original. That version brokered every
+call over an authenticated RPC channel back to the host, which the harness
+needed to count and audit tool use. Here the program is already sealed
+inside a namespace with no network and nothing but the artifact and its own
+scratch directory, so a host round-trip would add a channel to defend
+without adding a defence. The shim is plain Python doing plain reads.
+
+Only `read_file` exists. The successful trajectory imported the module in
+all nine of its actions and called `read_file` seven times; `search_file`
+and `run_command` were never called once, so neither is provided. A helper
+nobody used is surface with no upside, and `run_command` in particular
+would mean mounting executables the sandbox currently has none of.
+
+Paths are still checked here even though the mount topology already
+confines them: the check costs nothing and states the intent locally, so a
+future change to the mounts cannot quietly widen what a program may open.
+"""
+
+from __future__ import annotations
+
+SOURCE_MOUNT = "/workspace/input"
+WORK_MOUNT = "/workspace/work"
+MAX_READ_BYTES = 64 * 1024
+
+# Emitted verbatim into the sandbox as `orbit_tools.py`. Kept as source text
+# rather than a real importable module because it must exist on the *inside*
+# of the namespace, where nothing of Orbit's own code is mounted.
+ORBIT_TOOLS_SOURCE = f'''"""Bounded helpers available to a sandboxed analysis program."""
+
+import os
+
+SOURCE_PATH = "{SOURCE_MOUNT}"
+WORK_ROOT = "{WORK_MOUNT}"
+MAX_READ_BYTES = {MAX_READ_BYTES}
+
+
+def _safe_path(value):
+    """Resolve `value` and confirm it names the artifact or analyst scratch."""
+    if not isinstance(value, str) or not value or "\\x00" in value:
+        raise ValueError("path must be a non-empty string")
+    candidate = os.path.realpath(value)
+    if candidate == SOURCE_PATH:
+        return candidate
+    if candidate == WORK_ROOT or candidate.startswith(WORK_ROOT + "/"):
+        return candidate
+    raise PermissionError("path is outside the analyst workspace")
+
+
+def read_file(path, offset=0, limit=MAX_READ_BYTES):
+    """Return up to `limit` bytes of `path` from `offset`, decoded as UTF-8.
+
+    Opened with O_NOFOLLOW so a symlink planted in scratch cannot redirect
+    the read, and bounded so a large artifact cannot be pulled into memory
+    in one call.
+    """
+    canonical = _safe_path(path)
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        raise ValueError("offset must be a non-negative integer")
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or not 1 <= limit <= MAX_READ_BYTES
+    ):
+        raise ValueError("limit is outside the read bound")
+    descriptor = os.open(canonical, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        os.lseek(descriptor, offset, os.SEEK_SET)
+        raw = os.read(descriptor, limit + 1)
+    finally:
+        os.close(descriptor)
+    if len(raw) > limit:
+        raw = raw[:limit]
+    return raw.decode("utf-8", "strict")
+'''

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -1,0 +1,1092 @@
+"""One analyst step must end at the analyst, provably.
+
+The property under test is an absence: after an action runs, nothing calls
+the model again. Absences are easy to assert vacuously, so the backend here
+raises the moment it is invoked once more than the script allows. A runtime
+that quietly continued -- to interpret the result, repair a bad call, or
+decide what to do next -- fails these tests by exploding, not by returning
+a wrong value.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+import unittest.mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult
+from orbit.runtime.analysis_runtime import (
+    ANALYSIS_SYSTEM_PROMPT,
+    ANALYSIS_TOOL_NAME,
+    ANALYSIS_TOOL_SCHEMA,
+    MAX_EVIDENCE_CHARS,
+    SESSION_CAPACITY_EXHAUSTED,
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore
+
+FIXTURE = "alpha\nbeta\ngamma\n"
+
+
+class ExhaustedBackend(Exception):
+    """Raised when the runtime calls the model more times than scripted."""
+
+
+class ScriptedBackend:
+    """Serves scripted responses; explodes on an unscripted call."""
+
+    def __init__(self, *responses: ChatResult) -> None:
+        self._responses = list(responses)
+        self.calls = 0
+        self.seen_tools: list[list[str]] = []
+        self.seen_messages: list[list[dict]] = []
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta, on_progress=None):
+        if self.calls >= len(self._responses):
+            raise ExhaustedBackend(
+                f"model invoked {self.calls + 1} times; only {len(self._responses)} scripted "
+                "-- the analyst boundary was crossed"
+            )
+        self.seen_messages.append([dict(m) for m in messages])
+        self.seen_tools.append([t["function"]["name"] for t in (tools or [])])
+        response = self._responses[self.calls]
+        self.calls += 1
+        if response.content:
+            on_delta(response.content)
+        return response
+
+
+def tool_response(code: str, *, name: str = ANALYSIS_TOOL_NAME, count: int = 1, text: str = "") -> ChatResult:
+    calls = [
+        {
+            "id": f"call_{i}",
+            "type": "function",
+            "function": {"name": name, "arguments": json.dumps({"code": code})},
+        }
+        for i in range(count)
+    ]
+    return ChatResult(
+        content=text, model="m", finish_reason="stop", tool_calls=calls,
+        prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+def prose_response(text: str) -> ChatResult:
+    return ChatResult(
+        content=text, model="m", finish_reason="stop", tool_calls=[],
+        prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+class AnalysisRuntimeTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-analysis-rt-")
+        self.addCleanup(self._dir.cleanup)
+        self.tmp = Path(self._dir.name)
+        original = self.tmp / "artifact.txt"
+        original.write_text(FIXTURE, encoding="utf-8")
+        self.original = original
+        self.source = acquire_analysis_source(original, self.tmp / "owned")
+        self.store = EvidenceStore(root=self.tmp / "evidence")
+
+    def runtime(self, backend) -> AnalysisRuntime:
+        # Registered here rather than in each test: a session workspace that
+        # outlives its test leaves a directory behind, and 30-odd of those per
+        # run is how a suite quietly fills /tmp.
+        built = AnalysisRuntime(backend=backend, source=self.source, evidence_store=self.store)
+        self.addCleanup(built.close)
+        return built
+
+
+class AnalystBoundaryTest(AnalysisRuntimeTestBase):
+    def test_one_step_makes_one_call_runs_one_action_and_stops(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("import orbit_tools\nprint(orbit_tools.read_file('/workspace/input'), end='')")
+        )
+        runtime = self.runtime(backend)
+
+        result = runtime.step("inspect the artifact")
+
+        self.assertEqual(backend.calls, 1, "exactly one model call per analyst step")
+        self.assertEqual(result.model_calls, 1)
+        self.assertTrue(result.action_executed)
+        self.assertEqual(runtime.actions_executed, 1)
+        self.assertIsNotNone(result.evidence)
+        self.assertTrue(result.control_returned)
+        # The action really ran in the sandbox against the snapshot.
+        self.assertIn("alpha", result.result.stdout)
+
+    def test_tool_result_is_in_history_before_control_returns(self) -> None:
+        backend = ScriptedBackend(tool_response("print('recorded')"))
+        runtime = self.runtime(backend)
+        runtime.step("inspect")
+
+        roles = [m["role"] for m in runtime.messages]
+        self.assertEqual(roles[-3:], ["user", "assistant", "tool"])
+        self.assertIn("recorded", runtime.messages[-1]["content"])
+
+    def test_continuation_requires_a_new_analyst_message(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("print('first')"),
+            tool_response("print('second')"),
+        )
+        runtime = self.runtime(backend)
+
+        runtime.step("first instruction")
+        self.assertEqual(backend.calls, 1, "the runtime must not continue on its own")
+
+        runtime.step("continue")
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(runtime.actions_executed, 2)
+
+    def test_history_grows_append_only_across_steps(self) -> None:
+        backend = ScriptedBackend(tool_response("print('one')"), tool_response("print('two')"))
+        runtime = self.runtime(backend)
+        runtime.step("first")
+        after_first = [dict(m) for m in runtime.messages]
+        runtime.step("verify the length of the recovered text")
+
+        self.assertEqual(
+            runtime.messages[: len(after_first)],
+            after_first,
+            "step 2 history must extend step 1 history unchanged",
+        )
+
+    def test_analyst_message_becomes_model_visible_history(self) -> None:
+        # Steering only works if what the analyst said is actually in the
+        # history the next call sees -- otherwise the model is steered by
+        # nothing and the boundary is decorative.
+        backend = ScriptedBackend(prose_response("ok"), prose_response("ok2"))
+        runtime = self.runtime(backend)
+        runtime.step("decode the second stage")
+
+        user_texts = [m["content"] for m in runtime.messages if m["role"] == "user"]
+        self.assertIn("decode the second stage", user_texts)
+
+        runtime.step("verify the length")
+        sent = backend.seen_messages[1]
+        self.assertIn(
+            "verify the length",
+            [m.get("content") for m in sent],
+            "the second call must see the new analyst instruction",
+        )
+
+    def test_prose_response_returns_without_any_action(self) -> None:
+        backend = ScriptedBackend(prose_response("The artifact is plain text."))
+        runtime = self.runtime(backend)
+        result = runtime.step("summarise")
+
+        self.assertEqual(backend.calls, 1)
+        self.assertFalse(result.action_attempted)
+        self.assertFalse(result.action_executed)
+        self.assertEqual(result.assistant_text, "The artifact is plain text.")
+
+
+class StructuralRejectionTest(AnalysisRuntimeTestBase):
+    def test_two_tool_calls_execute_nothing(self) -> None:
+        backend = ScriptedBackend(tool_response("print('x')", count=2))
+        runtime = self.runtime(backend)
+        result = runtime.step("do two things")
+
+        self.assertEqual(backend.calls, 1, "no repair call may follow a rejection")
+        self.assertTrue(result.action_attempted)
+        self.assertFalse(result.action_executed, "neither call may run")
+        self.assertEqual(runtime.actions_executed, 0)
+        self.assertIn("at most one action", result.rejection)
+
+    def test_unsupported_tool_executes_nothing(self) -> None:
+        backend = ScriptedBackend(tool_response("print('x')", name="exec_shell_full_command"))
+        runtime = self.runtime(backend)
+        result = runtime.step("run a shell command")
+
+        self.assertFalse(result.action_executed)
+        self.assertEqual(runtime.actions_executed, 0)
+        self.assertIn("unsupported tool", result.rejection)
+        self.assertEqual(backend.calls, 1)
+
+    def test_malformed_arguments_execute_nothing(self) -> None:
+        bad = ChatResult(
+            content="", model="m", finish_reason="stop",
+            tool_calls=[{"id": "c", "type": "function",
+                         "function": {"name": ANALYSIS_TOOL_NAME, "arguments": "{not json"}}],
+            prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+        backend = ScriptedBackend(bad)
+        runtime = self.runtime(backend)
+        result = runtime.step("go")
+
+        self.assertFalse(result.action_executed)
+        self.assertIn("not valid JSON", result.rejection)
+
+    def test_oversized_code_is_refused_without_a_repair_call(self) -> None:
+        backend = ScriptedBackend(tool_response("#" * (64 * 1024)))
+        runtime = self.runtime(backend)
+        result = runtime.step("go")
+
+        self.assertEqual(backend.calls, 1)
+        self.assertFalse(result.action_executed)
+        self.assertIsNotNone(result.rejection)
+
+    def test_rejection_is_recorded_in_history_for_the_analyst(self) -> None:
+        backend = ScriptedBackend(tool_response("print('x')", count=2))
+        runtime = self.runtime(backend)
+        runtime.step("do two things")
+        self.assertEqual(runtime.messages[-1]["role"], "tool")
+        self.assertIn("rejected", runtime.messages[-1]["content"])
+
+
+class SourceOwnershipTest(AnalysisRuntimeTestBase):
+    def test_snapshot_matches_acquired_bytes_and_original_is_untouched(self) -> None:
+        import hashlib
+
+        self.assertEqual(
+            self.source.sha256, hashlib.sha256(FIXTURE.encode()).hexdigest()
+        )
+        self.assertEqual(self.source.snapshot_path.read_text(encoding="utf-8"), FIXTURE)
+        self.assertEqual(self.original.read_text(encoding="utf-8"), FIXTURE)
+
+    def test_analysis_uses_the_snapshot_not_the_mutable_original(self) -> None:
+        backend = ScriptedBackend(tool_response("print(open('/workspace/input').read(), end='')"))
+        runtime = self.runtime(backend)
+        # Swapping the original after acquisition must not change what runs.
+        self.original.write_text("SWAPPED", encoding="utf-8")
+        result = runtime.step("read it")
+
+        self.assertIn("alpha", result.result.stdout)
+        self.assertNotIn("SWAPPED", result.result.stdout)
+
+    def test_identity_is_content_not_path(self) -> None:
+        self.assertEqual(self.source.analysis_id, self.source.sha256[:16])
+
+
+class EvidenceBoundTest(AnalysisRuntimeTestBase):
+    def test_large_output_is_bounded_for_the_prompt_but_recorded_in_full(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"))
+        runtime = self.runtime(backend)
+        result = runtime.step("emit a lot")
+
+        observation = runtime.messages[-1]["content"]
+        self.assertLessEqual(
+            len(observation), MAX_EVIDENCE_CHARS, "model-facing evidence must stay bounded"
+        )
+        self.assertIn("truncated for prompt", observation)
+        metadata = result.evidence.metadata
+        self.assertTrue(metadata["observation_truncated"])
+        self.assertGreater(metadata["observation_full_chars"], MAX_EVIDENCE_CHARS)
+
+    def test_evidence_carries_full_provenance(self) -> None:
+        backend = ScriptedBackend(tool_response("open('/workspace/work/out.txt','w').write('d')\nprint('ok')"))
+        runtime = self.runtime(backend)
+        result = runtime.step("derive something")
+
+        metadata = result.evidence.metadata
+        self.assertEqual(metadata["analysis_source_sha256"], self.source.sha256)
+        self.assertEqual(metadata["input_sha256"], self.source.sha256)
+        self.assertEqual(metadata["status"], "ok")
+        self.assertTrue(metadata["code_sha256"])
+        self.assertEqual(metadata["artifacts"][0]["name"], "out.txt")
+
+    def test_evidence_survives_across_steps(self) -> None:
+        backend = ScriptedBackend(tool_response("print('first')"), tool_response("print('second')"))
+        runtime = self.runtime(backend)
+        first = runtime.step("one")
+        runtime.step("continue")
+        # Each action now records two entries: the bounded observation and the
+        # durable raw output. Assert the property -- earlier evidence survives
+        # and both actions are represented -- rather than a fixed count.
+        self.assertIn(first.evidence.evidence_id, self.store.records)
+        self.assertIn(first.raw_output_evidence_id, self.store.records)
+        bounded = [r for r in self.store.records.values() if r.tool_name == "execute_analysis"]
+        self.assertEqual(len(bounded), 2, "one bounded record per action")
+
+
+class AnalysisContractTest(AnalysisRuntimeTestBase):
+    def test_only_the_analysis_tool_is_offered(self) -> None:
+        backend = ScriptedBackend(prose_response("ok"))
+        self.runtime(backend).step("hello")
+        self.assertEqual(backend.seen_tools[0], [ANALYSIS_TOOL_NAME])
+
+    def test_chat_tools_are_absent_from_the_analysis_surface(self) -> None:
+        from orbit.runtime.tools import TOOL_NAMES
+
+        self.assertNotIn(ANALYSIS_TOOL_NAME, TOOL_NAMES)
+        offered = ANALYSIS_TOOL_SCHEMA["function"]["name"]
+        self.assertEqual(offered, ANALYSIS_TOOL_NAME)
+
+    def test_stable_prefix_holds_no_volatile_identity(self) -> None:
+        # A future exact-prefix prewarm can only cover text identical across
+        # every analysis, so the source hash and path must sit after it.
+        for volatile in (self.source.sha256, self.source.original_path, "workspace/owned"):
+            self.assertNotIn(volatile, ANALYSIS_SYSTEM_PROMPT)
+
+    def test_volatile_identity_appears_after_the_stable_prefix(self) -> None:
+        backend = ScriptedBackend(prose_response("ok"))
+        runtime = self.runtime(backend)
+        self.assertEqual(runtime.messages[0]["content"], ANALYSIS_SYSTEM_PROMPT)
+        self.assertIn(self.source.sha256, runtime.messages[1]["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class DurableEvidenceTest(AnalysisRuntimeTestBase):
+    """A recorded hash must name bytes somebody can still produce."""
+
+    def test_full_stdout_survives_truncated_observation(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        result = runtime.step("emit a lot")
+
+        observation = runtime.messages[-1]["content"]
+        self.assertLessEqual(len(observation), MAX_EVIDENCE_CHARS)
+        self.assertTrue(result.evidence.metadata["observation_truncated"])
+
+        raw = self.store.load_raw(result.raw_output_evidence_id)
+        self.assertGreaterEqual(raw.count("A"), 60000, "full output must remain retrievable")
+
+    def test_derived_artifact_survives_the_step_and_reattests(self) -> None:
+        import hashlib
+
+        backend = ScriptedBackend(
+            tool_response("open('/workspace/work/derived.txt','w').write('D' * 40000)\nprint('done')")
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        result = runtime.step("derive")
+
+        artifact = result.evidence.metadata["artifacts"][0]
+        on_disk = (runtime.workspace.scratch_root / "derived.txt").read_bytes()
+        self.assertEqual(
+            hashlib.sha256(on_disk).hexdigest(),
+            artifact["sha256"],
+            "the recorded SHA must match bytes that still exist",
+        )
+        self.assertEqual(artifact["handle"], "/workspace/work/derived.txt")
+
+    def test_later_step_reopens_the_previous_artifact(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("open('/workspace/work/derived.txt','w').write('D' * 40000)\nprint('written')"),
+            tool_response(
+                "import orbit_tools\n"
+                "print('REOPENED', len(orbit_tools.read_file('/workspace/work/derived.txt')))"
+            ),
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        runtime.step("derive")
+        second = runtime.step("verify the derived file")
+
+        self.assertIn("REOPENED 40000", second.result.stdout)
+
+    def test_large_output_does_not_enter_the_next_prompt(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"), prose_response("ok"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        runtime.step("emit a lot")
+        runtime.step("continue")
+
+        sent = backend.seen_messages[1]
+        for message in sent:
+            self.assertLessEqual(
+                len(message.get("content") or ""),
+                MAX_EVIDENCE_CHARS,
+                "durable raw output must not leak into the next prompt",
+            )
+
+    def test_truncation_metadata_keeps_full_size_and_raw_handle(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        metadata = runtime.step("emit").evidence.metadata
+
+        self.assertGreater(metadata["observation_full_chars"], MAX_EVIDENCE_CHARS)
+        self.assertTrue(metadata["raw_output_evidence_id"])
+
+    def test_sessions_do_not_share_scratch(self) -> None:
+        first = self.runtime(ScriptedBackend(tool_response("open('/workspace/work/a.txt','w').write('x')\nprint('1')")))
+        self.addCleanup(first.close)
+        first.step("one")
+
+        second = self.runtime(ScriptedBackend(tool_response("import os\nprint('LEAK', os.path.exists('/workspace/work/a.txt'))")))
+        self.addCleanup(second.close)
+        result = second.step("two")
+
+        self.assertNotEqual(first.workspace.root, second.workspace.root)
+        self.assertIn("LEAK False", result.result.stdout)
+
+    def test_close_removes_the_workspace_and_is_idempotent(self) -> None:
+        runtime = self.runtime(ScriptedBackend(tool_response("print('x')")))
+        runtime.step("one")
+        root = runtime.workspace.root
+        self.assertTrue(root.exists())
+        runtime.close()
+        self.assertFalse(root.exists())
+        runtime.close()  # must not raise
+
+    def test_host_paths_never_reach_model_visible_history(self) -> None:
+        backend = ScriptedBackend(tool_response("open('/workspace/work/x.txt','w').write('y')\nprint('ok')"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        runtime.step("derive")
+
+        host_root = str(runtime.workspace.root)
+        for message in runtime.messages:
+            self.assertNotIn(host_root, str(message.get("content") or ""))
+
+
+class CumulativeWedgeRegressionTest(AnalysisRuntimeTestBase):
+    """MAJOR-1: retained artifacts must not fail a later compliant action.
+
+    The historical 8 MiB / 32-file allowance was written for a scratch
+    directory that lived and died with one action. The session workspace
+    outlives the action, so scanning it whole charges every step for every
+    file every earlier step left behind. Eight 60 KiB files is a legal
+    action; doing it repeatedly must stay legal.
+    """
+
+    def _writer(self, step: int) -> str:
+        return (
+            "for j in range(8):\n"
+            f"    open('/workspace/work/s{step}_%d.bin' % j, 'w').write('Z' * 60000)\n"
+            f"print('step {step} done')"
+        )
+
+    def test_repeated_compliant_actions_are_not_charged_for_history(self) -> None:
+        backend = ScriptedBackend(*[tool_response(self._writer(i)) for i in range(5)])
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+
+        for step in range(5):
+            result = runtime.step(f"step {step}")
+            self.assertEqual(
+                result.result.status,
+                "ok",
+                f"step {step} writes 8 files / 480 KiB -- within the per-action "
+                f"allowance -- but was judged {result.result.status!r} "
+                f"({result.result.bound_exceeded!r})",
+            )
+            self.assertIsNone(result.result.bound_exceeded)
+            self.assertEqual(
+                len(result.evidence.metadata["artifacts"]),
+                8,
+                f"step {step} must record the 8 files it created",
+            )
+
+    def test_capacity_is_never_silently_lossy(self) -> None:
+        """A bounded action must never look like a success that lost artifacts.
+
+        Driven by an action that genuinely trips the bound, so the assertions
+        actually execute: a version of this test that only ran compliant work
+        would assert nothing at all on the happy path.
+        """
+        backend = ScriptedBackend(
+            tool_response(
+                "for j in range(40):\n"
+                "    open('/workspace/work/many_%d.bin' % j, 'w').write('Z')\n"
+                "print('LOOKS SUCCESSFUL')"
+            )
+        )
+        runtime = self.runtime(backend)
+        result = runtime.step("overrun the action bound")
+
+        self.assertEqual(result.result.status, "bounded", "this action must trip the bound")
+        self.assertIsNotNone(result.result.bound_exceeded, "it must say which bound it hit")
+        self.assertEqual(result.evidence.metadata["artifacts"], [])
+        # The give-away the original defect had: stdout reads like a success.
+        self.assertIn("LOOKS SUCCESSFUL", result.result.stdout)
+        raw = self.store.load_raw(result.raw_output_evidence_id)
+        self.assertIn(
+            result.result.bound_exceeded,
+            raw,
+            "the recorded evidence must state the bound, not just the happy stdout",
+        )
+        self.assertIn(
+            f"status: {result.result.status}",
+            raw,
+            "the durable record must state the status it is attesting to",
+        )
+
+
+class DirectoryAccountingTest(AnalysisRuntimeTestBase):
+    """Directories must be charged like files: once, to the action that made them.
+
+    The flat-file regression alone missed this. `work/tmp` exists from the
+    first action onward because bwrap creates it, so a directory recharged
+    every step wedges a session that only ever writes into subdirectories.
+    """
+
+    def test_nested_actions_do_not_accumulate_a_directory_charge(self) -> None:
+        steps = 34  # past the 32-entry per-action allowance
+        backend = ScriptedBackend(
+            *[
+                tool_response(
+                    f"import os\n"
+                    f"os.makedirs('/workspace/work/d{i}', exist_ok=True)\n"
+                    f"open('/workspace/work/d{i}/f.txt','w').write('x')\n"
+                    f"print('ok {i}')"
+                )
+                for i in range(steps)
+            ]
+        )
+        runtime = self.runtime(backend)
+
+        for index in range(steps):
+            result = runtime.step(f"step {index}")
+            self.assertEqual(
+                result.result.status,
+                "ok",
+                f"step {index} created one directory and one file -- well inside the "
+                f"per-action allowance -- but was judged {result.result.bound_exceeded!r}",
+            )
+            self.assertEqual(len(result.evidence.metadata["artifacts"]), 1)
+
+    def test_session_usage_counts_real_bytes_not_directory_sentinels(self) -> None:
+        """Directories must not discount the retained byte total."""
+        backend = ScriptedBackend(
+            *[
+                tool_response(
+                    f"import os\n"
+                    f"os.makedirs('/workspace/work/d{i}', exist_ok=True)\n"
+                    f"open('/workspace/work/d{i}/f.txt','w').write('Z' * 1000)\n"
+                    f"print('ok')"
+                )
+                for i in range(3)
+            ]
+        )
+        runtime = self.runtime(backend)
+
+        seen = []
+        for index in range(3):
+            runtime.step(f"step {index}")
+            used_bytes, used_files = runtime.session_usage()
+            self.assertGreater(used_bytes, 0, "directories must not drive the total negative")
+            self.assertEqual(
+                used_files,
+                index + 1,
+                "only real files count -- one per step here, whatever the directory count",
+            )
+            seen.append(used_bytes)
+
+        self.assertEqual(seen, [1000, 2000, 3000], "retained bytes must grow with real content")
+
+    def test_empty_directories_alone_do_not_exhaust_the_session(self) -> None:
+        """Directories hold no data, so they must not consume the file cap."""
+        steps = 6
+        backend = ScriptedBackend(
+            *[
+                tool_response(
+                    f"import os\n"
+                    f"for j in range(30):\n"
+                    f"    os.makedirs('/workspace/work/s{i}_%d' % j, exist_ok=True)\n"
+                    f"print('dirs')"
+                )
+                for i in range(steps)
+            ]
+        )
+        runtime = self.runtime(backend)
+
+        for index in range(steps):
+            result = runtime.step(f"step {index}")
+            used_bytes, used_files = runtime.session_usage()
+            self.assertTrue(
+                result.action_executed,
+                f"step {index} was refused with {used_files} files / {used_bytes} bytes "
+                f"retained, but the workspace holds no file at all",
+            )
+            self.assertEqual(used_files, 0)
+            self.assertEqual(used_bytes, 0)
+
+    def test_an_action_creating_too_many_directories_is_still_bounded(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(
+                "import os\n"
+                "for j in range(40):\n"
+                "    os.makedirs('/workspace/work/many_%d' % j, exist_ok=True)\n"
+                "print('made')"
+            )
+        )
+        runtime = self.runtime(backend)
+        result = runtime.step("make too many directories at once")
+
+        self.assertEqual(result.result.status, "bounded")
+        self.assertEqual(
+            result.result.bound_exceeded,
+            "scratch bound exceeded",
+            "it must be the per-action allowance that fired, not some other bound",
+        )
+
+
+class HardLinkRecoveryTest(AnalysisRuntimeTestBase):
+    """A hard link is refused as a bound, not raised as an exception.
+
+    `os.link` is ordinary Python available to model-authored code. Raising at
+    capture time would leave the link in the session workspace and brick every
+    later step, so the entry is rejected while the action is being bounded.
+    """
+
+    def test_hard_link_is_bounded_and_the_session_recovers(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(
+                "import os\n"
+                "open('/workspace/work/a.txt','w').write('x')\n"
+                "os.link('/workspace/work/a.txt','/workspace/work/b.txt')\n"
+                "print('linked')"
+            ),
+            tool_response("import os\nos.unlink('/workspace/work/b.txt')\nprint('cleaned')"),
+            tool_response("print('still usable')"),
+        )
+        runtime = self.runtime(backend)
+
+        linked = runtime.step("make a hard link")
+        self.assertEqual(linked.result.status, "bounded")
+        self.assertEqual(linked.result.bound_exceeded, "scratch contains a hard link")
+        self.assertEqual(linked.evidence.metadata["artifacts"], [])
+
+        self.assertEqual(runtime.step("remove the link").result.status, "ok")
+        self.assertEqual(runtime.step("carry on").result.status, "ok")
+
+
+class UnsafeEntryRecoveryTest(AnalysisRuntimeTestBase):
+    """Entries the capture step cannot read are bounded, never raised.
+
+    The workspace persists, so an exception escaping `step()` would repeat on
+    every later step and end the session. Each case here must therefore be a
+    clean bound that the analyst can undo.
+    """
+
+    def _case(self, make: str, undo: str, expected: str) -> None:
+        backend = ScriptedBackend(
+            tool_response(make), tool_response(undo), tool_response("print('fine')")
+        )
+        runtime = self.runtime(backend)
+
+        first = runtime.step("create the unsafe entry")
+        self.assertEqual(first.result.status, "bounded")
+        self.assertEqual(first.result.bound_exceeded, expected)
+        self.assertEqual(runtime.step("undo it").result.status, "ok")
+        self.assertEqual(runtime.step("carry on").result.status, "ok")
+
+    def test_unreadable_file_is_bounded_and_recoverable(self) -> None:
+        self._case(
+            "import os\n"
+            "open('/workspace/work/a','w').write('x')\n"
+            "os.chmod('/workspace/work/a', 0o000)\n"
+            "print('locked')",
+            "import os\nos.chmod('/workspace/work/a', 0o600)\nprint('unlocked')",
+            "scratch contains an unreadable entry",
+        )
+
+    def test_fifo_is_bounded_and_recoverable(self) -> None:
+        self._case(
+            "import os\nos.mkfifo('/workspace/work/p')\nprint('fifo')",
+            "import os\nos.unlink('/workspace/work/p')\nprint('removed')",
+            "scratch contains an unsupported entry",
+        )
+
+    def test_undecodable_name_is_bounded_and_recoverable(self) -> None:
+        self._case(
+            "import os\n"
+            "os.close(os.open(b'/workspace/work/' + bytes([0xff, 0xfe]),"
+            " os.O_CREAT | os.O_WRONLY, 0o600))\n"
+            "print('made')",
+            "import os\n"
+            "for name in os.listdir(b'/workspace/work'):\n"
+            "    path = os.path.join(b'/workspace/work', name)\n"
+            "    if not os.path.isdir(path):\n"
+            "        os.unlink(path)\n"
+            "print('removed')",
+            "scratch contains an undecodable name",
+        )
+
+    def test_unreadable_directory_is_bounded_and_recoverable(self) -> None:
+        """A directory os.walk cannot enter must not hide its contents.
+
+        Left unbounded, the file inside goes uncharged and uncaptured, then is
+        attributed to whichever later action happens to unlock the directory.
+        """
+        self._case(
+            "import os\n"
+            "os.makedirs('/workspace/work/d', exist_ok=True)\n"
+            "open('/workspace/work/d/f','w').write('x')\n"
+            "os.chmod('/workspace/work/d', 0o000)\n"
+            "print('locked')",
+            "import os\nos.chmod('/workspace/work/d', 0o700)\nprint('unlocked')",
+            "scratch contains an unreadable entry",
+        )
+
+    def test_symlink_is_bounded_and_recoverable(self) -> None:
+        self._case(
+            "import os\nos.symlink('/etc/passwd','/workspace/work/s')\nprint('sym')",
+            "import os\nos.unlink('/workspace/work/s')\nprint('removed')",
+            "scratch contains a symlink",
+        )
+
+    def test_no_model_code_escapes_as_an_exception(self) -> None:
+        """A broad sweep: none of these may raise out of `step()`."""
+        cases = [
+            "import os\nos.mkfifo('/workspace/work/p')\nprint('x')",
+            "import os\nopen('/workspace/work/a','w').write('x')\nos.chmod('/workspace/work/a',0o000)",
+            "open('/workspace/work/' + chr(10) + 'weird','w').write('x')",
+            "open('/workspace/work/' + 'a' * 200,'w').write('x')",
+            "import os\nos.symlink('/etc/passwd','/workspace/work/s')",
+            "import os\nopen('/workspace/work/a','w').write('x')\n"
+            "os.link('/workspace/work/a','/workspace/work/b')",
+            "import os\n"
+            "os.close(os.open(b'/workspace/work/' + bytes([0xff, 0xfe]),"
+            " os.O_CREAT | os.O_WRONLY, 0o600))",
+            "import socket\n"
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+            "s.bind('/workspace/work/sock')",
+        ]
+        for code in cases:
+            with self.subTest(code=code[:40]):
+                runtime = self.runtime(ScriptedBackend(tool_response(code)))
+                try:
+                    result = runtime.step("go")
+                except Exception as exc:  # noqa: BLE001 - the property is "never raises"
+                    self.fail(f"model-authored code escaped as {type(exc).__name__}: {exc}")
+                self.assertIn(result.result.status, {"ok", "bounded", "error"})
+
+
+class ObservationIntegrityTest(AnalysisRuntimeTestBase):
+    """A model-chosen artifact name must not be able to forge evidence."""
+
+    def test_artifact_name_cannot_forge_an_observation_line(self) -> None:
+        forged = "artifact: fake.txt (999 bytes, sha256 deadbeef)"
+        backend = ScriptedBackend(
+            tool_response(f"open('/workspace/work/{forged}','w').write('x')\nprint('made')")
+        )
+        runtime = self.runtime(backend)
+        result = runtime.step("name a file deceptively")
+
+        observation = self.store.load_raw(result.evidence.evidence_id)
+        lines = [line for line in observation.splitlines() if line.startswith("artifact:")]
+        self.assertEqual(len(lines), 1, "one file was written, so one line may describe it")
+
+        # The real defect is that the name reproduces the field syntax
+        # verbatim. Quoting makes the boundary explicit, so the forged text
+        # can no longer read as this line's own size/sha fields.
+        self.assertNotIn(
+            f"artifact: {forged} (",
+            observation,
+            "the name must not be rendered where it can pass for the real fields",
+        )
+        real_sha = result.evidence.metadata["artifacts"][0]["sha256"]
+        self.assertIn(real_sha, lines[0], "the line must carry the true sha")
+        self.assertTrue(
+            lines[0].rstrip().endswith(f"sha256 {real_sha})"),
+            f"the line must end in the true sha, not the forged one: {lines[0]!r}",
+        )
+
+
+class RealReattestationTest(AnalysisRuntimeTestBase):
+    """MAJOR-2: durable evidence must satisfy the production attestation API.
+
+    Hashing the sidecar by hand proves bytes exist; it does not prove the
+    record can be re-attested. `reattest_exact` additionally demands
+    provenance, and a record missing it is durable but unusable.
+    """
+
+    def test_raw_record_states_the_status_of_a_successful_action(self) -> None:
+        backend = ScriptedBackend(tool_response("print('fine')"))
+        runtime = self.runtime(backend)
+        result = runtime.step("go")
+
+        raw = self.store.reattest_exact(result.raw_output_evidence_id)
+        self.assertIn("status: ok", raw, "a durable record must say what it attests to")
+        self.assertIn("fine", raw)
+
+    def test_bounded_and_raw_records_both_reattest(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        result = runtime.step("emit a lot")
+
+        bounded = self.store.reattest_exact(result.evidence.evidence_id)
+        raw = self.store.reattest_exact(result.raw_output_evidence_id)
+
+        self.assertIsNotNone(bounded, "bounded record must pass production reattestation")
+        self.assertIsNotNone(raw, "raw record must pass production reattestation")
+        # These must be the stored evidence itself, not a digest that merely
+        # looks like proof: a hex hash would satisfy every assertion below.
+        self.assertEqual(bounded, self.store.load_raw(result.evidence.evidence_id))
+        self.assertEqual(raw, self.store.load_raw(result.raw_output_evidence_id))
+        self.assertEqual(len(raw), self.store.records[result.raw_output_evidence_id].raw_chars)
+        self.assertEqual(len(bounded), self.store.records[result.evidence.evidence_id].raw_chars)
+        self.assertLessEqual(len(bounded), MAX_EVIDENCE_CHARS)
+        self.assertIn("A" * 60000, raw, "raw reattestation returns the full output")
+        self.assertNotEqual(bounded, raw, "raw and bounded must not be confusable")
+
+    def test_reattestation_survives_a_later_step(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("print('A' * 60000)"),
+            tool_response("print('later')"),
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        first = runtime.step("emit a lot")
+        runtime.step("do something else")
+
+        self.assertIsNotNone(self.store.reattest_exact(first.evidence.evidence_id))
+        raw = self.store.reattest_exact(first.raw_output_evidence_id)
+        self.assertIsNotNone(raw)
+        self.assertIn("A" * 60000, raw)
+
+    def test_records_carry_the_models_own_call_id(self) -> None:
+        backend = ScriptedBackend(tool_response("print('x')"))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        result = runtime.step("go")
+
+        # `tool_response` emits id "call_0"; the record must carry that exact
+        # value rather than a placeholder minted to satisfy the check.
+        emitted = "call_0"
+        for record_id in (result.evidence.evidence_id, result.raw_output_evidence_id):
+            record = self.store.records[record_id]
+            self.assertEqual(record.tool_call_id, emitted, "must be the model's id, not a synthetic one")
+            self.assertEqual(record.user_turn_id, "turn_1")
+            self.assertTrue(record.produced_by_phase)
+
+
+class NegativeReattestationTest(AnalysisRuntimeTestBase):
+    """Reattestation must refuse anything it cannot vouch for."""
+
+    def _step(self):
+        backend = ScriptedBackend(
+            tool_response("open('/workspace/work/d.txt','w').write('D' * 500)\nprint('done')")
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        return runtime, runtime.step("derive")
+
+    def test_missing_provenance_field_fails(self) -> None:
+        import dataclasses
+
+        _, result = self._step()
+        rid = result.evidence.evidence_id
+        self.assertIsNotNone(self.store.reattest_exact(rid))
+        self.store.records[rid] = dataclasses.replace(self.store.records[rid], tool_call_id=None)
+        self.assertIsNone(self.store.reattest_exact(rid), "no provenance, no attestation")
+
+    def test_modified_sidecar_content_fails(self) -> None:
+        _, result = self._step()
+        rid = result.raw_output_evidence_id
+        self.assertIsNotNone(self.store.reattest_exact(rid))
+        path = self.store.root / f"{rid}.txt"
+        path.write_text(path.read_text() + "tampered", encoding="utf-8")
+        self.assertIsNone(self.store.reattest_exact(rid), "content hash must be checked")
+
+    def test_wrong_expected_reference_fails(self) -> None:
+        _, result = self._step()
+        rid = result.evidence.evidence_id
+        self.assertIsNone(
+            self.store.reattest_exact(rid, expected_reference="ev_not_this_one"),
+            "a mismatched reference must not attest",
+        )
+
+    def test_raw_and_bounded_are_not_interchangeable(self) -> None:
+        _, result = self._step()
+        bounded = self.store.reattest_exact(result.evidence.evidence_id)
+        raw = self.store.reattest_exact(result.raw_output_evidence_id)
+        self.assertNotEqual(bounded, raw)
+        self.assertNotEqual(result.evidence.evidence_id, result.raw_output_evidence_id)
+
+    def test_changed_artifact_bytes_break_the_recorded_sha(self) -> None:
+        import hashlib
+
+        runtime, result = self._step()
+        artifact = result.evidence.metadata["artifacts"][0]
+        path = runtime.workspace.scratch_root / "d.txt"
+        path.write_bytes(b"E" * 500)
+        self.assertNotEqual(
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+            artifact["sha256"],
+            "the recorded SHA must not silently describe rewritten bytes",
+        )
+
+
+class SessionCapacityTest(AnalysisRuntimeTestBase):
+    """The session bound is separate from the per-action bound.
+
+    Tests here shrink the session cap rather than write 64 MiB, so the policy
+    is exercised without the runtime becoming slow enough that nobody runs it.
+    """
+
+    def _shrink(self, runtime, *, files=None, byte_cap=None):
+        import orbit.runtime.analysis_runtime as module
+
+        if files is not None:
+            self.enterContext(unittest.mock.patch.object(module, "MAX_SESSION_SCRATCH_FILES", files))
+        if byte_cap is not None:
+            self.enterContext(unittest.mock.patch.object(module, "MAX_SESSION_SCRATCH_BYTES", byte_cap))
+        return runtime
+
+    def _writer(self, step: int, count: int = 8, size: int = 60000) -> str:
+        return (
+            f"for j in range({count}):\n"
+            f"    open('/workspace/work/s{step}_%d.bin' % j, 'w').write('Z' * {size})\n"
+            f"print('step {step}')"
+        )
+
+    def test_a_action_exceeding_the_file_allowance_is_bounded(self) -> None:
+        backend = ScriptedBackend(tool_response(self._writer(0, count=40, size=10)))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        result = runtime.step("write too many files at once")
+
+        self.assertEqual(result.result.status, "bounded")
+        self.assertEqual(result.result.bound_exceeded, "scratch bound exceeded")
+        self.assertEqual(result.evidence.metadata["artifacts"], [])
+
+    def test_b_action_exceeding_the_byte_allowance_is_bounded(self) -> None:
+        """Drive the byte bound specifically, with the file count kept legal.
+
+        RLIMIT_FSIZE caps any single file at 64 KiB, so exceeding 8 MiB needs
+        many files -- but 20 stays well under the 32-file allowance, so a
+        failure here can only be the byte path. Checked directly against
+        `_scratch_bound_error` too, since a status alone would not say which
+        of the two bounds fired.
+        """
+        from orbit.runtime.analysis_sandbox import (
+            MAX_SCRATCH_BYTES,
+            MAX_SCRATCH_FILES,
+            _scratch_bound_error,
+        )
+
+        scratch = self.tmp / "bytes-probe"
+        scratch.mkdir()
+        for index in range(20):
+            (scratch / f"f{index}.bin").write_bytes(b"Z" * (MAX_SCRATCH_BYTES // 10))
+
+        self.assertLess(20, MAX_SCRATCH_FILES, "the file count must stay legal")
+        self.assertEqual(
+            _scratch_bound_error(scratch),
+            "scratch bound exceeded",
+            "20 files totalling 2x the byte allowance must trip the byte bound",
+        )
+
+    def test_b2_file_allowance_is_enforced_independently_of_bytes(self) -> None:
+        from orbit.runtime.analysis_sandbox import MAX_SCRATCH_FILES, _scratch_bound_error
+
+        scratch = self.tmp / "count-probe"
+        scratch.mkdir()
+        for index in range(MAX_SCRATCH_FILES + 2):
+            (scratch / f"f{index}.bin").write_bytes(b"Z")
+
+        self.assertEqual(_scratch_bound_error(scratch), "scratch bound exceeded")
+
+    def test_c_many_legal_actions_reach_an_explicit_session_cap(self) -> None:
+        backend = ScriptedBackend(*[tool_response(self._writer(i)) for i in range(4)])
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        self._shrink(runtime, files=20)
+
+        outcomes = [runtime.step(f"step {i}") for i in range(4)]
+        refusals = [r for r in outcomes if r.rejection and SESSION_CAPACITY_EXHAUSTED in r.rejection]
+
+        self.assertTrue(refusals, "the session cap must eventually be reported")
+        for refused in refusals:
+            self.assertFalse(refused.action_executed, "capacity is refused before running code")
+            self.assertIsNone(refused.result)
+
+    def test_d_evidence_stays_readable_after_the_cap(self) -> None:
+        backend = ScriptedBackend(*[tool_response(self._writer(i)) for i in range(3)])
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        self._shrink(runtime, files=10)
+
+        first = runtime.step("step 0")
+        self.assertTrue(first.action_executed)
+        later = [runtime.step(f"step {i}") for i in (1, 2)]
+        self.assertTrue(any(r.rejection and SESSION_CAPACITY_EXHAUSTED in r.rejection for r in later))
+
+        # Nothing was evicted to make room.
+        self.assertIsNotNone(self.store.reattest_exact(first.evidence.evidence_id))
+        self.assertIsNotNone(self.store.reattest_exact(first.raw_output_evidence_id))
+        for artifact in first.evidence.metadata["artifacts"]:
+            self.assertTrue((runtime.workspace.scratch_root / artifact["name"]).is_file())
+        runtime.close()
+        self.assertFalse(runtime.workspace.root.exists())
+
+    def test_f_byte_session_cap_is_enforced_independently(self) -> None:
+        """Exhaust the session by bytes while the file count stays legal."""
+        backend = ScriptedBackend(*[tool_response(self._writer(i, count=4)) for i in range(4)])
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        # 4 files x 60 KiB per step; cap bytes low, leave the file cap high.
+        self._shrink(runtime, files=10_000, byte_cap=300_000)
+
+        outcomes = [runtime.step(f"step {i}") for i in range(4)]
+        refusals = [r for r in outcomes if r.rejection and SESSION_CAPACITY_EXHAUSTED in r.rejection]
+
+        self.assertTrue(refusals, "the session BYTE cap must be enforced on its own")
+        used_bytes, used_files = runtime.session_usage()
+        self.assertLess(used_files, 10_000, "the file cap must not be what fired")
+        for refused in refusals:
+            self.assertFalse(refused.action_executed)
+
+    def test_e_capacity_refusal_makes_no_extra_model_call(self) -> None:
+        backend = ScriptedBackend(tool_response(self._writer(0)), tool_response(self._writer(1)))
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+        self._shrink(runtime, files=4)
+
+        runtime.step("step 0")
+        runtime.step("step 1")
+        self.assertEqual(backend.calls, 2, "one model call per analyst step, cap or no cap")
+
+
+class ModifiedArtifactProvenanceTest(AnalysisRuntimeTestBase):
+    """Rewriting a derived file must produce a new, distinguishable version."""
+
+    def test_rewrite_is_recorded_as_a_new_version(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("open('/workspace/work/d.txt','w').write('A' * 100)\nprint('v1')"),
+            tool_response("open('/workspace/work/d.txt','w').write('B' * 200)\nprint('v2')"),
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+
+        first = runtime.step("write it")
+        second = runtime.step("rewrite it")
+
+        v1 = first.evidence.metadata["artifacts"][0]
+        v2 = second.evidence.metadata["artifacts"][0]
+        self.assertEqual(v1["name"], v2["name"])
+        self.assertNotEqual(v1["sha256"], v2["sha256"], "a rewrite must get a new hash")
+        self.assertEqual(v1["size_bytes"], 100)
+        self.assertEqual(v2["size_bytes"], 200)
+        # The superseded record still attests to what it actually described.
+        self.assertIsNotNone(self.store.reattest_exact(first.evidence.evidence_id))
+        self.assertNotEqual(first.evidence.evidence_id, second.evidence.evidence_id)
+
+    def test_untouched_artifacts_are_not_reattributed(self) -> None:
+        backend = ScriptedBackend(
+            tool_response("open('/workspace/work/keep.txt','w').write('K' * 50)\nprint('made')"),
+            tool_response("print('touched nothing')"),
+        )
+        runtime = self.runtime(backend)
+        self.addCleanup(runtime.close)
+
+        runtime.step("create")
+        second = runtime.step("do nothing to the file")
+
+        self.assertEqual(
+            second.evidence.metadata["artifacts"], [],
+            "an action that wrote nothing must not claim an earlier file",
+        )


### PR DESCRIPTION
Adds the ANALYSIS runtime foundation: an isolated mode in which the model
inspects a sample one step at a time and always returns control to the human
analyst. Baseline: `90a5365`.

## Implemented

- **`AnalysisRuntime`** — drives an analyst-guided session over a fixed sample.
- **Sandboxed `execute_analysis`** — bubblewrap isolation, no network, unchanged
  flags/mounts/rlimits/allowlist from the reviewed sandbox foundation.
- **Minimal `orbit_tools.read_file`** — the only in-sandbox helper exposed.
- **Stable source snapshot** — the sample the session reasons about cannot shift
  underneath it.
- **Persistent session workspace + artifacts** — files written by one step remain
  readable by later steps, and artifacts are captured with their SHA-256.
- **Bounded model-facing evidence** — 8 KiB observation ceiling.
- **Durable raw evidence via `EvidenceStore`** — the full untruncated output is
  retained out of band even when the model only ever sees the bounded form.
- **Real `reattest_exact` provenance** — records carry the model's actual emitted
  `execute_analysis` tool-call id, the analyst turn id, and the producing phase,
  so both the bounded and the raw record independently re-attest.
- **One model call and at most one action per analyst step.**
- **Mandatory return to the analyst** — the runtime cannot chain actions
  autonomously.
- **Append-only, strict-prefix-ready ANALYSIS history** — no volatile state
  (host paths, turn ids, timestamps, counters, cap values) in the stable prefix.

### Scratch bound semantics

Two concepts are now separated. The historical **per-action** allowance
(8 MiB / 32 entries) is charged against a pre-action baseline delta, so a
persistent workspace no longer wedges after a few steps. The **persistent
session workspace** has its own cap, enforced as a clean pre-action refusal
(nothing is evicted, prior artifacts stay readable and re-attestable).

Session workspace limits are **64 MiB / 256 files**, recorded as *conservative
engineering defaults requiring future telemetry validation* — the recorded
historical runs wrote no derived files at all, so these are not evidence-derived.

## Not implemented (deliberately out of scope)

- automatic CHAT/ANALYSIS recognition
- CLI exposure
- ANALYSIS rolling KV
- prewarm
- CHAT changes

## Qualification

- 103 ANALYSIS tests PASS
- 42 sandbox tests PASS
- 2318 full suite PASS
- 25/25 mutations CAUGHT
- compileall PASS
- diff-check PASS
- independent review PASS
- BLOCKER 0 / MAJOR 0 / MINOR 0
- historical replay 8/8 PASS
- strict Ornith token-prefix PASS
- CHAT unchanged

No live inference and no malware execution were involved in qualification: the
tokenizer was loaded vocab-only, and historical replay used recorded runs.
