### PR TITLE
fix(build): isolate native library runpaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ models/
 workdir/pdf/
 src/orbit/native_llama/vendor/build/
 src/orbit/native_llama/vendor/lib/*.so
+src/orbit/native_llama/vendor/lib/*.so.*
 src/orbit/native_llama/vendor/lib/*.dylib
+src/orbit/native_llama/vendor/lib/*.dylib.*
 src/orbit/native_llama/vendor/lib/*.a
 src/orbit/native_llama/vendor/lib/*.identity.json
 src/orbit/native_llama/vendor/shim/*.so

--- a/src/orbit/native_llama/build_cli.py
+++ b/src/orbit/native_llama/build_cli.py
@@ -11,7 +11,7 @@ import threading
 import time
 from pathlib import Path
 
-from .build_support import BUNDLED_SOURCE_ROOT, DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_ROOT, validate_llama_source_root
+from .build_support import BUNDLED_SOURCE_ROOT, DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_ROOT, ORIGIN_RUNPATH, validate_llama_source_root
 from .chat_bridge import build_chat_bridge, install_chat_bridge
 from .llama_provenance import load_llama_provenance
 from .mtp_accept_probe import build_mtp_accept_probe_helper
@@ -112,6 +112,17 @@ def main(argv: list[str] | None = None) -> int:
         "-DLLAMA_BUILD_UI=OFF",
         "-DLLAMA_BUILD_TOOLS=ON",
         "-DLLAMA_OPENSSL=OFF",
+        # Resolve sibling runtime libraries relative to the loaded library
+        # rather than through the absolute build directory CMake would embed.
+        # An absolute build-tree RUNPATH follows a copied checkout: its
+        # libllama keeps naming the directory it was built in, so a second
+        # checkout on the same machine loads its own libllama while resolving
+        # libggml back into the first one. Two families of llama/ggml then
+        # share one address space, which is not a configuration either was
+        # built for.
+        f"-DCMAKE_BUILD_RPATH={ORIGIN_RUNPATH}",
+        f"-DCMAKE_INSTALL_RPATH={ORIGIN_RUNPATH}",
+        "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
         *provenance_args,
     ]
     build_cmd = [cmake, "--build", str(build_dir)]
@@ -278,6 +289,32 @@ def _copy_runtime_libraries(build_bin: Path) -> None:
         if not source.exists():
             continue
         shutil.copy2(source, DEFAULT_VENDOR_LIB_DIR / name)
+        _copy_soname_aliases(source, DEFAULT_VENDOR_LIB_DIR)
+
+
+def _copy_soname_aliases(source: Path, destination: Path) -> None:
+    """Copy the versioned names a library is actually requested by.
+
+    `libllama.so` is the linker's name for the library; the loader is asked for
+    the SONAME its dependents record, which is `libllama.so.0`. Copying only
+    the bare name leaves the packaged directory unable to answer its own
+    dependencies, so resolution falls through to whatever else on the machine
+    offers that SONAME -- which is how a packaged runtime ended up loading
+    half of a second Orbit checkout's libraries.
+
+    In the build tree those versioned names are symlinks to one real file.
+    They are materialized as copies here because a symlink would point outside
+    the packaged directory once this tree is installed elsewhere.
+    """
+    real = source.resolve()
+    for candidate in source.parent.iterdir():
+        if candidate == source or not candidate.is_file():
+            continue
+        if not candidate.name.startswith(source.name):
+            continue
+        if candidate.resolve() != real:
+            continue
+        shutil.copy2(candidate, destination / candidate.name)
 
 
 def _build_packaged_shims(source_root: Path, build_bin: Path) -> None:

--- a/src/orbit/native_llama/build_support.py
+++ b/src/orbit/native_llama/build_support.py
@@ -9,6 +9,58 @@ from .native_names import platform_runtime_libs
 
 PACKAGE_NATIVE_ROOT = Path(__file__).resolve().parent / "vendor"
 BUNDLED_SOURCE_ROOT = PACKAGE_NATIVE_ROOT / "source" / "llama.cpp"
+
+# What a built artifact records as the place to find its sibling libraries.
+#
+# `$ORIGIN` is expanded by the dynamic loader to the directory of the object
+# holding the entry, so a runtime family resolves within itself wherever it is
+# copied. An absolute build path would instead follow the copy: a second Orbit
+# checkout on the same machine would load its own libllama while resolving
+# libggml back into the checkout it was built in, mapping two families of
+# llama/ggml into one address space.
+#
+# Written as a literal `$ORIGIN`, never expanded by Python or the shell: the
+# loader needs the token itself in DT_RUNPATH.
+ORIGIN_RUNPATH = "$ORIGIN"
+
+
+def origin_relative_runpath(artifact_dir: Path, library_dir: Path) -> str:
+    """`$ORIGIN`-relative search path from an artifact to its libraries.
+
+    Helpers are not all built beside the runtime: the MTP shims live in
+    `vendor/shim` while the libraries they link against live in the build
+    directory. A bare `$ORIGIN` would point those at their own directory,
+    which holds no libraries, so the entry has to carry the hop between the
+    two -- expressed relatively, so that copying the tree keeps it valid.
+    """
+    resolved_library = library_dir.resolve()
+    resolved_artifact = artifact_dir.resolve()
+    if not _share_a_tree(resolved_artifact, resolved_library):
+        # The artifact is being built outside the tree that holds the
+        # libraries -- a build directory under the user's home, say. A
+        # relative entry would then climb out of the artifact's own tree and
+        # re-enter the other one by traversal, which is neither relocatable
+        # nor meaningful once either side moves. An absolute entry is honest
+        # about that: it names one specific runtime rather than pretending
+        # the two travel together.
+        return str(resolved_library)
+    relative = os.path.relpath(resolved_library, resolved_artifact)
+    if relative == ".":
+        return ORIGIN_RUNPATH
+    return f"{ORIGIN_RUNPATH}/{relative}"
+
+
+def _share_a_tree(artifact_dir: Path, library_dir: Path) -> bool:
+    """Whether both live under the package root, so a copy moves them together.
+
+    `vendor/shim` and `vendor/lib` are siblings of `vendor/build`, so a hop
+    between them survives relocation. A directory outside `vendor` does not
+    travel with it, and a relative entry there would only describe where the
+    two happened to sit at build time.
+    """
+    root = PACKAGE_NATIVE_ROOT.resolve()
+    return artifact_dir.is_relative_to(root) and library_dir.is_relative_to(root)
+
 DEFAULT_VENDOR_BUILD_ROOT = PACKAGE_NATIVE_ROOT / "build" / "llama.cpp"
 DEFAULT_VENDOR_BUILD_BIN = DEFAULT_VENDOR_BUILD_ROOT / "bin"
 
@@ -75,7 +127,14 @@ def compile_cpp_helper(
             f"-I{resolved_root}",
             f"-I{resolved_root / 'ggml/include'}",
             f"-I{resolved_root / 'src'}",
-            f"-Wl,-rpath,{resolved_bin}",
+            # Relative to the artifact, so a copied tree keeps resolving.
+            f"-Wl,-rpath,{origin_relative_runpath(output.parent, resolved_bin)}",
+            # Keep DT_RUNPATH rather than the older DT_RPATH: RUNPATH is what
+            # the CMake-built libraries already carry, and unlike RPATH it does
+            # not apply to a dependency's own dependencies, so each library
+            # states where its siblings are instead of inheriting a parent's
+            # answer.
+            "-Wl,--enable-new-dtags",
         ]
     )
     command.extend(f"-I{path}" for path in extra_include_dirs)

--- a/tests/test_native_runpath_isolation.py
+++ b/tests/test_native_runpath_isolation.py
@@ -1,0 +1,292 @@
+"""Built native libraries must resolve their siblings relative to themselves.
+
+A runtime family built into one checkout used to name its own build directory
+by absolute path in `DT_RUNPATH`. Copying that checkout copied the path with
+it, so a second checkout on the same machine loaded its own `libllama` while
+resolving `libggml` back into the first one. Two independent copies of
+llama/ggml then shared an address space and one allocator freed what the other
+had allocated, which surfaced as an abort during exit handlers rather than as
+anything the tests could see.
+
+These tests read the ELF dynamic section of the artifacts actually on disk.
+Asserting on the build command instead would pass while the linker did
+something else, which is the failure this is meant to catch.
+"""
+
+from __future__ import annotations
+
+import struct
+import unittest
+from pathlib import Path
+
+from orbit.native_llama.build_support import ORIGIN_RUNPATH, origin_relative_runpath
+from orbit.native_llama.paths import (
+    DEFAULT_VENDOR_BUILD_BIN,
+    DEFAULT_VENDOR_LIB_DIR,
+    DEFAULT_VENDOR_SHIM_DIR,
+)
+
+
+DT_NEEDED = 1
+DT_RPATH = 15
+DT_RUNPATH = 29
+DT_STRTAB = 5
+DT_SONAME = 14
+
+
+def read_dynamic_entries(path: Path) -> dict[int, list[str]]:
+    """`{d_tag: [string values]}` from an ELF64 little-endian shared object.
+
+    Written against the file rather than a tool so the assertion cannot pass
+    because `readelf` was absent or its output format changed.
+    """
+    data = path.read_bytes()
+    if data[:4] != b"\x7fELF" or data[4] != 2 or data[5] != 1:
+        raise AssertionError(f"not an ELF64 little-endian object: {path}")
+
+    e_phoff = struct.unpack_from("<Q", data, 0x20)[0]
+    e_phentsize = struct.unpack_from("<H", data, 0x36)[0]
+    e_phnum = struct.unpack_from("<H", data, 0x38)[0]
+
+    dynamic: tuple[int, int] | None = None
+    segments: list[tuple[int, int, int]] = []
+    for index in range(e_phnum):
+        offset = e_phoff + index * e_phentsize
+        p_type = struct.unpack_from("<I", data, offset)[0]
+        p_offset = struct.unpack_from("<Q", data, offset + 0x08)[0]
+        p_vaddr = struct.unpack_from("<Q", data, offset + 0x10)[0]
+        p_filesz = struct.unpack_from("<Q", data, offset + 0x20)[0]
+        if p_type == 2:  # PT_DYNAMIC
+            dynamic = (p_offset, p_filesz)
+        elif p_type == 1:  # PT_LOAD
+            segments.append((p_vaddr, p_offset, p_filesz))
+    if dynamic is None:
+        raise AssertionError(f"no PT_DYNAMIC segment in {path}")
+
+    def to_offset(vaddr: int) -> int:
+        for seg_vaddr, seg_offset, seg_size in segments:
+            if seg_vaddr <= vaddr < seg_vaddr + seg_size:
+                return seg_offset + (vaddr - seg_vaddr)
+        raise AssertionError(f"vaddr {vaddr:#x} outside any PT_LOAD in {path}")
+
+    raw: list[tuple[int, int]] = []
+    offset, size = dynamic
+    for position in range(offset, offset + size, 16):
+        d_tag, d_val = struct.unpack_from("<Qq", data, position)
+        if d_tag == 0:  # DT_NULL
+            break
+        raw.append((d_tag, d_val))
+
+    strtab = next((value for tag, value in raw if tag == DT_STRTAB), None)
+    if strtab is None:
+        raise AssertionError(f"no DT_STRTAB in {path}")
+    strtab_offset = to_offset(strtab)
+
+    def string_at(index: int) -> str:
+        end = data.index(b"\0", strtab_offset + index)
+        return data[strtab_offset + index : end].decode("utf-8", "replace")
+
+    entries: dict[int, list[str]] = {}
+    for tag, value in raw:
+        if tag in (DT_NEEDED, DT_RPATH, DT_RUNPATH, DT_SONAME):
+            entries.setdefault(tag, []).append(string_at(value))
+    return entries
+
+
+def is_elf(path: Path) -> bool:
+    """Whether `path` starts with the ELF magic."""
+    with path.open("rb") as handle:
+        return handle.read(4) == b"\x7fELF"
+
+
+def elf_objects(directory: Path) -> list[Path]:
+    """Real, non-symlink ELF objects in `directory`.
+
+    Selected by ELF magic rather than by name: these directories also hold
+    `.so.identity.json` sidecars, `.cpp` sources and plain executables, and
+    matching by name would either skip the whole test on the first sidecar --
+    leaving everything after it unchecked while still reporting success -- or
+    miss the shim executables, which carry a RUNPATH just as the libraries do.
+    """
+    if not directory.is_dir():
+        return []
+    return sorted(
+        path
+        for path in directory.iterdir()
+        if path.is_file() and not path.is_symlink() and is_elf(path)
+    )
+
+
+def built_libraries() -> list[Path]:
+    """Every built native object Orbit loads, across all three directories.
+
+    `vendor/shim` is included deliberately: it is a production load path, and
+    it holds the only artifacts whose search entry is not a bare `$ORIGIN` but
+    a hop to the build directory. Leaving it out would pass while precisely
+    the harder value was wrong.
+    """
+    return [
+        path
+        for directory in (
+            DEFAULT_VENDOR_BUILD_BIN,
+            DEFAULT_VENDOR_LIB_DIR,
+            DEFAULT_VENDOR_SHIM_DIR,
+        )
+        for path in elf_objects(directory)
+    ]
+
+
+NATIVE_PREFIXES = ("libggml", "libllama", "libmtmd", "liborbit")
+
+
+class RunpathIsolationTests(unittest.TestCase):
+    """What the linker actually wrote, not what the build meant to ask for."""
+
+    def setUp(self) -> None:
+        self.libraries = built_libraries()
+        if not self.libraries:
+            self.skipTest("native runtime is not built")
+
+    def test_no_library_names_an_absolute_search_directory(self) -> None:
+        """An absolute entry is what survives a copy and finds the other tree.
+
+        Detected generically: any absolute path, not a particular checkout, so
+        this keeps working on a machine whose build root is somewhere else.
+        """
+        for path in self.libraries:
+            entries = read_dynamic_entries(path)
+            for tag, label in ((DT_RUNPATH, "DT_RUNPATH"), (DT_RPATH, "DT_RPATH")):
+                for value in entries.get(tag, []):
+                    for element in value.split(":"):
+                        if not element:
+                            continue
+                        self.assertFalse(
+                            element.startswith("/"),
+                            f"{path.name} {label} names an absolute directory: {element!r}",
+                        )
+
+    def test_libraries_with_native_dependencies_search_their_own_directory(self) -> None:
+        """`$ORIGIN` is what makes a copied family resolve within itself."""
+        checked = 0
+        for path in self.libraries:
+            entries = read_dynamic_entries(path)
+            needs_family = any(
+                needed.startswith(NATIVE_PREFIXES) for needed in entries.get(DT_NEEDED, [])
+            )
+            if not needs_family:
+                continue
+            checked += 1
+            search = entries.get(DT_RUNPATH, []) + entries.get(DT_RPATH, [])
+            elements = [part for value in search for part in value.split(":") if part]
+            self.assertTrue(
+                any(part.startswith(ORIGIN_RUNPATH) for part in elements),
+                f"{path.name} depends on the family but does not search {ORIGIN_RUNPATH}: {elements}",
+            )
+        self.assertGreater(checked, 0, "no native library declared a family dependency")
+
+    def test_family_dependencies_are_resolvable_along_the_search_path(self) -> None:
+        """Every sibling an object names is findable where it says to look.
+
+        `$ORIGIN` only helps if the directory it resolves to is complete; a
+        missing soname would send the loader to the system search path, which
+        is where a foreign family could be picked up again. Resolved through
+        each object's own entry rather than assuming its directory, because
+        the shims deliberately point at the build directory instead of at
+        themselves.
+        """
+        for path in self.libraries:
+            entries = read_dynamic_entries(path)
+            needed_family = [
+                needed
+                for needed in entries.get(DT_NEEDED, [])
+                if needed.startswith(NATIVE_PREFIXES)
+            ]
+            if not needed_family:
+                continue
+            search = entries.get(DT_RUNPATH, []) + entries.get(DT_RPATH, [])
+            directories = [
+                Path(part.replace(ORIGIN_RUNPATH, str(path.parent)))
+                for value in search
+                for part in value.split(":")
+                if part
+            ]
+            self.assertTrue(directories, f"{path.name} declares no search path")
+            for needed in needed_family:
+                self.assertTrue(
+                    any((directory / needed).exists() for directory in directories),
+                    f"{path.name} needs {needed}, not found in {directories}",
+                )
+
+
+class PackagedRuntimeTests(unittest.TestCase):
+    """The packaged runtime must answer its own dependencies.
+
+    `vendor/lib` used to hold only the bare `libX.so` linker names while every
+    dependent asks the loader for the SONAME `libX.so.0`. Those requests left
+    the directory, and with an absolute RUNPATH they landed in `vendor/build`
+    -- or, from a copied checkout, in a different checkout entirely. Once the
+    RUNPATH is relative the same gap stops resolving at all, so the directory
+    has to be complete rather than merely relative.
+    """
+
+    def setUp(self) -> None:
+        if not DEFAULT_VENDOR_LIB_DIR.is_dir():
+            self.skipTest("packaged runtime is not built")
+        self.libraries = elf_objects(DEFAULT_VENDOR_LIB_DIR)
+        if not self.libraries:
+            self.skipTest("packaged runtime is not built")
+
+    def test_every_native_dependency_is_present_in_the_packaged_directory(self) -> None:
+        for path in self.libraries:
+            entries = read_dynamic_entries(path)
+            for needed in entries.get(DT_NEEDED, []):
+                if not needed.startswith(NATIVE_PREFIXES):
+                    continue
+                self.assertTrue(
+                    (DEFAULT_VENDOR_LIB_DIR / needed).exists(),
+                    f"{path.name} needs {needed}, missing from the packaged runtime",
+                )
+
+    def test_packaged_libraries_do_not_name_an_absolute_search_directory(self) -> None:
+        for path in self.libraries:
+            entries = read_dynamic_entries(path)
+            for tag in (DT_RUNPATH, DT_RPATH):
+                for value in entries.get(tag, []):
+                    for element in value.split(":"):
+                        if element:
+                            self.assertFalse(
+                                element.startswith("/"),
+                                f"{path.name} searches an absolute directory: {element!r}",
+                            )
+
+
+class RunpathBuildSettingTests(unittest.TestCase):
+    """The build must ask for a relative entry, literally."""
+
+    def test_artifacts_inside_the_package_get_a_relative_entry(self) -> None:
+        """A hop between sibling directories survives being copied."""
+        self.assertEqual(
+            origin_relative_runpath(DEFAULT_VENDOR_BUILD_BIN, DEFAULT_VENDOR_BUILD_BIN),
+            ORIGIN_RUNPATH,
+        )
+        for directory in (DEFAULT_VENDOR_SHIM_DIR, DEFAULT_VENDOR_LIB_DIR):
+            with self.subTest(directory=directory.name):
+                entry = origin_relative_runpath(directory, DEFAULT_VENDOR_BUILD_BIN)
+                self.assertTrue(entry.startswith(ORIGIN_RUNPATH))
+                self.assertFalse(entry.startswith("/"))
+
+    def test_an_artifact_built_outside_the_package_does_not_climb_out(self) -> None:
+        """A relative entry would only describe where things sat at build time.
+
+        Nothing outside the package travels with it, so `..`-climbing back
+        into the checkout is not relocatable -- it just looks like it is.
+        """
+        entry = origin_relative_runpath(Path("/tmp/elsewhere/bin"), DEFAULT_VENDOR_BUILD_BIN)
+
+        self.assertNotIn("..", entry)
+        self.assertFalse(entry.startswith(ORIGIN_RUNPATH))
+
+    def test_origin_token_is_not_expanded_by_python(self) -> None:
+        """The loader needs the token; an expanded value would be a real path."""
+        self.assertEqual(ORIGIN_RUNPATH, "$ORIGIN")
+        self.assertFalse(ORIGIN_RUNPATH.startswith("/"))


### PR DESCRIPTION
Built native libraries recorded the absolute directory they were built in as
their `DT_RUNPATH`. That path travels with a copy, so a second Orbit checkout
on the same machine loaded its own `libllama` while resolving `libggml` back
into the first checkout.

## What changes

- **Removes checkout-specific absolute RUNPATHs** from every built artifact.
  Two sources: CMake auto-embedded the build-tree path because no RPATH flags
  were passed, and `build_support.py` hardcoded `-Wl,-rpath,{resolved_bin}`
  for the Orbit bridges.
- **Uses relocatable `$ORIGIN`-based `DT_RUNPATH`.** Libraries beside their
  siblings record `$ORIGIN`; the MTP shims, built into `vendor/shim` while the
  libraries live under `vendor/build`, record the single hop between them. An
  artifact built outside the package tree keeps an absolute entry, because
  nothing out there travels with the package.
- **Prevents one checkout resolving Orbit native libraries from another.**
  Two independently built checkouts each map only their own family.
- **Preserves the packaged and shim layouts.** Nothing moved.
- **The packaged native family is self-contained.** `vendor/lib` held only the
  bare `libX.so` linker names while dependents ask for the SONAME `libX.so.0`;
  those requests used to leave the directory and be answered by the absolute
  RUNPATH. The versioned names are now copied alongside, so the directory
  answers its own dependencies. Without this, removing the absolute path turns
  a silent cross-link into a hard load failure.
- **No runtime or native lifecycle behaviour changed.** `src/orbit/runtime`,
  `src/orbit/backend` and `src/orbit/terminal` are byte-identical to the
  baseline, as are the native loader and client modules (`bindings.py`,
  `paths.py`, `client.py`, `persistent_mtp.py`, `model_discovery.py`,
  `chat_bridge.py`, `mtmd_bridge.py`, `native_artifacts.py`). No
  `LD_LIBRARY_PATH` workaround, no loader patching, no new dependency.
- **No performance change intended.** Search-path metadata only.

## On the SIGABRT evidence

Crashed pytest processes were carrying **two complete native runtime families
at once**, from two different checkouts. That is established from the core
dumps' `NT_FILE` notes -- the kernel's record of file-backed mappings, not
incidental strings -- and the abort occurs in `__run_exit_handlers`, where
both families' static destructors run.

This PR removes the **enabling condition** for that topology: the absolute
RUNPATH that let one checkout's libraries resolve into another's.

It does **not** prove or fix every possible cause of that abort. Two families
mapped was shown to be *present* at the crash but not *sufficient* on its own
-- a direct probe loading both families exited cleanly. And `$ORIGIN` does not
make same-process dual-family loading safe: SONAME reuse is resolved before
search paths are consulted, so a process that deliberately loads both still
shares the first family's libraries. What is fixed is a single-checkout
process silently reaching into a different checkout.

## Verification

Two clean checkouts built independently, both exit 0. All 40 ELF objects
across `vendor/build`, `vendor/lib` and `vendor/shim` carry a relative entry;
**zero absolute RUNPATH, zero `DT_RPATH`**. Every object with native
dependencies carries its own entry, so `DT_RUNPATH` non-transitivity is safe.

Cross-checkout: loading from B maps only B's root, from A only A's. Baseline
control -- pre-fix libraries copied to a new root -- maps **two** roots,
reproducing the leak. Relocation: a packaged family copied to a fresh path
loads with zero external references and no rebuild.

Regression tests **8**, native bridge **42**, KV/prewarm **112**, build/native
**524**, full suite **3043 passed + 1 environment skip**, real exit 0.
compileall and `git diff --check` clean.

The tests read the ELF dynamic section of artifacts on disk rather than
asserting build intent, and were differential-tested against `readelf` on all
40 objects with 0 mismatches. Poison matrix: an absolute RUNPATH planted in
any of the three directories fails, and a removed SONAME fails.

## Follow-up work, not in this PR

- **`MtmdLibrary` family-guard completeness.** `MtmdLibrary` is the one native
  load site that calls neither `_claim_runtime_family()` nor
  `_require_runtime_prefix()`, so it can still map a foreign family directly.
  This PR removes the RUNPATH that made that reachable across checkouts, but
  the guard itself is still missing.
- The two existing guard tests check `libllama` and `libggml` but never
  `libmtmd`, so they pass while that gap is live.
- macOS dylib aliasing in `_copy_soname_aliases` is a no-op (`libllama.0.dylib`
  vs `libllama.dylib.0`). Pre-existing and latent: `$ORIGIN` is ELF-only and
  there is no `@loader_path` handling at baseline either.
