### PR TITLE
perf(runtime): add exact-prefix Ornith analysis prewarm

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import codecs
+import copy
 import ctypes
 import hashlib
 import json
@@ -90,6 +91,13 @@ from .qwen3_coder import (
     qwen3_coder_artifact_messages,
     qwen3_coder_artifact_prompt,
 )
+from .ornith_analysis_prefix import (
+    ORNITH_ANALYSIS_LINEAGE_ID,
+    ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION,
+    ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT,
+    ORNITH_ANALYSIS_TOKENIZER_IDENTITY,
+    derive_ornith_analysis_prefix_spec,
+)
 from .ornith_route_prefix import (
     ORNITH_ROUTE_PREFIX_FORMAT_VERSION,
     ORNITH_ROUTE_PREFIX_TOKEN_COUNT,
@@ -172,6 +180,9 @@ class NativeClientConfig:
     ornith_route_prefix_reuse_enabled: bool = False
     ornith_route_prefix_reuse_source: str = "default"
     ornith_route_prefix_reuse_config_error: str | None = None
+    ornith_analysis_prefix_reuse_enabled: bool = False
+    ornith_analysis_prefix_reuse_source: str = "default"
+    ornith_analysis_prefix_reuse_config_error: str | None = None
     moe_expert_usage_enabled: bool = False
     low_memory: bool = False
 
@@ -353,10 +364,16 @@ class NativeLlamaClient:
         # different token sequence and needs its own slot; it reuses the same
         # PrefixAnchorState type and the same restore path.
         self._ornith_route_prefix_anchor_state = PrefixAnchorState()
+        # A separate lineage: the ANALYSIS opening is a different token
+        # sequence from the route opening, so it gets its own slot rather
+        # than competing for Ornith's route one.
+        self._ornith_analysis_prefix_anchor_state = PrefixAnchorState()
         self._qwen3_coder_route_prefix_spec: QwenRoutePrefixSpec | None = None
         self._ornith_route_prefix_spec: QwenRoutePrefixSpec | None = None
+        self._ornith_analysis_prefix_spec: QwenRoutePrefixSpec | None = None
         self._qwen3_coder_route_prefix_status = QwenRoutePrefixStatus()
         self._ornith_route_prefix_status = QwenRoutePrefixStatus()
+        self._ornith_analysis_prefix_status = QwenRoutePrefixStatus()
         self._model_metadata_identity: dict[str, str] = {}
         self._qwen_native_build_identity: str | None = None
         self._final_prefix_anchor_state = PrefixAnchorState()
@@ -855,6 +872,9 @@ class NativeLlamaClient:
         self._invalidate_qwen_route_prefix(
             "session_reset", profile_id=ORNITH15_PROFILE_ID
         )
+        self._invalidate_qwen_route_prefix(
+            "session_reset", profile_id=ORNITH_ANALYSIS_LINEAGE_ID
+        )
         self._invalidate_qwen36_shell_tool_prefix("session_reset")
         if self._persistent_mtp_runtime is None:
             return
@@ -1115,6 +1135,8 @@ class NativeLlamaClient:
         *,
         system_prompt: str,
         tools_mode: str = "on",
+        tools: list[dict] | None = None,
+        analysis_lineage: bool = False,
     ) -> NativeRoutePrefixPrefillResult:
         profile = getattr(self, "model_profile", None)
         profile_id = getattr(profile, "profile_id", None)
@@ -1126,11 +1148,19 @@ class NativeLlamaClient:
             or not getattr(profile, "route_prefix_reuse_supported", False)
         ):
             return _route_prefix_prefill_skipped("model_profile_ineligible")
-        reuse_enabled = (
-            self.config.ornith_route_prefix_reuse_enabled
-            if profile_id == ORNITH15_PROFILE_ID
-            else self.config.qwen3_coder_route_prefix_reuse_enabled
-        )
+        if analysis_lineage:
+            if profile_id != ORNITH15_PROFILE_ID:
+                return _route_prefix_prefill_skipped("model_profile_ineligible")
+            # The capture is bookkept under the lineage it belongs to, so the
+            # analysis prefix lands in its own slot rather than the route one.
+            profile_id = ORNITH_ANALYSIS_LINEAGE_ID
+            reuse_enabled = self.config.ornith_analysis_prefix_reuse_enabled
+        else:
+            reuse_enabled = (
+                self.config.ornith_route_prefix_reuse_enabled
+                if profile_id == ORNITH15_PROFILE_ID
+                else self.config.qwen3_coder_route_prefix_reuse_enabled
+            )
         if not reuse_enabled:
             return _route_prefix_prefill_skipped("route_prefix_reuse_disabled")
         if tools_mode != "on":
@@ -1166,12 +1196,14 @@ class NativeLlamaClient:
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": "A-orbit-qwen-route-boundary"},
             ]
-            prompt = self.apply_chat_template(messages, tools=None, thinking=False)
+            capture_tools = [dict(tool) for tool in (tools or [])] if analysis_lineage else None
+            prompt = self.apply_chat_template(messages, tools=capture_tools, thinking=False)
             plan = self._qwen_route_anchor_plan_for_prompt(
                 messages,
-                tools=None,
+                tools=capture_tools,
                 thinking=False,
                 prompt=prompt,
+                analysis_lineage=analysis_lineage,
             )
             if plan is None or plan.profile_id != profile_id:
                 return _route_prefix_prefill_failed("route_anchor_plan_unavailable")
@@ -1291,12 +1323,20 @@ class NativeLlamaClient:
                 "completion_error"
             )
             raise
