### PR TITLE
fix(native): keep mtp probe in claimed runtime family

### DIFF
--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -177,10 +177,19 @@ def build_persistent_mtp_shim(
     llama_root: Path | None,
     build_dir: Path | None = None,
     build_bin: Path | None = None,
+    runtime_bin: Path | None = None,
     runner=subprocess.run,
 ) -> Path:
     packaged = packaged_shim_path(persistent_mtp_shim_filename())
-    if packaged is not None and _shim_exports_required_symbols(packaged):
+    # `build_bin` is where the compiler links from; `runtime_bin` is the family
+    # this process will actually run on. They are usually the same directory
+    # and diverge only when the resolved runtime lacks the SONAME aliases the
+    # linker needs. The probe has to preload the runtime, not the link
+    # directory: preloading the latter is what would put a second family in
+    # the process, which is the thing being prevented.
+    if packaged is not None and _shim_exports_required_symbols(
+        packaged, runtime_bin if runtime_bin is not None else build_bin
+    ):
         return packaged
     artifact_name = persistent_mtp_shim_filename()
     llama_root = require_legacy_llama_root(llama_root, artifact_name=artifact_name)
@@ -208,11 +217,32 @@ def _persistent_mtp_link_bin(paths: NativeLlamaPaths) -> Path:
     return build_bin
 
 
-def _shim_exports_required_symbols(path: Path) -> bool:
+def _shim_exports_required_symbols(path: Path, build_bin: Path | None = None) -> bool:
+    """Whether the packaged shim exports the symbols this process needs.
+
+    `build_bin` is the runtime the caller intends to use. It matters because
+    the shim records `$ORIGIN/../build/llama.cpp/bin` as its search path --
+    one specific directory, not "wherever this family lives". When the
+    resolved runtime is the packaged `vendor/lib` instead, dlopening the shim
+    unqualified pulls `libllama-common` out of the build directory: a second
+    runtime family in the process, by the same definition the family guard
+    uses, since it compares resolved paths.
+
+    Loading the runtime from `build_bin` first settles those dependencies by
+    SONAME before the shim is opened, exactly as `PersistentMtpLibrary` does.
+    That also removes a false negative: the mixed load made this probe report
+    a missing symbol, so a working packaged shim was discarded and the failure
+    surfaced later as "no packaged shim artifact is available".
+    """
     if not path.exists() or not path.is_file():
         return False
     flags = native_cdll_flags()
     try:
+        if build_bin is not None:
+            for dep in platform_runtime_libs():
+                dependency = build_bin / dep
+                if dependency.exists():
+                    load_native_cdll(dependency, mode=flags)
         lib = load_native_cdll(path, mode=flags)
     except OSError:
         return False
@@ -239,6 +269,7 @@ def create_persistent_mtp_session(
         llama_root=llama_root,
         build_dir=build_dir,
         build_bin=_persistent_mtp_link_bin(paths),
+        runtime_bin=paths.build_bin,
         runner=runner,
     )
     library = library_factory(paths.build_bin, shim)
@@ -274,7 +305,12 @@ def _runtime_library(
 ) -> object:
     if runtime.library is not None and hasattr(runtime.library, "lib"):
         return runtime.library
-    shim = build_persistent_mtp_shim(llama_root=llama_root, build_dir=build_dir, build_bin=_persistent_mtp_link_bin(paths))
+    shim = build_persistent_mtp_shim(
+        llama_root=llama_root,
+        build_dir=build_dir,
+        build_bin=_persistent_mtp_link_bin(paths),
+        runtime_bin=paths.build_bin,
+    )
     return library_factory(paths.build_bin, shim)
 
 

--- a/tests/test_native_persistent_mtp.py
+++ b/tests/test_native_persistent_mtp.py
@@ -8,10 +8,14 @@ from unittest import mock
 
 from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
 from orbit.native_llama.events import NativeTimings
