### PR TITLE
fix(terminal): sanitize command action output

### DIFF
--- a/src/orbit/terminal/cli.py
+++ b/src/orbit/terminal/cli.py
@@ -30,7 +30,7 @@ from orbit.terminal.commands import health_text, help_text, props_text, runtime_
 from orbit.terminal.session_selection import select_interactive_session
 from orbit.terminal.status import TokenUsageAccumulator, estimate_context_status_tokens, format_turn_status, summarize_turn_token_usage
 from orbit.terminal.streaming import StreamRenderer
-from orbit.terminal.theme import dim, runtime_error_text, warning_text
+from orbit.terminal.theme import dim, runtime_error_text, sanitize_terminal_text, warning_text
 from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import allowed_tool_names_for_spec, tools_are_enabled
 
@@ -98,7 +98,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(command_result)
                 return 0
             if not command_result.needs_model:
-                print(command_result.output)
+                # Same boundary as the interactive REPL: command output holds
+                # file content and filenames Orbit did not author.
+                print(sanitize_terminal_text(command_result.output, allow_newlines=True))
                 return 0
             if args.image or args.audio:
                 print("error: slash-command evidence prompts do not accept --image/--audio", file=sys.stderr)

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -585,7 +585,13 @@ class Repl:
             assert action.prompt is not None
             self._ask(action.prompt, command_action=action)
         else:
-            print(action.output)
+            # A command's output carries content Orbit did not author: file
+            # bytes, and filenames from whatever directory is being examined.
+            # A crafted name is enough to move the cursor or erase the screen,
+            # so it is neutralized here, where it is displayed. `action.output`
+            # itself is untouched, and the model never sees it -- a command
+            # that needs one sends `prompt` and `evidence` instead.
+            print(sanitize_terminal_text(action.output, allow_newlines=True))
         return True
 
     @staticmethod

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1239,6 +1239,222 @@ class AnalysisDuplicateProseTest(ModeTestBase):
         self.assertEqual(second.count(PROSE_MARKER), 1, "state must not leak between steps")
 
 
