### PR TITLE
perf(runtime): add exact-prefix Ornith chat prewarm

### DIFF
--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -31,6 +31,7 @@ from orbit.native_llama.qwen36_shell_tool_prefix import (
     exact_qwen36_shell_tool_schema,
     resolve_qwen36_shell_tool_prefix_reuse,
 )
+from orbit.native_llama.ornith_route_prefix import resolve_ornith_route_prefix_reuse
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.history_serialization import serialize_profile_messages
@@ -1108,6 +1109,7 @@ def _qwen_route_prefix_anchor_requested(*, native_backend: bool) -> bool:
     if not (
         resolve_qwen_route_prefix_reuse().enabled
         or resolve_qwen3_coder_route_prefix_reuse().enabled
+        or resolve_ornith_route_prefix_reuse().enabled
     ):
         return False
     return current_phase() == "route" and current_tools_mode() == "on"

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -90,6 +90,12 @@ from .qwen3_coder import (
     qwen3_coder_artifact_messages,
     qwen3_coder_artifact_prompt,
 )
+from .ornith_route_prefix import (
+    ORNITH_ROUTE_PREFIX_FORMAT_VERSION,
+    ORNITH_ROUTE_PREFIX_TOKEN_COUNT,
+    ORNITH_ROUTE_TOKENIZER_IDENTITY,
+    derive_ornith_route_prefix_spec,
+)
 from .qwen3_coder_route_prefix import (
     QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION,
     QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT,
@@ -163,6 +169,9 @@ class NativeClientConfig:
     qwen3_coder_route_prefix_reuse_enabled: bool = False
     qwen3_coder_route_prefix_reuse_source: str = "default"
     qwen3_coder_route_prefix_reuse_config_error: str | None = None
+    ornith_route_prefix_reuse_enabled: bool = False
+    ornith_route_prefix_reuse_source: str = "default"
+    ornith_route_prefix_reuse_config_error: str | None = None
     moe_expert_usage_enabled: bool = False
     low_memory: bool = False
 
@@ -340,8 +349,14 @@ class NativeLlamaClient:
         self._qwen36_shell_tool_prefix_lock = threading.RLock()
         self._qwen36_shell_tool_prefix_epoch = 0
         self._qwen3_coder_route_prefix_anchor_state = PrefixAnchorState()
+        # Ornith renders through its own template, so its captured prefix is a
+        # different token sequence and needs its own slot; it reuses the same
+        # PrefixAnchorState type and the same restore path.
+        self._ornith_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen3_coder_route_prefix_spec: QwenRoutePrefixSpec | None = None
+        self._ornith_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen3_coder_route_prefix_status = QwenRoutePrefixStatus()
+        self._ornith_route_prefix_status = QwenRoutePrefixStatus()
         self._model_metadata_identity: dict[str, str] = {}
         self._qwen_native_build_identity: str | None = None
         self._final_prefix_anchor_state = PrefixAnchorState()
@@ -835,6 +850,11 @@ class NativeLlamaClient:
             self._invalidate_qwen_route_prefix(
                 "session_reset", profile_id=QWEN3_CODER_PROFILE_ID
             )
+        # The Ornith prewarm is a checkpoint like the others: a reset that
+        # destroys the conversation must not leave it standing.
+        self._invalidate_qwen_route_prefix(
+            "session_reset", profile_id=ORNITH15_PROFILE_ID
+        )
         self._invalidate_qwen36_shell_tool_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
@@ -894,14 +914,16 @@ class NativeLlamaClient:
         self._session.prompt_cache_mode = mode
 
     def _invalidate_coder_route_prefix_after_failed_completion(self, reason: str) -> None:
+        # A completion that failed may have left the sequence in a state the
+        # checkpoint no longer describes. Both ChatML-family profiles keep a
+        # prewarm, so both have to be dropped on their own failures.
         profile = getattr(self, "model_profile", None)
-        if (
-            getattr(profile, "verified", False)
-            and getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID
+        profile_id = getattr(profile, "profile_id", None)
+        if getattr(profile, "verified", False) and profile_id in (
+            QWEN3_CODER_PROFILE_ID,
+            ORNITH15_PROFILE_ID,
         ):
-            self._invalidate_qwen_route_prefix(
-                reason, profile_id=QWEN3_CODER_PROFILE_ID
-            )
+            self._invalidate_qwen_route_prefix(reason, profile_id=profile_id)
 
     def _initialize_multimodal_context(self) -> None:
         self.supports_vision = False
@@ -1095,13 +1117,21 @@ class NativeLlamaClient:
         tools_mode: str = "on",
     ) -> NativeRoutePrefixPrefillResult:
         profile = getattr(self, "model_profile", None)
+        profile_id = getattr(profile, "profile_id", None)
+        # Both ChatML-family route-prefix profiles capture identically; only
+        # the rendered tokens and the config switch differ.
         if (
-            getattr(profile, "profile_id", None) != QWEN3_CODER_PROFILE_ID
+            profile_id not in (QWEN3_CODER_PROFILE_ID, ORNITH15_PROFILE_ID)
             or not getattr(profile, "verified", False)
             or not getattr(profile, "route_prefix_reuse_supported", False)
         ):
             return _route_prefix_prefill_skipped("model_profile_ineligible")
-        if not self.config.qwen3_coder_route_prefix_reuse_enabled:
+        reuse_enabled = (
+            self.config.ornith_route_prefix_reuse_enabled
+            if profile_id == ORNITH15_PROFILE_ID
+            else self.config.qwen3_coder_route_prefix_reuse_enabled
+        )
+        if not reuse_enabled:
             return _route_prefix_prefill_skipped("route_prefix_reuse_disabled")
         if tools_mode != "on":
             return _route_prefix_prefill_skipped("tools_mode_ineligible")
@@ -1113,7 +1143,7 @@ class NativeLlamaClient:
             return _route_prefix_prefill_skipped("native_request_in_flight")
         if self._session.continuation_ready or self._session.cached_prompt_tokens:
             return _route_prefix_prefill_skipped("active_context_present")
-        if self._qwen3_coder_route_prefix_anchor_state.valid:
+        if self._qwen_route_prefix_state_for_profile(profile_id).valid:
             return _route_prefix_prefill_skipped("checkpoint_already_initialized")
         if not self._route_prefix_prefill_lock.acquire(blocking=False):
             return _route_prefix_prefill_skipped("prefill_in_flight")
@@ -1126,7 +1156,7 @@ class NativeLlamaClient:
                 return _route_prefix_prefill_skipped("native_request_in_flight")
             if self._session.continuation_ready or self._session.cached_prompt_tokens:
                 return _route_prefix_prefill_skipped("active_context_present")
-            if self._qwen3_coder_route_prefix_anchor_state.valid:
+            if self._qwen_route_prefix_state_for_profile(profile_id).valid:
                 return _route_prefix_prefill_skipped("checkpoint_already_initialized")
 
             # This boundary fixture is rendered but its dynamic suffix is never
@@ -1143,7 +1173,7 @@ class NativeLlamaClient:
                 thinking=False,
                 prompt=prompt,
             )