-        qwen_route_anchor_plan = self._qwen_route_anchor_plan_for_prompt(
-            messages,
-            tools=tools,
-            thinking=thinking,
-            prompt=prompt,
-        ) if qwen_route_prefix_anchor else None
+        # The analysis step already declares itself for the rolling anchor;
+        # the same signal selects the analysis prefix lineage, so no second
+        # flag is introduced and the backend still just reads what it is told.
+        qwen_route_anchor_plan = (
+            self._qwen_route_anchor_plan_for_prompt(
+                messages,
+                tools=tools,
+                thinking=thinking,
+                prompt=prompt,
+                analysis_lineage=analysis_rolling_anchor,
+            )
+            if (qwen_route_prefix_anchor or analysis_rolling_anchor)
+            else None
+        )
         qwen36_shell_tool_anchor_plan = self._qwen36_shell_tool_anchor_plan_for_prompt(
             messages,
             tools=tools,
@@ -2329,7 +2369,12 @@ class NativeLlamaClient:
         pf_start = lib.llama_time_us()
         anchor_plan = self._route_anchor_plan(prompt, prompt_tokens, route_anchor_segments)
         if qwen_route_anchor_plan is not None and prompt_tokens[: len(qwen_route_anchor_plan.prefix_tokens)] != qwen_route_anchor_plan.prefix_tokens:
-            self._record_qwen_route_prefix_fallback("production_prefix_changed")
+            # The plan knows which lineage it belongs to; without this the
+            # counter lands on whichever profile the model happens to be,
+            # which is the CHAT lineage even for an analysis call.
+            self._record_qwen_route_prefix_fallback(
+                "production_prefix_changed", profile_id=qwen_route_anchor_plan.profile_id
+            )
             qwen_route_anchor_plan = None
         if (
             qwen36_shell_tool_anchor_plan is not None
@@ -2530,10 +2575,20 @@ class NativeLlamaClient:
         tools: list[dict] | None,
         thinking: bool,
         prompt: str,
+        analysis_lineage: bool = False,
     ) -> _QwenRouteAnchorRuntimePlan | None:
         profile = getattr(self, "model_profile", None)
         profile_id = getattr(profile, "profile_id", None)
-        if profile_id == QWEN36_PROFILE_ID:
+        if analysis_lineage:
+            # Same model, different opening: the caller says which chain this
+            # prompt belongs to, exactly as it does for the rolling anchors.
+            if profile_id != ORNITH15_PROFILE_ID:
+                return None
+            profile_id = ORNITH_ANALYSIS_LINEAGE_ID
+            enabled = self.config.ornith_analysis_prefix_reuse_enabled
+            prefix_token_count = ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT
+            derive_spec = derive_ornith_analysis_prefix_spec
+        elif profile_id == QWEN36_PROFILE_ID:
             enabled = self.config.qwen_route_prefix_reuse_enabled
             prefix_token_count = QWEN_ROUTE_PREFIX_TOKEN_COUNT
             derive_spec = derive_qwen_route_prefix_spec
@@ -2555,7 +2610,23 @@ class NativeLlamaClient:
         if self._model_metadata_identity.get("general.file_type") != "15":
             self._record_qwen_route_prefix_fallback("qwen_quantization_unverified", profile_id=profile_id)
             return None
-        if tools or thinking:
+        if thinking:
+            self._record_qwen_route_prefix_fallback("structured_route_mode_ineligible", profile_id=profile_id)
+            return None
+        if analysis_lineage:
+            # An analysis step always carries exactly one tool, and that schema
+            # is part of the prefix being captured, so a different tool surface
+            # is a different prefix and must not reuse this one.
+            if len(tools or []) != 1:
+                # The schema itself is inside the captured prefix, and the
+                # derivation re-verifies those tokens against the prompt being
+                # served, so a changed schema fails the exact-prefix check
+                # rather than needing the backend to recognise it by name.
+                self._record_qwen_route_prefix_fallback(
+                    "analysis_tool_surface_ineligible", profile_id=profile_id
+                )
+                return None
+        elif tools:
             self._record_qwen_route_prefix_fallback("structured_route_mode_ineligible", profile_id=profile_id)
             return None
         if self.config.use_mtp_experimental or self._session.mtp_enabled:
@@ -2576,11 +2647,19 @@ class NativeLlamaClient:
             if self._qwen_route_prefix_state_for_profile(profile_id).valid:
                 self._invalidate_qwen_route_prefix("route_identity_changed", profile_id=profile_id)
 
+            # The analysis prefix contains the tool schema, so the reference
+            # and restore renders must carry the same tools the production
+            # render did; rendering them bare would produce a different prompt
+            # and, for the restore, look like an unrepeatable render.
+            probe_tools = (
+                copy.deepcopy([dict(tool) for tool in (tools or [])]) if analysis_lineage else []
+            )
+
             def render_reference(user_text: str) -> str:
                 rendered = self.chat_bridge.render(
                     self._chat_bridge_context,
                     [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_text}],
-                    [],
+                    probe_tools,
                     thinking=False,
                 )
                 value = rendered.get("prompt")
@@ -2606,7 +2685,7 @@ class NativeLlamaClient:
                 restored = self.chat_bridge.render(
                     self._chat_bridge_context,
                     self._serialize_profile_messages([dict(message) for message in messages]),
-                    [],
+                    probe_tools,
                     thinking=False,
                 )
                 restored_prompt = restored.get("prompt")
@@ -2953,6 +3032,8 @@ class NativeLlamaClient:
             return self._qwen3_coder_route_prefix_anchor_state
         if profile_id == ORNITH15_PROFILE_ID:
             return self._ornith_route_prefix_anchor_state
+        if profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            return getattr(self, "_ornith_analysis_prefix_anchor_state", None) or PrefixAnchorState()
         return self._qwen_route_prefix_anchor_state
 
     def _set_qwen_route_prefix_state(self, profile_id: str, state: PrefixAnchorState) -> None:
@@ -2960,6 +3041,8 @@ class NativeLlamaClient:
             self._qwen3_coder_route_prefix_anchor_state = state
         elif profile_id == ORNITH15_PROFILE_ID:
             self._ornith_route_prefix_anchor_state = state
+        elif profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            self._ornith_analysis_prefix_anchor_state = state
         else:
             self._qwen_route_prefix_anchor_state = state
 
@@ -2968,6 +3051,8 @@ class NativeLlamaClient:
             return self._qwen3_coder_route_prefix_spec
         if profile_id == ORNITH15_PROFILE_ID:
             return self._ornith_route_prefix_spec
+        if profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            return getattr(self, "_ornith_analysis_prefix_spec", None)
         return self._qwen_route_prefix_spec
 
     def _set_qwen_route_prefix_spec(self, profile_id: str, spec: QwenRoutePrefixSpec | None) -> None:
@@ -2975,6 +3060,8 @@ class NativeLlamaClient:
             self._qwen3_coder_route_prefix_spec = spec
         elif profile_id == ORNITH15_PROFILE_ID:
             self._ornith_route_prefix_spec = spec
+        elif profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            self._ornith_analysis_prefix_spec = spec
         else:
             self._qwen_route_prefix_spec = spec
 
@@ -2983,6 +3070,8 @@ class NativeLlamaClient:
             return self._qwen3_coder_route_prefix_status
         if profile_id == ORNITH15_PROFILE_ID:
             return self._ornith_route_prefix_status
+        if profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            return self._ornith_analysis_prefix_status
         return self._qwen_route_prefix_status
 
     def _prepare_memory_with_qwen_route_anchor(self, plan: _QwenRouteAnchorRuntimePlan) -> tuple[int, int]:
@@ -3089,6 +3178,12 @@ class NativeLlamaClient:
             format_version = ORNITH_ROUTE_PREFIX_FORMAT_VERSION
             tokenizer_identity = ORNITH_ROUTE_TOKENIZER_IDENTITY
             tools_mode = "ornith-route-tools-on-thinking-off"
