### PR TITLE
cleanup(runtime): remove unused analysis delta retention

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -575,10 +575,7 @@ class AnalysisRuntime:
         self.analyst_turns += 1
         self.messages.append({"role": "user", "content": analyst_message})
 
-        deltas: list[str] = []
-
         def _capture(text: str) -> None:
-            deltas.append(text)
             if on_delta is not None and text:
                 on_delta(text)
 
@@ -844,10 +841,8 @@ class AnalysisRuntime:
             return AnalysisReport(text=NO_EVIDENCE_REPORT, model_calls=0, evidence_ids=())
 
         messages = self._report_messages(question, records)
-        deltas: list[str] = []
 
         def _capture(text: str) -> None:
-            deltas.append(text)
             if on_delta is not None and text:
                 on_delta(text)
 


### PR DESCRIPTION
## Why

ANALYSIS previously accumulated streamed deltas into local lists that were never read.

History:
- introduced originally as the callback target (`on_delta=deltas.append`, #222);
- later `_capture()` forwarding made retention unnecessary (#232);
- the dead pattern was subsequently copied into `/report` (#235).

Proven dead by AST rather than grep: exactly 2 `Store` nodes and 2 `Load` nodes, and both Loads are the base of `.append` — zero reads. Escape hatches ruled out: no closure capture by any other nested function, no `locals()`/`eval`/`exec`/`settrace`/`inspect` anywhere in `src/`, no decorators on `step()`/`report()`, `AnalysisRuntime` is never subclassed, and no `inspect.getsource` test targets this file. It is a plain `builtins.list`, so `append` has no observable side effect.

## Change

Remove only the unused list allocation and `.append()` calls.

`_capture()` remains as the existing callback-forwarding boundary. Note the guard asymmetry was inert: the append was unconditional while `on_delta(text)` is guarded by `on_delta is not None and text`, but no branch condition ever read the list, so removal cannot change when or whether the callback fires.

## Behavioral invariants

Unchanged: model calls; prompts; tools offered; streaming callbacks; visible deltas; assistant text; action execution; malformed-tool handling; fallback prose; history; EvidenceStore; `/report`; terminal rendering; sanitizer; progress; KV/prewarm.

`assistant_text` was always sourced from `response.content`, never from the collected deltas.

## Qualification

- production LOC: **−5** (+0); test LOC: **0**
- baseline/candidate deterministic comparison **PASS** — byte-identical across all 8 required scenarios (streamed prose, multiline, non-streamed fallback, tool call, malformed tool call, action success, action failure, reasoning fragments), covering model calls, prompts, tools offered, deltas delivered to the terminal callback, history, evidence, action count and the full terminal transcript. The independent reviewer repeated this with 16 scenarios and a wider observable set.
- causal checks **PASS** — disabling the surviving `on_delta` forward fails existing tests (3), and blanking the non-streamed fallback prose fails existing tests (4); the reverse check confirms no test observes the retention
- focused suites PASS (AnalysisRuntime 122, ANALYSIS streaming/rendering 266, malformed-tool 33, `/report` 9)
- **full suite 2805 PASS** — unchanged from baseline, as expected for a deletion adding no tests
- compileall / `git diff --check` PASS
- **independent review PASS — BLOCKER 0 / MAJOR 0 / MINOR 0**
- no real inference required

This is **dead-state cleanup only**. No performance improvement is claimed — the retention was trivial in cost and nothing was measured.