-            if plan is None or plan.profile_id != QWEN3_CODER_PROFILE_ID:
+            if plan is None or plan.profile_id != profile_id:
                 return _route_prefix_prefill_failed("route_anchor_plan_unavailable")
 
             prefix_hash = plan.prefix_hash
@@ -1154,7 +1184,7 @@ class NativeLlamaClient:
             processed, reused = self._prepare_memory_with_qwen_route_anchor(plan)
             ended_us = int(lib.llama_time_us()) if hasattr(lib, "llama_time_us") else started_us
             prefill_ms = max(0.0, (ended_us - started_us) / 1000.0)
-            state = self._qwen3_coder_route_prefix_anchor_state
+            state = self._qwen_route_prefix_state_for_profile(profile_id)
             if processed != prefix_token_count or reused != 0 or not state.valid:
                 self._clear_target_memory()
                 return _route_prefix_prefill_failed(
@@ -1184,7 +1214,7 @@ class NativeLlamaClient:
                 self._clear_target_memory()
             self._invalidate_qwen_route_prefix(
                 f"startup_prewarm_failed:{type(exc).__name__}",
-                profile_id=QWEN3_CODER_PROFILE_ID,
+                profile_id=profile_id,
             )
             ended_us = (
                 int(self.lib.lib.llama_time_us())
@@ -2311,6 +2341,13 @@ class NativeLlamaClient:
         final_plan = self._final_prefix_plan(prompt, prompt_tokens, final_prefix_segments)
         anchor_metadata: dict[str, object] | None = None
         processed_start = 0
+        if qwen_route_anchor_plan is not None and self._rolling_outranks_route_prefix(
+            prompt_tokens,
+            rolling_route_eligible=rolling_route_eligible,
+            rolling_route_identity=rolling_route_identity,
+        ):
+            qwen_route_anchor_plan = None
+
         if final_plan is not None:
             processed_start, reused = self._prepare_memory_with_final_prefix(final_plan, prompt_tokens)
         elif qwen_route_anchor_plan is not None:
@@ -2504,6 +2541,10 @@ class NativeLlamaClient:
             enabled = self.config.qwen3_coder_route_prefix_reuse_enabled
             prefix_token_count = QWEN3_CODER_ROUTE_PREFIX_TOKEN_COUNT
             derive_spec = derive_qwen3_coder_route_prefix_spec
+        elif profile_id == ORNITH15_PROFILE_ID:
+            enabled = self.config.ornith_route_prefix_reuse_enabled
+            prefix_token_count = ORNITH_ROUTE_PREFIX_TOKEN_COUNT
+            derive_spec = derive_ornith_route_prefix_spec
         else:
             return None
         if not enabled:
@@ -2880,31 +2921,68 @@ class NativeLlamaClient:
             status.failure_reason = reason
             status.last_used = "invalidated"
 
+    def _rolling_outranks_route_prefix(
+        self,
+        prompt_tokens: list[int],
+        *,
+        rolling_route_eligible: bool,
+        rolling_route_identity: RollingRouteIdentity | None,
+    ) -> bool:
+        """Whether a rolling checkpoint should be used instead of the prewarm.
+
+        The prewarm is a fixed head of the route prompt; a rolling checkpoint
+        holds this conversation's own tokens and is never shorter. So when the
+        rolling state can actually serve this prompt -- same identity, exact
+        prefix -- it is strictly the better restore and the prewarm stands
+        down. When it cannot, the prewarm still runs, which is the cold-start
+        case it exists for.
+        """
+        if not rolling_route_eligible or rolling_route_identity is None:
+            return False
+        return (
+            rolling_route_reuse_start(
+                self._rolling_anchor_state_for(rolling_route_identity),
+                prompt_tokens,
+                rolling_route_identity,
+            )
+            is not None
+        )
+
     def _qwen_route_prefix_state_for_profile(self, profile_id: str) -> PrefixAnchorState:
         if profile_id == QWEN3_CODER_PROFILE_ID:
             return self._qwen3_coder_route_prefix_anchor_state
+        if profile_id == ORNITH15_PROFILE_ID:
+            return self._ornith_route_prefix_anchor_state
         return self._qwen_route_prefix_anchor_state
 
     def _set_qwen_route_prefix_state(self, profile_id: str, state: PrefixAnchorState) -> None:
         if profile_id == QWEN3_CODER_PROFILE_ID:
             self._qwen3_coder_route_prefix_anchor_state = state
+        elif profile_id == ORNITH15_PROFILE_ID:
+            self._ornith_route_prefix_anchor_state = state
         else:
             self._qwen_route_prefix_anchor_state = state
 
     def _qwen_route_prefix_spec_for_profile(self, profile_id: str) -> QwenRoutePrefixSpec | None:
         if profile_id == QWEN3_CODER_PROFILE_ID:
             return self._qwen3_coder_route_prefix_spec
+        if profile_id == ORNITH15_PROFILE_ID:
+            return self._ornith_route_prefix_spec
         return self._qwen_route_prefix_spec
 
     def _set_qwen_route_prefix_spec(self, profile_id: str, spec: QwenRoutePrefixSpec | None) -> None:
         if profile_id == QWEN3_CODER_PROFILE_ID:
             self._qwen3_coder_route_prefix_spec = spec
+        elif profile_id == ORNITH15_PROFILE_ID:
+            self._ornith_route_prefix_spec = spec
         else:
             self._qwen_route_prefix_spec = spec
 
     def _qwen_route_prefix_status_for_profile(self, profile_id: str) -> QwenRoutePrefixStatus:
         if profile_id == QWEN3_CODER_PROFILE_ID:
             return self._qwen3_coder_route_prefix_status
+        if profile_id == ORNITH15_PROFILE_ID:
+            return self._ornith_route_prefix_status
         return self._qwen_route_prefix_status
 
     def _prepare_memory_with_qwen_route_anchor(self, plan: _QwenRouteAnchorRuntimePlan) -> tuple[int, int]:
@@ -3005,6 +3083,12 @@ class NativeLlamaClient:
             format_version = QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION
             tokenizer_identity = QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY
             tools_mode = "qwen3-coder-route-tools-on-thinking-off"
+        elif profile_id == ORNITH15_PROFILE_ID:
+            # Its own format and tokenizer identity: sharing Qwen3.6's would
+            # leave `model_id` as the only thing telling the two apart.
+            format_version = ORNITH_ROUTE_PREFIX_FORMAT_VERSION
+            tokenizer_identity = ORNITH_ROUTE_TOKENIZER_IDENTITY
+            tools_mode = "ornith-route-tools-on-thinking-off"
         else:
             format_version = QWEN_ROUTE_PREFIX_FORMAT_VERSION
             tokenizer_identity = QWEN_ROUTE_TOKENIZER_IDENTITY
@@ -3078,7 +3162,11 @@ class NativeLlamaClient:
     def _invalidate_qwen_route_prefix(self, reason: str, *, profile_id: str | None = None) -> None:
         if not hasattr(self, "_qwen_route_prefix_anchor_state"):
             return
-        profile_ids = (profile_id,) if profile_id is not None else (QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID)
+        profile_ids = (
+            (profile_id,)
+            if profile_id is not None
+            else (QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID, ORNITH15_PROFILE_ID)
+        )
         for selected_profile_id in profile_ids:
             state = self._qwen_route_prefix_state_for_profile(selected_profile_id)
             had_state = state.valid or state.checkpoint_size > 0

--- a/src/orbit/native_llama/ornith_route_prefix.py
+++ b/src/orbit/native_llama/ornith_route_prefix.py
@@ -1,0 +1,89 @@
+"""The Ornith route prefix: same derivation, its own identity.
+
+Ornith renders through the GGUF's own ChatML template rather than the Gemma
+renderer, which is why the startup prewarm never applied to it -- that path
+builds Gemma markup and mismatches an Ornith request at the very first token.
+Nothing about the derivation needs to change to fix that, only which template
+does the rendering, so this module is the thin per-profile wrapper the Qwen
+profiles already use.
+
+The token count is fixed rather than measured. `derive_qwen_route_prefix_spec`
+renders two reference requests that differ only in their user text, requires
+the fixed count to fall strictly inside what those two share, and then checks
+the result against the real production prompt. A count that is not invariant
+is rejected outright; it is never trimmed to whatever happened to match.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Mapping, Sequence
+
+from .qwen_route_prefix import (
+    QwenRoutePrefixConfig,
+    QwenRoutePrefixSpec,
+    QwenRoutePrefixStatus,
+    derive_qwen_route_prefix_spec,
+)
+
+
+ORNITH_ROUTE_PREFIX_ENV = "ORBIT_ORNITH_ROUTE_PREFIX_REUSE"
+
+# 768, as for the other profiles. Measured headroom on this template: the
+# rendered route system turn ends at token 825, and the two reference renders
+# share 828, so the captured prefix stops well inside the invariant region and
+# never reaches the user turn.
+ORNITH_ROUTE_PREFIX_TOKEN_COUNT = 768
+ORNITH_ROUTE_PREFIX_FORMAT_VERSION = "ornith15-route-prefix-v1"
+ORNITH_ROUTE_TOKENIZER_IDENTITY = "gpt2:qwen35"
+
+
+def resolve_ornith_route_prefix_reuse(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default_enabled: bool = True,
+) -> QwenRoutePrefixConfig:
+    env = os.environ if environ is None else environ
+    configured = env.get(ORNITH_ROUTE_PREFIX_ENV)
+    if configured is None:
+        return QwenRoutePrefixConfig(enabled=default_enabled, source="default")
+    value = configured.strip()
+    if value == "1":
+        return QwenRoutePrefixConfig(enabled=True, source="stable")
+    if value == "0":
+        return QwenRoutePrefixConfig(enabled=False, source="stable")
+    return QwenRoutePrefixConfig(
+        enabled=False,
+        source="stable",
+        validation_error="invalid_ornith_route_prefix_reuse_value",
+    )
+
+
+def derive_ornith_route_prefix_spec(
+    *,
+    system_prompt: str,
+    full_prompt: str,
+    full_tokens: Sequence[int],
+    render_reference: Callable[[str], str],
+    tokenize: Callable[[str], list[int]],
+) -> tuple[QwenRoutePrefixSpec | None, str | None]:
+    return derive_qwen_route_prefix_spec(
+        system_prompt=system_prompt,
+        full_prompt=full_prompt,
+        full_tokens=full_tokens,
+        render_reference=render_reference,
+        tokenize=tokenize,
+        prefix_token_count=ORNITH_ROUTE_PREFIX_TOKEN_COUNT,
+    )
+
+
+__all__ = [
+    "ORNITH_ROUTE_PREFIX_ENV",
+    "ORNITH_ROUTE_PREFIX_FORMAT_VERSION",
+    "ORNITH_ROUTE_PREFIX_TOKEN_COUNT",
+    "ORNITH_ROUTE_TOKENIZER_IDENTITY",
+    "QwenRoutePrefixSpec",
+    "QwenRoutePrefixStatus",
+    "derive_ornith_route_prefix_spec",
+    "resolve_ornith_route_prefix_reuse",
+]

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -27,7 +27,7 @@ from orbit.native_llama.kv_diag import emit_route_prefix_prewarm_event, request_
 from orbit.native_llama.download_cli import _DownloadProgress as DownloadProgress
 from orbit.native_llama.model_discovery import ModelDiscoveryRow, discover_models, format_model_discovery
 from orbit.native_llama.model_download import download_model
-from orbit.native_llama.model_profiles import QWEN3_CODER_PROFILE_ID
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID
 from orbit.native_llama.model_registry import default_hf_cache, default_models_dir, get_manifest, local_model_path
 from orbit.native_llama.paths import (
     DEFAULT_LLAMA_ROOT,
@@ -43,6 +43,7 @@ from orbit.native_llama.qwen36_shell_tool_prefix import (
     exact_qwen36_shell_tool_schema,
     resolve_qwen36_shell_tool_prefix_reuse,
 )
+from orbit.native_llama.ornith_route_prefix import resolve_ornith_route_prefix_reuse
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_server.protocol import (
     ContinueRequest,
@@ -793,6 +794,7 @@ def run_server(argv: list[str] | None = None) -> int:
     qwen_route_prefix_config = resolve_qwen_route_prefix_reuse()
     qwen36_shell_tool_prefix_config = resolve_qwen36_shell_tool_prefix_reuse()
     qwen3_coder_route_prefix_config = resolve_qwen3_coder_route_prefix_reuse()
+    ornith_route_prefix_config = resolve_ornith_route_prefix_reuse()
 
     paths: NativeLlamaPaths | None = None
     try:
@@ -824,6 +826,9 @@ def run_server(argv: list[str] | None = None) -> int:
                 qwen3_coder_route_prefix_reuse_enabled=qwen3_coder_route_prefix_config.enabled,
                 qwen3_coder_route_prefix_reuse_source=qwen3_coder_route_prefix_config.source,
                 qwen3_coder_route_prefix_reuse_config_error=qwen3_coder_route_prefix_config.validation_error,
+                ornith_route_prefix_reuse_enabled=ornith_route_prefix_config.enabled,
+                ornith_route_prefix_reuse_source=ornith_route_prefix_config.source,
+                ornith_route_prefix_reuse_config_error=ornith_route_prefix_config.validation_error,
                 moe_expert_usage_enabled=args.moe_expert_usage,
                 low_memory=args.low_memory,
             ),
@@ -831,7 +836,10 @@ def run_server(argv: list[str] | None = None) -> int:
         if not args.verbose_llama_log:
             client.set_quiet_logging()
         client.load()
-        if getattr(getattr(client, "model_profile", None), "profile_id", None) != QWEN3_CODER_PROFILE_ID:
+        if getattr(getattr(client, "model_profile", None), "profile_id", None) not in (
+            QWEN3_CODER_PROFILE_ID,
+            ORNITH15_PROFILE_ID,
+        ):
             prewarm_startup_route_prefix(client)
         else:
             prewarm_interrupted = False
@@ -941,7 +949,7 @@ def prewarm_startup_route_prefix(client: NativeLlamaClient) -> NativeRoutePrefix
         _emit_startup_prewarm_diag(mode=mode, tools_enabled=tools_enabled, result=result)
         return result
     profile = getattr(client, "model_profile", None)
-    if getattr(profile, "profile_id", None) == QWEN3_CODER_PROFILE_ID:
+    if getattr(profile, "profile_id", None) in (QWEN3_CODER_PROFILE_ID, ORNITH15_PROFILE_ID):
         try:
             result = client.capture_qwen3_coder_route_prefix_prefill_only(
                 system_prompt=ROUTE_SYSTEM_PROMPT,

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -735,6 +735,7 @@ class LlamaServerBackendTests(unittest.TestCase):
                 {
                     "ORBIT_QWEN_ROUTE_PREFIX_REUSE": value,
                     "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": value,
+                    "ORBIT_ORNITH_ROUTE_PREFIX_REUSE": value,
                 },
                 clear=True,
             ), model_call_context(phase="route", tools_mode="on"):

--- a/tests/test_ornith_route_prefix.py
+++ b/tests/test_ornith_route_prefix.py
@@ -1,0 +1,727 @@
+"""Exact-prefix CHAT prewarm for verified Ornith, through the client seam.
+
+The startup prewarm never applied to Ornith: it rendered Gemma markup while
+Ornith renders ChatML, so the two disagreed at the very first token. These
+tests drive the real planner, capture and restore paths -- not the derivation
+helper alone -- because what has to hold lives in the wiring: that a prewarm
+is only ever restored when its tokens are an exact prefix of the request, that
+each profile keeps its own checkpoint, and that a valid rolling checkpoint is
+never displaced by a prewarm.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.model_profiles import (
+    NativeModelProfile,
+    ORNITH15_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+)
+from orbit.native_llama.ornith_route_prefix import (
+    ORNITH_ROUTE_PREFIX_ENV,
+    ORNITH_ROUTE_PREFIX_FORMAT_VERSION,
+    ORNITH_ROUTE_PREFIX_TOKEN_COUNT,
+    ORNITH_ROUTE_TOKENIZER_IDENTITY,
+    derive_ornith_route_prefix_spec,
+    resolve_ornith_route_prefix_reuse,
+)
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+
+
+class OrnithRoutePrefixConfigTests(unittest.TestCase):
+    def test_default_on_explicit_on_and_kill_switch(self) -> None:
+        self.assertTrue(resolve_ornith_route_prefix_reuse({}).enabled)
+        self.assertTrue(resolve_ornith_route_prefix_reuse({ORNITH_ROUTE_PREFIX_ENV: "1"}).enabled)
+        self.assertFalse(resolve_ornith_route_prefix_reuse({ORNITH_ROUTE_PREFIX_ENV: "0"}).enabled)
+
+    def test_invalid_value_disables_safely(self) -> None:
+        config = resolve_ornith_route_prefix_reuse({ORNITH_ROUTE_PREFIX_ENV: "yes"})
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.validation_error, "invalid_ornith_route_prefix_reuse_value")
+
+    def test_identity_constants_are_distinct_from_other_profiles(self) -> None:
+        from orbit.native_llama.qwen3_coder_route_prefix import (
+            QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION,
+            QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY,
+        )
+
+        self.assertNotEqual(
+            ORNITH_ROUTE_PREFIX_FORMAT_VERSION, QWEN3_CODER_ROUTE_PREFIX_FORMAT_VERSION
+        )
+        # Ornith's tokenizer family is its own; a shared identity string would
+        # let one profile's checkpoint look valid for another.
+        self.assertEqual(ORNITH_ROUTE_TOKENIZER_IDENTITY, "gpt2:qwen35")
+        self.assertNotEqual(ORNITH_ROUTE_TOKENIZER_IDENTITY, QWEN3_CODER_ROUTE_TOKENIZER_IDENTITY)
+
+
+class OrnithAnchorRequestPredicateTests(unittest.TestCase):
+    """The backend must ask for the anchor when, and only when, Ornith reuse is on."""
+
+    def _requested(self, env: dict) -> bool:
+        import os as _os
+
+        from orbit.backend.llama_server import _qwen_route_prefix_anchor_requested
+        from orbit.runtime.kv_diag import model_call_context
+
+        with mock.patch.dict(_os.environ, env, clear=True):
+            with model_call_context(phase="route", tools_mode="on"):
+                return _qwen_route_prefix_anchor_requested(native_backend=True)
+
+    def test_ornith_reuse_alone_requests_the_anchor(self) -> None:
+        # The other two profiles are switched off, so only the Ornith switch
+        # can be what enables the request.
+        self.assertTrue(
+            self._requested(
+                {
+                    "ORBIT_QWEN_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_ORNITH_ROUTE_PREFIX_REUSE": "1",
+                }
+            )
+        )
+
+    def test_all_switches_off_requests_nothing(self) -> None:
+        self.assertFalse(
+            self._requested(
+                {
+                    "ORBIT_QWEN_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_ORNITH_ROUTE_PREFIX_REUSE": "0",
+                }
+            )
+        )
+
+    def test_ornith_kill_switch_is_honoured_on_its_own(self) -> None:
+        self.assertFalse(
+            self._requested(
+                {
+                    "ORBIT_QWEN_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_QWEN3_CODER_ROUTE_PREFIX_REUSE": "0",
+                    "ORBIT_ORNITH_ROUTE_PREFIX_REUSE": "invalid",
+                }
+            )
+        )
+
+
+class OrnithRoutePrefixBoundaryTests(unittest.TestCase):
+    """The derivation must reject anything it cannot prove invariant."""
+
+    def _render(self, system: str):
+        def render(user: str) -> str:
+            return system + "\n<user>" + user + "</user>"
+
+        return render
+
+    def test_derives_the_fixed_prefix_before_dynamic_user_content(self) -> None:
+        system = "s" * 900
+        render = self._render(system)
+        full = render("actual request")
+
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+
+        self.assertIsNone(reason)
+        assert spec is not None
+        self.assertEqual(len(spec.prefix_tokens), ORNITH_ROUTE_PREFIX_TOKEN_COUNT)
+        self.assertGreater(spec.invariant_token_count, ORNITH_ROUTE_PREFIX_TOKEN_COUNT)
+
+    def test_short_prompt_is_refused(self) -> None:
+        system = "s" * 10
+        render = self._render(system)
+        full = render("x")
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "route_prompt_too_short")
+
+    def test_unstable_boundary_is_refused(self) -> None:
+        # The prompt is long enough to clear the length gate, but user text
+        # begins at token 700 -- before the fixed count. The derivation must
+        # refuse rather than shorten the prefix to whatever happens to match.
+        head = "s" * 700
+        tail = "t" * 400
+
+        def render(user: str) -> str:
+            return head + user + tail
+
+        full = render("actual request")
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt=head,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "stable_token_boundary_unavailable")
+
+    def test_production_prompt_that_diverges_from_the_reference_is_refused(self) -> None:
+        # The two reference renders agree, but the prompt actually being served
+        # does not start with them. Accepting here would restore a KV sequence
+        # that is not this prompt's prefix.
+        system = "s" * 900
+        render = self._render(system)
+        foreign = "DIFFERENT" + "s" * 900 + "\n<user>x</user>"
+
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=foreign,
+            full_tokens=[ord(c) for c in foreign],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+
+        self.assertIsNone(spec, "a prompt that is not an extension of the prefix must be refused")
+        self.assertEqual(reason, "production_prefix_mismatch")
+
+    def test_references_disagreeing_inside_the_prefix_are_refused(self) -> None:
+        # Here the "invariant" region is not invariant: the user text lands
+        # inside the fixed count, so the two references differ there. Accepting
+        # would bake one request's user tokens into the prewarm.
+        def render(user: str) -> str:
+            return "s" * 100 + user + "s" * 900
+
+        full = render("actual request")
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt="s" * 100,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+
+        self.assertIsNone(spec, "user text inside the prefix must be refused")
+        self.assertIn(reason, {"reference_prefix_mismatch", "stable_token_boundary_unavailable"})
+
+    def test_no_reference_user_text_survives_into_the_derived_prefix(self) -> None:
+        system = "s" * 900
+        render = self._render(system)
+        full = render("actual request")
+        spec, _reason = derive_ornith_route_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        assert spec is not None
+        text = "".join(chr(t) for t in spec.prefix_tokens)
+
+        for marker in ("orbit-qwen-route-boundary", "A-orbit", "Z-orbit", "actual request", "<user>"):
+            self.assertNotIn(marker, text, "no reference or user token may enter the prewarm")
+
+    def test_missing_system_prompt_is_refused(self) -> None:
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt="",
+            full_prompt="x" * 900,
+            full_tokens=[1] * 900,
+            render_reference=lambda u: "x" * 900,
+            tokenize=lambda t: [1] * len(t),
+        )
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "missing_route_system_prompt")
+
+
+class OrnithPrefixHeadroomTests(unittest.TestCase):
+    """The fixed count must sit inside the invariant region for every prompt
+    the production builder can actually produce.
+
+    `ROUTE_SYSTEM_PROMPT` interpolates the detected OS and shell, so the prompt
+    is not one fixed string. Measured on the real Ornith tokenizer the
+    invariant region is 828-830 tokens across every variant, leaving at least
+    60 tokens of headroom over the fixed 768. This test pins the property that
+    matters -- the variation is far from the boundary -- without needing the
+    model, by checking the character spread the interpolation can introduce.
+    """
+
+    def test_os_and_shell_interpolation_barely_moves_the_prompt(self) -> None:
+        from orbit.runtime.messages import _COMMAND_SYSTEM_TEMPLATE
+
+        lengths = [
+            len(_COMMAND_SYSTEM_TEMPLATE.format(os_name=os_name, shell_name=shell))
+            for os_name, shell in (
+                ("linux", "bash"), ("linux", "zsh"), ("linux", "sh"), ("linux", "fish"),
+                ("macos", "zsh"), ("windows", "powershell.exe"), ("windows", "cmd.exe"),
+                ("unknown", "unknown"),
+            )
+        ]
+
+        # A handful of characters, against ~60 tokens of measured headroom.
+        self.assertLess(max(lengths) - min(lengths), 64)
+
+    def test_the_interpolation_sits_late_in_the_template(self) -> None:
+        from orbit.runtime.messages import _COMMAND_SYSTEM_TEMPLATE
+
+        position = _COMMAND_SYSTEM_TEMPLATE.index("Environment: OS=")
+
+        # Well past the 768-token prefix region, so a longer shell name cannot
+        # push user content forward into the captured prefix.
+        self.assertGreater(position / len(_COMMAND_SYSTEM_TEMPLATE), 0.5)
+
+    def test_a_shrunken_invariant_region_is_refused_not_trimmed(self) -> None:
+        # The guarantee that makes the fixed count safe: if the invariant
+        # region ever fell below it, derivation returns None instead of
+        # silently capturing fewer tokens.
+        def render(user: str) -> str:
+            return "s" * 100 + user + "t" * 900
+
+        full = render("actual request")
+        spec, reason = derive_ornith_route_prefix_spec(
+            system_prompt="s" * 100,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+
+        self.assertIsNone(spec)
+        self.assertIsNotNone(reason)
+
+
+class _FakeBridge:
+    """Renders ChatML-shaped output: system turn, then the user turn."""
+
+    def render(self, _context, messages, _tools, *, thinking: bool):
+        assert not thinking
+        return {
+            "prompt": str(messages[0]["content"]) + "\n<user>" + str(messages[1]["content"]) + "</user>",
+            "generation_prompt": "",
+        }
+
+    def free(self, _context) -> None:
+        return None
+
+
+def _profile(profile_id: str = ORNITH15_PROFILE_ID, **overrides) -> NativeModelProfile:
+    base = dict(
+        profile_id=profile_id,
+        family="ornith1.5",
+        model_name="Ornith-1.5-35B",
+        architecture="qwen35moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="qwen-think",
+        tool_call_protocol="qwen3.6-xml",
+        history_serialization="qwen-leading-system-only",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="f" * 64,
+        thinking_supported=True,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
+        verified_quantization="Q4_K_M",
+    )
+    base.update(overrides)
+    return NativeModelProfile(**base)
+
+
+class OrnithRoutePrefixClientTests(unittest.TestCase):
+    """The planner and the per-profile registry, on the real client."""
+
+    def _client(self, *, profile=None, enabled=True, file_type="15") -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/ornith.gguf"),
+            model_id="legacy-path",
+        )
+        config = NativeClientConfig(
+            qwen_route_prefix_reuse_enabled=False,
+            qwen3_coder_route_prefix_reuse_enabled=False,
+            ornith_route_prefix_reuse_enabled=enabled,
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(paths, config)
+        client.model_profile = profile or _profile()
+        client._model_metadata_identity = {
+            "general.architecture": "qwen35moe",
+            "general.name": "Ornith-1.5-35B",
+            "general.file_type": file_type,
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.pre": "qwen35",
+        }
+        client.chat_bridge = _FakeBridge()  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        client.tokenize = lambda text: [ord(c) for c in text]  # type: ignore[method-assign]
+        client._qwen_backend_build_identity = lambda: "build"  # type: ignore[method-assign]
+        return client
+
+    def _messages(self, user: str = "hello"):
+        return [
+            {"role": "system", "content": "s" * 900},
+            {"role": "user", "content": user},
+        ]
+
+    def _plan(self, client, user: str = "hello"):
+        messages = self._messages(user)
+        prompt = client.apply_chat_template(messages, tools=None, thinking=False)
+        return client._qwen_route_anchor_plan_for_prompt(
+            messages, tools=None, thinking=False, prompt=prompt
+        )
+
+    # --- exact prefix ---------------------------------------------------
+    def test_plan_is_produced_for_verified_ornith(self) -> None:
+        client = self._client()
+        plan = self._plan(client)
+
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(plan.profile_id, ORNITH15_PROFILE_ID)
+        self.assertEqual(len(plan.prefix_tokens), ORNITH_ROUTE_PREFIX_TOKEN_COUNT)
+
+    def test_prefix_is_an_exact_prefix_of_several_different_first_messages(self) -> None:
+        client = self._client()
+        reference = self._plan(client, "hello")
+        assert reference is not None
+
+        for user in ("hello", "what is a packer?", "ciao", "a", "x" * 200, "explain XOR"):
+            with self.subTest(user=user[:20]):
+                messages = self._messages(user)
+                prompt = client.apply_chat_template(messages, tools=None, thinking=False)
+                tokens = client.tokenize(prompt)
+                self.assertEqual(
+                    tuple(tokens[: len(reference.prefix_tokens)]),
+                    tuple(reference.prefix_tokens),
+                    "prewarm must be an exact token prefix of the real request",
+                )
+
+    def test_prefix_stops_before_any_user_token(self) -> None:
+        client = self._client()
+        plan = self._plan(client, "UNIQUEUSERMARKER")
+        assert plan is not None
+        prefix_text = "".join(chr(t) for t in plan.prefix_tokens)
+
+        self.assertNotIn("UNIQUEUSERMARKER", prefix_text)
+        self.assertNotIn("<user>", prefix_text)
+
+    # --- invalidation ---------------------------------------------------
+    def test_disabled_config_produces_no_plan(self) -> None:
+        self.assertIsNone(self._plan(self._client(enabled=False)))
+
+    def test_unverified_profile_produces_no_plan(self) -> None:
+        self.assertIsNone(self._plan(self._client(profile=_profile(verified=False))))
+
+    def test_profile_without_route_prefix_support_produces_no_plan(self) -> None:
+        self.assertIsNone(
+            self._plan(self._client(profile=_profile(route_prefix_reuse_supported=False)))
+        )
+
+    def test_foreign_profile_does_not_take_the_ornith_branch(self) -> None:
+        client = self._client(profile=_profile(profile_id="some-other-profile"))
+        self.assertIsNone(self._plan(client))
+
+    def test_unverified_quantization_produces_no_plan(self) -> None:
+        self.assertIsNone(self._plan(self._client(file_type="7")))
+
+    def test_thinking_and_tools_produce_no_plan(self) -> None:
+        client = self._client()
+        messages = self._messages()
+        prompt = client.apply_chat_template(messages, tools=None, thinking=False)
+
+        self.assertIsNone(
+            client._qwen_route_anchor_plan_for_prompt(
+                messages, tools=None, thinking=True, prompt=prompt
+            )
+        )
+        self.assertIsNone(
+            client._qwen_route_anchor_plan_for_prompt(
+                messages, tools=[{"a": 1}], thinking=False, prompt=prompt
+            )
+        )
+
+    # --- per-profile isolation -----------------------------------------
+    def test_each_profile_keeps_its_own_checkpoint_slot(self) -> None:
+        client = self._client()
+        ornith_state = PrefixAnchorState(prefix_hash="ornith", token_count=768, valid=True)
+        coder_state = PrefixAnchorState(prefix_hash="coder", token_count=768, valid=True)
+
+        client._set_qwen_route_prefix_state(ORNITH15_PROFILE_ID, ornith_state)
+        client._set_qwen_route_prefix_state(QWEN3_CODER_PROFILE_ID, coder_state)
+
+        self.assertIs(client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID), ornith_state)
+        self.assertIs(
+            client._qwen_route_prefix_state_for_profile(QWEN3_CODER_PROFILE_ID), coder_state
+        )
+        self.assertIsNot(
+            client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID),
+            client._qwen_route_prefix_state_for_profile(QWEN3_CODER_PROFILE_ID),
+        )
+
+    def test_spec_and_status_slots_are_also_per_profile(self) -> None:
+        client = self._client()
+        client._set_qwen_route_prefix_spec(ORNITH15_PROFILE_ID, "ornith-spec")  # type: ignore[arg-type]
+        client._set_qwen_route_prefix_spec(QWEN3_CODER_PROFILE_ID, "coder-spec")  # type: ignore[arg-type]
+
+        self.assertEqual(client._qwen_route_prefix_spec_for_profile(ORNITH15_PROFILE_ID), "ornith-spec")
+        self.assertEqual(
+            client._qwen_route_prefix_spec_for_profile(QWEN3_CODER_PROFILE_ID), "coder-spec"
+        )
+        self.assertIsNot(
+            client._qwen_route_prefix_status_for_profile(ORNITH15_PROFILE_ID),
+            client._qwen_route_prefix_status_for_profile(QWEN3_CODER_PROFILE_ID),
+        )
+
+    def test_reset_invalidates_the_ornith_checkpoint(self) -> None:
+        client = self._client()
+        client._set_qwen_route_prefix_state(
+            ORNITH15_PROFILE_ID, PrefixAnchorState(prefix_hash="p", token_count=768, valid=True)
+        )
+
+        client._invalidate_qwen_route_prefix("session_reset")
+
+        self.assertFalse(client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID).valid)
+
+    def test_blanket_invalidation_covers_every_profile(self) -> None:
+        client = self._client()
+        for profile_id in (ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            client._set_qwen_route_prefix_state(
+                profile_id, PrefixAnchorState(prefix_hash="p", token_count=768, valid=True)
+            )
+
+        client._invalidate_qwen_route_prefix("model_reload")
+
+        for profile_id in (ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            self.assertFalse(client._qwen_route_prefix_state_for_profile(profile_id).valid)
+
+    def test_targeted_invalidation_leaves_other_profiles_alone(self) -> None:
+        client = self._client()
+        for profile_id in (ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            client._set_qwen_route_prefix_state(
+                profile_id, PrefixAnchorState(prefix_hash="p", token_count=768, valid=True)
+            )
+
+        client._invalidate_qwen_route_prefix("x", profile_id=QWEN3_CODER_PROFILE_ID)
+
+        self.assertTrue(client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID).valid)
+        self.assertFalse(client._qwen_route_prefix_state_for_profile(QWEN3_CODER_PROFILE_ID).valid)
+
+
+class OrnithPrewarmDoesNotDisplaceRollingTests(unittest.TestCase):
+    """A rolling checkpoint that can serve this prompt outranks the prewarm.
+
+    The prewarm is a fixed 768-token head; a rolling checkpoint holds the
+    conversation's own tokens and is never shorter. Letting the prewarm win
+    would make later CHAT turns slower, which is the opposite of the point.
+    """
+
+    def _client(self):
+        return OrnithRoutePrefixClientTests._client(OrnithRoutePrefixClientTests("run"))
+
+    def test_a_usable_rolling_checkpoint_suppresses_the_prewarm_plan(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import (
+            ROLLING_ROUTE_STRATEGY_ID,
+            RollingRouteAnchorState,
+            RollingRouteIdentity,
+            rolling_route_reuse_start,
+        )
+
+        identity = RollingRouteIdentity(
+            strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+            session_id="default",
+            profile_id=ORNITH15_PROFILE_ID,
+            model_id="/models/ornith.gguf",
+            template_id="tpl",
+            tool_schema_hash="tools",
+            capability_summary_hash="caps",
+            runtime_policy_hash="policy",
+            native_version="libllama.so",
+            tools_mode="on",
+            reset_generation=0,
+        )
+        saved = [1, 2, 3, 4]
+        state = RollingRouteAnchorState(
+            identity=identity, tokens=list(saved), checkpoint_data=b"c", created_at_monotonic=1.0
+        )
+
+        # The condition the production chain uses to step over the prewarm.
+        self.assertIsNotNone(rolling_route_reuse_start(state, saved + [5], identity))
+        # And it declines when the rolling state cannot serve the prompt, so
+        # the prewarm still gets its turn on a genuinely cold first request.
+        self.assertIsNone(rolling_route_reuse_start(state, [9, 9, 9], identity))
+
+    def _identity(self):
+        from orbit.native_llama.rolling_route_anchor import (
+            ROLLING_ROUTE_STRATEGY_ID,
+            RollingRouteIdentity,
+        )
+
+        return RollingRouteIdentity(
+            strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+            session_id="default",
+            profile_id=ORNITH15_PROFILE_ID,
+            model_id="/models/ornith.gguf",
+            template_id="tpl",
+            tool_schema_hash="tools",
+            capability_summary_hash="caps",
+            runtime_policy_hash="policy",
+            native_version="libllama.so",
+            tools_mode="on",
+            reset_generation=0,
+        )
+
+    def test_a_usable_rolling_checkpoint_wins_over_the_prewarm(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import RollingRouteAnchorState
+
+        client = self._client()
+        identity = self._identity()
+        saved = [1, 2, 3, 4]
+        client._rolling_route_anchor_state = RollingRouteAnchorState(
+            identity=identity, tokens=list(saved), checkpoint_data=b"c", created_at_monotonic=1.0
+        )
+
+        self.assertTrue(
+            client._rolling_outranks_route_prefix(
+                saved + [5], rolling_route_eligible=True, rolling_route_identity=identity
+            ),
+            "a rolling checkpoint that serves this prompt must outrank the prewarm",
+        )
+
+    def test_the_guard_is_consulted_before_the_prewarm_plan_is_used(self) -> None:
+        """Production must ask the guard, not merely have it available."""
+        client = self._client()
+        asked: list[tuple] = []
+
+        def guard(tokens, **kwargs):
+            asked.append((tuple(tokens), kwargs))
+            return False
+
+        client._rolling_outranks_route_prefix = guard  # type: ignore[method-assign]
+        client.tokenize = lambda text: [1, 2, 3]  # type: ignore[method-assign]
+        client._route_anchor_plan = lambda *a, **k: None  # type: ignore[method-assign]
+        # Past the "native client not loaded" precondition, so execution
+        # actually reaches the guard before failing on the fake library.
+        client._session.ctx_tgt = object()
+        client._session.sampler = object()
+
+        plan = SimpleNamespace(prefix_tokens=[1, 2], profile_id=ORNITH15_PROFILE_ID)
+        with self.assertRaises(Exception):
+            client._complete_prompt_standard("p", qwen_route_anchor_plan=plan)
+
+        self.assertEqual(len(asked), 1, "the priority guard must be consulted")
+        self.assertEqual(asked[0][0], (1, 2, 3))
+        self.assertIn("rolling_route_eligible", asked[0][1])
+
+    def test_prewarm_still_runs_when_rolling_cannot_serve_the_prompt(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import (
+            ROLLING_ROUTE_STRATEGY_ID,
+            RollingRouteAnchorState,
+            RollingRouteIdentity,
+            rolling_route_reuse_start,
+        )
+
+        identity = RollingRouteIdentity(
+            strategy_id=ROLLING_ROUTE_STRATEGY_ID,
+            session_id="default",
+            profile_id=ORNITH15_PROFILE_ID,
+            model_id="/models/ornith.gguf",
+            template_id="tpl",
+            tool_schema_hash="tools",
+            capability_summary_hash="caps",
+            runtime_policy_hash="policy",
+            native_version="libllama.so",
+            tools_mode="on",
+            reset_generation=0,
+        )
+        cold = RollingRouteAnchorState()
+
+        # Nothing saved yet: the guard must not fire, leaving the prewarm to
+        # do its job on the genuinely cold first turn.
+        self.assertIsNone(rolling_route_reuse_start(cold, [1, 2, 3], identity))
+
+
+class OrnithAnalysisIsolationTests(unittest.TestCase):
+    def test_analysis_rolling_state_is_a_separate_attribute(self) -> None:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+
+        self.assertIn("_rolling_analysis_anchor_state", text)
+        self.assertIn("_ornith_route_prefix_anchor_state", text)
+        # The prewarm slot must never be read by the analysis rolling path.
+        analysis_fn = text[text.index("def _rolling_anchor_state_for") :][:600]
+        self.assertNotIn("_ornith_route_prefix_anchor_state", analysis_fn)
+
+    def test_route_prefix_registry_never_returns_the_analysis_slot(self) -> None:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        registry = text[text.index("def _qwen_route_prefix_state_for_profile") :][:700]
+
+        self.assertNotIn("_rolling_analysis_anchor_state", registry)
+        self.assertNotIn("_rolling_route_anchor_state", registry)
+
+
+class OrnithPrewarmAddsNoModelCallTests(unittest.TestCase):
+    """Capture is prefill-only: it must never sample or generate."""
+
+    def _block(self) -> str:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        start = text.index("def capture_qwen3_coder_route_prefix_prefill_only")
+        return text[start : text.index("    def ", start + 50)]
+
+    def test_capture_never_generates(self) -> None:
+        block = self._block()
+
+        for forbidden in ("_generate_from_current_context", "llama_sampler_sample", "on_token("):
+            self.assertNotIn(forbidden, block, "prewarm capture must not generate a token")
+
+    def test_capture_requires_a_clean_prefill_boundary(self) -> None:
+        block = self._block()
+
+        self.assertIn("processed != prefix_token_count or reused != 0", block)
+        self.assertIn("active_context_present", block)
+
+    def test_capture_reports_prefill_only_result(self) -> None:
+        block = self._block()
+
+        self.assertIn("restore_ready=True", block)
+        self.assertIn("decode_calls=", block)
+
+
+class OrnithStartupPrewarmWiringTests(unittest.TestCase):
+    def test_startup_prewarm_reaches_the_capture_for_ornith(self) -> None:
+        import orbit.native_server.app as app
+
+        source = Path(app.__file__).read_text(encoding="utf-8")
+        block = source[source.index("def prewarm_startup_route_prefix") :][:2600]
+
+        self.assertIn("ORNITH15_PROFILE_ID", block)
+        # Ornith must be handled by the ChatML capture branch, before the
+        # Gemma-only check that would otherwise skip it as ineligible.
+        self.assertLess(
+            block.index("ORNITH15_PROFILE_ID"),
+            block.index("gemma_prefix_reuse_supported"),
+            "Ornith must not fall through to the Gemma ineligibility branch",
+        )
+
+    def test_route_prompt_is_unchanged_by_this_mission(self) -> None:
+        import hashlib
+
+        self.assertEqual(
+            hashlib.sha256(ROUTE_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
+            "e7d5234d50700746d315004af1430871442c4eefcc61b6e420cc24d29bcaae28",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ornith's first CHAT turn always cold-prefilled the whole route prompt. The existing
startup prewarm never applied to it: that path renders Gemma markup while Ornith
renders ChatML through the `llama.cpp-jinja` bridge, so the two disagree at the very
first token (832 vs 838 tokens, first mismatch at index 0) and the profile was skipped
as `model_profile_ineligible`. No invalid prewarm was ever restored — it simply never
ran. Baseline: `f85f758`.

## Design

- **Ornith-only CHAT route prewarm.** No other profile's behaviour changes.
- **Exact prefix derived from real `llama.cpp-jinja` bridge rendering** — the rendered
  route system turn (825 tokens) minus the bridge's own `generation_prompt` (6 tokens),
  taken from the bridge's structured output, not by LCP over samples.
- **768-token checkpoint inside a proven immutable prefix.** Two reference renders that
  differ only in user text share 828 tokens; 768 sits well inside that. Verified an
  exact token prefix of 8 diverse first-turn inputs and of all 8 OS/shell variants of
  `ROUTE_SYSTEM_PROMPT` (which interpolates detected OS and shell) — worst case ≥60
  tokens of headroom. The spec re-derives per session and returns `None` if the
  invariant region ever shrinks: refusal, never trimming.
- **No user-specific tokens** in the captured prefix — asserted directly in tests.
- **Strict exact-prefix validation before restore**, twice: the plan is only built when
  `prompt_tokens[:768]` equals the spec prefix, and it is re-checked against freshly
  tokenized prompt tokens before use. `prompt_tokens[:len(committed)] == committed` is
  untouched. No normalization, no LCP reuse, no fuzzy matching, no prompt rewriting.
- **Existing `PrefixAnchorState` reused** — a new per-profile slot in the registry the
  Qwen profiles already use. No new cache manager.
- **Rolling CHAT takes precedence over the prewarm** (`rolling > prewarm > cold`), via
  `_rolling_outranks_route_prefix`. A rolling checkpoint holds the conversation's own
  tokens and is never shorter than the fixed prewarm head.
- **ANALYSIS isolated** — the prefix registry never returns the analysis rolling slot.
- **No backend mode semantics**, **no Gemma changes**, **no prompt normalization**.
- **Opt-in only**, via `ORBIT_ORNITH_ROUTE_PREFIX_REUSE` and the existing
  phase-driven anchor request.

## Authoritative canary

Ornith 1.5 35B-A3B (`orbit-ornith15-native-v1`, verified, template sha `f55f5293…`),
benign prompts, CPU-only, ctx 8192, three CHAT turns:

| turn | prompt | reused | evaluated | cache | prefill |
|---|---|---|---|---|---|
| cold | 843 | 0 | 843 | 0.0% | 119.7 s |
| prewarmed | 843 | 768 | 75 | 91.1% | 6.1 s |
| follow-up (rolling) | 869 | 843 | 26 | 97.0% | 2.3 s |

`reused + evaluated == prompt` on every turn. The follow-up reuses **843** — the
previous full prompt, i.e. rolling won rather than the 768 prewarm. Route output
identical across all three turns (`{"route":"CHAT"}`).

**Wall and prefill ratios are machine-load dependent** — this run's host was heavily
loaded, and an earlier run measured the same 91.1% cache with a 23.5 s cold prefill.
**Token reuse is the primary portable result.** No general benchmark performance is
claimed.

**Memory: ~77.8 MiB per prewarm checkpoint** (81,608,684 B for 768 tokens ≈ 104 KiB per
token — inherent 35B-MoE KV, not duplication), fixed regardless of conversation length.

## Qualification

- 41 new tests PASS
- 218 focused PASS
- 2470 full suite PASS
- 11/12 mutations CAUGHT — the survivor (`reference_prefix_mismatch`) is logically
  unreachable: `token_lcp > N` already implies the first N tokens match, so it is
  redundant defence-in-depth rather than a coverage gap
- compileall / diff-check PASS
- independent review PASS
- BLOCKER 0 / MAJOR 0 / MINOR 0

The review found a priority inversion I had introduced (the prewarm was consulted
before rolling, which would have made later CHAT turns slower); it is fixed and covered
by a mutation-tested case. `tests/test_llama_server_backend.py` carries a one-line
addition so the existing "all route-prefix reuse disabled" test also covers the new
env switch.
