### PR TITLE
cleanup(terminal): remove dead prompt queue

### DIFF
--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -77,7 +77,6 @@ class Repl:
     _analysis_acquired_hook: Callable[[], None] | None = field(default=None, repr=False)
     _announced_workdir: str | None = field(default=None, repr=False)
     analysis: AnalysisRuntime | None = field(default=None, repr=False)
-    queued_prompts: list[str] = field(default_factory=list)
     turn_model_steps: list[ModelStepMetrics] = field(default_factory=list, repr=False)
     turn_backend_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
     session_token_usage: TokenUsageAccumulator = field(default_factory=TokenUsageAccumulator, repr=False)
@@ -176,8 +175,6 @@ class Repl:
         return "analysis" if self.workflow_mode is WorkflowMode.ANALYSIS else "chat"
 
     def _read_next_prompt(self) -> str:
-        if self.queued_prompts:
-            return self.queued_prompts.pop(0)
         if self.prompt_gap_pending:
             print(flush=True)
             self.prompt_gap_pending = False

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -873,21 +874,6 @@ class ReplTests(unittest.TestCase):
             ),
         )
 
-    def test_repl_reads_queued_prompt_before_new_input(self) -> None:
-        runtime = CountingRuntime()
-        repl = Repl(
-            runtime=runtime,
-            backend=runtime.backend,
-            config=AppConfig(workdir=Path(".")),
-            queued_prompts=["queued prompt"],
-        )
-
-        with mock.patch("orbit.terminal.repl.read_prompt_input", side_effect=AssertionError("should not read input")):
-            prompt = repl._read_next_prompt()
-
-        self.assertEqual(prompt, "queued prompt")
-        self.assertEqual(repl.queued_prompts, [])
-
     def test_prompt_gap_is_exactly_one_blank_line_and_does_not_accumulate(self) -> None:
         for interactive in (False, True):
             with self.subTest(interactive=interactive):
@@ -1119,6 +1105,170 @@ class ReplTests(unittest.TestCase):
         self.assertEqual(runtime.messages, [])
         self.assertIsNotNone(repl.session)
         self.assertNotEqual(repl.session.path, session.path)
