### PR TITLE
fix(native): guard mtmd runtime family

### DIFF
--- a/src/orbit/native_llama/bindings.py
+++ b/src/orbit/native_llama/bindings.py
@@ -478,7 +478,32 @@ class MtmdLibrary:
     def __init__(self, build_bin: Path, bridge_path: Path | None = None) -> None:
         resolved_bridge = bridge_path or build_bin / runtime_library_filename("orbit-mtmd-bridge")
         self.build_identity = validate_mtmd_bridge_artifact(build_bin, resolved_bridge)
+        # `libmtmd` links against llama and ggml, so loading this bridge pulls a
+        # whole runtime family in behind it. Claim the family before anything is
+        # loaded, exactly as the llama and chat-bridge entry points do: the
+        # artifact identity checked above says these files belong together, not
+        # that they are the family this process already runs on. Without the
+        # claim a second, internally consistent family loads beside the first
+        # and both sets of static destructors run at exit.
+        # Through `llama-common`: that is the whole mandatory chain, and
+        # `libmtmd` is an optional member of the family rather than a step in
+        # the load order, so asking for it by name would not resolve. Its own
+        # `DT_NEEDED` set is llama and ggml, all of which this prefix covers.
+        required = _require_runtime_prefix(
+            build_bin.resolve(), runtime_library_filename("llama-common")
+        )
+        self.build_bin = _claim_runtime_family(build_bin)
         flags = native_cdll_flags()
+        self._handles: list[CDLL] = []
+        for path in required:
+            self._handles.append(load_native_cdll(path, mode=flags))
+        # `libmtmd` last: it is an optional member of the family, so the
+        # mandatory prefix above does not name it, and leaving it to the loader
+        # means the bridge's own DT_NEEDED decides where it comes from. Loading
+        # it by full path from the claimed family settles that here instead.
+        self._handles.append(
+            load_native_cdll(self.build_bin / runtime_library_filename("mtmd"), mode=flags)
+        )
         self.lib = load_native_cdll(
             resolved_bridge,
             mode=flags,

--- a/tests/test_native_chat_bridge.py
+++ b/tests/test_native_chat_bridge.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -15,7 +16,11 @@ from orbit.native_llama.bindings import ChatBridgeLibrary, LlamaLibrary
 from orbit.native_llama.build_support import DEFAULT_VENDOR_BUILD_BIN
 from orbit.native_llama.chat_bridge import CHAT_BRIDGE_API_VERSION, chat_bridge_filename, validate_chat_bridge_artifact
 from orbit.native_llama.client import _resolve_chat_bridge_path
-from orbit.native_llama.native_names import platform_runtime_libs, runtime_library_filename
+from orbit.native_llama.native_names import (
+    mtmd_bridge_filename,
+    platform_runtime_libs,
+    runtime_library_filename,
+)
 
 
 class NativeChatBridgeTests(unittest.TestCase):
@@ -150,7 +155,7 @@ ChatBridgeLibrary(runtime, runtime / chat_bridge_filename())
 mapped = {
     line.rsplit(' ', 1)[-1]
     for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
-    if '/libllama' in line or '/libggml' in line
+    if any(marker in line for marker in ('/libllama', '/libggml', '/libmtmd', '/liborbit-'))
 }
 outside = sorted(path for path in mapped if not path.startswith(str(runtime) + '/'))
 if outside:
@@ -176,6 +181,236 @@ if outside:
         ).exists(),
         "packaged native runtime or Linux process maps are unavailable",
     )
