### PR TITLE
docs(release): prepare v0.0.1-rc35

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -725,6 +725,18 @@ This file guides engineering agents and future sessions working on Orbit. It pre
   restore entirely, eager and lazy alike. The two switches answer different
   questions -- whether the prefix may be reused at all, and who pays to capture
   it -- so asking for the eager capture cannot override the kill switch.
+- `ORBIT_ANALYSIS_AUTONOMOUS=1` lets an analysis continue by itself while each
+  step produces verifiably new evidence, instead of returning to the analyst
+  after every step. It stops on natural completion, on stalled progress, on
+  repeated failure, or at a hard bound of 12 actions, and every ending except a
+  cancellation produces one grounded report. Off by default, and fail-closed:
+  any value other than `1` reads as off.
+
+  It is opt-in for cost, not for correctness. A step that measures something
+  new is counted as progress whether or not the measurement was worth making, so
+  an artifact with almost nothing to derive can still attract many actions.
+  Whether that trade is worthwhile is an operator judgement rather than a
+  default.
 
 ## Atomic Text Artifact Generation
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,62 @@ Linux is the main target environment. macOS may work. Windows is not a target.
 | [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
 | [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
 | [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
+| [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) | — | — | — | — | — |
 
 NUC10 Intel Core i7-10710U (6 cores / 12 threads) with 64 GB RAM, no GPU
 Linux, llama.cpp b9551, ctx=8192, 6 threads, batch/ubatch 256/128, Flash Attention AUTO, thinking off, and MTP off.
 
+Ornith 1.5 35B-A3B is the verified profile the analysis workflow was qualified on. Its row is empty
+because it has not been measured under the warm steady-state chat protocol used for the other rows.
+Expect memory in the same range as the other 35B-A3B profile.
+
 Chat and tool latencies are warm steady-state medians after one excluded warm-up. Prefill measures evaluated tokens only and excludes cache benefit. These are not universal performance claims; actual results vary with CPU, memory bandwidth, quantization, backend build, and workload.
 
 `orbit server --low-memory` is an opt-in mode supported only for the verified Qwen3-Coder 30B-A3B profile. Default behavior is unchanged and CPU repacking remains enabled unless this flag is specified. On the documented NUC10, peak RSS was approximately 31.3 GiB by default and 18.3 GiB in low-memory mode, a 41.6% reduction, with weighted prefill approximately 13.9% slower and decode approximately 1% slower. 24 GB RAM is the recommended practical minimum for a complete host; 20 GiB was qualified only as a process-memory limit and is not a general host recommendation.
+
+## Chat and Analysis
+
+Orbit has two workflows. Chat is the default and is unchanged: you ask, the model
+answers, and it may use the exposed tools.
+
+Analysis is for inspecting one local artifact in an isolated workspace. Start it
+explicitly, or let Orbit route to it when a request is clearly about analysing a
+file:
+
+```
+/analysis path/to/artifact
+/report            # answer from the evidence already collected, running nothing
+/chat              # back to normal chat
+```
+
+An analysis step is deliberately narrow. The model writes a short Python program,
+Orbit runs it in a sandbox with no network and a read-only copy of the artifact,
+and the output is recorded in an evidence store with its provenance. One model
+call performs at most one action, and control returns to you after each step, so
+you steer by typing the next instruction — `continue` included.
+
+Everything the model derives stays inside the session workspace. Full outputs
+remain re-attestable in the evidence store; only bounded excerpts are shown to
+the model.
+
+### Autonomous continuation (opt-in)
+
+By default an analysis advances one step at a time and waits for you. With
+
+```bash
+ORBIT_ANALYSIS_AUTONOMOUS=1 orbit
+```
+
+Orbit continues by itself while each step produces verifiably new evidence,
+stopping when the model finishes, when progress stalls, or at a hard bound of 12
+actions. Every ending except a cancellation produces one grounded report from the
+evidence collected.
+
+This mode is off by default. It is opt-in for cost rather than for
+correctness: a step that measures something new counts as progress whether or
+not the measurement was worth making, so an artifact with little to derive can
+still attract many actions. Whether that trade is worthwhile is a judgement for
+the operator. Ctrl-C stops a run immediately.
 
 ## Requirements
 
@@ -53,6 +102,20 @@ Inspect the host and review the recommended server configuration:
 ```bash
 scripts/suggest-server-profile.sh
 ```
+
+## Limitations
+
+- Linux x86_64 CPU-only is the qualified platform. macOS may work; Windows is not
+  a target. There is no GPU path.
+- Analysis runs one artifact per session, and the sandbox has no network.
+- Autonomous continuation is opt-in and may perform unnecessary work on trivial
+  artifacts (see above).
+- Eager capture of the analysis prefix at startup is opt-in
+  (`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1`); by default the prefix is captured
+  lazily by the first analysis step, which costs that step and benefits every
+  later one.
+- Analysis features are qualified on the verified Ornith 1.5 profile. Other
+  verified profiles fall back to ordinary cold behaviour rather than failing.
 
 ## Quick Start
 

--- a/docs/releases/v0.0.1-rc35.md
+++ b/docs/releases/v0.0.1-rc35.md
@@ -1,0 +1,58 @@
+# v0.0.1-rc35
+
+An analysis workflow: sandboxed execution, attested evidence, and an opt-in
+bounded autonomous mode, with KV reuse extended to both chat and analysis.
+
+Qualified production code: `d29490a1b208854627c45da352b26a03815dc374`
+
+## Highlights
+
+- Add explicit CHAT and ANALYSIS workflow modes, and route to analysis
+  automatically when a request is clearly about inspecting a local artifact.
+  Chat behaviour is unchanged.
+- Analyse one artifact per session inside an isolated sandbox: no network, a
+  read-only copy of the input, and bounded scratch space. The model writes the
+  program; the runtime enforces the boundaries.
+- Record every executed action in an evidence store with its provenance, so a
+  finding can be re-attested byte-exactly afterwards. Only bounded excerpts of
+  an observation ever reach the model.
+- Keep the analyst in control: one model call performs at most one action, and
+  control returns after every step. Steering is just the next instruction.
+- Answer from collected evidence with `/report`, which runs no analysis action
+  and is offered no tools.
+- Add bounded autonomous continuation, off by default. With
+  `ORBIT_ANALYSIS_AUTONOMOUS=1` Orbit takes the next step itself while each one
+  produces verifiably new evidence, stopping on natural completion, on stalled
+  progress, or at a hard bound of 12 actions. Repetition is detected from the
+  experiment rather than its output, so a program whose only novelty is a
+  timestamp or a random value does not count as discovery.
+- Produce one grounded report at the end of every autonomous run except a
+  cancellation, and say so when a bound rather than the model ended the run.
+- Reuse rolling KV across turns for both chat and analysis, so a continued
+  session prefills only its new suffix.
+- Capture exact-prefix anchors for both the chat route prompt and the analysis
+  contract, restoring them instead of re-evaluating. Analysis prefix capture is
+  lazy by default; capturing it eagerly at startup is opt-in.
+- Recover from malformed tool calls without corrupting history: a call that
+  cannot be parsed is reported to the analyst as prose and never committed.
+- Confine model-chosen artifact acquisition to the session workspace.
+- Sanitize model-authored output at the terminal boundary, and remove duplicate
+  analysis prose, dead prompt queueing and unused delta retention.
+
+## Known limitations
+
+- Autonomous ANALYSIS is qualified for correctness but may perform unnecessary
+  work on trivial artifacts, and therefore remains opt-in. Its qualification
+  runs were single-sample and are not a general efficiency claim: a step that
+  measures something new counts as progress whether or not the measurement was
+  worth making, so an artifact with little to derive can still attract many
+  actions.
+- Eager ANALYSIS prewarm is opt-in
+  (`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1`). It costs startup time and resident
+  memory, which a server that never analyses would pay for nothing.
+- Exact-prefix reuse is per profile, and a profile that does not support a given
+  prefix path falls back to ordinary cold behaviour rather than failing. The
+  analysis prefix is captured only for the verified Ornith 1.5 profile; every
+  other profile analyses normally without it.
+- The current primary qualified platform remains Linux x86_64, CPU-only. The
+  analysis workflow is qualified on the verified Ornith 1.5 35B-A3B profile.

--- a/src/orbit/terminal/command_registry.py
+++ b/src/orbit/terminal/command_registry.py
@@ -55,19 +55,19 @@ COMMANDS = (
     ),
     CommandSpec(
         "/analysis",
-        "Session",
+        "Analysis",
         "/analysis <path>",
         "Analyse one local artifact in an isolated workspace.",
         "analysis",
     ),
     CommandSpec(
         "/report",
-        "Session",
+        "Analysis",
         "/report [question]",
         "Report on the evidence already collected, running no analysis action.",
         "report",
     ),
-    CommandSpec("/chat", "Session", "/chat", "Return to normal chat mode.", "chat"),
+    CommandSpec("/chat", "Analysis", "/chat", "Return to normal chat mode.", "chat"),
     CommandSpec("/help", "Help", "/help", "Show command help.", "help"),
 )
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,6 +22,30 @@ class CommandTests(unittest.TestCase):
         self.assertNotIn("Compact conversation memory or old tool results.", help_text())
         self.assertIn("/max-tokens [n]", help_text())
         self.assertIn("/continue", help_text())
+
+    def test_each_help_category_appears_once(self) -> None:
+        """A category split across the registry renders its heading twice.
+
+        `help_text` emits a heading whenever the category changes while walking
+        COMMANDS in order, so two blocks sharing a name but separated by another
+        category produce it twice. That is how the analysis commands first
+        shipped: declared as "Session" but placed after "Runtime".
+        """
+        from collections import Counter
+
+        headings = [
+            line for line in help_text().splitlines()
+            if line and not line.startswith("/")
+        ]
+        repeated = [name for name, count in Counter(headings).items() if count > 1]
+        self.assertEqual(repeated, [], f"category rendered more than once: {repeated}")
+
+    def test_the_analysis_commands_are_grouped_together(self) -> None:
+        text = help_text()
+        self.assertIn("Analysis", text)
+        analysis_block = text[text.index("Analysis"):]
+        for command in ("/analysis <path>", "/report [question]", "/chat"):
+            self.assertIn(command, analysis_block)
         self.assertIn("/sessions clear", help_text())
         self.assertIn("/think [off|on]", help_text())
         self.assertIn("/status [ctx]", help_text())


### PR DESCRIPTION
Release preparation for **v0.0.1-rc35** from qualified production code
`d29490a1b208854627c45da352b26a03815dc374`.

## What this contains

- **README**: a "Chat and Analysis" section and a "Limitations" section. The
  analysis workflow shipped across the last 25 commits with no operator-facing
  documentation, and `ORBIT_ANALYSIS_AUTONOMOUS` was reachable but written down
  nowhere.
- **README**: Ornith 1.5 35B-A3B added to Supported Models. It is the profile
  every analysis feature was qualified on. Its row is left empty rather than
  estimated — it has not been measured under the warm steady-state protocol the
  other rows use.
- **AGENTS.md**: `ORBIT_ANALYSIS_AUTONOMOUS` documented alongside the two
  existing analysis-prefix switches.
- **`docs/releases/v0.0.1-rc35.md`**: release notes.
- **`command_registry.py`**: the analysis commands moved to their own "Analysis"
  category. They were declared as `"Session"` but placed after the Runtime
  block, and `help_text` emits a heading whenever the category changes while
  walking the registry in order, so `/help` printed **"Session" twice**.
  Presentation only — `resolve_command` dispatches on the command name and
  nothing reads `category` outside `help_text`.
- **`tests/test_commands.py`**: two regression tests (heading uniqueness,
  analysis grouping). Verified to fail against the pre-fix state.

## Qualification

Full suite **2943 collected — 2936 passed, 7 skipped** (the 7 skip for missing
environment). Autonomous ANALYSIS suites pass with the gate **OFF and ON**.
compileall and `git diff --check` clean. No runtime behaviour changed.

Production defaults verified by execution against a bare environment:
`ORBIT_ANALYSIS_AUTONOMOUS` OFF (fail-closed; only `1` enables), eager analysis
prewarm opt-in, lazy analysis prefix reuse on, no environment variable required
for normal use.

## Review corrections

An independent release review returned 0 BLOCKER / 2 MAJOR / 1 MINOR, all
documentation-only and all fixed here before this PR was opened:

- A limitation bullet described the Gemma prefix behaviour **backwards** —
  `gemma_prefix_reuse_supported=True` only for Gemma 4, so it is the one profile
  that *does* take that path — and cited a `SAFE_COLD_FALLBACK` audit term that
  exists nowhere in the repository. Replaced with an accurate, per-profile
  statement.
- A "five-artifact matrix" qualification claim appeared in the notes, README and
  AGENTS.md. The matrix was run, but its evidence lives outside the repository,
  so a reader could not verify it. Replaced with the causal reason autonomous
  mode can be expensive, which is verifiable from the code.
- The Ornith memory figure was unsourced and slightly wrong. Removed.
