### PR TITLE
fix(terminal): sanitize model-authored output

### DIFF
--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -30,6 +30,7 @@ from orbit.runtime.analysis_runtime import (
 from orbit.runtime.analysis_sandbox import AnalysisResult
 from orbit.runtime.confined_acquire import ConfinedAcquireError, acquire_confined_bytes
 from orbit.runtime.evidence import EvidenceStore
+from orbit.terminal.theme import sanitize_terminal_text
 
 
 class AnalysisModeError(Exception):
@@ -134,7 +135,9 @@ def _resolve_target(raw_path: str, *, workdir: Path) -> Path:
 def format_analysis_step(result: AnalysisStepResult) -> str:
     """Render one step for the analyst who has just been handed control back."""
     lines: list[str] = []
-    text = result.assistant_text.strip()
+    # Model-authored prose: sanitized here because this is where it is
+    # displayed. `result.assistant_text` itself stays the model's original.
+    text = sanitize_terminal_text(result.assistant_text, allow_newlines=True).strip()
     if text:
         lines.append(text)
     if result.rejection:
@@ -295,22 +298,14 @@ def _excerpt(text: str) -> list[str]:
     return out
 
 
-_CONTROL = {ord(c) for c in "\t"}
-
-
 def _sanitize(text: str) -> str:
     """Strip control characters that would act on the terminal.
 
-    Everything previewed here is model-authored output. Left as-is it can move
-    the cursor and overwrite what Orbit already printed -- a crafted action
-    could forge its own `action: ok` line above itself. Tabs survive because
-    they are ordinary in program output; everything else in the control range
-    becomes a visible escape.
+    Everything previewed here is model-authored output, and these previews are
+    single lines of a larger block, so newlines are escaped along with the rest
+    of the control range. `sanitize_terminal_text` is the shared boundary.
     """
-    return "".join(
-        ch if ch.isprintable() or ord(ch) in _CONTROL else repr(ch)[1:-1]
-        for ch in text
-    )
+    return sanitize_terminal_text(text)
 
 
 def _looks_binary(text: str) -> bool:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -46,7 +46,7 @@ from orbit.terminal.status import (
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
-from orbit.terminal.theme import dim, runtime_error_text
+from orbit.terminal.theme import dim, runtime_error_text, sanitize_terminal_text
 from orbit.runtime.thinking_mode import ThinkingMode
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
 
@@ -727,7 +727,11 @@ class Repl:
             return
         renderer.finish()
         if report.model_calls == 0:
-            print(report.text, flush=True)
+            # Today this branch can only carry NO_EVIDENCE_REPORT, a constant.
+            # It is sanitized anyway because it is a print that never passed
+            # the renderer's boundary: if the branch ever comes to carry model
+            # prose, it is already safe rather than newly vulnerable.
+            print(sanitize_terminal_text(report.text, allow_newlines=True), flush=True)
         elapsed = time.monotonic() - started
         summary = (
             f"report | mode: ANALYSIS | model calls: {report.model_calls} | "

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -8,7 +8,15 @@ import time
 from dataclasses import dataclass
 
 from orbit.backend.base import StreamProgress
-from orbit.terminal.theme import CYAN, DIM, RESET, dim, is_tty, supports_ansi
+from orbit.terminal.theme import (
+    CYAN,
+    DIM,
+    RESET,
+    dim,
+    is_tty,
+    sanitize_terminal_text,
+    supports_ansi,
+)
 
 
 PREFILL_COMPLETION_LABEL = "waiting for model..."
@@ -71,8 +79,22 @@ class StreamRenderer:
         self._thread.start()
 
     def write(self, text: str) -> None:
+        """Render one delta of model-authored text.
+
+        Every streamed delta passes through here -- CHAT, an analysis step,
+        and `/report` all hand theirs to this method -- so it is where model
+        text stops being able to act on the terminal. It is not the only such
+        boundary: `format_analysis_step` reprints the same prose and sanitizes
+        it too. Only what is displayed is sanitized; what the runtime keeps in
+        history, in the session file, and in evidence is the model's original.
+
+        Sanitizing here, before the thinking filter and the markdown renderer,
+        is deliberate: those run downstream and emit Orbit's own colour, which
+        must not be stripped.
+        """
         if not text:
             return
+        text = sanitize_terminal_text(text, allow_newlines=True)
         if self._timer_active:
             self._first_delta = True
             self._stop_timer(clear=True)

--- a/src/orbit/terminal/theme.py
+++ b/src/orbit/terminal/theme.py
@@ -66,3 +66,29 @@ def _styled(text: str, prefix: str) -> str:
     if not supports_ansi():
         return text
     return f"{prefix}{text}{RESET}"
+
+
+# Tab is ordinary in program output and in prose; everything else in the
+# control range is an instruction to the terminal rather than text.
+_SAFE_CONTROL = {ord("\t")}
+_SAFE_CONTROL_MULTILINE = {ord("\t"), ord("\n")}
+
+
+def sanitize_terminal_text(text: str, *, allow_newlines: bool = False) -> str:
+    """Neutralize control sequences in model-authored text before printing it.
+
+    Everything the model writes reaches the terminal as text, so left as-is it
+    can act on it instead: move the cursor, erase the screen, set the window
+    title, drive an OSC 52 clipboard write, or return to the start of the line
+    and overwrite what Orbit already printed -- which is how a crafted response
+    forges its own status line above itself. Printable text of any script
+    survives untouched; a control character becomes its visible escape.
+
+    `allow_newlines` keeps `\\n` for multi-line prose. Carriage return is never
+    kept: it is the line-overwrite primitive, and prose has no use for it.
+    """
+    safe = _SAFE_CONTROL_MULTILINE if allow_newlines else _SAFE_CONTROL
+    return "".join(
+        ch if ch.isprintable() or ord(ch) in safe else repr(ch)[1:-1]
+        for ch in text
+    )

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1840,3 +1840,272 @@ class ReportCommandTest(ModeTestBase):
         self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
         self.run_command(repl, "/chat")
         self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+
+
+# One string carrying every unsafe family at once, with safe text interleaved
+# so a test can prove the sanitizer removes control without eating content.
+HOSTILE_TEXT = (
+    "SAFE-HEAD\n"
+    "\x1b[31mred\x1b[0m "            # CSI colour
+    "\x1b[2J\x1b[H"                  # erase screen, home cursor
+    "\x1b[1A\x1b[2K"                 # cursor up, erase line
+    "\x1b]0;window-title\x07"        # OSC title, BEL terminated
+    "\x1b]8;;https://evil.example\x1b\\link\x1b]8;;\x1b\\"  # OSC 8 hyperlink
+    "\x1b]52;c;cGF5bG9hZA==\x07"     # OSC 52 clipboard write
+    "\rFORGED action: ok\n"          # carriage-return line overwrite
+    "\x00\x07\x08"                   # raw C0
+    "\x9b31m"                        # C1 CSI
+    "SAFE-TAIL café 日本語 🎯"
+)
+
+
+class HostileTextBackend(ScriptedBackend):
+    """Answers with terminal control sequences, the way a hostile model would."""
+
+    def __init__(self, text: str = HOSTILE_TEXT, tool_calls=None) -> None:
+        super().__init__(tool_calls=tool_calls)
+        self.text = text
+
+    def _result(self) -> ChatResult:
+        base = super()._result()
+        return ChatResult(
+            content=self.text,
+            model=base.model,
+            finish_reason=base.finish_reason,
+            tool_calls=base.tool_calls,
+            prompt_tokens=base.prompt_tokens,
+            completion_tokens=base.completion_tokens,
+            cached_tokens=base.cached_tokens,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+    def chat_stream(
+        self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None
+    ) -> ChatResult:
+        self.calls += 1
+        self.tools_seen.append(tools)
+        self.messages_seen.append([dict(m) for m in messages])
+        if on_delta:
+            on_delta(self.text)
+        return self._result()
+
+
+class AssistantTextSanitizerTest(unittest.TestCase):
+    """The sanitizer primitive itself."""
+
+    def sanitize(self, text: str, **kw) -> str:
+        from orbit.terminal.theme import sanitize_terminal_text
+
+        return sanitize_terminal_text(text, **kw)
+
+    def test_plain_ascii_is_unchanged(self) -> None:
+        text = "action: ok | evidence collected, 3 findings."
+        self.assertEqual(self.sanitize(text, allow_newlines=True), text)
+
+    def test_unicode_is_unchanged(self) -> None:
+        text = "café — 日本語 ✓ αβγ Ω 🎯 emoji, ünïcödé"
+        self.assertEqual(self.sanitize(text, allow_newlines=True), text)
+
+    def test_newlines_and_tabs_survive_multiline_prose(self) -> None:
+        text = "# Findings\n\n- one\n\t- indented\n\nEnd."
+        self.assertEqual(self.sanitize(text, allow_newlines=True), text)
+
+    def test_colour_csi_cannot_execute(self) -> None:
+        out = self.sanitize("\x1b[31mred\x1b[0m", allow_newlines=True)
+        self.assertNotIn("\x1b", out)
+        self.assertIn("red", out)
+
+    def test_cursor_movement_and_erase_cannot_execute(self) -> None:
+        out = self.sanitize("\x1b[2J\x1b[H\x1b[1A\x1b[2Kgone", allow_newlines=True)
+        self.assertNotIn("\x1b", out)
+        self.assertIn("gone", out)
+
+    def test_osc_title_sequence_cannot_execute(self) -> None:
+        out = self.sanitize("\x1b]0;pwned\x07after", allow_newlines=True)
+        self.assertNotIn("\x1b", out)
+        self.assertNotIn("\x07", out)
+        self.assertIn("after", out)
+
+    def test_osc8_hyperlink_cannot_execute(self) -> None:
+        out = self.sanitize(
+            "\x1b]8;;https://evil.example\x1b\\click\x1b]8;;\x1b\\", allow_newlines=True
+        )
+        self.assertNotIn("\x1b", out)
+        self.assertIn("click", out)
+
+    def test_osc52_clipboard_payload_cannot_execute(self) -> None:
+        out = self.sanitize("\x1b]52;c;cGF5bG9hZA==\x07", allow_newlines=True)
+        self.assertNotIn("\x1b", out)
+        self.assertNotIn("\x07", out)
+
+    def test_carriage_return_overwrite_is_neutralized(self) -> None:
+        out = self.sanitize("real line\rFORGED", allow_newlines=True)
+        self.assertNotIn("\r", out)
+        self.assertIn("real line", out)
+        self.assertIn("FORGED", out, "the text stays visible, it just cannot overwrite")
+
+    def test_c1_and_raw_c0_controls_are_neutralized(self) -> None:
+        out = self.sanitize("a\x9b31mb\x00c\x08d", allow_newlines=True)
+        for bad in ("\x9b", "\x00", "\x08"):
+            self.assertNotIn(bad, out)
+        for good in ("a", "b", "c", "d"):
+            self.assertIn(good, out)
+
+    def test_mixed_content_keeps_every_safe_fragment(self) -> None:
+        out = self.sanitize(HOSTILE_TEXT, allow_newlines=True)
+        for bad in ("\x1b", "\r", "\x07", "\x00", "\x9b", "\x08"):
+            self.assertNotIn(bad, out)
+        for good in ("SAFE-HEAD", "red", "link", "SAFE-TAIL", "café", "日本語", "🎯"):
+            self.assertIn(good, out)
+        self.assertIn("\n", out, "prose formatting survives")
+
+    def test_newlines_are_escaped_when_not_allowed(self) -> None:
+        """Single-line surfaces (evidence preview) keep the stricter default."""
+        self.assertNotIn("\n", self.sanitize("a\nb"))
+
+
+class RenderedAssistantTextTest(ModeTestBase):
+    """The real production rendering seams, not just the helper."""
+
+    UNSAFE = ("\x1b", "\r", "\x07", "\x00", "\x9b")
+
+    def assert_terminal_safe(self, output: str) -> None:
+        for bad in self.UNSAFE:
+            self.assertNotIn(bad, output, f"{bad!r} reached the terminal")
+
+    def test_chat_assistant_output_is_sanitized(self) -> None:
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        repl.tools_mode = "off"
+
+        output = self.run_prompt(repl, "hello")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("SAFE-HEAD", output)
+        self.assertIn("SAFE-TAIL", output)
+
+    def test_analysis_direct_prose_is_sanitized(self) -> None:
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        output = self.run_prompt(repl, "what is this file?")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("SAFE-TAIL", output)
+
+    def test_report_prose_is_sanitized(self) -> None:
+        # The step must run an action, otherwise `/report` takes the
+        # zero-evidence path and never renders model prose at all.
+        backend = HostileTextBackend(
+            tool_calls=[
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {
+                        "name": ANALYSIS_TOOL_NAME,
+                        "arguments": json.dumps({"code": "print(1)"}),
+                    },
+                }
+            ]
+        )
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "look at it")
+        self.assertTrue(
+            repl.analysis.evidence_store.records, "the report needs evidence to speak about"
+        )
+        calls_before = backend.calls
+
+        output = self.run_command(repl, "/report what did you find")
+
+        self.assertGreater(backend.calls, calls_before, "the report must actually run")
+        self.assert_terminal_safe(output)
+        self.assertIn("SAFE-TAIL", output, "the report prose must have been rendered")
+
+    def test_history_keeps_the_original_unsanitized_text(self) -> None:
+        """Sanitizing is presentation only: the record stays byte-exact."""
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "look at it")
+
+        stored = [
+            m for m in repl.analysis.messages if m.get("role") == "assistant"
+        ]
+        self.assertTrue(stored, "the step must be recorded")
+        self.assertIn(
+            HOSTILE_TEXT,
+            "".join(str(m.get("content") or "") for m in stored),
+            "history must keep the model's original output",
+        )
+
+    def test_chat_history_keeps_the_original_unsanitized_text(self) -> None:
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        repl.tools_mode = "off"
+        self.run_prompt(repl, "hello")
+
+        stored = "".join(
+            str(m.get("content") or "")
+            for m in repl.runtime.messages
+            if m.get("role") == "assistant"
+        )
+        self.assertIn(HOSTILE_TEXT, stored)
+
+    def test_step_result_keeps_the_original_unsanitized_text(self) -> None:
+        """The runtime's own field is data, not display: it must not be touched."""
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        result = repl.analysis.step("look at it")
+
+        self.assertEqual(
+            result.assistant_text,
+            HOSTILE_TEXT,
+            "sanitizing belongs at the terminal, not in the runtime result",
+        )
+
+    def test_report_result_keeps_the_original_unsanitized_text(self) -> None:
+        backend = HostileTextBackend(
+            tool_calls=[
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {
+                        "name": ANALYSIS_TOOL_NAME,
+                        "arguments": json.dumps({"code": "print(1)"}),
+                    },
+                }
+            ]
+        )
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        self.run_prompt(repl, "look at it")
+
+        report = repl.analysis.report("what did you find")
+
+        self.assertEqual(report.text, HOSTILE_TEXT)
+
+    def test_chat_result_keeps_the_original_unsanitized_text(self) -> None:
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        repl.tools_mode = "off"
+        self.run_prompt(repl, "hello")
+
+        stored = "".join(
+            str(m.get("content") or "")
+            for m in repl.runtime.messages
+            if m.get("role") == "assistant"
+        )
+        self.assertIn(HOSTILE_TEXT, stored)
+        self.assertIn("\x1b", stored, "storage keeps the real control byte")
+
+    def test_evidence_preview_sanitization_is_unchanged(self) -> None:
+        """The pre-existing analysis-output sanitization still applies."""
+        from orbit.terminal.analysis_mode import _sanitize
+
+        self.assertEqual(_sanitize("a\x1b[2Jb"), "a\\x1b[2Jb")
+        self.assertEqual(_sanitize("a\nb"), "a\\nb", "single-line surface unchanged")


