### PR TITLE
docs(release): prepare v0.0.1-rc36

### DIFF
--- a/docs/releases/v0.0.1-rc36.md
+++ b/docs/releases/v0.0.1-rc36.md
@@ -1,0 +1,49 @@
+# v0.0.1-rc36
+
+A correctness hotfix over rc35: a grounded analysis report can no longer cite a
+value the analysis has already corrected.
+
+Qualified production code: `0753dc7e2930e04388d06039485c951f195af280`
+
+## Highlights
+
+- Fix stale or superseded artifact evidence appearing with equal authority in
+  grounded ANALYSIS reports. When an analysis rewrites an artifact, the earlier
+  version of that handle is no longer offered to the report as current, so a
+  corrected value and the value it replaced can no longer be quoted
+  interchangeably.
+- Artifact history remains retained and re-attestable. Nothing is deleted: a
+  superseded record stays in the evidence store and still verifies byte-exactly
+  for audit. This decides which evidence may be cited as current, not what
+  exists.
+- Authority is provenance and version based, never content based. A record is
+  superseded only when every artifact version it wrote has since been rewritten
+  at the same handle with a different digest, ordered by the store's own
+  evidence sequence. Observations are never compared, so two records that share
+  no artifact handle cannot supersede one another, and a record that quotes an
+  earlier value in order to correct it keeps its standing.
+- No model prompt changes. Every model-facing constant is byte-identical to
+  rc35.
+- No change to autonomous-analysis defaults. `ORBIT_ANALYSIS_AUTONOMOUS`
+  remains opt-in and off by default.
+- No new feature beyond this correctness fix. The only production change since
+  rc35 is the one above.
+
+## Known limitations
+
+This resolves conflicting *versions of the same artifact*. It does not resolve
+contradictions in general: a disagreement between records that are not versions
+of one another is left standing, for the report to surface as unresolved.
+
+Everything else in rc35 is unchanged, including its limitations, which remain in
+force:
+
+- Autonomous ANALYSIS is qualified for correctness but may perform unnecessary
+  work on trivial artifacts, and therefore remains opt-in.
+- Eager ANALYSIS prewarm is opt-in
+  (`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1`).
+- Exact-prefix reuse is per profile; a profile without support for a given
+  prefix path falls back to ordinary cold behaviour rather than failing.
+- The primary qualified platform remains Linux x86_64, CPU-only.
+
+See `docs/releases/v0.0.1-rc35.md` for the features these describe.


### PR DESCRIPTION
Release notes for **v0.0.1-rc36**, a correctness hotfix over rc35.

Qualified production code: `0753dc7e2930e04388d06039485c951f195af280`.

## Scope of this PR

One new file: `docs/releases/v0.0.1-rc36.md`. No source changes, no version
constant changes — the RC lives in the tag, as in every prior release in this
series (`pyproject.toml` and `src/orbit/__init__.py` stay `0.0.1`).

## What rc36 contains

The only production change since rc35 is PR #245, strict evidence
authority/supersession. The rc35 → main delta is exactly three files
(`evidence_authority.py`, `analysis_runtime.py`, `test_evidence_authority.py`)
and is byte-identical to that single merged commit.

The notes state:
- fixes stale/superseded artifact evidence appearing with equal authority in
  grounded ANALYSIS reports
- artifact history remains retained and re-attestable — nothing is deleted
- authority is provenance/version based, not content based
- no model prompt changes
- no change to autonomous-analysis defaults (`ORBIT_ANALYSIS_AUTONOMOUS` stays
  opt-in, off by default)
- no new feature beyond the correctness fix

They explicitly disclaim universal contradiction resolution: this resolves
conflicting *versions of the same artifact* only.

## Verification

Audited against rc35, all at AST level rather than by line ranges:

- all six model-facing constants byte-identical
- the autonomous policy constants (soft/hard action bounds, model-call ceiling,
  gate env var) byte-identical, and the default verified OFF by execution
- zero changes to terminal, commands, routing, sandbox, prefix/rolling KV,
  client, chat or backend

Deterministic validation, no inference: evidence-authority 26 · ANALYSIS +
evidence + sandbox 231 · autonomous 98 gate OFF and 98 gate ON · routing +
workflow 454 · **full suite 2969** · compileall and `git diff --check` clean.
