### PR TITLE
fix(runtime): reject malformed analysis tool calls before history commit

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -236,6 +236,28 @@ def acquire_analysis_source(original: Path | str, workspace: Path | str) -> Anal
     )
 
 
+def _unencodable(value: object) -> bool:
+    """Whether this would fail the exact serialization the bridge performs."""
+    try:
+        json.dumps(value, ensure_ascii=False).encode("utf-8")
+    except (UnicodeEncodeError, TypeError, ValueError):
+        return True
+    return False
+
+
+def _rejected_action_text(assistant_text: str, rejection: str) -> str:
+    """The assistant turn for a step whose tool call was refused.
+
+    The refused call is deliberately not carried here in any form. It is
+    described, so the next step's prompt tells the model plainly what was
+    wrong, without re-serialising output that could not be parsed in the
+    first place.
+    """
+    note = f"[action refused: {rejection}]"
+    text = assistant_text.strip()
+    return f"{text}\n\n{note}" if text else note
+
+
 def _raw_action_output(result: AnalysisResult) -> str:
     """The complete output of one action, for durable retention.
 
@@ -362,7 +384,36 @@ class AnalysisRuntime:
         self.model_calls += 1
 
         calls = list(response.tool_calls or [])
-        assistant: Message = {"role": "assistant", "content": response.content or ""}
+        content = response.content or ""
+        if _unencodable(content):
+            # Decoding makes this practically unreachable, but the cost of
+            # being wrong is the same permanently unrenderable history, and
+            # the check is one comparison.
+            content = content.encode("utf-8", "replace").decode("utf-8")
+        assistant: Message = {"role": "assistant", "content": content}
+
+        # Structure is judged before the turn is committed, not after. A tool
+        # call the model got wrong -- truncated mid-JSON by an output budget,
+        # say -- still has to be told to the analyst, but it must never enter
+        # the history: this history is append-only and is re-rendered whole on
+        # every later step, so one unparseable `tool_calls` entry makes every
+        # subsequent step fail to render and ends the session. Recording the
+        # rejection as prose keeps the turn truthful and the history usable.
+        rejection = self._structural_rejection(calls) if calls else None
+        if rejection is not None:
+            assistant["content"] = _rejected_action_text(content, rejection)
+            self.messages.append(assistant)
+            # No repair call: repairing would mean a second model invocation
+            # before the analyst has seen anything, which is the boundary this
+            # runtime exists to hold.
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=True,
+                action_executed=False,
+                assistant_text=response.content or "",
+                rejection=rejection,
+            )
+
         if calls:
             assistant["tool_calls"] = calls
         self.messages.append(assistant)
@@ -373,20 +424,6 @@ class AnalysisRuntime:
                 action_attempted=False,
                 action_executed=False,
                 assistant_text=response.content or "",
-            )
-
-        rejection = self._structural_rejection(calls)
-        if rejection is not None:
-            # No repair call: repairing would mean a second model invocation
-            # before the analyst has seen anything, which is the boundary this
-            # runtime exists to hold.
-            self._append_tool_result(calls[0], f"rejected: {rejection}")
-            return AnalysisStepResult(
-                model_calls=1,
-                action_attempted=True,
-                action_executed=False,
-                assistant_text=response.content or "",
-                rejection=rejection,
             )
 
         capacity_error = self._session_capacity_error()
@@ -536,10 +573,29 @@ class AnalysisRuntime:
         return digests
 
     def _structural_rejection(self, calls: list[dict[str, Any]]) -> str | None:
+        """Why this tool call cannot be committed, or None if it can.
+
+        The bar is not just "did the model mean something sensible" but "can
+        this turn survive being written into the history and rendered again".
+        The template renders the whole history on every later step and
+        serializes it with `ensure_ascii=False`, so a call that cannot be
+        encoded is refused here rather than left to fail a future step.
+        """
         if len(calls) > 1:
             return f"{len(calls)} tool calls in one response; at most one action per step"
         call = calls[0]
-        function = call.get("function") or {}
+        if not isinstance(call, dict):
+            return f"tool call is not an object: {type(call).__name__}"
+        # The template requires these too (common/chat.cpp: "Missing tool call
+        # type" / "Unsupported tool call type" / "Missing tool call function").
+        # Producers normalise the shape today, so this is defence in depth --
+        # cheap, against a failure whose cost is an unusable session.
+        call_type = call.get("type")
+        if call_type is not None and call_type != "function":
+            return f"unsupported tool call type: {call_type!r}"
+        function = call.get("function")
+        if not isinstance(function, dict):
+            return "tool call has no function object"
         name = function.get("name")
         if name != ANALYSIS_TOOL_NAME:
             return f"unsupported tool: {name!r}"
@@ -549,6 +605,10 @@ class AnalysisRuntime:
             return "tool arguments are not valid JSON"
         if not isinstance(arguments, dict) or not isinstance(arguments.get("code"), str):
             return "tool arguments must supply a 'code' string"
+        if _unencodable(call):
+            # Lone surrogates survive json.loads but not the UTF-8 encode the
+            # bridge performs, so committing one would break every later step.
+            return "tool call contains characters that cannot be encoded"
         return None
 
     def _append_tool_result(self, call: dict[str, Any], content: str) -> None:

--- a/tests/test_analysis_malformed_tool_output.py
+++ b/tests/test_analysis_malformed_tool_output.py
@@ -1,0 +1,494 @@
+"""Malformed model tool output must never enter the analysis history.
+
+The history an analysis session keeps is append-only and is re-rendered whole
+on every later step, so one `tool_calls` entry the template cannot parse ends
+the session: not at the step that produced it, but at the next one, when the
+prompt fails to render. A tool call the model got wrong therefore has to be
+judged before the turn is committed, and reported as prose instead.
+
+The scripted backend here fails the test if a step makes a second model call,
+because the tempting fix -- asking the model to repair its own output -- is
+exactly the human boundary this runtime exists to hold.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult
+from orbit.runtime.analysis_runtime import (
+    ANALYSIS_TOOL_NAME,
+    AnalysisRuntime,
+    AnalysisWorkspace,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore
+
+# Verbatim from the preserved reproduction: the model was cut off mid-string by
+# a small output budget, so the arguments JSON has no closing quote or brace.
+# Rendering a history containing this raises from the C++ template parser:
+#   RuntimeError: Failed to parse tool call arguments as JSON: ... parse_error.101
+PRESERVED_TRUNCATED_ARGS = (
+    '{"code": "import orbit_tools\\ndata = orbit_tools.read_file(\\"/workspace/input\\")\\n'
+    'print(\\"length:\\", len(data))\\nprint(\\"repr:\\", repr(data))\\n'
+)
+
+
+def call(name: str = ANALYSIS_TOOL_NAME, arguments: str = '{"code": "print(1)"}', call_id: str = "call_0"):
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}
+
+
+class SingleCallBackend:
+    """Scripted, and hostile to a hidden second model call within one step."""
+
+    def __init__(self, responses: list[tuple[str, list[dict]]]) -> None:
+        self._responses = responses
+        self.calls = 0
+        self.calls_this_step = 0
+
+    def begin_step(self) -> None:
+        self.calls_this_step = 0
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None):
+        self.calls += 1
+        self.calls_this_step += 1
+        if self.calls_this_step > 1:
+            raise AssertionError("a step made a second model call")
+        content, tool_calls = self._responses[min(self.calls - 1, len(self._responses) - 1)]
+        if on_delta:
+            on_delta(content)
+        return ChatResult(content, "scripted", "stop", list(tool_calls), 1, 1, 0, None, None)
+
+    def chat(self, *args, **kwargs):
+        return self.chat_stream(*args, **kwargs)
+
+
+class MalformedToolOutputTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="orbit-malformed-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.artifact = self.tmp / "note.txt"
+        self.artifact.write_text("orbit canary fixture\n", encoding="utf-8")
+
+    def runtime(self, responses):
+        backend = SingleCallBackend(responses)
+        workspace = AnalysisWorkspace.create()
+        source = acquire_analysis_source(self.artifact, workspace.source_root)
+        built = AnalysisRuntime(
+            backend=backend,
+            source=source,
+            evidence_store=EvidenceStore(root=self.tmp / f"ev{id(workspace)}"),
+            workspace=workspace,
+        )
+        self.addCleanup(built.close)
+        return built, backend
+
+    def step(self, runtime, backend, text):
+        backend.begin_step()
+        return runtime.step(text)
+
+    def assert_history_renderable(self, runtime) -> None:
+        """Every tool_calls entry must parse, as the real template requires."""
+        for message in runtime.messages:
+            for entry in message.get("tool_calls") or []:
+                raw = entry.get("function", {}).get("arguments")
+                json.loads(raw)  # raises exactly where the bridge would
+
+    def assert_history_serializable(self, runtime) -> None:
+        json.dumps(runtime.messages)
+
+
+class PreservedReproductionTest(MalformedToolOutputTestBase):
+    """Case 1: the exact truncated JSON from the preserved reproduction."""
+
+    def responses(self):
+        return [("reading the file", [call(arguments=PRESERVED_TRUNCATED_ARGS)]), ("done", [])]
+
+    def test_the_preserved_truncated_call_is_refused(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+
+        result = self.step(runtime, backend, "read the file and report its length")
+
+        self.assertEqual(result.rejection, "tool arguments are not valid JSON")
+        self.assertTrue(result.action_attempted)
+        self.assertFalse(result.action_executed)
+        self.assertTrue(result.control_returned)
+
+    def test_history_stays_renderable_after_the_truncated_call(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+
+        self.step(runtime, backend, "read it")
+
+        self.assert_history_renderable(runtime)
+        self.assert_history_serializable(runtime)
+
+    def test_no_poisoned_assistant_turn_is_appended(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+
+        self.step(runtime, backend, "read it")
+
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message, "the refused call must not be committed")
+
+    def test_the_analyst_can_continue_afterwards(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+        self.step(runtime, backend, "read it")
+
+        result = self.step(runtime, backend, "continue")
+
+        self.assertEqual(result.model_calls, 1)
+        self.assertTrue(result.control_returned)
+        self.assert_history_renderable(runtime)
+
+    def test_zero_tools_executed(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+        self.step(runtime, backend, "read it")
+        self.assertEqual(runtime.actions_executed, 0)
+
+    def test_only_one_model_call_for_the_refused_step(self) -> None:
+        runtime, backend = self.runtime(self.responses())
+        self.step(runtime, backend, "read it")
+        self.assertEqual(backend.calls, 1)
+
+
+class MalformedShapeTest(MalformedToolOutputTestBase):
+    """Cases 2-4: every structural defect refuses without committing."""
+
+    CASES = {
+        "truncated_json": (PRESERVED_TRUNCATED_ARGS, "tool arguments are not valid JSON"),
+        "not_json_at_all": ("not json", "tool arguments are not valid JSON"),
+        "empty_arguments": ("", "tool arguments are not valid JSON"),
+        "json_but_not_an_object": ('"a string"', "tool arguments must supply a 'code' string"),
+        "missing_code_key": ('{"source": "print(1)"}', "tool arguments must supply a 'code' string"),
+        "code_not_a_string": ('{"code": 17}', "tool arguments must supply a 'code' string"),
+    }
+
+    def test_each_malformed_shape_refuses_and_leaves_history_clean(self) -> None:
+        for name, (arguments, expected) in self.CASES.items():
+            with self.subTest(case=name):
+                runtime, backend = self.runtime([("trying", [call(arguments=arguments)])])
+
+                result = self.step(runtime, backend, "go")
+
+                self.assertEqual(result.rejection, expected)
+                self.assertFalse(result.action_executed)
+                self.assertEqual(runtime.actions_executed, 0)
+                self.assert_history_renderable(runtime)
+                for message in runtime.messages:
+                    self.assertNotIn("tool_calls", message)
+
+    def test_unknown_tool_is_refused_without_committing(self) -> None:
+        runtime, backend = self.runtime([("trying", [call(name="rm_rf")])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIn("unsupported tool", result.rejection or "")
+        self.assertEqual(runtime.actions_executed, 0)
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message)
+
+    def test_multiple_tool_calls_are_refused_without_committing(self) -> None:
+        runtime, backend = self.runtime(
+            [("trying", [call(call_id="call_0"), call(call_id="call_1")])]
+        )
+
+        result = self.step(runtime, backend, "do two things")
+
+        self.assertIn("at most one action per step", result.rejection or "")
+        self.assertEqual(runtime.actions_executed, 0)
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message)
+
+
+class UnrenderableButParseableTest(MalformedToolOutputTestBase):
+    """Valid JSON is not enough: the turn must also survive being rendered.
+
+    The bridge serializes the history with `ensure_ascii=False` and encodes it
+    as UTF-8, so a lone surrogate parses fine and then breaks every later step
+    exactly like the truncated call did.
+    """
+
+    def test_a_lone_surrogate_in_code_is_refused(self) -> None:
+        runtime, backend = self.runtime(
+            [("trying", [call(arguments=json.dumps({"code": "print(1)"})[:-2] + '\\ud800"}')])]
+        )
+        result = self.step(runtime, backend, "go")
+        self.assertIsNotNone(result.rejection)
+
+    def test_a_surrogate_anywhere_in_the_call_is_refused(self) -> None:
+        for field in ("code", "id", "name"):
+            with self.subTest(field=field):
+                entry = call()
+                if field == "code":
+                    entry["function"]["arguments"] = '{"code": "\ud800"}'
+                elif field == "id":
+                    entry["id"] = "\ud800"
+                else:
+                    entry["function"]["name"] = "\ud800"
+                runtime, backend = self.runtime([("trying", [entry])])
+
+                result = self.step(runtime, backend, "go")
+
+                self.assertIsNotNone(result.rejection, f"{field} surrogate must be refused")
+                self.assertEqual(runtime.actions_executed, 0)
+
+    def test_committed_history_always_survives_the_bridge_encoding(self) -> None:
+        entry = call()
+        entry["function"]["arguments"] = '{"code": "\ud800"}'
+        runtime, backend = self.runtime([("trying", [entry]), ("ok", [])])
+        self.step(runtime, backend, "go")
+
+        # Exactly what bindings.render does before the C++ call.
+        json.dumps(runtime.messages, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+    def test_a_non_object_tool_call_is_refused_not_raised(self) -> None:
+        runtime, backend = self.runtime([("trying", ["not an object"])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIn("not an object", result.rejection or "")
+        self.assertEqual(runtime.actions_executed, 0)
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message)
+
+    def test_a_call_without_a_function_object_is_refused(self) -> None:
+        for entry in ({"id": "c0", "type": "function"}, {"id": "c0", "function": None}):
+            with self.subTest(entry=str(entry)):
+                runtime, backend = self.runtime([("trying", [entry])])
+                result = self.step(runtime, backend, "go")
+                self.assertIsNotNone(result.rejection)
+                self.assertEqual(runtime.actions_executed, 0)
+
+
+class TemplateShapeRequirementsTest(MalformedToolOutputTestBase):
+    """The template rejects more shapes than json.loads does."""
+
+    def test_a_non_function_call_type_is_refused(self) -> None:
+        entry = call()
+        entry["type"] = "custom"
+        runtime, backend = self.runtime([("trying", [entry])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIn("unsupported tool call type", result.rejection or "")
+        self.assertEqual(runtime.actions_executed, 0)
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message)
+
+    def test_a_missing_type_is_still_accepted(self) -> None:
+        # The template only objects to a *wrong* type; omitting it is fine and
+        # must not become a spurious refusal.
+        entry = call()
+        del entry["type"]
+        runtime, backend = self.runtime([("trying", [entry])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIsNone(result.rejection)
+
+    def test_a_missing_function_object_is_refused_by_name(self) -> None:
+        runtime, backend = self.runtime([("trying", [{"id": "c0", "type": "function"}])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIn("no function object", result.rejection or "")
+
+    def test_unencodable_assistant_content_never_reaches_history(self) -> None:
+        # Practically unreachable -- decoding uses errors="replace" -- but the
+        # consequence would be the same unrenderable history.
+        runtime, backend = self.runtime([("bad \ud800 text", [])])
+
+        self.step(runtime, backend, "go")
+
+        json.dumps(runtime.messages, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+class ValidOutputParityTest(MalformedToolOutputTestBase):
+    """Cases 5-6: nothing changes for output that is actually well formed."""
+
+    def test_a_valid_single_call_is_still_committed_with_its_tool_calls(self) -> None:
+        runtime, backend = self.runtime([("running", [call()])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertIsNone(result.rejection)
+        self.assertTrue(result.action_attempted)
+        assistant = [m for m in runtime.messages if m["role"] == "assistant"][-1]
+        self.assertIn("tool_calls", assistant, "a valid call must still reach the history")
+        self.assert_history_renderable(runtime)
+
+    def test_plain_prose_is_committed_unchanged(self) -> None:
+        runtime, backend = self.runtime([("just thinking out loud", [])])
+
+        result = self.step(runtime, backend, "what do you see?")
+
+        self.assertIsNone(result.rejection)
+        self.assertFalse(result.action_attempted)
+        assistant = [m for m in runtime.messages if m["role"] == "assistant"][-1]
+        self.assertEqual(assistant["content"], "just thinking out loud")
+        self.assertNotIn("tool_calls", assistant)
+
+    def test_the_refusal_is_visible_to_the_analyst_in_history(self) -> None:
+        runtime, backend = self.runtime([("trying", [call(arguments="not json")])])
+
+        self.step(runtime, backend, "go")
+
+        assistant = [m for m in runtime.messages if m["role"] == "assistant"][-1]
+        self.assertIn("refused", assistant["content"])
+        self.assertIn("not valid JSON", assistant["content"])
+
+    def test_the_refused_arguments_are_not_echoed_into_history(self) -> None:
+        marker = '{"code": "SECRETMARKER_UNTERMINATED'
+        runtime, backend = self.runtime([("trying", [call(arguments=marker)])])
+
+        self.step(runtime, backend, "go")
+
+        self.assertNotIn("SECRETMARKER_UNTERMINATED", json.dumps(runtime.messages))
+
+
+class AppendOnlyRecoveryTest(MalformedToolOutputTestBase):
+    """Cases 9, 11: recovery must not rewrite what came before."""
+
+    def test_history_remains_append_only_across_a_refusal(self) -> None:
+        runtime, backend = self.runtime(
+            [("ok", [call()]), ("trying", [call(arguments="not json")]), ("fine", [])]
+        )
+        self.step(runtime, backend, "first")
+        prefix = [dict(m) for m in runtime.messages]
+
+        self.step(runtime, backend, "second")
+        self.assertEqual(runtime.messages[: len(prefix)], prefix)
+
+        self.step(runtime, backend, "third")
+        self.assertEqual(runtime.messages[: len(prefix)], prefix)
+
+    def test_a_refusal_does_not_advance_the_action_count(self) -> None:
+        runtime, backend = self.runtime(
+            [("ok", [call()]), ("trying", [call(arguments="not json")])]
+        )
+        self.step(runtime, backend, "first")
+        after_valid = runtime.actions_executed
+
+        self.step(runtime, backend, "second")
+
+        self.assertEqual(runtime.actions_executed, after_valid)
+
+    def test_several_consecutive_refusals_keep_the_session_usable(self) -> None:
+        runtime, backend = self.runtime([("trying", [call(arguments=PRESERVED_TRUNCATED_ARGS)])])
+
+        for _ in range(3):
+            result = self.step(runtime, backend, "try again")
+            self.assertIsNotNone(result.rejection)
+
+        self.assert_history_renderable(runtime)
+        self.assertEqual(backend.calls, 3, "one model call per analyst step")
+
+    def test_analyst_turn_count_matches_the_steps_taken(self) -> None:
+        runtime, backend = self.runtime([("trying", [call(arguments="not json")])])
+        for _ in range(2):
+            self.step(runtime, backend, "go")
+        self.assertEqual(runtime.analyst_turns, 2)
+
+
+class NoHiddenRepairCallTest(MalformedToolOutputTestBase):
+    """Case 10: refusing must never trigger a repair or finalization call."""
+
+    def test_a_refused_step_makes_exactly_one_model_call(self) -> None:
+        runtime, backend = self.runtime([("trying", [call(arguments="not json")])])
+
+        result = self.step(runtime, backend, "go")
+
+        self.assertEqual(result.model_calls, 1)
+        self.assertEqual(backend.calls_this_step, 1)
+
+    def test_the_backend_would_fail_the_test_on_a_second_call(self) -> None:
+        # Guards the guard: the harness must actually detect a repair call.
+        runtime, backend = self.runtime([("trying", [call(arguments="not json")])])
+        backend.begin_step()
+        backend.chat_stream([], temperature=0.0, max_tokens=1)
+
+        with self.assertRaises(AssertionError):
+            backend.chat_stream([], temperature=0.0, max_tokens=1)
+
+
+class InternalFailuresStillPropagateTest(MalformedToolOutputTestBase):
+    """The fix must not become a broad exception swallow."""
+
+    def test_a_backend_failure_is_not_disguised_as_a_rejection(self) -> None:
+        class Failing(SingleCallBackend):
+            def chat_stream(self, *args, **kwargs):
+                raise RuntimeError("backend exploded")
+
+        runtime, backend = self.runtime([("x", [])])
+        runtime.backend = Failing([])
+
+        with self.assertRaises(RuntimeError):
+            runtime.step("go")
+
+    def test_step_does_not_wrap_the_model_call_in_a_try(self) -> None:
+        source = (SRC / "orbit" / "runtime" / "analysis_runtime.py").read_text(encoding="utf-8")
+        start = source.index("def step(self, analyst_message")
+        head = source[start : source.index("self.model_calls += 1", start)]
+
+        self.assertNotIn("try:", head, "the model call must not be broadly guarded")
+
+    def test_structural_rejection_only_inspects_parsed_output(self) -> None:
+        source = (SRC / "orbit" / "runtime" / "analysis_runtime.py").read_text(encoding="utf-8")
+        start = source.index("def _structural_rejection")
+        block = source[start : source.index("    def ", start + 50)]
+
+        # Narrow, structural checks only -- no blanket `except Exception`.
+        self.assertIn("except (TypeError, json.JSONDecodeError)", block)
+        self.assertNotIn("except Exception", block)
+
+
+class StrictPrefixAfterRefusalTest(MalformedToolOutputTestBase):
+    """Case 14: KV reuse must survive a refused step."""
+
+    def test_each_step_extends_the_previous_history_exactly(self) -> None:
+        runtime, backend = self.runtime(
+            [("ok", [call()]), ("trying", [call(arguments="not json")]), ("more", [])]
+        )
+        snapshots = []
+        for text in ("first", "second", "third"):
+            self.step(runtime, backend, text)
+            snapshots.append([dict(m) for m in runtime.messages])
+
+        for earlier, later in zip(snapshots, snapshots[1:]):
+            self.assertEqual(later[: len(earlier)], earlier)
+
+    def test_the_prompt_sent_after_a_refusal_extends_the_one_before_it(self) -> None:
+        seen: list[list[dict]] = []
+
+        class Recording(SingleCallBackend):
+            def chat_stream(self, messages, **kwargs):
+                seen.append([dict(m) for m in messages])
+                return super().chat_stream(messages, **kwargs)
+
+        runtime, backend = self.runtime([("x", [])])
+        recording = Recording(
+            [("trying", [call(arguments=PRESERVED_TRUNCATED_ARGS)]), ("after", [])]
+        )
+        runtime.backend = recording
+
+        recording.begin_step()
+        runtime.step("first")
+        recording.begin_step()
+        runtime.step("second")
+
+        self.assertEqual(len(seen), 2)
+        self.assertEqual(seen[1][: len(seen[0])], seen[0], "strict prefix must survive a refusal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -244,8 +244,13 @@ class StructuralRejectionTest(AnalysisRuntimeTestBase):
         backend = ScriptedBackend(tool_response("print('x')", count=2))
         runtime = self.runtime(backend)
         runtime.step("do two things")
-        self.assertEqual(runtime.messages[-1]["role"], "tool")
-        self.assertIn("rejected", runtime.messages[-1]["content"])
+        # Recorded in the assistant turn rather than a tool turn: a tool turn
+        # would have to answer a `tool_calls` entry, and committing the refused
+        # call is exactly what makes the history unrenderable afterwards.
+        last = runtime.messages[-1]
+        self.assertEqual(last["role"], "assistant")
+        self.assertIn("refused", last["content"])
+        self.assertNotIn("tool_calls", last)
 
 
 class SourceOwnershipTest(AnalysisRuntimeTestBase):


### PR DESCRIPTION
Fixes a **pre-existing ANALYSIS history-poisoning bug**. Baseline: `7ef0da1`.

An output budget can truncate the model mid-tool-call, leaving unterminated JSON in
its arguments. That turn was appended to the append-only history *before* validation,
and the history is re-rendered whole on every later step — so the session did not fail
on the step that produced the bad call, it failed on the **next** one, when the prompt
could no longer render and `RuntimeError` escaped the runtime entirely.

## The fix

**The structural rejection already existed; the ordering was wrong.**
`_structural_rejection()` ran *after* the append. It now runs first.

- **Malformed/truncated tool output is rejected before invalid `tool_calls` enter
  history.** The refused turn is recorded as prose: the model's text with
  `[action refused: <reason>]` appended, and **no `tool_calls` at all**. A tool turn is
  not used, because a tool turn must answer the very entry that cannot be committed —
  so the old shape was only accidentally survivable.
- **Refused calls execute zero tools**; `actions_executed` does not advance.
- **No automatic repair or model retry.** The scripted backend in the new tests raises
  if a step makes a second model call.
- **One-call / at-most-one-action / human-return semantics unchanged.**
- **Valid tool calls and plain prose are committed exactly as before.**
- **ANALYSIS rolling KV and prewarm preserved** — history stays append-only, so a
  strict prefix still holds across a refusal.
- **CHAT untouched.** No routing, KV, prewarm, parser, backend, Gemma, sandbox-policy
  or EvidenceStore changes.

While moving the check it also learned the rest of what the template requires: a call
that is not an object, a call type that is not `"function"`, a missing function object,
and — the one `json.loads` misses — anything that parses but fails the bridge's
`ensure_ascii=False` UTF-8 encode, such as a lone surrogate arriving via a `\ud800`
escape. `_unencodable` mirrors `bindings.py:438` exactly.

### Accepted semantic change

`assistant malformed output → structural rejection recorded as assistant content → no
tool turn → human regains control`. One existing assertion was updated accordingly; it
is strictly stronger than before (it now also pins `tool_calls` absent) and fails
against the unfixed parent.

## Real Ornith canary

One run, no retries. Ornith 1.5 35B-A3B, benign 21-byte fixture, **`max_tokens=48`** —
the exact budget that originally caused the crash:

| | result |
|---|---|
| truncated call reproduced | yes |
| crash | **none** |
| actions executed | **0** |
| rejection | `tool arguments are not valid JSON` (truthful) |
| control returned | yes, both steps |
| history renderable through the real template | **yes** |
| next analyst step | succeeds, **553 of 595 prompt tokens reused** |

Where the session previously died, it now stays fully usable.

## Qualification

- 33 new tests PASS
- 494 focused PASS
- 2544 full suite PASS
- 13/13 mutations CAUGHT
- compileall / diff-check PASS
- independent review PASS
- BLOCKER 0 / MAJOR 0 / MINOR 0

The reviewer copied the new suite onto the unfixed parent: 12 of 29 tests fail there,
confirming the coverage is causal rather than vacuous.

A separate, **pre-existing** flaky test (`test_temporary_directories_do_not_accumulate`,
which globs the shared temp dir) reproduces on the clean parent and is deliberately
**not** fixed here; it is recorded as its own TODO.
