### PR TITLE
feat(terminal): name the active runtime in the prompt and the failure in the summary

### DIFF
--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -13,6 +13,7 @@ the current session exactly as it was.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Callable
 
@@ -24,6 +25,7 @@ from orbit.runtime.analysis_runtime import (
     acquire_analysis_source,
     snapshot_analysis_bytes,
 )
+from orbit.runtime.analysis_sandbox import AnalysisResult
 from orbit.runtime.confined_acquire import ConfinedAcquireError, acquire_confined_bytes
 from orbit.runtime.evidence import EvidenceStore
 
@@ -146,6 +148,11 @@ def format_analysis_step(result: AnalysisStepResult) -> str:
     return "\n".join(lines)
 
 
+# Long enough to carry a Python exception line, short enough that a failing
+# action cannot flood the transcript. The full text stays in evidence.
+MAX_ACTION_CAUSE_CHARS = 160
+
+
 def _action_summary(result: AnalysisStepResult) -> str:
     action = result.result
     if action is None:
@@ -153,8 +160,70 @@ def _action_summary(result: AnalysisStepResult) -> str:
     summary = f"action: {action.status}"
     if action.bound_exceeded:
         summary += f" ({action.bound_exceeded})"
+    cause = _action_cause(action)
+    if cause:
+        summary += f" | {cause}"
     if result.evidence is not None:
         summary += f" | evidence {result.evidence.evidence_id}"
     if result.raw_output_evidence_id:
         summary += f" | raw {result.raw_output_evidence_id}"
     return summary
+
+
+def _action_cause(action: AnalysisResult) -> str | None:
+    """One line saying why an action did not succeed.
+
+    Read from what the sandbox already reported. An evidence id tells the
+    analyst where to look; it does not tell them what happened, and the
+    common case -- the program raised -- is answered by the last line of the
+    traceback that is already stored. Nothing is inferred and no model is
+    asked: if the run produced no diagnostic, this says nothing rather than
+    inventing a reason.
+    """
+    if action.ok:
+        return None
+    if action.status == "timeout":
+        return f"sandbox timeout after {action.duration_seconds:.1f}s"
+    if action.bound_exceeded:
+        # The bound is already named in the summary; repeating an exit status
+        # here would describe the symptom rather than the reason.
+        return None
+    exception = _last_exception_line(action.stderr)
+    if exception:
+        return _clip(exception)
+    if action.exit_status:
+        return f"Python exited with status {action.exit_status}"
+    return None
+
+
+# `SomeError: message`, the line a traceback ends on. Anchored so a line that
+# merely contains a colon cannot match.
+_EXCEPTION_LINE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*(Error|Exception|Warning|Exit)\b[^:]*:")
+
+
+def _last_exception_line(stderr: str) -> str | None:
+    """The `Error: message` line a traceback ends on, or None.
+
+    Matched by shape rather than by position. Taking the last non-frame line
+    looked equivalent and was not: an exception whose message spans lines ends
+    on the continuation, so the summary reported a fragment -- and, when that
+    fragment held a path, printed a host path the analyst never asked for.
+    Only the first line of the message is kept, for the same reason.
+
+    Returning None when nothing matches is deliberate: the caller then falls
+    back to the exit status, which says less but cannot say something wrong.
+    """
+    for line in reversed(stderr.splitlines()):
+        candidate = line.strip()
+        if not candidate or candidate.startswith(("File \"", "Traceback", "^", "~")):
+            continue
+        if _EXCEPTION_LINE.match(candidate):
+            return candidate
+    return None
+
+
+def _clip(text: str) -> str:
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= MAX_ACTION_CAUSE_CHARS:
+        return collapsed
+    return collapsed[: MAX_ACTION_CAUSE_CHARS - 1] + "\u2026"

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -108,8 +108,12 @@ class Repl:
                 return self._finish_interactive_session(130, leading_newline=True)
             if not prompt:
                 continue
