### PR TITLE
feat(runtime): add automatic analysis routing

### DIFF
--- a/src/orbit/native_llama/ornith_route_prefix.py
+++ b/src/orbit/native_llama/ornith_route_prefix.py
@@ -29,10 +29,11 @@ from .qwen_route_prefix import (
 
 ORNITH_ROUTE_PREFIX_ENV = "ORBIT_ORNITH_ROUTE_PREFIX_REUSE"
 
-# 768, as for the other profiles. Measured headroom on this template: the
-# rendered route system turn ends at token 825, and the two reference renders
-# share 828, so the captured prefix stops well inside the invariant region and
-# never reaches the user turn.
+# 768, as for the other profiles. Re-measured after the route language gained
+# its ANALYSIS form: the two reference renders now share 925 tokens, so the
+# captured prefix stops 157 tokens short of anything that varies and never
+# reaches the user turn. Derivation is fail-closed -- a prompt that ever
+# shrank below this count would be refused, not silently shortened.
 ORNITH_ROUTE_PREFIX_TOKEN_COUNT = 768
 ORNITH_ROUTE_PREFIX_FORMAT_VERSION = "ornith15-route-prefix-v1"
 ORNITH_ROUTE_TOKENIZER_IDENTITY = "gpt2:qwen35"

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -216,7 +216,21 @@ class AnalysisStepResult:
 def acquire_analysis_source(original: Path | str, workspace: Path | str) -> AnalysisSource:
     """Copy the artifact into Orbit-owned storage and identify it by content."""
     source = Path(original)
-    data = source.read_bytes()
+    return snapshot_analysis_bytes(
+        source.read_bytes(), workspace=workspace, original_path=str(source)
+    )
+
+
+def snapshot_analysis_bytes(
+    data: bytes, *, workspace: Path | str, original_path: str
+) -> AnalysisSource:
+    """Store already-acquired bytes as the session's immutable source.
+
+    The caller has the bytes because it opened the file itself; handing them
+    here rather than a path is what stops the file being opened a second time,
+    when it might no longer be the same file. `original_path` is carried for
+    the analyst to read and is never reopened.
+    """
     digest = hashlib.sha256(data).hexdigest()
     root = Path(workspace)
     root.mkdir(parents=True, exist_ok=True)
@@ -232,7 +246,7 @@ def acquire_analysis_source(original: Path | str, workspace: Path | str) -> Anal
         snapshot_path=snapshot,
         sha256=digest,
         size_bytes=len(data),
-        original_path=str(source),
+        original_path=original_path,
     )
 
 

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -168,6 +168,10 @@ class ChatRuntime:
     current_user_turn_id: str | None = None
     current_turn_evidence_sequence_start: int = 0
     completed_evidence_ids: set[str] = field(default_factory=set, repr=False)
+    # Set when the route asked for artifact analysis. The caller owns the
+    # transition: this runtime has no analysis session and must not start one,
+    # so it reports the request and answers nothing.
+    last_analysis_request: str | None = None
     last_chat_projection_used: bool = False
     last_chat_projection_fallback_reason: str | None = None
     last_chat_projection_omitted_evidence_count: int = 0
@@ -194,6 +198,7 @@ class ChatRuntime:
         return self.local_capabilities
 
     def _begin_user_turn(self) -> str:
+        self.last_analysis_request = None
         self.user_turn_counter += 1
         self.current_user_turn_id = f"turn_{self.user_turn_counter}"
         sequences = (
@@ -783,6 +788,12 @@ class ChatRuntime:
                 if on_final_delta and not streamed_final_retry and not retried_empty_final:
                     on_final_delta(first.content)
                 return self._remember_visible_result_streamed(_visible_delta, _delta_sink, first)
+        if decision.route == ToolRoute.ANALYSIS and decision.artifact:
+            # Reported, not acted on: opening a session is the caller's job,
+            # and running a filesystem tool first would both answer the wrong
+            # question and spend a model call the analysis step needs.
+            self.last_analysis_request = decision.artifact
+            return self._remember_visible_result_streamed(_visible_delta, _delta_sink, first)
         if decision.route == ToolRoute.CHAT:
             chat_messages = self._chat_final_messages()
             with model_call_context(phase="chat_final", tools_mode="on"):

--- a/src/orbit/runtime/command_request.py
+++ b/src/orbit/runtime/command_request.py
@@ -25,12 +25,18 @@ class ToolRoute(StrEnum):
     FILE_EDIT = "FILE_EDIT"
     WEB = "WEB"
     MEDIA = "MEDIA"
+    ANALYSIS = "ANALYSIS"
 
 
 @dataclass(frozen=True)
 class RouteDecision:
     route: ToolRoute
     tool_names: tuple[str, ...] = ()
+    # The artifact an ANALYSIS decision names. Every other route leaves this
+    # empty; the runtime needs it because an analysis session is bound to one
+    # file at construction, and re-deriving it from prose is exactly the
+    # guesswork this route form exists to avoid.
+    artifact: str | None = None
 
 
 class RouteOutputClass(StrEnum):
@@ -304,6 +310,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
         return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
     if _has_system_info_args(value):
         return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
+    if _has_analysis_route(value):
+        return _analysis_decision(value)
     if _has_chat_route(value):
         return RouteDecision(ToolRoute.CHAT)
     if _has_command(_extract_loose_command_object(text)):
@@ -320,6 +328,8 @@ def parse_command_decision(content: str) -> RouteDecision | None:
             return RouteDecision(ToolRoute.FILESYSTEM, ("list_directory",))
         if _has_system_info_args(value):
             return RouteDecision(ToolRoute.FILESYSTEM, ("system_info",))
+        if _has_analysis_route(value):
+            return _analysis_decision(value)
         if _has_chat_route(value):
             return RouteDecision(ToolRoute.CHAT)
     return None
@@ -611,6 +621,27 @@ def _artifact_args(value: dict[str, Any]) -> dict[str, Any]:
         for key in ("path", "overwrite", "create_parents")
         if key in value
     }
+
+
+def _has_analysis_route(value: dict[str, Any] | None) -> bool:
+    """`{"route":"ANALYSIS","artifact":"..."}` and nothing looser.
+
+    The artifact is required: an ANALYSIS decision without one cannot open a
+    session, and treating it as a bare route would silently drop the request
+    into a mode that has nothing to analyse. `artifact` rather than `path`
+    because a bare `path` key already means "list this directory" here.
+    """
+    if not isinstance(value, dict):
+        return False
+    route = value.get("route")
+    if not isinstance(route, str) or route.strip().upper() != ToolRoute.ANALYSIS.value:
+        return False
+    artifact = value.get("artifact")
+    return isinstance(artifact, str) and bool(artifact.strip())
+
+
+def _analysis_decision(value: dict[str, Any]) -> RouteDecision:
+    return RouteDecision(ToolRoute.ANALYSIS, (), str(value["artifact"]).strip())
 
 
 def _has_chat_route(value: dict[str, Any] | None) -> bool:

