### PR TITLE
fix(runtime): bound analysis evidence and action generation

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -103,7 +103,59 @@ ANALYSIS_TOOL_SCHEMA: dict[str, Any] = {
 # What may enter model-visible history from one action. The sandbox permits
 # 8 MiB of scratch; that ceiling governs what a program may write, not what
 # a prompt should carry. Full output stays addressable in EvidenceStore.
-MAX_EVIDENCE_CHARS = 8 * 1024
+#
+# 3200 rather than the previous 8192, measured rather than chosen. A real
+# failing turn carried a 7767-char observation -- under the old cap, so it was
+# never truncated -- which tokenised to 6226 tokens: 98.3% of that step's
+# 6331-token prefill, and 231.8s of the 376s the turn took.
+#
+# The bound is in characters because runtime has no exact tokenizer and must
+# not grow one; the backend owns tokenisation. `estimate_text_tokens` exists
+# but under-counts this content roughly threefold (0.28-0.42 of the real count
+# on the measured corpora), so budgeting with it would admit about three times
+# the intended prompt. A character cap is the honest instrument here, and the
+# number is derived from the densest content actually observed:
+#
+#   8 preserved successful observations: 1197-2435 chars, 788-2044 tokens
+#   densest ratio in that corpus:        1.123 chars/token (obfuscated JS)
+#   3200 chars is therefore about 2850 tokens on content of that kind
+#
+# That figure describes the measured corpora, not a guarantee. A character cap
+# does not bound tokens: rare codepoints reach 4 tokens per character on this
+# tokenizer, so 3200 characters of them would be roughly 12800 tokens. The cap
+# is still the right instrument -- runtime has no exact tokenizer and must not
+# grow one -- and it is a strict improvement at every density, because the
+# 8192 it replaces was four times worse on exactly that input. Analysis input
+# is attacker-supplied by definition, so this is a bound on the ordinary case
+# and a reduction, not a defence.
+#
+# Every one of the successful observations fits untruncated, and the failing
+# one drops from 6226 to about 2200 tokens. Full output remains byte-complete
+# and re-attestable in EvidenceStore; only this projection reaches the model,
+# which is told the output exists rather than being handed a way to fetch it.
+MAX_EVIDENCE_CHARS = 3200
+
+# What one analyst step may generate. Derived from the 8 model-authored actions
+# of the preserved successful trajectory, tokenised with the real Ornith
+# tokenizer:
+#
+#   outputs: 60, 80, 84, 296, 351, 354, 858, 1417, 1953 tokens
+#   median 351, largest 1953
+#
+# The previous 1024 was not a qualified number, and the measurement shows it
+# was already too small: it would have truncated two of those nine calls. That
+# is what the failing turn actually hit -- 1024 output tokens, finish_reason
+# `length`, and a tool call cut off mid-JSON after 1488 characters. The failure
+# was the ceiling being too low, not generation running away.
+#
+# 2048 is the smallest value that truncates none of them, clearing the largest
+# by 5%. Headroom beyond that is not free: decode runs about 7 tok/s here, so
+# every extra 1000 tokens of allowance is another ~140s that a doomed step
+# spends before it can be refused. At 2048 the worst refused turn costs roughly
+# what the observed failure already cost (~374s against 376s measured), while
+# no successful action is cut short. A larger 2560 would have bought 31%
+# headroom nothing has ever needed and made the bad case ~70s worse.
+QUALIFIED_ANALYSIS_MAX_TOKENS = 2048
 
 # The per-action allowance the qualified sandbox enforces is a limit on what
 # ONE action may produce. A persistent workspace also needs a ceiling on what
@@ -261,6 +313,16 @@ class AnalysisStepResult:
         return True
 
 
+def _stopped_at_generation_limit(response: Any) -> bool:
+    """Whether generation was cut off by the budget rather than finishing.
+
+    `length` is the backend's own word for "I stopped because I ran out", so
+    it is read rather than inferred from token counts, which would need this
+    module to know the effective limit at the point of judgement.
+    """
+    return str(getattr(response, "finish_reason", "") or "").lower() == "length"
+
+
 def _tool_argument_chars(calls: list[dict[str, Any]]) -> int:
     """Total size of the generated tool arguments, never their content.
 
@@ -395,7 +457,7 @@ class AnalysisRuntime:
     workspace: AnalysisWorkspace | None = None
     messages: list[Message] = field(default_factory=list)
     temperature: float = 0.0
-    max_tokens: int = 1024
+    max_tokens: int = QUALIFIED_ANALYSIS_MAX_TOKENS
     model_calls: int = 0
     actions_executed: int = 0
     analyst_turns: int = 0
@@ -416,6 +478,17 @@ class AnalysisRuntime:
                     ),
                 }
             )
+
+    @property
+    def effective_max_tokens(self) -> int:
+        """The smaller of what the analyst asked for and what is qualified.
+
+        A configured limit below the qualified one is a deliberate choice and
+        is honoured; a larger one is not, because nothing above this has been
+        shown to be needed and the cost of finding out is a minute of decode
+        the analyst waits through.
+        """
+        return min(int(self.max_tokens), QUALIFIED_ANALYSIS_MAX_TOKENS)
 
     def session_usage(self) -> tuple[int, int]:
         """Return (bytes, files) currently retained in the session workspace.
@@ -483,7 +556,7 @@ class AnalysisRuntime:
             response = self.backend.chat_stream(
                 list(self.messages),
                 temperature=self.temperature,
-                max_tokens=self.max_tokens,
+                max_tokens=self.effective_max_tokens,
                 tools=[ANALYSIS_TOOL_SCHEMA],
                 on_delta=_capture,
                 on_progress=on_progress,
@@ -523,6 +596,15 @@ class AnalysisRuntime:
             )
 
         rejection = self._structural_rejection(calls) if calls else None
+        if rejection is not None and _stopped_at_generation_limit(response):
+            # Same refusal path, a truer reason. The call is unparseable
+            # because generation ended mid-JSON, not because the model
+            # produced something malformed by choice, and an analyst who reads
+            # "not valid JSON" would look for the wrong problem.
+            rejection = (
+                "analysis step reached its generation limit before producing "
+                "a valid tool call"
+            )
         if rejection is not None:
             assistant["content"] = _rejected_action_text(content, rejection)
             self.messages.append(assistant)

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -1460,3 +1460,233 @@ class StepDiagnosticsTest(AnalysisRuntimeTestBase):
         self.assertTrue(recovered.action_executed)
         self.assertEqual(backend.calls, 2)
         json.dumps(runtime.messages, default=str)
+
+
+class EvidenceProjectionBudgetTest(AnalysisRuntimeTestBase):
+    """Raw evidence stays whole; only a bounded projection reaches the model.
+
+    A real failing turn carried a 7767-char observation that the old 8192 cap
+    never truncated. It tokenised to 6226 tokens -- 98.3% of that step's
+    prefill. The bound exists to keep the prompt proportionate, not to reduce
+    what is recorded.
+    """
+
+    def _big_result(self, size: int = 7767):
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        return AnalysisResult(
+            status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+            stdout="X" * size, stderr="", exit_status=0, duration_seconds=1.0,
+        )
+
+    def test_the_budget_is_the_measured_one(self) -> None:
+        from orbit.runtime.analysis_runtime import MAX_EVIDENCE_CHARS
+
+        # Derived: every preserved successful observation (max 2435 chars)
+        # fits untruncated, and the densest observed content (1.123
+        # chars/token) is bounded near 2850 tokens.
+        self.assertEqual(MAX_EVIDENCE_CHARS, 3200)
+        self.assertGreater(MAX_EVIDENCE_CHARS, 2435)
+
+    def test_every_preserved_successful_observation_still_fits(self) -> None:
+        from orbit.runtime.analysis_runtime import MAX_EVIDENCE_CHARS, _bounded_observation
+
+        # The eight model-authored actions of the successful trajectory.
+        for size in (1197, 1293, 1308, 1391, 2146, 2164, 2295, 2435):
+            with self.subTest(size=size):
+                # 19 = len("status: ok\nstdout:\n"), so the reconstructed
+                # observation is exactly the historical size.
+                text, truncated, full = _bounded_observation(self._big_result(size - 19))
+                self.assertFalse(truncated, "a successful observation must not be cut")
+                self.assertLessEqual(len(text), MAX_EVIDENCE_CHARS)
+
+    def test_an_observation_exactly_at_the_cap_is_not_truncated(self) -> None:
+        from orbit.runtime.analysis_runtime import MAX_EVIDENCE_CHARS, _bounded_observation
+
+        exact = self._big_result(MAX_EVIDENCE_CHARS - 19)
+        text, truncated, full = _bounded_observation(exact)
+        self.assertFalse(truncated, "at the cap is within the cap")
+        self.assertEqual(len(text), MAX_EVIDENCE_CHARS)
+
+        over, over_trunc, _ = _bounded_observation(self._big_result(MAX_EVIDENCE_CHARS - 18))
+        self.assertTrue(over_trunc, "one char past the cap must truncate")
+
+    def test_a_large_observation_is_bounded_for_the_prompt(self) -> None:
+        from orbit.runtime.analysis_runtime import MAX_EVIDENCE_CHARS, _bounded_observation
+
+        text, truncated, full = _bounded_observation(self._big_result())
+        self.assertTrue(truncated)
+        self.assertLessEqual(len(text), MAX_EVIDENCE_CHARS)
+        self.assertEqual(full, len("status: ok\nstdout:\n") + 7767)
+
+    def test_truncation_states_what_was_dropped(self) -> None:
+        from orbit.runtime.analysis_runtime import _bounded_observation
+
+        text, _, full = _bounded_observation(self._big_result())
+        self.assertIn(str(full), text, "the full size must be stated")
+        self.assertIn("truncated for prompt", text)
+        self.assertIn("stored in evidence", text)
+
+    def test_raw_evidence_stays_complete_and_reattestable(self) -> None:
+        """The bound is a projection, not a deletion."""
+        import hashlib
+
+        backend = ScriptedBackend(
+            tool_response("import orbit_tools\nprint('Z' * 40000, end='')")
+        )
+        runtime = self.runtime(backend)
+        result = runtime.step("produce a lot")
+
+        assert result.raw_output_evidence_id is not None
+        raw = runtime.evidence_store.reattest_exact(result.raw_output_evidence_id)
+        self.assertIsNotNone(raw, "raw evidence must remain re-attestable")
+        assert raw is not None
+        self.assertGreater(len(raw), 3200, "raw evidence must not be truncated")
+        record = runtime.evidence_store.records[result.raw_output_evidence_id]
+        self.assertEqual(record.raw_sha256, hashlib.sha256(raw.encode()).hexdigest())
+
+    def test_the_unique_tail_of_raw_evidence_never_reaches_the_prompt(self) -> None:
+        """The dropped tail exists in evidence and nowhere the model can read.
+
+        Checked on the tool RESULT message specifically: the assistant's own
+        tool call legitimately contains the code that produced the output, so
+        scanning the whole history would match the model's own text.
+        """
+        marker = "TAIL_SENTINEL_9f3a"
+        code = "import orbit_tools\nprint('P' * 9000 + chr(84) + %r, end='')" % marker[1:]
+        backend = ScriptedBackend(tool_response(code))
+        runtime = self.runtime(backend)
+        result = runtime.step("produce a lot")
+
+        observations = [
+            str(m.get("content") or "")
+            for m in runtime.messages
+            if m.get("role") == "tool"
+        ]
+        self.assertTrue(observations)
+        for text in observations:
+            self.assertNotIn(marker, text, "the dropped tail must not enter context")
+            self.assertLessEqual(len(text), 3200)
+
+        assert result.raw_output_evidence_id is not None
+        raw = runtime.evidence_store.reattest_exact(result.raw_output_evidence_id)
+        self.assertIsNotNone(raw, "raw evidence must remain re-attestable")
+        assert raw is not None
+        self.assertIn(marker, raw, "but it must still be recorded in full")
+
+
+class AnalysisGenerationBudgetTest(AnalysisRuntimeTestBase):
+    """One step's output is bounded by what successful actions actually needed.
+
+    The preserved trajectory's nine calls produced 60-1953 tokens. The former
+    1024 default would have truncated two of them -- and truncation is exactly
+    what broke the failing turn.
+    """
+
+    def test_the_limit_is_derived_from_the_successful_envelope(self) -> None:
+        from orbit.runtime.analysis_runtime import QUALIFIED_ANALYSIS_MAX_TOKENS
+
+        largest_successful_action = 1953
+        self.assertEqual(QUALIFIED_ANALYSIS_MAX_TOKENS, 2048)
+        self.assertGreater(QUALIFIED_ANALYSIS_MAX_TOKENS, largest_successful_action)
+        # Smallest value that cuts none of the nine, because headroom costs
+        # decode time a refused step has to spend before it can refuse.
+        self.assertLess(QUALIFIED_ANALYSIS_MAX_TOKENS, 2560)
+
+    def test_a_smaller_configured_limit_wins(self) -> None:
+        backend = ScriptedBackend(prose_response("ok"))
+        runtime = self.runtime(backend)
+        runtime.max_tokens = 256
+        self.assertEqual(runtime.effective_max_tokens, 256)
+
+    def test_a_larger_configured_limit_is_capped(self) -> None:
+        from orbit.runtime.analysis_runtime import QUALIFIED_ANALYSIS_MAX_TOKENS
+
+        backend = ScriptedBackend(prose_response("ok"))
+        runtime = self.runtime(backend)
+        runtime.max_tokens = 32000
+        self.assertEqual(runtime.effective_max_tokens, QUALIFIED_ANALYSIS_MAX_TOKENS)
+
+    def test_the_effective_limit_is_what_reaches_the_backend(self) -> None:
+        class Recording(ScriptedBackend):
+            seen_max = None
+
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta, on_progress=None):
+                Recording.seen_max = max_tokens
+                return super().chat_stream(
+                    messages, temperature=temperature, max_tokens=max_tokens,
+                    tools=tools, on_delta=on_delta, on_progress=on_progress)
+
+        backend = Recording(prose_response("ok"))
+        runtime = self.runtime(backend)
+        runtime.max_tokens = 99999
+        runtime.step("look")
+        self.assertEqual(Recording.seen_max, 2048)
+
+    def test_chat_max_tokens_is_untouched(self) -> None:
+        from orbit.terminal.config import AppConfig
+
+        self.assertEqual(AppConfig().max_tokens, 512)
+
+
+class GenerationLimitRefusalTest(AnalysisRuntimeTestBase):
+    """Hitting the limit mid-call is refused specifically, and cheaply."""
+
+    def _truncated_call(self):
+        response = tool_response("x")
+        response.tool_calls[0]["function"]["arguments"] = '{"code": "import orbit'
+        return ChatResult(
+            content="", model="m", finish_reason="length",
+            tool_calls=response.tool_calls, prompt_tokens=6926,
+            completion_tokens=2048, cached_tokens=595,
+            prompt_tokens_per_second=27.3, generation_tokens_per_second=7.1,
+        )
+
+    def test_the_refusal_names_the_generation_limit(self) -> None:
+        result = self.runtime(ScriptedBackend(self._truncated_call())).step("look")
+
+        assert result.rejection is not None
+        self.assertIn("generation limit", result.rejection)
+        self.assertNotIn("not valid JSON", result.rejection)
+
+    def test_no_action_runs_and_history_stays_renderable(self) -> None:
+        runtime = self.runtime(ScriptedBackend(self._truncated_call()))
+        result = runtime.step("look")
+
+        self.assertFalse(result.action_executed)
+        self.assertEqual(runtime.actions_executed, 0)
+        self.assertEqual(result.model_calls, 1)
+        json.dumps(runtime.messages, default=str)
+        for message in runtime.messages:
+            self.assertNotIn("tool_calls", message)
+
+    def test_diagnostics_survive_the_bounded_refusal(self) -> None:
+        result = self.runtime(ScriptedBackend(self._truncated_call())).step("look")
+
+        diag = result.diagnostics
+        assert diag is not None
+        self.assertEqual(diag.finish_reason, "length")
+        self.assertEqual(diag.output_tokens, 2048)
+        self.assertEqual(diag.refusal, result.rejection)
+
+    def test_the_next_step_still_works(self) -> None:
+        backend = ScriptedBackend(
+            self._truncated_call(),
+            tool_response("import orbit_tools\nprint('ok')"),
+        )
+        runtime = self.runtime(backend)
+        runtime.step("first")
+        recovered = runtime.step("second")
+
+        self.assertTrue(recovered.action_executed)
+        self.assertEqual(backend.calls, 2, "no automatic repair call")
+
+    def test_an_ordinary_malformed_call_keeps_its_own_reason(self) -> None:
+        response = tool_response("x")
+        response.tool_calls[0]["function"]["arguments"] = "{not json"
+        result = self.runtime(ScriptedBackend(response)).step("look")
+
+        assert result.rejection is not None
+        self.assertIn("not valid JSON", result.rejection)
+        self.assertNotIn("generation limit", result.rejection)


