### PR TITLE
fix(runtime): clarify analysis input file contract

### DIFF
--- a/src/orbit/native_llama/ornith_analysis_prefix.py
+++ b/src/orbit/native_llama/ornith_analysis_prefix.py
@@ -10,10 +10,10 @@ mechanism: the same `derive_qwen_route_prefix_spec`, the same
 `PrefixAnchorState`, the same capture and restore. Two things differ, and both
 are deliberate.
 
-The count is smaller. A whole first ANALYSIS request is around 480 tokens
+The count is smaller. A whole first ANALYSIS request is around 540 tokens
 against roughly 840 for a route request, so the route's 768 cannot fit; the
 derivation would refuse it outright rather than shorten it. Measured on this
-template the invariant region is 451 tokens, and 384 sits inside it with room
+template the invariant region is 485 tokens, and 384 sits inside it with room
 to spare.
 
 The identity is its own. Sharing the route lineage's format version and
@@ -44,10 +44,16 @@ ORNITH_ANALYSIS_PREFIX_ENV = "ORBIT_ORNITH_ANALYSIS_PREFIX_REUSE"
 # nothing about CHAT or ANALYSIS from it.
 ORNITH_ANALYSIS_LINEAGE_ID = "orbit-ornith15-native-v1#analysis"
 
-# 384: measured invariant region on this template is 451 tokens, so the
-# captured prefix stops 67 tokens short of anything that varies. The whole
-# request is ~480 tokens, which is why the route lineage's 768 is unusable
+# 384: measured invariant region on this template is 485 tokens, so the
+# captured prefix stops 101 tokens short of anything that varies. The whole
+# request is ~540 tokens, which is why the route lineage's 768 is unusable
 # here rather than merely wasteful.
