### PR TITLE
feat(runtime): improve bounded autonomous analysis progress

### DIFF
--- a/src/orbit/runtime/analysis_progress.py
+++ b/src/orbit/runtime/analysis_progress.py
@@ -17,11 +17,22 @@ guessed at novelty from the text of an observation. Production has
 `raw_sha256` and records a sha256 per artifact, so novelty here is read from
 attested state rather than inferred from prose.
 
+Two things are asked of every executed action, and both must pass for it to
+count as progress:
+
+  1. Is this a strategy that has not already been tried against this state?
+     The fingerprint is (code sha, source identity, pre-action workspace
+     state). Re-running the same program against the same inputs is the same
+     experiment, and an experiment already run cannot produce new knowledge --
+     however different its stdout looks. That is what makes a program printing
+     a timestamp, a pid or a random value stop counting as discovery.
+  2. Did it actually add attested state -- an evidence content hash not seen
+     before, or an artifact digest new or changed for its handle?
+
 Classification of one executed action:
 
-  NEW_CONTENT   the action produced an evidence content hash not seen before,
-                or an artifact digest that is new or changed for its handle.
-  NO_PROGRESS   the action executed and re-derived only what is already known.
+  NEW_CONTENT   an unseen strategy that also added attested state.
+  NO_PROGRESS   a repeated strategy, or a strategy that added nothing.
   ERROR         the action was attempted but not executed, or the model
                 produced a structurally invalid call.
   COMPLETE      the model returned prose and attempted no action. Control
@@ -34,6 +45,7 @@ classifies as COMPLETE, never NEW_CONTENT, however much the text asserts.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 
 NEW_CONTENT = "NEW_CONTENT"
@@ -53,7 +65,17 @@ class ProgressRecord:
     new_artifacts: tuple[str, ...] = ()
     changed_artifacts: tuple[str, ...] = ()
     repeated_action: bool = False
+    repeated_strategy: bool = False
     detail: str | None = None
+
+    @property
+    def is_new_content(self) -> bool:
+        """Whether this step added verifiably new state.
+
+        Read by the loop to decide whether a run may continue past its action
+        budget: only a step that actually advanced the analysis earns that.
+        """
+        return self.classification == NEW_CONTENT
 
 
 @dataclass
@@ -67,6 +89,7 @@ class ProgressLedger:
     known_evidence: set[str] = field(default_factory=set)
     artifacts: dict[str, str] = field(default_factory=dict)
     action_fingerprints: set[tuple[str, str]] = field(default_factory=set)
+    strategy_fingerprints: set[str] = field(default_factory=set)
     history: list[ProgressRecord] = field(default_factory=list)
 
     def classify(self, index: int, step: object) -> ProgressRecord:
@@ -102,10 +125,34 @@ class ProgressLedger:
         evidence_sha = getattr(evidence, "raw_sha256", None)
         code_sha = self._code_sha256(step, evidence)
 
+        # Computed before the delta is absorbed: the state a strategy is
+        # judged against is the state it actually ran against, not the one it
+        # produced.
+        strategy = self._strategy_fingerprint(step, evidence, code_sha)
+        repeated_strategy = strategy in self.strategy_fingerprints
+
         new_artifacts, changed_artifacts = self._artifact_delta(evidence)
         new_evidence = bool(evidence_sha) and evidence_sha not in self.known_evidence
+        added_state = bool(new_evidence or new_artifacts or changed_artifacts)
 
-        if new_evidence or new_artifacts or changed_artifacts:
+        # A repeated strategy is not discovery -- unless it materialised or
+        # changed an artifact. Writing a durable handle is transport, not
+        # inference: the bytes become addressable and re-attestable, which
+        # changes what the session can do next rather than restating what it
+        # already knew. Re-writing a handle with identical bytes is neither,
+        # and the delta is empty there.
+        #
+        # This exception is deliberately not bounded further. A program that
+        # writes on every run may be carving the next stage out of a packed
+        # artifact -- exactly the work autonomous analysis exists for -- or it
+        # may be rewriting random bytes and going nowhere. No deterministic
+        # signal available here separates them: both reuse one program, both
+        # write every run, and both produce a new evidence hash because the
+        # observation names the digest they just wrote. Every rule strong
+        # enough to stop the second was measured to halt the first mid-unpack,
+        # which is the worse failure and the one this mechanism exists to
+        # prevent. The action bound ends the spinning case, and ends it safely.
+        if added_state and (not repeated_strategy or new_artifacts or changed_artifacts):
             classification = NEW_CONTENT
         else:
             classification = NO_PROGRESS
@@ -121,11 +168,38 @@ class ProgressLedger:
             new_artifacts=new_artifacts,
             changed_artifacts=changed_artifacts,
             repeated_action=repeated,
+            repeated_strategy=repeated_strategy,
         )
         if evidence_sha:
             self.known_evidence.add(evidence_sha)
         self.action_fingerprints.add(fingerprint)
+        self.strategy_fingerprints.add(strategy)
         return self._append(record)
+
+    def _strategy_fingerprint(
+        self, step: object, evidence: object, code_sha: str | None
+    ) -> str:
+        """Identity of the experiment, independent of what it printed.
+
+        The same program, over the same input, against the same workspace, is
+        the same experiment. Its stdout may still differ -- a timestamp, a pid,
+        a random value, a dict that iterates in a new order -- and none of that
+        is a discovery about the artifact.
+
+        The workspace component is the set of artifact handles and digests the
+        ledger had already absorbed when this action ran, so a program that is
+        genuinely re-run after the workspace changed is a different experiment
+        and is judged on its own merits. Nothing here inspects or normalises
+        code or output: it is three hashes of state the runtime already had.
+        """
+        metadata = getattr(evidence, "metadata", None) or {}
+        result = getattr(step, "result", None)
+        source = getattr(result, "input_sha256", None)
+        if not source and isinstance(metadata, dict):
+            source = metadata.get("input_sha256") or metadata.get("analysis_source_sha256")
+        workspace = ";".join(f"{h}={d}" for h, d in sorted(self.artifacts.items()))
+        components = "\x00".join([code_sha or "", str(source or ""), workspace])
+        return hashlib.sha256(components.encode("utf-8")).hexdigest()
 
     def _append(self, record: ProgressRecord) -> ProgressRecord:
         self.history.append(record)

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -225,15 +225,98 @@ QUALIFIED_ANALYSIS_MAX_TOKENS = 2048
 # no-progress steps is the smallest number that distinguishes a model briefly
 # re-orienting from one that is stuck; one would abort on a single redundant
 # read. All four are configurable per run.
-MAX_AUTONOMOUS_ACTIONS = 8
-MAX_AUTONOMOUS_MODEL_CALLS = 10
+# Where a run stops asking for more, and where it is stopped.
+#
+# 8 is a budget, not a boundary. It came from the preserved research harness,
+# whose sibling variant ran at 6 and whose own tests asserted only the relation
+# between the two counts -- never that 8 was where an analysis becomes unsafe
+# or useless. A measured full-sample run then ended on it with all eight steps
+# still producing new evidence and the report naming the next deterministic
+# step, which is a budget cutting off work, not a policy declining it.
+#
+# So 8 is the point where continuing has to justify itself. A run still adding
+# verifiably new state may pass it; a run that is stagnating, repeating a
+# strategy, or failing is stopped there exactly as before. 12 is the ceiling,
+# and nothing crosses it.
+SOFT_MAX_AUTONOMOUS_ACTIONS = 8
+MAX_AUTONOMOUS_ACTIONS = 12
+
+# How many non-executing calls a whole run may spend before the budget, rather
+# than the analysis, decides when it ends.
+#
+# A step can consume a call without executing anything: a malformed tool call,
+# a refused action, a capacity stop. The error policy tolerates one of those
+# between productive steps -- progress resets the counter -- so in principle a
+# run could alternate progress and failure all the way to the action ceiling.
+# Affording every one of those would put the ceiling at 2*12+1 = 25 calls,
+# which on this hardware is hours spent mostly on rejected calls.
+#
+# 2 is the allowance. It is a judgement and is written down as one: the
+# qualified full-sample run spent zero non-executing calls in eight actions, and
+# the research harness that set these bounds allowed one in a whole run. Two is
+# the smallest number above the historical allowance, and it buys tolerance for
+# an occasional mis-formed call without buying an hour of them. A run that
+# needs more than two is not being cut short by arithmetic; it is failing.
+MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS = 2
+
+# Derived from the loop, not chosen. Every iteration spends exactly one model
+# call -- `step()` returns `model_calls=1` on all of its return paths -- so
+# calls and iterations are the same thing, and the ceiling has to cover the
+# largest run the action policy can legitimately want:
+#
+#     12 iterations that execute an action        (the hard ceiling)
+#   +  1 for the model to finish with prose       (natural completion)
+#   +  2 non-executing calls it may spend on the way
+#   = 15
+#
+# The 12 is forced by the control flow. The prose call is slack rather than a
+# requirement -- a run that reaches the ceiling breaks before spending it, so
+# it is only needed by a run that finishes early -- and the allowance is a
+# choice, the constant above. 14 would also be sufficient; 15 keeps one call
+# of margin. What is not optional is being above 13: that was the previous
+# value, and it made the hard ceiling unreachable for any run containing two
+# mis-formed calls, with its test correspondingly vacuous.
+#
+# The closing report is not counted here: it is made outside the loop, is not
+# part of the investigation, and its exclusion is what keeps this number a
+# statement about analysis rather than about bookkeeping.
+MAX_AUTONOMOUS_MODEL_CALLS = (
+    MAX_AUTONOMOUS_ACTIONS + 1 + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS
+)
+
 MAX_CONSECUTIVE_NO_PROGRESS = 2
 MAX_CONSECUTIVE_ERRORS = 2
 