### PR DESCRIPTION
A real ANALYSIS turn spent **376.37s** and produced nothing: prompt 6926 / evaluated 6331, prefill 231.8s, then 1024 output tokens ending on `finish_reason=length` with the tool JSON truncated at 1488 chars and **0 actions**. Measuring it showed two separate causes — and the second is the opposite of what the symptom suggested.

## 1. Model-facing evidence bound: 8192 → **3200 chars**

Attribution with the real Ornith tokenizer: the bounded observation was **6226 tokens — 98.3%** of the 6331-token suffix. The old 8192-char cap **never fired**, because the observation was 7767 chars, so a whole 7.7 KB artifact dump entered the context and cost 231.8s of prefill.

Derived from the **8 model-authored observations** of the preserved successful trajectory: 1197–2435 chars, 788–2044 tokens, densest ratio 1.123 chars/token. **Every one fits untruncated at 3200**; the failing observation drops to ~2206 tokens (−64.6%).

A character cap, stated honestly: runtime has no exact tokenizer and must not grow one, and the existing `estimate_text_tokens` (`len//4`) under-counts this content 2.4–3.6×. A char cap is *not* a token bound either — rare codepoints reach 4 tok/char — but it is the same instrument set 4× tighter, proportional at every density.

## 2. Qualified ANALYSIS generation: **2048 tokens**

