### PR TITLE
feat(terminal): improve analysis workflow UX

### DIFF
--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -19,6 +19,7 @@ from typing import Callable
 
 from orbit.backend.base import ChatBackend
 from orbit.runtime.analysis_runtime import (
+    WORK_MOUNT,
     AnalysisRuntime,
     AnalysisStepResult,
     StepDiagnostics,
@@ -142,7 +143,11 @@ def format_analysis_step(result: AnalysisStepResult) -> str:
         lines.append(_action_summary(result))
     elif result.action_attempted:
         lines.append("action attempted but not executed")
-    if result.artifact_handles:
+    if result.artifact_handles and not (
+        result.action_executed and result.result is not None and result.result.artifacts
+    ):
+        # Only when the preview did not already list them with size and digest;
+        # printing both says the same thing twice.
         lines.append(f"artifacts: {', '.join(result.artifact_handles)}")
     if not lines:
         lines.append("(no output)")
@@ -186,6 +191,15 @@ def format_step_diagnostics(diagnostics: "StepDiagnostics | None") -> str:
 MAX_ACTION_CAUSE_CHARS = 160
 
 
+# What an action's output may occupy on the analyst's screen. Independent of
+# the model-facing bound: that one is about prompt cost, this one is about a
+# terminal staying readable. Sized like the rest of the CLI's excerpts -- a
+# couple of dozen lines is enough to see what a step produced and decide the
+# next one, and the full text is a copyable evidence id away.
+MAX_PREVIEW_CHARS = 1200
+MAX_PREVIEW_LINES = 24
+
+
 def _action_summary(result: AnalysisStepResult) -> str:
     action = result.result
     if action is None:
@@ -196,11 +210,142 @@ def _action_summary(result: AnalysisStepResult) -> str:
     cause = _action_cause(action)
     if cause:
         summary += f" | {cause}"
+
+    preview = _preview_block(action)
+    trailer: list[str] = []
     if result.evidence is not None:
-        summary += f" | evidence {result.evidence.evidence_id}"
+        trailer.append(f"evidence: {result.evidence.evidence_id}")
     if result.raw_output_evidence_id:
-        summary += f" | raw {result.raw_output_evidence_id}"
-    return summary
+        trailer.append(f"raw: {result.raw_output_evidence_id}")
+
+    if not preview:
+        # Nothing to show: keep the one-line shape an action with no output
+        # always had.
+        if trailer:
+            summary += " | " + " | ".join(
+                part.replace("evidence: ", "evidence ").replace("raw: ", "raw ")
+                for part in trailer
+            )
+        return summary
+
+    lines = [summary, *preview]
+    if trailer:
+        lines.append("")
+        lines.extend(trailer)
+    return "\n".join(lines).rstrip()
+
+
+def _preview_block(action: AnalysisResult) -> list[str]:
+    """What the action produced, bounded for a terminal.
+
+    An evidence id says where to look; it does not say what happened. Without
+    this the analyst has to open the store by hand before they can choose the
+    next step, which is the one thing an interactive session should not
+    require. Nothing here is interpreted -- it is the action's own output,
+    excerpted -- and no model is consulted to explain it.
+    """
+    # stdout only. On failure the cause line already carries the exception,
+    # and printing stderr underneath would say the same sentence twice.
+    block: list[str] = []
+    excerpt = _excerpt(action.stdout)
+    if excerpt:
+        block.append("")
+        block.append("result:")
+        block.extend(f"  {_sanitize(line)}" for line in excerpt)
+    if action.artifacts:
+        block.append("")
+        block.append("artifacts:")
+        for artifact in action.artifacts:
+            # The virtual path the analyst can name in the next step, never the
+            # host temp directory the workspace happens to live in.
+            block.append(
+                f"  - {WORK_MOUNT}/{_sanitize(artifact.name)} | "
+                f"{_human_size(artifact.size_bytes)} | "
+                f"sha256 {_sanitize(_short_sha(artifact.sha256))}"
+            )
+    return block
+
+
+def _excerpt(text: str) -> list[str]:
+    """Readable lines from `text`, bounded and marked when shortened."""
+    if not text or not text.strip():
+        return []
+    if _looks_binary(text):
+        # Metadata only. Binary on a terminal corrupts the display and tells
+        # the analyst nothing they can act on.
+        return [f"<{len(text)} chars of non-text output; see raw evidence>"]
+    lines = text.splitlines()
+    kept = lines[:MAX_PREVIEW_LINES]
+    shortened = len(lines) > MAX_PREVIEW_LINES
+    out: list[str] = []
+    budget = MAX_PREVIEW_CHARS
+    for line in kept:
+        if budget <= 0:
+            shortened = True
+            break
+        if len(line) > budget:
+            out.append(line[:budget] + "…")
+            budget = 0
+            shortened = True
+            continue
+        out.append(line)
+        budget -= len(line)
+    if shortened:
+        out.append(f"[preview truncated; {len(text)} chars total, full output in evidence]")
+    return out
+
+
+_CONTROL = {ord(c) for c in "\t"}
+
+
+def _sanitize(text: str) -> str:
+    """Strip control characters that would act on the terminal.
+
+    Everything previewed here is model-authored output. Left as-is it can move
+    the cursor and overwrite what Orbit already printed -- a crafted action
+    could forge its own `action: ok` line above itself. Tabs survive because
+    they are ordinary in program output; everything else in the control range
+    becomes a visible escape.
+    """
+    return "".join(
+        ch if ch.isprintable() or ord(ch) in _CONTROL else repr(ch)[1:-1]
+        for ch in text
+    )
+
+
+def _looks_binary(text: str) -> bool:
+    """Control characters beyond the ordinary whitespace ones."""
+    printable = sum(1 for ch in text[:2000] if ch in "\t\n\r" or ch >= " ")
+    sample = min(len(text), 2000)
+    return sample > 0 and printable / sample < 0.9
+
+
+# Enough to tell two artifacts apart at a glance and to grep the full value
+# out of evidence; short enough that the line still fits an 80-column
+# terminal, which the full 64 hex characters did not.
+SHORT_SHA_CHARS = 12
+
+
+def _short_sha(value: str) -> str:
+    """The leading hex of a digest, for reading rather than verifying.
+
+    Presentation only: what is stored, provenanced and re-attested is always
+    the whole digest. Anything that is not a plain hex digest is shown as it
+    is, so a malformed value stays visible instead of being quietly trimmed
+    into something that looks well-formed.
+    """
+    text = str(value or "")
+    if len(text) <= SHORT_SHA_CHARS or not all(c in "0123456789abcdefABCDEF" for c in text):
+        return text
+    return f"{text[:SHORT_SHA_CHARS]}\u2026"
+
+
+def _human_size(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KiB"
+    return f"{size / (1024 * 1024):.1f} MiB"
 
 
 def _action_cause(action: AnalysisResult) -> str | None:

--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+from urllib.parse import urlparse
 import time
 
 from orbit import __version__
@@ -131,6 +133,21 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --image/--audio require a one-shot prompt", file=sys.stderr)
         return 1
 
+    # Only the interactive path checks this. `--health` is the question itself,
+    # and a one-shot already fails visibly on its single call; a session, by
+    # contrast, would draw a prompt and then fail on whatever the analyst
+    # typed, which reads as their mistake rather than a missing server.
+    # A single documented escape hatch, for tests that drive the REPL as a
+    # subprocess with no server behind it. Named so it cannot be mistaken for
+    # a supported way to run without one, and read only here.
+    if os.environ.get("ORBIT_SKIP_SERVER_READINESS") != "1" and not backend.health():
+        print(
+            f"error: Orbit server is not ready at {_endpoint_label(config.base_url)}. "
+            "Start the server and try again.",
+            file=sys.stderr,
+        )
+        return 1
+
     session = select_interactive_session(config.workdir)
     # Resuming, not merely reading: a stored history that cannot be parsed as a
     # conversation must not become the live one. On refusal the warning is
@@ -159,6 +176,14 @@ def main(argv: list[str] | None = None) -> int:
         history=history,
         workflow_mode=workflow_mode,
     ).run()
+
+
+def _endpoint_label(base_url: str) -> str:
+    """`host:port` for the error, falling back to whatever was configured."""
+    parsed = urlparse(base_url)
+    if parsed.hostname:
+        return f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
+    return base_url
 
 
 def _handle_one_shot_command(

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -51,6 +51,15 @@ from orbit.runtime.thinking_mode import ThinkingMode
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
 
+def _abbreviate_home(path: Path) -> str:
+    """`~/...` for paths under HOME, because the absolute form is noise."""
+    try:
+        relative = Path(path).resolve().relative_to(Path.home())
+    except (ValueError, RuntimeError, OSError):
+        return str(path)
+    return "~" if str(relative) == "." else f"~/{relative}"
+
+
 @dataclass
 class Repl:
     runtime: ChatRuntime
@@ -66,6 +75,7 @@ class Repl:
     # test sets this; it exists so the swap window can be exercised
     # deterministically instead of raced for.
     _analysis_acquired_hook: Callable[[], None] | None = field(default=None, repr=False)
+    _announced_workdir: str | None = field(default=None, repr=False)
     analysis: AnalysisRuntime | None = field(default=None, repr=False)
     queued_prompts: list[str] = field(default_factory=list)
     turn_model_steps: list[ModelStepMetrics] = field(default_factory=list, repr=False)
@@ -96,6 +106,7 @@ class Repl:
         status = collect_runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode)
         for line in format_startup_banner(status).splitlines():
             print(dim(line))
+        self._announce_workdir()
         if has_existing_session_context(self.runtime.messages):
             print(dim("recent session context:"))
             for line in format_recent_session_messages(self.runtime.messages):
@@ -137,6 +148,23 @@ class Repl:
                 self.history.save()
             self._ask(prompt)
             self.prompt_gap_pending = True
+
+    def _announce_workdir(self) -> None:
+        """Say where this session is working, once.
+
+        Called at startup only. `config.workdir` is resolved when the config
+        loads and nothing mutates it afterwards -- there is no `/cd` -- so a
+        per-turn change check would be a string comparison that can never
+        fire. Guarded anyway, so calling it twice stays harmless.
+
+        Display only: the model's view of the workdir is whatever the runtime
+        already sends, and this neither adds to nor alters it.
+        """
+        current = str(self.config.workdir)
+        if current == self._announced_workdir:
+            return
+        self._announced_workdir = current
+        print(dim(f"workdir: {_abbreviate_home(self.config.workdir)}"), flush=True)
 
     def _prompt_label(self) -> str:
         """The marker for the runtime that owns the next line.

--- a/src/orbit/terminal/repl_input.py
+++ b/src/orbit/terminal/repl_input.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from shutil import get_terminal_size
 
 from orbit.terminal.prompt_preview import compact_prompt_preview, is_long_text_prompt
-from orbit.terminal.theme import CYAN, RESET, accent, yellow_dim
+from orbit.terminal.theme import CYAN, RESET, YELLOW, accent, yellow_dim
 
 
 PASTE_BADGE_PATTERN = re.compile(r"(\[text \d+ chars #[0-9a-f]{8}\])$")
@@ -65,8 +65,12 @@ def input_prompt(label: str = "") -> str:
     """
     if not sys.stdout.isatty():
         return f"{label}> "
+    # ANALYSIS is amber, not red: the session is doing normal work under
+    # different rules, and red belongs to failures. The colour is chosen from
+    # the label the caller passed, so it cannot disagree with the text.
+    colour = YELLOW if label == "analysis" else CYAN
     return (
-        f"{READLINE_IGNORE_START}{CYAN}{READLINE_IGNORE_END}{label}> "
+        f"{READLINE_IGNORE_START}{colour}{READLINE_IGNORE_END}{label}> "
         f"{READLINE_IGNORE_START}{RESET}{READLINE_IGNORE_END}"
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,9 +350,110 @@ def _run_cli(stdin: str, *args: str) -> subprocess.CompletedProcess[str]:
             input=stdin,
             text=True,
             capture_output=True,
-            env={"PYTHONPATH": str(ROOT / "src"), "HOME": home},
+            env={
+                "PYTHONPATH": str(ROOT / "src"),
+                "HOME": home,
+                # These drive the REPL itself, not readiness; there is no
+                # server behind the subprocess.
+                "ORBIT_SKIP_SERVER_READINESS": "1",
+            },
             check=False,
         )
+
+
+
+class ServerReadinessTests(unittest.TestCase):
+    """An interactive session must not open against a server that is not there.
+
+    Drawing `chat>` and then failing on whatever the analyst types reads as
+    their mistake rather than a missing server.
+    """
+
+    def _args(self, tmp: Path):
+        return [
+            "--workdir", str(tmp),
+            "--base-url", "http://127.0.0.1:12120",
+        ]
+
+    def _run(self, *, healthy: bool):
+        with tempfile.TemporaryDirectory() as name:
+            tmp = Path(name)
+            backend = mock.MagicMock()
+            backend.health.return_value = healthy
+            backend.model_info.return_value = None
+            err = io.StringIO()
+            out = io.StringIO()
+            with (
+                mock.patch.object(cli, "LlamaServerBackend", return_value=backend),
+                mock.patch.object(cli, "Repl") as repl_cls,
+                contextlib.redirect_stderr(err),
+                contextlib.redirect_stdout(out),
+            ):
+                repl_cls.return_value.run.return_value = 0
+                code = cli.main(self._args(tmp))
+            return code, err.getvalue(), out.getvalue(), backend, repl_cls
+
+    def test_an_unavailable_server_exits_before_the_prompt(self) -> None:
+        code, err, out, backend, repl_cls = self._run(healthy=False)
+
+        self.assertEqual(code, 1)
+        repl_cls.assert_not_called()
+        self.assertNotIn("chat>", out)
+        self.assertIn("Orbit server is not ready", err)
+
+    def test_the_error_names_the_endpoint_and_the_remedy(self) -> None:
+        _, err, _, _, _ = self._run(healthy=False)
+
+        self.assertIn("127.0.0.1:12120", err)
+        self.assertIn("Start the server and try again", err)
+        self.assertEqual(len(err.strip().splitlines()), 1, "one concise line")
+
+    def test_it_does_not_retry(self) -> None:
+        _, _, _, backend, _ = self._run(healthy=False)
+
+        self.assertEqual(backend.health.call_count, 1, "no hidden retry loop")
+
+    def test_a_ready_server_enters_the_repl(self) -> None:
+        code, err, _, backend, repl_cls = self._run(healthy=True)
+
+        self.assertEqual(code, 0)
+        repl_cls.assert_called_once()
+        self.assertNotIn("not ready", err)
+
+    def test_it_reuses_the_existing_health_mechanism(self) -> None:
+        """No second protocol: the check is `backend.health()`."""
+        _, _, _, backend, _ = self._run(healthy=False)
+
+        backend.health.assert_called()
+
+    def test_the_escape_hatch_is_explicit_and_narrow(self) -> None:
+        """Only the exact opt-in string skips the check.
+
+        The hatch exists so subprocess REPL tests can run without a server. A
+        loose truthiness test would turn any stray value into a silent bypass.
+        """
+        with tempfile.TemporaryDirectory() as name:
+            tmp = Path(name)
+            for value, expect_repl in (("1", True), ("0", False), ("true", False), ("", False)):
+                backend = mock.MagicMock()
+                backend.health.return_value = False
+                backend.model_info.return_value = None
+                with (
+                    mock.patch.dict("os.environ", {"ORBIT_SKIP_SERVER_READINESS": value}),
+                    mock.patch.object(cli, "LlamaServerBackend", return_value=backend),
+                    mock.patch.object(cli, "Repl") as repl_cls,
+                    contextlib.redirect_stderr(io.StringIO()),
+                    contextlib.redirect_stdout(io.StringIO()),
+                ):
+                    repl_cls.return_value.run.return_value = 0
+                    cli.main(self._args(tmp))
+                    with self.subTest(value=value):
+                        self.assertEqual(repl_cls.called, expect_repl)
+
+    def test_endpoint_label_falls_back_to_the_configured_url(self) -> None:
+        self.assertEqual(cli._endpoint_label("http://127.0.0.1:12120"), "127.0.0.1:12120")
+        self.assertEqual(cli._endpoint_label("http://example.test"), "example.test")
+        self.assertEqual(cli._endpoint_label("not-a-url"), "not-a-url")
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1101,8 +1101,10 @@ class ActionCauseRenderingTest(unittest.TestCase):
         rendered = format_analysis_step(step)
         self.assertIn("action: error", rendered)
         self.assertIn("PermissionError: nope", rendered)
-        self.assertIn("evidence ev_aaa_bbb", rendered)
-        self.assertIn("raw ev_ccc_ddd", rendered)
+        # The ids moved onto their own lines once a preview can sit above
+        # them; they are for copying, and a long joined tail is hard to select.
+        self.assertIn("ev_aaa_bbb", rendered)
+        self.assertIn("ev_ccc_ddd", rendered)
 
     def test_a_successful_summary_is_unchanged(self) -> None:
         from orbit.runtime.analysis_runtime import AnalysisStepResult
@@ -1291,3 +1293,492 @@ class AnalysisProgressRenderingTest(ModeTestBase):
             renderer.finish()
         rendered = out.getvalue()
         self.assertNotIn("\x1b[", rendered, "no ANSI in non-interactive output")
+
+
+class EvidencePreviewTest(unittest.TestCase):
+    """After an action the analyst must be able to see what it produced.
+
+    An evidence id says where to look, not what happened. Without a preview
+    the only way to choose the next step is to open the store by hand.
+    """
+
+    def _result(self, **overrides):
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        base = dict(
+            status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+            stdout="", stderr="", exit_status=0, duration_seconds=1.0,
+        )
+        base.update(overrides)
+        return AnalysisResult(**base)
+
+    def _step(self, action, **overrides):
+        from orbit.runtime.analysis_runtime import AnalysisStepResult
+        from orbit.runtime.evidence import EvidenceRecord
+
+        record = EvidenceRecord(
+            evidence_id="ev_aaa_bbb", tool_name="execute_analysis", kind="fetch",
+            raw_ref="evidence:ev_aaa_bbb", raw_sha256="d" * 64, raw_chars=10,
+            raw_lines=1, status="ok", metadata={}, route_card=None, final_card=None,
+        )
+        base = dict(
+            model_calls=1, action_attempted=True, action_executed=True,
+            assistant_text="", result=action, evidence=record,
+            raw_output_evidence_id="ev_ccc_ddd",
+        )
+        base.update(overrides)
+        return AnalysisStepResult(**base)
+
+    def test_the_preview_caps_are_pinned_and_independent(self) -> None:
+        """Absolute values, not self-referential comparisons.
+
+        Asserting a bound against the constant it bounds passes at any value.
+        These are also deliberately separate from the model-facing budget:
+        one is about prompt cost, the other about a readable terminal.
+        """
+        from orbit.runtime.analysis_runtime import MAX_EVIDENCE_CHARS
+        from orbit.terminal.analysis_mode import MAX_PREVIEW_CHARS, MAX_PREVIEW_LINES
+
+        self.assertEqual(MAX_PREVIEW_CHARS, 1200)
+        self.assertEqual(MAX_PREVIEW_LINES, 24)
+        self.assertLess(MAX_PREVIEW_CHARS, MAX_EVIDENCE_CHARS)
+
+    def test_useful_stdout_is_visible(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(stdout="strings found: 12\nWScript.Shell\n"))
+        )
+        self.assertIn("result:", rendered)
+        self.assertIn("strings found: 12", rendered)
+        self.assertIn("WScript.Shell", rendered)
+
+    def test_multiline_output_is_bounded_by_lines(self) -> None:
+        from orbit.terminal.analysis_mode import MAX_PREVIEW_LINES, format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(stdout="\n".join(f"line {i}" for i in range(500))))
+        )
+        shown = [ln for ln in rendered.splitlines() if ln.startswith("  line ")]
+        self.assertLessEqual(len(shown), MAX_PREVIEW_LINES)
+        self.assertIn("preview truncated", rendered)
+
+    def test_a_single_enormous_line_is_bounded_by_chars(self) -> None:
+        from orbit.terminal.analysis_mode import MAX_PREVIEW_CHARS, format_analysis_step
+
+        rendered = format_analysis_step(self._step(self._result(stdout="Z" * 100000)))
+        body = "\n".join(
+            ln for ln in rendered.splitlines() if ln.startswith("  ") and "Z" in ln
+        )
+        self.assertLessEqual(len(body), MAX_PREVIEW_CHARS + 40)
+        self.assertIn("preview truncated", rendered)
+
+    def test_truncation_keeps_the_raw_evidence_id(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(self._step(self._result(stdout="Q" * 90000)))
+        self.assertIn("preview truncated", rendered)
+        self.assertIn("ev_ccc_ddd", rendered)
+        self.assertIn("full output in evidence", rendered)
+
+    def test_artifacts_show_virtual_path_size_and_sha(self) -> None:
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(
+                stdout="done\n",
+                artifacts=(DerivedArtifact(name="stage2.js", size_bytes=4096, sha256="a" * 64),),
+            ))
+        )
+        self.assertIn("artifacts:", rendered)
+        self.assertIn("/workspace/work/stage2.js", rendered)
+        self.assertIn("4.0 KiB", rendered)
+        # Shortened for the terminal; the stored digest keeps all 64 chars.
+        self.assertIn("sha256 " + "a" * 12 + "\u2026", rendered)
+
+    def test_the_artifact_digest_is_shortened_for_reading(self) -> None:
+        """Twelve hex characters and an ellipsis, not the whole digest.
+
+        The full 64 characters pushed the line past 80 columns, so it wrapped
+        and became harder to read than no digest at all. Twelve is enough to
+        tell two artifacts apart and to grep the full value out of evidence.
+        """
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import SHORT_SHA_CHARS, format_analysis_step
+
+        digest = "ec8ccda0a41f" + "3b" * 26
+        rendered = format_analysis_step(
+            self._step(self._result(
+                stdout="done\n",
+                artifacts=(DerivedArtifact(name="stage1.txt", size_bytes=1008, sha256=digest),),
+            ))
+        )
+        self.assertEqual(SHORT_SHA_CHARS, 12)
+        self.assertIn("sha256 ec8ccda0a41f\u2026", rendered)
+        self.assertNotIn(digest, rendered, "the full digest must not be on screen")
+
+    def test_the_stored_digest_is_never_truncated(self) -> None:
+        """Presentation only: what is recorded keeps all 64 characters."""
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        digest = "ec8ccda0a41f" + "3b" * 26
+        artifact = DerivedArtifact(name="stage1.txt", size_bytes=1008, sha256=digest)
+        step = self._step(self._result(stdout="done\n", artifacts=(artifact,)))
+        format_analysis_step(step)
+
+        self.assertEqual(artifact.sha256, digest)
+        self.assertEqual(len(artifact.sha256), 64)
+        self.assertEqual(step.result.artifacts[0].sha256, digest)
+
+    def test_two_artifacts_stay_distinguishable(self) -> None:
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        first = "aaaaaaaaaaaa" + "0" * 52
+        second = "bbbbbbbbbbbb" + "0" * 52
+        rendered = format_analysis_step(
+            self._step(self._result(
+                stdout="done\n",
+                artifacts=(
+                    DerivedArtifact(name="one.bin", size_bytes=1, sha256=first),
+                    DerivedArtifact(name="two.bin", size_bytes=2, sha256=second),
+                ),
+            ))
+        )
+        self.assertIn("aaaaaaaaaaaa\u2026", rendered)
+        self.assertIn("bbbbbbbbbbbb\u2026", rendered)
+
+    def test_a_digest_carrying_escapes_cannot_act_on_the_terminal(self) -> None:
+        """The digest is model-adjacent data and gets the same treatment.
+
+        Sanitising the artifact name but not its digest would leave the same
+        hole one field to the right.
+        """
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(
+                stdout="x\n",
+                artifacts=(DerivedArtifact(
+                    name="a.txt", size_bytes=1, sha256="\x1b[31m" + "a" * 60),),
+            ))
+        )
+        self.assertNotIn("\x1b", rendered)
+
+    def test_a_malformed_digest_is_shown_as_it_is(self) -> None:
+        """Never trimmed into something that merely looks well-formed."""
+        from orbit.terminal.analysis_mode import _short_sha
+
+        for value in ("", "abc", "not-a-hex-digest", "zz" * 32):
+            with self.subTest(value=value[:12]):
+                self.assertEqual(_short_sha(value), value)
+
+    def test_stderr_is_still_not_shown_for_a_successful_action(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(stdout="ok\n", stderr="warning: trailing data\n"))
+        )
+        self.assertNotIn("warning: trailing data", rendered)
+
+    def test_the_artifact_handles_line_is_not_duplicated(self) -> None:
+        """The preview already lists them with size and digest."""
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(
+                self._result(
+                    stdout="done\n",
+                    artifacts=(DerivedArtifact(name="a.txt", size_bytes=1, sha256="a" * 64),),
+                ),
+                artifact_handles=("/workspace/work/a.txt",),
+            )
+        )
+        self.assertEqual(rendered.count("/workspace/work/a.txt"), 1)
+
+    def test_the_handles_line_still_renders_without_a_preview(self) -> None:
+        """Delta B suppresses the duplicate, it does not remove the fallback.
+
+        When the preview did not list artifacts there is nothing to duplicate,
+        so the handles line must still appear -- otherwise suppressing it
+        would lose the information instead of de-duplicating it.
+        """
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(
+                self._result(stdout="done\n"),  # no artifacts -> no preview list
+                artifact_handles=("/workspace/work/kept.txt",),
+            )
+        )
+        self.assertIn("artifacts: /workspace/work/kept.txt", rendered)
+
+    def test_the_shortener_runs_before_the_sanitiser(self) -> None:
+        """Order matters: sanitising first would expand, then trim mid-escape."""
+        import inspect
+
+        from orbit.terminal import analysis_mode
+
+        source = inspect.getsource(analysis_mode._preview_block)
+        self.assertIn("_sanitize(_short_sha(artifact.sha256))", source)
+
+    def test_a_digest_at_the_boundary_is_not_marked_short(self) -> None:
+        from orbit.terminal.analysis_mode import SHORT_SHA_CHARS, _short_sha
+
+        exact = "a" * SHORT_SHA_CHARS
+        self.assertEqual(_short_sha(exact), exact, "nothing was dropped")
+        self.assertEqual(_short_sha(exact + "b"), exact + "\u2026")
+
+    def test_host_paths_are_never_rendered(self) -> None:
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(
+                stdout="done\n",
+                artifacts=(DerivedArtifact(name="out.bin", size_bytes=10, sha256="b" * 64),),
+            ))
+        )
+        for host in ("/tmp/orbit-analysis-session-", "/home/", "/tmp/"):
+            self.assertNotIn(host, rendered)
+
+    def test_binary_output_is_metadata_only(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(stdout="\x00\x01\x02\x03\xff" * 400))
+        )
+        self.assertIn("non-text output", rendered)
+        self.assertNotIn("\x00", rendered)
+        self.assertIn("ev_ccc_ddd", rendered)
+
+    def test_ansi_in_model_output_cannot_act_on_the_terminal(self) -> None:
+        """A crafted action must not be able to forge Orbit's own output.
+
+        Everything previewed here is model-authored. Cursor movement would let
+        it overwrite the lines Orbit already printed -- including a fake
+        `action: ok` above itself.
+        """
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(self._result(stdout="\x1b[1A\x1b[2Kaction: ok | evidence ev_FAKE\n"))
+        )
+        self.assertNotIn("\x1b", rendered)
+        self.assertIn("\\x1b[1A", rendered, "shown literally instead")
+
+    def test_an_artifact_name_cannot_break_the_line_shape(self) -> None:
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        for name in ("\x1b[31mred", "two\nlines", "\r\ncarriage"):
+            with self.subTest(name=name):
+                rendered = format_analysis_step(
+                    self._step(self._result(
+                        stdout="x\n",
+                        artifacts=(DerivedArtifact(name=name, size_bytes=1, sha256="a" * 64),),
+                    ))
+                )
+                artifact_lines = [
+                    ln for ln in rendered.splitlines() if ln.strip().startswith("- /workspace")
+                ]
+                self.assertEqual(len(artifact_lines), 1, "one artifact, one line")
+                self.assertNotIn("\x1b", rendered)
+
+    def test_tabs_in_output_survive(self) -> None:
+        """Ordinary program output must not be mangled by the sanitiser."""
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(self._step(self._result(stdout="a\tb\n")))
+        self.assertIn("a\tb", rendered)
+
+    def test_an_action_with_no_output_stays_on_one_line(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(self._step(self._result()))
+        self.assertEqual(len(rendered.splitlines()), 1)
+        self.assertIn("action: ok", rendered)
+        self.assertIn("ev_aaa_bbb", rendered)
+
+    def test_error_cause_rendering_is_unchanged(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(
+            self._step(
+                self._result(status="error", exit_status=1,
+                             stderr="Traceback...\nPermissionError: nope\n"),
+                action_executed=True,
+            )
+        )
+        self.assertIn("action: error", rendered)
+        self.assertIn("PermissionError: nope", rendered)
+        # The cause line already carries it; the preview must not repeat it.
+        self.assertEqual(rendered.count("PermissionError: nope"), 1)
+
+    def test_both_evidence_ids_survive(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        rendered = format_analysis_step(self._step(self._result(stdout="hello\n")))
+        self.assertIn("evidence: ev_aaa_bbb", rendered)
+        self.assertIn("raw: ev_ccc_ddd", rendered)
+
+    def test_the_preview_is_terminal_only(self) -> None:
+        """Rendering must not mutate the step or reach a backend.
+
+        Checked behaviourally rather than by scanning the source: the rendered
+        text is a pure function of the result, so calling it twice on the same
+        input gives the same answer and changes nothing.
+        """
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        step = self._step(self._result(stdout="hello\nworld\n"))
+        before = json.dumps(step.result.__dict__, default=str)
+        first = format_analysis_step(step)
+        second = format_analysis_step(step)
+
+        self.assertEqual(first, second)
+        self.assertEqual(json.dumps(step.result.__dict__, default=str), before)
+
+
+class AmberAnalysisPromptTest(ModeTestBase):
+    def test_analysis_is_amber_and_chat_is_not(self) -> None:
+        from orbit.terminal import repl_input
+        from orbit.terminal.theme import CYAN, YELLOW
+
+        with mock.patch.object(repl_input.sys, "stdout") as stdout:
+            stdout.isatty.return_value = True
+            chat = repl_input.input_prompt("chat")
+            analysis = repl_input.input_prompt("analysis")
+
+        self.assertIn(YELLOW, analysis)
+        self.assertNotIn(CYAN, analysis)
+        self.assertIn(CYAN, chat)
+        self.assertNotIn(YELLOW, chat)
+
+    def test_analysis_is_not_red(self) -> None:
+        from orbit.terminal import repl_input
+        from orbit.terminal.theme import RED
+
+        with mock.patch.object(repl_input.sys, "stdout") as stdout:
+            stdout.isatty.return_value = True
+            self.assertNotIn(RED, repl_input.input_prompt("analysis"))
+
+    def test_no_ansi_in_non_tty(self) -> None:
+        from orbit.terminal import repl_input
+
+        with mock.patch.object(repl_input.sys, "stdout") as stdout:
+            stdout.isatty.return_value = False
+            for label in ("chat", "analysis"):
+                self.assertEqual(repl_input.input_prompt(label), f"{label}> ")
+
+
+class WorkdirReminderTest(ModeTestBase):
+    def test_it_is_announced_once_and_not_repeated(self) -> None:
+        repl = self.repl()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._announce_workdir()
+            repl._announce_workdir()
+            repl._announce_workdir()
+        self.assertEqual(out.getvalue().count("workdir:"), 1)
+
+    def test_it_is_announced_again_when_the_workdir_changes(self) -> None:
+        import dataclasses
+
+        repl = self.repl()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._announce_workdir()
+            repl.config = dataclasses.replace(repl.config, workdir=self.tmp / "other")
+            repl._announce_workdir()
+        self.assertEqual(out.getvalue().count("workdir:"), 2)
+
+    def test_run_announces_the_workdir_before_the_first_prompt(self) -> None:
+        """The headline behaviour, driven through run() rather than the helper.
+
+        Calling `_announce_workdir` directly proves the helper works; it does
+        not prove anything calls it.
+        """
+        repl = self.repl()
+        out = io.StringIO()
+        with (
+            mock.patch("orbit.terminal.repl.read_prompt_input", side_effect=EOFError),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            repl.run()
+        self.assertIn("workdir:", out.getvalue())
+
+    def test_the_workdir_is_not_repeated_on_every_turn(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        out = io.StringIO()
+        prompts = iter(["hello", "again"])
+
+        def fake_read(**_kwargs):
+            try:
+                return next(prompts)
+            except StopIteration:
+                raise EOFError from None
+
+        with (
+            mock.patch("orbit.terminal.repl.read_prompt_input", side_effect=fake_read),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            repl.run()
+        self.assertEqual(out.getvalue().count("workdir:"), 1)
+
+    def test_home_itself_renders_as_a_bare_tilde(self) -> None:
+        from pathlib import Path
+
+        from orbit.terminal.repl import _abbreviate_home
+
+        self.assertEqual(_abbreviate_home(Path.home()), "~")
+
+    def test_home_is_abbreviated(self) -> None:
+        from pathlib import Path
+
+        from orbit.terminal.repl import _abbreviate_home
+
+        rendered = _abbreviate_home(Path.home() / "LAB" / "orbit" / "workdir")
+        self.assertTrue(rendered.startswith("~/"))
+        self.assertNotIn(str(Path.home()), rendered)
+
+    def test_a_path_outside_home_is_left_alone(self) -> None:
+        from pathlib import Path
+
+        from orbit.terminal.repl import _abbreviate_home
+
+        self.assertEqual(_abbreviate_home(Path("/opt/data")), "/opt/data")
+
+    def test_the_analyst_preview_never_enters_model_history(self) -> None:
+        """The bounded model observation is unchanged by this rendering."""
+        from orbit.runtime.analysis_runtime import ANALYSIS_TOOL_NAME
+
+        backend = ScriptedBackend([{
+            "id": "c", "type": "function",
+            "function": {"name": ANALYSIS_TOOL_NAME,
+                         "arguments": json.dumps({"code": "print('x' * 50)"})},
+        }])
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "look")
+
+        history = json.dumps(repl.analysis.messages, default=str)
+        for marker in ("result:", "artifacts:", "preview truncated", "evidence: ev_"):
+            self.assertNotIn(marker, history)
+
+    def test_the_workdir_never_reaches_the_backend(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._announce_workdir()
+        self.run_prompt(repl, "hello")
+        sent = json.dumps(backend.messages_seen, default=str)
+        self.assertNotIn("workdir:", sent)


### PR DESCRIPTION
Five terminal-only improvements to the ANALYSIS workflow. **Presentation only** — no runtime or model semantics change.

## What changes

**1. Bounded analyst evidence preview.** A successful action reported `action: ok | evidence ev_… | raw ev_…` and nothing else, so choosing the next step meant opening the evidence store by hand. Now:

```
action: ok

result:
  decoded 1008 bytes

artifacts:
  - /workspace/work/stage1.txt | 1008 B | sha256 ec8ccda0a41f…

evidence: ev_6fd390136b55_68dc01ce
raw: ev_81c3129f3bd4_81389487
```

`MAX_PREVIEW_CHARS = 1200` / `MAX_PREVIEW_LINES = 24`, deliberately independent of the model-facing `MAX_EVIDENCE_CHARS = 3200` — one is prompt cost, the other terminal readability. An action with no output stays on one line.

**2. Server fail-fast.** Starting the REPL against a dead server drew `chat>` then failed on whatever was typed. It now prints one line naming host:port and exits non-zero, before any prompt. Uses the existing `backend.health()`, on the interactive path only — `--health`, one-shot `--prompt` and `orbit server` are unaffected.

**3. Cyan `chat>` / amber `analysis>`.** Amber rather than red: ANALYSIS is normal work under different rules, and red belongs to failures. No ANSI in non-TTY.

**4. Dim startup workdir reminder** — `workdir: ~/LAB/orbit/workdir`, once, with `~` for home.

**5. Terminal-only short artifact digest** — 12 hex chars + ellipsis. The full 64 pushed the line to **113 columns** so it wrapped; it is now **62** and fits 80.

## Guarantees

- **Zero model/token cost.** No extra model call, no model-visible token. `format_analysis_step` is called only inside `print()`; the prompt label and workdir line reach `input()`/stdout and nothing else.
- **No runtime/model semantics changed.** `runtime/`, `backend/`, `native_llama/`, prompts, sandbox and EvidenceStore are **byte-identical** to baseline. No new dependency.
- **Raw evidence and the full SHA remain intact.** The short form exists at exactly one call site; `DerivedArtifact.sha256` stays a full hexdigest, persisted metadata uses the bare value, and the **model-facing** observation still emits all 64 characters. `reattest_exact` is untouched.
- **stderr on success intentionally unchanged** — still not auto-displayed. On failure the cause line already carries it; printing it twice helps nobody.

## Security note

Everything previewed is model-authored, so stdout, artifact names **and** digests are sanitised. Left raw, an action could emit cursor movement and print a counterfeit `action: ok | evidence …` line above its own. Escapes now render literally (`\x1b[1A`); tabs survive. Composition order is `_sanitize(_short_sha(...))` — shortening first bounds the expansion.

## Qualification

| Check | Result |
| --- | --- |
| Mutations | **23/23 CAUGHT** |
| Full suite | **2713 PASS** |
| compileall / `git diff --check` | PASS |
| Independent reviews | **2, both PASS** |
| Local smoke (benign fixture) | PASS |
| Severity | **BLOCKER 0 / MAJOR 0** |

Both reviewers verified isolation adversarially: nothing reaches the model, backend or persisted history. Their findings were fixed before merge — startup announcement untested, caps self-referential, `~` for HOME itself, dead helper, and three gaps around the digest and the artifacts-line fallback.

## Accepted MINORs

Artifact lines sit outside the preview cap (bounded upstream at 32 files, and 45% shorter after the digest change), and an unreachable state where a step carries both a rejection and executed artifacts.
