### PR TITLE
feat(runtime): add explicit chat and analysis workflow modes

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -404,7 +404,13 @@ class AnalysisRuntime:
                 scratch_baseline_sizes=baseline_sizes,
                 scratch_baseline_digests=baseline_digests,
             )
-        except (SandboxUnavailable, ValueError) as exc:
+        except (RuntimeError, OSError, ValueError) as exc:
+            # The sandbox refuses fail-closed for a tampered scratch entry or
+            # a changed read-only input, and it signals that with a plain
+            # RuntimeError. Those are refusals about this action, not reasons
+            # to end an investigation, so they are reported the same way an
+            # unavailable sandbox is. `SandboxUnavailable` is a RuntimeError
+            # and is covered here too.
             detail = f"{type(exc).__name__}: {exc}"
             self._append_tool_result(calls[0], f"action not executed: {detail}")
             return AnalysisStepResult(

--- a/src/orbit/runtime/sessions.py
+++ b/src/orbit/runtime/sessions.py
@@ -112,7 +112,22 @@ class SessionStore:
             return None, f"warning: ignoring invalid session {self.path}: malformed message"
         return messages, None
 
-    def save(self, *, messages: list[Message], workdir: Path, model: str, base_url: str) -> None:
+    def save(
+        self,
+        *,
+        messages: list[Message],
+        workdir: Path,
+        model: str,
+        base_url: str,
+        workflow_mode: str | None = None,
+    ) -> None:
+        """Persist this session. `workflow_mode` records the mode it ended in.
+
+        Recording a mode is not a promise that it can be resumed: what a mode
+        needs in order to continue is decided when the file is read, by
+        `load_workflow_mode`, and an ANALYSIS session has no durable workspace
+        to come back to. Omitting the key keeps older files loadable.
+        """
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "version": 1,
@@ -122,6 +137,8 @@ class SessionStore:
             "base_url": base_url,
             "messages": messages,
         }
+        if workflow_mode is not None:
+            payload["workflow_mode"] = workflow_mode
         tmp = self.path.with_suffix(".tmp")
         tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         os.replace(tmp, self.path)
@@ -131,6 +148,22 @@ class SessionStore:
             self.path.unlink()
         except FileNotFoundError:
             return
+
+    def load_workflow_mode(self) -> object | None:
+        """Return the mode recorded in this file, unvalidated, or None.
+
+        Interpreting it is the caller's job: this only reports what is stored,
+        so a missing file and an unusable value stay distinguishable.
+        """
+        if not self.path.exists():
+            return None
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data.get("workflow_mode")
 
     def _summary(self) -> SessionSummary | None:
         # The picker offers sessions to resume, so it asks the resumability

