### PR TITLE
feat(runtime): add evidence-grounded analysis reports

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -44,7 +44,7 @@ from orbit.runtime.analysis_sandbox import (
     execute_analysis,
     scratch_baseline,
 )
-from orbit.runtime.evidence import EvidenceRecord, EvidenceStore
+from orbit.runtime.evidence import EvidenceRecord, EvidenceStore, final_card
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
 
@@ -55,6 +55,30 @@ ANALYSIS_TOOL_NAME = "execute_analysis"
 # which rolling checkpoint this prompt continues, and learns nothing about CHAT
 # or ANALYSIS from it.
 ANALYSIS_STEP_PHASE = "analysis_step"
+
+# The phase a report declares. Distinct from a step because it is a different
+# kind of call -- no tools, no action -- and the KV lineages are keyed by what
+# the caller declares, so naming it separately keeps a report from being
+# mistaken for a link in the analysis chain.
+ANALYSIS_REPORT_PHASE = "analysis_report"
+
+# What one report may read from the store. The evidence cards are already
+# bounded by `final_card`; this caps how many of them a single report carries,
+# so a long session cannot grow the report prompt without limit.
+MAX_REPORT_EVIDENCE_RECORDS = 12
+
+ANALYSIS_REPORT_INSTRUCTION = (
+    "Report on the evidence already collected. Run nothing: this turn has no "
+    "tools and performs no analysis.\n"
+    "Ground every finding in that evidence and cite it as evidence:<id>. "
+    "Anything the evidence does not establish is unresolved -- say so rather "
+    "than supplying it.\n"
+    "Cover, briefly and only where the evidence supports it: confirmed "
+    "findings; indicators; artifacts produced; behaviour established; what "
+    "remains unresolved; and the single next step most worth taking."
+)
+
+NO_EVIDENCE_REPORT = "No analysis evidence has been collected yet."
 
 # Stable prefix. Everything here is identical for every step of every
 # analysis on a given profile, which is what makes a future exact-prefix
@@ -288,6 +312,16 @@ class StepDiagnostics:
             "tool_argument_chars": self.tool_argument_chars,
             "refusal": self.refusal,
         }
+
+
+@dataclass(frozen=True)
+class AnalysisReport:
+    """What one `/report` produced. Never evidence, never history."""
+
+    text: str
+    model_calls: int
+    evidence_ids: tuple[str, ...] = ()
+    diagnostics: "StepDiagnostics | None" = None
 
 
 @dataclass(frozen=True)
@@ -781,6 +815,134 @@ class AnalysisRuntime:
             except OSError:
                 continue
         return digests