+from orbit.native_llama.native_names import platform_runtime_libs
 from orbit.native_llama.paths import NativeLlamaPaths
 from orbit.native_llama.persistent_mtp import (
     PersistentMtpSessionRuntime,
+    create_persistent_mtp_session,
+    free_persistent_mtp_session,
     _persistent_mtp_link_bin,
+    _shim_exports_required_symbols,
     build_persistent_mtp_shim,
     run_persistent_mtp_completion,
 )
@@ -46,6 +50,189 @@ class NativePersistentMtpTests(unittest.TestCase):
 
         self.assertEqual(shim, packaged)
         mocked_compile.assert_called_once()
+
+    def test_symbol_probe_loads_the_runtime_before_opening_the_shim(self) -> None:
+        """The probe must settle the shim's dependencies from the claimed runtime.
+
+        The packaged shim records `$ORIGIN/../build/llama.cpp/bin` as its
+        search path -- one specific directory, not "wherever this family
+        lives". When the resolved runtime is `vendor/lib` instead, opening the
+        shim unqualified pulls `libllama-common` out of the build directory,
+        putting a second runtime family in the process by the same definition
+        the family guard uses.
+
+        Asserted on the load ORDER rather than on a message: the runtime has to
+        be in place before the shim is opened, or the loader has already
+        answered the shim's dependencies from somewhere else.
+        """
+        loaded: list[Path] = []
+
+        def record(path: Path, *, mode: int) -> object:
+            loaded.append(path)
+            return mock.Mock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp) / "runtime"
+            build_bin.mkdir()
+            for name in platform_runtime_libs():
+                (build_bin / name).write_bytes(b"")
+            shim = Path(tmp) / "liborbit-persistent-mtp.so"
+            shim.write_bytes(b"")
+
+            with mock.patch(
+                "orbit.native_llama.persistent_mtp.load_native_cdll", side_effect=record
+            ):
+                _shim_exports_required_symbols(shim, build_bin)
+
+        self.assertIn(shim, loaded, "the shim itself must still be opened")
+        self.assertGreater(
+            loaded.index(shim),
+            0,
+            "the runtime must be loaded before the shim, not after or not at all",
+        )
+        self.assertEqual(
+            loaded[: loaded.index(shim)],
+            [build_bin / name for name in platform_runtime_libs()],
+            "the shim's dependencies must come from the caller's runtime",
+        )
+
+    def test_shim_selection_passes_the_runtime_to_the_symbol_probe(self) -> None:
+        """The production caller must hand the probe the runtime it will claim.
+
+        The preload only helps if the call site supplies the right directory.
+        `build_bin` is where the compiler links from and can differ from the
+        resolved runtime; preloading it would map a family this process never
+        claimed, which is the state this change exists to remove.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            packaged = Path(tmp) / "liborbit-persistent-mtp.so"
+            packaged.write_bytes(b"")
+            build_bin = Path(tmp) / "runtime"
+            build_bin.mkdir()
+
+            runtime_bin = Path(tmp) / "claimed"
+            runtime_bin.mkdir()
+
+            with mock.patch(
+                "orbit.native_llama.persistent_mtp.packaged_shim_path", return_value=packaged
+            ), mock.patch(
+                "orbit.native_llama.persistent_mtp._shim_exports_required_symbols",
+                return_value=True,
+            ) as probe:
+                build_persistent_mtp_shim(
+                    llama_root=None, build_bin=build_bin, runtime_bin=runtime_bin
+                )
+
+        # The runtime this process will claim, not the directory the compiler
+        # links against: preloading the latter is what puts a second family in
+        # the process when the two diverge.
+        probe.assert_called_once_with(packaged, runtime_bin)
+
+    def test_session_creation_gives_the_shim_builder_the_claimed_runtime(self) -> None:
+        """The session paths must forward the family they are about to claim.
+
+        `build_persistent_mtp_shim` cannot know which runtime the caller
+        claimed unless the caller says so, and the link directory it already
+        receives is the wrong answer whenever the two diverge.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp) / "runtime"
+            build_bin.mkdir()
+            paths = NativeLlamaPaths(
+                llama_root=None,
+                build_bin=build_bin,
+                library=build_bin / "libllama.so",
+                model=Path(tmp) / "model.gguf",
+                draft_mtp_model=Path(tmp) / "draft.gguf",
+                mtp_available=True,
+            )
+
+            with mock.patch(
+                "orbit.native_llama.persistent_mtp.build_persistent_mtp_shim",
+                return_value=Path(tmp) / "shim.so",
+            ) as builder, mock.patch(
+                "orbit.native_llama.persistent_mtp._persistent_mtp_link_bin",
+                return_value=Path(tmp) / "link-elsewhere",
+            ):
+                with self.assertRaises(Exception):
+                    create_persistent_mtp_session(
+                        llama_root=Path(tmp),
+                        paths=paths,
+                        ctx_tgt=None,
+                        context_tokens=1,
+                        batch_size=1,
+                        ubatch_size=1,
+                        threads=1,
+                        threads_batch=1,
+                        library_factory=mock.Mock(),
+                    )
+
+        self.assertEqual(
+            builder.call_args.kwargs.get("runtime_bin"),
+            build_bin,
+            "the claimed runtime must reach the shim builder",
+        )
+
+    def test_runtime_library_reuse_also_forwards_the_claimed_runtime(self) -> None:
+        """The second shim-building call site must forward it too.
+
+        `_runtime_library` rebuilds the shim for reset, free and completion, so
+        leaving it unwired would keep the leak alive on every path except
+        session creation -- which is the shape of the wiring gap this change
+        exists to close.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            build_bin = Path(tmp) / "runtime"
+            build_bin.mkdir()
+            paths = NativeLlamaPaths(
+                llama_root=None,
+                build_bin=build_bin,
+                library=build_bin / "libllama.so",
+                model=Path(tmp) / "model.gguf",
+                draft_mtp_model=Path(tmp) / "draft.gguf",
+                mtp_available=True,
+            )
+            runtime = PersistentMtpSessionRuntime(
+                handle=None, ctx_dft=None, spec=None, library=None
+            )
+
+            with mock.patch(
+                "orbit.native_llama.persistent_mtp.build_persistent_mtp_shim",
+                return_value=Path(tmp) / "shim.so",
+            ) as builder, mock.patch(
+                "orbit.native_llama.persistent_mtp._persistent_mtp_link_bin",
+                return_value=Path(tmp) / "link-elsewhere",
+            ):
+                free_persistent_mtp_session(
+                    paths=paths,
+                    runtime=runtime,
+                    llama_root=Path(tmp),
+                    library_factory=lambda *_args: mock.Mock(),
+                )
+
+        self.assertEqual(
+            builder.call_args.kwargs.get("runtime_bin"),
+            build_bin,
+            "the claimed runtime must reach the shim builder on this path too",
+        )
+
+    def test_symbol_probe_without_a_runtime_keeps_its_previous_behaviour(self) -> None:
+        """Callers that pass no runtime still get a plain symbol check."""
+        loaded: list[Path] = []
+
+        def record(path: Path, *, mode: int) -> object:
+            loaded.append(path)
+            return mock.Mock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            shim = Path(tmp) / "liborbit-persistent-mtp.so"
+            shim.write_bytes(b"")
+            with mock.patch(
+                "orbit.native_llama.persistent_mtp.load_native_cdll", side_effect=record
+            ):
+                _shim_exports_required_symbols(shim)
+
+        self.assertEqual(loaded, [shim])
 
     def test_persistent_mtp_link_bin_uses_runtime_bin_when_sonames_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
`_shim_exports_required_symbols` opened the packaged MTP shim without first
loading the runtime it belongs to.

## What changes

- **Closes the remaining production-relevant shim-probe family leak.** The
  shim records `$ORIGIN/../build/llama.cpp/bin` as its search path -- one
  specific directory, not "wherever this family lives". When the resolved
  runtime is the packaged `vendor/lib` instead, the loader answered the shim's
  dependencies out of the build directory, putting `libllama-common` from one
  directory beside `libllama` from another in a single process: two runtime
  families by the same definition the family guard uses, since it compares
  resolved paths.
- **Separates the claimed runtime location from the compiler/link location.**
  `build_persistent_mtp_shim` now takes `runtime_bin` (the family this process
  will claim) alongside `build_bin` (what the compiler links against). They
  are usually one directory and diverge only when the resolved runtime lacks
  the SONAME aliases the linker needs -- exactly when preloading the link
  directory would map a family the process never claimed.
- **Prevents the probe from resolving a foreign runtime family.** It loads the
  runtime first, the way `PersistentMtpLibrary` already did; that asymmetry
  between the two was the whole defect.
- **No new family guard where the evidence says one is unnecessary.** The
  probe takes no claim: it answers a question before any claim may exist, and
  binding process-global state in a diagnostic would turn a degradable path
  into a hard failure.
- **No RUNPATH, lifecycle, teardown, backend or loader-design changes.**
  `src/orbit/runtime`, `src/orbit/backend`, `src/orbit/terminal`,
  `src/orbit/native_server` and every other native module are byte-identical
  to the baseline.

It also failed misleadingly: the mixed load made the probe report a missing
symbol, so a working packaged shim was discarded and the failure surfaced as
"no packaged shim artifact is available and no legacy llama_root was
provided" -- naming a cause that had nothing to do with it.

## Classifications

The three remaining native entry points were traced and classified:

- **`PersistentMtpLibrary._load_library` -- SAFE WITHOUT GUARD**, under the
  proven preload invariant. It can map a foreign family in isolation, but all
  four call sites pass `paths.build_bin` from the same frozen
  `NativeLlamaPaths` the client already claimed, and its preload loop settles
  the shim's dependencies from that family.
- **`_shim_exports_required_symbols` -- GUARD REQUIRED**, fixed by this PR.
- **`read_llama_cpp_build_info` -- SAFE WITHOUT GUARD.** It is *technically
  capable* of loading a foreign family when called directly with a foreign
  `build_bin` -- demonstrated, two families mapped -- but its production
  callers are structurally constrained to the claimed, frozen runtime family.

This is a statement about the production call paths that were traced, **not a
claim that every imaginable direct or internal call is safe.**

## Verification

Divergent, non-divergent and pristine layouts each map **zero** runtime
libraries outside the claimed family; the divergent case previously mapped
four. Mutations M1 (drop preload), M2 (preload after opening the shim -- order
only), M4 (probe fed the link directory instead of the runtime), M5 (create
site drops `runtime_bin`) and M6 (`_runtime_library` drops it) are all caught,
each by a test that pins the specific wiring.

Persistent MTP **18** (`test_native_persistent_mtp.py`), family guard **14**
(`test_native_chat_bridge.py`), native bridge/MTP **59** (`test_mtmd_bridge_abi.py`,
`test_native_bindings.py`, `test_native_capabilities.py`, `test_native_mtp_probe.py`,
`test_native_mtp_dry_run.py`, `test_native_model_profiles.py`), RUNPATH isolation
**8** (`test_native_runpath_isolation.py`), KV/prewarm **112** (`test_kv_diag.py`,
`test_eager_analysis_prewarm.py`, `test_analysis_rolling_kv.py`), full suite
**3053 passed + 1 environment skip**, real exit code 0, zero crash markers, no
new core dumps. compileall and `git diff --check` clean.

Run the focused gates with `PYTHONPATH=src`.

## Not addressed here

- The packaged shim genuinely lacks `orbit_mtp_session_set_followup_suffix_tokens`
  (one of four required symbols), so the probe still returns `False` on a
  build where that is true. Pre-existing and unrelated to the family question.
- `model_discovery.py` catching `RuntimeError` around `NativeProfileInspector`,
  which makes a family conflict there silent rather than surfaced.
- `_client_build_bin` duck-typing on a Protocol rather than a concrete type.