The turn ended on `length`, which reads like runaway generation. It was not. The **9 successful calls** produced 60, 80, 84, 296, 351, 354, 858, 1417, **1953** tokens — all `finish_reason=tool_calls`, genuinely complete. **The 1024 default would have truncated 2 of those 9.** The ceiling was too low; it cut off a call still being written.

**2048 is the smallest value that truncates none of them** (+5% over 1953). Headroom is not free at ~7 tok/s: 2560 would buy 31% headroom nothing has ever used and make the worst refused turn ~70s slower.

`effective_max_tokens = min(user_limit, 2048)` — **a smaller configured limit still wins**. CHAT's `AppConfig.max_tokens` (512) is untouched, and neither `AnalysisRuntime` site passes `max_tokens`.

## 3. Bounded generation refusal

Hitting the limit mid-call now reports *"analysis step reached its generation limit before producing a valid tool call"* instead of *"tool arguments are not valid JSON"*. **Same existing rejection path, no new controller**: zero actions, no `tool_calls` in history, diagnostics preserved, next step works, no automatic repair call.

## Three layers stay distinct

| Layer | Status |
| --- | --- |
| **Raw evidence** | complete, durable, **re-attestable** via `reattest_exact` — unchanged |
| **Model-facing observation** | bounded projection, now 3200 chars |
| Analyst-facing preview | **not in this change** — a later UX mission |

Proven by a sentinel test: the dropped tail is absent from every model-visible `tool` message and present in the raw record, whose sha and size still verify.

## Qualification

| Check | Result |
| --- | --- |
| Mutations | **13/13 CAUGHT** |
| Full suite | **2669 PASS** |
| compileall / `git diff --check` | PASS |
| Independent review | **PASS**, BLOCKER 0 |
| Benign Ornith canary | PASS (tiny.js, 2 steps, 1 action each) |

### Manual Fattura gate — PASS (run by the maintainer on these exact bytes)

| | before | after |
| --- | --- | --- |
| prompt | 6926 | **2905** |
| evaluated | 6331 | **2310** |
| output | 1024 (`length`) | **46** |
| result | invalid JSON, **0 actions** | **action: ok** |
| wall | 401.6s | **125.4s** |

The reviewer independently re-derived every load-bearing number from the two preserved sources with the real tokenizer; all matched to the digit. Its MAJOR-1 (a comment overstating the char cap as a token bound) and three MINORs were fixed before merge.

## Out of scope

No analyst evidence preview, no prompt changes, no routing/KV/prewarm/backend/sandbox changes, no malware-specific logic, no terminal UX work.