+
+    def report(
+        self,
+        question: str = "",
+        *,
+        on_progress: Callable[[Any], None] | None = None,
+        on_delta: Callable[[str], None] | None = None,
+    ) -> "AnalysisReport":
+        """Answer from the evidence already collected, running nothing.
+
+        A view over the store, not a step in the investigation. The failure
+        this replaces was a model choosing to re-read an artifact it had
+        already read when asked to interpret it; the fix is to remove the
+        choice rather than argue with it, so this call is made with no tools
+        at all. It cannot run an action because it is not offered one.
+
+        Nothing here is appended to `self.messages`. The analysis history is
+        the append-only record a later exact-prefix strategy depends on, and a
+        report is not evidence: the prose it produces is an answer about the
+        record, never part of it.
+        """
+        records = self._reportable_records()
+        if not records:
+            # Deterministic, and free: there is nothing to ground a report in,
+            # and asking a model to say so would be a call spent on a fact the
+            # runtime already knows.
+            return AnalysisReport(text=NO_EVIDENCE_REPORT, model_calls=0, evidence_ids=())
+
+        messages = self._report_messages(question, records)
+        deltas: list[str] = []
+
+        def _capture(text: str) -> None:
+            deltas.append(text)
+            if on_delta is not None and text:
+                on_delta(text)
+
+        started = time.monotonic()
+        with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
+            response = self.backend.chat_stream(
+                messages,
+                temperature=self.temperature,
+                max_tokens=self.effective_max_tokens,
+                tools=[],
+                on_delta=_capture,
+                on_progress=on_progress,
+            )
+        seconds = time.monotonic() - started
+
+        text = (response.content or "").strip()
+        if not text:
+            # Truthful rather than silent, and no repair call: a second
+            # invocation would cross the boundary this runtime holds.
+            text = "the report call produced no usable text"
+        return AnalysisReport(
+            text=text,
+            model_calls=1,
+            evidence_ids=tuple(r.evidence_id for r in records),
+            diagnostics=StepDiagnostics(
+                prompt_tokens=getattr(response, "prompt_tokens", None),
+                output_tokens=getattr(response, "completion_tokens", None),
+                reused_tokens=getattr(response, "cached_tokens", None),
+                finish_reason=getattr(response, "finish_reason", None),
+                generation_tokens_per_second=getattr(
+                    response, "generation_tokens_per_second", None
+                ),
+                duration_seconds=round(seconds, 3),
+            ),
+        )
+
+    def _reportable_records(self) -> list[EvidenceRecord]:
+        """The action evidence a report may cite, oldest first and bounded."""
+        records = [
+            record
+            for record in self.evidence_store.records.values()
+            if record.tool_name == ANALYSIS_TOOL_NAME
+        ]
+        return records[-MAX_REPORT_EVIDENCE_RECORDS:]
+
+    def _evidence_card(self, record: EvidenceRecord) -> str:
+        """One record as the report sees it: header plus the observation.
+
+        `final_card` shows a 700/300 head-and-tail excerpt, which is right for
+        a citation card but wrong here -- a finding in the middle of a step's
+        output would vanish, and the report would then call it unresolved,
+        which is a confident wrong answer rather than a missing one. The
+        re-attested text is the same bounded observation the step already put
+        in front of the model, so carrying it adds nothing the model has not
+        already been trusted with, and it is verified rather than remembered.
+        """
+        body = self.evidence_store.reattest_exact(record.evidence_id)
+        if body is None:
+            # Re-attestation is the gate; a record that cannot pass it is
+            # described, never quoted.
+            return final_card(record)
+        return "\n".join(
+            [
+                "tool_evidence_card: true",
+                f"evidence_id: {record.evidence_id}",
+                f"status: {record.status}",
+                f"size: {record.raw_chars} chars",
+                "evidence:",
+                body,
+            ]
+        )
+
+    def _report_messages(
+        self, question: str, records: list[EvidenceRecord]
+    ) -> list[NativeMessage]:
+        """A fresh grounded context, built from the store rather than history.
+
+        Deliberately not the analysis conversation: that carries tool calls and
+        an artifact identity this turn must not act on, and reusing it would
+        put the model back in the frame where running something is the
+        expected move.
+        """
+        cards = "\n\n".join(self._evidence_card(record) for record in records)
+        asked = question.strip() or "Report on what the evidence establishes."
+        return [
+            {"role": "system", "content": ANALYSIS_REPORT_INSTRUCTION},
+            {
+                "role": "user",
+                "content": (
+                    f"Artifact under analysis: {self.source.size_bytes} bytes, "
+                    f"sha256 {self.source.sha256}.\n\n"
+                    f"Evidence collected so far:\n\n{cards}\n\n{asked}"
+                ),
+            },
+        ]
 
     def _structural_rejection(self, calls: list[dict[str, Any]]) -> str | None:
         """Why this tool call cannot be committed, or None if it can.

--- a/src/orbit/terminal/command_registry.py
+++ b/src/orbit/terminal/command_registry.py
@@ -60,6 +60,13 @@ COMMANDS = (
         "Analyse one local artifact in an isolated workspace.",
         "analysis",
     ),
+    CommandSpec(
+        "/report",
+        "Session",
+        "/report [question]",
+        "Report on the evidence already collected, running no analysis action.",
+        "report",
+    ),
     CommandSpec("/chat", "Session", "/chat", "Return to normal chat mode.", "chat"),
     CommandSpec("/help", "Help", "/help", "Show command help.", "help"),
 )

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -560,6 +560,9 @@ class Repl:
         if handler == "analysis":
             print(self._handle_analysis_command(arguments))
             return True
+        if handler == "report":
+            self._handle_report_command(arguments)
+            return True
         if handler == "chat":
             if arguments:
                 print(self._command_usage_error(invocation.spec.usage), file=sys.stderr)
@@ -687,6 +690,53 @@ class Repl:
             f"mode: ANALYSIS | {source.original_path} "
             f"({source.size_bytes} bytes, sha256 {source.sha256})"
         )
+
+    def _handle_report_command(self, question: str) -> None:
+        """`/report` -- answer from the evidence already collected.
+
+        Valid only inside a session, because there is nothing to report on
+        otherwise. It runs no action, so the analysis history and the evidence
+        store are both left exactly as they were; what it returns is displayed
+        and not recorded.
+        """
+        if self.workflow_mode is not WorkflowMode.ANALYSIS or self.analysis is None:
+            print(
+                "error: /report needs an analysis session; start one with /analysis <path>",
+                file=sys.stderr,
+            )
+            return
+        print()
+        started = time.monotonic()
+        renderer = StreamRenderer(thinking=False, render_markdown_mode="plain")
+        renderer.set_activity("analysis")
+        renderer.start()
+        try:
+            report = self.analysis.report(
+                question,
+                on_progress=renderer.progress,
+                on_delta=renderer.write,
+            )
+        except KeyboardInterrupt:
+            renderer.finish(interrupted=True)
+            print(dim("cancelled"), flush=True)
+            return
+        except (ContextAdmissionError, LlamaServerError, TimeoutError) as exc:
+            # Recoverable: a failed report leaves the session exactly as it was.
+            renderer.finish(interrupted=True)
+            print(runtime_error_text(exc), file=sys.stderr)
+            return
+        renderer.finish()
+        if report.model_calls == 0:
+            print(report.text, flush=True)
+        elapsed = time.monotonic() - started
+        summary = (
+            f"report | mode: ANALYSIS | model calls: {report.model_calls} | "
+            f"actions: 0 | {elapsed:.1f}s"
+        )
+        detail = format_step_diagnostics(report.diagnostics)
+        if detail:
+            summary += f" | {detail}"
+        print(dim(summary), flush=True)
 
     def _handle_chat_command(self) -> str:
         """Return to CHAT. No model call, and the analysis is kept.

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -26,6 +26,7 @@ from orbit.runtime.analysis_runtime import (
     ANALYSIS_SYSTEM_PROMPT,
     ANALYSIS_TOOL_NAME,
     ANALYSIS_TOOL_SCHEMA,
+    NO_EVIDENCE_REPORT,
     MAX_EVIDENCE_CHARS,
     SESSION_CAPACITY_EXHAUSTED,
     AnalysisRuntime,
@@ -1690,3 +1691,271 @@ class GenerationLimitRefusalTest(AnalysisRuntimeTestBase):
         assert result.rejection is not None
         self.assertIn("not valid JSON", result.rejection)
         self.assertNotIn("generation limit", result.rejection)
+
+
+class AnalysisReportTest(AnalysisRuntimeTestBase):
+    """`/report` answers from evidence already collected, and runs nothing.
+
+    A prompt-only attempt to teach this failed its real gate: asked to
+    interpret what it had found, the model called the tool again and reprinted
+    the artifact. This removes the choice instead of arguing with it -- the
+    report call is made with no tools, so no action is reachable from it.
+    """
+
+    def _with_evidence(self, *extra):
+        backend = ScriptedBackend(
+            tool_response("import orbit_tools\nprint('three strings found')"), *extra
+        )
+        runtime = self.runtime(backend)
+        runtime.step("look at it")
+        return runtime, backend
+
+    def test_no_evidence_reports_without_calling_the_model(self) -> None:
+        backend = ScriptedBackend()
+        runtime = self.runtime(backend)
+
+        report = runtime.report()
+
+        self.assertEqual(backend.calls, 0, "nothing to ground a report in")
+        self.assertEqual(report.model_calls, 0)
+        self.assertEqual(report.text, NO_EVIDENCE_REPORT)
+
+    def test_a_report_makes_exactly_one_model_call(self) -> None:
+        runtime, backend = self._with_evidence(prose_response("Confirmed: three strings."))
+
+        report = runtime.report()
+
+        self.assertEqual(report.model_calls, 1)
+        self.assertEqual(backend.calls, 2, "one step, one report, nothing else")
+
+    def test_the_report_call_is_offered_no_tools(self) -> None:
+        """The whole point: the model cannot choose to run an action."""
+        runtime, backend = self._with_evidence(prose_response("Confirmed."))
+
+        runtime.report()
+
+        self.assertEqual(backend.seen_tools[-1], [], "no tool surface at all")
+        self.assertIn(ANALYSIS_TOOL_NAME, backend.seen_tools[0], "but the step still had one")
+
+    def test_a_report_executes_no_action(self) -> None:
+        runtime, _ = self._with_evidence(prose_response("Confirmed."))
+        before = runtime.actions_executed
+
+        runtime.report()
+
+        self.assertEqual(runtime.actions_executed, before)
+
+    def test_a_report_leaves_the_evidence_store_untouched(self) -> None:
+        runtime, _ = self._with_evidence(prose_response("Confirmed: much."))
+        before = dict(runtime.evidence_store.records)
+
+        runtime.report("what did we find?")
+
+        self.assertEqual(runtime.evidence_store.records.keys(), before.keys())
+        for key, record in before.items():
+            self.assertEqual(runtime.evidence_store.records[key], record)
+
+    def test_report_prose_is_never_attested_as_evidence(self) -> None:
+        runtime, _ = self._with_evidence(prose_response("I believe there are five indicators."))
+        before = len(runtime.evidence_store.records)
+
+        report = runtime.report()
+
+        self.assertEqual(len(runtime.evidence_store.records), before)
+        self.assertIn("five indicators", report.text)
+
+    def test_a_report_does_not_enter_the_analysis_history(self) -> None:
+        """The history is the append-only record; a report is a view of it."""
+        runtime, _ = self._with_evidence(prose_response("Confirmed."))
+        before = json.dumps(runtime.messages, default=str)
+
+        runtime.report("summarise")
+
+        self.assertEqual(json.dumps(runtime.messages, default=str), before)
+
+    def test_the_analyst_question_reaches_the_model(self) -> None:
+        runtime, backend = self._with_evidence(prose_response("Answering."))
+
+        runtime.report("tell me the IoCs and artifacts")
+
+        sent = json.dumps(backend.seen_messages[-1], default=str)
+        self.assertIn("tell me the IoCs and artifacts", sent)
+
+    def test_a_default_report_asks_for_the_standard_shape(self) -> None:
+        runtime, backend = self._with_evidence(prose_response("Answering."))
+
+        runtime.report()
+
+        sent = json.dumps(backend.seen_messages[-1], default=str).lower()
+        for expected in ("confirmed", "indicators", "artifacts", "unresolved", "next step"):
+            self.assertIn(expected, sent)
+
+    def test_the_report_context_is_grounded_and_bounded(self) -> None:
+        runtime, backend = self._with_evidence(prose_response("Answering."))
+
+        report = runtime.report()
+
+        sent = json.dumps(backend.seen_messages[-1], default=str)
+        self.assertIn("evidence:<id>", sent, "citation contract stated")
+        self.assertIn("unresolved", sent.lower())
+        self.assertTrue(report.evidence_ids, "the report names what it read")
+        for evidence_id in report.evidence_ids:
+            self.assertIn(evidence_id, sent)
+
+    def test_the_report_context_never_carries_the_whole_history(self) -> None:
+        """Built from the store, not the conversation."""
+        runtime, backend = self._with_evidence(prose_response("Answering."))
+
+        runtime.report()
+
+        report_messages = backend.seen_messages[-1]
+        self.assertEqual(len(report_messages), 2, "one system, one user")
+        self.assertEqual(report_messages[0]["role"], "system")
+        for message in report_messages:
+            self.assertNotIn("tool_calls", message)
+
+    def test_the_evidence_carried_is_capped(self) -> None:
+        """Checked with more records than the cap, or it proves nothing."""
+        from orbit.runtime.analysis_runtime import MAX_REPORT_EVIDENCE_RECORDS
+
+        self.assertEqual(MAX_REPORT_EVIDENCE_RECORDS, 12)
+        steps = MAX_REPORT_EVIDENCE_RECORDS + 5
+        backend = ScriptedBackend(
+            *[tool_response(f"import orbit_tools\nprint('step {i}')") for i in range(steps)]
+        )
+        runtime = self.runtime(backend)
+        for i in range(steps):
+            runtime.step(f"step {i}")
+
+        records = runtime._reportable_records()
+
+        self.assertEqual(len(records), MAX_REPORT_EVIDENCE_RECORDS, "the cap must bite")
+        self.assertLess(len(records), steps)
+
+    def test_only_the_bounded_record_is_carried_not_the_raw_one(self) -> None:
+        """Each action writes two records; the report must read the bounded one."""
+        runtime, _ = self._with_evidence(prose_response("Answering."))
+
+        names = {record.tool_name for record in runtime._reportable_records()}
+
+        self.assertEqual(names, {ANALYSIS_TOOL_NAME})
+        self.assertNotIn(f"{ANALYSIS_TOOL_NAME}_raw", names)
+        stored = {r.tool_name for r in runtime.evidence_store.records.values()}
+        self.assertIn(f"{ANALYSIS_TOOL_NAME}_raw", stored, "both exist; one was chosen")
+
+    def test_the_report_sees_what_the_step_saw(self) -> None:
+        """A finding in the middle of an observation must not vanish.
+
+        A head-and-tail excerpt drops the middle silently, and the report is
+        told to call anything the evidence does not establish unresolved --
+        so a dropped finding becomes a confident wrong answer rather than a
+        visible gap.
+        """
+        marker = "CRITICAL_MIDDLE_MARKER"
+        payload = "H" * 700 + "\n" + marker + "\n" + "T" * 700
+        backend = ScriptedBackend(
+            tool_response(f"import orbit_tools\nprint({payload!r})"),
+            prose_response("Answering."),
+        )
+        runtime = self.runtime(backend)
+        runtime.step("look")
+
+        runtime.report()
+
+        sent = json.dumps(backend.seen_messages[-1], default=str)
+        self.assertIn(marker, sent, "the middle of the observation must survive")
+
+    def test_a_record_that_cannot_reattest_is_described_not_quoted(self) -> None:
+        runtime, _ = self._with_evidence(prose_response("Answering."))
+        record = runtime._reportable_records()[0]
+        with unittest.mock.patch.object(
+            runtime.evidence_store, "reattest_exact", return_value=None
+        ):
+            card = runtime._evidence_card(record)
+
+        self.assertIn("tool_evidence_card", card)
+        self.assertIn(record.evidence_id, card)
+
+    def test_a_tool_shaped_report_response_executes_nothing(self) -> None:
+        """Even offered no tools, a model may emit something tool-shaped."""
+        runtime, backend = self._with_evidence(
+            tool_response("import orbit_tools\nprint('should never run')")
+        )
+        before = runtime.actions_executed
+
+        report = runtime.report()
+
+        self.assertEqual(runtime.actions_executed, before, "zero actions from a report")
+        self.assertEqual(report.model_calls, 1, "and no repair call")
+        json.dumps(runtime.messages, default=str)
+
+    def test_an_empty_report_response_is_truthful(self) -> None:
+        runtime, _ = self._with_evidence(prose_response(""))
+
+        report = runtime.report()
+
+        self.assertIn("no usable text", report.text)
+        self.assertEqual(report.model_calls, 1)
+
+    def test_the_session_still_works_after_a_report(self) -> None:
+        runtime, backend = self._with_evidence(
+            prose_response("Confirmed."),
+            tool_response("import orbit_tools\nprint('second stage')"),
+        )
+
+        runtime.report()
+        resumed = runtime.step("decode the next stage")
+
+        self.assertTrue(resumed.action_executed, "tools are available again")
+        self.assertEqual(runtime.actions_executed, 2)
+        self.assertEqual(backend.calls, 3)
+
+    def test_a_report_is_outside_the_rolling_analysis_lineage(self) -> None:
+        """A report cannot replace the checkpoint a `continue` depends on.
+
+        The backend joins the rolling ANALYSIS lineage only for calls whose
+        declared phase is the step phase. A report declares its own, so it is
+        excluded by construction rather than by anything it remembers to do --
+        which is why `continue` afterwards still meets the pre-report state.
+        """
+        from orbit.backend.llama_server import _analysis_rolling_anchor_requested
+        from orbit.runtime.analysis_runtime import ANALYSIS_REPORT_PHASE, ANALYSIS_STEP_PHASE
+        from orbit.runtime.kv_diag import model_call_context
+
+        with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+            step_eligible = _analysis_rolling_anchor_requested(native_backend=True)
+        with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
+            report_eligible = _analysis_rolling_anchor_requested(native_backend=True)
+
+        self.assertTrue(step_eligible, "a step joins the lineage")
+        self.assertFalse(report_eligible, "a report must not")
+
+        # And the phase report() actually declares, observed at the backend
+        # rather than read off a constant -- otherwise declaring the step
+        # phase here would silently rejoin the lineage.
+        seen: list[bool] = []
+
+        class PhaseWatchingBackend(ScriptedBackend):
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta, on_progress=None):
+                seen.append(_analysis_rolling_anchor_requested(native_backend=True))
+                return super().chat_stream(
+                    messages, temperature=temperature, max_tokens=max_tokens,
+                    tools=tools, on_delta=on_delta, on_progress=on_progress)
+
+        backend = PhaseWatchingBackend(
+            tool_response("import orbit_tools\nprint('x')"),
+            prose_response("Confirmed."),
+        )
+        runtime = self.runtime(backend)
+        runtime.step("look")
+        runtime.report()
+
+        self.assertEqual(seen, [True, False], "step joins, report does not")
+
+    def test_a_report_declares_its_own_phase(self) -> None:
+        """A report is not a link in the analysis chain, and says so."""
+        from orbit.runtime.analysis_runtime import ANALYSIS_REPORT_PHASE, ANALYSIS_STEP_PHASE
+
+        self.assertNotEqual(ANALYSIS_REPORT_PHASE, ANALYSIS_STEP_PHASE)
+        self.assertEqual(ANALYSIS_REPORT_PHASE, "analysis_report")

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -73,7 +73,10 @@ class SlashCommandTests(unittest.TestCase):
         names = [command.name for command in COMMANDS]
 
         self.assertEqual(len(names), len(set(names)))