+        elif profile_id == ORNITH_ANALYSIS_LINEAGE_ID:
+            # Same model, entirely different opening tokens, so the identity
+            # has to say so or a CHAT checkpoint could look valid here.
+            format_version = ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION
+            tokenizer_identity = ORNITH_ANALYSIS_TOKENIZER_IDENTITY
+            tools_mode = "ornith-analysis-tools-on-thinking-off"
         else:
             format_version = QWEN_ROUTE_PREFIX_FORMAT_VERSION
             tokenizer_identity = QWEN_ROUTE_TOKENIZER_IDENTITY
@@ -3165,7 +3260,12 @@ class NativeLlamaClient:
         profile_ids = (
             (profile_id,)
             if profile_id is not None
-            else (QWEN36_PROFILE_ID, QWEN3_CODER_PROFILE_ID, ORNITH15_PROFILE_ID)
+            else (
+                QWEN36_PROFILE_ID,
+                QWEN3_CODER_PROFILE_ID,
+                ORNITH15_PROFILE_ID,
+                ORNITH_ANALYSIS_LINEAGE_ID,
+            )
         )
         for selected_profile_id in profile_ids:
             state = self._qwen_route_prefix_state_for_profile(selected_profile_id)

--- a/src/orbit/native_llama/ornith_analysis_prefix.py
+++ b/src/orbit/native_llama/ornith_analysis_prefix.py
@@ -1,0 +1,105 @@
+"""The Ornith ANALYSIS prewarm prefix: same derivation, its own identity.
+
+An analysis step opens with a fixed contract -- the ANALYSIS system prompt and
+the `execute_analysis` schema -- and only then names the artifact and the
+analyst's instruction. That opening is identical for every session on a given
+profile, so it can be prefilled once and restored instead of re-evaluated.
+
+This is the CHAT route prefix mechanism with different content, not a second
+mechanism: the same `derive_qwen_route_prefix_spec`, the same
+`PrefixAnchorState`, the same capture and restore. Two things differ, and both
+are deliberate.
+
+The count is smaller. A whole first ANALYSIS request is around 480 tokens
+against roughly 840 for a route request, so the route's 768 cannot fit; the
+derivation would refuse it outright rather than shorten it. Measured on this
+template the invariant region is 451 tokens, and 384 sits inside it with room
+to spare.
+
+The identity is its own. Sharing the route lineage's format version and
+tokenizer identity would leave nothing but `model_id` separating an ANALYSIS
+checkpoint from a CHAT one on the same model, and those two prefixes are
+entirely different token sequences.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Mapping, Sequence
+
+from .qwen_route_prefix import (
+    QwenRoutePrefixConfig,
+    QwenRoutePrefixSpec,
+    QwenRoutePrefixStatus,
+    derive_qwen_route_prefix_spec,
+)
+
+
+ORNITH_ANALYSIS_PREFIX_ENV = "ORBIT_ORNITH_ANALYSIS_PREFIX_REUSE"
+
+# The lineage key. Every per-profile registry, identity and invalidation path
+# in the client is keyed by a profile id, so the analysis prefix takes a key of
+# its own rather than sharing Ornith's route key. It names a lineage, not a
+# model: it never reaches a model profile lookup, and the backend still learns
+# nothing about CHAT or ANALYSIS from it.
+ORNITH_ANALYSIS_LINEAGE_ID = "orbit-ornith15-native-v1#analysis"
+
+# 384: measured invariant region on this template is 451 tokens, so the
+# captured prefix stops 67 tokens short of anything that varies. The whole
+# request is ~480 tokens, which is why the route lineage's 768 is unusable
+# here rather than merely wasteful.
+ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT = 384
+ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION = "ornith15-analysis-prefix-v1"
+ORNITH_ANALYSIS_TOKENIZER_IDENTITY = "gpt2:qwen35"
+
+
+def resolve_ornith_analysis_prefix_reuse(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default_enabled: bool = True,
+) -> QwenRoutePrefixConfig:
+    env = os.environ if environ is None else environ
+    configured = env.get(ORNITH_ANALYSIS_PREFIX_ENV)
+    if configured is None:
+        return QwenRoutePrefixConfig(enabled=default_enabled, source="default")
+    value = configured.strip()
+    if value == "1":
+        return QwenRoutePrefixConfig(enabled=True, source="stable")
+    if value == "0":
+        return QwenRoutePrefixConfig(enabled=False, source="stable")
+    return QwenRoutePrefixConfig(
+        enabled=False,
+        source="stable",
+        validation_error="invalid_ornith_analysis_prefix_reuse_value",
+    )
+
+
+def derive_ornith_analysis_prefix_spec(
+    *,
+    system_prompt: str,
+    full_prompt: str,
+    full_tokens: Sequence[int],
+    render_reference: Callable[[str], str],
+    tokenize: Callable[[str], list[int]],
+) -> tuple[QwenRoutePrefixSpec | None, str | None]:
+    return derive_qwen_route_prefix_spec(
+        system_prompt=system_prompt,
+        full_prompt=full_prompt,
+        full_tokens=full_tokens,
+        render_reference=render_reference,
+        tokenize=tokenize,
+        prefix_token_count=ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT,
+    )
+
+
+__all__ = [
+    "ORNITH_ANALYSIS_LINEAGE_ID",
+    "ORNITH_ANALYSIS_PREFIX_ENV",
+    "ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION",
+    "ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT",
+    "ORNITH_ANALYSIS_TOKENIZER_IDENTITY",
+    "QwenRoutePrefixSpec",
+    "QwenRoutePrefixStatus",
+    "derive_ornith_analysis_prefix_spec",
+    "resolve_ornith_analysis_prefix_reuse",
+]

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -43,6 +43,7 @@ from orbit.native_llama.qwen36_shell_tool_prefix import (
     exact_qwen36_shell_tool_schema,
     resolve_qwen36_shell_tool_prefix_reuse,
 )
+from orbit.native_llama.ornith_analysis_prefix import resolve_ornith_analysis_prefix_reuse
 from orbit.native_llama.ornith_route_prefix import resolve_ornith_route_prefix_reuse
 from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_route_prefix_reuse
 from orbit.native_server.protocol import (
@@ -795,6 +796,7 @@ def run_server(argv: list[str] | None = None) -> int:
     qwen36_shell_tool_prefix_config = resolve_qwen36_shell_tool_prefix_reuse()
     qwen3_coder_route_prefix_config = resolve_qwen3_coder_route_prefix_reuse()
     ornith_route_prefix_config = resolve_ornith_route_prefix_reuse()
+    ornith_analysis_prefix_config = resolve_ornith_analysis_prefix_reuse()
 
     paths: NativeLlamaPaths | None = None
     try:
@@ -829,6 +831,9 @@ def run_server(argv: list[str] | None = None) -> int:
                 ornith_route_prefix_reuse_enabled=ornith_route_prefix_config.enabled,
                 ornith_route_prefix_reuse_source=ornith_route_prefix_config.source,
                 ornith_route_prefix_reuse_config_error=ornith_route_prefix_config.validation_error,
+                ornith_analysis_prefix_reuse_enabled=ornith_analysis_prefix_config.enabled,
+                ornith_analysis_prefix_reuse_source=ornith_analysis_prefix_config.source,
+                ornith_analysis_prefix_reuse_config_error=ornith_analysis_prefix_config.validation_error,
                 moe_expert_usage_enabled=args.moe_expert_usage,
                 low_memory=args.low_memory,
             ),

--- a/tests/test_ornith_analysis_prefix.py
+++ b/tests/test_ornith_analysis_prefix.py
@@ -1,0 +1,681 @@
+"""Exact-prefix ANALYSIS prewarm for verified Ornith, through the client seam.
+
+An analysis step opens with a fixed contract -- the ANALYSIS system prompt and
+the `execute_analysis` schema -- before it names the artifact or the analyst's
+instruction. These tests drive the real planner and per-lineage registry, not
+the derivation helper alone, because the properties that matter live in the
+wiring: that the captured prefix stops before anything session-specific, that
+an ANALYSIS checkpoint and a CHAT one can never stand in for each other, and
+that a rolling ANALYSIS checkpoint still outranks the prewarm.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.model_profiles import (
+    NativeModelProfile,
+    ORNITH15_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+)
+from orbit.native_llama.ornith_analysis_prefix import (
+    ORNITH_ANALYSIS_LINEAGE_ID,
+    ORNITH_ANALYSIS_PREFIX_ENV,
+    ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION,
+    ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT,
+    ORNITH_ANALYSIS_TOKENIZER_IDENTITY,
+    derive_ornith_analysis_prefix_spec,
+    resolve_ornith_analysis_prefix_reuse,
+)
+from orbit.native_llama.ornith_route_prefix import (
+    ORNITH_ROUTE_PREFIX_FORMAT_VERSION,
+    ORNITH_ROUTE_PREFIX_TOKEN_COUNT,
+)
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+from orbit.runtime.analysis_runtime import ANALYSIS_SYSTEM_PROMPT, ANALYSIS_TOOL_SCHEMA
+
+# Pinned literal: the prewarm captures this contract verbatim.
+ANALYSIS_SYSTEM_PROMPT_SHA256 = "313f3b7a8ae1c13379e1015a7abbc24ec313ef37949124b6355b98e3c4e0142e"
+
+
+class AnalysisPrefixConfigTests(unittest.TestCase):
+    def test_default_on_explicit_on_and_kill_switch(self) -> None:
+        self.assertTrue(resolve_ornith_analysis_prefix_reuse({}).enabled)
+        self.assertTrue(
+            resolve_ornith_analysis_prefix_reuse({ORNITH_ANALYSIS_PREFIX_ENV: "1"}).enabled
+        )
+        self.assertFalse(
+            resolve_ornith_analysis_prefix_reuse({ORNITH_ANALYSIS_PREFIX_ENV: "0"}).enabled
+        )
+
+    def test_invalid_value_disables_safely(self) -> None:
+        config = resolve_ornith_analysis_prefix_reuse({ORNITH_ANALYSIS_PREFIX_ENV: "maybe"})
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.validation_error, "invalid_ornith_analysis_prefix_reuse_value")
+
+    def test_env_switch_is_distinct_from_the_chat_one(self) -> None:
+        from orbit.native_llama.ornith_route_prefix import ORNITH_ROUTE_PREFIX_ENV
+
+        self.assertNotEqual(ORNITH_ANALYSIS_PREFIX_ENV, ORNITH_ROUTE_PREFIX_ENV)
+
+    def test_identity_constants_differ_from_the_chat_lineage(self) -> None:
+        # Same model and tokenizer family, entirely different opening tokens,
+        # so the format version is what keeps the two identities apart.
+        self.assertNotEqual(
+            ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION, ORNITH_ROUTE_PREFIX_FORMAT_VERSION
+        )
+        self.assertEqual(ORNITH_ANALYSIS_TOKENIZER_IDENTITY, "gpt2:qwen35")
+        self.assertNotEqual(ORNITH_ANALYSIS_LINEAGE_ID, ORNITH15_PROFILE_ID)
+
+    def test_count_is_smaller_than_the_route_count(self) -> None:
+        # A whole first ANALYSIS request is ~480 tokens against ~840 for a
+        # route request, so the route's count cannot fit here.
+        self.assertLess(ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT, ORNITH_ROUTE_PREFIX_TOKEN_COUNT)
+
+
+class AnalysisPrefixDerivationTests(unittest.TestCase):
+    """The derivation must refuse anything it cannot prove invariant."""
+
+    def _render(self, system: str):
+        def render(user: str) -> str:
+            return system + "\n<user>" + user + "</user>"
+
+        return render
+
+    def test_derives_the_fixed_prefix_before_dynamic_content(self) -> None:
+        system = "s" * 500
+        render = self._render(system)
+        full = render("Artifact under analysis: /workspace/input (21 bytes, sha256 abc).")
+
+        spec, reason = derive_ornith_analysis_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+
+        self.assertIsNone(reason)
+        assert spec is not None
+        self.assertEqual(len(spec.prefix_tokens), ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT)
+        self.assertGreater(spec.invariant_token_count, ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT)
+
+    def test_no_volatile_source_identity_survives_into_the_prefix(self) -> None:
+        system = "s" * 500
+        render = self._render(system)
+        full = render("Artifact under analysis: /workspace/input (4096 bytes, sha256 deadbeef).")
+        spec, _reason = derive_ornith_analysis_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        assert spec is not None
+        text = "".join(chr(t) for t in spec.prefix_tokens)
+
+        for volatile in ("deadbeef", "4096 bytes", "orbit-qwen-route-boundary", "<user>"):
+            self.assertNotIn(volatile, text, "no session-specific token may enter the prewarm")
+
+    def test_short_prompt_is_refused(self) -> None:
+        system = "s" * 10
+        render = self._render(system)
+        full = render("x")
+        spec, reason = derive_ornith_analysis_prefix_spec(
+            system_prompt=system,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "route_prompt_too_short")
+
+    def test_unstable_boundary_is_refused_not_trimmed(self) -> None:
+        # User text lands before the fixed count: refuse, never shorten.
+        head = "s" * 100
+
+        def render(user: str) -> str:
+            return head + user + "t" * 500
+
+        full = render("actual analyst message")
+        spec, reason = derive_ornith_analysis_prefix_spec(
+            system_prompt=head,
+            full_prompt=full,
+            full_tokens=[ord(c) for c in full],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        self.assertIsNone(spec)
+        self.assertIsNotNone(reason)
+
+    def test_production_prompt_diverging_from_the_reference_is_refused(self) -> None:
+        system = "s" * 500
+        render = self._render(system)
+        foreign = "DIFFERENT" + "s" * 500 + "\n<user>x</user>"
+        spec, reason = derive_ornith_analysis_prefix_spec(
+            system_prompt=system,
+            full_prompt=foreign,
+            full_tokens=[ord(c) for c in foreign],
+            render_reference=render,
+            tokenize=lambda t: [ord(c) for c in t],
+        )
+        self.assertIsNone(spec)
+        self.assertEqual(reason, "production_prefix_mismatch")
+
+
+class _FakeBridge:
+    """ChatML-shaped render whose output depends on the tools it is given."""
+
+    def __init__(self) -> None:
+        self.tool_calls: list[int] = []
+
+    def render(self, _context, messages, tools, *, thinking: bool):
+        assert not thinking
+        self.tool_calls.append(len(tools or []))
+        schema = f"<tools:{len(tools or [])}>"
+        # Schema first, as the real ChatML template renders it inside the
+        # system turn ahead of the rest of the contract.
+        body = schema + str(messages[0]["content"])
+        if len(messages) > 1:
+            body += "\n<user>" + str(messages[1]["content"]) + "</user>"
+        return {"prompt": body, "generation_prompt": ""}
+
+    def free(self, _context) -> None:
+        return None
+
+
+def _profile(**overrides) -> NativeModelProfile:
+    base = dict(
+        profile_id=ORNITH15_PROFILE_ID,
+        family="ornith1.5",
+        model_name="Ornith-1.5-35B",
+        architecture="qwen35moe",
+        renderer="llama.cpp-jinja",
+        reasoning_protocol="qwen-think",
+        tool_call_protocol="qwen3.6-xml",
+        history_serialization="qwen-leading-system-only",
+        verified=True,
+        failure_reason=None,
+        template_source="gguf-embedded-official",
+        template_sha256="f" * 64,
+        thinking_supported=True,
+        mtp_supported=False,
+        gemma_prefix_reuse_supported=False,
+        route_prefix_reuse_supported=True,
+        verified_quantization="Q4_K_M",
+    )
+    base.update(overrides)
+    return NativeModelProfile(**base)
+
+
+class AnalysisPrefixClientTests(unittest.TestCase):
+    def _client(self, *, profile=None, enabled=True, file_type="15") -> NativeLlamaClient:
+        paths = NativeLlamaPaths(
+            llama_root=Path("/llama"),
+            build_bin=Path("/llama/build/bin"),
+            library=Path("/llama/build/bin/libllama.so"),
+            model=Path("/models/ornith.gguf"),
+            model_id="legacy-path",
+        )
+        config = NativeClientConfig(
+            qwen_route_prefix_reuse_enabled=False,
+            qwen3_coder_route_prefix_reuse_enabled=False,
+            ornith_route_prefix_reuse_enabled=False,
+            ornith_analysis_prefix_reuse_enabled=enabled,
+        )
+        with mock.patch("orbit.native_llama.client.LlamaLibrary"):
+            client = NativeLlamaClient(paths, config)
+        client.model_profile = profile or _profile()
+        client._model_metadata_identity = {
+            "general.architecture": "qwen35moe",
+            "general.name": "Ornith-1.5-35B",
+            "general.file_type": file_type,
+            "tokenizer.ggml.model": "gpt2",
+            "tokenizer.ggml.pre": "qwen35",
+        }
+        client.chat_bridge = _FakeBridge()  # type: ignore[assignment]
+        client._chat_bridge_context = 1  # type: ignore[assignment]
+        client._model = 1  # type: ignore[assignment]
+        client._vocab = 1  # type: ignore[assignment]
+        client.tokenize = lambda text: [ord(c) for c in text]  # type: ignore[method-assign]
+        client._qwen_backend_build_identity = lambda: "build"  # type: ignore[method-assign]
+        return client
+
+    def _messages(self, artifact: str = "(21 bytes, sha256 abc)"):
+        return [
+            {"role": "system", "content": "s" * 500},
+            {"role": "user", "content": f"Artifact under analysis: /workspace/input {artifact}."},
+        ]
+
+    def _plan(self, client, artifact: str = "(21 bytes, sha256 abc)", *, lineage=True, tools=None):
+        messages = self._messages(artifact)
+        tools = [{"name": "execute_analysis"}] if tools is None else tools
+        prompt = client.apply_chat_template(messages, tools=tools, thinking=False)
+        return client._qwen_route_anchor_plan_for_prompt(
+            messages, tools=tools, thinking=False, prompt=prompt, analysis_lineage=lineage
+        )
+
+    # --- exact prefix ---------------------------------------------------
+    def test_plan_is_produced_on_the_analysis_lineage(self) -> None:
+        plan = self._plan(self._client())
+
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(plan.profile_id, ORNITH_ANALYSIS_LINEAGE_ID)
+        self.assertEqual(len(plan.prefix_tokens), ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT)
+
+    def test_prefix_is_exact_across_different_sources_and_messages(self) -> None:
+        client = self._client()
+        reference = self._plan(client)
+        assert reference is not None
+
+        for artifact in (
+            "(21 bytes, sha256 abc)",
+            "(4096 bytes, sha256 deadbeefcafe)",
+            "(1 bytes, sha256 0)",
+            "(5000000 bytes, sha256 " + "f" * 64 + ")",
+        ):
+            with self.subTest(artifact=artifact[:24]):
+                messages = self._messages(artifact)
+                tools = [{"name": "execute_analysis"}]
+                prompt = client.apply_chat_template(messages, tools=tools, thinking=False)
+                tokens = client.tokenize(prompt)
+                self.assertEqual(
+                    tuple(tokens[: len(reference.prefix_tokens)]),
+                    tuple(reference.prefix_tokens),
+                    "the prewarm must be an exact token prefix of every real request",
+                )
+
+    def test_prefix_stops_before_the_artifact_identity(self) -> None:
+        plan = self._plan(self._client(), "(4096 bytes, sha256 deadbeef)")
+        assert plan is not None
+        text = "".join(chr(t) for t in plan.prefix_tokens)
+
+        for volatile in ("deadbeef", "4096", "/workspace/input", "<user>"):
+            self.assertNotIn(volatile, text)
+
+    def test_the_tool_schema_is_inside_the_prefix(self) -> None:
+        # The schema is part of the fixed contract, so it must be captured --
+        # otherwise a changed tool surface would reuse the wrong prefix.
+        plan = self._plan(self._client())
+        assert plan is not None
+        self.assertIn("<tools:1>", "".join(chr(t) for t in plan.prefix_tokens))
+
+    # --- gating ---------------------------------------------------------
+    def test_disabled_config_produces_no_plan(self) -> None:
+        self.assertIsNone(self._plan(self._client(enabled=False)))
+
+    def test_thinking_produces_no_plan(self) -> None:
+        client = self._client()
+        messages = self._messages()
+        tools = [{"name": "execute_analysis"}]
+        prompt = client.apply_chat_template(messages, tools=tools, thinking=False)
+        self.assertIsNone(
+            client._qwen_route_anchor_plan_for_prompt(
+                messages, tools=tools, thinking=True, prompt=prompt, analysis_lineage=True
+            )
+        )
+
+    def test_a_different_tool_surface_produces_no_plan(self) -> None:
+        for tools in ([], [{"a": 1}, {"b": 2}]):
+            with self.subTest(tools=len(tools)):
+                self.assertIsNone(self._plan(self._client(), tools=tools))
+
+    def test_unverified_profile_or_quantization_produces_no_plan(self) -> None:
+        self.assertIsNone(self._plan(self._client(profile=_profile(verified=False))))
+        self.assertIsNone(self._plan(self._client(file_type="7")))
+
+    def test_foreign_profile_produces_no_plan(self) -> None:
+        client = self._client(profile=_profile(profile_id=QWEN3_CODER_PROFILE_ID))
+        self.assertIsNone(self._plan(client))
+
+
+class AnalysisPrefixIsolationTests(unittest.TestCase):
+    """CHAT and ANALYSIS prefixes must never stand in for each other."""
+
+    def _client(self):
+        return AnalysisPrefixClientTests._client(AnalysisPrefixClientTests("run"))
+
+    def test_each_lineage_keeps_its_own_slot(self) -> None:
+        client = self._client()
+        analysis = PrefixAnchorState(prefix_hash="analysis", token_count=384, valid=True)
+        chat = PrefixAnchorState(prefix_hash="chat", token_count=768, valid=True)
+
+        client._set_qwen_route_prefix_state(ORNITH_ANALYSIS_LINEAGE_ID, analysis)
+        client._set_qwen_route_prefix_state(ORNITH15_PROFILE_ID, chat)
+
+        self.assertIs(
+            client._qwen_route_prefix_state_for_profile(ORNITH_ANALYSIS_LINEAGE_ID), analysis
+        )
+        self.assertIs(client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID), chat)
+
+    def test_spec_and_status_slots_are_per_lineage(self) -> None:
+        client = self._client()
+        client._set_qwen_route_prefix_spec(ORNITH_ANALYSIS_LINEAGE_ID, "analysis-spec")  # type: ignore[arg-type]
+        client._set_qwen_route_prefix_spec(ORNITH15_PROFILE_ID, "chat-spec")  # type: ignore[arg-type]
+
+        self.assertEqual(
+            client._qwen_route_prefix_spec_for_profile(ORNITH_ANALYSIS_LINEAGE_ID), "analysis-spec"
+        )
+        self.assertEqual(
+            client._qwen_route_prefix_spec_for_profile(ORNITH15_PROFILE_ID), "chat-spec"
+        )
+        self.assertIsNot(
+            client._qwen_route_prefix_status_for_profile(ORNITH_ANALYSIS_LINEAGE_ID),
+            client._qwen_route_prefix_status_for_profile(ORNITH15_PROFILE_ID),
+        )
+
+    def test_identities_differ_so_neither_checkpoint_validates_the_other(self) -> None:
+        client = self._client()
+        spec = SimpleNamespace(prefix_token_hash="h", invariant_text_hash="i", system_prompt_hash="s")
+
+        analysis = client._qwen_route_prefix_state_kwargs(spec, profile_id=ORNITH_ANALYSIS_LINEAGE_ID)
+        chat = client._qwen_route_prefix_state_kwargs(spec, profile_id=ORNITH15_PROFILE_ID)
+
+        self.assertNotEqual(analysis["template_id"], chat["template_id"])
+        self.assertNotEqual(analysis["tools_mode"], chat["tools_mode"])
+
+    def test_analysis_lineage_never_returns_a_rolling_slot(self) -> None:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        start = text.index("def _qwen_route_prefix_state_for_profile")
+        registry = text[start : text.index("    def ", start + 50)]
+
+        self.assertNotIn("_rolling_analysis_anchor_state", registry)
+        self.assertNotIn("_rolling_route_anchor_state", registry)
+
+    def test_chat_lineage_refuses_a_prompt_carrying_the_analysis_tool(self) -> None:
+        client = self._client()
+        messages = AnalysisPrefixClientTests._messages(AnalysisPrefixClientTests("run"))
+        tools = [{"name": "execute_analysis"}]
+        prompt = client.apply_chat_template(messages, tools=tools, thinking=False)
+
+        self.assertIsNone(
+            client._qwen_route_anchor_plan_for_prompt(
+                messages, tools=tools, thinking=False, prompt=prompt, analysis_lineage=False
+            ),
+            "a tools-bearing prompt must not take the CHAT route-prefix lineage",
+        )
+
+
+class AnalysisPrefixInvalidationTests(unittest.TestCase):
+    def _client(self):
+        return AnalysisPrefixClientTests._client(AnalysisPrefixClientTests("run"))
+
+    def test_reset_invalidates_the_analysis_prefix(self) -> None:
+        client = self._client()
+        client._set_qwen_route_prefix_state(
+            ORNITH_ANALYSIS_LINEAGE_ID,
+            PrefixAnchorState(prefix_hash="p", token_count=384, valid=True),
+        )
+
+        client._invalidate_qwen_route_prefix("session_reset")
+
+        self.assertFalse(
+            client._qwen_route_prefix_state_for_profile(ORNITH_ANALYSIS_LINEAGE_ID).valid
+        )
+
+    def test_blanket_invalidation_covers_every_lineage(self) -> None:
+        client = self._client()
+        for lineage in (ORNITH_ANALYSIS_LINEAGE_ID, ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            client._set_qwen_route_prefix_state(
+                lineage, PrefixAnchorState(prefix_hash="p", token_count=384, valid=True)
+            )
+
+        client._invalidate_qwen_route_prefix("model_reload")
+
+        for lineage in (ORNITH_ANALYSIS_LINEAGE_ID, ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID):
+            self.assertFalse(client._qwen_route_prefix_state_for_profile(lineage).valid, lineage)
+
+    def test_targeted_invalidation_leaves_the_chat_lineage_alone(self) -> None:
+        client = self._client()
+        for lineage in (ORNITH_ANALYSIS_LINEAGE_ID, ORNITH15_PROFILE_ID):
+            client._set_qwen_route_prefix_state(
+                lineage, PrefixAnchorState(prefix_hash="p", token_count=384, valid=True)
+            )
+
+        client._invalidate_qwen_route_prefix("x", profile_id=ORNITH_ANALYSIS_LINEAGE_ID)
+
+        self.assertFalse(
+            client._qwen_route_prefix_state_for_profile(ORNITH_ANALYSIS_LINEAGE_ID).valid
+        )
+        self.assertTrue(client._qwen_route_prefix_state_for_profile(ORNITH15_PROFILE_ID).valid)
+
+    def test_session_reset_path_names_the_analysis_lineage(self) -> None:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        start = text.index("def reset_session_state")
+        block = text[start : text.index("    def ", start + 50)]
+
+        self.assertIn("ORNITH_ANALYSIS_LINEAGE_ID", block)
+
+
+class RollingAnalysisOutranksPrewarmTests(unittest.TestCase):
+    """Required priority: rolling ANALYSIS > ANALYSIS prewarm > cold."""
+
+    def _client(self):
+        return AnalysisPrefixClientTests._client(AnalysisPrefixClientTests("run"))
+
+    def _identity(self):
+        from orbit.native_llama.rolling_route_anchor import (
+            ROLLING_ANALYSIS_STRATEGY_ID,
+            RollingRouteIdentity,
+        )
+
+        return RollingRouteIdentity(
+            strategy_id=ROLLING_ANALYSIS_STRATEGY_ID,
+            session_id="default",
+            profile_id=ORNITH15_PROFILE_ID,
+            model_id="/models/ornith.gguf",
+            template_id="tpl",
+            tool_schema_hash="analysis-tools",
+            capability_summary_hash="caps",
+            runtime_policy_hash="policy",
+            native_version="libllama.so",
+            tools_mode="on",
+            reset_generation=0,
+        )
+
+    def test_a_usable_rolling_analysis_checkpoint_outranks_the_prewarm(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import RollingRouteAnchorState
+
+        client = self._client()
+        identity = self._identity()
+        saved = [1, 2, 3, 4, 5]
+        client._rolling_analysis_anchor_state = RollingRouteAnchorState(
+            identity=identity, tokens=list(saved), checkpoint_data=b"c", created_at_monotonic=1.0
+        )
+
+        self.assertTrue(
+            client._rolling_outranks_route_prefix(
+                saved + [6], rolling_route_eligible=True, rolling_route_identity=identity
+            ),
+            "rolling ANALYSIS must win when it can serve this prompt",
+        )
+
+    def test_the_guard_reads_the_analysis_rolling_slot_not_the_chat_one(self) -> None:
+        from orbit.native_llama.rolling_route_anchor import RollingRouteAnchorState
+
+        client = self._client()
+        identity = self._identity()
+        # Only the CHAT rolling slot holds anything; the analysis identity must
+        # not be served from it.
+        client._rolling_route_anchor_state = RollingRouteAnchorState(
+            identity=identity, tokens=[1, 2, 3], checkpoint_data=b"c", created_at_monotonic=1.0
+        )
+
+        self.assertFalse(
+            client._rolling_outranks_route_prefix(
+                [1, 2, 3, 4], rolling_route_eligible=True, rolling_route_identity=identity
+            )
+        )
+
+    def test_prewarm_still_runs_when_rolling_cannot_serve_the_prompt(self) -> None:
+        client = self._client()
+        identity = self._identity()
+
+        self.assertFalse(
+            client._rolling_outranks_route_prefix(
+                [9, 9, 9], rolling_route_eligible=True, rolling_route_identity=identity
+            ),
+            "a cold analysis session must still get its prewarm",
+        )
+
+
+class AnalysisPrewarmAddsNoModelCallTests(unittest.TestCase):
+    def _capture_block(self) -> str:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        start = text.index("def capture_qwen3_coder_route_prefix_prefill_only")
+        return text[start : text.index("    def ", start + 50)]
+
+    def test_capture_never_generates(self) -> None:
+        block = self._capture_block()
+        for forbidden in ("_generate_from_current_context", "llama_sampler_sample"):
+            self.assertNotIn(forbidden, block)
+
+    def test_analysis_step_makes_exactly_one_model_call(self) -> None:
+        import shutil
+        import tempfile
+
+        from orbit.backend.base import ChatResult
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime,
+            AnalysisWorkspace,
+            acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmp = Path(tempfile.mkdtemp(prefix="orbit-aprewarm-test-"))
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        artifact = tmp / "note.txt"
+        artifact.write_text("fixture\n", encoding="utf-8")
+        workspace = AnalysisWorkspace.create()
+        source = acquire_analysis_source(artifact, workspace.source_root)
+
+        class Backend:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                self.calls += 1
+                return ChatResult("ok", "scripted", "stop", [], 1, 1, 0, None, None)
+
+            def chat(self, *args, **kwargs):
+                return self.chat_stream(*args, **kwargs)
+
+        backend = Backend()
+        runtime = AnalysisRuntime(
+            backend=backend,
+            source=source,
+            evidence_store=EvidenceStore(root=tmp / "ev"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+
+        for expected in (1, 2, 3):
+            result = runtime.step("continue")
+            self.assertEqual(backend.calls, expected)
+            self.assertEqual(result.model_calls, 1)
+            self.assertTrue(result.control_returned)
+
+
+class AnalysisCaptureWiringTests(unittest.TestCase):
+    """Without a capture path the prewarm would be inert: nothing populates it."""
+
+    def _capture_block(self) -> str:
+        source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"
+        text = source.read_text(encoding="utf-8")
+        start = text.index("def capture_qwen3_coder_route_prefix_prefill_only")
+        return text[start : text.index("    def ", start + 50)]
+
+    def test_capture_accepts_the_analysis_lineage(self) -> None:
+        import inspect
+
+        sig = inspect.signature(NativeLlamaClient.capture_qwen3_coder_route_prefix_prefill_only)
+
+        self.assertIn("analysis_lineage", sig.parameters)
+        self.assertIn("tools", sig.parameters)
+
+    def test_capture_books_the_result_under_the_analysis_lineage(self) -> None:
+        block = self._capture_block()
+
+        self.assertIn("ORNITH_ANALYSIS_LINEAGE_ID", block)
+        self.assertIn("ornith_analysis_prefix_reuse_enabled", block)
+
+    def test_capture_passes_the_tools_through_to_the_planner(self) -> None:
+        block = self._capture_block()
+
+        # Rendering the capture without the schema would produce a different
+        # prompt from production and derivation would refuse it.
+        self.assertIn("capture_tools", block)
+        self.assertIn("analysis_lineage=analysis_lineage", block)
+
+    def test_capture_refuses_the_analysis_lineage_on_a_foreign_profile(self) -> None:
+        client = AnalysisPrefixClientTests._client(
+            AnalysisPrefixClientTests("run"), profile=_profile(profile_id=QWEN3_CODER_PROFILE_ID)
+        )
+        result = client.capture_qwen3_coder_route_prefix_prefill_only(
+            system_prompt="s" * 500, tools_mode="on", tools=[{"n": 1}], analysis_lineage=True
+        )
+        self.assertTrue(result.skipped)
+        self.assertEqual(result.skip_reason, "model_profile_ineligible")
+
+
+class AnalysisFallbackAttributionTests(unittest.TestCase):
+    def test_serve_time_fallback_is_recorded_against_the_plan_lineage(self) -> None:
+        client = AnalysisPrefixClientTests._client(AnalysisPrefixClientTests("run"))
+        plan = SimpleNamespace(prefix_tokens=[1, 2, 3], profile_id=ORNITH_ANALYSIS_LINEAGE_ID)
+        client.tokenize = lambda text: [9, 9, 9, 9]  # type: ignore[method-assign]
+        client._route_anchor_plan = lambda *a, **k: None  # type: ignore[method-assign]
+        client._session.ctx_tgt = object()
+        client._session.sampler = object()
+
+        with self.assertRaises(Exception):
+            client._complete_prompt_standard("p", qwen_route_anchor_plan=plan)
+
+        analysis_status = client._qwen_route_prefix_status_for_profile(ORNITH_ANALYSIS_LINEAGE_ID)
+        chat_status = client._qwen_route_prefix_status_for_profile(ORNITH15_PROFILE_ID)
+        self.assertEqual(analysis_status.failure_reason, "production_prefix_changed")
+        self.assertGreaterEqual(analysis_status.fallback_count, 1)
+        self.assertIsNone(chat_status.failure_reason, "the CHAT lineage must not absorb it")
+
+    def test_probe_tools_does_not_alias_the_module_level_schema(self) -> None:
+        import copy as _copy
+
+        original = _copy.deepcopy(ANALYSIS_TOOL_SCHEMA)
+        client = AnalysisPrefixClientTests._client(AnalysisPrefixClientTests("run"))
+        messages = AnalysisPrefixClientTests._messages(AnalysisPrefixClientTests("run"))
+        tools = [ANALYSIS_TOOL_SCHEMA]
+        prompt = client.apply_chat_template(messages, tools=tools, thinking=False)
+        client._qwen_route_anchor_plan_for_prompt(
+            messages, tools=tools, thinking=False, prompt=prompt, analysis_lineage=True
+        )
+
+        self.assertEqual(ANALYSIS_TOOL_SCHEMA, original, "the shared schema must not be mutated")
+
+
+class AnalysisPromptUnchangedTests(unittest.TestCase):
+    def test_analysis_system_prompt_is_untouched_by_this_mission(self) -> None:
+        import hashlib
+
+        # Pinned: the prewarm captures this contract, so a silent edit would
+        # change the prefix without changing the identity that guards it.
+        self.assertEqual(
+            hashlib.sha256(ANALYSIS_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
+            ANALYSIS_SYSTEM_PROMPT_SHA256,
+        )
+
+    def test_analysis_tool_surface_is_still_a_single_tool(self) -> None:
+        self.assertEqual(ANALYSIS_TOOL_SCHEMA["function"]["name"], "execute_analysis")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An analysis step opens with a fixed contract — the ANALYSIS system prompt and the
`execute_analysis` schema — before it names the artifact or the analyst's instruction.
That opening is prefilled once and restored instead of being evaluated again on the
first step of every analysis. Baseline: `bc25fff`.

## Design

- **Ornith-only ANALYSIS prewarm.** No other profile and no other mode changes.
- **384-token checkpoint from the real `llama.cpp-jinja` rendering.** The structural
  candidate (system contract + schema, minus the bridge's 6-token generation prompt)
  measures 448 tokens; the captured count is 384, inside a measured invariant region of
  451 — 67 tokens of margin. The route lineage's 768 is impossible here: a whole first
  request is ~480–552 tokens, and the derivation refuses 512+ with
  `route_prompt_too_short` rather than shortening.
- **Exact prefix checked before restore**, three times over: the derivation verifies the
  fixed count against two reference renders *and* the production prompt; the planner
  re-checks on the cached-spec path; `_complete_prompt_standard` re-checks at serve time.
  `prompt_tokens[:len(committed)] == committed` is untouched. No normalization, no LCP
  reuse, no fuzzy matching, no prompt rewriting.
- **Volatile source/session/analyst data excluded.** Verified as an exact prefix of five
  real first requests differing in source path, size (1 B → 5 000 B), SHA-256 and analyst
  message, with 93 tokens of minimum headroom. `AnalysisRuntime` already places the
  artifact identity in the turn *after* the system contract.
- **Separate ANALYSIS lineage** — its own registry slot, spec, status, env switch,
  format version and tools mode, so an ANALYSIS checkpoint and a CHAT one on the same
  model cannot validate each other.
- **Rolling ANALYSIS outranks the prewarm** (`rolling ANALYSIS > ANALYSIS prewarm >
  cold`). This needed no new code: the existing precedence guard resolves its slot from
  the identity's own `strategy_id`.
- **CHAT untouched** — the shared probe-render change is `… if analysis_lineage else []`,
  so non-analysis callers get the literal `[]` they had before.
- **No Gemma or routing changes. No prompt normalization. No extra model call** — capture
  is prefill-only.

## Authoritative canary

Ornith 1.5 35B-A3B (`orbit-ornith15-native-v1`, verified), benign 21-byte fixture,
CPU-only, three analyst steps:

| step | prompt | reused | evaluated | cache | prefill |
|---|---|---|---|---|---|
| cold | 552 | 0 | 552 | 0.0% | 14.2 s |
| prewarmed | 552 | 384 | 168 | 69.6% | 4.2 s |
| follow-up (rolling) | 653 | 552 | 101 | 84.5% | 2.8 s |

`reused + evaluated == prompt` on every step. The follow-up reuses **552** — step B's
full prompt — so rolling won over the 384 prewarm. One model call per step, at most one
action, control returned each time; the action reported length 21 for the 21-byte
fixture.

**Timing ratios are specific to this configuration and machine load and are not
generalized.** Token reuse is the portable result.

**Memory: ~70.3 MiB per ANALYSIS prewarm checkpoint** (73,736,684 B for 384 tokens).
Note this is not proportional to token count — halving the tokens versus the CHAT prewarm
saved only 7.5 MiB, because the checkpoint is dominated by fixed per-layer buffers.

## Qualification

- 41 new tests PASS
- 570 focused PASS
- 2511 full suite PASS
- 12/12 mutations CAUGHT
- compileall / diff-check PASS
- independent review PASS
- BLOCKER 0 / MAJOR 0 / MINOR 0

Two review MINORs were fixed: a serve-time fallback misattributed to the CHAT lineage
(pre-existing, newly reachable through this lineage), and a shallow copy that aliased the
module-level `ANALYSIS_TOOL_SCHEMA`.

## Deferred, deliberately not in this PR

A **pre-existing** crash surfaced during canary work: a small `max_tokens` can truncate a
tool call mid-JSON, and re-rendering that history later raises `RuntimeError` out of
`AnalysisRuntime.step()`, whose refusal guard wraps only `execute_analysis`. It depends
only on `max_tokens` and the bridge parser, both of which predate this branch, and this
candidate does not touch that path. It is recorded for its own mission, as is the Gemma
prefix-reuse audit.