+
+
+# The cursor-up + erase-to-end block `replace_input_echo` emits to rewrite the
+# terminal's own echo of a typed line. Matched as a pair: moving the cursor up
+# without erasing is destructive too, since later output overwrites those rows.
+ECHO_REPLACEMENT = re.compile(r"\x1b\[\d+F\x1b\[J")
+
+
+class _EchoTty(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class TypedPromptInputTest(unittest.TestCase):
+    """What survives after the unused prompt queue was removed.
+
+    Every prompt now comes from the terminal, so these pin the real typed-input
+    behaviour rather than the deleted feature.
+    """
+
+    LONG = "L" * 900          # over the 800-char long-text threshold
+    MULTILINE = "first\nsecond"
+
+    def drive(self, typed, *, history=None, workflow_mode=None):
+        """Run the real REPL loop over a scripted terminal."""
+        out = _EchoTty()
+        runtime = CountingRuntime()
+        asked: list[str] = []
+        for name in ("ask_auto", "ask_chat"):
+            original = getattr(runtime, name)
+
+            def record(prompt, *args, _original=original, **kwargs):
+                asked.append(prompt)
+                return _original(prompt, *args, **kwargs)
+
+            setattr(runtime, name, record)
+        kwargs = {}
+        if workflow_mode is not None:
+            kwargs["workflow_mode"] = workflow_mode
+        repl = Repl(
+            runtime=runtime,
+            backend=runtime.backend,
+            config=AppConfig(workdir=Path(".")),
+            history=history,
+            **kwargs,
+        )
+        pending = list(typed)
+
+        def fake_input(*args, **kwargs):
+            if pending:
+                return pending.pop(0)
+            raise EOFError
+
+        with contextlib.redirect_stdout(out), \
+             mock.patch("orbit.terminal.repl.read_prompt_input", side_effect=fake_input), \
+             mock.patch("sys.stdin", _EchoTty()):
+            repl.run()
+        return out.getvalue(), asked, repl, runtime
+
+    def history_for(self, root: Path) -> PromptHistory:
+        """A history on an isolated root, the way cli.py always supplies one."""
+        return PromptHistory.for_workdir(root, root=root)
+
+    # Under the long-text threshold, so the echo is left exactly as typed.
+    def test_short_typed_prompt_is_not_rewritten(self) -> None:
+        output, asked, _, _ = self.drive(["short one"])
+
+        self.assertNotRegex(output, ECHO_REPLACEMENT)
+        self.assertEqual(asked, ["short one"])
+
+    # Over the threshold: the terminal's own echo is replaced with a preview.
+    def test_long_typed_prompt_echo_is_replaced(self) -> None:
+        output, asked, _, _ = self.drive([self.LONG])
+
+        self.assertRegex(output, ECHO_REPLACEMENT)
+        self.assertEqual(asked, [self.LONG])
+
+    # Multiline is the other trigger for replacement.
+    def test_multiline_typed_prompt_echo_is_replaced(self) -> None:
+        output, asked, _, _ = self.drive([self.MULTILINE])
+
+        self.assertRegex(output, ECHO_REPLACEMENT)
+        self.assertEqual(asked, [self.MULTILINE])
+
+    # The configuration cli.py actually ships: a history is always present, and
+    # the loop takes a different echo branch when it is.
+    def test_long_typed_prompt_with_history_echo_is_replaced(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output, asked, _, _ = self.drive(
+                [self.LONG], history=self.history_for(Path(tmp))
+            )
+
+        self.assertRegex(output, ECHO_REPLACEMENT)
+        self.assertEqual(asked, [self.LONG])
+
+    # A slash command clears the echo of its own line and runs no model turn.
+    def test_slash_command_clears_its_echo_and_asks_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output, asked, _, runtime = self.drive(
+                ["/help"], history=self.history_for(Path(tmp))
+            )
+
+        self.assertEqual(asked, [])
+        self.assertEqual(runtime.ask_calls, 0)
+        self.assertIn("/report", output, "the command still produced its output")
+        self.assertIn(
+            "\x1b[J",
+            output,
+            "a typed command clears the echo of the line that invoked it",
+        )
+
+    # One typed line is exactly one turn.
+    def test_chat_prompt_is_processed_exactly_once(self) -> None:
+        _, asked, _, runtime = self.drive(["what is a packer?"])
+
+        self.assertEqual(asked, ["what is a packer?"])
+        self.assertEqual(runtime.ask_calls, 1)
+
+    # Identical prompts are two turns, never deduplicated.
+    def test_two_identical_typed_prompts_execute_twice(self) -> None:
+        _, asked, _, runtime = self.drive(["same", "same"])
+
+        self.assertEqual(asked, ["same", "same"])
+        self.assertEqual(runtime.ask_calls, 2)
+
+    # What reaches the history file is the prompt, verbatim and once.
+    def test_typed_prompt_is_written_to_history(self) -> None:
+        # PromptHistory wraps the process-global readline module, so entries
+        # from earlier tests in this process would otherwise lead the file.
+        # Production never sees that: one process, one workdir, one history.
+        readline = _load_readline()
+        if readline is not None:
+            readline.clear_history()
+            self.addCleanup(readline.clear_history)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            history = self.history_for(Path(tmp))
+            _, asked, _, _ = self.drive(["remember me"], history=history)
+
+            self.assertEqual(asked, ["remember me"])
+            self.assertTrue(history.path.exists(), "the prompt must be persisted")
+            self.assertEqual(
+                history.path.read_text(encoding="utf-8").splitlines(),
+                ["remember me"],
+                "written once, verbatim",
+            )
+
+    # The removed feature leaves nothing behind on the class.
+    def test_repl_has_no_prompt_queue(self) -> None:
+        runtime = CountingRuntime()
+        repl = Repl(
+            runtime=runtime,
+            backend=runtime.backend,
+            config=AppConfig(workdir=Path(".")),
+        )
+
+        self.assertFalse(hasattr(repl, "queued_prompts"))
+        with self.assertRaises(TypeError):
+            Repl(
+                runtime=runtime,
+                backend=runtime.backend,
+                config=AppConfig(workdir=Path(".")),
+                queued_prompts=["x"],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -918,6 +918,49 @@ class ChatNonRegressionTest(ModeTestBase):
         self.assertNotIn(ANALYSIS_TOOL_NAME, seen["allowed"] or ())
 
 
+class PromptQueueRemovalTest(ModeTestBase):
+    """The unused prompt queue is gone; ANALYSIS input is unaffected by that."""
+
+    def test_repl_exposes_no_prompt_queue(self) -> None:
+        repl = self.repl()
+
+        self.assertFalse(hasattr(repl, "queued_prompts"))
+
+    def test_analysis_prompt_is_processed_exactly_once(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        calls_before = backend.calls
+
+        self.run_prompt(repl, "what is this file?")
+
+        self.assertEqual(backend.calls - calls_before, 1, "one analyst line, one step")
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+    def test_two_identical_analysis_prompts_run_twice(self) -> None:
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        calls_before = backend.calls
+
+        self.run_prompt(repl, "look again")
+        self.run_prompt(repl, "look again")
+
+        self.assertEqual(backend.calls - calls_before, 2, "identical input is still two steps")
+
+    def test_assistant_text_sanitizer_still_applies(self) -> None:
+        """The queue removal must not disturb the terminal sanitizer."""
+        backend = HostileTextBackend()
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+
+        output = self.run_prompt(repl, "what is this file?")
+
+        for unsafe in ("\x1b", "\r", "\x07", "\x00", "\x9b"):
+            self.assertNotIn(unsafe, output)
+        self.assertIn("SAFE-TAIL", output)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Why

`queued_prompts` was introduced in `4ba98f5` but **never had a production producer**.

Historical and current audit found:
- **zero production producers** — the sole production `Repl(...)` (`cli.py:171-177`) never passes it; no dynamic path either (no `setattr`/`__dict__`/`dataclasses.replace`/`fields()` over `Repl`, and `Repl.__init__` has no `**kwargs` catch-all). The most plausible candidate — positional CLI prompt args — is excluded: `cli.py:94` joins them into a *single* one-shot prompt that never reaches the interactive REPL.
- **one unreachable consumer branch** — the drain in `_read_next_prompt`, which could never be taken;
- **no public/exported API contract** — `terminal/__init__.py` is empty, the only entry point is `[project.scripts] orbit = "orbit.terminal.cli:main"`; this is an application, not a published library;
- **no persistence/session dependency** — sessions store messages and workflow mode only;
- **no documentation/config/script dependency**.

`git log -S queued_prompts --all` returns exactly one commit — the introducing one — and the only line ever assigning the field in all of history is a *test* line in that same commit.

Therefore deletion is preferable to carrying a latent echo fix for unreachable code. (A guard for the queued-prompt echo was written, fully qualified, and deliberately **rejected** on exactly these grounds; its evidence is preserved separately.)

**This is dead-code cleanup / latent-defect removal by construction. No current user-visible production bug was fixed** — the defect was real at the seam but unreachable, severity zero in production.

## What

Removes:
- the dead `queued_prompts` field;
- the unreachable `_read_next_prompt` queue branch;
- the obsolete queue test (the feature's only caller).

Production delta: **−3 LOC, zero additions**. No compatibility shim.

## Invariants

- typed input unchanged;
- long/multiline input echo replacement unchanged (`replace_input_echo` and `clear_input_echo` untouched — `repl_input.py` is not modified);
- prompts processed exactly once;
- intentional duplicate prompts still execute twice;
- history/session unchanged;
- model-call behavior unchanged;
- CHAT/ANALYSIS unchanged;
- sanitizer/streaming unchanged.

## Qualification

- **typed-input comparison byte-identical across 12 production-shaped scenarios** (short / long-900 / multiline / slash+prose / two-identical / long-no-history, each with and without a `history`), capturing real ANSI echo sequences; the reviewer reproduced this independently and additionally compared history-file content
- **11/11 mutations CAUGHT**
- focused suites PASS (REPL 71, streaming 82, workflow-mode+analysis 285, session/history 47, sanitizer 21)
- **full suite 2771 PASS**
- compileall / `git diff --check` PASS
- **independent review PASS — BLOCKER 0 / MAJOR 0 / MINOR 0**
- **no real inference required**

Surviving typed-input tests were **strengthened during the audit**: the removal exposed that the real typed path had no direct coverage, so this adds 13 mutation-verified tests, including one that constructs `Repl` with a `history` exactly as `cli.py` does.

Remaining `queued_prompts` references are test-only removal guards (asserting the attribute is gone and the kwarg is rejected).