+    @unittest.skipUnless(
+        (DEFAULT_VENDOR_BUILD_BIN / mtmd_bridge_filename()).exists()
+        and (DEFAULT_VENDOR_BUILD_BIN / runtime_library_filename("mtmd")).exists()
+        and Path("/proc/self/maps").exists(),
+        "native mtmd bridge or Linux process maps are unavailable",
+    )
+    def test_mtmd_bridge_cannot_introduce_a_second_runtime_family(self) -> None:
+        """The mtmd bridge claims the family like every other entry point.
+
+        `libmtmd` links against llama and ggml, so this bridge pulls a whole
+        runtime family in behind it. Verifying the bridge's own artifact
+        identity only says those files belong together -- not that they are
+        the family this process already runs on. Without a claim a second,
+        internally consistent family loads beside the first, which is the
+        topology observed in the crashed processes.
+
+        Exercised through `MtmdLibrary` rather than by inspecting the source,
+        because the defect this replaces was invisible to tests that only ever
+        constructed `LlamaLibrary`.
+        """
+        root = Path(__file__).resolve().parents[1]
+        source = DEFAULT_VENDOR_BUILD_BIN
+        script = """
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from orbit.native_llama.bindings import LlamaLibrary, MtmdLibrary
+from orbit.native_llama.native_names import (
+    mtmd_bridge_filename,
+    platform_runtime_load_order,
+    runtime_library_filename,
+)
+
+source = Path(sys.argv[1])
+bridge_name = mtmd_bridge_filename()
+family = [*platform_runtime_load_order(), runtime_library_filename('mtmd'), bridge_name]
+with tempfile.TemporaryDirectory(prefix='orbit-mtmd-family.') as tmp:
+    second = Path(tmp) / 'second'
+    second.mkdir()
+    for name in family:
+        # Copy the SONAME spellings too, not just the linker name: the loader
+        # asks for `libmtmd.so.0`, so a directory holding only `libmtmd.so`
+        # fails to load before the guard is ever consulted -- which would let
+        # this test pass for the wrong reason.
+        for candidate in sorted(source.glob(name + '*')):
+            if candidate.is_file():
+                shutil.copy2(candidate.resolve(), second / candidate.name)
+        real = source / name
+        if real.exists() and not (second / name).exists():
+            shutil.copy2(real.resolve(), second / name)
+    identity = source / (bridge_name + '.identity.json')
+    if identity.exists():
+        shutil.copy2(identity, second / identity.name)
+
+    # First family: the one this process is entitled to.
+    LlamaLibrary(source)
+    try:
+        MtmdLibrary(second, second / bridge_name)
+    except RuntimeError as exc:
+        if 'native runtime family conflict' not in str(exc):
+            raise
+    else:
+        raise SystemExit('mtmd bridge accepted a second native runtime family')
+
+    mapped = {
+        line.rsplit(' ', 1)[-1]
+        for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
+        if any(m in line for m in ('/libllama', '/libggml', '/libmtmd', '/liborbit-'))
+    }
+    if any(path.startswith(str(second) + '/') for path in mapped):
+        raise SystemExit('second family was mapped before rejection')
+"""
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(root / "src")
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(source)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
+    def test_a_path_alias_is_the_same_family(self) -> None:
+        """Two names for one directory are one runtime, not two.
+
+        The guard compares canonical paths. Comparing the paths as written
+        would refuse a legitimate load whenever the caller reached the same
+        directory through a symlink or a non-normalised path -- a false
+        conflict that would look exactly like the real one.
+        """
+        from orbit.native_llama import bindings
+
+        with tempfile.TemporaryDirectory(prefix="orbit-family-alias.") as tmp:
+            real = Path(tmp) / "real"
+            real.mkdir()
+            alias = Path(tmp) / "alias"
+            alias.symlink_to(real, target_is_directory=True)
+            indirect = Path(tmp) / "." / "real"
+
+            with mock.patch.object(bindings, "_RUNTIME_FAMILY_ROOT", None):
+                bindings._claim_runtime_family(real)
+                # Neither spelling is a second family.
+                self.assertEqual(bindings._claim_runtime_family(alias), real.resolve())
+                self.assertEqual(bindings._claim_runtime_family(indirect), real.resolve())
+
+    def test_an_incomplete_family_is_refused_before_it_is_claimed(self) -> None:
+        """A directory missing part of the runtime is not a family.
+
+        Claiming it would bind the process to something that cannot satisfy
+        its own dependencies, and the loader would then answer the missing
+        pieces from wherever else it could find them.
+        """
+        from orbit.native_llama import bindings
+
+        with tempfile.TemporaryDirectory(prefix="orbit-family-partial.") as tmp:
+            partial = Path(tmp) / "partial"
+            partial.mkdir()
+            (partial / runtime_library_filename("mtmd")).write_bytes(b"")
+
+            with mock.patch.object(bindings, "_RUNTIME_FAMILY_ROOT", None):
+                with self.assertRaises(RuntimeError) as caught:
+                    bindings._require_runtime_prefix(
+                        partial.resolve(), runtime_library_filename("llama-common")
+                    )
+                self.assertIn("incomplete native runtime family", str(caught.exception))
+                self.assertIsNone(
+                    bindings._RUNTIME_FAMILY_ROOT,
+                    "an incomplete family must not be claimed",
+                )
+
+    @unittest.skipUnless(
+        (DEFAULT_VENDOR_BUILD_BIN / mtmd_bridge_filename()).exists()
+        and (DEFAULT_VENDOR_BUILD_BIN / runtime_library_filename("mtmd")).exists()
+        and Path("/proc/self/maps").exists(),
+        "native mtmd bridge or Linux process maps are unavailable",
+    )
+    def test_mtmd_family_is_loaded_by_path_not_by_search(self) -> None:
+        """A search path must not decide which family answers.
+
+        `libmtmd` is an optional member of the family, so the mandatory prefix
+        does not name it. Left to the loader, the bridge's own `DT_NEEDED`
+        would be answered by whatever the search path offered first -- here a
+        foreign copy -- which puts a second family in the process even though
+        the claim succeeded.
+        """
+        root = Path(__file__).resolve().parents[1]
+        script = """
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from orbit.native_llama.bindings import MtmdLibrary
+from orbit.native_llama.native_names import mtmd_bridge_filename, runtime_library_filename
+
+source = Path(sys.argv[1])
+foreign = Path(sys.argv[2])
+MtmdLibrary(source, source / mtmd_bridge_filename())
+mapped = {
+    line.rsplit(' ', 1)[-1]
+    for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
+    if any(m in line for m in ('/libllama', '/libggml', '/libmtmd', '/liborbit-'))
+}
+outside = sorted(path for path in mapped if path.startswith(str(foreign) + '/'))
+if outside:
+    raise SystemExit('foreign family answered the search path: ' + ','.join(outside))
+"""
+        with tempfile.TemporaryDirectory(prefix="orbit-mtmd-search.") as tmp:
+            foreign = Path(tmp) / "foreign"
+            foreign.mkdir()
+            for candidate in DEFAULT_VENDOR_BUILD_BIN.glob(
+                runtime_library_filename("mtmd") + "*"
+            ):
+                if candidate.is_file():
+                    shutil.copy2(candidate.resolve(), foreign / candidate.name)
+
+            env = dict(os.environ)
+            env["PYTHONPATH"] = str(root / "src")
+            # The condition under test: a search path that offers the same
+            # SONAME from somewhere else.
+            env["LD_LIBRARY_PATH"] = str(foreign)
+            result = subprocess.run(
+                [sys.executable, "-c", script, str(DEFAULT_VENDOR_BUILD_BIN), str(foreign)],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
+    def test_a_rejected_family_does_not_replace_the_claimed_one(self) -> None:
+        """A refusal must not quietly rebind the process to the family it refused.
+
+        If the conflict path recorded the rejected root, the first rejection
+        would move the claim: the next load from the original family would
+        then be refused instead, and a third from the rejected family would be
+        accepted. The process would end up running the family it just said no
+        to, and every later check would agree with it.
+
+        Exercised through the guard directly because no artifact needs to
+        exist for the ordering to be wrong.
+        """
+        from orbit.native_llama import bindings
+
+        with tempfile.TemporaryDirectory(prefix="orbit-claim-order.") as tmp:
+            first = Path(tmp) / "first"
+            second = Path(tmp) / "second"
+            first.mkdir()
+            second.mkdir()
+
+            with mock.patch.object(bindings, "_RUNTIME_FAMILY_ROOT", None):
+                claimed = bindings._claim_runtime_family(first)
+                self.assertEqual(claimed, first.resolve())
+
+                with self.assertRaises(RuntimeError):
+                    bindings._claim_runtime_family(second)
+
+                self.assertEqual(
+                    bindings._RUNTIME_FAMILY_ROOT,
+                    first.resolve(),
+                    "a rejected family replaced the claimed one",
+                )
+                # The original family is still the one this process may load.
+                self.assertEqual(bindings._claim_runtime_family(first), first.resolve())
+                with self.assertRaises(RuntimeError):
+                    bindings._claim_runtime_family(second)
+
     def test_process_rejects_a_second_runtime_family(self) -> None:
         root = Path(__file__).resolve().parents[1]
         source = root / "src/orbit/native_llama/vendor/lib"
@@ -205,7 +440,7 @@ with tempfile.TemporaryDirectory(prefix='orbit-runtime-family.') as tmp:
     mapped = {
         line.rsplit(' ', 1)[-1]
         for line in Path('/proc/self/maps').read_text(encoding='utf-8').splitlines()
-        if '/libllama' in line or '/libggml' in line
+        if any(marker in line for marker in ('/libllama', '/libggml', '/libmtmd', '/liborbit-'))
     }
     if any(path.startswith(str(roots[1]) + '/') for path in mapped):
         raise SystemExit('second native runtime family was mapped')


### PR DESCRIPTION
`MtmdLibrary` was the one native entry point that loaded its bridge without
first claiming a runtime family.

## What changes

- **Closes the `MtmdLibrary` family-guard gap.** `libmtmd` links against llama
  and ggml, so loading the bridge pulls a whole family in behind it. The
  bridge's own artifact identity says those files belong *to each other*, not
  that they are the family this process already runs on, so an internally
  consistent second family passed the check.
- **Reuses the existing runtime-family claim mechanism.** The same
  `_claim_runtime_family` / `_require_runtime_prefix` pair the llama and
  chat-bridge entry points already use. No second guard, no new global state,
  no lifecycle redesign.
- **Resolves and preloads `libmtmd` explicitly from the already-claimed
  family**, by full path from the claimed root. `libmtmd` is an optional
  member that the mandatory prefix does not name, so left implicit a search
  path could answer that dependency from elsewhere even though the claim
  succeeded.
- **Prevents mixed-family Mtmd loading.** Rejection happens before any foreign
  library is mapped, and the already-claimed family is left untouched.
- **Does not attempt to make dual-family loading safe.** Orbit refuses it.
  Once a library is resolved by SONAME the loader reuses it, so a process that
  deliberately loads two families still shares the first one's libraries.
  That is out of reach of a guard and is not claimed here.
- **No RUNPATH, lifecycle, teardown, ownership or backend behaviour changed.**
  The build files, native loader paths (`paths.py`, `client.py`,
  `persistent_mtp.py`, `model_discovery.py`, `capabilities.py`) and
  `src/orbit/{runtime,backend,terminal}` are byte-identical to the baseline.
- **Existing single-family behaviour preserved**, including two spellings of
  one directory (symlink or non-normalised path) resolving to one family
  without a false conflict.

## Evidence

The defect reproduces on the baseline: with family A claimed through
`LlamaLibrary`, `ChatBridgeLibrary(B)` was **rejected** while `MtmdLibrary(B)`
was **accepted**, and `/proc/self/maps` then showed two families resident --
`libmtmd` and the mtmd bridge from B alongside llama/ggml from A. This is the
same topology observed in the crashed processes investigated earlier.

Adversarial matrix **A-F all pass**: same family accepted; mixed family
rejected in both directions; repeated same-family loads reuse the cache; a
path alias to the same canonical root is accepted; genuinely different
families fail closed. **All 9 load orderings** (llama / mtmd / chat-bridge,
each first from A then second from B) reject with **zero** foreign mappings,
so the guard is load-order independent. Thread-safety: **0 violations in 400**
barrier-synchronised trials.

With a poisoned `LD_LIBRARY_PATH`, a first `MtmdLibrary` load maps **zero**
foreign libraries in both directions; the baseline under identical conditions
leaks five. The preload uses the *return value* of `_claim_runtime_family`, so
a caller cannot redirect it.

Family guard **14**, mtmd/native bridge **33**, KV/prewarm **112**, RUNPATH
isolation regression **8**, full suite **3048 passed + 1 environment skip**,
real exit code 0, zero crash markers and no new core dumps. compileall and
`git diff --check` clean.

Two pre-existing guard tests were repaired: both stayed green against the
historical defect because they filtered `/proc/self/maps` on `/libllama` and
`/libggml` only -- neither pattern matches `libmtmd` or the orbit bridges --
and neither ever constructed an `MtmdLibrary`. Their filters were widened and
a test that actually exercises the bridge was added; existing assertions are
unchanged.

## Follow-up work, not in this PR

This closes the production-relevant `MtmdLibrary` gap. **It does not guard
every native entry point.** Three loader paths remain unclassified and are
deliberately untouched here:

- `PersistentMtpLibrary._load_library` (`persistent_mtp.py`)
- `_shim_exports_required_symbols` (`persistent_mtp.py`)
- `read_llama_cpp_build_info` (`capabilities.py`)

Each can map a foreign family if handed a foreign `build_bin` -- verified
directly for `read_llama_cpp_build_info`. None is reachable that way in
production today: every call site derives `build_bin` from the same frozen
`NativeLlamaPaths` object already claimed by the client, and
`ORBIT_LLAMA_ROOT` / `ORBIT_LLAMA_LIB_DIR` are module constants read once at
import. Their safety therefore rests on an ordering invariant rather than an
enforced check, which is worth classifying separately.