-# What Orbit says to itself to take the next step. It carries no guidance
-# about what to examine: choosing that is the model's job, and a runtime that
-# suggested a direction would be doing analysis rather than orchestration.
-AUTONOMOUS_CONTINUATION_MESSAGE = "continue"
+# What Orbit says to itself to take the next step.
+#
+# It names no artifact, no technique and no direction: choosing those is the
+# model's job, and a runtime that suggested one would be doing analysis rather
+# than orchestration. What it does say is the standing rule of the loop -- one
+# new useful step, nothing already established -- because the alternative is a
+# bare "continue" that leaves the model to infer whether re-examining what it
+# has already seen counts as continuing. It does not.
+AUTONOMOUS_CONTINUATION_MESSAGE = (
+    "Continue from the current evidence. Choose one new useful "
+    "evidence-producing step. Do not repeat established actions, inputs or "
+    "findings."
+)
+
+# Sent on the first unproductive step of a streak. The previous instruction
+# asked for a new step; this one says plainly that the last attempt was not
+# one, and asks for a different strategy rather than a different phrasing of
+# the same one.
+#
+# Once per episode, not once per run: a step that adds new state resets the
+# streak, so a later unproductive step is a new situation and is told so again.
+# What is never repeated is asking twice about the same stall -- a second
+# consecutive unproductive step ends the run, because a runtime that kept
+# asking would be arguing with the model. The total is bounded by the action
+# ceiling regardless, since every replan follows a step that consumed one.
+AUTONOMOUS_REPLAN_MESSAGE = (
+    "The previous action produced no new evidence. Choose a different "
+    "deterministic strategy using the current evidence and artifacts. Do not "
+    "repeat an exhausted action, input or established finding."
+)
 
 # Off until it has been measured on real work. Existing one-step behaviour --
 # one analyst line, one model call, control back -- is what every analysis does
@@ -245,6 +328,7 @@ STOP_COMPLETE = "model returned prose with no action"
 STOP_NO_PROGRESS = "no new evidence"
 STOP_ERROR = "repeated action failures"
 STOP_MAX_ACTIONS = "action bound reached"
+STOP_SOFT_MAX_ACTIONS = "action budget reached without further progress"
 STOP_MAX_MODEL_CALLS = "model call bound reached"
 STOP_CANCELLED = "cancelled"
 STOP_BACKEND_ERROR = "backend error"
@@ -424,6 +508,8 @@ class AutonomousRunResult:
     model_calls: int
     actions_executed: int
     cancelled: bool = False
+    replans: int = 0
+    final_report: "AnalysisReport | None" = None
 
     @property
     def last_step(self) -> AnalysisStepResult | None:
@@ -869,12 +955,14 @@ class AnalysisRuntime:
         analyst_message: str,
         *,
         max_actions: int = MAX_AUTONOMOUS_ACTIONS,
-        max_model_calls: int = MAX_AUTONOMOUS_MODEL_CALLS,
+        soft_max_actions: int = SOFT_MAX_AUTONOMOUS_ACTIONS,
+        max_model_calls: int = MAX_AUTONOMOUS_MODEL_CALLS,  # plus one closing report
         max_no_progress: int = MAX_CONSECUTIVE_NO_PROGRESS,
         max_errors: int = MAX_CONSECUTIVE_ERRORS,
         on_progress: Callable[[Any], None] | None = None,
         on_delta: Callable[[str], None] | None = None,
         on_step: Callable[[AnalysisStepResult, ProgressRecord], None] | None = None,
+        finalize: bool = True,
     ) -> AutonomousRunResult:
         """Run analyst-directed steps until progress stops or a bound is hit.
 
@@ -898,6 +986,12 @@ class AnalysisRuntime:
         Cancellation propagates: `KeyboardInterrupt` from the backend ends the
         run and returns what has already been established, with the workspace
         and evidence intact.
+
+        `max_model_calls` bounds the investigation loop. A run that is not
+        cancelled then spends one further call on the closing report, so the
+        backend may see `max_model_calls + 1` calls in total; the returned
+        `model_calls` counts them all, so the figure reported is the figure
+        spent.
         """
         ledger = ProgressLedger()
         steps: list[AnalysisStepResult] = []
@@ -906,9 +1000,12 @@ class AnalysisRuntime:
         actions = 0
         consecutive_no_progress = 0
         consecutive_errors = 0
+        replans = 0
+        replan_pending = False
         message = analyst_message
         stop_reason = STOP_MAX_MODEL_CALLS
         cancelled = False
+        final_report: "AnalysisReport | None" = None
 
         while True:
             if model_calls >= max_model_calls:
@@ -974,11 +1071,21 @@ class AnalysisRuntime:
                 consecutive_errors = 0
                 if consecutive_no_progress >= max_no_progress:
                     stop_reason = (
-                        f"{STOP_NO_PROGRESS}: action repeated"
+                        f"{STOP_NO_PROGRESS}: strategy repeated"
+                        if record.repeated_strategy
+                        else f"{STOP_NO_PROGRESS}: action repeated"
                         if record.repeated_action
                         else STOP_NO_PROGRESS
                     )
                     break
+                # First unproductive step of this streak: say so, and ask for
+                # a different strategy rather than another attempt at the same
+                # one. Reached only when the consecutive bound above did not
+                # fire, so it is never sent twice about the same stall; a run
+                # that recovers and stalls again is told again, because that is
+                # a different stall.
+                replan_pending = True
+                replans += 1
             else:
                 consecutive_no_progress = 0
                 consecutive_errors = 0
@@ -997,8 +1104,69 @@ class AnalysisRuntime:
             if actions >= max_actions:
                 stop_reason = STOP_MAX_ACTIONS
                 break
+            if actions >= soft_max_actions and not record.is_new_content:
+                # Past the soft budget, continuing has to be earned. A step
+                # that added verifiably new state earns it; anything else --
+                # stagnation, a repeated strategy, a refused action -- stops
+                # here exactly as it did when this was the only bound.
+                #
+                # Reached only when the consecutive counters have not already
+                # ended the run, so this is the single-failure case they
+                # deliberately tolerate: tolerated below the budget, not above
+                # it.
+                stop_reason = STOP_SOFT_MAX_ACTIONS
+                break
 