+            # The marker this line was actually displayed with. A command may
+            # change the mode, so re-deriving it after the fact would erase
+            # the wrong number of rows.
+            echo_label = self._prompt_label()
             if prompt.startswith("/"):
-                clear_input_echo(prompt)
+                clear_input_echo(prompt, echo_label)
                 self.prompt_redisplay_pending = True
                 if self._handle_command(prompt):
                     self.prompt_gap_pending = True
@@ -124,14 +128,23 @@ class Repl:
                 if resolution.prompt != prompt:
                     prompt = resolution.prompt
                 else:
-                    replace_input_echo(prompt)
+                    replace_input_echo(prompt, echo_label)
             else:
-                replace_input_echo(prompt)
+                replace_input_echo(prompt, echo_label)
             if self.history:
                 self.history.add(prompt)
                 self.history.save()
             self._ask(prompt)
             self.prompt_gap_pending = True
+
+    def _prompt_label(self) -> str:
+        """The marker for the runtime that owns the next line.
+
+        Read straight off `workflow_mode`, the state the Repl already keeps,
+        so the marker cannot drift from the mode it names. Display only: it
+        is never appended to history and never reaches the backend.
+        """
+        return "analysis" if self.workflow_mode is WorkflowMode.ANALYSIS else "chat"
 
     def _read_next_prompt(self) -> str:
         if self.queued_prompts:
@@ -139,10 +152,11 @@ class Repl:
         if self.prompt_gap_pending:
             print(flush=True)
             self.prompt_gap_pending = False
+        label = self._prompt_label()
         if self.prompt_redisplay_pending:
             self.prompt_redisplay_pending = False
-            return read_prompt_input(redisplay=True)
-        return read_prompt_input()
+            return read_prompt_input(redisplay=True, label=label)
+        return read_prompt_input(label=label)
 
     def _ask(self, prompt: str, *, command_action: CommandAction | None = None) -> None:
         # The mode decides which runtime owns this line before anything else

--- a/src/orbit/terminal/repl_input.py
+++ b/src/orbit/terminal/repl_input.py
@@ -17,10 +17,10 @@ READLINE_IGNORE_START = "\001"
 READLINE_IGNORE_END = "\002"
 
 
-def read_prompt_input(*, redisplay: bool = False) -> str:
+def read_prompt_input(*, redisplay: bool = False, label: str = "") -> str:
     clear_redisplay_hook = _install_redisplay_hook() if redisplay else None
     try:
-        first_line = input(input_prompt())
+        first_line = input(input_prompt(label))
     finally:
         if clear_redisplay_hook is not None:
             clear_redisplay_hook()
@@ -56,29 +56,40 @@ def _install_redisplay_hook() -> Callable[[], None] | None:
     return clear_hook
 
 
-def input_prompt() -> str:
+def input_prompt(label: str = "") -> str:
+    """The marker the analyst types after.
+
+    `label` names the runtime that owns the next line. It is display only:
+    the caller passes the mode it already holds, so nothing here decides or
+    stores what mode the session is in, and the string never reaches a model.
+    """
     if not sys.stdout.isatty():
-        return "> "
-    return f"{READLINE_IGNORE_START}{CYAN}{READLINE_IGNORE_END}> {READLINE_IGNORE_START}{RESET}{READLINE_IGNORE_END}"
+        return f"{label}> "
+    return (
+        f"{READLINE_IGNORE_START}{CYAN}{READLINE_IGNORE_END}{label}> "
+        f"{READLINE_IGNORE_START}{RESET}{READLINE_IGNORE_END}"
+    )
 
 
-def replace_input_echo(prompt: str) -> None:
+def replace_input_echo(prompt: str, label: str = "") -> None:
     if not should_replace_input_echo(prompt):
         return
     if not sys.stdout.isatty():
         return
     preview = compact_prompt_preview(prompt, multiline=True)
-    rendered = colorize_user_prompt(f"> {preview}")
+    rendered = colorize_user_prompt(f"{label}> {preview}")
     columns = max(20, get_terminal_size((80, 20)).columns)