### PR DESCRIPTION
## Problem

Model-authored `assistant_text` could reach terminal rendering with unsafe control characters intact. Confirmed empirically before the fix — a crafted delta arrived at the terminal with ESC, CR and BEL all preserved:

```
STREAM  ESC present: True | CR present: True | BEL: True
'safe-before\x1b[2J\x1b[H\x1b]0;PWNED\x07\rFORGED action: ok\x1b[31mred'
```

That is enough to erase the screen, set the window title, drive an OSC 52 clipboard write, or use a carriage return to overwrite a line Orbit had already printed — forging its own status line, the same attack the ANALYSIS evidence preview was previously hardened against.

## Solution

Sanitize **only at presentation boundaries**, reusing the existing sanitizer semantics. The sanitizer that already guarded analysis stdout and artifact metadata moves to `theme.py` as `sanitize_terminal_text`; `analysis_mode._sanitize` now delegates to it. The one addition is an opt-in `allow_newlines` for multi-line prose — carriage return is never allowed in either mode.

## Explicit invariants

- Persisted/model/history text remains **original** (verified byte-equality including real `\x1b`)
- EvidenceStore **unchanged**
- SessionStore **unchanged**
- **No** backend/model/prompt/routing/KV/prewarm changes
- Printable Unicode and normal line formatting **preserved**
- Unsafe terminal controls **neutralized**
- **All** production assistant rendering paths covered — all 12 `renderer.write` call sites funnel through `StreamRenderer.write`; `format_analysis_step` covers the prose it reprints

