### PR TITLE
fix(runtime): supersede stale analysis evidence

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -55,6 +55,7 @@ from orbit.runtime.analysis_sandbox import (
     scratch_baseline,
 )
 from orbit.runtime.evidence import EvidenceRecord, EvidenceStore, final_card
+from orbit.runtime.evidence_authority import active_records, evaluate_standing
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
 
@@ -1315,13 +1316,42 @@ class AnalysisRuntime:
         )
 
     def _reportable_records(self) -> list[EvidenceRecord]:
-        """The action evidence a report may cite, oldest first and bounded."""
+        """The action evidence a report may cite, oldest first and bounded.
+
+        Superseded versions are dropped before the bound is applied, not after.
+        An analysis that rewrote an artifact leaves both versions in the store,
+        and handing the finalizer a value beside its own correction lets it
+        quote either -- which is how a stale value once reached a report that
+        had the corrected one in front of it. Dropping first also means the
+        bound spends its places on current evidence rather than on history.
+
+        Nothing is deleted: the store keeps every version, and a superseded
+        record stays re-attestable for audit. This decides what may be cited as
+        authoritative, not what exists.
+        """
         records = [
             record
             for record in self.evidence_store.records.values()
             if record.tool_name == ANALYSIS_TOOL_NAME
         ]