-    visual_rows = visual_row_count(f"> {prompt}", columns=columns)
+    # The marker occupies columns on the first row, so the label has to be
+    # counted or a wrapped line is erased one row short.
+    visual_rows = visual_row_count(f"{label}> {prompt}", columns=columns)
     print(f"\x1b[{visual_rows}F\x1b[J{rendered}", flush=True)
 
 
-def clear_input_echo(prompt: str) -> None:
+def clear_input_echo(prompt: str, label: str = "") -> None:
     if not sys.stdout.isatty():
         return
     columns = max(20, get_terminal_size((80, 20)).columns)
-    visual_rows = visual_row_count(f"> {prompt}", columns=columns)
+    visual_rows = visual_row_count(f"{label}> {prompt}", columns=columns)
     print(f"\x1b[{visual_rows}F\x1b[J", end="", flush=True)
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -896,7 +896,7 @@ class ReplTests(unittest.TestCase):
                 responses = iter(("", "next"))
                 stdout = io.StringIO()
 
-                def fake_read() -> str:
+                def fake_read(*, label: str = "") -> str:
                     print("> ")
                     return next(responses)
 
@@ -935,7 +935,7 @@ class ReplTests(unittest.TestCase):
 
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False) -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
                 nonlocal reads
                 reads += 1
                 redisplays.append(redisplay)
@@ -971,7 +971,7 @@ class ReplTests(unittest.TestCase):
             )
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False) -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
                 redisplays.append(redisplay)
                 try:
                     return next(prompts)