Sanitizing runs *before* the thinking filter and markdown renderer, which emit Orbit's own colour downstream — the reverse order would have stripped Orbit's own styling.

## Qualification

- **Exhaustive 0x110000-code-point validation**: old vs new sanitizer — 0 behavioural differences; output-safety sweep — 0 violations; `repr(ch)[1:-1]` sound for every non-printable code point — 0 failures
- **10/10 mutations CAUGHT** (bypass, allow ESC/BEL/CR/C1, sanitize-storage ×3, bypass `format_analysis_step`, weakened default)
- **Focused 291 PASS**
- **Full suite 2759 PASS** (2738 baseline + 21 new)
- compileall / `git diff --check` PASS
- **Independent review PASS — BLOCKER 0, MAJOR 0**; found no bypass path, no over-reach, no vacuous test, no ANSI regression
- **No real inference required** — the production seam is fully exercisable with a scripted backend

Neutralized and covered by tests: CSI colour, cursor movement/erase, OSC title, OSC 8 hyperlink, OSC 52 clipboard, CR overwrite, raw C0, DEL, all C1, U+2028/2029, and (as a side effect of `isprintable()`) bidi/zero-width. Preserved: printable Unicode of every script, astral characters, combining marks, quotes, backslashes, tabs, newlines.

## Recorded, deliberately NOT fixed here

- Pre-existing duplicate ANALYSIS prose print (confirmed to pre-date this change on baseline `main`; both copies are sanitized)
- `CommandAction.output` terminal surface (locally-built tool output, not model-authored)
- `queued_prompts` echo
- `/report` latency