-        return records[-MAX_REPORT_EVIDENCE_RECORDS:]
+        return active_records(records)[-MAX_REPORT_EVIDENCE_RECORDS:]
+
+    def superseded_records(self) -> list[EvidenceRecord]:
+        """Versions a report may not cite as current. Retained, not deleted."""
+        records = [
+            record
+            for record in self.evidence_store.records.values()
+            if record.tool_name == ANALYSIS_TOOL_NAME
+        ]
+        standing = evaluate_standing(records)
+        # Same tolerance `active_records` applies: a record the evaluator
+        # skipped has no entry, and the two views must agree about that or a
+        # record one accepts becomes a KeyError in the other.
+        return [
+            r
+            for r in records
+            if r.evidence_id in standing and not standing[r.evidence_id].is_active
+        ]
 
     def _evidence_card(self, record: EvidenceRecord) -> str:
         """One record as the report sees it: header plus the observation.

--- a/src/orbit/runtime/evidence_authority.py
+++ b/src/orbit/runtime/evidence_authority.py
@@ -1,0 +1,164 @@
+"""Which evidence a grounded report may treat as authoritative.
+
+An analysis that corrects itself leaves both versions in the store: the record
+that wrote an artifact and the record that rewrote it. That is the right thing
+for an append-only, re-attestable store -- nothing is deleted, and the history
+of a correction is itself evidence. It is the wrong thing to hand a finalizer,
+which then sees a value and its correction side by side with equal standing and
+can quote either.
+
+This module decides standing, never content. It reads the provenance the store
+already records -- the durable handle an action wrote and the digest it wrote
+there -- and marks an earlier version of a handle SUPERSEDED once a later one
+exists. It never compares observations, never prefers a later string, and never
+knows what any value means: two records that share no artifact handle cannot
+supersede one another however much they disagree.
+
+Supersession is about versions of a thing, not about who is right. A record
+that argues with an earlier finding in prose stays ACTIVE, and so does the one
+it argues with, because resolving that is the report's job and the disagreement
+is exactly what a reader needs to see.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ACTIVE = "ACTIVE"
+SUPERSEDED = "SUPERSEDED"
+
+
+@dataclass(frozen=True)
+class EvidenceStanding:
+    """What standing one record has, and why."""
+
+    evidence_id: str
+    status: str
+    superseded_by: str | None = None
+    handle: str | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == ACTIVE
+
+
+_DEFAULT_ACTIVE = EvidenceStanding("", ACTIVE)
+
+
+def _artifact_versions(record: object) -> list[tuple[str, str]]:
+    """(handle, digest) pairs this record durably wrote. Provenance only."""
+    metadata = getattr(record, "metadata", None) or {}
+    entries = metadata.get("artifacts") if isinstance(metadata, dict) else None
+    if not isinstance(entries, list):
+        return []
+    versions: list[tuple[str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        handle = entry.get("handle") or entry.get("name")
+        digest = entry.get("sha256")
+        if handle and digest:
+            versions.append((str(handle), str(digest)))
+    return versions
+
+
+def evaluate_standing(records: list) -> dict[str, EvidenceStanding]:
+    """Standing for each record, in the order the store produced them.
+
+    A record is SUPERSEDED when every artifact version it contributed has since
+    been rewritten at the same handle with a different digest. "Every" matters:
+    a record that wrote two artifacts and had only one replaced still holds
+    something current, and demoting it would lose that.
+
+    A record that wrote nothing durable is always ACTIVE. It cannot be a stale
+    version of anything, because it never claimed to be a version of anything --
+    which is what keeps a correction that merely quotes an old value from being
+    mistaken for the old value itself.
+    """
+    # Which version of a handle is current is decided by the order the store
+    # recorded them, never by the order this list happens to arrive in. The
+    # caller passes `records.values()`, which is insertion-ordered today and so
+    # would usually be right -- but a reversed or re-serialized index would
+    # silently invert every verdict and mark the corrected version stale, which
+    # is the exact failure this module exists to prevent. `evidence_sequence`
+    # is the store's own answer and every record carries it.
+    # A record the store never sequenced cannot be shown to be newer than one
+    # it did, so it must not displace it. Sorting the unsequenced ones last
+    # would let exactly that happen -- a stale version from a legacy or damaged
+    # index would supersede the correction that replaced it, which is this
+    # module's own failure mode inverted. They sort first, where they may be
+    # superseded but can supersede nothing that carries a sequence.
+    def _order(record: object) -> tuple[int, int, str]:
+        # The id breaks ties. Two records can share a key -- both unsequenced,
+        # or holding the same number after a discard freed it, since the store
+        # numbers by max+1 over what it currently holds. `sorted` is stable, so
+        # without a tiebreak those would resolve by arrival order, and the
+        # verdict would flip when the same records were read back in a
+        # different order. That is precisely the property this ordering exists
+        # to remove, so it must not survive at the margin.
+        rid = str(getattr(record, "evidence_id", "") or "")
+        sequence = getattr(record, "evidence_sequence", None)
+        try:
+            # A sequence that is not a number is not a sequence. The store
+            # normalises junk away on load, but this module takes any record
+            # shaped like one, and an unreadable number should demote a record
+            # to unsequenced rather than raise from a read-only audit.
+            numbered = int(sequence)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            # Unsequenced first: it may be superseded, but it can supersede
+            # nothing the store actually numbered.
+            return (0, 0, rid)
+        return (1, numbered, rid)
+
+    ordered = sorted(
+        (r for r in records if getattr(r, "evidence_id", None)), key=_order
+    )
+
+    latest: dict[str, tuple[str, str]] = {}
+    for record in ordered:
+        rid = record.evidence_id
+        for handle, digest in _artifact_versions(record):
+            latest[handle] = (digest, rid)
+
+    standing: dict[str, EvidenceStanding] = {}
+    for record in records:
+        rid = getattr(record, "evidence_id", None)
+        if not rid:
+            continue
+        versions = _artifact_versions(record)
+        if not versions:
+            standing[rid] = EvidenceStanding(rid, ACTIVE)
+            continue
+        stale: list[tuple[str, str]] = []
+        for handle, digest in versions:
+            current_digest, current_id = latest.get(handle, (digest, rid))
+            if current_digest != digest and current_id != rid:
+                stale.append((handle, current_id))
+        if stale and len(stale) == len(versions):
+            handle, current_id = stale[0]
+            standing[rid] = EvidenceStanding(rid, SUPERSEDED, current_id, handle)
+        else:
+            standing[rid] = EvidenceStanding(rid, ACTIVE)
+    return standing
+
+
+def active_records(records: list) -> list:
+    """The records a grounded report may cite as authoritative."""
+    standing = evaluate_standing(records)
+    # A record `evaluate_standing` skipped has no entry; treat it as active
+    # rather than raising. The two functions must agree about how defensive to
+    # be, or a record one of them tolerates becomes a KeyError in the other.
+    return [
+        record
+        for record in records
+        if standing.get(getattr(record, "evidence_id", ""), _DEFAULT_ACTIVE).is_active
+    ]
+
+
+__all__ = [
+    "ACTIVE",
+    "SUPERSEDED",
+    "EvidenceStanding",
+    "active_records",
+    "evaluate_standing",
+]

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -1,0 +1,548 @@
+"""Grounded finalization must not quote a value it has already corrected.
+
+The failure this guards against was measured: an analysis wrote an IoC report
+artifact, later rewrote it at the same handle with a corrected domain, and
+explicitly revalidated the correction against the source -- and the final
+grounded report still cited the superseded spelling. Both versions were in the
+store, both re-attested, and nothing said which one was current.
+
+Standing is decided from provenance alone: same durable handle, newer digest.
+No content is compared, so a record that merely disagrees in prose supersedes
+nothing, and a record that quotes an old value to correct it keeps its place.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.runtime.analysis_runtime import ANALYSIS_TOOL_NAME
+from orbit.runtime.evidence_authority import (
+    ACTIVE,
+    SUPERSEDED,
+    active_records,
+    evaluate_standing,
+)
+
+
+class _Record:
+    """The shape `evaluate_standing` reads: an id and artifact provenance."""
+
+    def __init__(self, evidence_id: str, artifacts=(), sequence: int | None = None):
+        self.evidence_id = evidence_id
+        self.evidence_sequence = sequence
+        self.metadata = {
+            "artifacts": [
+                {"handle": handle, "sha256": digest} for handle, digest in artifacts
+            ]
+        }
+
+
+HANDLE = "/workspace/work/ioc_report.txt"
+
+
+class SupersessionTests(unittest.TestCase):
+    """The measured class of failure, reproduced generically."""
+
+    def _abc(self):
+        # A: report v1 carries value X.  B: same handle rewritten as v2 with Y.
+        # C: a validation record that confirms Y and quotes X to contradict it.
+        a = _Record("ev_a", [(HANDLE, "sha_v1")], 1)
+        b = _Record("ev_b", [(HANDLE, "sha_v2")], 2)
+        c = _Record("ev_c", [], 3)
+        return a, b, c
+
+    def test_the_earlier_version_of_a_handle_is_superseded(self) -> None:
+        a, b, c = self._abc()
+        standing = evaluate_standing([a, b, c])
+
+        self.assertEqual(standing["ev_a"].status, SUPERSEDED)
+        self.assertEqual(standing["ev_a"].superseded_by, "ev_b")
+        self.assertEqual(standing["ev_a"].handle, HANDLE)
+        self.assertEqual(standing["ev_b"].status, ACTIVE)
+
+    def test_the_correction_record_keeps_its_standing(self) -> None:
+        """C quotes the wrong value to contradict it; it is not the wrong value.
+
+        This is why standing is decided on handles rather than on content: a
+        rule that demoted whatever mentions a stale string would delete the
+        very record that explains the correction.
+        """
+        a, b, c = self._abc()
+        standing = evaluate_standing([a, b, c])
+        self.assertEqual(standing["ev_c"].status, ACTIVE)
+
+    def test_the_superseded_record_is_excluded_from_the_report(self) -> None:
+        a, b, c = self._abc()
+        active = active_records([a, b, c])
+        self.assertEqual([r.evidence_id for r in active], ["ev_b", "ev_c"])
+
+    def test_nothing_is_deleted(self) -> None:
+        """Standing decides what may be cited, never what exists."""
+        a, b, c = self._abc()
+        given = [a, b, c]
+        active_records(given)
+        self.assertEqual([r.evidence_id for r in given], ["ev_a", "ev_b", "ev_c"])
+        self.assertIn("ev_a", evaluate_standing(given))
+
+    def test_an_unrelated_artifact_is_never_superseded(self) -> None:
+        """Only versions of the same handle compete.
+
+        Several distinct handles are written between the two versions of
+        HANDLE, so a lookup that consulted the wrong handle -- the most recent
+        one, say -- would demote a record that nothing replaced. Two handles
+        are not enough to catch that: the wrong answer can coincide with the
+        right one.
+        """
+        a = _Record("ev_a", [(HANDLE, "sha_v1")], 1)
+        others = [
+            _Record(f"ev_other{i}", [(f"/workspace/work/other{i}.bin", f"s{i}")], i + 2)
+            for i in range(4)
+        ]
+        b = _Record("ev_b", [(HANDLE, "sha_v2")], 9)
+
+        standing = evaluate_standing([a, *others, b])
+
+        for other in others:
+            self.assertEqual(
+                standing[other.evidence_id].status,
+                ACTIVE,
+                f"{other.evidence_id} was replaced by nothing",
+            )
+        self.assertEqual(standing["ev_a"].status, SUPERSEDED)
+        self.assertEqual(standing["ev_a"].superseded_by, "ev_b")
+        self.assertEqual(standing["ev_b"].status, ACTIVE)
+
+    def test_supersession_names_the_handle_that_replaced_it(self) -> None:
+        """The recorded reason must identify the actual handle, not any handle."""
+        a = _Record("ev_a", [(HANDLE, "v1")], 1)
+        noise = _Record("ev_noise", [("/workspace/work/unrelated.bin", "n1")], 2)
+        b = _Record("ev_b", [(HANDLE, "v2")], 3)
+
+        standing = evaluate_standing([a, noise, b])
+
+        self.assertEqual(standing["ev_a"].handle, HANDLE)
+        self.assertEqual(standing["ev_a"].superseded_by, "ev_b")
+
+    def test_a_record_with_no_artifact_is_always_active(self) -> None:
+        observation = _Record("ev_obs", [], 1)
+        later = _Record("ev_later", [(HANDLE, "sha_v1")], 2)
+        standing = evaluate_standing([observation, later])
+        self.assertEqual(standing["ev_obs"].status, ACTIVE)
+
+    def test_rewriting_a_handle_with_identical_bytes_supersedes_nothing(self) -> None:
+        """A rewrite that changed nothing did not produce a new version."""
+        a = _Record("ev_a", [(HANDLE, "same")], 1)
+        b = _Record("ev_b", [(HANDLE, "same")], 2)
+        standing = evaluate_standing([a, b])
+        self.assertEqual(standing["ev_a"].status, ACTIVE)
+        self.assertEqual(standing["ev_b"].status, ACTIVE)
+
+    def test_a_record_keeping_one_current_artifact_stays_active(self) -> None:
+        """Partial replacement must not discard what is still current."""
+        a = _Record("ev_a", [(HANDLE, "v1"), ("/workspace/work/keep.bin", "k1")], 1)
+        b = _Record("ev_b", [(HANDLE, "v2")], 2)
+
+        standing = evaluate_standing([a, b])
+
+        self.assertEqual(standing["ev_a"].status, ACTIVE)
+
+    def test_three_versions_leave_only_the_newest_active(self) -> None:
+        v1 = _Record("ev_1", [(HANDLE, "a")], 1)
+        v2 = _Record("ev_2", [(HANDLE, "b")], 2)
+        v3 = _Record("ev_3", [(HANDLE, "c")], 3)
+
+        standing = evaluate_standing([v1, v2, v3])
+
+        self.assertEqual(standing["ev_1"].status, SUPERSEDED)
+        self.assertEqual(standing["ev_2"].status, SUPERSEDED)
+        self.assertEqual(standing["ev_3"].status, ACTIVE)
+
+    def test_standing_does_not_depend_on_input_order(self) -> None:
+        """Which version is current is the store's answer, not the caller's.
+
+        The records arrive as `records.values()`, insertion-ordered today. A
+        reversed or re-serialized index would otherwise invert every verdict and
+        mark the *corrected* version superseded -- reintroducing, silently and
+        with confidence, the exact failure this module exists to prevent.
+        """
+        import itertools
+
+        v1 = _Record("ev_v1", [(HANDLE, "digest_v1")], 10)
+        v2 = _Record("ev_v2", [(HANDLE, "digest_v2")], 14)
+
+        for order in itertools.permutations([v1, v2]):
+            with self.subTest(order=[r.evidence_id for r in order]):
+                standing = evaluate_standing(list(order))
+                self.assertEqual(standing["ev_v1"].status, SUPERSEDED)
+                self.assertEqual(standing["ev_v2"].status, ACTIVE)
+
+    def test_order_independence_holds_for_three_versions(self) -> None:
+        import itertools
+
+        versions = [
+            _Record("ev_1", [(HANDLE, "a")], 1),
+            _Record("ev_2", [(HANDLE, "b")], 2),
+            _Record("ev_3", [(HANDLE, "c")], 3),
+        ]
+        for order in itertools.permutations(versions):
+            with self.subTest(order=[r.evidence_id for r in order]):
+                standing = evaluate_standing(list(order))
+                self.assertEqual(standing["ev_3"].status, ACTIVE)
+                self.assertEqual(standing["ev_1"].status, SUPERSEDED)
+                self.assertEqual(standing["ev_2"].status, SUPERSEDED)
+
+    def test_an_unsequenced_record_cannot_supersede_a_sequenced_one(self) -> None:
+        """A record the store never numbered is not evidence of being newer.
+
+        Treating it as newest inverts the module's own purpose: a stale version
+        from a legacy or damaged index would supersede the correction that
+        replaced it. It sorts first instead -- it may be superseded, but it
+        supersedes nothing that carries a sequence.
+        """
+        stale_unsequenced = _Record("ev_none", [(HANDLE, "stale")], None)
+        corrected = _Record("ev_seq", [(HANDLE, "current")], 5)
+
+        for order in ([stale_unsequenced, corrected], [corrected, stale_unsequenced]):
+            with self.subTest(order=[r.evidence_id for r in order]):
+                standing = evaluate_standing(order)
+                self.assertEqual(standing["ev_none"].status, SUPERSEDED)
+                self.assertEqual(standing["ev_seq"].status, ACTIVE)
+
+    def test_sequence_zero_is_not_treated_as_missing(self) -> None:
+        """`0` is a real sequence; a falsy check would confuse it with None.
+
+        The discriminating case needs an unsequenced record in the same chain:
+        if `0` were read as missing, it would tie with the unsequenced record
+        and the tie could resolve either way. Ordered correctly, `0` is newer
+        than unsequenced and older than everything else.
+        """
+        unsequenced = _Record("ev_none", [(HANDLE, "u")], None)
+        zero = _Record("ev_zero", [(HANDLE, "a")], 0)
+        later = _Record("ev_five", [(HANDLE, "b")], 5)
+
+        # Every arrival order, because a key that conflated 0 with None would
+        # leave their relative order to sort stability -- correct in some
+        # inputs and wrong in others.
+        import itertools
+
+        for order in itertools.permutations([later, zero, unsequenced]):
+            with self.subTest(order=[r.evidence_id for r in order]):
+                standing = evaluate_standing(list(order))
+                self.assertEqual(standing["ev_five"].status, ACTIVE)
+                self.assertEqual(standing["ev_zero"].status, SUPERSEDED)
+                self.assertEqual(standing["ev_none"].status, SUPERSEDED)
+                self.assertEqual(standing["ev_none"].superseded_by, "ev_five")
+
+        # And with no later record, 0 must outrank unsequenced in any order.
+        for order in itertools.permutations([zero, unsequenced]):
+            with self.subTest(pair=[r.evidence_id for r in order]):
+                standing = evaluate_standing(list(order))
+                self.assertEqual(standing["ev_zero"].status, ACTIVE)
+                self.assertEqual(standing["ev_none"].status, SUPERSEDED)
+
+    def test_a_record_without_an_id_does_not_raise(self) -> None:
+        """`evaluate_standing` skips it; `active_records` must agree."""
+        class _Anonymous:
+            evidence_id = ""
+            evidence_sequence = 1
+            metadata: dict = {}
+
+        good = _Record("ev_good", [(HANDLE, "d")], 2)
+        kept = active_records([_Anonymous(), good])
+
+        self.assertIn(good, kept)
+
+    def test_tied_sort_keys_do_not_resolve_by_arrival_order(self) -> None:
+        """Order-independence must hold at the margin too, or it is not a rule.
+
+        Two records can share a sort key: both unsequenced, or holding the same
+        number after a discard freed it, since the store numbers by max+1 over
+        what it currently holds. `sorted` is stable, so without a tiebreak those
+        resolve by arrival order and the verdict flips when the same records are
+        read back differently -- which is the property this ordering exists to
+        remove.
+        """
+        import itertools
+
+        cases = {
+            "both unsequenced": (
+                _Record("ev_a", [(HANDLE, "d1")], None),
+                _Record("ev_b", [(HANDLE, "d2")], None),
+            ),
+            "same sequence": (
+                _Record("ev_c", [(HANDLE, "d1")], 7),
+                _Record("ev_d", [(HANDLE, "d2")], 7),
+            ),
+        }
+        for label, pair in cases.items():
+            with self.subTest(case=label):
+                verdicts = set()
+                for order in itertools.permutations(pair):
+                    standing = evaluate_standing(list(order))
+                    verdicts.add(
+                        tuple(sorted((k, v.status) for k, v in standing.items()))
+                    )
+                self.assertEqual(
+                    len(verdicts), 1, f"{label}: verdict depends on arrival order"
+                )
+
+    def test_an_unreadable_sequence_is_treated_as_unsequenced(self) -> None:
+        """A read-only audit must not raise on a record it cannot number.
+
+        The store normalises a junk sequence away on load, but this module
+        accepts anything shaped like a record, and demoting is the conservative
+        answer: it may be superseded, and supersedes nothing numbered.
+        """
+        junk = _Record("ev_junk", [(HANDLE, "d1")], "not-a-number")
+        numbered = _Record("ev_ok", [(HANDLE, "d2")], 5)
+
+        standing = evaluate_standing([junk, numbered])
+
+        self.assertEqual(standing["ev_junk"].status, SUPERSEDED)
+        self.assertEqual(standing["ev_ok"].status, ACTIVE)
+
+    def test_standing_never_inspects_content(self) -> None:
+        """It reads handles and digests; it cannot know what a value means."""
+        import inspect
+
+        from orbit.runtime import evidence_authority
+
+        source = inspect.getsource(evidence_authority.evaluate_standing)
+        for banned in ("re.", "startswith", ".lower()", "in body", "raw_sha256"):
+            self.assertNotIn(banned, source, f"{banned!r} suggests content matching")
+
+
+class NoModelFacingTextChangedTests(unittest.TestCase):
+    """This fix is mechanical. It must not touch what the model is told.
+
+    Standing is decided from provenance the store already records, so the
+    finalizer needs no new instruction to honour it: a superseded version
+    simply never reaches the context. Pinning that here keeps a later
+    "just one sentence" from turning an evidence-selection fix into a prompt
+    change, which is a different kind of change with a different risk.
+    """
+
+    BASELINE = "0c9d8ba330dc67c7500cbd75c80940c222a3a573"
+    NAMES = (
+        "ANALYSIS_SYSTEM_PROMPT",
+        "ANALYSIS_REPORT_INSTRUCTION",
+        "NO_EVIDENCE_REPORT",
+        "AUTONOMOUS_CONTINUATION_MESSAGE",
+        "AUTONOMOUS_REPLAN_MESSAGE",
+    )
+
+    def _constant(self, text: str, name: str) -> str | None:
+        import re
+
+        block = re.search(rf"^{name} = \(.*?^\)", text, re.S | re.M)
+        if block:
+            return block.group(0)
+        line = re.search(rf"^{name} = .*?$", text, re.M)
+        return line.group(0) if line else None
+
+    def test_no_model_facing_constant_changed(self) -> None:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "show", f"{self.BASELINE}:src/orbit/runtime/analysis_runtime.py"],
+            cwd=ROOT, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            self.skipTest("baseline revision unavailable")
+        baseline = result.stdout
+        current = (ROOT / "src/orbit/runtime/analysis_runtime.py").read_text()
+
+        for name in self.NAMES:
+            with self.subTest(constant=name):
+                before = self._constant(baseline, name)
+                self.assertIsNotNone(before, f"{name} not found in baseline")
+                self.assertEqual(
+                    before,
+                    self._constant(current, name),
+                    f"{name} changed; this fix must not alter model-facing text",
+                )
+
+    def test_the_tool_schema_is_unchanged(self) -> None:
+        """The schema is inside the prewarmed prefix; changing it moves it."""
+        import hashlib
+        import json
+
+        from orbit.runtime.analysis_runtime import ANALYSIS_TOOL_SCHEMA
+
+        self.assertEqual(
+            hashlib.sha256(
+                json.dumps(ANALYSIS_TOOL_SCHEMA, sort_keys=True).encode()
+            ).hexdigest(),
+            "57710e9ee2c19683cb74b854d5b6f0714fb4802ad1a51971e43cd7f6d080f2a4",
+        )
+
+
+class FinalizationIntegrationTests(unittest.TestCase):
+    """The real runtime selector, through a real store, with real artifacts."""
+
+    def _runtime(self, backend):
+        import tempfile
+
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime, AnalysisWorkspace, acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmp = Path(tempfile.mkdtemp(prefix="orbit-authority-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        artifact = tmp / "input.txt"
+        artifact.write_text("alpha\n", encoding="utf-8")
+        ws = AnalysisWorkspace.create()
+        self.addCleanup(ws.close)
+        source = acquire_analysis_source(artifact, ws.source_root)
+        store = EvidenceStore(root=tmp / "ev")
+        built = AnalysisRuntime(
+            backend=backend, source=source, evidence_store=store, workspace=ws
+        )
+        self.addCleanup(built.close)
+        return built, store
+
+    def _write(self, name: str, body: str) -> str:
+        return (
+            "import pathlib\n"
+            f"pathlib.Path('/workspace/work/{name}').write_text({body!r})\n"
+            f"print('wrote {name}:', {body!r}, end='')"
+        )
+
+    def test_a_rewritten_artifact_supersedes_its_earlier_version(self) -> None:
+        from tests.test_analysis_runtime import ScriptedBackend, tool_response
+
+        backend = ScriptedBackend(
+            tool_response(self._write("report.txt", "value=WRONG")),
+            tool_response(self._write("report.txt", "value=RIGHT")),
+        )
+        runtime, store = self._runtime(backend)
+        runtime.step("write it")
+        runtime.step("correct it")
+
+        cited = runtime._reportable_records()
+        bodies = " ".join(store.reattest_exact(r.evidence_id) or "" for r in cited)
+
+        self.assertIn("RIGHT", bodies)
+        self.assertNotIn("WRONG", bodies)
+
+    def test_the_superseded_record_is_retained_and_reattestable(self) -> None:
+        from tests.test_analysis_runtime import ScriptedBackend, tool_response
+
+        backend = ScriptedBackend(
+            tool_response(self._write("report.txt", "value=WRONG")),
+            tool_response(self._write("report.txt", "value=RIGHT")),
+        )
+        runtime, store = self._runtime(backend)
+        runtime.step("write it")
+        runtime.step("correct it")
+
+        superseded = runtime.superseded_records()
+
+        self.assertEqual(len(superseded), 1)
+        body = store.reattest_exact(superseded[0].evidence_id)
+        self.assertIsNotNone(body, "history must stay verifiable")
+        self.assertIn("WRONG", body)
+
+    def test_finalization_stays_bounded(self) -> None:
+        """Dropping superseded records must not raise the record ceiling."""
+        from orbit.runtime.analysis_runtime import MAX_REPORT_EVIDENCE_RECORDS
+        from tests.test_analysis_runtime import ScriptedBackend, tool_response
+
+        n = MAX_REPORT_EVIDENCE_RECORDS + 4
+        backend = ScriptedBackend(
+            *[tool_response(f"print('step {i}', end='')") for i in range(n)]
+        )
+        runtime, _ = self._runtime(backend)
+        for i in range(n):
+            runtime.step(f"step {i}")
+
+        self.assertLessEqual(len(runtime._reportable_records()), MAX_REPORT_EVIDENCE_RECORDS)
+
+    def test_superseded_records_are_dropped_before_the_bound(self) -> None:
+        """Order matters: filtering after the bound wastes places on history.
+
+        With more actions than the ceiling, a superseded record inside the
+        last-N window would push a current one out if the bound were applied
+        first. Filtering first spends every place on evidence a report may
+        actually cite.
+        """
+        from orbit.runtime.analysis_runtime import MAX_REPORT_EVIDENCE_RECORDS
+        from tests.test_analysis_runtime import ScriptedBackend, tool_response
+
+        # The rewrite happens LATE, so the superseded version sits inside the
+        # last-N window. That is the only arrangement where the two orders
+        # differ: filtering first keeps N citable records, filtering afterwards
+        # spends one of the N places on history and returns N-1.
+        script = [
+            tool_response(f"print('step {i}', end='')")
+            for i in range(MAX_REPORT_EVIDENCE_RECORDS - 1)
+        ]
+        script += [
+            tool_response(self._write("report.txt", "v1")),
+            tool_response(self._write("report.txt", "v2")),
+        ]
+        runtime, store = self._runtime(ScriptedBackend(*script))
+        for i in range(len(script)):
+            runtime.step(f"step {i}")
+
+        cited = runtime._reportable_records()
+        bodies = " ".join(store.reattest_exact(r.evidence_id) or "" for r in cited)
+
+        self.assertLessEqual(len(cited), MAX_REPORT_EVIDENCE_RECORDS)
+        # Filtering first fills every available place with citable evidence.
+        self.assertEqual(len(cited), MAX_REPORT_EVIDENCE_RECORDS)
+        self.assertEqual(len(runtime.superseded_records()), 1)
+        # The superseded version is gone from the citable set...
+        self.assertNotIn("report.txt: 'v1'", bodies)
+        # ...and no superseded record occupies one of the bounded places.
+        superseded_ids = {r.evidence_id for r in runtime.superseded_records()}
+        self.assertFalse(superseded_ids & {r.evidence_id for r in cited})
+
+    def test_superseded_records_tolerates_a_record_without_an_id(self) -> None:
+        """The two views must agree about how defensive to be.
+
+        `active_records` skips a record the evaluator never scored; if
+        `superseded_records` indexed the same map directly it would raise on
+        exactly the record its sibling accepts.
+        """
+        class _Anonymous:
+            evidence_id = ""
+            evidence_sequence = 1
+            tool_name = ANALYSIS_TOOL_NAME
+            metadata: dict = {}
+
+        from tests.test_analysis_runtime import ScriptedBackend, tool_response
+
+        runtime, store = self._runtime(
+            ScriptedBackend(tool_response("print('a', end='')"))
+        )
+        runtime.step("look")
+        store.records["anon"] = _Anonymous()
+
+        self.assertIsInstance(runtime.superseded_records(), list)
+        self.assertIsInstance(runtime._reportable_records(), list)
+
+    def test_the_report_makes_exactly_one_model_call(self) -> None:
+        from tests.test_analysis_runtime import ScriptedBackend, prose_response, tool_response
+
+        backend = ScriptedBackend(
+            tool_response("print('a', end='')"), prose_response("REPORT")
+        )
+        runtime, _ = self._runtime(backend)
+        runtime.step("look")
+        report = runtime.report()
+
+        self.assertEqual(report.model_calls, 1)
+        self.assertEqual(backend.calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes stale artifact versions entering the grounded report context.

A measured analysis wrote an IoC report, rewrote the same file with a corrected
domain, and separately re-extracted that domain from the source — and the final
grounded report cited the superseded spelling anyway. Both versions were in the
store, both re-attested, and nothing said which was current.

## What changes

- **Fixes stale artifact versions entering grounded report context.**
  `_reportable_records()` selected on tool name and took the last twelve; it
  never read the artifact handles it had recorded, so a value and its own
  correction arrived with equal standing.
- **No evidence is deleted.** Superseded records stay in the store and remain
  re-attestable for audit. `superseded_records()` exposes them.
- **Supersession is provenance/version based, not semantic or content based.** A
  record is superseded once *every* artifact version it wrote has been rewritten
  at the same handle with a different digest. Nothing compares observations. Two
  records sharing no handle cannot supersede one another however much they
  disagree, and a record that quotes a stale value in order to contradict it
  keeps its standing.
- **Filtering precedes the report bound**, so the twelve places are spent on
  evidence the report may cite rather than on history.
- **Physical/index iteration order cannot affect authority.** Which version is
  current comes from the store's own `evidence_sequence`. `load_index()`
  populates records in JSON file order, so a re-serialized or reversed index
  would otherwise invert every verdict.
- **Unsequenced legacy records fail conservatively.** A record carrying no
  sequence sorts first: it may be superseded, but it cannot displace evidence
  the store actually numbered.
- **Zero model-facing prompt changes.** `ANALYSIS_SYSTEM_PROMPT`,
  `ANALYSIS_REPORT_INSTRUCTION`, `ANALYSIS_TOOL_SCHEMA`, `NO_EVIDENCE_REPORT`,
  `AUTONOMOUS_CONTINUATION_MESSAGE` and `AUTONOMOUS_REPLAN_MESSAGE` are all
  byte-identical to baseline, verified at AST level. Prewarm prefix identity is
  untouched.
- **No unrelated runtime behaviour changes.** Autonomous continuation, progress
  fingerprinting, routing, sandbox, EvidenceStore semantics, KV/prewarm, CHAT
  and backend inference are all untouched. Three files; the runtime diff is 32
  insertions.

This decides which evidence is authoritative. It does not resolve contradictions
in general and performs no epistemic reasoning: a disagreement between records
that are not versions of the same artifact is left standing, for the report to
surface.

## Verification

Replayed against the preserved EvidenceStore from the failing run, zero
inference:

- stale artifact version SUPERSEDED by the corrected one
- corrected version ACTIVE
- filtering before the bound (8 active records, ceiling 12)
- stale record retained and re-attestable
- 7 unrelated records ACTIVE
- 24 order permutations stable
- corrected `http://gibuzuy37v2v.top/1.php?s=mints13` present
- superseded content absent from the authoritative context

The one ACTIVE record still containing the stale spelling is the validation
record, which quotes it under a `[WARNING] Domain mismatch` header to flag the
error. Five active records assert the correct value; none asserts the stale one.

**24 deterministic tests · focused 309 · autonomous gate ON 122 · full suite
2967 · 15/15 mutations caught · independent review BLOCKER 0 / MAJOR 0 / MINOR
0.** compileall and `git diff --check` clean.