+#
+# Re-measured after the input contract was reworded to say /workspace/input is
+# the artifact file rather than a place it sits: the region grew 451 -> 485, so
+# 384 was re-validated against a different token sequence rather than left
+# alone. The count is derived, never trimmed to fit -- a prompt that shrank the
+# region below it would be refused outright.
 ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT = 384
 ORNITH_ANALYSIS_PREFIX_FORMAT_VERSION = "ornith15-analysis-prefix-v1"
 ORNITH_ANALYSIS_TOKENIZER_IDENTITY = "gpt2:qwen35"

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -61,7 +61,9 @@ ANALYSIS_STEP_PHASE = "analysis_step"
 # path, no hash, no session id, no timestamp, no analyst text.
 ANALYSIS_SYSTEM_PROMPT = (
     "You are performing static analysis of one artifact in an isolated offline workspace.\n"
-    "The artifact is mounted read-only at /workspace/input. There is no network.\n"
+    "/workspace/input is the artifact file itself, mounted read-only: read exactly\n"
+    "that path and never append the original filename or a subpath to it\n"
+    "(`orbit_tools.SOURCE_PATH` is it). There is no network.\n"
     "Inspect and transform it by writing Python and running it with execute_analysis; "
     "`import orbit_tools` provides read_file(path, offset, limit).\n"
     "Write bounded files under /workspace/work to keep a derived artifact.\n"
@@ -76,8 +78,9 @@ ANALYSIS_TOOL_SCHEMA: dict[str, Any] = {
         "name": ANALYSIS_TOOL_NAME,
         "description": (
             "Run one bounded Python program in the isolated analysis workspace. "
-            "The artifact is read-only at /workspace/input; write derived files under "
-            "/workspace/work. Print the facts you want recorded as evidence."
+            "/workspace/input is the read-only artifact file itself, not a directory; "
+            "write derived files under /workspace/work. "
+            "Print the facts you want recorded as evidence."
         ),
         "parameters": {
             "type": "object",
@@ -342,7 +345,7 @@ class AnalysisRuntime:
                 {
                     "role": "user",
                     "content": (
-                        f"Artifact under analysis: /workspace/input "
+                        f"Artifact under analysis: the file /workspace/input "
                         f"({self.source.size_bytes} bytes, sha256 {self.source.sha256})."
                     ),
                 }

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -1095,3 +1095,145 @@ class ModifiedArtifactProvenanceTest(AnalysisRuntimeTestBase):
             second.evidence.metadata["artifacts"], [],
             "an action that wrote nothing must not claim an earlier file",
         )
+
+
+class InputMountContractTest(AnalysisRuntimeTestBase):
+    """`/workspace/input` is the artifact file, and every surface says so.
+
+    A production run read `/workspace/input/<original filename>` and was
+    correctly refused: the sandbox binds the artifact *as* that path, so a
+    subpath under it cannot exist. The wording invited the mistake by
+    describing the artifact as "mounted at" a bare path, which reads as a
+    directory. These pin the corrected contract on all three model-facing
+    surfaces, because one of them reverting would reintroduce the ambiguity.
+    """
+
+    def _surfaces(self) -> dict[str, str]:
+        runtime = self.runtime(ScriptedBackend(prose_response("ok")))
+        return {
+            "system prompt": ANALYSIS_SYSTEM_PROMPT,
+            "tool schema": ANALYSIS_TOOL_SCHEMA["function"]["description"],
+            "first user turn": runtime.messages[1]["content"],
+        }
+
+    def test_every_surface_calls_it_a_file(self) -> None:
+        for name, text in self._surfaces().items():
+            with self.subTest(surface=name):
+                lowered = text.lower()
+                self.assertIn("/workspace/input", lowered)
+                self.assertIn("file", lowered, "the surface must name it a file")
+
+    # Prepositions that put the artifact *inside* the path rather than
+    # equating it with the path. Checking the literal old sentence was not
+    # enough: "the artifact file lives read-only under /workspace/input"
+    # keeps every required keyword and still says directory.
+    CONTAINER_FRAMINGS = (
+        "mounted at /workspace/input",
+        "at /workspace/input",
+        "under /workspace/input",
+        "in /workspace/input",
+        "inside /workspace/input",
+        "into /workspace/input",
+        "from /workspace/input/",
+        "within /workspace/input",
+        "/workspace/input directory",
+        "/workspace/input folder",
+        "/workspace/input area",
+        "/workspace/input/",
+    )
+
+    def test_no_surface_describes_it_as_a_container(self) -> None:
+        # Not a keyword check: these are the shapes that make the path read as
+        # somewhere the artifact lives rather than as the artifact.
+        for name, text in self._surfaces().items():
+            lowered = text.lower()
+            for framing in self.CONTAINER_FRAMINGS:
+                with self.subTest(surface=name, framing=framing):
+                    self.assertNotIn(
+                        framing,
+                        lowered,
+                        f"{name} frames /workspace/input as a container",
+                    )
+
+    def test_each_surface_equates_the_path_with_the_file(self) -> None:
+        """Positive form: the path must be *identified* with the artifact.
+
+        The prohibition above can be satisfied by saying nothing at all, so
+        each surface also has to make the equation explicitly.
+        """
+        equations = (
+            "/workspace/input is the artifact file",
+            "/workspace/input is the read-only artifact file",
+            "the file /workspace/input",
+        )
+        for name, text in self._surfaces().items():
+            lowered = text.lower()
+            with self.subTest(surface=name):
+                self.assertTrue(
+                    any(phrase in lowered for phrase in equations),
+                    f"{name} never equates /workspace/input with the file",
+                )
+
+    def test_the_system_prompt_forbids_appending_a_path(self) -> None:
+        lowered = ANALYSIS_SYSTEM_PROMPT.lower()
+        self.assertIn("read exactly", lowered)
+        self.assertIn("never append", lowered)
+        self.assertIn("subpath", lowered)
+
+    def test_the_tool_schema_says_it_is_not_a_directory(self) -> None:
+        description = ANALYSIS_TOOL_SCHEMA["function"]["description"].lower()
+        self.assertIn("not a directory", description)
+
+    def test_derived_files_still_belong_under_the_work_root(self) -> None:
+        for name, text in self._surfaces().items():
+            if "/workspace/work" not in text:
+                continue
+            with self.subTest(surface=name):
+                self.assertIn("/workspace/work", text)
+        self.assertIn("/workspace/work", ANALYSIS_SYSTEM_PROMPT)
+        self.assertIn("/workspace/work", ANALYSIS_TOOL_SCHEMA["function"]["description"])
+
+    def test_the_contract_names_no_sample_and_no_malware_hint(self) -> None:
+        # The fix must generalise; a filename from the failing run would make
+        # it advice about one artifact.
+        for name, text in self._surfaces().items():
+            with self.subTest(surface=name):
+                lowered = text.lower()
+                for banned in ("fattura", ".js", "malware", "dropper", "sample"):
+                    self.assertNotIn(banned, lowered)
+
+    def test_the_shim_exposes_the_same_path_it_accepts(self) -> None:
+        # The prompt points at `orbit_tools.SOURCE_PATH`; that has to be the
+        # one path `_safe_path` will allow, or the hint sends the model wrong.
+        from orbit.runtime.analysis_tools_shim import ORBIT_TOOLS_SOURCE, SOURCE_MOUNT
+        from orbit.runtime.analysis_sandbox import SOURCE_MOUNT as SANDBOX_MOUNT
+
+        self.assertEqual(SOURCE_MOUNT, SANDBOX_MOUNT)
+        self.assertIn(f'SOURCE_PATH = "{SOURCE_MOUNT}"', ORBIT_TOOLS_SOURCE)
+        self.assertIn("SOURCE_PATH", ANALYSIS_SYSTEM_PROMPT)
+
+    def test_the_stable_prefix_still_holds_no_volatile_identity(self) -> None:
+        # The wording grew; it must not have grown to include session data.
+        for volatile in (self.source.sha256, self.source.original_path):
+            self.assertNotIn(volatile, ANALYSIS_SYSTEM_PROMPT)
+            self.assertNotIn(volatile, ANALYSIS_TOOL_SCHEMA["function"]["description"])
+
+    def test_the_first_turn_never_shows_the_original_filename(self) -> None:
+        """The analyst's own path must not be echoed back at the model.
+
+        Naming `samples/<file>` beside the mount is exactly what invites
+        appending it to `/workspace/input`. The size and hash identify the
+        artifact without handing the model a path to concatenate.
+        """
+        runtime = self.runtime(ScriptedBackend(prose_response("ok")))
+        first_turn = runtime.messages[1]["content"]
+
+        self.assertNotIn(self.source.original_path, first_turn)
+        self.assertNotIn(Path(self.source.original_path).name, first_turn)
+        self.assertIn(self.source.sha256, first_turn)
+
+    def test_chat_prompts_are_untouched_by_the_analysis_contract(self) -> None:
+        from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
+
+        for prompt in (CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT):
+            self.assertNotIn("/workspace/input", prompt)

--- a/tests/test_ornith_analysis_prefix.py
+++ b/tests/test_ornith_analysis_prefix.py
@@ -40,7 +40,7 @@ from orbit.native_llama.prefix_anchor import PrefixAnchorState
 from orbit.runtime.analysis_runtime import ANALYSIS_SYSTEM_PROMPT, ANALYSIS_TOOL_SCHEMA
 
 # Pinned literal: the prewarm captures this contract verbatim.
-ANALYSIS_SYSTEM_PROMPT_SHA256 = "313f3b7a8ae1c13379e1015a7abbc24ec313ef37949124b6355b98e3c4e0142e"
+ANALYSIS_SYSTEM_PROMPT_SHA256 = "fad4cd857bfb631058a7f5279f81573d800fe56013d82f3e4abab5fb50e2a2c8"
 
 
 class AnalysisPrefixConfigTests(unittest.TestCase):
@@ -73,7 +73,7 @@ class AnalysisPrefixConfigTests(unittest.TestCase):
         self.assertNotEqual(ORNITH_ANALYSIS_LINEAGE_ID, ORNITH15_PROFILE_ID)
 
     def test_count_is_smaller_than_the_route_count(self) -> None:
-        # A whole first ANALYSIS request is ~480 tokens against ~840 for a
+        # A whole first ANALYSIS request is ~540 tokens against ~840 for a
         # route request, so the route's count cannot fit here.
         self.assertLess(ORNITH_ANALYSIS_PREFIX_TOKEN_COUNT, ORNITH_ROUTE_PREFIX_TOKEN_COUNT)
 
@@ -663,11 +663,14 @@ class AnalysisFallbackAttributionTests(unittest.TestCase):
 
 
 class AnalysisPromptUnchangedTests(unittest.TestCase):
-    def test_analysis_system_prompt_is_untouched_by_this_mission(self) -> None:
+    def test_analysis_system_prompt_matches_the_qualified_pin(self) -> None:
         import hashlib
 
         # Pinned: the prewarm captures this contract, so a silent edit would
-        # change the prefix without changing the identity that guards it.
+        # change the prefix without changing the identity that guards it. The
+        # pin moved once, with the input-contract fix that told the model
+        # /workspace/input is the artifact file rather than a directory, and
+        # only alongside the prefix requalification that change forced.
         self.assertEqual(
             hashlib.sha256(ANALYSIS_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
             ANALYSIS_SYSTEM_PROMPT_SHA256,


### PR DESCRIPTION
## The problem

Asked to analyse a file, Ornith generated `read_file("/workspace/input/<name>")` and the sandbox refused it with `PermissionError: path is outside the analyst workspace`.

That was the sandbox working correctly — the artifact is bind-mounted **as** `/workspace/input` (`--ro-bind <file> /workspace/input`), so nothing exists beneath that path. The model was reading the contract it was given: *"The artifact is mounted read-only at /workspace/input"* is how you describe a directory, and having been told the artifact was mounted somewhere, appending its filename is the reasonable next step.

## The fix

- **`/workspace/input` is now unambiguously defined as the artifact file itself.**
- **The model must read exactly `/workspace/input`.**
- **The original filename and any subpath must not be appended** — stated explicitly, naming the exact error.
- **`/workspace/work/...` remains for derived files**, unchanged.
- **All three model-facing ANALYSIS surfaces are consistent** — system prompt, `execute_analysis` schema description, and the first turn naming the artifact. One of them still implying a container is enough to invite the mistake again.
- The prompt points at `orbit_tools.SOURCE_PATH`, which is the one path the shim accepts by equality, so following it cannot be wrong.
- **No malware-specific logic**, no sample filename, no artifact-specific hint.

## Cache requalification

Changing the contract changes the captured ANALYSIS prefix, so the count was **structurally re-derived, not forced**:

| | before | after |
| --- | --- | --- |
| Invariant region | 451 tokens | **485** |
| Max accepted N | 450 | 484 |
| Headroom at 384 | 67 | **101** |

**The qualified prefix remains 384 tokens with increased headroom** — the same number for a different reason. Proof it was re-validated rather than left alone: the token at index 384 now lands in different text (before `...read_file(path, offset,`; after `` ...(`orbit_tools.SOURCE_PATH` is ``). N=484 accepted, N=485 refused. All four prefix constants are byte-identical to baseline; that file's only non-comment change is a corrected measurement in its docstring.

**CHAT/KV/prewarm behaviour is unchanged** — `src/orbit/native_llama/` has zero behavioural diff, `messages.py` zero diff.

## Qualification

| Check | Result |
| --- | --- |
| Benign Ornith canary | **PASS** — `action: ok`, correct content |
| Original `analyze samples/Fattura981033956_clean.js` first-step smoke | **PASS** |
| Model-generated path | **`/workspace/input`** |
| Bytes read | **7707**, correct |
| Sample | **unchanged** (size + mtime identical) |
| ANALYSIS exact-prefix (real Ornith) | PASS — 36 artifact/message combinations, 0 mismatches |
| ANALYSIS rolling + prefix anchor | PASS — rolling > anchor > cold |
| Historical unedited replay | PASS (real bubblewrap) |
| Mutations | **12/12 CAUGHT** |
| Full suite | **2633 PASS** |
| compileall / `git diff --check` | PASS |
| Independent review | PASS |
| Severity | **BLOCKER 0 / MAJOR 0** |

Three mutations survived the first version of the tests — a reviewer showed that *"the artifact file lives read-only **under** /workspace/input"* keeps every asserted keyword and still says directory. The guards were rewritten to check container **framings** and to require each surface to state the equation positively; all three are now caught.

## Accepted MINORs

1. The `ANALYSIS_SYSTEM_PROMPT_SHA256` pin is a human tripwire — re-stamping it always passes. Inherent to the mechanism, and the property this change itself relied on to move the pin legitimately.
2. The parenthetical `` (`orbit_tools.SOURCE_PATH` is it) `` is correct but has a distant pronoun antecedent.

## Non-blocking follow-up

Make the shim's `PermissionError` name the correct path (`"...; the artifact is exactly /workspace/input"`), which would make recovery self-correcting on a second attempt at zero prompt-token cost. Touches sandbox-facing text, so it is left to its own mission.