-            message = AUTONOMOUS_CONTINUATION_MESSAGE
+            if replan_pending:
+                message = AUTONOMOUS_REPLAN_MESSAGE
+                replan_pending = False
+            else:
+                message = AUTONOMOUS_CONTINUATION_MESSAGE
+
+        # One grounded answer at the end, from the evidence already stored.
+        #
+        # A protective stop is the case that needs this most: a run that ended
+        # on a bound or on stagnation has collected real evidence and would
+        # otherwise hand the analyst a stop reason and nothing else. The
+        # natural ending gets one too, so a completed analysis reads the same
+        # way whichever way it finished.
+        #
+        # `report()` is the qualified primitive for this and is reused
+        # unchanged: it is offered no tools, appends nothing to history, and
+        # cannot continue the analysis. It is called once, outside the loop, so
+        # there is no path from a report back into another step.
+        #
+        # Cancellation is the exception. The analyst asked for the run to stop,
+        # and spending another model call -- minutes of generation -- to
+        # summarise it is the opposite of stopping.
+        if not cancelled and finalize and steps:
+            try:
+                final_report = self.report(
+                    question=self._final_question(stop_reason),
+                    on_progress=on_progress,
+                    on_delta=on_delta,
+                )
+            except (
+                KeyboardInterrupt,
+                ContextAdmissionError,
+                TimeoutError,
+                RecoverableBackendError,
+            ):
+                # A report that cannot be produced must not discard the run
+                # that earned it. The analyst keeps the evidence and the stop
+                # reason, and can ask for a report themselves.
+                #
+                # `KeyboardInterrupt` belongs here for the same reason as the
+                # rest, and more urgently: the closing report is the longest
+                # single generation in a run and the one an analyst is most
+                # likely to interrupt, having already read every step. Letting
+                # it propagate would unwind past a caller holding only a
+                # pre-run checkpoint, and rewinding to that point deletes the
+                # history and provenance of every completed step -- leaving
+                # their evidence durable on disk with nothing referring to it.
+                final_report = None
+            else:
+                model_calls += final_report.model_calls
 
         return AutonomousRunResult(
             steps=tuple(steps),
@@ -1007,6 +1175,24 @@ class AnalysisRuntime:
             model_calls=model_calls,
             actions_executed=actions,
             cancelled=cancelled,
+            replans=replans,
+            final_report=final_report,
+        )
+
+    @staticmethod
+    def _final_question(stop_reason: str) -> str:
+        """What the closing report is asked, given how the run ended.
+
+        A run that ended naturally is simply asked to report. One that was cut
+        short says so, because a reader who is not told that a bound intervened
+        would read an incomplete analysis as a finished one.
+        """
+        if stop_reason == STOP_COMPLETE:
+            return ""
+        return (
+            "This analysis stopped before the model chose to finish "
+            f"({stop_reason}). Report what the evidence establishes and what "
+            "remains unresolved."
         )
 
     def _close_incomplete_turn(self) -> None:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -414,9 +414,16 @@ class Repl:
             print(step_block, flush=True)
         elapsed = time.monotonic() - started
         if run is not None:
+            # The closing report streamed as it was generated, like any other
+            # prose. Print it here only if it did not: a backend that does not
+            # stream would otherwise produce a run whose grounded conclusion
+            # never reached the analyst at all.
+            if run.final_report is not None and not renderer.rendered_visible_text:
+                print(run.final_report.text, flush=True)
+            replans = f" | replans: {run.replans}" if run.replans else ""
             summary = (
                 f"analysis | mode: ANALYSIS | model calls: {run.model_calls} | "
-                f"actions: {run.actions_executed} | steps: {len(run.steps)} | "
+                f"actions: {run.actions_executed} | steps: {len(run.steps)}{replans} | "
                 f"stopped: {run.stop_reason} | {elapsed:.1f}s"
             )
         else:

--- a/tests/test_analysis_autonomous.py
+++ b/tests/test_analysis_autonomous.py
@@ -36,12 +36,16 @@ from orbit.runtime.analysis_progress import (
 )
 from orbit.runtime.analysis_runtime import (
     ANALYSIS_AUTONOMY_ENV,
+    AUTONOMOUS_REPLAN_MESSAGE,
     ANALYSIS_TOOL_NAME,
     AUTONOMOUS_CONTINUATION_MESSAGE,
     MAX_AUTONOMOUS_ACTIONS,
     MAX_AUTONOMOUS_MODEL_CALLS,
     MAX_CONSECUTIVE_ERRORS,
     MAX_CONSECUTIVE_NO_PROGRESS,
+    MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS,
+    SOFT_MAX_AUTONOMOUS_ACTIONS,
+    STOP_SOFT_MAX_ACTIONS,
     STOP_BACKEND_ERROR,
     STOP_CANCELLED,
     STOP_COMPLETE,
@@ -126,7 +130,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
             tool_response(emit("first")),
             prose_response("nothing further"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         # Two calls: the action earned the second one.
         self.assertEqual(backend.calls, 2)
@@ -142,12 +146,14 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
         backend = ScriptedBackend(
             tool_response(emit("first")), prose_response("done")
         )
-        self.runtime(backend).run_autonomous("inspect it")
+        self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         second_prompt = backend.seen_messages[1]
         analyst_lines = [m for m in second_prompt if m.get("role") == "user"]
         self.assertEqual(analyst_lines[-1]["content"], AUTONOMOUS_CONTINUATION_MESSAGE)
-        self.assertEqual(AUTONOMOUS_CONTINUATION_MESSAGE, "continue")
+        # Generic: it asks for one new useful step and names nothing specific.
+        self.assertIn("new useful", AUTONOMOUS_CONTINUATION_MESSAGE)
+        self.assertIn("Do not repeat", AUTONOMOUS_CONTINUATION_MESSAGE)
 
     def test_several_new_content_steps_continue(self) -> None:
         backend = ScriptedBackend(
@@ -156,7 +162,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
             tool_response(emit("three")),
             prose_response("that is all"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(run.actions_executed, 3)
         self.assertEqual(run.model_calls, 4)
@@ -167,7 +173,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
 
     def test_prose_with_no_action_stops_immediately(self) -> None:
         backend = ScriptedBackend(prose_response("I have nothing to run"))
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(backend.calls, 1)
         self.assertEqual(run.actions_executed, 0)
@@ -179,7 +185,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
         backend = ScriptedBackend(
             prose_response("I have decoded stage two and will continue shortly")
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(backend.calls, 1)
         self.assertNotIn(NEW_CONTENT, [r.classification for r in run.progress])
@@ -191,7 +197,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
             tool_response(write_artifact("stage.bin", "bbb")),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("transform it")
+        run = self.runtime(backend).run_autonomous("transform it", finalize=False)
 
         self.assertEqual(run.actions_executed, 2)
         second = run.progress[1]
@@ -204,7 +210,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
             tool_response(emit("two")),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         recorded = [s.evidence for s in run.steps if s.evidence is not None]
         self.assertEqual(len(recorded), 2)
@@ -219,7 +225,7 @@ class ContinuationIsDrivenByNewContentTests(AutonomousTestBase):
             tool_response(emit("x"), count=2),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         first = run.steps[0]
         self.assertTrue(first.action_attempted)
@@ -235,7 +241,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
         backend = ScriptedBackend(
             tool_response(code), tool_response(code), tool_response(code)
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(
             [r.classification for r in run.progress],
@@ -253,7 +259,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
             tool_response("x = 1\n" + emit("same")),
             tool_response("y = 2\n" + emit("same")),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(
             [r.classification for r in run.progress],
@@ -271,7 +277,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
         """
         code = write_artifact("same.bin", "identical")
         backend = ScriptedBackend(*[tool_response(code)] * 5)
-        run = self.runtime(backend).run_autonomous("transform it")
+        run = self.runtime(backend).run_autonomous("transform it", finalize=False)
 
         self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
         # No step after the first ever reports a changed digest for the handle.
@@ -284,7 +290,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
     def test_stagnation_bound_stops_the_run(self) -> None:
         code = emit("same")
         backend = ScriptedBackend(*[tool_response(code)] * 6)
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS), run.stop_reason)
         self.assertEqual(backend.calls, 1 + MAX_CONSECUTIVE_NO_PROGRESS)
@@ -297,7 +303,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
             tool_response(emit("b")),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(
             [r.classification for r in run.progress],
@@ -309,7 +315,7 @@ class DuplicateWorkIsNotProgressTests(AutonomousTestBase):
 class ErrorsAreBoundedTests(AutonomousTestBase):
     def test_consecutive_errors_stop_the_run(self) -> None:
         backend = ScriptedBackend(*[tool_response(emit("x"), count=2)] * 5)
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.stop_reason.startswith(STOP_ERROR), run.stop_reason)
         self.assertEqual(backend.calls, MAX_CONSECUTIVE_ERRORS)
@@ -326,7 +332,7 @@ class ErrorsAreBoundedTests(AutonomousTestBase):
             prompt_tokens_per_second=None, generation_tokens_per_second=None,
         )
         backend = ScriptedBackend(broken, broken, broken)
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.stop_reason.startswith(STOP_ERROR), run.stop_reason)
         self.assertEqual(backend.calls, MAX_CONSECUTIVE_ERRORS)
@@ -341,7 +347,7 @@ class ErrorsAreBoundedTests(AutonomousTestBase):
             tool_response(emit("x"), count=2),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(
             [r.classification for r in run.progress],
@@ -356,7 +362,7 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
             *[tool_response(emit(f"v{i}")) for i in range(MAX_AUTONOMOUS_ACTIONS + 3)]
         )
         run = self.runtime(backend).run_autonomous(
-            "inspect it", max_model_calls=MAX_AUTONOMOUS_ACTIONS + 3
+            "inspect it", max_model_calls=MAX_AUTONOMOUS_ACTIONS + 3, finalize=False
         )
 
         self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
@@ -368,7 +374,7 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
             *[tool_response(emit(f"v{i}")) for i in range(12)]
         )
         run = self.runtime(backend).run_autonomous(
-            "inspect it", max_model_calls=3, max_actions=99
+            "inspect it", max_model_calls=3, max_actions=99, finalize=False
         )
 
         self.assertEqual(run.stop_reason, STOP_MAX_MODEL_CALLS)
@@ -376,8 +382,9 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
         self.assertEqual(backend.calls, 3)
 
     def test_bounds_are_small_and_explicit(self) -> None:
-        self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 8)
-        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 10)
+        self.assertEqual(SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 15)
         self.assertEqual(MAX_CONSECUTIVE_NO_PROGRESS, 2)
         self.assertEqual(MAX_CONSECUTIVE_ERRORS, 2)
         # The call bound must leave room for calls that execute nothing.
@@ -398,7 +405,7 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
         for _ in range(20):
             script.append(tool_response(same, count=2))  # ERROR
             script.append(tool_response(same))           # NO_PROGRESS
-        run = self.runtime(ScriptedBackend(*script)).run_autonomous("inspect it")
+        run = self.runtime(ScriptedBackend(*script)).run_autonomous("inspect it", finalize=False)
 
         classifications = [r.classification for r in run.progress]
         self.assertIn(ERROR, classifications)
@@ -413,7 +420,7 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
             tool_response(emit("two")),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(backend.calls, run.model_calls)
         for offered in backend.seen_tools:
@@ -429,7 +436,7 @@ class HumanControlTests(AutonomousTestBase):
                 return super().chat_stream(messages, **kwargs)
 
         backend = CancellingBackend(tool_response(emit("one")))
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.cancelled)
         self.assertEqual(run.stop_reason, STOP_CANCELLED)
@@ -457,7 +464,7 @@ class HumanControlTests(AutonomousTestBase):
             tool_response(emit("one")), tool_response(emit("two"))
         )
         runtime = self.runtime(backend)
-        run = runtime.run_autonomous("inspect it")
+        run = runtime.run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.cancelled)
         self.assertEqual(run.actions_executed, 2)
@@ -475,7 +482,7 @@ class HumanControlTests(AutonomousTestBase):
             def chat_stream(self, messages, **kwargs):
                 raise KeyboardInterrupt
 
-        run = self.runtime(CancelImmediately()).run_autonomous("inspect it")
+        run = self.runtime(CancelImmediately()).run_autonomous("inspect it", finalize=False)
 
         self.assertTrue(run.cancelled)
         self.assertEqual(run.steps, ())
@@ -491,10 +498,10 @@ class HumanControlTests(AutonomousTestBase):
             prose_response("done"),
         )
         runtime = self.runtime(backend)
-        first = runtime.run_autonomous("inspect it")
+        first = runtime.run_autonomous("inspect it", finalize=False)
         history_after_first = len(runtime.messages)
 
-        second = runtime.run_autonomous("now look at the header instead")
+        second = runtime.run_autonomous("now look at the header instead", finalize=False)
 
         self.assertEqual(first.stop_reason, STOP_COMPLETE)
         self.assertEqual(second.actions_executed, 1)
@@ -526,7 +533,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
         from orbit.backend.llama_server import LlamaServerError
 
         runtime = self.runtime(self._failing(LlamaServerError("backend died")))
-        run = runtime.run_autonomous("inspect it")  # must not raise
+        run = runtime.run_autonomous("inspect it", finalize=False)  # must not raise
 
         self.assertTrue(run.stop_reason.startswith(STOP_BACKEND_ERROR))
         self.assertIn("LlamaServerError", run.stop_reason)
@@ -537,7 +544,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
         from orbit.backend.llama_server import LlamaServerError
 
         runtime = self.runtime(self._failing(LlamaServerError("backend died")))
-        run = runtime.run_autonomous("inspect it")
+        run = runtime.run_autonomous("inspect it", finalize=False)
 
         for step in run.steps:
             self.assertTrue(self.store.reattest_exact(step.evidence.evidence_id))
@@ -568,7 +575,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
         for exc in (LlamaServerError("died"), KeyboardInterrupt()):
             with self.subTest(exc=type(exc).__name__):
                 runtime = self.runtime(self._failing(exc))
-                runtime.run_autonomous("inspect it")
+                runtime.run_autonomous("inspect it", finalize=False)
 
                 roles = [m["role"] for m in runtime.messages]
                 self.assertNotEqual(roles[-1], "user")
@@ -585,7 +592,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
             tool_response(emit("one")), prose_response("done")
         )
         runtime = self.runtime(backend)
-        runtime.run_autonomous("inspect it")
+        runtime.run_autonomous("inspect it", finalize=False)
         before = [dict(m) for m in runtime.messages]
 
         # History ends with an assistant turn; the guard must do nothing.
@@ -602,7 +609,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
         """
         backend = ScriptedBackend(tool_response(emit("one")), prose_response("done"))
         runtime = self.runtime(backend)
-        runtime.run_autonomous("inspect it")
+        runtime.run_autonomous("inspect it", finalize=False)
 
         turns_before = runtime.analyst_turns
         runtime.messages.append({"role": "user", "content": "unanswered"})
@@ -631,7 +638,7 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
         runtime = self.runtime(Exploding(tool_response(emit("one"))))
 
         with self.assertRaises(RuntimeError) as caught:
-            runtime.run_autonomous("inspect it")
+            runtime.run_autonomous("inspect it", finalize=False)
         self.assertEqual(str(caught.exception), "backend exploded")
 
     def test_a_recoverable_error_is_absorbed_but_a_bug_is_not(self) -> None:
@@ -665,8 +672,8 @@ class RecoverableBackendFailureTests(AutonomousTestBase):
             prose_response("done"),
         )
         runtime = self.runtime(backend)
-        first = runtime.run_autonomous("inspect it")
-        second = runtime.run_autonomous("look at the header instead")
+        first = runtime.run_autonomous("inspect it", finalize=False)
+        second = runtime.run_autonomous("look at the header instead", finalize=False)
 
         self.assertTrue(first.stop_reason.startswith(STOP_BACKEND_ERROR))
         self.assertEqual(second.actions_executed, 1)
@@ -725,7 +732,7 @@ class RollingLineageTests(AutonomousTestBase):
             tool_response(emit("two")),
             prose_response("done"),
         )
-        run = self.runtime(backend).run_autonomous("inspect it")
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(len(seen), 3)
         self.assertEqual(set(seen), {ANALYSIS_STEP_PHASE})
@@ -747,7 +754,7 @@ class RollingLineageTests(AutonomousTestBase):
             tool_response(emit("two")),
             prose_response("done"),
         )
-        self.runtime(backend).run_autonomous("inspect it")
+        self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         self.assertEqual(len(backend.seen_messages), 3)
         for earlier, later in zip(backend.seen_messages, backend.seen_messages[1:]):
@@ -768,7 +775,7 @@ class RollingLineageTests(AutonomousTestBase):
         backend = PhaseObservingBackend(
             tool_response(emit("one")), prose_response("done")
         )
-        self.runtime(backend).run_autonomous("inspect it")
+        self.runtime(backend).run_autonomous("inspect it", finalize=False)
 
         for phase in seen:
             self.assertEqual(phase, ANALYSIS_STEP_PHASE)
@@ -787,7 +794,7 @@ class IntermediateEvidenceIsShownTests(AutonomousTestBase):
             prose_response("done"),
         )
         self.runtime(backend).run_autonomous(
-            "inspect it", on_step=lambda step, record: rendered.append(step)
+            "inspect it", on_step=lambda step, record: rendered.append(step), finalize=False
         )
 
         # The hook the terminal renders through fires once per completed step.
@@ -823,7 +830,7 @@ class IntermediateEvidenceIsShownTests(AutonomousTestBase):
 
         try:
             self.runtime(backend).run_autonomous(
-                "inspect it", on_delta=renderer.write, on_step=show
+                "inspect it", on_delta=renderer.write, on_step=show, finalize=False
             )
         finally:
             renderer.finish()
@@ -857,7 +864,7 @@ class IntermediateEvidenceIsShownTests(AutonomousTestBase):
             def chat_stream(self, messages, **kwargs):
                 raise LlamaServerError("upstream is down")
 
-        run = self.runtime(DeadBackend()).run_autonomous("inspect it")
+        run = self.runtime(DeadBackend()).run_autonomous("inspect it", finalize=False)
 
         self.assertIsNone(run.last_step)
         self.assertFalse(run.cancelled, "a dead backend is not a cancellation")
@@ -868,7 +875,7 @@ class IntermediateEvidenceIsShownTests(AutonomousTestBase):
             def chat_stream(self, messages, **kwargs):
                 raise KeyboardInterrupt
 
-        run = self.runtime(Interrupting()).run_autonomous("inspect it")
+        run = self.runtime(Interrupting()).run_autonomous("inspect it", finalize=False)
 
         self.assertIsNone(run.last_step)
         self.assertTrue(run.cancelled)
@@ -961,3 +968,784 @@ class ProgressLedgerUnitTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# --- progress reliability: strategy fingerprint, replan, grounded ending ----
+
+
+def nondet(tag: str) -> str:
+    """A program whose stdout differs every run but whose experiment does not."""
+    return (
+        "import os, random, time\n"
+        f"print({tag!r}, random.random(), time.time(), os.getpid(), end='')"
+    )
+
+
+class StrategyFingerprintTests(AutonomousTestBase):
+    """Re-running one experiment is not discovery, whatever it prints.
+
+    Novelty by evidence hash alone cannot see this: a program that prints a
+    timestamp, a pid or a random value produces a different hash every time and
+    looked like progress on every repetition. The fingerprint asks the other
+    question -- has this strategy already been tried against this state -- and
+    only an unseen strategy that also added attested state counts.
+    """
+
+    def test_repeated_action_with_random_output_is_not_progress(self) -> None:
+        run = self.runtime(
+            ScriptedBackend(*[tool_response(nondet("scan"))] * 8)
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS))
+        self.assertTrue(run.progress[-1].repeated_strategy)
+        # It stops far short of the action bound it used to run to.
+        self.assertEqual(run.actions_executed, 3)
+
+    def test_repeated_action_with_timestamp_output_is_not_progress(self) -> None:
+        code = "import time\nprint('t', time.time(), end='')"
+        run = self.runtime(ScriptedBackend(*[tool_response(code)] * 8)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+
+    def test_repeated_action_with_pid_output_is_not_progress(self) -> None:
+        code = "import os\nprint('pid', os.getpid(), os.urandom(8).hex(), end='')"
+        run = self.runtime(ScriptedBackend(*[tool_response(code)] * 8)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+
+    def test_a_new_action_producing_new_evidence_is_still_progress(self) -> None:
+        """The fingerprint must not suppress genuine work."""
+        run = self.runtime(
+            ScriptedBackend(
+                tool_response(emit("a")),
+                tool_response(emit("b")),
+                tool_response(emit("c")),
+                prose_response("done"),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NEW_CONTENT, NEW_CONTENT, COMPLETE],
+        )
+
+    def test_duplicate_evidence_from_a_new_action_is_not_progress(self) -> None:
+        """Both questions must pass: an unseen strategy that adds nothing fails."""
+        run = self.runtime(
+            ScriptedBackend(
+                tool_response(emit("same")),
+                tool_response("x = 1\n" + emit("same")),
+                tool_response("y = 2\n" + emit("same")),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NO_PROGRESS],
+        )
+
+    def test_the_same_code_after_the_workspace_changed_is_a_new_experiment(
+        self,
+    ) -> None:
+        """Re-running a program over changed inputs is not a repeat.
+
+        Without the workspace component the fingerprint would be (code, source)
+        alone, and a program legitimately re-run after an earlier step
+        materialised a new artifact would be suppressed as a repeat -- exactly
+        the multi-stage case autonomous analysis exists for.
+        """
+        read_work = (
+            "import pathlib\n"
+            "p = pathlib.Path('/workspace/work/stage.txt')\n"
+            "print(p.read_text() if p.exists() else 'absent', end='')"
+        )
+        run = self.runtime(
+            ScriptedBackend(
+                tool_response(read_work),                       # 'absent'
+                tool_response(write_artifact("stage.txt", "one")),
+                tool_response(read_work),                       # same code, new state
+                prose_response("done"),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NEW_CONTENT, NEW_CONTENT, COMPLETE],
+        )
+        self.assertFalse(run.progress[2].repeated_strategy)
+
+    def test_an_iterative_carver_is_never_suppressed(self) -> None:
+        """The case that matters most: one program, real progress every run.
+
+        A carver that extracts the next embedded object each time reuses one
+        program and writes on every run. It must keep going. An earlier version
+        of this classifier bounded how often one program could claim artifact
+        progress, and it halted this exact trajectory after two objects while
+        three more remained -- a confidently incomplete analysis, which is
+        worse than a slow one.
+        """
+        carver = (
+            "import pathlib\n"
+            "w = pathlib.Path('/workspace/work')\n"
+            "n = len(list(w.glob('obj*.bin')))\n"
+            "(w / f'obj{n}.bin').write_text('object-%d' % n)\n"
+            "print('carved object', n, end='')"
+        )
+        run = self.runtime(
+            ScriptedBackend(*[tool_response(carver)] * MAX_AUTONOMOUS_ACTIONS)
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT] * MAX_AUTONOMOUS_ACTIONS,
+        )
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+
+    def test_a_program_that_only_rewrites_random_bytes_is_still_bounded(self) -> None:
+        """The honest limit of the classifier, recorded rather than papered over.
+
+        A program rewriting random bytes into an artifact is indistinguishable
+        here from one carving the next stage: same program, writes every run,
+        and a new evidence hash each time because the observation names the
+        digest just written. No deterministic signal available to the ledger
+        separates them, so this case is not caught by classification at all --
+        it is ended by the action bound. That is a bounded, safe stop, and the
+        alternative was suppressing genuine unpacking.
+        """
+        code = (
+            "import random, pathlib\n"
+            "pathlib.Path('/workspace/work/a.bin').write_text(str(random.random()))\n"
+            "print('wrote', end='')"
+        )
+        run = self.runtime(ScriptedBackend(*[tool_response(code)] * 12)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+
+    def test_genuine_multi_stage_work_is_not_suppressed(self) -> None:
+        """Distinct programs building on each other must run to the bound.
+
+        This is the case autonomous analysis exists for, and it is what the
+        artifact credit must not break: each stage is a different program, so
+        none of them exhausts its own credit.
+        """
+        stages = [
+            tool_response(
+                "import pathlib\n"
+                f"pathlib.Path('/workspace/work/s{i}.bin').write_text('{i}')\n"
+                f"print('stage{i}', end='')"
+            )
+            for i in range(1, MAX_AUTONOMOUS_ACTIONS + 1)
+        ]
+        run = self.runtime(ScriptedBackend(*stages)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT] * MAX_AUTONOMOUS_ACTIONS,
+        )
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+
+    def test_the_fingerprint_covers_code_source_and_workspace(self) -> None:
+        """All three components are load-bearing, checked directly."""
+        from orbit.runtime.analysis_progress import ProgressLedger
+
+        ledger = ProgressLedger()
+
+        class R:
+            def __init__(self, code, src):
+                self.code_sha256 = code
+                self.input_sha256 = src
+
+        class S:
+            def __init__(self, code, src):
+                self.result = R(code, src)
+
+        base = ledger._strategy_fingerprint(S("c1", "s1"), None, "c1")
+        self.assertNotEqual(base, ledger._strategy_fingerprint(S("c2", "s1"), None, "c2"))
+        self.assertNotEqual(base, ledger._strategy_fingerprint(S("c1", "s2"), None, "c1"))
+        # Workspace state participates too.
+        ledger.artifacts["/workspace/work/a"] = "d1"
+        self.assertNotEqual(base, ledger._strategy_fingerprint(S("c1", "s1"), None, "c1"))
+
+    def test_the_fingerprint_does_not_inspect_code_or_output(self) -> None:
+        """It is three hashes of state, not an interpreter."""
+        import inspect
+
+        from orbit.runtime import analysis_progress
+
+        # Executable code only: the docstring says the method does not
+        # normalise, and a check that tripped on its own disclaimer would push
+        # that explanation out of the file.
+        import textwrap
+
+        source = _without_docstrings(
+            textwrap.dedent(
+                inspect.getsource(analysis_progress.ProgressLedger._strategy_fingerprint)
+            )
+        )
+        for banned in ("ast.", "re.", "normali", ".lower()", ".split(", ".strip()"):
+            self.assertNotIn(banned, source, f"{banned!r} suggests inspection")
+        self.assertIn("sha256", source)
+
+
+class BoundedReplanTests(AutonomousTestBase):
+    """Exactly one replan, and only on the first unproductive step."""
+
+    def _messages(self, backend) -> list[str]:
+        return [
+            m["content"]
+            for msgs in backend.seen_messages
+            for m in msgs[-1:]
+            if m["role"] == "user"
+        ]
+
+    def test_first_no_progress_inserts_exactly_one_replan(self) -> None:
+        same = emit("x")
+        backend = ScriptedBackend(
+            tool_response(same), tool_response(same),
+            tool_response(emit("new")), prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        sent = self._messages(backend)
+        self.assertEqual(sent.count(AUTONOMOUS_REPLAN_MESSAGE), 1)
+        self.assertEqual(run.replans, 1)
+        # It is sent after the unproductive step, not before.
+        self.assertEqual(sent.index(AUTONOMOUS_REPLAN_MESSAGE), 2)
+
+    def test_the_replan_message_is_model_visible(self) -> None:
+        same = emit("x")
+        backend = ScriptedBackend(
+            tool_response(same), tool_response(same),
+            tool_response(emit("new")), prose_response("done"),
+        )
+        self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        third_prompt = backend.seen_messages[2]
+        self.assertEqual(third_prompt[-1]["content"], AUTONOMOUS_REPLAN_MESSAGE)
+
+    def test_replan_followed_by_new_content_resumes_the_normal_loop(self) -> None:
+        same = emit("x")
+        backend = ScriptedBackend(
+            tool_response(same), tool_response(same),
+            tool_response(emit("new")), tool_response(emit("newer")),
+            prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NEW_CONTENT, NEW_CONTENT, COMPLETE],
+        )
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        # Only the one replan, even though the loop continued afterwards.
+        self.assertEqual(self._messages(backend).count(AUTONOMOUS_REPLAN_MESSAGE), 1)
+
+    def test_the_replan_is_once_per_episode_not_once_per_run(self) -> None:
+        """A recovered run that stalls again is told again.
+
+        `consecutive_no_progress` resets on progress, so an alternating
+        trajectory re-arms the replan: each stall is a new situation and gets
+        its own message. What is never repeated is asking twice about the SAME
+        stall -- a second consecutive unproductive step ends the run.
+
+        The earlier tests all used a single stall, so this property went
+        untested while the code comment claimed "exactly one is ever sent".
+        The total stays bounded: every replan follows a step that consumed an
+        action, so replans <= actions <= the hard ceiling.
+        """
+        script = []
+        for i in range(6):
+            script.append(tool_response(emit(f"v{i}")))
+            script.append(tool_response(emit(f"v{i}")))  # duplicate -> NO_PROGRESS
+        backend = ScriptedBackend(*script)
+
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        classifications = [r.classification for r in run.progress]
+        self.assertEqual(classifications, [NEW_CONTENT, NO_PROGRESS] * (len(classifications) // 2))
+        stalls = classifications.count(NO_PROGRESS)
+        # Every stall was a fresh one -- none followed another -- so each got
+        # its own replan. This is the property; the exact count depends on
+        # where the action budget cuts the trajectory off.
+        self.assertGreater(run.replans, 1, "each fresh stall earns its own replan")
+        self.assertEqual(run.replans, stalls)
+        self.assertLessEqual(
+            run.replans, run.actions_executed, "replans cannot outnumber actions"
+        )
+        sent = [
+            m["content"]
+            for msgs in backend.seen_messages
+            for m in msgs[-1:]
+            if m["role"] == "user"
+        ]
+        # One fewer message than armings: the last stall arms a replan the run
+        # never gets to send, because the action budget ends it first. The
+        # counter records intent, the transcript records what the model saw.
+        self.assertEqual(sent.count(AUTONOMOUS_REPLAN_MESSAGE), run.replans - 1)
+        self.assertTrue(
+            all(a == AUTONOMOUS_CONTINUATION_MESSAGE or a == AUTONOMOUS_REPLAN_MESSAGE
+                for a in sent[1:]),
+            "the runtime sends only its two generic messages",
+        )
+
+    def test_the_same_stall_is_never_replanned_twice(self) -> None:
+        """Two consecutive unproductive steps end the run after one replan."""
+        same = emit("x")
+        backend = ScriptedBackend(*[tool_response(same)] * 6)
+
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.replans, 1)
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS))
+
+    def test_second_consecutive_no_progress_stops(self) -> None:
+        same = emit("x")
+        backend = ScriptedBackend(*[tool_response(same)] * 6)
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS))
+        self.assertEqual(run.replans, 1, "no second replan")
+        self.assertEqual(self._messages(backend).count(AUTONOMOUS_REPLAN_MESSAGE), 1)
+
+    def test_the_continuation_message_asks_for_one_new_useful_step(self) -> None:
+        """Generic: it names no artifact, technique or direction."""
+        text = AUTONOMOUS_CONTINUATION_MESSAGE.lower()
+        self.assertIn("new", text)
+        self.assertIn("do not repeat", text)
+        for domain in ("xor", "powershell", "url", "base64", "decode", "malware", "ioc"):
+            self.assertNotIn(domain, text)
+            self.assertNotIn(domain, AUTONOMOUS_REPLAN_MESSAGE.lower())
+
+    def test_the_continuation_message_is_model_visible(self) -> None:
+        backend = ScriptedBackend(tool_response(emit("a")), prose_response("done"))
+        self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            backend.seen_messages[1][-1]["content"], AUTONOMOUS_CONTINUATION_MESSAGE
+        )
+
+
+class GroundedFinalizationTests(AutonomousTestBase):
+    """Every ending that is not a cancellation produces one grounded answer."""
+
+    def _run(self, *responses, **kw):
+        backend = ScriptedBackend(*responses)
+        run = self.runtime(backend).run_autonomous("inspect it", **kw)
+        return run, backend
+
+    def test_natural_completion_produces_a_grounded_report(self) -> None:
+        run, backend = self._run(
+            tool_response(emit("a")), prose_response("done"), prose_response("REPORT")
+        )
+
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(run.final_report.text, "REPORT")
+
+    def test_a_protective_stop_produces_a_grounded_report(self) -> None:
+        same = emit("x")
+        run, backend = self._run(
+            tool_response(same), tool_response(same), tool_response(same),
+            prose_response("REPORT"),
+        )
+
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS))
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(run.final_report.text, "REPORT")
+
+    def test_the_report_is_told_the_run_stopped_early(self) -> None:
+        """A reader must not mistake a bounded stop for a finished analysis."""
+        same = emit("x")
+        run, backend = self._run(
+            tool_response(same), tool_response(same), tool_response(same),
+            prose_response("REPORT"),
+        )
+
+        final_prompt = backend.seen_messages[-1]
+        text = " ".join(str(m.get("content", "")) for m in final_prompt)
+        self.assertIn("stopped before the model chose to finish", text)
+        self.assertIn(STOP_NO_PROGRESS, text)
+
+    def test_a_natural_ending_is_not_labelled_as_stopped_early(self) -> None:
+        run, backend = self._run(
+            tool_response(emit("a")), prose_response("done"), prose_response("REPORT")
+        )
+
+        final_prompt = backend.seen_messages[-1]
+        text = " ".join(str(m.get("content", "")) for m in final_prompt)
+        self.assertNotIn("stopped before the model chose to finish", text)
+
+    def test_finalization_is_offered_no_tools(self) -> None:
+        run, backend = self._run(
+            tool_response(emit("a")), prose_response("done"), prose_response("REPORT")
+        )
+
+        # The analysis steps carry the tool; the closing report carries none.
+        self.assertEqual(backend.seen_tools[0], [ANALYSIS_TOOL_NAME])
+        self.assertEqual(backend.seen_tools[-1], [])
+
+    def test_finalization_cannot_restart_the_analysis(self) -> None:
+        """A tool call in the closing report must execute nothing."""
+        run, backend = self._run(
+            tool_response(emit("a")),
+            prose_response("done"),
+            tool_response(emit("should never run"), text="REPORT"),
+        )
+
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(len(run.steps), 2, "the report is not a step")
+        # Exactly one closing call: no loop back into stepping.
+        self.assertEqual(backend.calls, 3)
+
+    def test_finalization_appends_nothing_to_history(self) -> None:
+        backend = ScriptedBackend(
+            tool_response(emit("a")), prose_response("done"), prose_response("REPORT")
+        )
+        runtime = self.runtime(backend)
+        runtime.run_autonomous("inspect it")
+
+        self.assertNotIn("REPORT", [m.get("content") for m in runtime.messages])
+        self.assertEqual(runtime.messages[-1]["role"], "assistant")
+
+    def test_cancellation_does_not_finalise(self) -> None:
+        """The analyst asked it to stop; another model call is not stopping."""
+
+        class CancelStepsOnly(ScriptedBackend):
+            """Interrupts the loop, but would happily serve a report.
+
+            A backend that raised on every call could not tell a run that
+            skipped finalization from one that attempted it and was itself
+            interrupted -- both end with no report. This one answers a
+            no-tools call normally, so an unwanted finalization is visible.
+            """
+
+            def chat_stream(self, messages, *, tools=None, **kwargs):
+                if tools != [] and self.calls >= 1:
+                    raise KeyboardInterrupt
+                return super().chat_stream(messages, tools=tools, **kwargs)
+
+        backend = CancelStepsOnly(tool_response(emit("a")), prose_response("REPORT"))
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertTrue(run.cancelled)
+        self.assertIsNone(run.final_report)
+        # No closing call was spent: the analyst asked for the run to stop.
+        # Asserted on the tool surface too, because a finalization attempt that
+        # was itself interrupted would also leave `final_report` None -- only
+        # the absence of a no-tools call proves none was attempted.
+        self.assertEqual(backend.calls, 1)
+        self.assertNotIn([], backend.seen_tools)
+
+    def test_a_backend_failure_during_finalization_keeps_the_run(self) -> None:
+        from orbit.backend.llama_server import LlamaServerError
+
+        class FailAtReport(ScriptedBackend):
+            def chat_stream(self, messages, *, tools=None, **kwargs):
+                if tools == []:
+                    raise LlamaServerError("died at report")
+                return super().chat_stream(messages, tools=tools, **kwargs)
+
+        backend = FailAtReport(tool_response(emit("a")), prose_response("done"))
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        self.assertIsNone(run.final_report)
+        self.assertEqual(run.actions_executed, 1)
+        self.assertTrue(
+            self.store.reattest_exact(run.steps[0].evidence.evidence_id)
+        )
+
+    def test_cancelling_the_closing_report_does_not_destroy_the_run(self) -> None:
+        """Ctrl-C during the report is the likeliest interrupt of all.
+
+        It is the longest single generation in a run, and by then the analyst
+        has already read every step. If it escaped `run_autonomous` the caller
+        would unwind to a pre-run checkpoint and rewind past every completed
+        step, leaving their evidence durable on disk with nothing referring to
+        it.
+        """
+        class CancelAtReport(ScriptedBackend):
+            def chat_stream(self, messages, *, tools=None, **kwargs):
+                if tools == []:
+                    raise KeyboardInterrupt
+                return super().chat_stream(messages, tools=tools, **kwargs)
+
+        backend = CancelAtReport(
+            tool_response(emit("one")), tool_response(emit("two")), prose_response("done")
+        )
+        runtime = self.runtime(backend)
+
+        run = runtime.run_autonomous("inspect it")  # must not raise
+
+        self.assertIsNone(run.final_report)
+        self.assertEqual(run.actions_executed, 2)
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        self.assertGreater(len(runtime.messages), 2)
+        for step in run.steps:
+            if step.evidence is not None:
+                self.assertTrue(self.store.reattest_exact(step.evidence.evidence_id))
+
+    def test_a_run_with_no_steps_produces_no_report(self) -> None:
+        class Dead(ScriptedBackend):
+            def chat_stream(self, messages, **kwargs):
+                raise KeyboardInterrupt
+
+        run = self.runtime(Dead()).run_autonomous("inspect it")
+        self.assertIsNone(run.final_report)
+
+
+# --- soft action budget with a hard ceiling ---------------------------------
+
+
+class SoftActionBudgetTests(AutonomousTestBase):
+    """Past the budget, continuing must be earned by verifiable progress.
+
+    8 was a budget inherited from the research harness, not a boundary: a
+    measured full-sample run ended on it with all eight steps still producing
+    new evidence and the report naming the next deterministic step. A budget
+    that cuts off work is a different thing from a policy that declines it, so
+    the budget now yields to demonstrated progress -- and only to that.
+    """
+
+    def _productive(self, n: int) -> list:
+        return [tool_response(emit(f"v{i}")) for i in range(n)]
+
+    def test_new_content_at_the_soft_limit_may_continue(self) -> None:
+        run = self.runtime(
+            ScriptedBackend(
+                *self._productive(SOFT_MAX_AUTONOMOUS_ACTIONS + 2),
+                prose_response("done"),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertGreater(run.actions_executed, SOFT_MAX_AUTONOMOUS_ACTIONS)
+        self.assertNotEqual(run.stop_reason, STOP_SOFT_MAX_ACTIONS)
+
+    def test_no_progress_at_the_soft_limit_stops(self) -> None:
+        same = emit("repeat")
+        run = self.runtime(
+            ScriptedBackend(
+                *self._productive(SOFT_MAX_AUTONOMOUS_ACTIONS),
+                tool_response(same),
+                tool_response(same),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.stop_reason, STOP_SOFT_MAX_ACTIONS)
+        self.assertEqual(run.progress[-1].classification, NO_PROGRESS)
+        self.assertLess(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+
+    def test_an_error_at_the_soft_limit_stops_the_run(self) -> None:
+        """At the budget an error is a non-productive step, so the run ends.
+
+        Below the budget one error is tolerated and only a second consecutive
+        one stops the run. At or past it, continuing must be earned, and a
+        refused action has earned nothing -- so the soft gate ends the run
+        before the error counter can reach two. The error policy itself is
+        unchanged; it is simply not the bound that fires first here.
+        """
+        run = self.runtime(
+            ScriptedBackend(
+                *self._productive(SOFT_MAX_AUTONOMOUS_ACTIONS),
+                tool_response(emit("x"), count=2),
+                tool_response(emit("x"), count=2),
+                prose_response("unreached"),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.stop_reason, STOP_SOFT_MAX_ACTIONS)
+        self.assertEqual(run.progress[-1].classification, ERROR)
+        self.assertEqual(run.actions_executed, SOFT_MAX_AUTONOMOUS_ACTIONS)
+
+    def test_a_single_error_below_the_budget_is_still_tolerated(self) -> None:
+        """The unchanged error policy, exercised where the budget is not in play."""
+        run = self.runtime(
+            ScriptedBackend(
+                tool_response(emit("a")),
+                tool_response(emit("x"), count=2),
+                tool_response(emit("b")),
+                prose_response("done"),
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, ERROR, NEW_CONTENT, COMPLETE],
+        )
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+
+    def test_actions_beyond_the_soft_limit_keep_running_while_productive(self) -> None:
+        run = self.runtime(
+            ScriptedBackend(*self._productive(MAX_AUTONOMOUS_ACTIONS - 1), prose_response("done"))
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS - 1)
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+
+    def test_the_hard_ceiling_stops_even_while_still_productive(self) -> None:
+        """The ceiling is not conditional. Progress does not extend it."""
+        run = self.runtime(
+            ScriptedBackend(*self._productive(MAX_AUTONOMOUS_ACTIONS + 4))
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertEqual(
+            [r.classification for r in run.progress], [NEW_CONTENT] * MAX_AUTONOMOUS_ACTIONS
+        )
+
+    def test_the_ceiling_is_exact_not_off_by_one(self) -> None:
+        run = self.runtime(
+            ScriptedBackend(*self._productive(MAX_AUTONOMOUS_ACTIONS + 4))
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.actions_executed, 12)
+        self.assertNotEqual(run.actions_executed, 11)
+        self.assertNotEqual(run.actions_executed, 13)
+
+    def test_natural_completion_before_the_ceiling_stops_normally(self) -> None:
+        run = self.runtime(
+            ScriptedBackend(*self._productive(3), prose_response("done"))
+        ).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.stop_reason, STOP_COMPLETE)
+        self.assertEqual(run.actions_executed, 3)
+
+    def test_the_hard_ceiling_is_reachable_despite_tolerated_failures(self) -> None:
+        """The call ceiling must not truncate a trajectory the policy allows.
+
+        The error policy tolerates one failure between productive steps --
+        progress resets the counter -- so a run can legitimately interleave
+        them. An earlier ceiling of `actions + 1` made the hard action ceiling
+        unreachable for any run containing even one mis-formed call: it stopped
+        at 7 actions on `model call bound reached`, below the soft budget, and
+        the ceiling's own test was then only exercised by flawless runs.
+        """
+        script = []
+        for i in range(MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS):
+            script.append(tool_response(emit(f"p{i}")))
+            script.append(tool_response(emit("bad"), count=2))
+        script += [
+            tool_response(emit(f"q{i}"))
+            for i in range(MAX_AUTONOMOUS_ACTIONS - MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS)
+        ]
+        script.append(prose_response("unreached"))
+
+        run = self.runtime(ScriptedBackend(*script)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+        self.assertNotEqual(run.stop_reason, STOP_MAX_MODEL_CALLS)
+
+    def test_the_nonproductive_allowance_is_explicit(self) -> None:
+        """The only chosen term in the budget is named, not folded into a number."""
+        self.assertEqual(MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS, 2)
+        self.assertEqual(
+            MAX_AUTONOMOUS_MODEL_CALLS,
+            MAX_AUTONOMOUS_ACTIONS + 1 + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS,
+        )
+
+    def test_the_budget_relation_is_derived_not_guessed(self) -> None:
+        """The call ceiling must not be able to truncate the action policy.
+
+        Every loop iteration spends exactly one model call, so a ceiling below
+        hard actions + one closing prose call could end a run for want of
+        budget while the action policy still allowed it -- making the hard
+        ceiling unreachable and its test vacuous.
+        """
+        self.assertEqual(SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertGreater(MAX_AUTONOMOUS_ACTIONS, SOFT_MAX_AUTONOMOUS_ACTIONS)
+        self.assertGreaterEqual(
+            MAX_AUTONOMOUS_MODEL_CALLS,
+            MAX_AUTONOMOUS_ACTIONS + 1 + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS,
+        )
+
+    def test_the_call_ceiling_cannot_cut_the_hard_action_policy_short(self) -> None:
+        """Driven, not asserted: 12 actions then prose must fit the budget."""
+        run = self.runtime(
+            ScriptedBackend(
+                *self._productive(MAX_AUTONOMOUS_ACTIONS), prose_response("done")
+            )
+        ).run_autonomous("inspect it", finalize=False)
+
+        # The action ceiling is what stops it, not the call ceiling.
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertLessEqual(run.model_calls, MAX_AUTONOMOUS_MODEL_CALLS)
+
+    def test_replan_semantics_are_unchanged_by_the_budget(self) -> None:
+        same = emit("x")
+        backend = ScriptedBackend(
+            tool_response(same), tool_response(same),
+            tool_response(emit("new")), prose_response("done"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it", finalize=False)
+
+        self.assertEqual(run.replans, 1)
+        self.assertEqual(
+            [r.classification for r in run.progress],
+            [NEW_CONTENT, NO_PROGRESS, NEW_CONTENT, COMPLETE],
+        )
+
+    def test_consecutive_limits_are_unchanged_below_the_budget(self) -> None:
+        same = emit("x")
+        run = self.runtime(ScriptedBackend(*[tool_response(same)] * 6)).run_autonomous(
+            "inspect it", finalize=False
+        )
+
+        self.assertTrue(run.stop_reason.startswith(STOP_NO_PROGRESS))
+        self.assertEqual(run.actions_executed, 3)
+
+    def test_the_report_runs_exactly_once_after_a_soft_budget_stop(self) -> None:
+        same = emit("repeat")
+        backend = ScriptedBackend(
+            *self._productive(SOFT_MAX_AUTONOMOUS_ACTIONS),
+            tool_response(same), tool_response(same),
+            prose_response("REPORT"),
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(run.stop_reason, STOP_SOFT_MAX_ACTIONS)
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(run.final_report.text, "REPORT")
+        self.assertEqual(backend.seen_tools.count([]), 1)
+
+    def test_the_report_runs_exactly_once_after_the_hard_ceiling(self) -> None:
+        backend = ScriptedBackend(
+            *self._productive(MAX_AUTONOMOUS_ACTIONS), prose_response("REPORT")
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(run.stop_reason, STOP_MAX_ACTIONS)
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(backend.seen_tools.count([]), 1)
+
+    def test_the_report_is_not_counted_as_an_action(self) -> None:
+        backend = ScriptedBackend(
+            *self._productive(3), prose_response("done"), prose_response("REPORT")
+        )
+        run = self.runtime(backend).run_autonomous("inspect it")
+
+        self.assertEqual(run.actions_executed, 3)
+        self.assertEqual(len(run.steps), 4, "the report is not a step")


### PR DESCRIPTION
Makes autonomous ANALYSIS progress reliably to a grounded conclusion instead of
re-deriving what it already knew, and stops treating an inherited action count
as a correctness boundary.

## What this changes

- **Autonomous ANALYSIS remains opt-in and default OFF** (`ORBIT_ANALYSIS_AUTONOMOUS`).
  Unchanged in this PR.
- **The model still chooses every analysis step.** Orbit owns only evidence,
  progress, bounds, cancellation and orchestration.
- **No malware-specific planner or heuristics.** No XOR/PowerShell/IoC/URL
  knowledge anywhere; progress is hash arithmetic over attested state.
- **Strategy repetition is detected generically** — a fingerprint of (code sha,
  source identity, pre-action workspace state). Re-running one experiment is not
  discovery, however its stdout varies.
- **One bounded generic replan per stall.** The first unproductive step of a
  streak gets a replan; a second *consecutive* one ends the run. A run that
  recovers and stalls again is told again, because that is a different stall,
  so a run can send more than one over its life. The total is bounded by the
  action ceiling: every replan follows a step that consumed an action.
- **Soft action budget of 8 may extend while genuine NEW_CONTENT continues.**
- **Hard ceiling remains 12 actions**, unconditional.
- **Model-call ceiling is 15**: 12 actions, plus one for a run that finishes
  early with prose, plus a named allowance of 2 non-productive calls. Only the
  12 is forced by the control flow; 14 would also suffice, and 15 keeps a call
  of margin. The previous value of 13 was genuinely unsafe — it made the hard
  ceiling unreachable for any run containing two mis-formed calls.
- **Prose / no action gives natural COMPLETE.**
- **Protective stops produce one grounded report**, and it says the run stopped
  early.
- **Cancellation remains immediate** — no closing report is spent.
- **CHAT, routing, sandbox, EvidenceStore, KV/prewarm, backend inference and the
  model prompts are unchanged.** `ANALYSIS_SYSTEM_PROMPT` and
  `ANALYSIS_TOOL_SCHEMA` are byte-identical to the baseline, so prewarm identity
  is preserved.

## Why 8 moved

8 came from a research harness whose sibling variant ran at 6, and whose own
tests asserted only the *relation* between the action and call counts — never
that 8 was a correctness boundary. A measured full-sample run then ended on it
with all eight steps still classified NEW_CONTENT and the report naming the next
deterministic step: a budget cutting off work, not a policy declining it.

Past the budget, continuing must now be earned. Stagnation, a repeated strategy
or a refused action stops the run exactly as before.

## Real full-sample evidence

One run, production Orbit + verified Ornith, exact prompt, no manual `continue`,
no steering, no retries, no tuning, no oracle visible to the model, no network,
sample sha256 unchanged.

- **11 actions**, **11 NEW_CONTENT**, **natural COMPLETE** (hard ceiling not reached)
- soft budget crossed while still producing new evidence
- **10/10 reference findings** recovered: the full `WScript.Sleep` → XOR decoder →
  WMI `Win32_Process` → `Win32_ProcessStartup` `ShowWindow = 0` → hidden
  PowerShell → inner XOR key 34 chain
- **exact C2 URL and GUID** recovered, character-identical to the preserved
  reference
- **zero hallucinations** — one URL, one GUID, both real; no IPs; every sha256
  and every cited evidence id real
- **all 11 evidence records re-attest**
- **~53.7 min wall**
- **95,799 tokens reused / 24,943 evaluated**; late-run rolling reuse **~96%**

Actions 9–11 — the ones the old budget refused — are where the model decoded the
inner stage and reached the URL.

**These figures describe one run on one sample with this hardware and profile.
They are not a general performance claim.**

## Qualification

- **96 autonomous tests PASS**
- **focused 818 PASS**
- **full suite passes identically with the gate OFF and ON** — 2939 collected:
  **2932 passed, 7 skipped** in both modes (the 7 skip for missing environment).
  Baseline was 2887 passed + 7 skipped, so the new tests account for the
  difference exactly and nothing regressed.
- **12/12 mutations CAUGHT** (plus 2 further budget-regression mutants)
- **Independent review PASS** — BLOCKER 0 / MAJOR 0 / MINOR 0
- compileall and `git diff --check` clean

Nine deterministic trajectories recorded at zero inference, covering the soft
limit in all three states, the hard ceiling, natural completion, replan, ceiling
reachability under tolerated failures, and the report on both stop kinds.

## Known residual

The strategy fingerprint cannot distinguish a program carving the next stage
from one rewriting an artifact in place — the observation names the digest just
written, so both look novel for the same structural reason. Every rule strong
enough to stop the second was measured to halt the first mid-unpack, so that
case is left to the action ceiling. Documented in code and pinned by a test that
asserts the honest stop reason.

