### PR TITLE
feat(runtime): add bounded autonomous analysis continuation

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -16,6 +16,18 @@ class StreamPromptMetrics:
     cached_tokens: int | None = None
 
 
+class RecoverableBackendError(RuntimeError):
+    """A backend failure that ends the current request, not the session.
+
+    The distinction matters because the two are handled oppositely: a
+    recoverable failure leaves the analyst their session and evidence, while an
+    unexpected `RuntimeError` is a bug and must propagate so the process tears
+    down and releases its workspace. Naming the recoverable case here lets a
+    runtime catch exactly it without importing upward from the backend layer,
+    and without widening to bare `RuntimeError` and swallowing real crashes.
+    """
+
+
 class StreamConsumerAbort(Exception):
     """A stream consumer stopped its own call on purpose; the backend is fine.
 

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -36,11 +36,12 @@ from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_rout
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.history_serialization import serialize_profile_messages
 from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
+from orbit.backend.base import RecoverableBackendError
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
 
 
-class LlamaServerError(RuntimeError):
+class LlamaServerError(RecoverableBackendError):
     pass
 
 

--- a/src/orbit/runtime/analysis_progress.py
+++ b/src/orbit/runtime/analysis_progress.py
@@ -1,0 +1,184 @@
+"""Generic progress classification for bounded autonomous analysis.
+
+Runtime-side orchestration only. This module reasons about verifiable state
+changes -- evidence content hashes, artifact digests, action identity -- and
+never about what an artifact means. There is no malware, encoding, protocol or
+indicator knowledge here, and nothing in it can be made to depend on any.
+
+Recovered from the preserved research harness
+(`research/autonomous-malware-analysis/harnesses/ornith-native-ptc/progress_controller.py`)
+which carried the same disclaimer. What is reused is the shape: an append-only
+ledger, action fingerprints, and a three-way classification driving a bounded
+loop. What is deliberately not reused is its `evidence_atoms` heuristic -- a
+regex over runs of >=24 non-whitespace characters, normalised for quoting.
+That predicate existed because the harness had no evidence store to ask; it
+guessed at novelty from the text of an observation. Production has
+`EvidenceStore`, which already content-addresses every action's full output as
+`raw_sha256` and records a sha256 per artifact, so novelty here is read from
+attested state rather than inferred from prose.
+
+Classification of one executed action:
+
+  NEW_CONTENT   the action produced an evidence content hash not seen before,
+                or an artifact digest that is new or changed for its handle.
+  NO_PROGRESS   the action executed and re-derived only what is already known.
+  ERROR         the action was attempted but not executed, or the model
+                produced a structurally invalid call.
+  COMPLETE      the model returned prose and attempted no action. Control
+                belongs to the analyst; the runtime does not judge whether the
+                analysis is finished.
+
+Model prose is never evidence of progress. A step whose only output is text
+classifies as COMPLETE, never NEW_CONTENT, however much the text asserts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+NEW_CONTENT = "NEW_CONTENT"
+NO_PROGRESS = "NO_PROGRESS"
+ERROR = "ERROR"
+COMPLETE = "COMPLETE"
+
+
+@dataclass(frozen=True)
+class ProgressRecord:
+    """What one step contributed, judged against everything before it."""
+
+    index: int
+    classification: str
+    evidence_sha256: str | None = None
+    code_sha256: str | None = None
+    new_artifacts: tuple[str, ...] = ()
+    changed_artifacts: tuple[str, ...] = ()
+    repeated_action: bool = False
+    detail: str | None = None
+
+
+@dataclass
+class ProgressLedger:
+    """Append-only record of what an autonomous run has already established.
+
+    Holds hashes, never content: it decides whether something is new, and has
+    no way to decide whether something is interesting.
+    """
+
+    known_evidence: set[str] = field(default_factory=set)
+    artifacts: dict[str, str] = field(default_factory=dict)
+    action_fingerprints: set[tuple[str, str]] = field(default_factory=set)
+    history: list[ProgressRecord] = field(default_factory=list)
+
+    def classify(self, index: int, step: object) -> ProgressRecord:
+        """Classify one `AnalysisStepResult` against the ledger, then absorb it.
+
+        Reads only fields the production runtime already fills in. A step is
+        passed whole rather than destructured by the caller so that the rule
+        for what counts as progress lives in exactly one place.
+        """
+        attempted = bool(getattr(step, "action_attempted", False))
+        executed = bool(getattr(step, "action_executed", False))
+        rejection = getattr(step, "rejection", None)
+
+        if not attempted:
+            # Prose with no action. Not a failure and not progress: the model
+            # has nothing further it wants to run, so control returns.
+            return self._append(
+                ProgressRecord(index=index, classification=COMPLETE)
+            )
+
+        if not executed:
+            # Attempted but refused: malformed call, capacity, sandbox refusal.
+            # The refusal text is carried so a bound can be reported truthfully.
+            return self._append(
+                ProgressRecord(
+                    index=index,
+                    classification=ERROR,
+                    detail=str(rejection) if rejection else "action not executed",
+                )
+            )
+
+        evidence = getattr(step, "evidence", None)
+        evidence_sha = getattr(evidence, "raw_sha256", None)
+        code_sha = self._code_sha256(step, evidence)
+
+        new_artifacts, changed_artifacts = self._artifact_delta(evidence)
+        new_evidence = bool(evidence_sha) and evidence_sha not in self.known_evidence
+
+        if new_evidence or new_artifacts or changed_artifacts:
+            classification = NEW_CONTENT
+        else:
+            classification = NO_PROGRESS
+
+        fingerprint = (code_sha or "", evidence_sha or "")
+        repeated = fingerprint in self.action_fingerprints
+
+        record = ProgressRecord(
+            index=index,
+            classification=classification,
+            evidence_sha256=evidence_sha,
+            code_sha256=code_sha,
+            new_artifacts=new_artifacts,
+            changed_artifacts=changed_artifacts,
+            repeated_action=repeated,
+        )
+        if evidence_sha:
+            self.known_evidence.add(evidence_sha)
+        self.action_fingerprints.add(fingerprint)
+        return self._append(record)
+
+    def _append(self, record: ProgressRecord) -> ProgressRecord:
+        self.history.append(record)
+        return record
+
+    @staticmethod
+    def _code_sha256(step: object, evidence: object) -> str | None:
+        result = getattr(step, "result", None)
+        code_sha = getattr(result, "code_sha256", None)
+        if code_sha:
+            return str(code_sha)
+        metadata = getattr(evidence, "metadata", None) or {}
+        value = metadata.get("code_sha256") if isinstance(metadata, dict) else None
+        return str(value) if value else None
+
+    def _artifact_delta(self, evidence: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """Handles whose digest is new, and handles whose digest changed.
+
+        Both count as progress. A handle appearing for the first time is new
+        transport; the same handle carrying different bytes is a genuine state
+        transition, which is exactly what a multi-stage transformation looks
+        like from outside. Rewriting a file with identical bytes is neither.
+        """
+        metadata = getattr(evidence, "metadata", None) or {}
+        entries = metadata.get("artifacts") if isinstance(metadata, dict) else None
+        if not isinstance(entries, list):
+            return (), ()
+        new: list[str] = []
+        changed: list[str] = []
+        seen: dict[str, str] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            handle = entry.get("handle") or entry.get("name")
+            digest = entry.get("sha256")
+            if not handle or not digest:
+                continue
+            handle, digest = str(handle), str(digest)
+            seen[handle] = digest
+            previous = self.artifacts.get(handle)
+            if previous is None:
+                new.append(handle)
+            elif previous != digest:
+                changed.append(handle)
+        self.artifacts.update(seen)
+        return tuple(new), tuple(changed)
+
+
+__all__ = [
+    "COMPLETE",
+    "ERROR",
+    "NEW_CONTENT",
+    "NO_PROGRESS",
+    "ProgressLedger",
+    "ProgressRecord",
+]

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -28,15 +28,25 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import stat
 import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
-from orbit.backend.base import ChatBackend, Message
+from orbit.backend.base import ChatBackend, Message, RecoverableBackendError
+from orbit.runtime.context_manager import ContextAdmissionError
+from orbit.runtime.analysis_progress import (
+    COMPLETE,
+    ERROR,
+    NEW_CONTENT,
+    NO_PROGRESS,
+    ProgressLedger,
+    ProgressRecord,
+)
 from orbit.runtime.analysis_sandbox import (
     WORK_MOUNT,
     AnalysisResult,
@@ -193,6 +203,52 @@ QUALIFIED_ANALYSIS_MAX_TOKENS = 2048
 # and 256 files is eight times the per-action file count -- enough headroom for
 # a session far longer than any recorded run, small enough to stay a bound.
 # Revisit with real analyst-session telemetry.
+# --- bounded autonomous continuation ------------------------------------
+#
+# Orbit continues an analysis by itself only while each step is still adding
+# verifiable state. Every bound below exists so that a run ends, truthfully,
+# with its evidence intact rather than spending the analyst's machine on
+# repetition.
+#
+# The action and model-call bounds are the values the preserved research
+# harness ran with (`MAX_ACTIONS = 8`, `MAX_MODEL_CALLS = 10`). Those are the
+# figures its measured trajectories were bounded by, so they are reused rather
+# than re-invented -- but they are reused as a starting point, not as a proven
+# optimum: that harness reached a FAIL verdict on a different model and
+# profile, so nothing about its outcome transfers. The margin between them is
+# the harness's own: two calls above the action bound, there because a run may
+# spend calls that execute nothing.
+#
+# The stagnation and error bounds have no historical value to inherit -- the
+# harness bounded stagnation by a replan counter, not by consecutive
+# classification -- so they are set conservatively at 2. Two consecutive
+# no-progress steps is the smallest number that distinguishes a model briefly
+# re-orienting from one that is stuck; one would abort on a single redundant
+# read. All four are configurable per run.
+MAX_AUTONOMOUS_ACTIONS = 8
+MAX_AUTONOMOUS_MODEL_CALLS = 10
+MAX_CONSECUTIVE_NO_PROGRESS = 2
+MAX_CONSECUTIVE_ERRORS = 2
+
+# What Orbit says to itself to take the next step. It carries no guidance
+# about what to examine: choosing that is the model's job, and a runtime that
+# suggested a direction would be doing analysis rather than orchestration.
+AUTONOMOUS_CONTINUATION_MESSAGE = "continue"
+
+# Off until it has been measured on real work. Existing one-step behaviour --
+# one analyst line, one model call, control back -- is what every analysis does
+# unless this is set, so nothing about production changes by merging the loop.
+ANALYSIS_AUTONOMY_ENV = "ORBIT_ANALYSIS_AUTONOMOUS"
+
+# Why a run stopped. Reported verbatim to the analyst.
+STOP_COMPLETE = "model returned prose with no action"
+STOP_NO_PROGRESS = "no new evidence"
+STOP_ERROR = "repeated action failures"
+STOP_MAX_ACTIONS = "action bound reached"
+STOP_MAX_MODEL_CALLS = "model call bound reached"
+STOP_CANCELLED = "cancelled"
+STOP_BACKEND_ERROR = "backend error"
+
 MAX_SESSION_SCRATCH_BYTES = 64 * 1024 * 1024
 MAX_SESSION_SCRATCH_FILES = 256
 SESSION_CAPACITY_EXHAUSTED = "session artifact capacity exhausted"
@@ -344,6 +400,37 @@ class AnalysisStepResult:
         # Always true by construction: step() has no path that continues past
         # here. Named so tests assert the property rather than the absence of
         # a loop.
+        return True
+
+
+def analysis_autonomy_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """Whether ANALYSIS may continue itself. Off by default, fail-closed.
+
+    Same `1`/`0` grammar as the other Orbit runtime switches, and anything
+    unrecognised reads as off: an operator who mistypes gets the behaviour
+    that was already shipping, not an unbounded loop.
+    """
+    env = os.environ if environ is None else environ
+    return env.get(ANALYSIS_AUTONOMY_ENV, "").strip() == "1"
+
+
+@dataclass
+class AutonomousRunResult:
+    """What one bounded autonomous run produced. Control is with the analyst."""
+
+    steps: tuple[AnalysisStepResult, ...]
+    progress: tuple[ProgressRecord, ...]
+    stop_reason: str
+    model_calls: int
+    actions_executed: int
+    cancelled: bool = False
+
+    @property
+    def last_step(self) -> AnalysisStepResult | None:
+        return self.steps[-1] if self.steps else None
+
+    @property
+    def control_returned(self) -> bool:
         return True
 
 
@@ -776,6 +863,168 @@ class AnalysisRuntime:
             artifact_handles=tuple(f"{WORK_MOUNT}/{a.name}" for a in result.artifacts),
             diagnostics=_diagnostics(None),
         )
+
+    def run_autonomous(
+        self,
+        analyst_message: str,
+        *,
+        max_actions: int = MAX_AUTONOMOUS_ACTIONS,
+        max_model_calls: int = MAX_AUTONOMOUS_MODEL_CALLS,
+        max_no_progress: int = MAX_CONSECUTIVE_NO_PROGRESS,
+        max_errors: int = MAX_CONSECUTIVE_ERRORS,
+        on_progress: Callable[[Any], None] | None = None,
+        on_delta: Callable[[str], None] | None = None,
+        on_step: Callable[[AnalysisStepResult, ProgressRecord], None] | None = None,
+    ) -> AutonomousRunResult:
+        """Run analyst-directed steps until progress stops or a bound is hit.
+
+        Autonomy here is only this: Orbit issues the next ordinary step itself
+        instead of waiting for the analyst to type `continue`, and stops as
+        soon as steps stop producing verifiably new state. A step that adds
+        nothing is allowed exactly one retry -- two consecutive no-progress or
+        error steps end the run -- so novelty governs how long a run lives
+        without making every single step prove itself first. Every step is the same qualified
+        `step()` -- one model call, at most one action, structural rejection,
+        sandbox, evidence, append-only history, rolling KV -- so nothing about
+        what a step may do changes. The model still chooses what to examine;
+        the runtime only decides whether it is worth asking again.
+
+        The loop stops the moment a step stops adding state. It never repairs,
+        never retries, never re-runs a rejected action, and never makes a
+        second kind of model call: there is no finalisation pass and no
+        classifier, because both would be the runtime forming an opinion about
+        an analysis it is not qualified to judge.
+
+        Cancellation propagates: `KeyboardInterrupt` from the backend ends the
+        run and returns what has already been established, with the workspace
+        and evidence intact.
+        """
+        ledger = ProgressLedger()
+        steps: list[AnalysisStepResult] = []
+        records: list[ProgressRecord] = []
+        model_calls = 0
+        actions = 0
+        consecutive_no_progress = 0
+        consecutive_errors = 0
+        message = analyst_message
+        stop_reason = STOP_MAX_MODEL_CALLS
+        cancelled = False
+
+        while True:
+            if model_calls >= max_model_calls:
+                stop_reason = STOP_MAX_MODEL_CALLS
+                break
+            try:
+                step = self.step(message, on_progress=on_progress, on_delta=on_delta)
+            except KeyboardInterrupt:
+                # What ran already stands. `step()` has committed its own
+                # history and evidence, or rewound nothing; the analyst keeps
+                # the session either way.
+                cancelled = True
+                stop_reason = STOP_CANCELLED
+                self._close_incomplete_turn()
+                break
+            except (ContextAdmissionError, TimeoutError, RecoverableBackendError) as exc:
+                # A recoverable backend failure ends the run, it does not undo
+                # it. Letting this propagate would unwind to a caller holding
+                # only a pre-run checkpoint, and rewinding to that point would
+                # delete the history and provenance of every step that already
+                # succeeded -- leaving their evidence on disk with nothing
+                # referring to it, and re-issuing turn ids that are already in
+                # use. What ran, ran; the analyst is told why it stopped.
+                #
+                # Only the recoverable failures. An unexpected `RuntimeError`
+                # must still propagate: this repo overloads bare RuntimeError to
+                # mean "a bug, tear the session down and release the
+                # workspace", and catching it here would both swallow real
+                # crashes and leak the temporary workspace. `RecoverableBackendError`
+                # lives in the backend base module so this can name exactly the
+                # recoverable case without importing upward.
+                error = f"{type(exc).__name__}: {exc}"
+                stop_reason = f"{STOP_BACKEND_ERROR}: {error}"
+                self._close_incomplete_turn()
+                break
+
+            steps.append(step)
+            model_calls += step.model_calls
+            if step.action_executed:
+                actions += 1
+
+            record = ledger.classify(len(records) + 1, step)
+            records.append(record)
+            if on_step is not None:
+                on_step(step, record)
+
+            if record.classification == COMPLETE:
+                stop_reason = STOP_COMPLETE
+                break
+
+            if record.classification == ERROR:
+                consecutive_errors += 1
+                consecutive_no_progress = 0
+                if consecutive_errors >= max_errors:
+                    # Carry the last refusal: "repeated action failures" alone
+                    # tells the analyst a bound was hit but not what failed.
+                    stop_reason = (
+                        f"{STOP_ERROR}: {record.detail}" if record.detail else STOP_ERROR
+                    )
+                    break
+            elif record.classification == NO_PROGRESS:
+                consecutive_no_progress += 1
+                consecutive_errors = 0
+                if consecutive_no_progress >= max_no_progress:
+                    stop_reason = (
+                        f"{STOP_NO_PROGRESS}: action repeated"
+                        if record.repeated_action
+                        else STOP_NO_PROGRESS
+                    )
+                    break
+            else:
+                consecutive_no_progress = 0
+                consecutive_errors = 0
+
+            # The rule is "continue unless a bound trips", not "continue only
+            # after NEW_CONTENT". A single ERROR or NO_PROGRESS step still
+            # earns one more call, because a model that mis-formed a call or
+            # re-read something it already had is often one step from useful
+            # work, and refusing to ask again would make the loop less capable
+            # than an analyst typing `continue` by hand. What makes that safe
+            # is that those steps are the only ones counted: two consecutively
+            # ends the run, and the totals below bound it regardless.
+            #
+            # Checked after the counters above so a run that is both stagnating
+            # and out of budget reports the reason it actually hit first.
+            if actions >= max_actions:
+                stop_reason = STOP_MAX_ACTIONS
+                break
+
+            message = AUTONOMOUS_CONTINUATION_MESSAGE
+
+        return AutonomousRunResult(
+            steps=tuple(steps),
+            progress=tuple(records),
+            stop_reason=stop_reason,
+            model_calls=model_calls,
+            actions_executed=actions,
+            cancelled=cancelled,
+        )
+
+    def _close_incomplete_turn(self) -> None:
+        """Drop a trailing analyst turn whose step never produced a reply.
+
+        `step()` appends the analyst line before it calls the model, so a step
+        that was cancelled or failed mid-call leaves an unanswered `user` entry
+        at the end of an append-only history. Two consecutive user turns is a
+        shape the history is not supposed to contain, and every later step
+        re-renders the whole thing, so the damage is permanent if it is left.
+
+        Only a trailing user message is removed, and only the one this run put
+        there: anything a step actually answered is already followed by an
+        assistant turn and is untouched.
+        """
+        if self.messages and self.messages[-1].get("role") == "user":
+            self.messages.pop()
+            self.analyst_turns = max(0, self.analyst_turns - 1)
 
     def close(self) -> None:
         """Release the session workspace. Idempotent."""

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -9,7 +9,11 @@ from typing import Callable
 from orbit.backend.base import ChatResult, StreamPromptMetrics
 from orbit.backend.llama_server import LlamaServerBackend, LlamaServerError
 from orbit.runtime import ChatRuntime
-from orbit.runtime.analysis_runtime import AnalysisRuntime
+from orbit.runtime.analysis_runtime import (
+    AnalysisRuntime,
+    AutonomousRunResult,
+    analysis_autonomy_enabled,
+)
 from orbit.runtime.context_manager import ContextAdmissionError
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
@@ -324,12 +328,54 @@ class Repl:
         # append-only record a later exact-prefix strategy depends on.
         checkpoint = self._analysis_checkpoint()
         renderer.start()
+        run: AutonomousRunResult | None = None
         try:
-            result = self.analysis.step(
-                analyst_message,
-                on_progress=renderer.progress,
-                on_delta=renderer.write,
-            )
+            if analysis_autonomy_enabled():
+                # Same step primitive, issued repeatedly while each one adds
+                # verifiable state. `step()` still owns every guarantee; the
+                # loop only decides whether to ask again.
+                #
+                # Each completed step is rendered as it lands. Showing only the
+                # last one would hide every action an autonomous run took --
+                # and its terminating step is usually prose, so the analyst
+                # would be told actions ran and given no evidence id to cite or
+                # re-attest.
+                def show(step, record) -> None:
+                    block = format_analysis_step(
+                        step, prose_already_shown=renderer.rendered_visible_text
+                    )
+                    if renderer.rendered_visible_text:
+                        print(flush=True)
+                    if block:
+                        print(block, flush=True)
+                    renderer.reset_visible_text()
+
+                run = self.analysis.run_autonomous(
+                    analyst_message,
+                    on_progress=renderer.progress,
+                    on_delta=renderer.write,
+                    on_step=show,
+                )
+                result = run.last_step
+                if result is None:
+                    # No step completed -- cancelled, a backend failure, or a
+                    # zero call budget -- so there is nothing to render and the
+                    # pre-run turn is safe to undo. Why it ended still has to be
+                    # told truthfully: a backend that died must not be reported
+                    # as an analyst interrupt.
+                    renderer.finish(interrupted=True)
+                    self._restore_analysis_checkpoint(checkpoint)
+                    if run.cancelled:
+                        print(dim("cancelled"), flush=True)
+                    else:
+                        print(dim(run.stop_reason), flush=True)
+                    return
+            else:
+                result = self.analysis.step(
+                    analyst_message,
+                    on_progress=renderer.progress,
+                    on_delta=renderer.write,
+                )
         except KeyboardInterrupt:
             renderer.finish(interrupted=True)
             self._restore_analysis_checkpoint(checkpoint)
@@ -353,8 +399,13 @@ class Repl:
         # the final block then carries only what streaming could not: action
         # status, evidence preview, artifacts.
         prose_already_shown = renderer.rendered_visible_text
-        step_block = format_analysis_step(result, prose_already_shown=prose_already_shown)
-        if prose_already_shown:
+        # An autonomous run already rendered every step through `on_step`.
+        step_block = (
+            ""
+            if run is not None
+            else format_analysis_step(result, prose_already_shown=prose_already_shown)
+        )
+        if prose_already_shown and run is None:
             # Streamed deltas leave the cursor mid-line; close that line so the
             # block below starts on its own. Previously the reprinted copy of
             # the prose supplied this break.
@@ -362,10 +413,17 @@ class Repl:
         if step_block:
             print(step_block, flush=True)
         elapsed = time.monotonic() - started
-        summary = (
-            f"analysis | mode: ANALYSIS | model calls: {result.model_calls} | "
-            f"actions: {1 if result.action_executed else 0} | {elapsed:.1f}s"
-        )
+        if run is not None:
+            summary = (
+                f"analysis | mode: ANALYSIS | model calls: {run.model_calls} | "
+                f"actions: {run.actions_executed} | steps: {len(run.steps)} | "
+                f"stopped: {run.stop_reason} | {elapsed:.1f}s"
+            )
+        else:
+            summary = (
+                f"analysis | mode: ANALYSIS | model calls: {result.model_calls} | "
+                f"actions: {1 if result.action_executed else 0} | {elapsed:.1f}s"
+            )
         detail = format_step_diagnostics(result.diagnostics)
         if detail:
             summary += f" | {detail}"

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -154,6 +154,15 @@ class StreamRenderer:
         """Whether the analyst has already seen model prose from this renderer."""
         return self._rendered_visible_text
 
+    def reset_visible_text(self) -> None:
+        """Forget that prose was shown, so the next step is judged on its own.
+
+        An autonomous run renders several steps through one renderer. Without
+        this, one step that streamed prose would suppress the prose of every
+        later step, because the flag would still be set from the earlier one.
+        """
+        self._rendered_visible_text = False
+
     def finish(self, *, interrupted: bool = False) -> None:
         if self._thinking_filter is not None:
             for fragment, dimmed in self._thinking_filter.finish():

--- a/tests/test_analysis_autonomous.py
+++ b/tests/test_analysis_autonomous.py
@@ -1,0 +1,963 @@
+"""Bounded autonomous continuation: Orbit continues only while state changes.
+
+The property under test is causal. A step that adds verifiable state -- a new
+evidence content hash, a new or changed artifact digest -- earns another model
+call; a step that adds nothing does not. These tests drive the real production
+entry point (`AnalysisRuntime.run_autonomous`) through the real sandbox and the
+real EvidenceStore, with only the model scripted, because the mechanism being
+tested is exactly the decision to invoke the model again.
+
+The scripted backend explodes when invoked more times than scripted, so a loop
+that continued past its bound fails by raising rather than by returning a value
+a lenient assertion might accept.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.backend.base import ChatResult
+from orbit.runtime.analysis_progress import (
+    COMPLETE,
+    ERROR,
+    NEW_CONTENT,
+    NO_PROGRESS,
+    ProgressLedger,
+)
+from orbit.runtime.analysis_runtime import (
+    ANALYSIS_AUTONOMY_ENV,
+    ANALYSIS_TOOL_NAME,
+    AUTONOMOUS_CONTINUATION_MESSAGE,
+    MAX_AUTONOMOUS_ACTIONS,
+    MAX_AUTONOMOUS_MODEL_CALLS,
+    MAX_CONSECUTIVE_ERRORS,
+    MAX_CONSECUTIVE_NO_PROGRESS,
+    STOP_BACKEND_ERROR,
+    STOP_CANCELLED,
+    STOP_COMPLETE,
+    STOP_ERROR,
+    STOP_MAX_ACTIONS,
+    STOP_MAX_MODEL_CALLS,
+    STOP_NO_PROGRESS,
+    AnalysisRuntime,
+    acquire_analysis_source,
+    analysis_autonomy_enabled,
+)
+from orbit.runtime.evidence import EvidenceStore
+
+from tests.test_analysis_runtime import (
+    ExhaustedBackend,
+    ScriptedBackend,
+    prose_response,
+    tool_response,
+)
+
+FIXTURE = "alpha\nbeta\ngamma\n"
+
+
+def emit(text: str) -> str:
+    """A program whose output is fixed, so its evidence hash is fixed."""
+    return f"print({text!r}, end='')"
+
+
+def write_artifact(name: str, body: str) -> str:
+    """A program that materialises a durable artifact under the work mount."""
+    return (
+        "import pathlib\n"
+        f"p = pathlib.Path('/workspace/work/{name}')\n"
+        f"p.write_text({body!r})\n"
+        f"print('wrote {name}', end='')"
+    )
+
+
+def _is_docstring(node) -> bool:
+    import ast
+
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(
+        node.value.value, str
+    )
+
+
+def _without_docstrings(source: str) -> str:
+    """Drop every docstring and comment, leaving only executable text."""
+    import ast
+
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if isinstance(body, list) and body and _is_docstring(body[0]):
+            node.body = body[1:] or [ast.Pass()]
+    return ast.unparse(tree)
+
+
+class AutonomousTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-autonomous-")
+        self.addCleanup(self._dir.cleanup)
+        self.tmp = Path(self._dir.name)
+        original = self.tmp / "artifact.txt"
+        original.write_text(FIXTURE, encoding="utf-8")
+        self.source = acquire_analysis_source(original, self.tmp / "owned")
+        self.store = EvidenceStore(root=self.tmp / "evidence")
+
+    def runtime(self, backend) -> AnalysisRuntime:
+        built = AnalysisRuntime(
+            backend=backend, source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(built.close)
+        return built
+
+
+class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
+    def test_new_content_causes_the_next_model_call(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("first")),
+            prose_response("nothing further"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        # Two calls: the action earned the second one.
+        self.assertEqual(backend.calls, 2)
+        self.assertEqual(run.model_calls, 2)
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(
+            [r.classification for r in run.progress], [NEW_CONTENT, COMPLETE]
+        )
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+
+    def test_the_continuation_message_is_the_generic_one(self) -> None:
+        """Orbit must not steer. The follow-up carries no direction."""
+        backend = ScriptedBackend(
+            tool_response(emit("first")), prose_response("done")
+        )
+        self.runtime(backend).run_autonomous("inspect it")
+
+        second_prompt = backend.seen_messages[1]
+        analyst_lines = [m for m in second_prompt if m.get("role") == "user"]
+        self.assertEqual(analyst_lines[-1]["content"], AUTONOMOUS_CONTINUATION_MESSAGE)
+        self.assertEqual(AUTONOMOUS_CONTINUATION_MESSAGE, "continue")
+
+    def test_several_new_content_steps_continue(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            tool_response(emit("three")),
+            prose_response("that is all"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(run.actions_executed, 3)
+        self.assertEqual(run.model_calls, 4)
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NEW_CONTENT, NEW_CONTENT, COMPLETE],
+        )
+
+    def test_prose_with_no_action_stops_immediately(self) -> None:
+        backend = ScriptedBackend(prose_response("I have nothing to run"))
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(backend.calls, 1)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        self.assertEqual([r.classification for r in run.progress], [COMPLETE])
+
+    def test_model_prose_is_never_progress(self) -> None:
+        """A confident claim in prose must not buy another step."""
+        backend = ScriptedBackend(
+            prose_response("I have decoded stage two and will continue shortly")
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(backend.calls, 1)
+        self.assertNotIn(NEW_CONTENT, [r.classification for r in run.progress])
+
+    def test_a_changed_artifact_sha_counts_as_new_content(self) -> None:
+        """Same handle, different bytes: a real state transition."""
+        backend = ScriptedBackend(
+            tool_response(write_artifact("stage.bin", "aaa")),
+            tool_response(write_artifact("stage.bin", "bbb")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("transform it")
+
+        self.assertEqual(run.actions_executed, 2)
+        second = run.progress[1]
+        self.assertEqual(second.classification, NEW_CONTENT)
+        self.assertEqual(second.changed_artifacts, ("/workspace/work/stage.bin",))
+
+    def test_evidence_persists_across_autonomous_steps(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        recorded = [s.evidence for s in run.steps if s.evidence is not None]
+        self.assertEqual(len(recorded), 2)
+        for record in recorded:
+            # Still durable and re-attestable after the run ended.
+            self.assertTrue(self.store.reattest_exact(record.evidence_id))
+        self.assertEqual(len({r.raw_sha256 for r in recorded}), 2)
+
+    def test_one_action_maximum_per_model_call(self) -> None:
+        """Two calls in one response is rejected, exactly as in one-step mode."""
+        backend = ScriptedBackend(
+            tool_response(emit("x"), count=2),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        first = run.steps[0]
+        self.assertTrue(first.action_attempted)
+        self.assertFalse(first.action_executed)
+        self.assertIsNotNone(first.rejection)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.progress[0].classification, ERROR)
+
+
+class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
+    def test_repeated_identical_action_is_no_progress(self) -> None:
+        code = emit("same")
+        backend = ScriptedBackend(
+            tool_response(code), tool_response(code), tool_response(code)
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
+        # It stopped rather than exhausting the script.
+        self.assertEqual(backend.calls, 3)
+        self.assertTrue(run.progress[-1].repeated_action)
+
+    def test_different_code_with_identical_output_is_not_progress(self) -> None:
+        """Novelty is judged on evidence, not on the program that produced it."""
+        backend = ScriptedBackend(
+            tool_response(emit("same")),
+            tool_response("x = 1\n" + emit("same")),
+            tool_response("y = 2\n" + emit("same")),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
+
+    def test_rewriting_an_artifact_with_identical_bytes_is_not_progress(self) -> None:
+        """Re-writing the same bytes yields no artifact delta, so it stagnates.
+
+        The first two steps differ in raw output -- the sandbox reports a new
+        artifact only on the step that changed it -- so stagnation is judged
+        from the third step, once the observation itself repeats. What is being
+        asserted is that an unchanged digest buys nothing.
+        """
+        code = write_artifact("same.bin", "identical")
+        backend = ScriptedBackend(*[tool_response(code)] * 5)
+        run = self.runtime(backend).run_autonomous("transform it")
+
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
+        # No step after the first ever reports a changed digest for the handle.
+        for record in run.progress[1:]:
+            self.assertEqual(record.changed_artifacts, ())
+        self.assertEqual(
+            [r.classification for r in run.progress[-2:]], [NO_PROGRESS, NO_PROGRESS]
+        )
+
+    def test_stagnation_bound_stops_the_run(self) -> None:
+        code = emit("same")
+        backend = ScriptedBackend(*[tool_response(code)] * 6)
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
+        self.assertEqual(backend.calls, 1 + MAX_CONSECUTIVE_NO_PROGRESS)
+
+    def test_progress_resets_the_stagnation_counter(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("a")),
+            tool_response(emit("a")),
+            tool_response(emit("b")),
+            tool_response(emit("b")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NEW_CONTENT, NO_PROGRESS, COMPLETE],
+        )
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+
+
+class ErrorsAreBoundedTests(AutonomousTestBase):
+    def test_consecutive_errors_stop_the_run(self) -> None:
+        backend = ScriptedBackend(*[tool_response(emit("x"), count=2)] * 5)
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertTrue(run.stop_reason.startswith(STOP_ERROR), run.stop_reason)
+        self.assertEqual(backend.calls, MAX_CONSECUTIVE_ERRORS)
+        self.assertEqual(run.actions_executed, 0)
+
+    def test_malformed_tool_output_does_not_auto_repair(self) -> None:
+        """A rejected call is never re-run; the loop only ever takes new steps."""
+        broken = ChatResult(
+            content="", model="m", finish_reason="stop",
+            tool_calls=[{"id": "c", "type": "function",
+                         "function": {"name": ANALYSIS_TOOL_NAME,
+                                      "arguments": "{\"code\": \"print(1)"}}],
+            prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+        backend = ScriptedBackend(broken, broken, broken)
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertTrue(run.stop_reason.startswith(STOP_ERROR), run.stop_reason)
+        self.assertEqual(backend.calls, MAX_CONSECUTIVE_ERRORS)
+        self.assertEqual(run.actions_executed, 0)
+        for step in run.steps:
+            self.assertIsNotNone(step.rejection)
+
+    def test_progress_resets_the_error_counter(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("x"), count=2),
+            tool_response(emit("real")),
+            tool_response(emit("x"), count=2),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [ERROR, NEW_CONTENT, ERROR, COMPLETE],
+        )
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+
+
+class BoundsAreEnforcedTests(AutonomousTestBase):
+    def test_max_actions_stops_the_run(self) -> None:
+        backend = ScriptedBackend(
+            *[tool_response(emit(f"v{i}")) for i in range(MAX_AUTONOMOUS_ACTIONS + 3)]
+        )
+        run = self.runtime(backend).run_autonomous(
+            "inspect it", max_model_calls=MAX_AUTONOMOUS_ACTIONS + 3
+        )
+
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+        self.assertEqual(backend.calls, MAX_AUTONOMOUS_ACTIONS)
+
+    def test_max_model_calls_stops_the_run(self) -> None:
+        backend = ScriptedBackend(
+            *[tool_response(emit(f"v{i}")) for i in range(12)]
+        )
+        run = self.runtime(backend).run_autonomous(
+            "inspect it", max_model_calls=3, max_actions=99
+        )
+
+        self.assertEqual(run.stop_reason, STOP_MAX_MODEL_CALLS)
+        self.assertEqual(run.model_calls, 3)
+        self.assertEqual(backend.calls, 3)
+
+    def test_bounds_are_small_and_explicit(self) -> None:
+        self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 10)
+        self.assertEqual(MAX_CONSECUTIVE_NO_PROGRESS, 2)
+        self.assertEqual(MAX_CONSECUTIVE_ERRORS, 2)
+        # The call bound must leave room for calls that execute nothing.
+        self.assertGreater(MAX_AUTONOMOUS_MODEL_CALLS, MAX_AUTONOMOUS_ACTIONS)
+
+    def test_alternating_error_and_stagnation_is_still_bounded(self) -> None:
+        """Alternation defeats both consecutive counters; the call bound holds.
+
+        A run that alternates ERROR and NO_PROGRESS resets each consecutive
+        counter before it can trip, so neither stagnation nor error alone ends
+        it. That is by design -- a counter that survived an intervening failure
+        would abort runs that were merely recovering -- and it is exactly why
+        the total model-call bound exists as the outer backstop. Worst case is
+        therefore MAX_AUTONOMOUS_MODEL_CALLS, never unbounded.
+        """
+        same = emit("same")
+        script = []
+        for _ in range(20):
+            script.append(tool_response(same, count=2))  # ERROR
+            script.append(tool_response(same))           # NO_PROGRESS
+        run = self.runtime(ScriptedBackend(*script)).run_autonomous("inspect it")
+
+        classifications = [r.classification for r in run.progress]
+        self.assertIn(ERROR, classifications)
+        self.assertIn(NO_PROGRESS, classifications)
+        self.assertEqual(run.stop_reason, STOP_MAX_MODEL_CALLS)
+        self.assertEqual(run.model_calls, MAX_AUTONOMOUS_MODEL_CALLS)
+
+    def test_no_second_finalization_or_classifier_call(self) -> None:
+        """Every model call is an ordinary step with the ordinary tool surface."""
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(backend.calls, run.model_calls)
+        for offered in backend.seen_tools:
+            self.assertEqual(offered, [ANALYSIS_TOOL_NAME])
+
+
+class HumanControlTests(AutonomousTestBase):
+    def test_cancellation_stops_the_loop_and_keeps_evidence(self) -> None:
+        class CancellingBackend(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                if self.calls >= 1:
+                    raise KeyboardInterrupt
+                return super().chat_stream(messages, **kwargs)
+
+        backend = CancellingBackend(tool_response(emit("one")))
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, STOP_CANCELLED)
+        self.assertEqual(run.actions_executed, 1)
+        self.assertIsNotNone(run.steps[0].evidence)
+        self.assertTrue(self.store.reattest_exact(run.steps[0].evidence.evidence_id))
+
+    def test_cancelling_a_multi_step_run_keeps_the_completed_steps(self) -> None:
+        """Cancellation must not discard history from steps that succeeded.
+
+        The terminal rewinds to a pre-run checkpoint only when a run produced
+        nothing at all. A multi-step run that is interrupted has already
+        committed history and evidence for its completed steps, and truncating
+        back past those would destroy the append-only record the rolling KV
+        lineage and evidence provenance both depend on.
+        """
+
+        class CancelOnThird(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                if self.calls >= 2:
+                    raise KeyboardInterrupt
+                return super().chat_stream(messages, **kwargs)
+
+        backend = CancelOnThird(
+            tool_response(emit("one")), tool_response(emit("two"))
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("inspect it")
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.actions_executed, 2)
+        # Not None, so the terminal's rewind path is not taken.
+        self.assertIsNotNone(run.last_step)
+        self.assertGreater(len(runtime.messages), 2)
+        for step in run.steps:
+            self.assertIsNotNone(step.evidence)
+            self.assertTrue(self.store.reattest_exact(step.evidence.evidence_id))
+
+    def test_a_run_cancelled_before_any_step_reports_nothing(self) -> None:
+        """The only case where the terminal rewinds: no step ever completed."""
+
+        class CancelImmediately(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                raise KeyboardInterrupt
+
+        run = self.runtime(CancelImmediately()).run_autonomous("inspect it")
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.steps, ())
+        self.assertIsNone(run.last_step)
+        self.assertEqual(run.actions_executed, 0)
+
+    def test_the_analyst_can_steer_after_an_autonomous_stop(self) -> None:
+        """The same session and history continue; nothing is rebuilt."""
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            prose_response("stopping"),
+            tool_response(emit("steered")),
+            prose_response("done"),
+        )
+        runtime = self.runtime(backend)
+        first = runtime.run_autonomous("inspect it")
+        history_after_first = len(runtime.messages)
+
+        second = runtime.run_autonomous("now look at the header instead")
+
+        self.assertEqual(first.stop_reason, STOP_COMPLETE)
+        self.assertEqual(second.actions_executed, 1)
+        # Append-only: the second run extended the same history.
+        self.assertGreater(len(runtime.messages), history_after_first)
+        steering = [m for m in backend.seen_messages[2] if m.get("role") == "user"]
+        self.assertEqual(steering[-1]["content"], "now look at the header instead")
+
+
+class RecoverableBackendFailureTests(AutonomousTestBase):
+    """A mid-run backend failure ends the run without undoing it."""
+
+    def _failing(self, exc: Exception):
+        class FailAfterTwo(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                if self.calls >= 2:
+                    raise exc
+                return super().chat_stream(messages, **kwargs)
+
+        return FailAfterTwo(tool_response(emit("one")), tool_response(emit("two")))
+
+    def test_a_backend_error_does_not_escape_the_run(self) -> None:
+        """It must not propagate to a caller holding a pre-run checkpoint.
+
+        A caller that rewinds to that checkpoint would delete the history and
+        provenance of every step that already succeeded, orphaning their
+        evidence on disk and re-issuing turn ids that are already in use.
+        """
+        from orbit.backend.llama_server import LlamaServerError
+
+        runtime = self.runtime(self._failing(LlamaServerError("backend died")))
+        run = runtime.run_autonomous("inspect it")  # must not raise
+
+        self.assertTrue(run.stop_reason.startswith(STOP_BACKEND_ERROR))
+        self.assertIn("LlamaServerError", run.stop_reason)
+        self.assertEqual(run.actions_executed, 2)
+        self.assertIsNotNone(run.last_step)
+
+    def test_completed_steps_survive_a_backend_error(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        runtime = self.runtime(self._failing(LlamaServerError("backend died")))
+        run = runtime.run_autonomous("inspect it")
+
+        for step in run.steps:
+            self.assertTrue(self.store.reattest_exact(step.evidence.evidence_id))
+        turn_ids = [
+            step.evidence.user_turn_id for step in run.steps if step.evidence
+        ]
+        self.assertEqual(len(set(turn_ids)), len(turn_ids), "turn ids must be unique")
+
+    def test_a_context_admission_error_is_handled_the_same_way(self) -> None:
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        run = self.runtime(self._failing(ContextAdmissionError("too big"))).run_autonomous(
+            "inspect it"
+        )
+
+        self.assertTrue(run.stop_reason.startswith(STOP_BACKEND_ERROR))
+        self.assertEqual(run.actions_executed, 2)
+
+    def test_no_unanswered_analyst_turn_is_left_behind(self) -> None:
+        """`step()` appends the analyst line before calling the model.
+
+        A step that never returned leaves that line unanswered at the end of an
+        append-only history, and the next analyst message would then sit
+        directly after it -- two consecutive user turns, permanently.
+        """
+        from orbit.backend.llama_server import LlamaServerError
+
+        for exc in (LlamaServerError("died"), KeyboardInterrupt()):
+            with self.subTest(exc=type(exc).__name__):
+                runtime = self.runtime(self._failing(exc))
+                runtime.run_autonomous("inspect it")
+
+                roles = [m["role"] for m in runtime.messages]
+                self.assertNotEqual(roles[-1], "user")
+                # No run of unanswered user turns after the opening preamble.
+                tail = roles[2:]
+                self.assertFalse(
+                    any(a == "user" and b == "user" for a, b in zip(tail, tail[1:])),
+                    f"consecutive user turns in {roles}",
+                )
+
+    def test_only_a_trailing_user_turn_is_removed(self) -> None:
+        """The guard must not eat an answered turn or an assistant reply."""
+        backend = ScriptedBackend(
+            tool_response(emit("one")), prose_response("done")
+        )
+        runtime = self.runtime(backend)
+        runtime.run_autonomous("inspect it")
+        before = [dict(m) for m in runtime.messages]
+
+        # History ends with an assistant turn; the guard must do nothing.
+        runtime._close_incomplete_turn()
+
+        self.assertEqual(runtime.messages, before)
+
+    def test_the_turn_counter_is_decremented_with_the_message(self) -> None:
+        """A removed analyst turn must not leave its number consumed.
+
+        `user_turn_id` in evidence provenance is derived from this counter, so
+        a turn that is removed but still counted would make the next real turn
+        skip a number and misname every record it produces.
+        """
+        backend = ScriptedBackend(tool_response(emit("one")), prose_response("done"))
+        runtime = self.runtime(backend)
+        runtime.run_autonomous("inspect it")
+
+        turns_before = runtime.analyst_turns
+        runtime.messages.append({"role": "user", "content": "unanswered"})
+        runtime.analyst_turns += 1
+        runtime._close_incomplete_turn()
+
+        self.assertEqual(runtime.analyst_turns, turns_before)
+        self.assertNotEqual(runtime.messages[-1]["role"], "user")
+
+    def test_an_unexpected_runtime_error_still_propagates(self) -> None:
+        """Only recoverable backend failures are absorbed.
+
+        This repo overloads a bare `RuntimeError` to mean "a bug: tear the
+        session down and release its workspace", and an existing lifecycle test
+        asserts exactly that. Widening the catch to `RuntimeError` would both
+        swallow real crashes and leak the temporary workspace, so the loop
+        names `RecoverableBackendError` instead.
+        """
+
+        class Exploding(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                if self.calls >= 1:
+                    raise RuntimeError("backend exploded")
+                return super().chat_stream(messages, **kwargs)
+
+        runtime = self.runtime(Exploding(tool_response(emit("one"))))
+
+        with self.assertRaises(RuntimeError) as caught:
+            runtime.run_autonomous("inspect it")
+        self.assertEqual(str(caught.exception), "backend exploded")
+
+    def test_a_recoverable_error_is_absorbed_but_a_bug_is_not(self) -> None:
+        """The two are distinguished by type, not by message or timing."""
+        from orbit.backend.base import RecoverableBackendError
+        from orbit.backend.llama_server import LlamaServerError
+
+        self.assertTrue(issubclass(LlamaServerError, RecoverableBackendError))
+        self.assertTrue(issubclass(RecoverableBackendError, RuntimeError))
+        # A plain RuntimeError must not satisfy the recoverable contract.
+        self.assertFalse(isinstance(RuntimeError("x"), RecoverableBackendError))
+
+    def test_the_analyst_can_steer_after_a_backend_error(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        class FailOnceThenWork(ScriptedBackend):
+            def __init__(self, *responses):
+                super().__init__(*responses)
+                self.failed = False
+
+            def chat_stream(self, messages, **kwargs):
+                if self.calls >= 2 and not self.failed:
+                    self.failed = True
+                    raise LlamaServerError("transient")
+                return super().chat_stream(messages, **kwargs)
+
+        backend = FailOnceThenWork(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            tool_response(emit("steered")),
+            prose_response("done"),
+        )
+        runtime = self.runtime(backend)
+        first = runtime.run_autonomous("inspect it")
+        second = runtime.run_autonomous("look at the header instead")
+
+        self.assertTrue(first.stop_reason.startswith(STOP_BACKEND_ERROR))
+        self.assertEqual(second.actions_executed, 1)
+        self.assertEqual(second.stop_reason, STOP_COMPLETE)
+
+
+class AutonomyIsOptInTests(unittest.TestCase):
+    def test_the_gate_variable_is_named_exactly(self) -> None:
+        """Pinned literal: a renamed constant makes the feature unreachable.
+
+        Fail-closed, so a typo is not a safety problem -- but it would be
+        silently undiscoverable, and every other test here refers to the
+        symbol rather than the name an operator actually types.
+        """
+        self.assertEqual(ANALYSIS_AUTONOMY_ENV, "ORBIT_ANALYSIS_AUTONOMOUS")
+
+    @mock.patch.dict(os.environ, {"ORBIT_ANALYSIS_AUTONOMOUS": "1"}, clear=True)
+    def test_the_literal_variable_enables_autonomy(self) -> None:
+        self.assertTrue(analysis_autonomy_enabled())
+
+    def test_the_gate_defaults_off_and_fails_closed(self) -> None:
+        self.assertFalse(analysis_autonomy_enabled({}))
+        self.assertTrue(analysis_autonomy_enabled({ANALYSIS_AUTONOMY_ENV: "1"}))
+        self.assertFalse(analysis_autonomy_enabled({ANALYSIS_AUTONOMY_ENV: "0"}))
+        self.assertFalse(analysis_autonomy_enabled({ANALYSIS_AUTONOMY_ENV: "yes"}))
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_the_terminal_uses_one_step_when_the_gate_is_off(self) -> None:
+        from orbit.terminal import repl as repl_module
+
+        import inspect
+
+        source = inspect.getsource(repl_module.Repl._ask_analysis)
+        self.assertIn("analysis_autonomy_enabled()", source)
+        self.assertIn("self.analysis.step(", source)
+        self.assertFalse(analysis_autonomy_enabled())
+
+
+class RollingLineageTests(AutonomousTestBase):
+    """Autonomous steps stay on the existing ANALYSIS rolling lineage."""
+
+    def test_every_autonomous_step_declares_the_analysis_step_phase(self) -> None:
+        from orbit.backend.llama_server import _analysis_rolling_anchor_requested
+        from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
+        from orbit.runtime.kv_diag import current_phase, model_call_context
+
+        seen: list[str | None] = []
+
+        class PhaseObservingBackend(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                seen.append(current_phase())
+                return super().chat_stream(messages, **kwargs)
+
+        backend = PhaseObservingBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(len(seen), 3)
+        self.assertEqual(set(seen), {ANALYSIS_STEP_PHASE})
+        # And that phase is the one the backend joins the rolling lineage for.
+        with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+            self.assertTrue(_analysis_rolling_anchor_requested(native_backend=True))
+        self.assertEqual(run.model_calls, 3)
+
+    def test_each_step_prompt_extends_the_previous_one(self) -> None:
+        """History is append-only, so step N's messages prefix step N+1's.
+
+        This is the runtime-side precondition for exact-prefix KV reuse: the
+        backend can only reuse a committed prefix if the prompt it is asked to
+        serve still begins with it. Nothing here normalises or approximates --
+        the earlier messages must be present, unchanged, in order.
+        """
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            prose_response("done"),
+        )
+        self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(len(backend.seen_messages), 3)
+        for earlier, later in zip(backend.seen_messages, backend.seen_messages[1:]):
+            self.assertLess(len(earlier), len(later))
+            self.assertEqual(later[: len(earlier)], earlier)
+
+    def test_autonomous_steps_never_declare_a_chat_phase(self) -> None:
+        from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
+        from orbit.runtime.kv_diag import current_phase
+
+        seen: list[str | None] = []
+
+        class PhaseObservingBackend(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                seen.append(current_phase())
+                return super().chat_stream(messages, **kwargs)
+
+        backend = PhaseObservingBackend(
+            tool_response(emit("one")), prose_response("done")
+        )
+        self.runtime(backend).run_autonomous("inspect it")
+
+        for phase in seen:
+            self.assertEqual(phase, ANALYSIS_STEP_PHASE)
+            self.assertNotIn("chat", str(phase).lower())
+
+
+class IntermediateEvidenceIsShownTests(AutonomousTestBase):
+    """Every step of an autonomous run reaches the analyst, not just the last."""
+
+    def test_the_terminal_renders_each_completed_step(self) -> None:
+        rendered: list[object] = []
+
+        backend = ScriptedBackend(
+            tool_response(emit("one")),
+            tool_response(emit("two")),
+            prose_response("done"),
+        )
+        self.runtime(backend).run_autonomous(
+            "inspect it", on_step=lambda step, record: rendered.append(step)
+        )
+
+        # The hook the terminal renders through fires once per completed step.
+        self.assertEqual(len(rendered), 3)
+        with_evidence = [s for s in rendered if s.evidence is not None]
+        self.assertEqual(len(with_evidence), 2)
+
+    def test_a_silent_step_after_a_talkative_one_is_not_told_prose_was_shown(
+        self,
+    ) -> None:
+        """One renderer serves every step, so its prose flag must be per-step.
+
+        `format_analysis_step(prose_already_shown=True)` suppresses the prose
+        it would otherwise reprint. Without a reset between steps the flag
+        stays set from the first step that streamed anything, so a later step
+        that streamed nothing would be told its prose was already on screen and
+        would silently drop it.
+        """
+        from orbit.terminal.streaming import StreamRenderer
+
+        backend = ScriptedBackend(
+            tool_response(emit("a"), text="thinking out loud"),
+            tool_response(emit("b"), text=""),
+            prose_response("final answer"),
+        )
+        renderer = StreamRenderer(thinking=False, render_markdown_mode="plain")
+        renderer.start()
+        flags: list[bool] = []
+
+        def show(step, record) -> None:
+            flags.append(renderer.rendered_visible_text)
+            renderer.reset_visible_text()
+
+        try:
+            self.runtime(backend).run_autonomous(
+                "inspect it", on_delta=renderer.write, on_step=show
+            )
+        finally:
+            renderer.finish()
+
+        # The silent middle step must not inherit the first step's flag.
+        self.assertEqual(flags, [True, False, True])
+
+    def test_the_repl_names_a_first_step_failure_truthfully(self) -> None:
+        """A backend that died must not be reported as an analyst interrupt.
+
+        When no step completes there is nothing to render, and that branch used
+        to print "cancelled" unconditionally -- so a first-step backend failure
+        told the analyst they had interrupted their own run, and discarded the
+        diagnostic. The run already carries both facts.
+        """
+        import inspect
+
+        from orbit.terminal.repl import Repl
+
+        source = inspect.getsource(Repl._ask_analysis)
+        head, _, tail = source.partition("if result is None:")
+        self.assertTrue(tail, "the no-step branch must exist")
+        branch = tail.split("return")[0]
+        self.assertIn("run.cancelled", branch)
+        self.assertIn("run.stop_reason", branch)
+
+    def test_a_first_step_backend_error_is_not_labelled_cancelled(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        class DeadBackend(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                raise LlamaServerError("upstream is down")
+
+        run = self.runtime(DeadBackend()).run_autonomous("inspect it")
+
+        self.assertIsNone(run.last_step)
+        self.assertFalse(run.cancelled, "a dead backend is not a cancellation")
+        self.assertIn("upstream is down", run.stop_reason)
+
+    def test_a_first_step_cancellation_is_labelled_cancelled(self) -> None:
+        class Interrupting(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                raise KeyboardInterrupt
+
+        run = self.runtime(Interrupting()).run_autonomous("inspect it")
+
+        self.assertIsNone(run.last_step)
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, STOP_CANCELLED)
+
+    def test_the_repl_wires_the_on_step_hook(self) -> None:
+        """A run whose last step is prose would otherwise show no evidence.
+
+        `STOP_COMPLETE` is the ordinary ending, and its final step carries no
+        action, so rendering only `run.last_step` would tell the analyst that
+        actions ran while showing none of what they produced.
+        """
+        import inspect
+
+        from orbit.terminal.repl import Repl
+
+        source = inspect.getsource(Repl._ask_analysis)
+        self.assertIn("on_step=", source)
+        self.assertIn("format_analysis_step(", source)
+
+
+class ProgressLedgerUnitTests(unittest.TestCase):
+    """The classifier alone, on hand-built step shapes."""
+
+    class Step:
+        def __init__(self, **kw):
+            self.action_attempted = kw.get("attempted", True)
+            self.action_executed = kw.get("executed", True)
+            self.rejection = kw.get("rejection")
+            self.result = None
+            self.evidence = kw.get("evidence")
+
+    class Evidence:
+        def __init__(self, sha, artifacts=()):
+            self.raw_sha256 = sha
+            self.metadata = {"artifacts": list(artifacts), "code_sha256": "c"}
+
+    def test_duplicate_evidence_is_not_progress(self) -> None:
+        ledger = ProgressLedger()
+        a = self.Step(evidence=self.Evidence("sha-1"))
+        b = self.Step(evidence=self.Evidence("sha-1"))
+        self.assertEqual(ledger.classify(1, a).classification, NEW_CONTENT)
+        self.assertEqual(ledger.classify(2, b).classification, NO_PROGRESS)
+
+    def test_a_new_artifact_is_progress_without_new_evidence(self) -> None:
+        ledger = ProgressLedger()
+        art = [{"handle": "/workspace/work/a.bin", "sha256": "d1"}]
+        first = self.Step(evidence=self.Evidence("sha-1"))
+        second = self.Step(evidence=self.Evidence("sha-1", art))
+        ledger.classify(1, first)
+        record = ledger.classify(2, second)
+        self.assertEqual(record.classification, NEW_CONTENT)
+        self.assertEqual(record.new_artifacts, ("/workspace/work/a.bin",))
+
+    def test_prose_is_complete_and_a_refusal_is_error(self) -> None:
+        ledger = ProgressLedger()
+        self.assertEqual(
+            ledger.classify(1, self.Step(attempted=False, executed=False)).classification,
+            COMPLETE,
+        )
+        self.assertEqual(
+            ledger.classify(
+                2, self.Step(executed=False, rejection="bad call")
+            ).classification,
+            ERROR,
+        )
+
+    def test_the_classifier_carries_no_domain_vocabulary(self) -> None:
+        """A generic mechanism must not mention what it might be looking at."""
+        from orbit.runtime import analysis_progress
+
+        # Executable code only: the module docstring names what it refuses to
+        # know, and a check that failed on its own disclaimer would push that
+        # explanation out of the file.
+        import ast
+
+        tree = ast.parse(Path(analysis_progress.__file__).read_text())
+        stripped = ast.unparse(
+            ast.Module(
+                body=[n for n in tree.body if not _is_docstring(n)], type_ignores=[]
+            )
+        )
+        lowered = _without_docstrings(stripped).lower()
+        for term in (
+            "malware", "xor", "powershell", "ioc", "payload", "obfusc",
+            "base64", "decode", "url", "shellcode", "virus", "indicator",
+        ):
+            self.assertNotIn(term, lowered, f"domain term {term!r} leaked in")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -17,7 +17,7 @@ if str(SRC) not in sys.path:
 
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
-from orbit.runtime.analysis_runtime import ANALYSIS_TOOL_NAME, AnalysisRuntime
+from orbit.runtime.analysis_runtime import ANALYSIS_AUTONOMY_ENV, ANALYSIS_TOOL_NAME, AnalysisRuntime
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.sessions import SessionStore
 from orbit.runtime.tools import TOOL_NAMES
@@ -85,6 +85,17 @@ class ScriptedBackend:
 
 class ModeTestBase(unittest.TestCase):
     def setUp(self) -> None:
+        # These tests describe the one-step analyst boundary, which is the
+        # default and stays available. Pinning the autonomy switch off makes
+        # that explicit: without it the suite's result depends on the
+        # environment it happens to run in, and an operator who exported the
+        # switch would see these fail for a behaviour that is working.
+        # Autonomous continuation has its own suite.
+        patcher = unittest.mock.patch.dict(
+            os.environ, {ANALYSIS_AUTONOMY_ENV: "0"}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
         self.tmp = Path(tempfile.mkdtemp(prefix="orbit-mode-test-"))
         self.addCleanup(self._cleanup)
         self.artifact = self.tmp / "sample.js"
@@ -1756,13 +1767,67 @@ class AnalysisProgressRenderingTest(ModeTestBase):
         self.assertIn("StreamRenderer(", source)
 
     def test_the_renderer_is_finished_on_every_exit_path(self) -> None:
-        # A renderer left running keeps a timer thread and a stale status line.
+        """A renderer left running keeps a timer thread and a stale status line.
+
+        Checked structurally rather than by counting call sites: the property
+        is that no path leaves the method without finishing the renderer, and a
+        pinned count asserts something narrower that a legitimate new exit path
+        breaks. Every `return` and `raise` after the renderer starts must be
+        preceded, within its own branch, by a `renderer.finish(` call.
+        """
+        import ast
         import inspect
+        import textwrap
 
         from orbit.terminal.repl import Repl
 
-        source = inspect.getsource(Repl._ask_analysis)
-        self.assertEqual(source.count("renderer.finish("), 4)
+        source = textwrap.dedent(inspect.getsource(Repl._ask_analysis))
+        tree = ast.parse(source)
+
+        def is_finish(stmt) -> bool:
+            """A bare `renderer.finish(...)` call statement, not a nested one."""
+            return (
+                isinstance(stmt, ast.Expr)
+                and isinstance(stmt.value, ast.Call)
+                and ast.unparse(stmt.value.func) == "renderer.finish"
+            )
+
+        def exits_are_guarded(block, finished: bool) -> list[str]:
+            """Walk one linear block, tracking whether finish() ran before an exit.
+
+            Only a finish executed on this path counts. A finish that appears
+            inside a nested branch or an exception handler does not guard the
+            statements that follow the enclosing statement, because that path
+            may not have run it -- which is exactly the mistake that let an
+            unguarded early return pass an earlier version of this check.
+            """
+            problems: list[str] = []
+            for stmt in block:
+                if is_finish(stmt):
+                    finished = True
+                    continue
+                if isinstance(stmt, (ast.Return, ast.Raise)):
+                    if not finished:
+                        problems.append(ast.unparse(stmt))
+                    continue
+                for field in ("body", "orelse", "finalbody"):
+                    branch = getattr(stmt, field, None)
+                    if isinstance(branch, list) and branch:
+                        problems += exits_are_guarded(branch, finished)
+                for handler in getattr(stmt, "handlers", []):
+                    problems += exits_are_guarded(handler.body, False)
+            return problems
+
+        body = tree.body[0].body
+        start = next(
+            (i for i, stmt in enumerate(body) if "renderer.start()" in ast.unparse(stmt)),
+            None,
+        )
+        self.assertIsNotNone(start, "the renderer must be started")
+        unguarded = exits_are_guarded(body[start + 1 :], False)
+        self.assertEqual(unguarded, [], f"exit paths without renderer.finish(): {unguarded}")
+        # And it is actually called, so an empty method could not pass.
+        self.assertIn("renderer.finish(", source)
 
     def test_analysis_never_renders_reasoning(self) -> None:
         """Checked on the constructed renderer, not on the source text.


### PR DESCRIPTION
After a step that produced verifiably new state, Orbit issues the next ordinary
analysis step itself instead of waiting for the analyst to type `continue`.
**ANALYSIS-only and default OFF.**

## What this changes

- Autonomous continuation is **ANALYSIS-only** and **default OFF**.
- Enabled through **`ORBIT_ANALYSIS_AUTONOMOUS=1`**.
- **The model chooses each analysis step.** Orbit controls only evidence,
  progress, bounds, cancellation and orchestration — it never decides what to
  examine or how.
- **No malware-specific logic.** No XOR/PowerShell/IoC/base64/URL/indicator
  knowledge anywhere; progress is hash arithmetic over attested state.
- **No deterministic analysis plan.** There is no script, no stage list, no
  expected sequence.
- **One action per model call**, preserved by the existing structural rejection.
- **NEW_CONTENT automatically permits the next call.**
- **Prose / no action produces natural completion** — the runtime does not judge
  whether an analysis is finished.
- **Stagnation, errors and bounds return control safely**, with evidence intact.
- **The existing analyst-guided mode remains available** and is what every
  analysis does unless the switch is set.
- **Rolling KV / prewarm unchanged.** `client.py`, the prefix derivation, KV
  identity, routing, CHAT, sandbox, EvidenceStore, model profiles and Gemma are
  all untouched.

Every step is the same qualified `step()` — one model call, at most one action,
structural rejection, sandbox, evidence, append-only history, rolling KV. There
is no second model path: no finalisation call, no classifier, no repair.

## Progress classification

`NEW_CONTENT` / `NO_PROGRESS` / `ERROR` / `COMPLETE`.

`NEW_CONTENT` is a new `EvidenceRecord.raw_sha256`, or an artifact digest that
is new or changed for its handle. Nothing else. **Model prose alone is never
progress**: prose with no action classifies `COMPLETE` unconditionally, however
confidently the text asserts otherwise.

## Bounds

8 actions · 10 model calls · 2 consecutive `NO_PROGRESS` · 2 consecutive
`ERROR`. All configurable per run.

A single unproductive step earns one more call; two in a row ends the run.
Alternating error and stagnation resets both consecutive counters by design, so
the model-call bound is the backstop — worst case is exactly 10 calls, never
unbounded.

## Scope note

`src/orbit/backend/base.py` and `src/orbit/backend/llama_server.py` are beyond
the runtime/terminal core and are called out explicitly. They add
`RecoverableBackendError` and have `LlamaServerError` subclass it, so the loop
can end on a recoverable failure without swallowing a genuine crash — this repo
overloads a bare `RuntimeError` to mean "a bug, tear the session down and
release the workspace". Both changes are additive; the base-class widening
means every existing `except LlamaServerError` site catches exactly what it did
before.

## Qualification

- **51 new tests**
- **Full suite passes identically with the gate OFF and with it ON.**
  2894 collected: in this working repository all 2894 pass; in a bare
  clone 7 of them skip for missing environment (model file, unbuilt
  native bridges, PDF fixtures), giving **2887 passed, 7 skipped** in
  both modes. The parent baseline is 2836 passed + 7 skipped, so the
  51 new tests account for the difference exactly and nothing regressed.
- **22/22 mutations CAUGHT** (physical mutation + causal failure)
- **Independent review PASS** — BLOCKER 0 / MAJOR 0 / MINOR 0, after three
  adversarial rounds
- compileall and `git diff --check` clean

Seven deterministic trajectories recorded at zero inference: autonomous run,
stagnation, error, immediate prose, max model calls, max actions, and the
alternating error/stagnation worst case.

## Benign real canary

One run, no retries, no tuning. 47-byte CSV fixture, one initial request, **no
manual `continue`**.

- **3 model calls, 2 actions**, `NEW_CONTENT → NEW_CONTENT → COMPLETE`
- stop reason: **"model returned prose with no action"** — natural completion,
  not a bound
- rolling ANALYSIS reuse **0% → 79.9% → 85.4%**, exact token accounting on every
  call
- both evidence records re-attest; no dangling analyst turn
- 186.9s wall

## Known residual — documented, not fixed here

Novelty is `raw_sha256` inequality, so if the model's own program emits a
timestamp, PID, random value or an unordered `set`/`dict` repr, every repetition
of identical work classifies `NEW_CONTENT` and the stagnation bound never fires.

**The run is still bounded** — the action bound (8) terminates it. A run ending
on `action bound reached` rather than on prose is the signal that this deserves
a progress fingerprint of its own, in a separate mission. Deliberately out of
scope here.