@@ -1006,7 +1006,7 @@ class ReplTests(unittest.TestCase):
             prompts = iter(("/read note.txt summarize",))
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False) -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
                 redisplays.append(redisplay)
                 try:
                     return next(prompts)

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -919,3 +920,279 @@ class ChatNonRegressionTest(ModeTestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PromptMarkerTest(ModeTestBase):
+    """The marker names the runtime that owns the next line.
+
+    It is display only. These pin both halves of that: the text follows
+    `workflow_mode`, and it never becomes something the model can read.
+    """
+
+    def test_chat_is_the_default_marker(self) -> None:
+        self.assertEqual(self.repl()._prompt_label(), "chat")
+
+    def test_explicit_analysis_switches_the_marker(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertEqual(repl._prompt_label(), "analysis")
+
+    def test_slash_chat_restores_the_marker(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_command(repl, "/chat")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertEqual(repl._prompt_label(), "chat")
+
+    def test_the_marker_follows_the_mode_rather_than_being_stored(self) -> None:
+        # No second variable to drift: setting the authoritative state is
+        # enough to change what is displayed.
+        repl = self.repl()
+        repl.workflow_mode = WorkflowMode.ANALYSIS
+        self.assertEqual(repl._prompt_label(), "analysis")
+        repl.workflow_mode = WorkflowMode.CHAT
+        self.assertEqual(repl._prompt_label(), "chat")
+
+    def test_switching_mode_costs_no_model_call(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        before = backend.calls
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.assertEqual(repl._prompt_label(), "analysis")
+        self.run_command(repl, "/chat")
+        self.assertEqual(repl._prompt_label(), "chat")
+        self.assertEqual(backend.calls, before)
+
+    def test_the_marker_never_reaches_the_backend(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_command(repl, "/chat")
+        self.run_prompt(repl, "hello")
+        sent = json.dumps(backend.messages_seen, default=str)
+        for marker in ("chat> ", "analysis> "):
+            self.assertNotIn(marker, sent)
+        for message in repl.runtime.messages:
+            self.assertNotIn("analysis> ", str(message.get("content") or ""))
+
+    def test_rendered_prompt_carries_the_label(self) -> None:
+        from orbit.terminal.repl_input import input_prompt
+
+        with mock.patch("orbit.terminal.repl_input.sys.stdout") as stdout:
+            stdout.isatty.return_value = False
+            self.assertEqual(input_prompt("chat"), "chat> ")
+            self.assertEqual(input_prompt("analysis"), "analysis> ")
+        with mock.patch("orbit.terminal.repl_input.sys.stdout") as stdout:
+            stdout.isatty.return_value = True
+            self.assertIn("analysis> ", input_prompt("analysis"))
+
+
+class ActionCauseRenderingTest(unittest.TestCase):
+    """A failed action has to say what went wrong, not only where to look.
+
+    The cause is read from what the sandbox already reported. Nothing is
+    inferred, no model is asked, and the full text stays in evidence.
+    """
+
+    def _result(self, **overrides):
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        base = dict(
+            status="error",
+            code_sha256="c" * 64,
+            input_sha256="i" * 64,
+            stdout="",
+            stderr="",
+            exit_status=1,
+            duration_seconds=0.4,
+        )
+        base.update(overrides)
+        return AnalysisResult(**base)
+
+    def test_the_real_recorded_failure_renders_its_exception(self) -> None:
+        # Verbatim stderr from the observed run whose summary showed only ids.
+        stderr = (
+            "Traceback (most recent call last):\n"
+            '  File "/program/main.py", line 10, in <module>\n'
+            '    data = orbit_tools.read_file("/workspace/input/samples/x.js")\n'
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            '  File "orbit_tools.py", line 29, in read_file\n'
+            '  File "orbit_tools.py", line 19, in _safe_path\n'
+            "PermissionError: path is outside the analyst workspace\n"
+        )
+        from orbit.terminal.analysis_mode import _action_cause
+
+        self.assertEqual(
+            _action_cause(self._result(stderr=stderr)),
+            "PermissionError: path is outside the analyst workspace",
+        )
+
+    def test_a_timeout_says_so(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        cause = _action_cause(self._result(status="timeout", duration_seconds=30.0))
+        self.assertEqual(cause, "sandbox timeout after 30.0s")
+
+    def test_a_bare_nonzero_exit_is_reported(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        self.assertEqual(
+            _action_cause(self._result(stderr="", exit_status=3)),
+            "Python exited with status 3",
+        )
+
+    def test_a_successful_action_has_no_cause(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        self.assertIsNone(_action_cause(self._result(status="ok", exit_status=0)))
+
+    def test_enormous_stderr_stays_bounded(self) -> None:
+        from orbit.terminal.analysis_mode import MAX_ACTION_CAUSE_CHARS, _action_cause
+
+        noise = "\n".join(f"  File \"/host/private/{i}.py\", line {i}" for i in range(5000))
+        stderr = f"Traceback (most recent call last):\n{noise}\nValueError: {'x' * 20000}\n"
+        cause = _action_cause(self._result(stderr=stderr))
+        assert cause is not None
+        self.assertLessEqual(len(cause), MAX_ACTION_CAUSE_CHARS)
+        self.assertTrue(cause.startswith("ValueError: "))
+        self.assertNotIn("/host/private", cause)
+
+    def test_host_frames_are_not_echoed(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        stderr = (
+            "Traceback (most recent call last):\n"
+            '  File "/home/someone/secret/main.py", line 1, in <module>\n'
+            "RuntimeError: boom\n"
+        )
+        cause = _action_cause(self._result(stderr=stderr))
+        self.assertEqual(cause, "RuntimeError: boom")
+        self.assertNotIn("/home/someone", cause or "")
+
+    def test_summary_keeps_ids_and_adds_the_cause(self) -> None:
+        from orbit.runtime.analysis_runtime import AnalysisStepResult
+        from orbit.runtime.evidence import EvidenceRecord
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        action = self._result(stderr="PermissionError: nope\n")
+        record = EvidenceRecord(
+            evidence_id="ev_aaa_bbb",
+            tool_name="execute_analysis",
+            kind="fetch",
+            raw_ref="evidence:ev_aaa_bbb",
+            raw_sha256="d" * 64,
+            raw_chars=10,
+            raw_lines=1,
+            status="ok",
+            metadata={},
+            route_card=None,
+            final_card=None,
+        )
+        step = AnalysisStepResult(
+            model_calls=1,
+            action_attempted=True,
+            action_executed=True,
+            assistant_text="",
+            result=action,
+            evidence=record,
+            raw_output_evidence_id="ev_ccc_ddd",
+        )
+        rendered = format_analysis_step(step)
+        self.assertIn("action: error", rendered)
+        self.assertIn("PermissionError: nope", rendered)
+        self.assertIn("evidence ev_aaa_bbb", rendered)
+        self.assertIn("raw ev_ccc_ddd", rendered)
+
+    def test_a_successful_summary_is_unchanged(self) -> None:
+        from orbit.runtime.analysis_runtime import AnalysisStepResult
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        step = AnalysisStepResult(
+            model_calls=1,
+            action_attempted=True,
+            action_executed=True,
+            assistant_text="",
+            result=self._result(status="ok", exit_status=0),
+        )
+        self.assertEqual(format_analysis_step(step), "action: ok")
+
+    def test_a_multiline_exception_message_leaks_no_host_path(self) -> None:
+        # The last non-frame line of a multi-line message is a continuation,
+        # not the failure; reporting it printed a host path nobody asked for.
+        from orbit.terminal.analysis_mode import _action_cause
+
+        stderr = (
+            "Traceback (most recent call last):\n"
+            '  File "/program/main.py", line 3, in <module>\n'
+            "ValueError: line one\n"
+            "of the message continues /home/someone/secret/path\n"
+        )
+        cause = _action_cause(self._result(stderr=stderr))
+        self.assertEqual(cause, "ValueError: line one")
+        self.assertNotIn("/home/someone", cause or "")
+
+    def test_stderr_without_an_exception_falls_back_to_the_exit_status(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        stderr = "some warning: not an exception\ntrailing /home/someone/noise\n"
+        cause = _action_cause(self._result(stderr=stderr, exit_status=2))
+        self.assertEqual(cause, "Python exited with status 2")
+        self.assertNotIn("/home/someone", cause or "")
+
+    def test_a_bounded_result_does_not_add_an_exit_status(self) -> None:
+        # The bound is already named in the summary; the exit status would
+        # describe the symptom rather than the reason.
+        from orbit.terminal.analysis_mode import _action_cause
+
+        cause = _action_cause(
+            self._result(status="bounded", bound_exceeded="scratch_bytes", stderr="")
+        )
+        self.assertIsNone(cause)
+
+    def test_whitespace_only_stderr_yields_the_exit_status(self) -> None:
+        from orbit.terminal.analysis_mode import _action_cause
+
+        self.assertEqual(
+            _action_cause(self._result(stderr="   \n\n  \n", exit_status=1)),
+            "Python exited with status 1",
+        )
+
+
+class PromptEchoLabelTest(ModeTestBase):
+    """The echo must use the marker the line was displayed with.
+
+    A command can change the mode between reading a line and erasing it, so
+    re-deriving the label afterwards would erase the wrong number of rows.
+    """
+
+    def test_the_erase_width_counts_the_label(self) -> None:
+        from orbit.terminal.repl_input import visual_row_count
+
+        prompt = "x" * 74
+        # 74 chars fits one 80-column row bare, but not behind "analysis> ".
+        self.assertEqual(visual_row_count(f"> {prompt}", columns=80), 1)
+        self.assertEqual(visual_row_count(f"analysis> {prompt}", columns=80), 2)
+
+    def test_clear_input_echo_uses_the_supplied_label(self) -> None:
+        from orbit.terminal import repl_input
+
+        seen: list[str] = []
+        with (
+            mock.patch.object(repl_input.sys.stdout, "isatty", return_value=True),
+            mock.patch.object(repl_input, "get_terminal_size", return_value=os.terminal_size((80, 20))),
+            mock.patch("builtins.print", side_effect=lambda *a, **k: seen.append(str(a[0]))),
+        ):
+            repl_input.clear_input_echo("x" * 74, "analysis")
+        # Two rows because the marker pushed the line over the column count.
+        self.assertIn("2F", seen[0])
+
+    def test_the_echo_label_is_the_displayed_one_not_the_post_command_one(self) -> None:
+        repl = self.repl()
+        displayed = repl._prompt_label()
+        self.assertEqual(displayed, "chat")
+        self.run_command(repl, f"/analysis {self.artifact}")
+        # The mode changed, so re-deriving now would give the wrong marker for
+        # the line that was typed while CHAT was displayed.
+        self.assertEqual(repl._prompt_label(), "analysis")
+        self.assertNotEqual(displayed, repl._prompt_label())


### PR DESCRIPTION
Two small pre-release CLI/UX improvements. **Presentation only** — no runtime, backend, sandbox, EvidenceStore, KV, prewarm, routing or prompt-contract change, and no new dependency.

## 1. The prompt names the active runtime

The marker was `> ` in both modes, so the one thing the screen did not show was which runtime owned your next line. `/analysis` and `/chat` change what typing means — one tool against one artifact versus five tools against a conversation.

Now `chat> ` / `analysis> `.

- Derived from the existing authoritative `workflow_mode` on each read. **No second mode variable**, so the marker cannot drift from the mode it names.
- Display only: the label reaches `input()` and the erase escapes, nothing else. `prompt` is never rewritten, so history, `runtime.messages` and the backend cannot see it. `repl_input.py` is imported by exactly one module, which makes this containment structural rather than incidental.
- Counted in `visual_row_count` — the marker occupies columns on the first row, and omitting it erases one row short on a wrapped line (312 enumerated column/length cases).
- The label is captured **when the line is read**, not when it is erased: a command typed at `chat> ` can leave the session in ANALYSIS before the echo is rewritten.
- Zero model calls; default stays `"> "` for callers that pass no label.

## 2. A failed action says what happened

Before, a failure reported only where to look:

```
action: error | evidence ev_7a25d56feed5_… | raw ev_869f95f79bde_…
```

Now:

```
action: error | PermissionError: path is outside the analyst workspace | evidence … | raw …
```

- Read only from authoritative `AnalysisResult` fields (`status`, `stderr`, `exit_status`, `duration_seconds`, `bound_exceeded`). **No model is invoked** — `_action_cause` takes an `AnalysisResult` and `analysis_mode.py` holds no backend handle.
- Clipped to 160 chars; the full text stays in evidence. Traceback frames and host paths are not echoed.
- The exception line is picked **by shape, not position**: taking the last non-frame line printed a continuation for multi-line messages, and with it a host path.
- A `bounded` result names only the bound, since its exit status describes the symptom.
- **Successful output is byte-identical to baseline** (`action: ok`).

## Qualification

| Check | Result |
| --- | --- |
| Focused REPL/workflow/ANALYSIS | 304 PASS |
| CHAT/ANALYSIS KV + both prewarms | 162 PASS |
| Full suite | **2622 PASS** (2600 + 22 new tests) |
| Mutations | **8/8 CAUGHT** |
| compileall / `git diff --check` | PASS |
| Independent review | SAFE TO COMMIT |
| Severity | BLOCKER 0 / MAJOR 0 |

Three review findings were fixed before freeze: a host-path leak on multi-line exception messages, a misleading exit status on `bounded` results, and missing coverage of the echo/erase path (all three previously-surviving mutations now caught).

## Accepted MINORs (pre-existing, not introduced)

- ANSI escapes in model-authored stderr reach the terminal — `assistant_text` is already printed raw at baseline; deserves a shared sanitizer.
- A `queued_prompts` line is never displayed yet still passes through the echo helpers — identical at baseline.

## Filed separately, not fixed here

The ANALYSIS prompt says *"The artifact is mounted read-only at /workspace/input"*, which reads as a directory and invites `read_file("/workspace/input/<name>")` — the exact failure quoted above. The sandbox behaved correctly (the mount **is** the file), so this is a model error with a contributing prompt defect. Fixing it edits the ANALYSIS prompt contract and the captured prefix, so it needs its own KV/prewarm requalification as a separate mission.