-        self.assertEqual([command.name for command in commands_matching("/re")], ["/read", "/reset"])
+        self.assertEqual(
+            [command.name for command in commands_matching("/re")],
+            ["/read", "/reset", "/report"],
+        )
         rendered = help_text()
         for name in ("/read", "/search", "/ls", "/models", "/help", "/status", "/props", "/clear", "/reset", "/exit"):
             self.assertIn(name, rendered)

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1782,3 +1782,61 @@ class WorkdirReminderTest(ModeTestBase):
         self.run_prompt(repl, "hello")
         sent = json.dumps(backend.messages_seen, default=str)
         self.assertNotIn("workdir:", sent)
+
+
+class ReportCommandTest(ModeTestBase):
+    """`/report` is analyst-controlled and mode-scoped."""
+
+    def _analysis_repl(self, *responses):
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        return repl, backend
+
+    def test_report_is_refused_in_chat(self) -> None:
+        repl = self.repl()
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+        output = self.run_command(repl, "/report")
+
+        self.assertIn("needs an analysis session", output)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+    def test_report_with_no_evidence_calls_no_model(self) -> None:
+        repl, backend = self._analysis_repl()
+        before = backend.calls
+
+        output = self.run_command(repl, "/report")
+
+        self.assertEqual(backend.calls, before, "nothing to report on, nothing to ask")
+        self.assertIn("No analysis evidence has been collected yet", output)
+
+    def test_report_keeps_the_session_in_analysis(self) -> None:
+        repl, _ = self._analysis_repl()
+
+        self.run_command(repl, "/report")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.assertIsNotNone(repl.analysis)
+        self.assertEqual(repl._prompt_label(), "analysis")
+
+    def test_the_command_is_registered_with_its_question_form(self) -> None:
+        from orbit.terminal.command_registry import resolve_command
+
+        plain = resolve_command("/report")
+        asked = resolve_command("/report tell me the IoCs and artifacts")
+
+        assert plain is not None and asked is not None
+        self.assertEqual(plain.spec.handler, "report")
+        self.assertEqual(plain.arguments, "")
+        self.assertEqual(asked.arguments, "tell me the IoCs and artifacts")
+
+    def test_report_does_not_change_chat_or_routing(self) -> None:
+        repl = self.repl()
+        self.run_command(repl, "/report")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        self.run_command(repl, "/chat")
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)


