### PR TITLE
perf(runtime): add rolling KV reuse for analysis

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -34,6 +34,7 @@ from orbit.native_llama.qwen36_shell_tool_prefix import (
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.history_serialization import serialize_profile_messages
+from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
 
@@ -86,6 +87,7 @@ class LlamaServerBackend:
                 thinking=self.thinking,
                 tools=tools,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                analysis_rolling_anchor=_analysis_rolling_anchor_requested(native_backend=native_backend),
                 qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
                 qwen36_shell_tool_prefix_anchor=_qwen36_shell_tool_prefix_anchor_requested(
                     native_backend=native_backend,
@@ -129,6 +131,7 @@ class LlamaServerBackend:
                 tools=tools,
                 stream=True,
                 route_prefix_anchor=_route_prefix_anchor_requested(native_backend=native_backend),
+                analysis_rolling_anchor=_analysis_rolling_anchor_requested(native_backend=native_backend),
                 qwen_route_prefix_anchor=_qwen_route_prefix_anchor_requested(native_backend=native_backend),
                 qwen36_shell_tool_prefix_anchor=_qwen36_shell_tool_prefix_anchor_requested(
                     native_backend=native_backend,
@@ -1084,6 +1087,19 @@ def _route_prefix_anchor_requested(*, native_backend: bool) -> bool:
     if not prefix_anchor_enabled():
         return False
     return current_phase() == "route" and current_tools_mode() == "on"
+
+
+def _analysis_rolling_anchor_requested(*, native_backend: bool) -> bool:
+    """Whether this call is an analysis step eligible for rolling reuse.
+
+    Read from the phase the runtime already declares for its own call, the
+    same way the route anchor is: the backend is told, never infers.
+    """
+    if not native_backend:
+        return False
+    if not prefix_anchor_enabled():
+        return False
+    return current_phase() == ANALYSIS_STEP_PHASE
 
 
 def _qwen_route_prefix_anchor_requested(*, native_backend: bool) -> bool:

--- a/src/orbit/backend/payloads.py
+++ b/src/orbit/backend/payloads.py
@@ -23,6 +23,7 @@ class ChatPayloadOptions:
     route_prefix_anchor: bool = False
     qwen_route_prefix_anchor: bool = False
     qwen36_shell_tool_prefix_anchor: bool = False
+    analysis_rolling_anchor: bool = False
     allow_mtp_experimental: bool | None = None
     final_prefix_experiment: bool = False
     artifact_content: bool = False
@@ -46,6 +47,8 @@ def build_chat_payload(options: ChatPayloadOptions) -> dict[str, Any]:
         payload["qwen_route_prefix_anchor"] = True
     if options.qwen36_shell_tool_prefix_anchor:
         payload["qwen36_shell_tool_prefix_anchor"] = True
+    if options.analysis_rolling_anchor:
+        payload["analysis_rolling_anchor"] = True
     if options.allow_mtp_experimental is not None:
         payload["allow_mtp_experimental"] = options.allow_mtp_experimental
     if options.final_prefix_experiment:

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -49,6 +49,7 @@ from .mtp_probe import MtpProbeResult, run_mtp_probe
 from .native_names import mtmd_bridge_filename, runtime_library_filename
 from .paths import NativeLlamaPaths
 from .rolling_route_anchor import (
+    ROLLING_ANALYSIS_STRATEGY_ID,
     ROLLING_ROUTE_STRATEGY_ID,
     RollingRouteAnchorState,
     RollingRouteIdentity,
@@ -324,6 +325,11 @@ class NativeLlamaClient:
         # Exactly one rolling route checkpoint per client, replaced in place.
         self._rolling_route_anchor_state = RollingRouteAnchorState()
         self._rolling_route_identity_cache: RollingRouteIdentity | None = None
+        # A second slot, not a second mechanism: same state type, same
+        # primitives. Two slots exist because the route chain and an analysis
+        # chain are different conversations that interleave, and one slot
+        # would make each switch evict the other's still-valid checkpoint.
+        self._rolling_analysis_anchor_state = RollingRouteAnchorState()
         self._reset_generation = 0
         self._qwen_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
@@ -1205,6 +1211,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        analysis_rolling_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
         qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
@@ -1290,12 +1297,27 @@ class NativeLlamaClient:
             allow_mtp = False
         if allow_mtp_experimental is False:
             allow_mtp = False
+        # One strategy, two lineages. Which one this call belongs to is decided
+        # by the anchor the caller asked for, and the strategy id it produces is
+        # what keeps the two checkpoints from ever standing in for each other.
         rolling_route_eligible = self._ornith_rolling_route_eligible(
             route_prefix_anchor=route_prefix_anchor, tools=tools, thinking=thinking
         )
-        rolling_route_identity = (
-            self._rolling_route_identity(tools=tools) if rolling_route_eligible else None
+        rolling_analysis_eligible = (
+            not rolling_route_eligible
+            and self._ornith_rolling_analysis_eligible(
+                analysis_rolling_anchor=analysis_rolling_anchor, thinking=thinking
+            )
         )
+        if rolling_route_eligible:
+            rolling_route_identity = self._rolling_route_identity(tools=tools)
+        elif rolling_analysis_eligible:
+            rolling_route_identity = self._rolling_route_identity(
+                tools=tools, strategy_id=ROLLING_ANALYSIS_STRATEGY_ID
+            )
+        else:
+            rolling_route_identity = None
+        rolling_route_eligible = rolling_route_eligible or rolling_analysis_eligible
         return self.complete_prompt(
             prompt,
             max_tokens=max_tokens,
@@ -1323,6 +1345,7 @@ class NativeLlamaClient:
         tools: list[dict] | None = None,
         thinking: bool | None = None,
         route_prefix_anchor: bool = False,
+        analysis_rolling_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
         qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
@@ -1339,6 +1362,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            analysis_rolling_anchor=analysis_rolling_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
             qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
@@ -1502,6 +1526,7 @@ class NativeLlamaClient:
         tools: list[dict] | None,
         thinking: bool,
         route_prefix_anchor: bool = False,
+        analysis_rolling_anchor: bool = False,
         qwen_route_prefix_anchor: bool = False,
         qwen36_shell_tool_prefix_anchor: bool = False,
         allow_mtp_experimental: bool | None = None,
@@ -1519,6 +1544,7 @@ class NativeLlamaClient:
                 tools=tools,
                 thinking=thinking,
                 route_prefix_anchor=route_prefix_anchor,
+                analysis_rolling_anchor=analysis_rolling_anchor,
                 qwen_route_prefix_anchor=qwen_route_prefix_anchor,
                 qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
                 allow_mtp_experimental=allow_mtp_experimental,
@@ -1588,6 +1614,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            analysis_rolling_anchor=analysis_rolling_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
             qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
@@ -1617,6 +1644,7 @@ class NativeLlamaClient:
         qwen36_shell_tool_prefix_anchor: bool,
         allow_mtp_experimental: bool | None,
         final_prefix_experiment: bool,
+        analysis_rolling_anchor: bool = False,
         on_progress=None,
         on_token=None,
         should_cancel=None,
@@ -1661,6 +1689,7 @@ class NativeLlamaClient:
             tools=tools,
             thinking=thinking,
             route_prefix_anchor=route_prefix_anchor,
+            analysis_rolling_anchor=analysis_rolling_anchor,
             qwen_route_prefix_anchor=qwen_route_prefix_anchor,
             qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
             allow_mtp_experimental=allow_mtp_experimental,
@@ -2345,8 +2374,9 @@ class NativeLlamaClient:
         ):
             # Prefill completed exactly through the prompt and nothing has been
             # generated yet, so the snapshot is the prompt and only the prompt.
+            slot_state = self._rolling_anchor_state_for(rolling_route_identity)
             if rolling_route_should_replace(
-                self._rolling_route_anchor_state, prompt_tokens, rolling_route_identity
+                slot_state, prompt_tokens, rolling_route_identity
             ):
                 captured, _capture_meta = capture_rolling_route_anchor(
                     lib,
@@ -2356,7 +2386,7 @@ class NativeLlamaClient:
                 )
                 # A failed capture must not discard a still-usable checkpoint.
                 if captured.valid:
-                    self._rolling_route_anchor_state = captured
+                    self._store_rolling_anchor_state(rolling_route_identity, captured)
         self.last_committed_generated_tokens = []
         generated, gen_ms, cancelled = self._generate_from_current_context(
             max_tokens=max_tokens,
@@ -3124,10 +3154,32 @@ class NativeLlamaClient:
             return False
         return True
 
-    def _rolling_route_identity(self, *, tools: list[dict] | None) -> RollingRouteIdentity:
+    def _ornith_rolling_analysis_eligible(self, *, analysis_rolling_anchor: bool, thinking: bool) -> bool:
+        """Same gate as the route lineage, asked about an analysis step.
+
+        The prerequisites are identical because the risk is: only a verified
+        Ornith profile, never with thinking or MTP, and only when the caller
+        declared this call is part of an analysis chain.
+        """
+        if not analysis_rolling_anchor:
+            return False
+        profile = getattr(self, "model_profile", None)
+        if not getattr(profile, "verified", False):
+            return False
+        if getattr(profile, "profile_id", None) != ORNITH15_PROFILE_ID:
+            return False
+        if thinking:
+            return False
+        if self.config.use_mtp_experimental or self._session.mtp_enabled:
+            return False
+        return True
+
+    def _rolling_route_identity(
+        self, *, tools: list[dict] | None, strategy_id: str = ROLLING_ROUTE_STRATEGY_ID
+    ) -> RollingRouteIdentity:
         profile = getattr(self, "model_profile", None)
         return RollingRouteIdentity(
-            strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+            strategy_id=strategy_id,
             session_id=str(self._session.session_id),
             profile_id=str(getattr(profile, "profile_id", "")),
             model_id=str(self.paths.model),
@@ -3147,10 +3199,45 @@ class NativeLlamaClient:
             reset_generation=self._reset_generation,
         )
 
+    def _rolling_anchor_slot(self, identity: RollingRouteIdentity | None) -> str:
+        """Which checkpoint an identity addresses, decided by its own strategy.
+
+        The backend still knows nothing about CHAT or ANALYSIS: it reads the
+        strategy the caller already put in the identity it supplied.
+        """
+        if identity is not None and identity.strategy_id == ROLLING_ANALYSIS_STRATEGY_ID:
+            return "analysis"
+        return "route"
+
+    def _rolling_anchor_state_for(self, identity: RollingRouteIdentity | None) -> RollingRouteAnchorState:
+        # An absent slot reads as empty rather than raising: a checkpoint that
+        # is not there must fall cold, never fail the call.
+        if self._rolling_anchor_slot(identity) == "analysis":
+            return getattr(self, "_rolling_analysis_anchor_state", None) or RollingRouteAnchorState()
+        return self._rolling_route_anchor_state
+
+    def _store_rolling_anchor_state(
+        self, identity: RollingRouteIdentity | None, state: RollingRouteAnchorState
+    ) -> None:
+        if self._rolling_anchor_slot(identity) == "analysis":
+            self._rolling_analysis_anchor_state = state
+        else:
+            self._rolling_route_anchor_state = state
+
     def _invalidate_rolling_route_anchor(self, reason: str) -> None:
+        # Both lineages: a reset destroys the conversation whose tokens these
+        # are, and an analysis checkpoint surviving it would be exactly the
+        # stale-state reuse the identity check exists to prevent.
         if self._rolling_route_anchor_state.valid or self._rolling_route_anchor_state.identity is not None:
             self._rolling_route_anchor_state = invalidate_rolling_route_anchor(
                 self._rolling_route_anchor_state, reason
+            )
+        analysis_state = getattr(self, "_rolling_analysis_anchor_state", None)
+        if analysis_state is not None and (
+            analysis_state.valid or analysis_state.identity is not None
+        ):
+            self._rolling_analysis_anchor_state = invalidate_rolling_route_anchor(
+                analysis_state, reason
             )
 
     def _prepare_memory_with_ornith_rolling_route_anchor(self, prompt_tokens: list[int]) -> int:
@@ -3161,14 +3248,18 @@ class NativeLlamaClient:
         authorized, so PR #210's exact-prefix rule stays the single authority.
         """
         identity = self._rolling_route_identity_cache
-        state = self._rolling_route_anchor_state
+        # The slot follows the staged identity, so a route prompt can only ever
+        # meet a route checkpoint and an analysis prompt an analysis one. The
+        # identity comparison inside `rolling_route_reuse_start` then still has
+        # to pass, which is what rejects a stale checkpoint within a lineage.
+        state = self._rolling_anchor_state_for(identity)
         reuse_start = rolling_route_reuse_start(state, prompt_tokens, identity)
         if reuse_start is None:
             return self._prepare_memory_for_prompt(prompt_tokens)
         ok, restored, _meta = restore_rolling_route_anchor(
             self.lib.lib, self._session.ctx_tgt, state
         )
-        self._rolling_route_anchor_state = restored
+        self._store_rolling_anchor_state(identity, restored)
         if not ok:
             # A partial restore leaves KV unknown; clear before falling cold.
             self._clear_target_memory()

--- a/src/orbit/native_llama/rolling_route_anchor.py
+++ b/src/orbit/native_llama/rolling_route_anchor.py
@@ -27,6 +27,15 @@ from typing import Any
 
 ROLLING_ROUTE_STRATEGY_ID = "ornith15-rolling-route-v1"
 
+# The analysis lineage reuses every primitive below unchanged -- the checkpoint
+# format, the exact-prefix rule, the capture precondition -- and differs only in
+# which conversation the saved tokens belong to. Keeping that difference in the
+# identity's `strategy_id` is what makes a CHAT checkpoint and an ANALYSIS
+# checkpoint mutually unusable: identities are compared whole, so neither can
+# ever satisfy the other's reuse check, without a second cache or a mode flag
+# reaching the backend.
+ROLLING_ANALYSIS_STRATEGY_ID = "ornith15-rolling-analysis-v1"
+
 
 @dataclass(frozen=True)
 class RollingRouteIdentity:

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -178,6 +178,7 @@ class OrbitNativeServer:
                     tools=request.tools,
                     thinking=thinking,
                     route_prefix_anchor=request.route_prefix_anchor,
+                    analysis_rolling_anchor=request.analysis_rolling_anchor,
                     qwen_route_prefix_anchor=qwen_route_prefix_anchor,
                     qwen36_shell_tool_prefix_anchor=qwen36_shell_tool_prefix_anchor,
                     allow_mtp_experimental=request.allow_mtp_experimental,

--- a/src/orbit/native_server/protocol.py
+++ b/src/orbit/native_server/protocol.py
@@ -20,6 +20,7 @@ class ChatRequest:
     tools: list[dict[str, Any]]
     route_prefix_anchor: bool
     qwen_route_prefix_anchor: bool
+    analysis_rolling_anchor: bool
     qwen36_shell_tool_prefix_anchor: bool
     allow_mtp_experimental: bool | None
     final_prefix_experiment: bool
@@ -46,6 +47,7 @@ def parse_chat_request(payload: dict[str, Any]) -> ChatRequest:
         tools=_tools_from_payload(payload.get("tools")),
         route_prefix_anchor=payload.get("route_prefix_anchor") is True,
         qwen_route_prefix_anchor=payload.get("qwen_route_prefix_anchor") is True,
+        analysis_rolling_anchor=payload.get("analysis_rolling_anchor") is True,
         qwen36_shell_tool_prefix_anchor=payload.get("qwen36_shell_tool_prefix_anchor") is True,
         allow_mtp_experimental=_optional_bool(payload.get("allow_mtp_experimental")),
         final_prefix_experiment=payload.get("final_prefix_experiment") is True,

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -44,9 +44,16 @@ from orbit.runtime.analysis_sandbox import (
     scratch_baseline,
 )
 from orbit.runtime.evidence import EvidenceRecord, EvidenceStore
+from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
 
 ANALYSIS_TOOL_NAME = "execute_analysis"
+
+# The phase this runtime declares around its one model call. It names a kind of
+# call, not a mode: the backend uses it the way it already uses "route", to know
+# which rolling checkpoint this prompt continues, and learns nothing about CHAT
+# or ANALYSIS from it.
+ANALYSIS_STEP_PHASE = "analysis_step"
 
 # Stable prefix. Everything here is identical for every step of every
 # analysis on a given profile, which is what makes a future exact-prefix
@@ -341,13 +348,17 @@ class AnalysisRuntime:
         self.messages.append({"role": "user", "content": analyst_message})
 
         deltas: list[str] = []
-        response = self.backend.chat_stream(
-            list(self.messages),
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            tools=[ANALYSIS_TOOL_SCHEMA],
-            on_delta=deltas.append,
-        )
+        # Declaring the phase adds no call: it only labels the one call this
+        # step already makes, so the backend can continue the analysis chain's
+        # own KV instead of prefilling it again.
+        with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+            response = self.backend.chat_stream(
+                list(self.messages),
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                tools=[ANALYSIS_TOOL_SCHEMA],
+                on_delta=deltas.append,
+            )
         self.model_calls += 1
 
         calls = list(response.tool_calls or [])

--- a/tests/test_analysis_rolling_kv.py
+++ b/tests/test_analysis_rolling_kv.py
@@ -1,0 +1,765 @@
+"""Rolling KV for consecutive ANALYSIS steps, driven through the real client.
+
+These tests enter the production methods -- `_prepare_memory_with_ornith_
+rolling_route_anchor`, the capture site's helpers, the eligibility gates and
+the identity builder -- rather than exercising the anchor module in isolation,
+because what has to be true lives in the wiring: that an analysis prompt can
+only meet an analysis checkpoint, that restoring still has to satisfy strict
+append, and that a CHAT checkpoint can never stand in for an ANALYSIS one.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.backend.llama_server as llama_server
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID
+from orbit.native_llama.rolling_route_anchor import (
+    ROLLING_ANALYSIS_STRATEGY_ID,
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+    rolling_route_reuse_start,
+)
+from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
+from orbit.runtime.kv_diag import model_call_context
+
+STEP1 = [10, 11, 12, 13]
+STEP2 = STEP1 + [14, 15, 16]
+STEP3 = STEP2 + [17, 18]
+CHECKPOINT = b"analysis-checkpoint"
+
+
+def identity(strategy_id: str = ROLLING_ANALYSIS_STRATEGY_ID, **overrides) -> RollingRouteIdentity:
+    base = dict(
+        strategy_id=strategy_id,
+        session_id="default",
+        profile_id=ORNITH15_PROFILE_ID,
+        model_id="/models/ornith.gguf",
+        template_id="tpl",
+        tool_schema_hash="analysis-tools",
+        capability_summary_hash="caps",
+        runtime_policy_hash="policy",
+        native_version="libllama.so",
+        tools_mode="on",
+        reset_generation=0,
+    )
+    base.update(overrides)
+    return RollingRouteIdentity(**base)
+
+
+class _Lib:
+    def __init__(self, *, fail_set: bool = False) -> None:
+        self.fail_set = fail_set
+        self.cleared = 0
+        self.set_data_calls = 0
+
+    def llama_state_seq_set_data(self, ctx, buffer, size, seq_id):
+        self.set_data_calls += 1
+        if self.fail_set:
+            raise RuntimeError("restore exploded")
+        return size
+
+    def llama_get_memory(self, ctx):
+        return object()
+
+    def llama_memory_clear(self, mem, flag):
+        self.cleared += 1
+
+
+class _LibHolder:
+    def __init__(self, lib: _Lib) -> None:
+        self.lib = lib
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.ctx_tgt = object()
+        self.session_id = "default"
+        self.cached_prompt_tokens: list[int] = []
+        self.committed_sequence_tokens: list[int] = []
+        self.mtp_enabled = False
+
+
+def strategy_client(
+    *,
+    analysis_state: RollingRouteAnchorState | None = None,
+    route_state: RollingRouteAnchorState | None = None,
+    fail_set: bool = False,
+    prepare_result: int = 99,
+):
+    """A client holding only what the rolling strategy path reaches."""
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    lib = _Lib(fail_set=fail_set)
+    client.lib = _LibHolder(lib)
+    client._session = _Session()
+    client._rolling_route_anchor_state = route_state or RollingRouteAnchorState()
+    client._rolling_analysis_anchor_state = analysis_state or RollingRouteAnchorState()
+    client._rolling_route_identity_cache = None
+    calls: list[list[int]] = []
+
+    def fake_prepare(prompt_tokens):
+        # Stands in for the real strict-append gate, and records that the
+        # strategy actually deferred the decision to it.
+        calls.append(list(prompt_tokens))
+        return prepare_result
+
+    client._prepare_memory_for_prompt = fake_prepare  # type: ignore[method-assign]
+    client._invalidate_committed_sequence = (  # type: ignore[method-assign]
+        lambda: client._session.committed_sequence_tokens.clear()
+    )
+    return client, lib, calls
+
+
+def valid_state(tokens=STEP1, ident=None) -> RollingRouteAnchorState:
+    return RollingRouteAnchorState(
+        identity=ident or identity(),
+        tokens=list(tokens),
+        checkpoint_data=CHECKPOINT,
+        created_at_monotonic=1.0,
+    )
+
+
+class ExactPrefixReuseTest(unittest.TestCase):
+    """Step N -> step N+1: the saved chain is restored, then judged."""
+
+    def test_step2_restores_the_step1_checkpoint(self) -> None:
+        client, lib, calls = strategy_client(analysis_state=valid_state(STEP1))
+        client._rolling_route_identity_cache = identity()
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 1, "the analysis checkpoint must be restored")
+        self.assertEqual(client._session.committed_sequence_tokens, STEP1)
+        self.assertEqual(client._session.cached_prompt_tokens, STEP1)
+        self.assertEqual(calls, [STEP2], "strict append must still decide reuse")
+        self.assertEqual(result, 99, "the strategy returns strict append's verdict")
+        self.assertNotEqual(
+            result, len(STEP1), "returning the restored length would bypass the exact-prefix gate"
+        )
+
+    def test_only_the_new_suffix_remains_to_evaluate(self) -> None:
+        # `_prepare_memory_for_prompt` returns the reused prefix length, so the
+        # suffix is what the caller still has to prefill.
+        client, _lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1), prepare_result=len(STEP1)
+        )
+        client._rolling_route_identity_cache = identity()
+
+        reused = client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(reused, len(STEP1))
+        self.assertEqual(len(STEP2) - reused, 3, "only the three new tokens are evaluated")
+
+    def test_step3_rolls_forward_from_step2(self) -> None:
+        client, lib, calls = strategy_client(analysis_state=valid_state(STEP2))
+        client._rolling_route_identity_cache = identity()
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP3)
+
+        self.assertEqual(lib.set_data_calls, 1)
+        self.assertEqual(client._session.committed_sequence_tokens, STEP2)
+        self.assertEqual(calls, [STEP3])
+
+    def test_reuse_start_is_exact_prefix_only(self) -> None:
+        state = valid_state(STEP1)
+        ident = identity()
+
+        self.assertEqual(rolling_route_reuse_start(state, STEP2, ident), len(STEP1))
+        # One byte different anywhere in the prefix and it is not a prefix.
+        self.assertIsNone(rolling_route_reuse_start(state, [10, 11, 99, 13, 14], ident))
+        # An equal-length prompt leaves nothing to evaluate.
+        self.assertIsNone(rolling_route_reuse_start(state, STEP1, ident))
+
+
+class MismatchColdPathTest(unittest.TestCase):
+    def test_prefix_mismatch_never_restores(self) -> None:
+        client, lib, calls = strategy_client(analysis_state=valid_state(STEP1))
+        client._rolling_route_identity_cache = identity()
+
+        result = client._prepare_memory_with_ornith_rolling_route_anchor([10, 11, 99, 13, 14])
+
+        self.assertEqual(lib.set_data_calls, 0, "a mismatched prompt must not restore")
+        self.assertEqual(calls, [[10, 11, 99, 13, 14]], "it still goes through strict append")
+        self.assertEqual(result, 99)
+
+    def test_shorter_prompt_falls_cold(self) -> None:
+        client, lib, _calls = strategy_client(analysis_state=valid_state(STEP2))
+        client._rolling_route_identity_cache = identity()
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP1)
+
+        self.assertEqual(lib.set_data_calls, 0)
+
+    def test_failed_restore_clears_then_falls_cold(self) -> None:
+        client, lib, calls = strategy_client(analysis_state=valid_state(STEP1), fail_set=True)
+        client._rolling_route_identity_cache = identity()
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 1)
+        self.assertGreaterEqual(lib.cleared, 1, "a partial restore leaves KV unknown; clear it")
+        self.assertFalse(
+            client._rolling_analysis_anchor_state.valid,
+            "a failed restore must drop the analysis checkpoint",
+        )
+        self.assertEqual(calls, [STEP2])
+
+    def test_no_staged_identity_refuses_reuse(self) -> None:
+        client, lib, calls = strategy_client(analysis_state=valid_state(STEP1))
+        client._rolling_route_identity_cache = None
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0, "without a staged identity nothing may be reused")
+        self.assertEqual(calls, [STEP2])
+
+    def test_missing_analysis_slot_falls_cold_instead_of_raising(self) -> None:
+        client, lib, calls = strategy_client()
+        del client._rolling_analysis_anchor_state
+        client._rolling_route_identity_cache = identity()
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0)
+        self.assertEqual(calls, [STEP2])
+
+
+class CrossModeIsolationTest(unittest.TestCase):
+    """Neither lineage may ever be restored into the other."""
+
+    def test_chat_checkpoint_cannot_restore_into_analysis(self) -> None:
+        chat_state = valid_state(STEP1, ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID))
+        client, lib, calls = strategy_client(route_state=chat_state)
+        # An analysis step arrives while only a CHAT checkpoint exists.
+        client._rolling_route_identity_cache = identity()
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0, "a CHAT checkpoint must not serve an analysis step")
+        self.assertEqual(calls, [STEP2])
+        self.assertTrue(chat_state.valid, "and it must be left intact for CHAT")
+
+    def test_analysis_checkpoint_cannot_restore_into_chat(self) -> None:
+        analysis_state = valid_state(STEP1, ident=identity())
+        client, lib, calls = strategy_client(analysis_state=analysis_state)
+        client._rolling_route_identity_cache = identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0, "an analysis checkpoint must not serve a route call")
+        self.assertEqual(calls, [STEP2])
+        self.assertTrue(analysis_state.valid)
+
+    def test_the_two_identities_are_never_equal(self) -> None:
+        self.assertNotEqual(identity(), identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID))
+        self.assertIsNone(
+            rolling_route_reuse_start(
+                valid_state(STEP1, ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)),
+                STEP2,
+                identity(),
+            )
+        )
+
+    def test_each_lineage_keeps_its_own_slot(self) -> None:
+        client, _lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1, ident=identity()),
+            route_state=valid_state([90, 91], ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)),
+        )
+
+        self.assertEqual(client._rolling_anchor_state_for(identity()).tokens, STEP1)
+        self.assertEqual(
+            client._rolling_anchor_state_for(identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)).tokens,
+            [90, 91],
+        )
+
+    def test_storing_one_lineage_leaves_the_other_untouched(self) -> None:
+        client, _lib, _calls = strategy_client(
+            route_state=valid_state([90, 91], ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID))
+        )
+
+        client._store_rolling_anchor_state(identity(), valid_state(STEP3))
+
+        self.assertEqual(client._rolling_analysis_anchor_state.tokens, STEP3)
+        self.assertEqual(client._rolling_route_anchor_state.tokens, [90, 91])
+
+    def test_mode_switch_round_trip_reuses_neither_wrongly(self) -> None:
+        # /analysis -> /chat -> /analysis: the analysis chain resumes, and the
+        # route chain is never offered analysis tokens.
+        client, lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1, ident=identity()),
+            route_state=valid_state([90, 91], ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)),
+        )
+
+        client._rolling_route_identity_cache = identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)
+        client._prepare_memory_with_ornith_rolling_route_anchor([90, 91, 92])
+        self.assertEqual(client._session.committed_sequence_tokens, [90, 91])
+
+        client._rolling_route_identity_cache = identity()
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+        self.assertEqual(client._session.committed_sequence_tokens, STEP1)
+        self.assertEqual(lib.set_data_calls, 2, "each lineage restored its own checkpoint")
+
+
+class IdentityInvalidationTest(unittest.TestCase):
+    def test_tool_schema_change_invalidates_reuse(self) -> None:
+        state = valid_state(STEP1, ident=identity(tool_schema_hash="old"))
+        client, lib, calls = strategy_client(analysis_state=state)
+        client._rolling_route_identity_cache = identity(tool_schema_hash="new")
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0)
+        self.assertEqual(calls, [STEP2])
+
+    def test_every_identity_field_invalidates_reuse(self) -> None:
+        for field, value in (
+            ("session_id", "other"),
+            ("profile_id", "other-profile"),
+            ("model_id", "/models/other.gguf"),
+            ("template_id", "other-tpl"),
+            ("tool_schema_hash", "other-tools"),
+            ("capability_summary_hash", "other-caps"),
+            ("runtime_policy_hash", "other-policy"),
+            ("native_version", "other.so"),
+            ("tools_mode", "off"),
+            ("reset_generation", 1),
+        ):
+            with self.subTest(field=field):
+                state = valid_state(STEP1, ident=identity())
+                self.assertIsNone(
+                    rolling_route_reuse_start(state, STEP2, identity(**{field: value})),
+                    f"{field} must invalidate reuse",
+                )
+
+    def test_reset_generation_bump_invalidates(self) -> None:
+        state = valid_state(STEP1, ident=identity(reset_generation=0))
+        client, lib, _calls = strategy_client(analysis_state=state)
+        client._rolling_route_identity_cache = identity(reset_generation=1)
+
+        client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+
+        self.assertEqual(lib.set_data_calls, 0, "a reset must not leave reusable analysis state")
+
+    def test_invalidate_clears_both_lineages(self) -> None:
+        client, _lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1, ident=identity()),
+            route_state=valid_state([90, 91], ident=identity(strategy_id=ROLLING_ROUTE_STRATEGY_ID)),
+        )
+
+        client._invalidate_rolling_route_anchor("session_reset")
+
+        self.assertFalse(client._rolling_route_anchor_state.valid)
+        self.assertFalse(client._rolling_analysis_anchor_state.valid)
+
+
+class EligibilityTest(unittest.TestCase):
+    """The gate is the phase the runtime declares, never an inferred mode."""
+
+    def client_for(self, *, profile_id=ORNITH15_PROFILE_ID, verified=True, mtp=False):
+        client = NativeLlamaClient.__new__(NativeLlamaClient)
+        client.model_profile = mock.Mock(profile_id=profile_id, verified=verified)
+        client.config = mock.Mock(use_mtp_experimental=mtp)
+        client._session = _Session()
+        return client
+
+    def test_analysis_anchor_enables_reuse(self) -> None:
+        client = self.client_for()
+        self.assertTrue(
+            client._ornith_rolling_analysis_eligible(analysis_rolling_anchor=True, thinking=False)
+        )
+
+    def test_without_the_anchor_flag_nothing_is_eligible(self) -> None:
+        client = self.client_for()
+        self.assertFalse(
+            client._ornith_rolling_analysis_eligible(analysis_rolling_anchor=False, thinking=False)
+        )
+
+    def test_unverified_or_foreign_profile_is_refused(self) -> None:
+        for kwargs in ({"verified": False}, {"profile_id": "some-other-profile"}):
+            with self.subTest(**kwargs):
+                client = self.client_for(**kwargs)
+                self.assertFalse(
+                    client._ornith_rolling_analysis_eligible(
+                        analysis_rolling_anchor=True, thinking=False
+                    )
+                )
+
+    def test_thinking_and_mtp_are_refused(self) -> None:
+        self.assertFalse(
+            self.client_for()._ornith_rolling_analysis_eligible(
+                analysis_rolling_anchor=True, thinking=True
+            )
+        )
+        self.assertFalse(
+            self.client_for(mtp=True)._ornith_rolling_analysis_eligible(
+                analysis_rolling_anchor=True, thinking=False
+            )
+        )
+
+    def test_identity_carries_the_analysis_strategy(self) -> None:
+        client = self.client_for()
+        client.paths = mock.Mock(model="/models/ornith.gguf")
+        client._model_metadata_identity = {}
+        client._reset_generation = 0
+        client.config = mock.Mock(
+            use_mtp_experimental=False, context_tokens=4096, thinking=False
+        )
+        client._session = _Session()
+
+        analysis = client._rolling_route_identity(
+            tools=[{"a": 1}], strategy_id=ROLLING_ANALYSIS_STRATEGY_ID
+        )
+        route = client._rolling_route_identity(tools=[{"a": 1}])
+
+        self.assertEqual(analysis.strategy_id, ROLLING_ANALYSIS_STRATEGY_ID)
+        self.assertEqual(route.strategy_id, ROLLING_ROUTE_STRATEGY_ID)
+        self.assertNotEqual(analysis, route)
+
+
+class PhaseWiringTest(unittest.TestCase):
+    """The backend is told which chain a call belongs to; it never guesses."""
+
+    def test_analysis_phase_requests_the_analysis_anchor_only(self) -> None:
+        with mock.patch.object(llama_server, "prefix_anchor_enabled", lambda: True):
+            with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+                self.assertTrue(
+                    llama_server._analysis_rolling_anchor_requested(native_backend=True)
+                )
+                self.assertFalse(
+                    llama_server._route_prefix_anchor_requested(native_backend=True),
+                    "an analysis step must not also claim the route anchor",
+                )
+
+    def test_route_phase_requests_the_route_anchor_only(self) -> None:
+        with mock.patch.object(llama_server, "prefix_anchor_enabled", lambda: True):
+            with model_call_context(phase="route", tools_mode="on"):
+                self.assertTrue(llama_server._route_prefix_anchor_requested(native_backend=True))
+                self.assertFalse(
+                    llama_server._analysis_rolling_anchor_requested(native_backend=True)
+                )
+
+    def test_no_phase_requests_neither(self) -> None:
+        with mock.patch.object(llama_server, "prefix_anchor_enabled", lambda: True):
+            self.assertFalse(llama_server._analysis_rolling_anchor_requested(native_backend=True))
+
+    def test_non_native_backend_never_requests_it(self) -> None:
+        with mock.patch.object(llama_server, "prefix_anchor_enabled", lambda: True):
+            with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+                self.assertFalse(
+                    llama_server._analysis_rolling_anchor_requested(native_backend=False)
+                )
+
+    def test_payload_carries_the_flag_only_when_asked(self) -> None:
+        from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
+
+        on = build_chat_payload(
+            ChatPayloadOptions(
+                model="m", messages=[], temperature=0.0, max_tokens=1, analysis_rolling_anchor=True
+            )
+        )
+        off = build_chat_payload(
+            ChatPayloadOptions(model="m", messages=[], temperature=0.0, max_tokens=1)
+        )
+
+        self.assertTrue(on["analysis_rolling_anchor"])
+        self.assertNotIn("analysis_rolling_anchor", off)
+
+    def test_request_parsing_round_trips_the_flag(self) -> None:
+        from orbit.native_server.protocol import parse_chat_request
+
+        messages = [{"role": "user", "content": "hi"}]
+        request = parse_chat_request(
+            {"model": "m", "messages": messages, "analysis_rolling_anchor": True}
+        )
+        self.assertTrue(request.analysis_rolling_anchor)
+        self.assertFalse(
+            parse_chat_request({"model": "m", "messages": messages}).analysis_rolling_anchor
+        )
+
+    def test_no_mode_string_reaches_the_backend_payload(self) -> None:
+        from orbit.backend.payloads import ChatPayloadOptions, build_chat_payload
+
+        payload = build_chat_payload(
+            ChatPayloadOptions(
+                model="m", messages=[], temperature=0.0, max_tokens=1, analysis_rolling_anchor=True
+            )
+        )
+        serialized = repr(payload)
+        for token in ("ANALYSIS", "CHAT", "WorkflowMode", "workflow_mode"):
+            self.assertNotIn(token, serialized)
+
+
+class HumanBoundaryTest(unittest.TestCase):
+    """Declaring a phase must not change what a step does."""
+
+    def analysis_runtime(self):
+        import shutil
+        import tempfile
+
+        from orbit.backend.base import ChatResult
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime,
+            AnalysisWorkspace,
+            acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmp = Path(tempfile.mkdtemp(prefix="orbit-rollingkv-test-"))
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        artifact = tmp / "sample.js"
+        artifact.write_text("var a = 1;\n", encoding="utf-8")
+        workspace = AnalysisWorkspace.create()
+        source = acquire_analysis_source(artifact, workspace.source_root)
+
+        phases: list[str | None] = []
+
+        class Backend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                self.calls += 1
+                from orbit.runtime.kv_diag import current_phase
+
+                phases.append(current_phase())
+                return ChatResult("ok", "scripted", "stop", [], 1, 1, 0, None, None)
+
+            def chat(self, *args, **kwargs):
+                return self.chat_stream(*args, **kwargs)
+
+        backend = Backend()
+        runtime = AnalysisRuntime(
+            backend=backend,
+            source=source,
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+        return runtime, backend, phases
+
+    def test_one_model_call_per_step_with_the_phase_declared(self) -> None:
+        runtime, backend, phases = self.analysis_runtime()
+
+        for expected in (1, 2, 3):
+            runtime.step("continue")
+            self.assertEqual(backend.calls, expected, "the phase must not add a model call")
+
+        self.assertEqual(phases, [ANALYSIS_STEP_PHASE] * 3)
+
+    def test_phase_is_scoped_to_the_call_and_restored_after(self) -> None:
+        from orbit.runtime.kv_diag import current_phase
+
+        runtime, _backend, _phases = self.analysis_runtime()
+        before = current_phase()
+
+        runtime.step("continue")
+
+        self.assertEqual(current_phase(), before, "the phase must not leak past the call")
+
+    def test_step_still_returns_control_with_at_most_one_action(self) -> None:
+        runtime, _backend, _phases = self.analysis_runtime()
+
+        result = runtime.step("continue")
+
+        self.assertEqual(result.model_calls, 1)
+        self.assertFalse(result.action_executed)
+        self.assertTrue(result.control_returned)
+        self.assertEqual(runtime.actions_executed, 0)
+
+    def test_history_stays_append_only_across_steps(self) -> None:
+        runtime, _backend, _phases = self.analysis_runtime()
+
+        runtime.step("one")
+        first = [dict(m) for m in runtime.messages]
+        runtime.step("two")
+
+        self.assertEqual(runtime.messages[: len(first)], first)
+
+
+class CaptureCommitmentTest(unittest.TestCase):
+    """A checkpoint may only be taken from a fully committed prompt."""
+
+    def test_should_replace_requires_a_continuing_chain(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import rolling_route_should_replace
+
+        ident = identity()
+        empty = RollingRouteAnchorState()
+        self.assertTrue(rolling_route_should_replace(empty, STEP1, ident), "cold: capture")
+
+        state = valid_state(STEP1, ident=ident)
+        self.assertTrue(
+            rolling_route_should_replace(state, STEP2, ident), "a continuation replaces"
+        )
+        self.assertFalse(
+            rolling_route_should_replace(state, [7, 8, 9], ident),
+            "an unrelated prompt must not evict a usable checkpoint",
+        )
+
+    def test_identity_change_replaces_rather_than_reuses(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import rolling_route_should_replace
+
+        state = valid_state(STEP1, ident=identity(tool_schema_hash="old"))
+        self.assertTrue(
+            rolling_route_should_replace(state, STEP2, identity(tool_schema_hash="new"))
+        )
+
+    def test_capture_records_exactly_the_prompt_tokens(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import capture_rolling_route_anchor
+
+        class Lib:
+            def llama_state_seq_get_size(self, ctx, seq):
+                return 4
+
+            def llama_state_seq_get_data(self, ctx, buf, size, seq):
+                return size
+
+        captured, meta = capture_rolling_route_anchor(
+            Lib(), object(), prompt_tokens=STEP2, identity=identity()
+        )
+
+        self.assertTrue(captured.valid)
+        self.assertEqual(captured.tokens, STEP2, "the snapshot is the prompt and only the prompt")
+        self.assertEqual(meta["checkpoint_tokens"], len(STEP2))
+
+
+class RenderedPrefixPreconditionTest(unittest.TestCase):
+    """The precondition the whole strategy rests on, asserted not assumed.
+
+    Every other test in this file builds `STEP2 = STEP1 + [...]`, which proves
+    the machinery given a prefix but never that consecutive analysis prompts
+    actually are one. That relation has two halves: the history must be
+    append-only, and the template must absorb its own generation prompt rather
+    than replace it. The first is asserted here against the real runtime; the
+    second is asserted against a ChatML-shaped renderer standing in for the
+    Ornith template, which is not on this machine.
+    """
+
+    def analysis_messages(self, steps: int) -> list[list[dict]]:
+        import shutil
+        import tempfile
+
+        from orbit.backend.base import ChatResult
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime,
+            AnalysisWorkspace,
+            acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmp = Path(tempfile.mkdtemp(prefix="orbit-prefix-test-"))
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        artifact = tmp / "sample.js"
+        artifact.write_text("var a = 1;\n", encoding="utf-8")
+        workspace = AnalysisWorkspace.create()
+        source = acquire_analysis_source(artifact, workspace.source_root)
+        seen: list[list[dict]] = []
+
+        class Backend:
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                seen.append([dict(m) for m in messages])
+                return ChatResult("observing", "scripted", "stop", [], 1, 1, 0, None, None)
+
+            def chat(self, *args, **kwargs):
+                return self.chat_stream(*args, **kwargs)
+
+        runtime = AnalysisRuntime(
+            backend=Backend(),
+            source=source,
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+        for index in range(steps):
+            runtime.step(f"step {index}")
+        return seen
+
+    def test_each_step_sends_a_message_list_extending_the_last(self) -> None:
+        seen = self.analysis_messages(4)
+
+        self.assertEqual(len(seen), 4)
+        for index in range(len(seen) - 1):
+            earlier, later = seen[index], seen[index + 1]
+            self.assertGreater(len(later), len(earlier))
+            self.assertEqual(
+                later[: len(earlier)], earlier, f"step {index + 2} must extend step {index + 1}"
+            )
+
+    def test_a_chatml_template_keeps_consecutive_prompts_exact_prefixes(self) -> None:
+        # Ornith renders through the GGUF's embedded ChatML-family template
+        # (profile renderer "llama.cpp-jinja"). What matters for reuse is that
+        # the assistant turn re-emits the generation header the previous prompt
+        # ended on, so the earlier prompt survives intact inside the later one.
+        def render(messages: list[dict]) -> str:
+            body = "".join(
+                f"<|im_start|>{m['role']}\n{_text(m)}<|im_end|>\n" for m in messages
+            )
+            return body + "<|im_start|>assistant\n"
+
+        def _text(message: dict) -> str:
+            content = message.get("content")
+            return content if isinstance(content, str) else ""
+
+        rendered = [render(messages) for messages in self.analysis_messages(4)]
+        for index in range(len(rendered) - 1):
+            self.assertTrue(
+                rendered[index + 1].startswith(rendered[index]),
+                f"prompt {index + 2} must extend prompt {index + 1} exactly",
+            )
+
+    def test_a_template_that_replaces_its_generation_prompt_breaks_reuse(self) -> None:
+        # The counter-case, kept explicit: a template whose assistant turn does
+        # not re-emit the trailing generation prompt cannot support this
+        # strategy, and must never be given a rolling anchor.
+        def render(messages: list[dict]) -> str:
+            body = "".join(f"[{m['role']}:{m.get('content', '')}]" for m in messages)
+            return body + "<GEN>"
+
+        messages = self.analysis_messages(2)
+        first, second = render(messages[0]), render(messages[1])
+
+        self.assertFalse(second.startswith(first))
+        self.assertTrue(second.startswith(first[: -len("<GEN>")]))
+
+
+class MetricsTest(unittest.TestCase):
+    """Reused and evaluated tokens must add up to the prompt."""
+
+    def test_reuse_reports_a_positive_reused_prefix(self) -> None:
+        client, _lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1), prepare_result=len(STEP1)
+        )
+        client._rolling_route_identity_cache = identity()
+
+        reused = client._prepare_memory_with_ornith_rolling_route_anchor(STEP2)
+        evaluated = len(STEP2) - reused
+
+        self.assertGreater(reused, 0)
+        self.assertEqual(evaluated, len(STEP2) - len(STEP1))
+        self.assertEqual(reused + evaluated, len(STEP2), "accounting must cover the whole prompt")
+
+    def test_cold_path_reports_no_reuse(self) -> None:
+        client, _lib, _calls = strategy_client(
+            analysis_state=valid_state(STEP1), prepare_result=0
+        )
+        client._rolling_route_identity_cache = identity()
+
+        reused = client._prepare_memory_with_ornith_rolling_route_anchor([7, 8, 9])
+
+        self.assertEqual(reused, 0)
+        self.assertEqual(len([7, 8, 9]) - reused, 3, "a cold prompt is evaluated in full")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_server_think.py
+++ b/tests/test_native_server_think.py
@@ -57,6 +57,7 @@ class _FakeClient:
         tools,
         thinking,
         route_prefix_anchor=False,
+        analysis_rolling_anchor=False,
         qwen_route_prefix_anchor=False,
         qwen36_shell_tool_prefix_anchor=False,
         allow_mtp_experimental=None,


### PR DESCRIPTION
Consecutive analyst steps rebuild a prompt that only grows, so each step was
prefilling everything the previous step had already evaluated. This gives the
analysis chain its own rolling checkpoint. Baseline: `1d83e3c`.

## Design

- **Reuses the existing rolling-anchor machinery** — same `RollingRouteAnchorState`,
  same capture precondition, same restore. No new inference stack, no cache manager.
- **Adds a separate ANALYSIS checkpoint slot.** Which slot a call addresses is decided
  by the `strategy_id` already carried in the identity it supplies.
- **`_prepare_memory_for_prompt` remains the exact-prefix authority.** The checkpoint
  only offers candidate state; `prompt_tokens[:len(committed)] == committed` still
  decides. No normalization, no LCP or approximate matching.
- **CHAT and ANALYSIS lineages are structurally isolated.** Identities are compared
  whole and differ in `strategy_id`, so neither checkpoint can satisfy the other's
  check, and each has its own slot so neither evicts the other on `/analysis → /chat →
  /analysis`. A reset clears both.
- **No backend mode semantics.** Eligibility follows the phase the analysis runtime
  declares around the one model call it already makes, exactly as the route anchor
  follows its own phase. The backend reads a strategy, never a mode — no `CHAT` or
  `ANALYSIS` string reaches the wire.
- **No telemetry contract change.** `reused_prompt_tokens` / `evaluated_prompt_tokens`
  / `prompt_tokens` are the existing authoritative fields.
- **No prewarm.** **No Gemma changes.**
- **Human boundary unchanged** — one model call and at most one action per analyst
  step; declaring a phase adds no call.

## Real canary evidence

Ornith 1.5 35B-A3B (`orbit-ornith15-native-v1`, verified, template sha `f55f5293…`),
benign 21-byte fixture, three analyst steps, CPU-only, ctx 8192:

| call | prompt | reused | evaluated | cache | prefill |
|---|---|---|---|---|---|
| 1 (cold) | 560 | 0 | 560 | 0.0% | 19.9 s |
| 2 | 682 | 560 | 122 | 82.1% | 3.86 s |
| 3 | 776 | 682 | 94 | 87.9% | 3.95 s |

`reused + evaluated == prompt` on every call, and `reused` equals the previous call's
full prompt, so only the new suffix is evaluated.

Exact-prefix verified against the real Ornith GGUF template (tokenize-only, zero
generation): 545 → 602 → 625 tokens, both prefix relations hold.

Follow-up prefill improved **~5.1×** (19.9 s → ~3.9 s) *on this fixture and
configuration*. This is a single-case canary, not a general benchmark, and no
broader performance claim is made.

Human boundary held: 3 analyst steps → 3 model calls, 1 action executed, control
returned each time. Step 3's tool call was truncated by the 96-token output budget and
the pre-existing structural guard refused it without a repair call — the boundary
behaving as designed.

## Deterministic qualification

- 43 new KV tests PASS
- 393 focused PASS
- 2429 full suite PASS
- 12/12 mutations CAUGHT
- compileall / diff-check PASS
- BLOCKER 0 / MAJOR 0 / MINOR 0

`tests/test_native_server_think.py` carries a one-line test-double signature update;
6 tests fail without it.
