### PR TITLE
fix(terminal): avoid duplicate analysis prose

### DIFF
--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -132,13 +132,31 @@ def _resolve_target(raw_path: str, *, workdir: Path) -> Path:
     return candidate
 
 
-def format_analysis_step(result: AnalysisStepResult) -> str:
-    """Render one step for the analyst who has just been handed control back."""
+def format_analysis_step(
+    result: AnalysisStepResult, *, prose_already_shown: bool = False
+) -> str:
+    """Render one step for the analyst who has just been handed control back.
+
+    `prose_already_shown` says the assistant prose was streamed to the terminal
+    as it arrived, so repeating it here would show the analyst the same answer
+    twice. It is rendering state supplied by the caller that did the streaming,
+    not something inferred from the text: a backend that returns content
+    without emitting deltas streams nothing, and then this is the only place
+    the prose is shown at all.
+
+    The streamed copy is the filtered one. `result.assistant_text` is the raw
+    response content, which still holds any raw tool-call markup the backend's
+    stream filter kept off the terminal; preferring what was streamed keeps
+    that markup hidden, which is what the filter is for.
+
+    Everything else -- action status, evidence preview, artifacts -- is
+    rendered either way, because none of it was streamed.
+    """
     lines: list[str] = []
     # Model-authored prose: sanitized here because this is where it is
     # displayed. `result.assistant_text` itself stays the model's original.
     text = sanitize_terminal_text(result.assistant_text, allow_newlines=True).strip()
-    if text:
+    if text and not prose_already_shown:
         lines.append(text)
     if result.rejection:
         lines.append(f"action refused: {result.rejection}")
@@ -152,7 +170,9 @@ def format_analysis_step(result: AnalysisStepResult) -> str:
         # Only when the preview did not already list them with size and digest;
         # printing both says the same thing twice.
         lines.append(f"artifacts: {', '.join(result.artifact_handles)}")
-    if not lines:
+    if not lines and not (text and prose_already_shown):
+        # "(no output)" means the step produced nothing worth showing -- not
+        # that the prose was already streamed a moment ago.
         lines.append("(no output)")
     return "\n".join(lines)
 

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -349,7 +349,18 @@ class Repl:
             self._close_analysis()
             raise
         renderer.finish()