### PR DESCRIPTION
Adds `/report [question]`: an ANALYSIS-only command that answers from evidence already collected, running no analysis action.

## Why

An earlier attempt tried to get this behaviour by *prompt wording alone* — asking the model to report rather than re-run. It failed its real Ornith gate: step 2 called `execute_analysis` again and re-dumped the source. That candidate was rejected and never merged; its evidence is preserved separately.

This PR removes the choice instead of arguing with it.

## Contract

- `/report [question]` is **ANALYSIS-only** — refused in any other mode.
- Uses **existing evidence only**; runs no analysis action.
- **Tools are disabled** for the report call (`tools=[]`), so an action is not representable.
- **At most one report model call.**
- **Zero analysis actions.**
- **Zero-evidence path avoids inference entirely** (0 model calls).
- **Report prose is not attested as evidence** — the EvidenceStore is untouched.
- **Bounded, re-attested evidence context**: records are capped, and each card is the complete bounded observation via `reattest_exact`, so a finding in the middle of a long tool output is not lost to a head/tail excerpt.
- **Does not evict rolling ANALYSIS state** — the report declares its own phase and sits outside the rolling lineage by construction.
- **Normal ANALYSIS resumes afterward.**

## Qualification

Deterministic:
- 20 `AnalysisReport` tests, 5 `ReportCommand` tests
- **12/12 mutations CAUGHT** (physical mutation + causal failure)
- **Full suite 2738 PASS**
- compileall, `git diff --check` clean
- Independent review **PASS — BLOCKER 0**

Review found and this PR fixes a **MAJOR**: the report initially saw only a 700-head/300-tail excerpt, silently dropping mid-output findings (reproduced: IoC present in the step observation, absent from the report card). Fixed via re-attested evidence cards.

Real Ornith gate (one fresh server, one run, no retries), on the real sample:
- `/report` **model calls: 1**, **actions: 0**, **tools: []**, finish `stop`
- **No source re-dump**
- Findings grounded and cited as `evidence:<id>`; confirmed vs unresolved kept distinct; **nothing invented** — it declined to name a C2 URL, reporting only that the `//STAT_URL` marker implies one was intended
- `continue` afterward **restored rolling ANALYSIS state** (595 tokens reused) and analysis advanced normally

## Non-blocking follow-up

Measured `/report` latency was **215.9s (2461 input / 983 output)**. Recorded as a performance follow-up only — **this PR makes no claim to optimize reporting speed**, and latency/prompt-output cost optimization (preserving grounding and zero-action semantics) is left as separate future work.