+# Filenames a hostile directory can carry. Each is a real terminal instruction
+# if it reaches the interpreter unescaped.
+HOSTILE_NAMES = (
+    "erase\x1b[2Jme.txt",
+    "osc\x1b]0;PWNED\x07title.txt",
+    "cr\rFORGED.txt",
+    "c1\x9b31m.txt",
+    "hyper\x1b]8;;https://evil.example\x1b\\link.txt",
+    "clip\x1b]52;c;cGF5bG9hZA==\x07.txt",
+)
+UNSAFE_BYTES = ("\x1b", "\r", "\x07", "\x00", "\x9b")
+
+
+class CommandActionOutputTerminalTest(ModeTestBase):
+    """`CommandAction.output` carries content Orbit did not author.
+
+    A command lists a directory or reads a file, so the text it prints holds
+    filenames and file bytes from whatever is being examined -- for Orbit,
+    often a malware sample directory. It is display-only: a command that needs
+    a model sends `prompt` and `evidence` instead, and `output` is never
+    persisted.
+    """
+
+    def hostile_dir(self) -> tuple[Path, list[str]]:
+        root = self.tmp / "hostile"
+        root.mkdir()
+        created: list[str] = []
+        for name in HOSTILE_NAMES:
+            try:
+                (root / name).write_text("x", encoding="utf-8")
+            except OSError:  # pragma: no cover - filesystem dependent
+                continue
+            created.append(name)
+        (root / "plain.txt").write_text("x", encoding="utf-8")
+        return root, created
+
+    def assert_terminal_safe(self, output: str) -> None:
+        for unsafe in UNSAFE_BYTES:
+            self.assertNotIn(unsafe, output, f"{unsafe!r} reached the terminal")
+
+    # 1 / 2 / 9 / 10: the real defect, at the real sink.
+    def test_ls_neutralizes_hostile_filenames(self) -> None:
+        root, created = self.hostile_dir()
+        self.assertTrue(created, "the filesystem must accept at least one hostile name")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/ls {root}")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("plain.txt", output, "ordinary entries still listed")
+
+    def test_read_neutralizes_control_bytes_in_file_content(self) -> None:
+        target = self.tmp / "ctrl.txt"
+        target.write_text("A\x1b[2J\rB\x07 SAFE-TAIL", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("SAFE-TAIL", output)
+
+    def test_read_neutralizes_a_hostile_filename_in_its_header(self) -> None:
+        target = self.tmp / "head\x1b[2Jer.txt"
+        try:
+            target.write_text("body", encoding="utf-8")
+        except OSError:  # pragma: no cover - filesystem dependent
+            self.skipTest("filesystem rejects escape characters in names")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("body", output)
+
+    def test_search_over_a_local_document_is_sanitized(self) -> None:
+        """`/search` carries document text, which is external content too."""
+        target = self.tmp / "doc.txt"
+        target.write_text("alpha NEEDLE\x1b[2J\rFORGED beta\n", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/search NEEDLE {target}")
+
+        self.assert_terminal_safe(output)
+        self.assertIn("NEEDLE", output)
+
+    # 3 / 4 / 5: ordinary output is untouched.
+    def test_plain_listing_is_unchanged(self) -> None:
+        root = self.tmp / "plain_dir"
+        root.mkdir()
+        (root / "one.txt").write_text("x", encoding="utf-8")
+        (root / "two.txt").write_text("x", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/ls {root}")
+
+        self.assertIn("one.txt", output)
+        self.assertIn("two.txt", output)
+        self.assertIn("\n", output, "line structure preserved")
+
+    def test_unicode_filenames_survive_the_sanitized_sink(self) -> None:
+        """Filenames go through the display boundary, so they pin over-sanitizing."""
+        root = self.tmp / "unicode_dir"
+        root.mkdir()
+        for name in ("café.txt", "日本語.txt", "αβγ.txt", "🎯.txt", "ünïcödé.txt"):
+            (root / name).write_text("x", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/ls {root}")
+
+        for fragment in ("café", "日本語", "αβγ", "🎯", "ünïcödé"):
+            self.assertIn(fragment, output, "printable Unicode must not be escaped")
+
+    def test_unicode_file_content_is_unchanged(self) -> None:
+        target = self.tmp / "unicode.txt"
+        target.write_text("café 日本語 αβγ 🎯 ünïcödé", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        for fragment in ("café", "日本語", "αβγ", "🎯", "ünïcödé"):
+            self.assertIn(fragment, output)
+
+    def test_one_shot_cli_sink_is_also_sanitized(self) -> None:
+        """The non-interactive `orbit /ls ...` path prints through cli.main."""
+        from orbit.terminal import cli
+
+        root, created = self.hostile_dir()
+        self.assertTrue(created)
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+            exit_code = cli.main(["--workdir", str(self.tmp), "/ls", str(root)])
+
+        self.assertEqual(exit_code, 0)
+        output = buffer.getvalue()
+        self.assert_terminal_safe(output)
+        self.assertIn("plain.txt", output, "the listing still reached the analyst")
+
+    def test_newlines_in_file_content_are_preserved(self) -> None:
+        target = self.tmp / "lines.txt"
+        target.write_text("first\nsecond\nthird", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        for fragment in ("first", "second", "third"):
+            self.assertIn(fragment, output)
+        self.assertNotIn("\\n", output, "real newlines, not escaped ones")
+
+    # 11: mixed content keeps every safe fragment.
+    def test_mixed_content_keeps_the_safe_text(self) -> None:
+        target = self.tmp / "mixed.txt"
+        target.write_text("HEAD-OK\x1b[2J middle \rTAIL-OK", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        self.assert_terminal_safe(output)
+        for fragment in ("HEAD-OK", "middle", "TAIL-OK"):
+            self.assertIn(fragment, output)
+
+    # 12 / 13 / 14: status and error output still reach the analyst.
+    def test_usage_errors_are_still_shown(self) -> None:
+        repl = self.repl()
+
+        output = self.run_command(repl, "/read")
+
+        self.assertIn("error:", output)
+        self.assertIn("usage:", output)
+
+    def test_missing_file_error_is_still_shown(self) -> None:
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {self.tmp / 'absent.txt'}")
+
+        self.assertIn("error:", output)
+
+    def test_successful_read_still_shows_its_metadata(self) -> None:
+        target = self.tmp / "ok.txt"
+        target.write_text("hello\n", encoding="utf-8")
+        repl = self.repl()
+
+        output = self.run_command(repl, f"/read {target}")
+
+        self.assertIn("hello", output)
+        self.assertIn("ok.txt", output)
+
+    # 15: the raw object is display-sanitized only, never mutated.
+    def test_raw_command_action_output_is_not_mutated(self) -> None:
+        from orbit.terminal.command_actions import build_list_action
+
+        root, created = self.hostile_dir()
+        self.assertTrue(created)
+
+        action = build_list_action(str(root), workdir=self.tmp)
+
+        self.assertIn(
+            "\x1b",
+            action.output,
+            "the producer keeps the real bytes; only the display escapes them",
+        )
+
+    # 16 / 17 / 18: nothing about a data command touches the model or storage.
+    def test_data_command_makes_no_model_call_and_stores_nothing(self) -> None:
+        root, _ = self.hostile_dir()
+        backend = ScriptedBackend()
+        repl = self.repl(backend)
+        before_messages = list(repl.runtime.messages)
+
+        self.run_command(repl, f"/ls {root}")
+
+        self.assertEqual(backend.calls, 0, "a data command asks no model")
+        self.assertEqual(repl.runtime.messages, before_messages, "history unchanged")
+        self.assertEqual(len(repl.runtime.evidence_store.records), 0, "no evidence written")
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Problem

`CommandAction.output` reaches two live terminal sinks via raw `print()` — `Repl._handle_data_action` (interactive slash commands) and `cli.main` (one-shot `orbit /cmd`).

The output is **not** purely Orbit-owned. Reachable production producers can contain:

- **attacker-controlled filesystem names/content** — `/ls` (filenames, symlink targets), `/read` (file text, and the path echoed in its header);
- **network/external content** — `/read <url>` via `execute_fetch_url`, `/search <query>` via `search_web`, PDF text via `read_pdf`;
- **subprocess stdout/stderr** — `/search` over a PDF via `execute_exec_shell_full_command`;
- **user-controlled arguments** — echoed in usage/error strings.

A crafted filename or text can therefore emit terminal control sequences: CSI erase/cursor movement, OSC title/hyperlink/clipboard, BEL, carriage-return overwrite, and C1 controls.

Baseline reproduction with attacker-named files proved raw control bytes reached the real terminal sink:

```
BYTES AT THE PRODUCTION TERMINAL SINK (baseline):
  ESC: True | CR: True | BEL: True | C1: True
'[file] c1\x9b31m.txt (1 B)\n[file] cr\rFORGED.txt (1 B)\n[file] erase\x1b[2Jme.txt (1 B)\n[file] osc\x1b]0;PWNED\x07t.txt (1 B)\n'
```

Orbit analyses malware samples, so listing a directory somebody else named is the ordinary case.

## Solution

Sanitize `CommandAction.output` **only at the two presentation boundaries**, using the existing `sanitize_terminal_text(..., allow_newlines=True)`. The raw internal object and every producer are untouched. 5 production lines.

## Trust-boundary clarification

Model-controlled assistant prose does **not** enter `CommandAction.output`; it is covered by the separate assistant-text sanitizer already merged (#236). This PR addresses filesystem/network/subprocess/user-originated command output.

## Preserved invariants

- raw `.output` unchanged; history unchanged; session unchanged; EvidenceStore unchanged;
- model/tool semantics unchanged; action status unchanged; return codes unchanged;
- newlines preserved; Unicode preserved; existing assistant sanitizer unchanged;
- ANALYSIS/CHAT behavior unchanged except that unsafe terminal control interpretation is neutralized at these sinks.

## Qualification

- **15 deterministic production-seam tests** (driving `repl._handle_command` and `cli.main`, not the helper alone);
- **6 fail on baseline** for the real unsafe behavior;
- **8/8 mutations CAUGHT** — including sanitizing at the producer instead of the display, which proves the fix is display-only;
- focused suites PASS;
- **full suite 2805 PASS on verified-clean bytes**;
- compileall / `git diff --check` PASS;
- **independent review PASS — BLOCKER 0 / MAJOR 0 / MINOR 0**;
- no real inference required.

**Note on an earlier figure:** a mutation residue temporarily left ESC permitted in `theme.py` during qualification. The **2804-pass result measured then is void.** It was found by reading the production diff, reverted, and the entire mutation set plus the full suite were rerun on clean bytes. `theme.py` is byte-identical to the parent and does not appear in this diff. **2805 on verified-clean bytes is the authoritative result.**

## Out of scope

- unused `deltas` local in `analysis_runtime.py`;
- `/report` latency optimization.