-        print(format_analysis_step(result), flush=True)
+        # The renderer already showed the prose if the backend streamed it;
+        # the final block then carries only what streaming could not: action
+        # status, evidence preview, artifacts.
+        prose_already_shown = renderer.rendered_visible_text
+        step_block = format_analysis_step(result, prose_already_shown=prose_already_shown)
+        if prose_already_shown:
+            # Streamed deltas leave the cursor mid-line; close that line so the
+            # block below starts on its own. Previously the reprinted copy of
+            # the prose supplied this break.
+            print(flush=True)
+        if step_block:
+            print(step_block, flush=True)
         elapsed = time.monotonic() - started
         summary = (
             f"analysis | mode: ANALYSIS | model calls: {result.model_calls} | "

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -58,6 +58,13 @@ class StreamRenderer:
         self._markdown_live = _LiveMarkdownRenderer(enabled=self._markdown_mode == "live")
         self._started = False
         self._first_delta = False
+        # Whether model prose with visible content has reached the terminal
+        # through this renderer. Rendering state, owned by the terminal: a
+        # caller that also holds a final copy of the same prose uses it to
+        # avoid printing it twice. Whitespace alone does not count -- it shows
+        # the analyst nothing, and the final copy would still be worth having.
+        # Never reset by `finish()`, because what was displayed stays displayed.
+        self._rendered_visible_text = False
         self._timer_active = False
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -84,9 +91,10 @@ class StreamRenderer:
         Every streamed delta passes through here -- CHAT, an analysis step,
         and `/report` all hand theirs to this method -- so it is where model
         text stops being able to act on the terminal. It is not the only such
-        boundary: `format_analysis_step` reprints the same prose and sanitizes
-        it too. Only what is displayed is sanitized; what the runtime keeps in
-        history, in the session file, and in evidence is the model's original.
+        boundary: `format_analysis_step` sanitizes the prose it renders when
+        nothing was streamed. Only what is displayed is sanitized; what the
+        runtime keeps in history, in the session file, and in evidence is the
+        model's original.
 
         Sanitizing here, before the thinking filter and the markdown renderer,
         is deliberate: those run downstream and emit Orbit's own colour, which
@@ -141,6 +149,11 @@ class StreamRenderer:
         if self._interactive and self._started and not self._first_delta:
             self._render_wait_line()
 
+    @property
+    def rendered_visible_text(self) -> bool:
+        """Whether the analyst has already seen model prose from this renderer."""
+        return self._rendered_visible_text
+
     def finish(self, *, interrupted: bool = False) -> None:
         if self._thinking_filter is not None:
             for fragment, dimmed in self._thinking_filter.finish():
@@ -174,6 +187,11 @@ class StreamRenderer:
         self._write_visible_text(fragment)
 
     def _write_visible_text(self, text: str) -> None:
+        # Set here rather than in `write()`: with a thinking filter active the
+        # incoming delta may be entirely hidden reasoning, which the analyst
+        # never sees and which must not suppress the final prose. Whitespace is
+        # excluded for the same reason -- nothing legible was shown.
+        self._rendered_visible_text = self._rendered_visible_text or bool(text.strip())
         try:
             if self._markdown_mode == "live":
                 for chunk in self._markdown_live.write(text):

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -961,6 +961,284 @@ class PromptQueueRemovalTest(ModeTestBase):
         self.assertIn("SAFE-TAIL", output)
 
 
+PROSE_MARKER = "PROSE-MARKER"
+ANALYSIS_PROSE = f"{PROSE_MARKER} this file is a JScript dropper."
+
+
+class ProseBackend(ScriptedBackend):
+    """Streams its prose the way the real backend does, then returns it."""
+
+    def __init__(self, text: str = ANALYSIS_PROSE, tool_calls=None) -> None:
+        super().__init__(tool_calls=tool_calls)
+        self.text = text
+
+    def _result(self) -> ChatResult:
+        base = super()._result()
+        return ChatResult(
+            content=self.text,
+            model=base.model,
+            finish_reason=base.finish_reason,
+            tool_calls=base.tool_calls,
+            prompt_tokens=base.prompt_tokens,
+            completion_tokens=base.completion_tokens,
+            cached_tokens=base.cached_tokens,
+            prompt_tokens_per_second=None,
+            generation_tokens_per_second=None,
+        )
+
+    def chat_stream(
+        self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None
+    ) -> ChatResult:
+        self.calls += 1
+        self.tools_seen.append(tools)
+        self.messages_seen.append([dict(m) for m in messages])
+        if on_delta:
+            on_delta(self.text)
+        return self._result()
+
+
+class NonStreamingProseBackend(ProseBackend):
+    """Returns content without ever emitting a delta.
+
+    A real possibility -- `AnalysisRuntime` only forwards a delta when the
+    backend produces one -- and the case where the final block is the only
+    thing that can show the prose at all.
+    """
+
+    def chat_stream(
+        self, messages, *, temperature, max_tokens, tools=None, on_delta=None, on_progress=None
+    ) -> ChatResult:
+        self.calls += 1
+        self.tools_seen.append(tools)
+        self.messages_seen.append([dict(m) for m in messages])
+        return self._result()
+
+
+ANALYSIS_ACTION_CALL = [
+    {
+        "id": "call_0",
+        "type": "function",
+        "function": {"name": ANALYSIS_TOOL_NAME, "arguments": json.dumps({"code": "print(1)"})},
+    }
+]
+
+
+class AnalysisDuplicateProseTest(ModeTestBase):
+    """One logical assistant answer is shown to the analyst exactly once."""
+
+    def analysis_repl(self, backend):
+        repl = self.repl(backend)
+        self.run_command(repl, f"/analysis {self.artifact}")
+        return repl
+
+    def test_direct_prose_is_displayed_exactly_once(self) -> None:
+        backend = ProseBackend()
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "what is this?")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        self.assertEqual(backend.calls, 1, "one model call")
+
+    def test_streamed_text_is_complete_and_ordered(self) -> None:
+        backend = ProseBackend(text=f"{PROSE_MARKER} alpha beta gamma delta")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "describe it")
+
+        self.assertIn(f"{PROSE_MARKER} alpha beta gamma delta", output)
+        self.assertLess(
+            output.index("alpha"), output.index("delta"), "streamed order preserved"
+        )
+
+    def test_multiline_prose_is_displayed_once(self) -> None:
+        backend = ProseBackend(text=f"{PROSE_MARKER} first line\nsecond line\nthird line")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "describe it")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        self.assertEqual(output.count("second line"), 1)
+        self.assertEqual(output.count("third line"), 1)
+
+    def test_long_prose_is_displayed_once(self) -> None:
+        backend = ProseBackend(text=f"{PROSE_MARKER} " + ("word " * 400))
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "describe it")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        self.assertEqual(output.count("word "), 400)
+
+    def test_unicode_prose_is_displayed_once_and_unchanged(self) -> None:
+        backend = ProseBackend(text=f"{PROSE_MARKER} caf\u00e9 \u65e5\u672c\u8a9e \u03b1\u03b2\u03b3 \U0001f3af")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "describe it")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        for fragment in ("caf\u00e9", "\u65e5\u672c\u8a9e", "\u03b1\u03b2\u03b3", "\U0001f3af"):
+            self.assertEqual(output.count(fragment), 1)
+
+    def test_unsafe_control_input_stays_sanitized_on_the_surviving_path(self) -> None:
+        backend = ProseBackend(text=f"{PROSE_MARKER}\x1b[2J\x1b]52;c;cGF5\x07\rFORGED\x9b31m tail")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "describe it")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        for unsafe in ("\x1b", "\r", "\x07", "\x9b"):
+            self.assertNotIn(unsafe, output)
+        self.assertIn("tail", output)
+
+    def test_action_step_does_not_duplicate_prose(self) -> None:
+        backend = ProseBackend(tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "run something")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+
+    def test_action_status_and_evidence_preview_survive_exactly_once(self) -> None:
+        backend = ProseBackend(tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "run something")
+
+        self.assertEqual(output.count("action: ok"), 1, "action status still shown")
+        self.assertEqual(output.count("evidence:"), 1, "evidence preview still shown")
+        self.assertEqual(output.count("result:"), 1)
+
+    def test_diagnostics_line_survives(self) -> None:
+        backend = ProseBackend()
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "what is this?")
+
+        self.assertIn("mode: ANALYSIS", output)
+        self.assertIn("model calls: 1", output)
+
+    def test_action_only_response_still_renders_final_status(self) -> None:
+        """No prose at all: the final block must still say what happened."""
+        backend = ProseBackend(text="", tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "run something")
+
+        self.assertIn("action: ok", output)
+        self.assertIn("evidence:", output)
+
+    def test_empty_response_still_reports_no_output(self) -> None:
+        """Nothing streamed and nothing done still tells the analyst so."""
+        backend = ProseBackend(text="")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "what is this?")
+
+        self.assertIn("(no output)", output)
+
+    def test_non_streamed_prose_is_still_displayed_once(self) -> None:
+        """The fallback: nothing was streamed, so the final block must show it."""
+        backend = NonStreamingProseBackend()
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "what is this?")
+
+        self.assertEqual(
+            output.count(PROSE_MARKER), 1, "the only copy must not be suppressed"
+        )
+
+    def test_non_streamed_prose_is_sanitized(self) -> None:
+        backend = NonStreamingProseBackend(text=f"{PROSE_MARKER}\x1b[2J\rFORGED tail")
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "what is this?")
+
+        self.assertEqual(output.count(PROSE_MARKER), 1)
+        for unsafe in ("\x1b", "\r"):
+            self.assertNotIn(unsafe, output)
+
+    def test_history_and_evidence_keep_the_original_text(self) -> None:
+        backend = ProseBackend(tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+        self.run_prompt(repl, "run something")
+
+        stored = "".join(
+            str(message.get("content") or "")
+            for message in repl.analysis.messages
+            if message.get("role") == "assistant"
+        )
+        self.assertIn(ANALYSIS_PROSE, stored, "history unchanged by a display fix")
+        self.assertEqual(len(repl.analysis.evidence_store.records), 2)
+
+    def test_model_and_action_counts_are_unchanged(self) -> None:
+        backend = ProseBackend(tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+        calls_before = backend.calls
+
+        self.run_prompt(repl, "run something")
+
+        self.assertEqual(backend.calls - calls_before, 1, "one model call per step")
+        self.assertEqual(repl.analysis.actions_executed, 1)
+
+    def test_visible_text_sets_the_render_flag(self) -> None:
+        from orbit.terminal.streaming import StreamRenderer
+
+        renderer = StreamRenderer(thinking=False, render_markdown_mode="plain", interactive=False)
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer.start()
+            self.assertFalse(renderer.rendered_visible_text)
+            renderer.write(ANALYSIS_PROSE)
+
+        self.assertTrue(renderer.rendered_visible_text)
+
+    def test_streamed_prose_ends_its_line_before_the_final_block(self) -> None:
+        """Streamed deltas leave the cursor mid-line.
+
+        The reprinted copy used to supply the break; with it gone the terminal
+        must close the line itself, or the action status runs onto the prose.
+        """
+        backend = ProseBackend(tool_calls=ANALYSIS_ACTION_CALL)
+        repl = self.analysis_repl(backend)
+
+        output = self.run_prompt(repl, "run something")
+
+        self.assertNotIn(
+            f"{PROSE_MARKER} this file is a JScript dropper.action:",
+            output,
+            "the action status must not run onto the prose line",
+        )
+        self.assertIn("dropper.\naction: ok", output)
+
+    def test_whitespace_only_stream_does_not_count_as_displayed_prose(self) -> None:
+        """Whitespace shows the analyst nothing, so it must not suppress the copy."""
+        from orbit.terminal.streaming import StreamRenderer
+
+        renderer = StreamRenderer(thinking=False, render_markdown_mode="plain", interactive=False)
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer.start()
+            renderer.write("   \n  ")
+
+        self.assertFalse(renderer.rendered_visible_text)
+
+        with contextlib.redirect_stdout(buffer):
+            renderer.write(ANALYSIS_PROSE)
+
+        self.assertTrue(renderer.rendered_visible_text, "real prose still counts")
+
+    def test_two_steps_each_show_their_own_prose_once(self) -> None:
+        backend = ProseBackend()
+        repl = self.analysis_repl(backend)
+
+        first = self.run_prompt(repl, "what is this?")
+        second = self.run_prompt(repl, "and now?")
+
+        self.assertEqual(first.count(PROSE_MARKER), 1)
+        self.assertEqual(second.count(PROSE_MARKER), 1, "state must not leak between steps")
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Problem

A single ANALYSIS assistant response could be displayed **twice**:

1. once from streamed visible deltas (`streaming.py`, via `on_delta=renderer.write`);
2. again from the final `format_analysis_step(...)` (`repl.py`).

Reproduced on the production rendering seam with a scripted backend — one model call, the prose visibly concatenated:

```
PROSE-MARKER this file is a JScript dropper.PROSE-MARKER this file is a JScript dropper.
```

A naive removal of the final prose path would be **incorrect**, because a legitimate backend path may return `response.content` without emitting visible deltas — `AnalysisRuntime` forwards a delta only when the backend produces one. In that case the final block is the *only* thing that displays the prose at all. This was proved before the fix was written, not assumed.

## Solution

Track terminal rendering state in `StreamRenderer`.

If visible assistant prose was already rendered:
- final ANALYSIS formatting omits **only that prose copy**.

If no visible prose was streamed:
- final formatting **preserves the fallback prose**.

No text comparison or semantic deduplication. No extra model calls, no buffering. The flag is rendering state, terminal-owned, set only where visible text is actually written — whitespace alone does not count, and hidden reasoning cannot set it.

## Important detail

The streamed copy is preferred when available **because it passes through the content stream filter**. `response.content` may differ from the visible deltas: `_ContentStreamFilter` deliberately keeps raw `<|tool_call>…<tool_call|>` markup off the terminal while `content_parts` retains it. The reprint had therefore been putting that markup back on screen — so preferring the streamed copy also stops a pre-existing leak.

## Preserved behavior

- one model call remains one model call;
- action count unchanged;
- prompts/tools unchanged;
- history unchanged;
- EvidenceStore unchanged;
- action status visible;
- evidence preview visible;
- diagnostics/refusals visible;
- non-streamed fallback visible;
- sanitizer preserved on **both** prose paths (PR #236);
- `/report` unchanged;
- CHAT unchanged.

A baseline-vs-candidate comparison across scripted scenarios shows the **entire** content difference is the two removed duplicate copies; model calls, actions, evidence, history, prompts and tools offered are identical.

## Qualification

- **19 deterministic tests** covering all required scenarios;
- **8 tests fail on baseline** because of the actual duplicate behavior;
- **10/10 mutations CAUGHT**;
- focused suites PASS (workflow+analysis 357, streaming 82, sanitizer 21, `/report` 9, CHAT+REPL 101, session/history 47);
- **full suite 2790 PASS**;
- compileall / `git diff --check` PASS;
- **independent review PASS — BLOCKER 0 / MAJOR 0 / MINOR 0**;
- **no real inference required**.

## Out-of-scope follow-ups (recorded, not started)

1. `CommandAction.output` terminal-surface audit;
2. unused `deltas` local in `analysis_runtime.py`;
3. `/report` latency optimization.
