### PR TITLE
test(runtime): isolate analysis tempdir cleanup check

### DIFF
--- a/tests/test_analysis_sandbox.py
+++ b/tests/test_analysis_sandbox.py
@@ -272,16 +272,84 @@ class SandboxBehaviourTest(SandboxTestBase):
         # itself via a GC finalizer, so removing the explicit call is not
         # observable from outside. What is worth pinning is the property that
         # matters -- actions leave nothing behind on the host.
+        #
+        # Only the prefixes an action actually creates are counted. The old
+        # assertion globbed `orbit-analysis-*` in the shared temp root, which
+        # also matches `orbit-analysis-session-*` -- the name `AnalysisWorkspace`
+        # gives a session. A workspace another module held open while this ran
+        # therefore landed in the delta and failed this test for a directory it
+        # never created. Redirecting TMPDIR does not fix that either: the root
+        # is process-global, so a concurrent workspace lands inside it too.
+        #
+        # `execute_analysis` creates exactly these two, both owned by a
+        # `TemporaryDirectory` it closes before returning.
         import tempfile
 
         root = Path(tempfile.gettempdir())
-        pattern = "orbit-analysis-*"
-        before = {p.name for p in root.glob(pattern)}
+        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
+
+        def owned_dirs() -> set[str]:
+            return {
+                entry.name
+                for prefix in owned
+                for entry in root.glob(f"{prefix}*")
+            }
+
+        before = owned_dirs()
         for _ in range(3):
             self.run_code("print('tick')")
-        after = {p.name for p in root.glob(pattern)}
         self.assertEqual(
-            after - before, set(), "each action must remove its temporary directories"
+            owned_dirs() - before,
+            set(),
+            "each action must remove its temporary directories",
+        )
+
+    def test_an_unrelated_matching_directory_is_ignored(self) -> None:
+        """A session workspace is not this test's to account for.
+
+        This is the exact shape that made the old assertion flaky: the name
+        matches `orbit-analysis-*`, it appears between the two samples, and no
+        action here created it.
+        """
+        from orbit.runtime.analysis_runtime import AnalysisWorkspace
+
+        import tempfile
+
+        root = Path(tempfile.gettempdir())
+        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
+
+        def owned_dirs() -> set[str]:
+            return {e.name for prefix in owned for e in root.glob(f"{prefix}*")}
+
+        before = owned_dirs()
+        unrelated = AnalysisWorkspace.create()
+        self.addCleanup(unrelated.close)
+        # Created after the baseline and still present at the second sample.
+        self.assertTrue(unrelated.root.exists())
+        self.assertTrue(unrelated.root.name.startswith("orbit-analysis-"))
+        for _ in range(3):
+            self.run_code("print('tick')")
+        self.assertEqual(owned_dirs() - before, set())
+
+    def test_a_leaked_owned_directory_still_fails(self) -> None:
+        """The assertion must still catch a real leak with an owned prefix.
+
+        Narrowing the prefixes must not have narrowed away the property. A
+        directory named as one an action owns, left behind, has to be seen.
+        """
+        import tempfile
+
+        root = Path(tempfile.gettempdir())
+        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
+
+        def owned_dirs() -> set[str]:
+            return {e.name for prefix in owned for e in root.glob(f"{prefix}*")}
+
+        before = owned_dirs()
+        leaked = Path(tempfile.mkdtemp(prefix="orbit-analysis-work-"))
+        self.addCleanup(shutil.rmtree, leaked, True)
+        self.assertNotEqual(
+            owned_dirs() - before, set(), "a leak under an owned prefix must be visible"
         )
 
     def test_nonzero_exit_is_classified_as_error(self) -> None:


### PR DESCRIPTION
Fixes **pre-existing test flakiness only**. No production code changes.

## The problem

`test_temporary_directories_do_not_accumulate` sampled `Path(tempfile.gettempdir()).glob("orbit-analysis-*")` before and after three sandbox actions and asserted the set difference was empty. That prefix is shared by four distinct producers, only two of which the test owns:

| Prefix | Created by | Owned by this test |
| --- | --- | --- |
| `orbit-analysis-program-` | `analysis_sandbox.py:476` | yes |
| `orbit-analysis-work-` | `analysis_sandbox.py:479` | yes |
| `orbit-analysis-session-` | `AnalysisWorkspace.create()`, `analysis_runtime.py:166` | **no** |
| `orbit-analysis-rt-` | `tests/test_analysis_runtime.py:95` | **no** |

A workspace another module held open between the two samples landed in the delta and failed this test for a directory it never created. It passed alone and in the full suite but could fail in focused parallel subsets — the worst shape, because the signal looks like the sandbox leaking.

**The sandbox does not leak.** `execute_analysis` creates exactly the two owned prefixes, both `TemporaryDirectory`, both cleaned in its `finally` (and on the OSError start path). The import direction is one-way, so it cannot produce a session directory. Instrumenting `mkdtemp` across repeated calls shows residue `set()`.

## The fix

The assertion now observes **only the two temp prefixes owned by `execute_analysis`**. Ownership is the property that was always meant; stating it directly makes the test independent of whatever else is running.

- No threshold widening, no sleeps, no retries, no disabled parallelism.
- The assertion is still an exact `assertEqual(..., set())`.
- Production cleanup untouched.
- **Real cleanup leaks are still detected** — disabling the sandbox's cleanup fails the test, naming the leaked directories.

Redirecting `TMPDIR` to a private root was tried first and rejected: the temp root is process-global, so a concurrent workspace is created *inside* it — that captures the noise rather than excluding it.

Two tests added: one creates a real workspace mid-assertion (the exact failing shape) and requires it to be ignored; the other plants an owned-prefix directory and requires it to be seen, so narrowing the prefixes cannot silently narrow away the property.

## Qualification

| Check | Result |
| --- | --- |
| Pre-fix reproduction on clean parent | **FAILS** as expected (names a session dir) |
| Same harness, fixed | 20/20 PASS under concurrent churn |
| Focused repeated | 25/25 PASS |
| `tests/test_analysis_sandbox.py` (real bubblewrap) | **44 PASS** |
| `tests/test_analysis_runtime.py` | **61 PASS** |
| Full suite | **2600 PASS** (2598 + 2 new tests) |
| Mutation (real cleanup leak) | **CAUGHT** |
| compileall / `git diff --check` | PASS |
| Independent review | PASS — SAFE TO COMMIT |
| Severity | BLOCKER 0 / MAJOR 0 |

## Accepted MINORs (test-only, not fixed here)

1. The `owned` tuple and `owned_dirs()` helper are duplicated three times, and the literals are duplicated from `analysis_sandbox.py:476,479`. A third owned prefix added in production would silently stop being covered.
2. Latent and pre-existing: the assertion still reads a process-global temp root, so it remains structurally vulnerable to a *future* concurrent creator of the owned prefixes. This removes today's real trigger; it does not make the test hermetic.

Both would widen a test-only change past its scope.