--- a/src/orbit/runtime/confined_acquire.py
+++ b/src/orbit/runtime/confined_acquire.py
@@ -1,0 +1,170 @@
+"""Acquiring one model-named file without ever trusting the name twice.
+
+A path that has been checked and then reopened has not been secured, only
+inspected: between the two the name can be pointed somewhere else, and the
+bytes that arrive are whichever file it points to last. That is not a
+hypothetical here -- validating a pathname and reopening it later let an
+outside file be snapshotted on a few racing turns out of a hundred, which is
+exactly the shape of bug that hides behind a green test run.
+
+So this module never returns a path for someone else to open. It walks the
+path one component at a time relative to an open directory descriptor, with
+`O_NOFOLLOW` on every step, opens the final component once, proves through
+`fstat` that the thing it is holding is a regular file, and reads the bytes
+from that same descriptor. The security decision and the read are made about
+one object, so there is no interval for anything to change underneath them.
+
+Symlinks are refused outright rather than resolved, including on intermediate
+components. For an analyst typing a path that would be unhelpfully strict; for
+a path chosen by a model out of text it has just read, following a link is
+precisely what must not happen.
+
+The read-time checks are deliberately close to `file_tools._read_stable_
+regular_file`, which already solved this for text. This one exists because an
+artifact under analysis is arbitrary bytes: no decoding, no text ceiling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Large enough for the artifacts an analyst actually brings, small enough that
+# a mistaken target cannot exhaust memory before it is rejected.
+MAX_ACQUIRE_BYTES = 64 * 1024 * 1024
+
+
+class ConfinedAcquireError(Exception):
+    """The named file could not be safely acquired from inside the workdir."""
+
+
+@dataclass(frozen=True)
+class AcquiredBytes:
+    """Bytes taken from one opened inode, with the identity they came from."""
+
+    data: bytes
+    sha256: str
+    size_bytes: int
+    # What the caller asked for, kept for the analyst-facing message only. It
+    # is never reopened: the bytes above are the source of truth.
+    requested_path: str
+    resolved_path: str
+
+
+def acquire_confined_bytes(
+    raw_path: str,
+    *,
+    workdir: Path,
+    max_bytes: int = MAX_ACQUIRE_BYTES,
+) -> AcquiredBytes:
+    """Read one regular file confined to `workdir`, refusing every symlink.
+
+    Raises `ConfinedAcquireError` for anything that is not a plain regular
+    file reachable from the workdir without traversing a link.
+    """
+    if not isinstance(raw_path, str):
+        raise ConfinedAcquireError("artifact path must be a string")
+    supplied = raw_path.strip()
+    if not supplied:
+        raise ConfinedAcquireError("artifact path is empty")
+    if "\x00" in supplied:
+        raise ConfinedAcquireError("artifact path contains a NUL byte")
+
+    try:
+        root = workdir.expanduser().resolve()
+        # `expanduser` here mirrors what a caller would expect of `~`, but the
+        # result still has to survive containment below, so expanding cannot
+        # widen what is reachable.
+        candidate = Path(supplied).expanduser()
+        lexical = Path(os.path.abspath(candidate if candidate.is_absolute() else root / candidate))
+        relative = lexical.relative_to(root)
+    except ValueError:
+        raise ConfinedAcquireError("artifact path escapes the workdir") from None
+    except (OSError, RuntimeError) as exc:
+        # `~nosuchuser` and malformed inputs land here.
+        raise ConfinedAcquireError(f"artifact path cannot be resolved: {exc}") from exc
+
+    if not relative.parts:
+        raise ConfinedAcquireError("artifact path is the workdir itself")
+
+    directory_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_DIRECTORY", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:  # pragma: no cover - refuse rather than silently follow
+        raise ConfinedAcquireError("platform cannot open files without following symlinks")
+
+    directory_fd = -1
+    file_fd = -1
+    try:
+        directory_fd = os.open(root, directory_flags)
+        for part in relative.parts[:-1]:
+            # O_NOFOLLOW on every intermediate component: a symlinked parent
+            # directory is as good an escape as a symlinked file.
+            next_fd = os.open(part, directory_flags | nofollow, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = next_fd
+        file_fd = os.open(
+            relative.parts[-1],
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | nofollow | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=directory_fd,
+        )
+
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ConfinedAcquireError("artifact is not a regular file")
+        if before.st_size > max_bytes:
+            raise ConfinedAcquireError(
+                f"artifact is too large: {before.st_size} bytes, max {max_bytes}"
+            )
+
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(file_fd, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > max_bytes:
+            raise ConfinedAcquireError(f"artifact is too large: more than {max_bytes} bytes")
+
+        after = os.fstat(file_fd)
+        if _version(before) != _version(after):
+            raise ConfinedAcquireError("artifact changed while it was being read")
+    except ConfinedAcquireError:
+        raise
+    except OSError as exc:
+        if exc.errno in (getattr(os, "ELOOP", 40), 40):
+            raise ConfinedAcquireError("artifact path contains a symlink") from exc
+        raise ConfinedAcquireError(f"artifact cannot be read: {exc}") from exc
+    finally:
+        for descriptor in (file_fd, directory_fd):
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+
+    return AcquiredBytes(
+        data=data,
+        sha256=hashlib.sha256(data).hexdigest(),
+        size_bytes=len(data),
+        requested_path=supplied,
+        resolved_path=str(lexical),
+    )
+
+
+def _version(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns)
+
+
+__all__ = [
+    "MAX_ACQUIRE_BYTES",
+    "AcquiredBytes",
+    "ConfinedAcquireError",
+    "acquire_confined_bytes",
+]

--- a/src/orbit/runtime/messages.py
+++ b/src/orbit/runtime/messages.py
@@ -40,6 +40,8 @@ If the latest request is only a recap, repeat, summary, explanation, comparison,
 Call tools for fresh/current data, verification, changed files/state, new information, or missing/stale/ambiguous/insufficient prior context.
 Web/search/latest/current/online and URL fetch/read/open/explain/summarize/analyze requests are tool tasks; return a compact tool decision, not a direct answer.
 Specific file read/explain/summarize/analyze requests require file content evidence; return a content-reading command decision, not a directory listing.
+Reading, summarizing, explaining or answering questions about a file is a content-reading command, never ANALYSIS.
+Use ANALYSIS only when the request asks to investigate one named local artifact as an artifact: derive findings, extract indicators, decode or reconstruct transformations, or determine behaviour. It runs isolated code against that file across several steps.
 If the target is a file path or filename, use a content-reading command; do not inspect it with list_directory.
 Use directory listing only when the user asks to list files or inspect directory structure; never use {{"path":"..."}} to answer about a file's contents.
 The one-sentence direct-answer exception below is only for requests that are not tool tasks and need no external evidence.
@@ -66,6 +68,9 @@ For URL fetch/read page:
 For normal no-tool final answer pass:
 {{"route":"CHAT"}}
 
+For isolated artifact analysis of one local file:
+{{"route":"ANALYSIS","artifact":"samples/foo.js"}}
+
 For compact directory listing only:
 {{"path":".","recursive":false}}
 
@@ -84,7 +89,7 @@ Create/save one bounded UTF-8 text file ->
 {{"tool":"write_artifact","arguments":{{"path":"x","overwrite":false,"create_parents":true}}}}
 Use model-selected values; never emit file content in this route pass.
 
-For analysis, prefer content, source, binaries, strings, logs, archives, or fetched data, not metadata."""
+When gathering evidence with a command, prefer content, source, binaries, strings, logs, archives, or fetched data, not metadata."""
 ROUTE_SYSTEM_PROMPT = _COMMAND_SYSTEM_TEMPLATE.format(os_name=_detect_os(), shell_name=_detect_shell())
 TOOL_CALL_SYSTEM_PROMPT = (
     "Call exactly one available tool and output no prose. "

--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -22,7 +22,9 @@ from orbit.runtime.analysis_runtime import (
     AnalysisStepResult,
     AnalysisWorkspace,
     acquire_analysis_source,
+    snapshot_analysis_bytes,
 )
+from orbit.runtime.confined_acquire import ConfinedAcquireError, acquire_confined_bytes
 from orbit.runtime.evidence import EvidenceStore
 
 
@@ -52,6 +54,52 @@ def open_analysis_session(
     except OSError as exc:
         workspace.close()
         raise AnalysisModeError(f"cannot read artifact: {exc}") from exc
+    except Exception:
+        workspace.close()
+        raise
+    return AnalysisRuntime(
+        backend=backend,
+        source=source,
+        evidence_store=evidence_store,
+        workspace=workspace,
+    )
+
+
+def open_confined_analysis_session(
+    raw_path: str,
+    *,
+    backend: ChatBackend,
+    workdir: Path,
+    evidence_store_factory: Callable[[Path], EvidenceStore],
+    on_acquired: Callable[[], None] | None = None,
+) -> AnalysisRuntime:
+    """Open a session on a path the model chose, acquiring it safely.
+
+    The difference from `open_analysis_session` is that the file is opened
+    once, under the workdir, following no symlinks, and the bytes come from
+    that same descriptor. Nothing downstream reopens the name, so there is no
+    window in which it can be pointed elsewhere.
+
+    `on_acquired` is a test seam: it runs after the bytes are held and before
+    the snapshot exists, which is exactly the interval an attacker would want.
+    """
+    try:
+        acquired = acquire_confined_bytes(raw_path, workdir=workdir)
+    except ConfinedAcquireError as exc:
+        raise AnalysisModeError(str(exc)) from exc
+    if on_acquired is not None:
+        on_acquired()
+    workspace = AnalysisWorkspace.create()
+    try:
+        source = snapshot_analysis_bytes(
+            acquired.data,
+            workspace=workspace.source_root,
+            original_path=acquired.resolved_path,
+        )
+        evidence_store = evidence_store_factory(workspace.root)
+    except OSError as exc:
+        workspace.close()
+        raise AnalysisModeError(f"cannot store artifact: {exc}") from exc
     except Exception:
         workspace.close()
         raise

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -4,6 +4,7 @@ import sys
 import time
 from pathlib import Path
 from dataclasses import dataclass, field, replace
+from typing import Callable
 
 from orbit.backend.base import ChatResult, StreamPromptMetrics
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
@@ -18,6 +19,7 @@ from orbit.terminal.analysis_mode import (
     AnalysisModeError,
     format_analysis_step,
     open_analysis_session,
+    open_confined_analysis_session,
 )
 from orbit.terminal.compact_reports import format_memory_compaction_report, format_tool_compaction_report
 from orbit.terminal.command_actions import CommandAction, build_list_action, build_models_action, build_read_action, build_search_action
@@ -59,6 +61,10 @@ class Repl:
     can_continue: bool = False
     tools_mode: ToolSpec | None = None
     workflow_mode: WorkflowMode = DEFAULT_WORKFLOW_MODE
+    # Runs between acquiring the artifact's bytes and storing them. Only a
+    # test sets this; it exists so the swap window can be exercised
+    # deterministically instead of raced for.
+    _analysis_acquired_hook: Callable[[], None] | None = field(default=None, repr=False)
     analysis: AnalysisRuntime | None = field(default=None, repr=False)
     queued_prompts: list[str] = field(default_factory=list)
     turn_model_steps: list[ModelStepMetrics] = field(default_factory=list, repr=False)
@@ -234,6 +240,18 @@ class Repl:
             renderer.finish()
             raise
         renderer.finish()
+        if self.workflow_mode is WorkflowMode.CHAT and self.runtime.last_analysis_request:
+            # The route asked for artifact analysis. Nothing was answered and
+            # no tool ran, so the analyst's original request is still owed a
+            # reply -- it becomes the first analyst step of the new session.
+            if self._enter_analysis_from_route(self.runtime.last_analysis_request):
+                self._ask_analysis(prompt)
+                return
+            # Refused: the route turn answered nothing, so rewinding leaves no
+            # unanswered user turn behind for every later prompt to carry.
+            self.runtime.restore_message_count(checkpoint)
+            self.runtime.last_analysis_request = None
+            return
         self._save_session()
         elapsed = time.monotonic() - started
         print("\n\n", end="", flush=True)
@@ -544,6 +562,45 @@ class Repl:
         self.backend.thinking = self.config.think
         self.runtime.thinking_mode = self.config.think
         return f"think: {value}"
+
+    def _enter_analysis_from_route(self, artifact: str) -> bool:
+        """Open an analysis session the route asked for. True if it opened.
+
+        The path came from the model, not the analyst, so it is acquired
+        rather than merely checked: opened once under the workdir, following
+        no symlink on any component, with the bytes read from that same
+        descriptor. An earlier version validated the name and let the session
+        reopen it, which left a window in which the name could be pointed at
+        an outside file between the two -- reproducibly, on a few racing turns
+        in a hundred. Nothing here hands a pathname on to be opened again.
+
+        Explicit `/analysis` keeps its own, wider policy: the analyst typed
+        that path and may legitimately name anything on the machine.
+        """
+        try:
+            runtime = open_confined_analysis_session(
+                artifact,
+                backend=self.backend,
+                workdir=self.config.workdir,
+                evidence_store_factory=self._analysis_evidence_store,
+                on_acquired=self._analysis_acquired_hook,
+            )
+        except AnalysisModeError as exc:
+            print(f"error: refusing analysis: {exc}", file=sys.stderr)
+            return False
+        self._close_analysis()
+        self.analysis = runtime
+        self.workflow_mode = WorkflowMode.ANALYSIS
+        self.can_continue = False
+        source = runtime.source
+        print(
+            dim(
+                f"mode: ANALYSIS | {source.original_path} "
+                f"({source.size_bytes} bytes, sha256 {source.sha256})"
+            ),
+            flush=True,
+        )
+        return True
 
     def _handle_analysis_command(self, arguments: str) -> str:
         """Enter ANALYSIS on one artifact. No model call happens here."""

--- a/tests/test_automatic_analysis_routing.py
+++ b/tests/test_automatic_analysis_routing.py
@@ -1,0 +1,834 @@
+"""Automatic CHAT -> ANALYSIS recognition, decided by the route call itself.
+
+The distinction has to come from the model's route decision, not from the
+runtime inspecting the user's words. So the route language gained one form,
+`{"route":"ANALYSIS","artifact":"..."}`, and everything here checks that the
+form is honoured exactly: that it carries a path (a session cannot open
+without one), that it never becomes a catch-all for reads and summaries, and
+that recognising it costs one route call and no classifier of its own.
+
+The scripted backends count their calls, because the failure this design most
+needs to avoid is a second model call quietly appearing per turn.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult
+from orbit.runtime import ChatRuntime
+from orbit.runtime.command_request import (
+    RouteDecision,
+    ToolRoute,
+    decision_tool_names,
+    parse_command_decision,
+)
+from orbit.runtime.evidence import EvidenceStore
+from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT
+from orbit.runtime.workflow_mode import WorkflowMode
+from orbit.terminal.config import AppConfig
+from orbit.terminal.repl import Repl
+
+# The qualified route prompt. Changing the route language forces the Ornith
+# CHAT prewarm to be re-derived, so this pin and that requalification move
+# together or not at all.
+ROUTE_PROMPT_SHA256 = "d38e293a1d8fc0efb5371cff08bb5870ffc4faa6b96b889ff2af54ba2b66a38d"
+
+
+class RouteLanguageTest(unittest.TestCase):
+    """The parser side: one new form, nothing else disturbed."""
+
+    def test_the_analysis_form_parses_with_its_artifact(self) -> None:
+        decision = parse_command_decision('{"route":"ANALYSIS","artifact":"samples/foo.js"}')
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.route, ToolRoute.ANALYSIS)
+        self.assertEqual(decision.artifact, "samples/foo.js")
+
+    def test_analysis_without_an_artifact_is_not_a_decision(self) -> None:
+        # A session is bound to one file at construction, so a route that
+        # names none cannot be honoured and must not masquerade as a bare
+        # route either.
+        for text in ('{"route":"ANALYSIS"}', '{"route":"ANALYSIS","artifact":"   "}',
+                     '{"route":"ANALYSIS","artifact":null}', '{"route":"ANALYSIS","artifact":7}'):
+            with self.subTest(text=text):
+                self.assertIsNone(parse_command_decision(text))
+
+    def test_the_artifact_is_carried_verbatim(self) -> None:
+        for path in ("samples/foo.js", "/abs/path/x.bin", "deeply/nested/name.dat", "a"):
+            with self.subTest(path=path):
+                decision = parse_command_decision(json.dumps({"route": "ANALYSIS", "artifact": path}))
+                assert decision is not None
+                self.assertEqual(decision.artifact, path)
+
+    def test_analysis_offers_no_chat_tools(self) -> None:
+        decision = RouteDecision(ToolRoute.ANALYSIS, (), "x.js")
+        self.assertEqual(decision_tool_names(decision), ())
+
+    def test_every_other_route_still_carries_no_artifact(self) -> None:
+        for text in ('{"route":"CHAT"}', '{"command":"cat README.md"}', '{"url":"https://x"}',
+                     '{"path":".","recursive":false}'):
+            with self.subTest(text=text):
+                decision = parse_command_decision(text)
+                assert decision is not None
+                self.assertIsNone(decision.artifact)
+
+
+class ExistingRouteParityTest(unittest.TestCase):
+    """Case: nothing that routed correctly before may route differently now."""
+
+    CORPUS = {
+        '{"route":"CHAT"}': (ToolRoute.CHAT, ()),
+        '{"command":"cat README.md"}': (ToolRoute.FILESYSTEM, ("exec_shell_full_command",)),
+        '{"command":"ls -la"}': (ToolRoute.FILESYSTEM, ("exec_shell_full_command",)),
+        '{"command":"orbit-web-search \\"x\\""}': (ToolRoute.FILESYSTEM, ("exec_shell_full_command",)),
+        '{"url":"https://example.com"}': (ToolRoute.FILESYSTEM, ("fetch_url",)),
+        '{"path":".","recursive":false}': (ToolRoute.FILESYSTEM, ("list_directory",)),
+        '{"include_cpu":true,"include_memory":true,"include_disks":true,"include_os":true}':
+            (ToolRoute.FILESYSTEM, ("system_info",)),
+        '{"tool":"write_artifact","arguments":{"path":"x","overwrite":false,"create_parents":true}}':
+            (ToolRoute.FILESYSTEM, ("write_artifact",)),
+    }
+
+    def test_the_existing_corpus_routes_exactly_as_before(self) -> None:
+        for text, (route, tools) in self.CORPUS.items():
+            with self.subTest(text=text[:40]):
+                decision = parse_command_decision(text)
+                assert decision is not None, text
+                self.assertEqual(decision.route, route)
+                self.assertEqual(decision_tool_names(decision), tools)
+                self.assertNotEqual(decision.route, ToolRoute.ANALYSIS)
+
+    def test_a_file_read_is_never_analysis(self) -> None:
+        # The failure mode this guards: ANALYSIS quietly swallowing every
+        # request that mentions a file.
+        for text in ('{"command":"cat README.md"}', '{"command":"head -20 config.json"}',
+                     '{"command":"strings sample.bin"}'):
+            with self.subTest(text=text):
+                decision = parse_command_decision(text)
+                assert decision is not None
+                self.assertEqual(decision.route, ToolRoute.FILESYSTEM)
+
+    def test_a_hedged_output_keeps_its_existing_filesystem_decision(self) -> None:
+        """Precedence: filesystem key-shapes win over a hedged ANALYSIS route.
+
+        The single most load-bearing decision for parity is that
+        `_has_analysis_route` is checked AFTER the filesystem predicates. A
+        model that hedges -- naming a route and a command in one object --
+        must keep doing exactly what it did before this mission.
+        """
+        cases = {
+            '{"route":"ANALYSIS","artifact":"x.js","command":"cat y"}':
+                (ToolRoute.FILESYSTEM, ("exec_shell_full_command",)),
+            '{"route":"ANALYSIS","artifact":"x.js","path":".","recursive":false}':
+                (ToolRoute.FILESYSTEM, ("list_directory",)),
+            '{"route":"ANALYSIS","artifact":"x.js","url":"https://example.com"}':
+                (ToolRoute.FILESYSTEM, ("fetch_url",)),
+        }
+        for text, (route, tools) in cases.items():
+            with self.subTest(text=text[:48]):
+                decision = parse_command_decision(text)
+                assert decision is not None
+                self.assertEqual(decision.route, route, "filesystem shapes must win")
+                self.assertEqual(decision_tool_names(decision), tools)
+                self.assertIsNone(decision.artifact)
+
+    def test_a_chat_route_carrying_an_artifact_key_stays_chat(self) -> None:
+        decision = parse_command_decision('{"route":"CHAT","artifact":"x.js"}')
+
+        assert decision is not None
+        self.assertEqual(decision.route, ToolRoute.CHAT)
+        self.assertIsNone(decision.artifact)
+
+    def test_malformed_route_output_is_still_no_decision(self) -> None:
+        for text in ("", "not json", "{", '{"route":"NONSENSE"}', '{"artifact":"x.js"}'):
+            with self.subTest(text=text):
+                self.assertIsNone(parse_command_decision(text))
+
+
+class RoutePromptTest(unittest.TestCase):
+    def test_the_route_prompt_matches_the_qualified_pin(self) -> None:
+        self.assertEqual(
+            hashlib.sha256(ROUTE_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
+            ROUTE_PROMPT_SHA256,
+        )
+
+    def test_the_prompt_teaches_the_analysis_form_and_its_boundary(self) -> None:
+        self.assertIn('{"route":"ANALYSIS","artifact":', ROUTE_SYSTEM_PROMPT)
+        # And says plainly what must NOT take it.
+        self.assertIn("never ANALYSIS", ROUTE_SYSTEM_PROMPT)
+
+    def test_the_prompt_still_teaches_the_existing_forms(self) -> None:
+        for form in ('{"route":"CHAT"}', '{"command":"cat README.md"}', '{"url":"https://example.com"}'):
+            self.assertIn(form, ROUTE_SYSTEM_PROMPT)
+
+
+class CountingBackend:
+    """Answers the route call, then any analysis call. Counts both."""
+
+    def __init__(self, route_payload: str, analysis_text: str = "looking at it") -> None:
+        self.route_payload = route_payload
+        self.analysis_text = analysis_text
+        self.route_calls = 0
+        self.analysis_calls = 0
+
+    def _is_analysis(self, tools) -> bool:
+        return bool(tools) and tools[0].get("function", {}).get("name") == "execute_analysis"
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None):
+        if self._is_analysis(tools):
+            self.analysis_calls += 1
+            content = self.analysis_text
+        else:
+            self.route_calls += 1
+            content = self.route_payload
+        if on_delta:
+            on_delta(content)
+        return ChatResult(content, "scripted", "stop", [], 1, 1, 0, None, None)
+
+    def chat(self, *args, **kwargs):
+        return self.chat_stream(*args, **kwargs)
+
+    def server_tools(self):
+        return []
+
+    def display_model_name(self):
+        return "scripted"
+
+
+class TransitionTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="orbit-autoroute-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.artifact = self.tmp / "foo.js"
+        self.artifact.write_text("var a = 1;\n", encoding="utf-8")
+
+    def repl(self, backend):
+        runtime = ChatRuntime(backend=backend, system_prompt=None)
+        runtime.evidence_store = EvidenceStore(root=self.tmp / "evidence")
+        built = Repl(runtime=runtime, backend=backend, config=AppConfig(workdir=self.tmp))
+        built.tools_mode = "on"
+        self.addCleanup(built._close_analysis)
+        return built
+
+    def ask(self, repl, prompt):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(out):
+            repl._ask(prompt)
+        return out.getvalue()
+
+    def analysis_payload(self, artifact=None):
+        return json.dumps({"route": "ANALYSIS", "artifact": str(artifact or self.artifact)})
+
+
+class AutomaticTransitionTest(TransitionTestBase):
+    def test_an_analysis_route_enters_analysis(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js as an artifact and extract indicators")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsNotNone(repl.analysis)
+
+    def test_the_original_request_becomes_the_first_analyst_step(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+        request = "extract indicators and reconstruct transformations from foo.js"
+
+        self.ask(repl, request)
+
+        user_turns = [m for m in repl.analysis.messages if m["role"] == "user"]
+        self.assertEqual(user_turns[-1]["content"], request, "the request must reach step 1 unchanged")
+        self.assertEqual(repl.analysis.analyst_turns, 1)
+
+    def test_exactly_one_route_call_and_one_analysis_call(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js as an artifact")
+
+        self.assertEqual(backend.route_calls, 1, "no second classifier call")
+        self.assertEqual(backend.analysis_calls, 1, "exactly one analysis step")
+
+    def test_no_chat_tool_runs_before_the_transition(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js as an artifact")
+
+        self.assertFalse(
+            any(m.get("role") == "tool" for m in repl.runtime.messages),
+            "a filesystem tool must not answer first",
+        )
+
+    def test_the_route_turn_answers_nothing_and_runs_no_tool(self) -> None:
+        """The runtime must stop at the route, not fall through to CHAT work.
+
+        Deleting the early return leaves the ANALYSIS decision falling into the
+        filesystem branch, which both answers the wrong question and spends the
+        model call the analysis step needs.
+        """
+        calls: list[str] = []
+
+        class Watching(CountingBackend):
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                calls.append("analysis" if self._is_analysis(tools) else "route")
+                return super().chat_stream(
+                    messages, temperature=temperature, max_tokens=max_tokens,
+                    tools=tools, on_delta=on_delta, on_progress=on_progress,
+                )
+
+        backend = Watching(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js as an artifact")
+
+        # Exactly the route call, then exactly the analysis step. Anything in
+        # between is CHAT work that should never have happened.
+        self.assertEqual(calls, ["route", "analysis"])
+
+    def test_no_assistant_answer_is_appended_to_chat_history(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js as an artifact")
+
+        # The route turn produced no answer: the reply is owed to the analysis
+        # step, so CHAT history must not carry a finalized assistant answer.
+        assistants = [m for m in repl.runtime.messages if m.get("role") == "assistant"]
+        self.assertEqual(assistants, [], "the route turn must not answer in CHAT")
+
+    def test_the_session_is_bound_to_the_routed_artifact(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js")
+
+        self.assertEqual(repl.analysis.source.original_path, str(self.artifact))
+
+    def test_the_human_boundary_holds_on_the_first_step(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze foo.js")
+
+        self.assertEqual(repl.analysis.model_calls, 1)
+        self.assertEqual(repl.analysis.actions_executed, 0)
+
+
+class NoTransitionTest(TransitionTestBase):
+    """Ordinary CHAT turns must be untouched."""
+
+    def test_a_chat_route_stays_in_chat(self) -> None:
+        backend = CountingBackend('{"route":"CHAT"}')
+        repl = self.repl(backend)
+        repl.runtime.ask_auto = lambda prompt, **kw: ChatResult("ok", "s", "stop", [], 1, 1, 0, None, None)
+
+        self.ask(repl, "explain XOR")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+
+    def test_a_filesystem_route_stays_in_chat(self) -> None:
+        seen: list[str] = []
+        backend = CountingBackend('{"command":"cat README.md"}')
+        repl = self.repl(backend)
+        repl.runtime.ask_auto = lambda prompt, **kw: (
+            seen.append(prompt) or ChatResult("ok", "s", "stop", [], 1, 1, 0, None, None)
+        )
+
+        self.ask(repl, "summarize README.md")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertEqual(seen, ["summarize README.md"])
+
+    def test_the_signal_is_cleared_between_turns(self) -> None:
+        backend = CountingBackend('{"route":"CHAT"}')
+        repl = self.repl(backend)
+        repl.runtime.last_analysis_request = "stale/path.js"
+        repl.runtime.ask_auto = lambda prompt, **kw: ChatResult("ok", "s", "stop", [], 1, 1, 0, None, None)
+
+        self.ask(repl, "hello")
+
+        # ask_auto is stubbed here, so assert the runtime clears it itself.
+        repl.runtime._begin_user_turn()
+        self.assertIsNone(repl.runtime.last_analysis_request)
+
+
+class InvalidArtifactTest(TransitionTestBase):
+    def test_a_missing_artifact_path_does_not_enter_analysis(self) -> None:
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+
+        output = self.ask(repl, "analyze nope.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertIn("refusing analysis", output)
+
+    def test_a_directory_artifact_is_refused(self) -> None:
+        backend = CountingBackend(self.analysis_payload(self.tmp))
+        repl = self.repl(backend)
+
+        output = self.ask(repl, "analyze that directory")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIn("refusing analysis", output)
+
+    def test_a_refused_transition_makes_no_second_model_call(self) -> None:
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze nope.js")
+
+        self.assertEqual(backend.route_calls, 1)
+        self.assertEqual(backend.analysis_calls, 0)
+
+    def test_a_refused_transition_leaves_no_unanswered_turn(self) -> None:
+        """The route turn answered nothing, so its user turn must be rewound.
+
+        Left in place it would sit unanswered in CHAT history and be resent on
+        every later turn, producing two consecutive user turns.
+        """
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze nope.js")
+
+        roles = [m.get("role") for m in repl.runtime.messages]
+        self.assertNotIn("user", roles, "the unanswered user turn must be rewound")
+        for earlier, later in zip(roles, roles[1:]):
+            self.assertFalse(earlier == "user" and later == "user")
+
+    def test_a_refused_transition_clears_the_signal(self) -> None:
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze nope.js")
+
+        self.assertIsNone(repl.runtime.last_analysis_request)
+
+    def test_chat_still_works_after_a_refused_transition(self) -> None:
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+        self.ask(repl, "analyze nope.js")
+
+        seen: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: (
+            seen.append(prompt) or ChatResult("ok", "s", "stop", [], 1, 1, 0, None, None)
+        )
+        self.ask(repl, "what is 2+2")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertEqual(seen, ["what is 2+2"])
+
+    def test_a_refused_transition_leaks_no_workspace(self) -> None:
+        pattern = "orbit-analysis-session-*"
+        before = set(Path(tempfile.gettempdir()).glob(pattern))
+        backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
+        repl = self.repl(backend)
+
+        self.ask(repl, "analyze nope.js")
+
+        self.assertEqual(set(Path(tempfile.gettempdir()).glob(pattern)) - before, set())
+
+
+class ConfinedAcquisitionTest(TransitionTestBase):
+    """A model-chosen artifact is acquired from an opened object, not a name.
+
+    Validating a pathname and letting the session reopen it left a window in
+    which the name could be repointed between the two -- reproducibly, on a
+    few racing turns in a hundred. So the file is opened once under the
+    workdir, following no symlink on any component, and the bytes come from
+    that descriptor. Symlinks are refused outright here, even ones currently
+    pointing inside: for model-chosen input, following a link is the thing
+    that must not happen.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.outside = Path(tempfile.mkdtemp(prefix="orbit-outside-"))
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+        self.secret = self.outside / "secret.txt"
+        self.secret.write_text("OUTSIDE\n", encoding="utf-8")
+        (self.tmp / "samples").mkdir(exist_ok=True)
+        self.inside = self.tmp / "samples" / "inner.js"
+        self.inside.write_text("INSIDE\n", encoding="utf-8")
+
+    def transition(self, artifact, *, on_acquired=None):
+        backend = CountingBackend(self.analysis_payload(artifact))
+        repl = self.repl(backend)
+        if on_acquired is not None:
+            repl._analysis_acquired_hook = on_acquired
+        output = self.ask(repl, "analyze it")
+        return repl, backend, output
+
+    # --- the deterministic TOCTOU proof --------------------------------
+    def test_a_swap_after_acquisition_cannot_change_the_snapshot(self) -> None:
+        """The primary proof: no racing, the swap is forced at the seam."""
+        target = self.tmp / "art.js"
+        target.write_text("ORIGINAL\n", encoding="utf-8")
+        swapped: list[bool] = []
+
+        def swap() -> None:
+            target.unlink()
+            target.symlink_to(self.secret)
+            swapped.append(True)
+
+        repl, _backend, _out = self.transition("art.js", on_acquired=swap)
+
+        self.assertEqual(swapped, [True], "the swap must actually have happened")
+        # No escape hatch: the swap lands after acquisition, so the session
+        # must have opened. Allowing `None` here would let a future change
+        # that refuses everything leave this test vacuously green.
+        self.assertIsNotNone(repl.analysis, "acquisition must succeed before the swap")
+        snapshot = repl.analysis.source.snapshot_path.read_bytes()
+        self.assertEqual(snapshot, b"ORIGINAL\n")
+        self.assertNotIn(b"OUTSIDE", snapshot)
+
+    def test_no_workspace_ever_holds_outside_content(self) -> None:
+        target = self.tmp / "art.js"
+        target.write_text("ORIGINAL\n", encoding="utf-8")
+
+        def swap() -> None:
+            target.unlink()
+            target.symlink_to(self.secret)
+
+        repl, _backend, _out = self.transition("art.js", on_acquired=swap)
+
+        self.assertIsNotNone(repl.analysis, "acquisition must succeed before the swap")
+        for path in repl.analysis.workspace.root.rglob("*"):
+            if path.is_file():
+                self.assertNotIn(b"OUTSIDE", path.read_bytes(), str(path))
+
+    def test_an_oversize_artifact_is_refused_before_it_is_read(self) -> None:
+        from orbit.runtime.confined_acquire import (
+            ConfinedAcquireError,
+            acquire_confined_bytes,
+        )
+
+        big = self.tmp / "big.bin"
+        big.write_bytes(b"x" * 5000)
+
+        with self.assertRaises(ConfinedAcquireError) as caught:
+            acquire_confined_bytes("big.bin", workdir=self.tmp, max_bytes=1000)
+
+        self.assertIn("too large", str(caught.exception))
+
+    def test_an_oversize_artifact_is_rejected_without_being_read(self) -> None:
+        """The `st_size` pre-check must fire before any byte is read.
+
+        The bounded read loop would also stop an oversize file, so this
+        asserts the cheaper guard specifically: no `os.read` may happen at
+        all. Without it, a caller would pull the whole file into memory
+        before rejecting it.
+        """
+        from unittest import mock
+
+        from orbit.runtime.confined_acquire import (
+            ConfinedAcquireError,
+            acquire_confined_bytes,
+        )
+
+        big = self.tmp / "huge.bin"
+        big.write_bytes(b"z" * 8192)
+
+        real_read = os.read
+        reads: list[int] = []
+
+        def counting_read(fd, size):
+            reads.append(size)
+            return real_read(fd, size)
+
+        with mock.patch("orbit.runtime.confined_acquire.os.read", counting_read):
+            with self.assertRaises(ConfinedAcquireError) as caught:
+                acquire_confined_bytes("huge.bin", workdir=self.tmp, max_bytes=100)
+
+        self.assertIn("too large", str(caught.exception))
+        self.assertEqual(reads, [], "an oversize file must be refused before reading")
+
+    def test_a_swap_before_acquisition_is_refused(self) -> None:
+        # Already a symlink when the route names it: refused outright.
+        target = self.tmp / "art.js"
+        target.symlink_to(self.secret)
+
+        repl, backend, output = self.transition("art.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertEqual(backend.analysis_calls, 0)
+        self.assertIn("refusing analysis", output)
+
+    # --- accepted -------------------------------------------------------
+    def test_a_relative_file_inside_the_workdir_is_accepted(self) -> None:
+        repl, backend, _out = self.transition("samples/inner.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(repl.analysis.source.snapshot_path.read_bytes(), b"INSIDE\n")
+        self.assertEqual(backend.route_calls, 1)
+        self.assertEqual(backend.analysis_calls, 1)
+        self.assertEqual(repl.analysis.analyst_turns, 1)
+
+    def test_a_nested_internal_file_is_accepted(self) -> None:
+        nested = self.tmp / "a" / "b"
+        nested.mkdir(parents=True)
+        (nested / "deep.js").write_text("DEEP\n", encoding="utf-8")
+
+        repl, _backend, _out = self.transition("a/b/deep.js")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(repl.analysis.source.snapshot_path.read_bytes(), b"DEEP\n")
+
+    def test_an_absolute_internal_path_is_accepted(self) -> None:
+        repl, _backend, _out = self.transition(self.inside)
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(repl.analysis.source.snapshot_path.read_bytes(), b"INSIDE\n")
+
+    def test_the_identity_is_the_acquired_bytes(self) -> None:
+        import hashlib
+
+        repl, _backend, _out = self.transition("samples/inner.js")
+
+        self.assertEqual(
+            repl.analysis.source.sha256, hashlib.sha256(b"INSIDE\n").hexdigest()
+        )
+        self.assertEqual(repl.analysis.source.size_bytes, len(b"INSIDE\n"))
+
+    # --- rejected -------------------------------------------------------
+    def _assert_refused(self, artifact, marker=None):
+        repl, backend, output = self.transition(artifact)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+        self.assertEqual(backend.route_calls, 1)
+        self.assertEqual(backend.analysis_calls, 0)
+        self.assertNotIn("user", [m.get("role") for m in repl.runtime.messages])
+        self.assertIsNone(repl.runtime.last_analysis_request)
+        self.assertIn("refusing analysis", output)
+        if marker:
+            self.assertIn(marker, output)
+        return repl
+
+    def test_every_unsafe_shape_is_refused(self) -> None:
+        (self.tmp / "dir").mkdir()
+        (self.tmp / "final_link").symlink_to(self.secret)
+        (self.tmp / "inside_link").symlink_to(self.inside)
+        (self.tmp / "dangling").symlink_to(self.tmp / "missing")
+        (self.tmp / "dirlink").symlink_to(self.outside)
+        os.mkfifo(self.tmp / "fifo")
+        sibling = Path(str(self.tmp) + "-evil")
+        sibling.mkdir()
+        self.addCleanup(shutil.rmtree, sibling, ignore_errors=True)
+        (sibling / "x.js").write_text("SIB\n", encoding="utf-8")
+
+        cases = {
+            "parent escape": "../../etc/passwd",
+            "absolute outside": str(self.secret),
+            "final symlink": "final_link",
+            "symlink pointing inside": "inside_link",
+            "intermediate symlink": "dirlink/secret.txt",
+            "dangling symlink": "dangling",
+            "missing": "nope.js",
+            "directory": "dir",
+            "fifo": "fifo",
+            "sibling prefix": str(sibling / "x.js"),
+            "home relative": "~/.bashrc",
+            "unknown user": "~nosuchuser/x",
+            "nul byte": "a\x00b",
+        }
+        for label, artifact in cases.items():
+            with self.subTest(case=label):
+                self._assert_refused(artifact)
+
+    def test_a_symlink_pointing_inside_is_still_refused(self) -> None:
+        # Stricter than `/analysis` on purpose: the target is fine today and
+        # can be repointed tomorrow, and the model chose the name.
+        (self.tmp / "ok_link").symlink_to(self.inside)
+
+        self._assert_refused("ok_link")
+
+    def test_chat_still_works_after_a_refusal(self) -> None:
+        repl = self._assert_refused(str(self.secret))
+        seen: list[str] = []
+        repl.runtime.ask_auto = lambda prompt, **kw: (
+            seen.append(prompt) or ChatResult("ok", "s", "stop", [], 1, 1, 0, None, None)
+        )
+
+        self.ask(repl, "what is 2+2")
+
+        self.assertEqual(seen, ["what is 2+2"])
+
+    def test_a_refusal_leaks_no_workspace(self) -> None:
+        pattern = "orbit-analysis-session-*"
+        before = set(Path(tempfile.gettempdir()).glob(pattern))
+
+        self._assert_refused(str(self.secret))
+
+        self.assertEqual(set(Path(tempfile.gettempdir()).glob(pattern)) - before, set())
+
+    # --- explicit command parity ----------------------------------------
+    def test_explicit_analysis_may_still_name_an_outside_path(self) -> None:
+        backend = CountingBackend('{"route":"CHAT"}')
+        repl = self.repl(backend)
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(out):
+            repl._handle_command(f"/analysis {self.secret}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(repl.analysis.source.original_path, str(self.secret))
+
+    def test_explicit_analysis_may_still_name_a_symlink(self) -> None:
+        link = self.tmp / "explicit_link"
+        link.symlink_to(self.inside)
+        backend = CountingBackend('{"route":"CHAT"}')
+        repl = self.repl(backend)
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(out):
+            repl._handle_command(f"/analysis {link}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS, "explicit policy unchanged")
+
+
+class NoReRoutingInAnalysisTest(TransitionTestBase):
+    """Once in ANALYSIS, steering must not be re-classified."""
+
+    def test_continue_does_not_route_again(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+        self.ask(repl, "analyze foo.js")
+        route_calls_after_entry = backend.route_calls
+
+        self.ask(repl, "continue")
+
+        self.assertEqual(backend.route_calls, route_calls_after_entry, "no re-routing in ANALYSIS")
+        self.assertEqual(backend.analysis_calls, 2)
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+    def test_steering_stays_in_analysis_without_routing(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+        self.ask(repl, "analyze foo.js")
+
+        for text in ("look at the strings", "continue", "now the header"):
+            self.ask(repl, text)
+            self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+        self.assertEqual(backend.route_calls, 1, "the route ran once, at entry")
+        self.assertEqual(backend.analysis_calls, 4)
+
+    def test_explicit_chat_returns_and_routing_resumes(self) -> None:
+        backend = CountingBackend(self.analysis_payload())
+        repl = self.repl(backend)
+        self.ask(repl, "analyze foo.js")
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._handle_command("/chat")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertEqual(backend.route_calls, 1, "/chat makes no model call")
+
+
+class ExplicitCommandUnchangedTest(TransitionTestBase):
+    def test_explicit_analysis_still_works_without_any_route_call(self) -> None:
+        backend = CountingBackend('{"route":"CHAT"}')
+        repl = self.repl(backend)
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._handle_command(f"/analysis {self.artifact}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(backend.route_calls, 0)
+        self.assertEqual(backend.analysis_calls, 0)
+
+    def test_neither_entry_path_persists_a_chat_session_on_transition(self) -> None:
+        """Parity, and deliberate: ANALYSIS is not resumable.
+
+        The routed transition skips `_save_session` exactly as `/analysis`
+        does. Pinned so the two paths cannot quietly diverge.
+        """
+        from orbit.runtime.sessions import SessionStore
+
+        routed_store = SessionStore(self.tmp / "routed.json")
+        routed = self.repl(CountingBackend(self.analysis_payload()))
+        routed.session = routed_store
+        self.ask(routed, "analyze foo.js as an artifact")
+
+        explicit_store = SessionStore(self.tmp / "explicit.json")
+        explicit = self.repl(CountingBackend('{"route":"CHAT"}'))
+        explicit.session = explicit_store
+        with contextlib.redirect_stdout(io.StringIO()):
+            explicit._handle_command(f"/analysis {self.artifact}")
+
+        self.assertEqual(routed_store.path.exists(), explicit_store.path.exists())
+        self.assertFalse(routed_store.path.exists())
+
+    def test_both_entry_paths_produce_the_same_session_shape(self) -> None:
+        explicit_backend = CountingBackend('{"route":"CHAT"}')
+        explicit = self.repl(explicit_backend)
+        with contextlib.redirect_stdout(io.StringIO()):
+            explicit._handle_command(f"/analysis {self.artifact}")
+
+        routed_backend = CountingBackend(self.analysis_payload())
+        routed = self.repl(routed_backend)
+        self.ask(routed, "analyze foo.js")
+
+        self.assertEqual(
+            explicit.analysis.source.sha256, routed.analysis.source.sha256
+        )
+        self.assertEqual(explicit.analysis.messages[0], routed.analysis.messages[0])
+
+
+class BackendStaysModeAgnosticTest(TransitionTestBase):
+    def test_no_workflow_mode_reaches_the_backend(self) -> None:
+        seen: list[list[dict]] = []
+
+        class Recording(CountingBackend):
+            def chat_stream(self, messages, **kwargs):
+                seen.append([dict(m) for m in messages])
+                return super().chat_stream(messages, **kwargs)
+
+        backend = Recording(self.analysis_payload())
+        repl = self.repl(backend)
+        self.ask(repl, "analyze foo.js")
+
+        blob = json.dumps(seen)
+        for token in ("workflow_mode", "WorkflowMode", "last_analysis_request"):
+            self.assertNotIn(token, blob)
+
+    def test_the_backend_module_has_no_route_analysis_logic(self) -> None:
+        # The backend may name ANALYSIS_STEP_PHASE -- that is the KV phase
+        # label the analysis runtime already declares, and it predates this
+        # mission. What it must not do is decide anything about the ANALYSIS
+        # route: no ToolRoute.ANALYSIS, no artifact handling.
+        for path in (SRC / "orbit" / "backend").glob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("ToolRoute", text, path.name)
+            self.assertNotIn("last_analysis_request", text, path.name)
+            self.assertNotIn('"ANALYSIS"', text, path.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ornith_route_prefix.py
+++ b/tests/test_ornith_route_prefix.py
@@ -245,8 +245,8 @@ class OrnithPrefixHeadroomTests(unittest.TestCase):
 
     `ROUTE_SYSTEM_PROMPT` interpolates the detected OS and shell, so the prompt
     is not one fixed string. Measured on the real Ornith tokenizer the
-    invariant region is 828-830 tokens across every variant, leaving at least
-    60 tokens of headroom over the fixed 768. This test pins the property that
+    invariant region is 925-927 tokens across every variant, leaving at least
+    157 tokens of headroom over the fixed 768. This test pins the property that
     matters -- the variation is far from the boundary -- without needing the
     model, by checking the character spread the interpolation can introduce.
     """
@@ -719,7 +719,7 @@ class OrnithStartupPrewarmWiringTests(unittest.TestCase):
 
         self.assertEqual(
             hashlib.sha256(ROUTE_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
-            "e7d5234d50700746d315004af1430871442c4eefcc61b6e420cc24d29bcaae28",
+            "d38e293a1d8fc0efb5371cff08bb5870ffc4faa6b96b889ff2af54ba2b66a38d",
         )
 
 

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -31,8 +31,10 @@ from orbit.terminal.analysis_mode import AnalysisModeError, open_analysis_sessio
 from orbit.terminal.config import AppConfig
 from orbit.terminal.repl import Repl
 
-# Pinned literal: the route language must not change in this mission.
-ROUTE_PROMPT_SHA256 = "e7d5234d50700746d315004af1430871442c4eefcc61b6e420cc24d29bcaae28"
+# Pinned literal. The route language gained an ANALYSIS form in the
+# automatic-recognition mission; the pin is updated only alongside the
+# prewarm requalification that a changed route prompt forces.
+ROUTE_PROMPT_SHA256 = "d38e293a1d8fc0efb5371cff08bb5870ffc4faa6b96b889ff2af54ba2b66a38d"
 
 
 class ScriptedBackend:
@@ -874,7 +876,7 @@ class StrictPrefixTest(ModeTestBase):
 
 
 class ChatNonRegressionTest(ModeTestBase):
-    def test_route_prompt_is_untouched_by_this_mission(self) -> None:
+    def test_route_prompt_matches_the_qualified_pin(self) -> None:
         import hashlib
 
         from orbit.runtime.messages import ROUTE_SYSTEM_PROMPT


### PR DESCRIPTION
## What this changes

Asking Orbit to look at a file it has just mentioned required the analyst to notice the filename, copy it, and type `/analysis <path>`. The classifier that already runs on every CHAT turn can see that request for what it is, so this teaches it one more route rather than adding anything that has to think.

- **Extends the existing route contract with `ANALYSIS`**, carrying the artifact it names.
- **No second classifier call and no second model call.** The same decision already being made now has one more answer available to it.
- The boundary is drawn in the route language itself: reading, summarizing or explaining a file stays a content-reading command; `ANALYSIS` is only for investigating one named local artifact *as* an artifact.

## The trust boundary

A model-chosen artifact path is different in kind from one an analyst types — it was chosen out of text the model may have just read, so it is reachable by anything that can get text in front of the model.

- **Model-chosen artifact paths are acquired only inside the Repl workdir.**
- **Acquisition is FD/object based: no validate-then-reopen TOCTOU.** `runtime/confined_acquire.py` walks the path one component at a time relative to an open directory descriptor with `O_NOFOLLOW` on every step, proves through `fstat` that it holds a regular file, and reads the bytes from that same descriptor. It returns bytes, never a path.
- **Symlinks are refused for automatic model-chosen paths**, including on intermediate components.
- **Malformed and outside paths fail closed.**
- **Rejected transitions rewind state cleanly** — no workspace, no history entry, CHAT still usable.

That shape is deliberate. An earlier revision validated the path and let the snapshot reopen it; on a few racing turns out of a hundred an outside file was what got read. There is no longer an interval between the decision and the read, because they are made about the same open object.

## What is unchanged

- **Explicit `/analysis` semantics remain unchanged** — it keeps its wider analyst-typed path policy through its own entry point.
- **Once ANALYSIS starts, `continue` and steering do not re-route.**
- **CHAT/ANALYSIS tool surfaces remain isolated.**
- **Both rolling KV lineages and both prewarms remain unchanged.** The Ornith prefix count is still 768; that file's diff is comment-only, recording 157 tokens of headroom under the longer route prompt rather than 60.

## Qualification

| Check | Result |
| --- | --- |
| Deterministic TOCTOU proof | PASS |
| Race stress (incl. intermediate-directory) | PASS — 0 escapes |
| Mutation testing | 11/11 CAUGHT |
| Routing tests | 54 PASS |
| Full suite | 2598 PASS |
| compileall / `git diff --check` | PASS |
| Final independent review | PASS |
| Test-count audit | PASS |
| Severity | BLOCKER 0 / MAJOR 0 / MINOR 0 |

The routing file moved 58 → 54 tests. That is one class swap — `ModelChosenPathContainmentTest` (19) → `ConfinedAcquisitionTest` (15) — audited test by test: 7 MERGED_EQUIVALENT, 7 REPLACED_STRONGER, 3 INTENTIONALLY_OBSOLETE, 2 folded verbatim, none accidentally lost. Refusal assertions went from ~40 to ~100 over a strictly larger set of unsafe shapes.

## Known limitation (accepted)

Hardlinks inside the workdir to files outside it are not detected — inherent to hardlink semantics, since the inode has no single parent to check against. Setting one up requires local write access to the workdir, no Orbit tool creates hardlinks, and `fs.protected_hardlinks=1` is the platform default.