--- a/src/orbit/runtime/workflow_mode.py
+++ b/src/orbit/runtime/workflow_mode.py
@@ -1,0 +1,83 @@
+"""Which runtime a typed line belongs to, and nothing else.
+
+Orbit has two runtimes that answer a human. `ChatRuntime` holds a
+conversation with five tools; `AnalysisRuntime` inspects one artifact with
+one tool, one model call at a time. They are not variants of each other and
+the code here does not try to unify them: it decides which of the two owns
+the next line, and hands the line over unchanged.
+
+That decision is explicit. An earlier audit established that the existing
+route call cannot separate "explain this malware family" from "analyse this
+dropper" -- the route prompt deliberately maps read, summarise and analyse
+onto the same command shape -- and that inferring it would cost either a
+second classifier call per turn or a redesign of the route language. Both
+were ruled out, so mode is selected by the analyst with `/analysis` and
+`/chat` and never guessed. Selecting a mode makes no model call at all.
+
+The backend is not told any of this. Both runtimes already reach it through
+the same `ChatBackend`, so a mode is a fact about which object holds the
+conversation, never a parameter on the wire.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WorkflowMode(StrEnum):
+    """The runtime that owns the analyst's next line."""
+
+    CHAT = "CHAT"
+    ANALYSIS = "ANALYSIS"
+
+
+DEFAULT_WORKFLOW_MODE = WorkflowMode.CHAT
+
+# A session file records the mode it was saved in, but recording is not the
+# same as being able to resume. `AnalysisWorkspace` is a mkdtemp directory
+# removed on close, and the artifacts an analysis produces live only inside
+# it, so a restarted process has no source snapshot, no scratch tree and no
+# way to re-hash what earlier steps recorded. Restoring ANALYSIS would name a
+# session that cannot be continued, which is worse than starting in CHAT and
+# saying so. Only CHAT is therefore resumable; ANALYSIS falls back with a
+# warning until the workspace itself becomes durable.
+RESUMABLE_WORKFLOW_MODES = frozenset({WorkflowMode.CHAT})
+
+
+def parse_workflow_mode(value: object) -> WorkflowMode | None:
+    """Read a persisted mode, or None if the value is not one.
+
+    Deliberately strict: an unknown string is not coerced to a default here,
+    because the caller has to tell "absent" from "unusable" to warn about the
+    second.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return WorkflowMode(value)
+    except ValueError:
+        return None
+
+
+def restored_workflow_mode(value: object) -> tuple[WorkflowMode, str | None]:
+    """Resolve a persisted mode to one this process can actually honour.
+
+    Returns the mode to start in and, when that is not what was stored, the
+    warning explaining why. Every failure resolves to CHAT: it is the mode
+    whose state a session file genuinely carries.
+    """
+    if value is None:
+        return DEFAULT_WORKFLOW_MODE, None
+    mode = parse_workflow_mode(value)
+    if mode is None:
+        return (
+            DEFAULT_WORKFLOW_MODE,
+            f"warning: ignoring unknown workflow mode {value!r}: starting in CHAT",
+        )
+    if mode not in RESUMABLE_WORKFLOW_MODES:
+        return (
+            DEFAULT_WORKFLOW_MODE,
+            "warning: ANALYSIS sessions cannot be resumed after restart "
+            "(workspace and artifacts are not durable): starting in CHAT",
+        )
+    return mode, None

--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -1,0 +1,112 @@
+"""Opening an analysis session from the terminal, and showing what a step did.
+
+Two jobs, kept apart from the REPL so neither grows into the other: turn a
+path the analyst typed into a live `AnalysisRuntime`, and turn the result of
+one step into lines a person can read. Nothing here calls a model, and
+nothing here decides when a step happens -- that stays with the REPL, which
+is where the analyst's input arrives.
+
+Failures on the way in are ordinary refusals, not exceptions escaping into
+the prompt loop: a path that is missing, a directory, or unreadable leaves
+the current session exactly as it was.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from orbit.backend.base import ChatBackend
+from orbit.runtime.analysis_runtime import (
+    AnalysisRuntime,
+    AnalysisStepResult,
+    AnalysisWorkspace,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore
+
+
+class AnalysisModeError(Exception):
+    """The analyst asked for a session that cannot be opened."""
+
+
+def open_analysis_session(
+    raw_path: str,
+    *,
+    backend: ChatBackend,
+    workdir: Path,
+    evidence_store_factory: Callable[[Path], EvidenceStore],
+) -> AnalysisRuntime:
+    """Snapshot the artifact and return a runtime bound to it.
+
+    The workspace is created first, so a failure to acquire the source removes
+    it again rather than leaking a temporary directory for a session that
+    never started. The store is built from the workspace root, which keeps an
+    analysis session's evidence inside the session that produced it.
+    """
+    target = _resolve_target(raw_path, workdir=workdir)
+    workspace = AnalysisWorkspace.create()
+    try:
+        source = acquire_analysis_source(target, workspace.source_root)
+        evidence_store = evidence_store_factory(workspace.root)
+    except OSError as exc:
+        workspace.close()
+        raise AnalysisModeError(f"cannot read artifact: {exc}") from exc
+    except Exception:
+        workspace.close()
+        raise
+    return AnalysisRuntime(
+        backend=backend,
+        source=source,
+        evidence_store=evidence_store,
+        workspace=workspace,
+    )
+
+
+def _resolve_target(raw_path: str, *, workdir: Path) -> Path:
+    value = raw_path.strip()
+    if not value:
+        raise AnalysisModeError("usage: /analysis <path>")
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = workdir / candidate
+    if not candidate.exists():
+        raise AnalysisModeError(f"no such artifact: {value}")
+    if candidate.is_dir():
+        raise AnalysisModeError(f"not a file: {value}")
+    if not candidate.is_file():
+        raise AnalysisModeError(f"not a regular file: {value}")
+    return candidate
+
+
+def format_analysis_step(result: AnalysisStepResult) -> str:
+    """Render one step for the analyst who has just been handed control back."""
+    lines: list[str] = []
+    text = result.assistant_text.strip()
+    if text:
+        lines.append(text)
+    if result.rejection:
+        lines.append(f"action refused: {result.rejection}")
+    elif result.action_executed and result.result is not None:
+        lines.append(_action_summary(result))
+    elif result.action_attempted:
+        lines.append("action attempted but not executed")
+    if result.artifact_handles:
+        lines.append(f"artifacts: {', '.join(result.artifact_handles)}")
+    if not lines:
+        lines.append("(no output)")
+    return "\n".join(lines)
+
+
+def _action_summary(result: AnalysisStepResult) -> str:
+    action = result.result
+    if action is None:
+        return "action: executed"
+    summary = f"action: {action.status}"
+    if action.bound_exceeded:
+        summary += f" ({action.bound_exceeded})"
+    if result.evidence is not None:
+        summary += f" | evidence {result.evidence.evidence_id}"
+    if result.raw_output_evidence_id:
+        summary += f" | raw {result.raw_output_evidence_id}"
+    return summary

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -15,6 +15,7 @@ from orbit.runtime.artifacts import cleanup_stale_artifact_entries
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.media import load_audio, load_image
 from orbit.runtime.turn_trace import ModelStepMetrics
+from orbit.runtime.workflow_mode import restored_workflow_mode
 from orbit.terminal.config import add_config_arguments, load_app_config
 from orbit.terminal.command_actions import CommandAction, build_list_action, build_models_action, build_read_action, build_search_action
 from orbit.terminal.command_registry import resolve_command
@@ -137,6 +138,11 @@ def main(argv: list[str] | None = None) -> int:
     session_messages, session_warning = session.load_resumable()
     if session_warning:
         print(dim(warning_text(session_warning)), file=sys.stderr)
+    # A recorded mode is honoured only where this process can actually
+    # rebuild what it needs; anything else starts in CHAT and says why.
+    workflow_mode, mode_warning = restored_workflow_mode(session.load_workflow_mode())
+    if mode_warning:
+        print(dim(warning_text(mode_warning)), file=sys.stderr)
     runtime = ChatRuntime(
         backend=backend,
         system_prompt=None if config.no_system else config.system,
@@ -145,7 +151,14 @@ def main(argv: list[str] | None = None) -> int:
         diagnostic_session_id=str(config.workdir),
     )
     history = PromptHistory.for_workdir(config.workdir)
-    return Repl(runtime=runtime, backend=backend, config=config, session=session, history=history).run()
+    return Repl(
+        runtime=runtime,
+        backend=backend,
+        config=config,
+        session=session,
+        history=history,
+        workflow_mode=workflow_mode,
+    ).run()
 
 
 def _handle_one_shot_command(

--- a/src/orbit/terminal/command_registry.py
+++ b/src/orbit/terminal/command_registry.py
@@ -53,6 +53,14 @@ COMMANDS = (
         "Show tool access or local capabilities.",
         "tools",
     ),
+    CommandSpec(
+        "/analysis",
+        "Session",
+        "/analysis <path>",
+        "Analyse one local artifact in an isolated workspace.",
+        "analysis",
+    ),
+    CommandSpec("/chat", "Session", "/chat", "Return to normal chat mode.", "chat"),
     CommandSpec("/help", "Help", "/help", "Show command help.", "help"),
 )
 

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -2,14 +2,23 @@ from __future__ import annotations
 
 import sys
 import time
+from pathlib import Path
 from dataclasses import dataclass, field, replace
 
 from orbit.backend.base import ChatResult, StreamPromptMetrics
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
+from orbit.runtime.analysis_runtime import AnalysisRuntime
 from orbit.runtime.context_manager import ContextAdmissionError
+from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.sessions import SessionStore
+from orbit.runtime.workflow_mode import DEFAULT_WORKFLOW_MODE, WorkflowMode
+from orbit.terminal.analysis_mode import (
+    AnalysisModeError,
+    format_analysis_step,
+    open_analysis_session,
+)
 from orbit.terminal.compact_reports import format_memory_compaction_report, format_tool_compaction_report
 from orbit.terminal.command_actions import CommandAction, build_list_action, build_models_action, build_read_action, build_search_action
 from orbit.terminal.command_registry import resolve_command
@@ -49,6 +58,8 @@ class Repl:
     prefill_estimator: PrefillEstimator = field(default_factory=PrefillEstimator)
     can_continue: bool = False
     tools_mode: ToolSpec | None = None
+    workflow_mode: WorkflowMode = DEFAULT_WORKFLOW_MODE
+    analysis: AnalysisRuntime | None = field(default=None, repr=False)
     queued_prompts: list[str] = field(default_factory=list)
     turn_model_steps: list[ModelStepMetrics] = field(default_factory=list, repr=False)
     turn_backend_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
@@ -128,6 +139,18 @@ class Repl:
         return read_prompt_input()
 
     def _ask(self, prompt: str, *, command_action: CommandAction | None = None) -> None:
+        # The mode decides which runtime owns this line before anything else
+        # happens. ANALYSIS returns here, so no CHAT machinery -- route,
+        # tools, finalization -- is reached while a session is open.
+        if self.workflow_mode is WorkflowMode.ANALYSIS:
+            if self.analysis is None:
+                # The two are set together everywhere; if they ever diverge,
+                # say so rather than quietly answering as CHAT.
+                print("error: analysis session unavailable: returning to CHAT", file=sys.stderr)
+                self.workflow_mode = DEFAULT_WORKFLOW_MODE
+                return
+            self._ask_analysis(prompt)
+            return
         self.turn_model_steps.clear()
         self.turn_backend_token_usage = TokenUsageAccumulator()
         tools_enabled = tools_are_enabled(self.tools_mode or "off")
@@ -215,6 +238,68 @@ class Repl:
         elapsed = time.monotonic() - started
         print("\n\n", end="", flush=True)
         self._print_turn_footer(result, elapsed_seconds=elapsed)
+
+    def _ask_analysis(self, analyst_message: str) -> None:
+        """One analyst line -> exactly one `AnalysisRuntime.step()`.
+
+        There is no loop and no retry: whatever the step returns is printed
+        and control is back with the analyst. Steering, `continue`, and any
+        other text are all just the next analyst message, passed verbatim.
+        """
+        assert self.analysis is not None
+        print()
+        started = time.monotonic()
+        # `step()` appends the analyst line before it calls the model, so a
+        # cancelled or failed step would otherwise leave an unanswered user
+        # turn in the history. CHAT rewinds to a checkpoint for the same
+        # reason; ANALYSIS has more at stake, because that history is the
+        # append-only record a later exact-prefix strategy depends on.
+        checkpoint = self._analysis_checkpoint()
+        try:
+            result = self.analysis.step(analyst_message)
+        except KeyboardInterrupt:
+            self._restore_analysis_checkpoint(checkpoint)
+            print(dim("cancelled"), flush=True)
+            return
+        except (ContextAdmissionError, LlamaServerError, TimeoutError) as exc:
+            # Recoverable: the analyst keeps the session and can steer again.
+            self._restore_analysis_checkpoint(checkpoint)
+            print(runtime_error_text(exc), file=sys.stderr)
+            return
+        except BaseException:
+            # Anything else ends the process, as it does in CHAT. CHAT leaves
+            # nothing behind when it does; an analysis session would leave a
+            # temporary workspace, so release it before the exception goes up.
+            self._close_analysis()
+            raise
+        print(format_analysis_step(result), flush=True)
+        elapsed = time.monotonic() - started
+        print(
+            dim(
+                f"analysis | mode: ANALYSIS | model calls: {result.model_calls} | "
+                f"actions: {1 if result.action_executed else 0} | {elapsed:.1f}s"
+            ),
+            flush=True,
+        )
+
+    def _analysis_checkpoint(self) -> tuple[int, int]:
+        """History length and analyst-turn count before a step is attempted."""
+        assert self.analysis is not None
+        return len(self.analysis.messages), self.analysis.analyst_turns
+
+    def _restore_analysis_checkpoint(self, checkpoint: tuple[int, int]) -> None:
+        """Undo a step that produced nothing, so the record stays truthful.
+
+        A step that never reached the model must not leave a turn behind: the
+        `turn_N` in evidence provenance counts analyst turns, and a counter
+        that advances on failed attempts would name turns that produced no
+        evidence at all.
+        """
+        if self.analysis is None:
+            return
+        message_count, analyst_turns = checkpoint
+        del self.analysis.messages[message_count:]
+        self.analysis.analyst_turns = analyst_turns
 
     def _print_turn_footer(self, result, *, elapsed_seconds: float) -> None:
         self.can_continue = self.runtime.can_continue_last_response() or (
@@ -337,6 +422,8 @@ class Repl:
                 print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
                 return True
             print(reset_session(self.runtime, self.session))
+            self._close_analysis()
+            self.workflow_mode = DEFAULT_WORKFLOW_MODE
             self._reset_token_usage()
             self.can_continue = False
             return True
@@ -389,6 +476,15 @@ class Repl:
         if handler == "tools":
             print(self._handle_tools_command(f"/tools {arguments}".rstrip()))
             return True
+        if handler == "analysis":
+            print(self._handle_analysis_command(arguments))
+            return True
+        if handler == "chat":
+            if arguments:
+                print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
+                return True
+            print(self._handle_chat_command())
+            return True
         print(f"error: command handler unavailable: {invocation.spec.name}", file=sys.stderr)
         return True
 
@@ -409,6 +505,8 @@ class Repl:
             return "sessions clear cancelled"
         removed = SessionStore.clear_for_workdir(self.config.workdir)
         self.runtime.reset()
+        self._close_analysis()
+        self.workflow_mode = DEFAULT_WORKFLOW_MODE
         self._reset_token_usage()
         self.can_continue = False
         self.session = SessionStore.new_for_workdir(self.config.workdir)
@@ -447,6 +545,68 @@ class Repl:
         self.runtime.thinking_mode = self.config.think
         return f"think: {value}"
 
+    def _handle_analysis_command(self, arguments: str) -> str:
+        """Enter ANALYSIS on one artifact. No model call happens here."""
+        try:
+            runtime = open_analysis_session(
+                arguments,
+                backend=self.backend,
+                workdir=self.config.workdir,
+                evidence_store_factory=self._analysis_evidence_store,
+            )
+        except AnalysisModeError as exc:
+            # A refused session leaves the current mode untouched: a typo must
+            # not silently drop the analyst out of the session they were in.
+            return f"error: {exc}"
+        self._close_analysis()
+        self.analysis = runtime
+        self.workflow_mode = WorkflowMode.ANALYSIS
+        self.can_continue = False
+        source = runtime.source
+        return (
+            f"mode: ANALYSIS | {source.original_path} "
+            f"({source.size_bytes} bytes, sha256 {source.sha256})"
+        )
+
+    def _handle_chat_command(self) -> str:
+        """Return to CHAT. No model call, and the analysis is kept.
+
+        Closing the workspace here would destroy artifacts the analyst may
+        still want to come back to within this process, and nothing about
+        answering a chat question requires that. The session is released by
+        the ordinary lifecycle instead: `/reset`, `/analysis` on another
+        artifact, or leaving the REPL.
+        """
+        if self.workflow_mode is WorkflowMode.CHAT:
+            return "mode: CHAT"
+        self.workflow_mode = WorkflowMode.CHAT
+        self.can_continue = False
+        if self.analysis is not None:
+            return "mode: CHAT | analysis session kept (/analysis <path> starts a new one)"
+        return "mode: CHAT"
+
+    def _analysis_evidence_store(self, workspace_root: Path) -> EvidenceStore:
+        """A store of its own, per analysis session.
+
+        Sharing CHAT's store looks economical and is not: CHAT reads that
+        store to decide which route window to build and which evidence ids a
+        final answer may cite, both keyed on the most recent record and on a
+        `turn_N` string that each runtime mints from its own counter. An
+        analysis record landing there truncates the next CHAT route window,
+        advertises `execute_analysis` inside it, and can be authorised for
+        citation by a CHAT turn that never produced it. The two evidence
+        spaces are therefore kept apart, which is also what lets `/reset`
+        clear CHAT without reaching into a live analysis session.
+        """
+        return EvidenceStore(root=workspace_root / "evidence")
+
+    def _close_analysis(self) -> None:
+        """Release the analysis workspace, if one is open. Idempotent."""
+        if self.analysis is None:
+            return
+        self.analysis.close()
+        self.analysis = None
+
     def _continue_last_answer(self) -> None:
         self.can_continue = self.can_continue or self.runtime.can_continue_last_response()
         if not self.can_continue:
@@ -462,6 +622,7 @@ class Repl:
             workdir=self.config.workdir,
             model=self.backend.display_model_name() or "unknown",
             base_url=self.config.base_url,
+            workflow_mode=str(self.workflow_mode),
         )
 
     def _save_history(self) -> None:
@@ -469,6 +630,7 @@ class Repl:
             self.history.save()
 
     def _finish_interactive_session(self, code: int, *, leading_newline: bool = False) -> int:
+        self._close_analysis()
         self._save_history()
         if leading_newline:
             print()

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1,0 +1,919 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult, Message
+from orbit.runtime import ChatRuntime
+from orbit.runtime.analysis_runtime import ANALYSIS_TOOL_NAME, AnalysisRuntime
+from orbit.runtime.evidence import EvidenceStore
+from orbit.runtime.sessions import SessionStore
+from orbit.runtime.tools import TOOL_NAMES
+from orbit.runtime.workflow_mode import (
+    DEFAULT_WORKFLOW_MODE,
+    RESUMABLE_WORKFLOW_MODES,
+    WorkflowMode,
+    parse_workflow_mode,
+    restored_workflow_mode,
+)
+from orbit.terminal.analysis_mode import AnalysisModeError, open_analysis_session
+from orbit.terminal.config import AppConfig
+from orbit.terminal.repl import Repl
+
+# Pinned literal: the route language must not change in this mission.
+ROUTE_PROMPT_SHA256 = "e7d5234d50700746d315004af1430871442c4eefcc61b6e420cc24d29bcaae28"
+
+
+class ScriptedBackend:
+    """A backend that records what it was asked and never infers anything."""
+
+    def __init__(self, tool_calls: list[dict] | None = None) -> None:
+        self.calls = 0
+        self.tools_seen: list[object] = []
+        self.messages_seen: list[list[Message]] = []
+        self._tool_calls = tool_calls or []
+
+    def _result(self) -> ChatResult:
+        return ChatResult(
+            content="observing",
+            model="scripted",
+            finish_reason="stop",
+            tool_calls=list(self._tool_calls),
+            prompt_tokens=1,
+            completion_tokens=1,
+            cached_tokens=0,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None) -> ChatResult:
+        self.calls += 1
+        self.tools_seen.append(tools)
+        self.messages_seen.append([dict(m) for m in messages])
+        return self._result()
+
+    def chat_stream(
+        self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None
+    ) -> ChatResult:
+        self.calls += 1
+        self.tools_seen.append(tools)
+        self.messages_seen.append([dict(m) for m in messages])
+        if on_delta:
+            on_delta("observing")
+        return self._result()
+
+    def server_tools(self):
+        return []
+
+    def display_model_name(self):
+        return "scripted"
+
+
+class ModeTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="orbit-mode-test-"))
+        self.addCleanup(self._cleanup)
+        self.artifact = self.tmp / "sample.js"
+        self.artifact.write_text("var a = 1;\n", encoding="utf-8")
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def repl(self, backend: ScriptedBackend | None = None, **kwargs) -> Repl:
+        backend = backend or ScriptedBackend()
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+        runtime.evidence_store = EvidenceStore(root=self.tmp / "evidence")
+        built = Repl(
+            runtime=runtime,
+            backend=backend,
+            config=AppConfig(workdir=self.tmp),
+            **kwargs,
+        )
+        # Every test closes its workspace, so a failure cannot leak one.
+        self.addCleanup(built._close_analysis)
+        return built
+
+    def run_command(self, repl: Repl, command: str) -> str:
+        out = io.StringIO()
+        err = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            repl._handle_command(command)
+        return out.getvalue() + err.getvalue()
+
+    def run_prompt(self, repl: Repl, prompt: str) -> str:
+        out = io.StringIO()
+        err = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            repl._ask(prompt)
+        return out.getvalue() + err.getvalue()
+
+
+class DefaultModeTest(ModeTestBase):
+    def test_session_starts_in_chat(self) -> None:
+        self.assertIs(self.repl().workflow_mode, WorkflowMode.CHAT)
+        self.assertIs(DEFAULT_WORKFLOW_MODE, WorkflowMode.CHAT)
+
+    def test_chat_input_reaches_chat_runtime_not_analysis(self) -> None:
+        repl = self.repl()
+        seen: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: seen.append(prompt) or ChatResult(
+            "ok", "scripted", "stop", [], 1, 1, 0, None, None
+        )
+        repl.tools_mode = "on"
+        self.run_prompt(repl, "what is a packer?")
+
+        self.assertEqual(seen, ["what is a packer?"])
+        self.assertIsNone(repl.analysis)
+
+
+class EnterAnalysisTest(ModeTestBase):
+    def test_valid_path_enters_analysis_without_a_model_call(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+
+        output = self.run_command(repl, f"/analysis {self.artifact}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsInstance(repl.analysis, AnalysisRuntime)
+        self.assertEqual(backend.calls, 0)
+        self.assertIn("mode: ANALYSIS", output)
+        self.assertIn(self.artifact.name, output)
+
+    def test_relative_path_resolves_against_workdir(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, "/analysis sample.js")
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+    def test_source_is_snapshotted_by_content(self) -> None:
+        import hashlib
+
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        digest = hashlib.sha256(self.artifact.read_bytes()).hexdigest()
+
+        self.assertEqual(repl.analysis.source.sha256, digest)
+        # Editing the original afterwards must not change what is analysed.
+        self.artifact.write_text("var a = 2;\n", encoding="utf-8")
+        self.assertEqual(repl.analysis.source.sha256, digest)
+
+    def test_missing_path_fails_safely_and_stays_in_chat(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+
+        output = self.run_command(repl, "/analysis /nonexistent/zzz.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertEqual(backend.calls, 0)
+        self.assertIn("no such artifact", output)
+
+    def test_directory_is_refused(self) -> None:
+        repl = self.repl()
+        output = self.run_command(repl, f"/analysis {self.tmp}")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIn("not a file", output)
+
+    def test_empty_argument_is_refused(self) -> None:
+        repl = self.repl()
+        output = self.run_command(repl, "/analysis")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIn("usage", output)
+
+    def test_bad_path_while_in_analysis_keeps_current_session(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        first = repl.analysis
+
+        self.run_command(repl, "/analysis /nonexistent/zzz.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIs(repl.analysis, first)
+
+    def test_failed_open_leaves_no_workspace_behind(self) -> None:
+        before = set(Path(tempfile.gettempdir()).glob("orbit-analysis-session-*"))
+        with self.assertRaises(AnalysisModeError):
+            open_analysis_session(
+                "/nonexistent/zzz.js",
+                backend=ScriptedBackend(),
+                workdir=self.tmp,
+                evidence_store_factory=lambda root: EvidenceStore(root=root / "evidence"),
+            )
+        after = set(Path(tempfile.gettempdir()).glob("orbit-analysis-session-*"))
+        self.assertEqual(before, after)
+
+
+class AnalysisDispatchTest(ModeTestBase):
+    def test_analyst_line_goes_to_analysis_runtime_not_chat(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        chat_calls: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: chat_calls.append(prompt)
+        repl.runtime.ask_chat = lambda prompt, **kw: chat_calls.append(prompt)
+
+        self.run_prompt(repl, "decode the payload")
+
+        self.assertEqual(chat_calls, [])
+        self.assertEqual(repl.analysis.analyst_turns, 1)
+
+    def test_continue_is_one_analysis_step_with_verbatim_text(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        self.run_prompt(repl, "continue")
+
+        user_messages = [m for m in repl.analysis.messages if m["role"] == "user"]
+        self.assertEqual(user_messages[-1]["content"], "continue")
+        self.assertEqual(repl.analysis.analyst_turns, 1)
+
+    def test_steering_stays_in_analysis(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        for text in ("look at the strings", "continue", "now dump the header"):
+            self.run_prompt(repl, text)
+            self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+        self.assertEqual(repl.analysis.analyst_turns, 3)
+
+    def test_one_model_call_per_analyst_line(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        for expected in (1, 2, 3):
+            self.run_prompt(repl, "continue")
+            self.assertEqual(backend.calls, expected)
+
+    def test_analysis_history_is_append_only(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "first")
+        prefix = [dict(m) for m in repl.analysis.messages]
+
+        self.run_prompt(repl, "second")
+
+        self.assertEqual(repl.analysis.messages[: len(prefix)], prefix)
+
+
+class ToolIsolationTest(ModeTestBase):
+    def test_analysis_offers_only_execute_analysis(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        self.run_prompt(repl, "continue")
+
+        offered = backend.tools_seen[-1]
+        names = [tool["function"]["name"] for tool in offered]
+        self.assertEqual(names, [ANALYSIS_TOOL_NAME])
+        for chat_tool in TOOL_NAMES:
+            self.assertNotIn(chat_tool, names)
+
+    def test_chat_tool_registry_never_contains_execute_analysis(self) -> None:
+        from orbit.runtime.tools import tool_definitions, tool_names
+
+        self.assertNotIn(ANALYSIS_TOOL_NAME, tool_names())
+        names = [tool["function"]["name"] for tool in tool_definitions()]
+        self.assertNotIn(ANALYSIS_TOOL_NAME, names)
+
+    def test_execute_analysis_is_not_executable_through_the_chat_tool_path(self) -> None:
+        from orbit.runtime.tools import execute_tool
+
+        result = execute_tool(ANALYSIS_TOOL_NAME, "{}", workdir=self.tmp)
+        self.assertIn("unknown tool", result.content)
+
+    def test_chat_surface_modules_do_not_reference_execute_analysis(self) -> None:
+        for name in ("chat.py", "tools.py", "tool_loop.py"):
+            text = (SRC / "orbit" / "runtime" / name).read_text(encoding="utf-8")
+            self.assertNotIn(ANALYSIS_TOOL_NAME, text, name)
+
+    def test_analysis_runtime_does_not_reference_chat_tools(self) -> None:
+        text = (SRC / "orbit" / "runtime" / "analysis_runtime.py").read_text(encoding="utf-8")
+        for chat_tool in TOOL_NAMES:
+            self.assertNotIn(chat_tool, text)
+
+
+class ReturnToChatTest(ModeTestBase):
+    def test_chat_command_returns_to_chat_without_a_model_call(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        calls_before = backend.calls
+
+        output = self.run_command(repl, "/chat")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertEqual(backend.calls, calls_before)
+        self.assertIn("mode: CHAT", output)
+
+    def test_chat_keeps_the_analysis_session_alive(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        self.run_command(repl, "/chat")
+
+        self.assertIsNotNone(repl.analysis)
+        self.assertTrue(workspace_root.exists())
+
+    def test_after_chat_input_goes_back_to_chat_runtime(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_command(repl, "/chat")
+        seen: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: seen.append(prompt) or ChatResult(
+            "ok", "scripted", "stop", [], 1, 1, 0, None, None
+        )
+        repl.tools_mode = "on"
+
+        self.run_prompt(repl, "explain XOR")
+
+        self.assertEqual(seen, ["explain XOR"])
+        self.assertEqual(repl.analysis.analyst_turns, 0)
+
+    def test_no_flapping_a_conversational_line_does_not_switch_mode(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        for text in ("thanks", "what do you think?", "hello"):
+            self.run_prompt(repl, text)
+            self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+    def test_chat_twice_is_idempotent(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, "/chat")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.run_command(repl, "/chat")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+    def test_chat_rejects_arguments(self) -> None:
+        repl = self.repl()
+        output = self.run_command(repl, "/chat now")
+        self.assertIn("usage", output)
+
+
+class LifecycleTest(ModeTestBase):
+    def test_reset_closes_the_workspace_and_returns_to_chat(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        self.run_command(repl, "/reset")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertFalse(workspace_root.exists())
+
+    def test_exit_closes_the_workspace(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            repl._finish_interactive_session(0)
+
+        self.assertFalse(workspace_root.exists())
+
+    def test_starting_a_second_analysis_releases_the_first(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        first_root = repl.analysis.workspace.root
+        other = self.tmp / "other.js"
+        other.write_text("var b = 2;\n", encoding="utf-8")
+
+        self.run_command(repl, f"/analysis {other}")
+
+        self.assertFalse(first_root.exists())
+        self.assertTrue(repl.analysis.workspace.root.exists())
+        self.assertNotEqual(repl.analysis.workspace.root, first_root)
+
+    def test_close_analysis_is_idempotent(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        repl._close_analysis()
+        repl._close_analysis()
+        self.assertIsNone(repl.analysis)
+
+    def test_unexpected_error_releases_the_workspace_before_propagating(self) -> None:
+        class Exploding(ScriptedBackend):
+            def chat_stream(self, *args, **kwargs):
+                raise RuntimeError("backend exploded")
+
+        backend = Exploding()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        with self.assertRaises(RuntimeError):
+            with contextlib.redirect_stdout(io.StringIO()):
+                repl._ask("go")
+
+        # Crashing still ends the process as it does in CHAT, but a temporary
+        # workspace must not be what survives it.
+        self.assertFalse(workspace_root.exists())
+        self.assertIsNone(repl.analysis)
+
+    def test_recoverable_backend_error_keeps_the_session(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        class Failing(ScriptedBackend):
+            def chat_stream(self, *args, **kwargs):
+                raise LlamaServerError("upstream down")
+
+        backend = Failing()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        self.run_prompt(repl, "go")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsNotNone(repl.analysis)
+        self.assertTrue(workspace_root.exists())
+
+    def test_no_workspace_leaks_across_a_full_cycle(self) -> None:
+        pattern = "orbit-analysis-session-*"
+        before = set(Path(tempfile.gettempdir()).glob(pattern))
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "continue")
+        self.run_command(repl, "/chat")
+        with contextlib.redirect_stdout(io.StringIO()):
+            repl._finish_interactive_session(0)
+        after = set(Path(tempfile.gettempdir()).glob(pattern))
+        self.assertEqual(before, after)
+
+
+class PersistenceTest(ModeTestBase):
+    def store(self) -> SessionStore:
+        return SessionStore(self.tmp / "session.json")
+
+    def test_chat_mode_is_saved_and_restored(self) -> None:
+        store = self.store()
+        store.save(
+            messages=[{"role": "user", "content": "hi"}],
+            workdir=self.tmp,
+            model="m",
+            base_url="u",
+            workflow_mode="CHAT",
+        )
+        mode, warning = restored_workflow_mode(store.load_workflow_mode())
+        self.assertIs(mode, WorkflowMode.CHAT)
+        self.assertIsNone(warning)
+
+    def test_analysis_is_not_falsely_resumable(self) -> None:
+        store = self.store()
+        store.save(
+            messages=[{"role": "user", "content": "hi"}],
+            workdir=self.tmp,
+            model="m",
+            base_url="u",
+            workflow_mode="ANALYSIS",
+        )
+        mode, warning = restored_workflow_mode(store.load_workflow_mode())
+
+        self.assertIs(mode, WorkflowMode.CHAT)
+        self.assertIsNotNone(warning)
+        self.assertIn("cannot be resumed", warning)
+        self.assertNotIn(WorkflowMode.ANALYSIS, RESUMABLE_WORKFLOW_MODES)
+
+    def test_unknown_mode_falls_back_to_chat_with_a_warning(self) -> None:
+        mode, warning = restored_workflow_mode("SUPERVISOR")
+        self.assertIs(mode, WorkflowMode.CHAT)
+        self.assertIn("unknown workflow mode", warning)
+
+    def test_missing_mode_is_chat_without_a_warning(self) -> None:
+        store = self.store()
+        store.save(messages=[{"role": "user", "content": "hi"}], workdir=self.tmp, model="m", base_url="u")
+        self.assertIsNone(store.load_workflow_mode())
+        mode, warning = restored_workflow_mode(store.load_workflow_mode())
+        self.assertIs(mode, WorkflowMode.CHAT)
+        self.assertIsNone(warning)
+
+    def test_non_string_mode_is_rejected(self) -> None:
+        for value in (17, [], {}, True):
+            self.assertIsNone(parse_workflow_mode(value))
+            mode, warning = restored_workflow_mode(value)
+            self.assertIs(mode, WorkflowMode.CHAT)
+            self.assertIsNotNone(warning)
+
+    def test_omitting_mode_keeps_the_payload_shape_unchanged(self) -> None:
+        store = self.store()
+        store.save(messages=[{"role": "user", "content": "hi"}], workdir=self.tmp, model="m", base_url="u")
+        payload = json.loads(store.path.read_text(encoding="utf-8"))
+        self.assertNotIn("workflow_mode", payload)
+        self.assertEqual(payload["version"], 1)
+
+    def test_saved_mode_round_trips_through_the_repl(self) -> None:
+        repl = self.repl(session=self.store())
+        self.run_command(repl, f"/analysis {self.artifact}")
+        repl._save_session()
+        payload = json.loads(repl.session.path.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["workflow_mode"], "ANALYSIS")
+        # Recorded, but deliberately not resumable.
+        mode, warning = restored_workflow_mode(payload["workflow_mode"])
+        self.assertIs(mode, WorkflowMode.CHAT)
+        self.assertIsNotNone(warning)
+
+    def test_corrupt_session_file_yields_no_mode(self) -> None:
+        store = self.store()
+        store.path.write_text("{not json", encoding="utf-8")
+        self.assertIsNone(store.load_workflow_mode())
+
+    def test_repl_honours_an_injected_restored_mode(self) -> None:
+        repl = self.repl(workflow_mode=WorkflowMode.CHAT)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+
+class ModeInvariantTest(ModeTestBase):
+    def test_analysis_mode_without_a_runtime_refuses_instead_of_answering_as_chat(self) -> None:
+        repl = self.repl()
+        seen: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: seen.append(prompt)
+        repl.workflow_mode = WorkflowMode.ANALYSIS
+        repl.analysis = None
+
+        output = self.run_prompt(repl, "decode it")
+
+        self.assertEqual(seen, [])
+        self.assertIn("analysis session unavailable", output)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+
+class EvidenceSeparationTest(ModeTestBase):
+    """CHAT reads its evidence store to make decisions, so ANALYSIS keeps its own."""
+
+    def _analysis_record(self, repl: Repl):
+        self.run_prompt(repl, "look")
+        records = list(repl.analysis.evidence_store.records.values())
+        self.assertTrue(records, "the step should have recorded evidence")
+        return records
+
+    def repl_with_action(self):
+        backend = ScriptedBackend(
+            tool_calls=[
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": ANALYSIS_TOOL_NAME, "arguments": json.dumps({"code": "print(1)"})},
+                }
+            ]
+        )
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        return repl, backend
+
+    def test_analysis_uses_a_store_of_its_own(self) -> None:
+        repl = self.repl()
+        chat_store = repl.runtime.evidence_store
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        self.assertIsNot(repl.analysis.evidence_store, chat_store)
+
+    def test_analysis_evidence_lives_inside_the_analysis_workspace(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        store_root = repl.analysis.evidence_store.root
+
+        self.assertTrue(str(store_root).startswith(str(repl.analysis.workspace.root)))
+
+    def test_analysis_never_writes_into_the_chat_store(self) -> None:
+        repl, _ = self.repl_with_action()
+        chat_store = repl.runtime.evidence_store
+        self.run_prompt(repl, "look")
+
+        self.assertEqual(chat_store.records, {})
+
+    def test_chat_route_window_is_unaffected_by_an_analysis_action(self) -> None:
+        repl, _ = self.repl_with_action()
+        repl.runtime.messages = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "my name is G"},
+            {"role": "assistant", "content": "Hi G."},
+            {"role": "user", "content": "what is my name?"},
+        ]
+        before = repl.runtime._route_messages()
+
+        self.run_prompt(repl, "look")
+        self.run_command(repl, "/chat")
+        after = repl.runtime._route_messages()
+
+        # The prior conversation must still be in the route window, and the
+        # analysis tool must not be advertised inside it.
+        self.assertEqual(len(after), len(before))
+        self.assertEqual(after, before)
+        for message in after:
+            self.assertNotIn(ANALYSIS_TOOL_NAME, str(message["content"]))
+
+    def test_chat_citation_gate_cannot_authorize_analysis_evidence(self) -> None:
+        repl, _ = self.repl_with_action()
+        self.run_prompt(repl, "look")
+        self.run_command(repl, "/chat")
+
+        # Both runtimes mint "turn_N" from independent counters, so the only
+        # safe separation is that CHAT's store never holds analysis records.
+        repl.runtime.current_user_turn_id = "turn_1"
+        authorized = [
+            record.tool_name
+            for record in (repl.runtime.evidence_store.records.values())
+            if record.user_turn_id == "turn_1"
+        ]
+        self.assertNotIn(ANALYSIS_TOOL_NAME, authorized)
+
+    def test_chat_reset_does_not_clear_a_live_analysis_store(self) -> None:
+        repl, _ = self.repl_with_action()
+        self.run_prompt(repl, "look")
+        analysis_store = repl.analysis.evidence_store
+        count = len(analysis_store.records)
+
+        repl.runtime.reset()
+
+        self.assertEqual(len(analysis_store.records), count)
+
+
+class FailedStepRollbackTest(ModeTestBase):
+    """A step that produced nothing must leave no trace in the record."""
+
+    def _failing_repl(self, exc: BaseException):
+        class Failing(ScriptedBackend):
+            def chat_stream(self, *args, **kwargs):
+                raise exc
+
+        backend = Failing()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        return repl
+
+    def test_cancelled_step_leaves_no_dangling_user_message(self) -> None:
+        repl = self._failing_repl(KeyboardInterrupt())
+        before = [dict(m) for m in repl.analysis.messages]
+
+        self.run_prompt(repl, "decode it")
+
+        self.assertEqual(repl.analysis.messages, before)
+        self.assertEqual(repl.analysis.analyst_turns, 0)
+
+    def test_failed_step_leaves_no_dangling_user_message(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        repl = self._failing_repl(LlamaServerError("upstream down"))
+        before = [dict(m) for m in repl.analysis.messages]
+
+        self.run_prompt(repl, "decode it")
+
+        self.assertEqual(repl.analysis.messages, before)
+        self.assertEqual(repl.analysis.analyst_turns, 0)
+
+    def test_no_run_of_unanswered_user_turns_after_retries(self) -> None:
+        repl = self._failing_repl(KeyboardInterrupt())
+        for _ in range(3):
+            self.run_prompt(repl, "decode it")
+
+        roles = [m["role"] for m in repl.analysis.messages]
+        for first, second in zip(roles, roles[1:]):
+            self.assertFalse(first == "user" and second == "user", roles)
+
+    def test_analyst_turn_ids_only_count_steps_that_ran(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        class Flaky(ScriptedBackend):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fail_next = True
+
+            def chat_stream(self, *args, **kwargs):
+                if self.fail_next:
+                    self.fail_next = False
+                    raise LlamaServerError("transient")
+                return super().chat_stream(*args, **kwargs)
+
+        repl = self.repl(Flaky())
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "first attempt")
+        self.run_prompt(repl, "second attempt")
+
+        self.assertEqual(repl.analysis.analyst_turns, 1)
+
+
+class SandboxRefusalTest(ModeTestBase):
+    """A sandbox refusal is an answer to the analyst, not the end of a session."""
+
+    def _repl_raising(self, exc: BaseException):
+        backend = ScriptedBackend(
+            tool_calls=[
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": ANALYSIS_TOOL_NAME, "arguments": json.dumps({"code": "pass"})},
+                }
+            ]
+        )
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        import orbit.runtime.analysis_runtime as module
+
+        def boom(**kwargs):
+            raise exc
+
+        self.enterContext(mock.patch.object(module, "execute_analysis", boom))
+        return repl
+
+    def test_unsafe_scratch_entry_is_a_refusal_not_a_dead_session(self) -> None:
+        repl = self._repl_raising(RuntimeError("unsafe scratch entry"))
+
+        output = self.run_prompt(repl, "run it")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsNotNone(repl.analysis)
+        self.assertTrue(repl.analysis.workspace.root.exists())
+        self.assertIn("action refused", output)
+
+    def test_os_error_from_the_sandbox_is_a_refusal(self) -> None:
+        repl = self._repl_raising(OSError("scratch vanished"))
+
+        self.run_prompt(repl, "run it")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsNotNone(repl.analysis)
+
+    def test_a_refusal_still_returns_control_with_one_model_call(self) -> None:
+        repl = self._repl_raising(RuntimeError("read-only input changed during analysis"))
+        result = repl.analysis.step("run it")
+
+        self.assertEqual(result.model_calls, 1)
+        self.assertFalse(result.action_executed)
+        self.assertTrue(result.control_returned)
+        self.assertIn("read-only input changed", result.rejection)
+
+    def test_mode_and_runtime_never_desynchronize_on_a_refusal(self) -> None:
+        repl = self._repl_raising(RuntimeError("unsafe scratch entry"))
+        self.run_prompt(repl, "run it")
+
+        # The bug this guards: an escaping RuntimeError closed the session
+        # while the REPL still believed it was in ANALYSIS.
+        self.assertEqual(
+            repl.workflow_mode is WorkflowMode.ANALYSIS,
+            repl.analysis is not None,
+        )
+
+
+class EvidenceOrderingTest(ModeTestBase):
+    def test_an_executed_action_leaves_evidence_and_tool_result_together(self) -> None:
+        backend = ScriptedBackend(
+            tool_calls=[
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": ANALYSIS_TOOL_NAME, "arguments": json.dumps({"code": "print(1)"})},
+                }
+            ]
+        )
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "run it")
+
+        # Two records (bounded + raw) and exactly one tool message for them.
+        records = list(repl.analysis.evidence_store.records.values())
+        tool_messages = [m for m in repl.analysis.messages if m["role"] == "tool"]
+        self.assertEqual(len(records), 2)
+        self.assertEqual(len(tool_messages), 1)
+        self.assertEqual(repl.analysis.messages[-1]["role"], "tool")
+
+
+class SessionsClearLifecycleTest(ModeTestBase):
+    def test_sessions_clear_closes_the_analysis_session(self) -> None:
+        import unittest.mock as mock
+
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        workspace_root = repl.analysis.workspace.root
+
+        with mock.patch("orbit.terminal.repl._confirm_clear_sessions", return_value=True):
+            self.run_command(repl, "/sessions clear")
+
+        self.assertFalse(workspace_root.exists())
+        self.assertIsNone(repl.analysis)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+
+class BackendAgnosticTest(ModeTestBase):
+    def test_backend_never_receives_a_mode_argument(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "continue")
+
+        for messages in backend.messages_seen:
+            for message in messages:
+                self.assertNotIn("workflow_mode", message)
+                self.assertNotIn("mode", message)
+
+    def test_mode_is_not_written_into_the_analysis_prompt(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "continue")
+
+        system = repl.analysis.messages[0]["content"]
+        for token in ("ANALYSIS mode", "workflow_mode", "WorkflowMode", "/analysis", "/chat"):
+            self.assertNotIn(token, system)
+
+    def test_backend_module_does_not_branch_on_workflow_mode(self) -> None:
+        for path in (SRC / "orbit" / "backend").glob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("WorkflowMode", text, path.name)
+            self.assertNotIn("workflow_mode", text, path.name)
+
+
+class StrictPrefixTest(ModeTestBase):
+    def test_analysis_stable_prefix_is_free_of_volatile_state(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        system = repl.analysis.messages[0]["content"]
+
+        for volatile in (
+            str(self.tmp),
+            str(self.artifact),
+            repl.analysis.source.sha256,
+            str(repl.analysis.workspace.root),
+            "turn_",
+        ):
+            self.assertNotIn(volatile, system)
+
+    def test_step_messages_extend_the_previous_step_exactly(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "one")
+        first = [dict(m) for m in repl.analysis.messages]
+        self.run_prompt(repl, "two")
+        second = repl.analysis.messages
+
+        self.assertGreater(len(second), len(first))
+        self.assertEqual(second[: len(first)], first)
+
+    def test_chat_and_analysis_prompts_are_disjoint(self) -> None:
+        from orbit.runtime.analysis_runtime import ANALYSIS_SYSTEM_PROMPT
+        from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
+
+        self.assertNotIn(ANALYSIS_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT)
+        self.assertNotIn(ANALYSIS_SYSTEM_PROMPT, CHAT_SYSTEM_PROMPT)
+        self.assertNotIn(ROUTE_SYSTEM_PROMPT, ANALYSIS_SYSTEM_PROMPT)
+
+
+class ChatNonRegressionTest(ModeTestBase):
+    def test_route_prompt_is_untouched_by_this_mission(self) -> None:
+        import hashlib
+
+        from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+
+        # Pinned so a future mode change cannot quietly edit route language,
+        # which is what the deferred recognition mission has to qualify.
+        self.assertEqual(
+            hashlib.sha256(ROUTE_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
+            ROUTE_PROMPT_SHA256,
+        )
+
+    def test_chat_five_tool_surface_is_unchanged(self) -> None:
+        self.assertEqual(
+            TOOL_NAMES,
+            (
+                "exec_shell_full_command",
+                "fetch_url",
+                "list_directory",
+                "system_info",
+                "write_artifact",
+            ),
+        )
+
+    def test_chat_turn_still_uses_ask_auto_with_chat_tools(self) -> None:
+        repl = self.repl()
+        repl.tools_mode = "on"
+        seen: dict[str, object] = {}
+
+        def fake_ask_auto(prompt, **kwargs):
+            seen["prompt"] = prompt
+            seen["allowed"] = kwargs.get("allowed_tool_names")
+            return ChatResult("ok", "scripted", "stop", [], 1, 1, 0, None, None)
+
+        repl.runtime.ask_auto = fake_ask_auto
+        self.run_prompt(repl, "list the files")
+
+        self.assertEqual(seen["prompt"], "list the files")
+        self.assertNotIn(ANALYSIS_TOOL_NAME, seen["allowed"] or ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Gives the REPL an explicit workflow mode so Orbit's two runtimes can each own the
analyst's next line. Baseline: `b3b44e0`.

## Implemented

- **`Repl` owns explicit `CHAT | ANALYSIS`** — mode is session state on the REPL,
  alongside the existing `tools_mode`. No new orchestration layer.
- **Default is CHAT.** A session always starts there.
- **`/analysis <path>` enters ANALYSIS with zero model calls** — it resolves the
  path, snapshots the artifact by content, and opens a session. A missing path,
  a directory or an empty argument is a refusal that leaves the current mode and
  any live session untouched, with no workspace left behind.
- **`/chat` returns to CHAT with zero model calls** — and deliberately *keeps* the
  analysis session alive, so artifacts stay reachable. It is released by `/reset`,
  `/sessions clear`, a new `/analysis`, or leaving the REPL.
- **ANALYSIS keeps its qualified semantics** — one model call per analyst line, at
  most one action, then control returns to the human. `continue` and steering are
  passed through verbatim as the next analyst message. No autonomous continuation.
- **Tool surfaces remain structurally isolated** — `execute_analysis` is never
  registered for CHAT (absent from `tool_names()`, `tool_definitions()` and
  `execute_tool`), and the five CHAT tools never reach ANALYSIS. No global sixth tool.
- **ANALYSIS owns its own `EvidenceStore`**, rooted inside its own workspace. CHAT
  reads its store to build route windows and authorise citations, so analysis
  records must not land there.
- **Failed or cancelled steps rewind to a checkpoint**, keeping ANALYSIS history
  append-only and its `turn_N` provenance ids honest.

### Not resumable across restart — on purpose

A session records the mode it ended in, but only CHAT is resumable. An analysis
workspace is a temporary directory that does not survive the process, and the
source snapshot and artifacts live only inside it. A stored `ANALYSIS` therefore
**falls back to CHAT with an explicit warning** rather than promising a session
that cannot be continued. Making it truly resumable needs a durable workspace,
source snapshot and evidence root — recorded as a missing persistence requirement,
not implemented here.

### Unchanged

CHAT routing, rolling KV, backend/native inference and telemetry are untouched.
The route prompt is pinned by SHA in the tests. Mode never reaches the wire: the
backend is not told which mode is running, and nothing volatile enters either
immutable prompt prefix, so future CHAT and ANALYSIS exact-prefix prewarm both
stay open. The two modes already carry distinct `tool_schema_hash` values, so no
rolling-KV state can be reused across them.

### Automatic recognition deferred

An audit established that the current route language cannot represent ANALYSIS:
`RouteDecision` carries no field for it and discards the command payload, and the
route prompt deliberately maps *read*, *summarise* and *analyse* onto the same
`{"command":"cat …"}` shape. Expressing the distinction would need either a
route-language redesign or a second classifier call per turn. Both are out of
scope here and will be qualified separately.

## Qualification

- full suite: 2386 PASS
- mode tests: 68 PASS
- focused CHAT/KV: 316 PASS
- ANALYSIS + sandbox: 103 PASS
- mutations: 19/19 CAUGHT
- compileall / diff-check: PASS
- independent final review: PASS
- BLOCKER 0 / MAJOR 0

An earlier independent review returned FAIL (2 BLOCKER, 3 MAJOR); all five were
reproduced and fixed, and the re-review verified each fix by reverting it.

### Accepted latent MINOR (not fixed)

In `AnalysisRuntime.step()` the two `evidence_store.add()` calls precede
`_append_tool_result`, so a raise between them would leave evidence with no
corresponding tool message. This is **not reachable by any current code path** —
a latent ordering fragility, not a live defect. Reordering would alter qualified
ANALYSIS semantics for an unreachable case, so the invariant is pinned by test
and the ordering is left as is.

No live inference and no malware execution were involved: all tests use a
scripted backend.
