### PR TITLE
test: isolate analysis temp resource ownership

### DIFF
--- a/tests/test_analysis_sandbox.py
+++ b/tests/test_analysis_sandbox.py
@@ -12,12 +12,14 @@ import shutil
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from orbit.runtime import analysis_sandbox
 from orbit.runtime.analysis_sandbox import (
     ALLOWED_COMMANDS,
     MAX_CODE_CHARS,
@@ -97,6 +99,37 @@ class PreflightTest(unittest.TestCase):
                     analysis_sandbox.execute_analysis(source_path=src, code="print(1)")
             finally:
                 analysis_sandbox.BWRAP = original
+
+
+def track_sandbox_temp_dirs(test: unittest.TestCase) -> list[Path]:
+    """Record the temporary directories `analysis_sandbox` creates from here on.
+
+    The alternative -- listing the shared temp root before and after -- reads
+    state this process does not own. Another Orbit run creating a directory
+    under the same prefix between the two samples lands in the difference, and
+    the test fails for a directory it never created. Redirecting `TMPDIR` does
+    not help: `tempfile.gettempdir()` is resolved once per process, so a
+    concurrent run still writes into the same root.
+
+    Wrapping the constructor the module actually calls gives the exact paths
+    this test caused to exist, which is both narrower and stronger: it can
+    distinguish a directory that was cleaned up from one that merely never
+    appeared, and no other process can add to it.
+    """
+    created: list[Path] = []
+    real = analysis_sandbox.tempfile.TemporaryDirectory
+
+    class Recording(real):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(Path(self.name))
+
+    patcher = mock.patch.object(
+        analysis_sandbox.tempfile, "TemporaryDirectory", Recording
+    )
+    patcher.start()
+    test.addCleanup(patcher.stop)
+    return created
 
 
 @requires_bwrap
@@ -268,88 +301,79 @@ class SandboxBehaviourTest(SandboxTestBase):
         self.assertIn("LEFTOVER False", second.stdout)
 
     def test_temporary_directories_do_not_accumulate(self) -> None:
-        # Explicit cleanup is defence in depth: TemporaryDirectory also removes
-        # itself via a GC finalizer, so removing the explicit call is not
-        # observable from outside. What is worth pinning is the property that
-        # matters -- actions leave nothing behind on the host.
-        #
-        # Only the prefixes an action actually creates are counted. The old
-        # assertion globbed `orbit-analysis-*` in the shared temp root, which
-        # also matches `orbit-analysis-session-*` -- the name `AnalysisWorkspace`
-        # gives a session. A workspace another module held open while this ran
-        # therefore landed in the delta and failed this test for a directory it
-        # never created. Redirecting TMPDIR does not fix that either: the root
-        # is process-global, so a concurrent workspace lands inside it too.
-        #
-        # `execute_analysis` creates exactly these two, both owned by a
-        # `TemporaryDirectory` it closes before returning.
-        import tempfile
+        """Actions leave nothing behind on the host.
 
-        root = Path(tempfile.gettempdir())
-        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
+        Explicit cleanup is defence in depth: `TemporaryDirectory` also removes
+        itself via a GC finalizer, so deleting the explicit call is not
+        observable from outside. What is worth pinning is the property that
+        matters, and it is asserted over the directories these actions actually
+        created rather than over whatever the shared temp root happens to hold.
+        """
+        created = track_sandbox_temp_dirs(self)
 
-        def owned_dirs() -> set[str]:
-            return {
-                entry.name
-                for prefix in owned
-                for entry in root.glob(f"{prefix}*")
-            }
-
-        before = owned_dirs()
         for _ in range(3):
             self.run_code("print('tick')")
+
+        # One per action per owner: the program directory and the scratch
+        # directory. Pinning the count means an assertion that saw nothing --
+        # because the tracker watched the wrong thing -- cannot pass by
+        # observing an empty list.
         self.assertEqual(
-            owned_dirs() - before,
-            set(),
-            "each action must remove its temporary directories",
+            len(created), 6, "each action creates a program and a scratch directory"
+        )
+        self.assertEqual(
+            [path for path in created if path.exists()],
+            [],
+            "each action must remove the temporary directories it created",
         )
 
     def test_an_unrelated_matching_directory_is_ignored(self) -> None:
         """A session workspace is not this test's to account for.
 
-        This is the exact shape that made the old assertion flaky: the name
-        matches `orbit-analysis-*`, it appears between the two samples, and no
-        action here created it.
+        This is the shape that made the old assertion flaky: the name matches
+        the prefixes an action uses, it appears between the two samples, and no
+        action here created it. Tracking what this test caused makes the
+        distinction directly instead of hoping the names do not collide.
         """
         from orbit.runtime.analysis_runtime import AnalysisWorkspace
 
-        import tempfile
-
-        root = Path(tempfile.gettempdir())
-        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
-
-        def owned_dirs() -> set[str]:
-            return {e.name for prefix in owned for e in root.glob(f"{prefix}*")}
-
-        before = owned_dirs()
+        created = track_sandbox_temp_dirs(self)
         unrelated = AnalysisWorkspace.create()
         self.addCleanup(unrelated.close)
-        # Created after the baseline and still present at the second sample.
         self.assertTrue(unrelated.root.exists())
         self.assertTrue(unrelated.root.name.startswith("orbit-analysis-"))
+
         for _ in range(3):
             self.run_code("print('tick')")
-        self.assertEqual(owned_dirs() - before, set())
+
+        self.assertNotIn(
+            unrelated.root,
+            created,
+            "a workspace this test did not run through the sandbox is not owned",
+        )
+        self.assertEqual([path for path in created if path.exists()], [])
+        # Still open, and unaffected by the sandbox's own cleanup.
+        self.assertTrue(unrelated.root.exists())
 
     def test_a_leaked_owned_directory_still_fails(self) -> None:
-        """The assertion must still catch a real leak with an owned prefix.
+        """The assertion must still catch a real leak.
 
-        Narrowing the prefixes must not have narrowed away the property. A
-        directory named as one an action owns, left behind, has to be seen.
+        Narrowing what is observed must not narrow away the property: a
+        directory the sandbox created and failed to remove has to be seen.
         """
-        import tempfile
+        created = track_sandbox_temp_dirs(self)
+        self.run_code("print('tick')")
+        self.assertTrue(created)
 
-        root = Path(tempfile.gettempdir())
-        owned = ("orbit-analysis-program-", "orbit-analysis-work-")
-
-        def owned_dirs() -> set[str]:
-            return {e.name for prefix in owned for e in root.glob(f"{prefix}*")}
-
-        before = owned_dirs()
-        leaked = Path(tempfile.mkdtemp(prefix="orbit-analysis-work-"))
+        # Recreate one of the directories the action owned, as a leak would.
+        leaked = created[0]
+        leaked.mkdir(parents=True, exist_ok=True)
         self.addCleanup(shutil.rmtree, leaked, True)
+
         self.assertNotEqual(
-            owned_dirs() - before, set(), "a leak under an owned prefix must be visible"
+            [path for path in created if path.exists()],
+            [],
+            "a directory the action owned, left behind, must be visible",
         )
 
     def test_nonzero_exit_is_classified_as_error(self) -> None:

--- a/tests/test_automatic_analysis_routing.py
+++ b/tests/test_automatic_analysis_routing.py
@@ -23,12 +23,15 @@ import sys
 import tempfile
 import unittest
 from unittest import mock
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+from orbit.runtime import analysis_runtime
 
 from orbit.backend.base import ChatResult
 from orbit.runtime import ChatRuntime
@@ -48,6 +51,33 @@ from orbit.terminal.repl import Repl
 # CHAT prewarm to be re-derived, so this pin and that requalification move
 # together or not at all.
 ROUTE_PROMPT_SHA256 = "d38e293a1d8fc0efb5371cff08bb5870ffc4faa6b96b889ff2af54ba2b66a38d"
+
+
+def track_session_workspaces(test) -> list[Path]:
+    """Record the session workspaces created from here on.
+
+    Listing the shared temp root before and after reads state this process
+    does not own: a concurrent Orbit run creating a workspace between the two
+    samples lands in the difference and fails the test for a directory it
+    never created. Wrapping the call the workspace factory actually makes
+    yields only what this test caused to exist.
+    """
+    created: list[Path] = []
+    real = analysis_runtime.tempfile.mkdtemp
+
+    def recording(*args, **kwargs):
+        path = real(*args, **kwargs)
+        # Recorded by the name the call actually produced rather than by the
+        # `prefix` keyword: `mkdtemp` also takes it positionally, and reading
+        # the argument would silently miss such a call.
+        if Path(path).name.startswith("orbit-analysis-session-"):
+            created.append(Path(path))
+        return path
+
+    patcher = mock.patch.object(analysis_runtime.tempfile, "mkdtemp", recording)
+    patcher.start()
+    test.addCleanup(patcher.stop)
+    return created
 
 
 class RouteLanguageTest(unittest.TestCase):
@@ -442,14 +472,15 @@ class InvalidArtifactTest(TransitionTestBase):
         self.assertEqual(seen, ["what is 2+2"])
 
     def test_a_refused_transition_leaks_no_workspace(self) -> None:
-        pattern = "orbit-analysis-session-*"
-        before = set(Path(tempfile.gettempdir()).glob(pattern))
+        created = track_session_workspaces(self)
         backend = CountingBackend(self.analysis_payload(self.tmp / "nope.js"))
         repl = self.repl(backend)
 
         self.ask(repl, "analyze nope.js")
 
-        self.assertEqual(set(Path(tempfile.gettempdir()).glob(pattern)) - before, set())
+        # Refused before a workspace is created, so `created` is normally
+        # empty; the assertion still holds if creation ever moves earlier.
+        self.assertEqual([path for path in created if path.exists()], [])
 
 
 class ConfinedAcquisitionTest(TransitionTestBase):
@@ -678,12 +709,13 @@ class ConfinedAcquisitionTest(TransitionTestBase):
         self.assertEqual(seen, ["what is 2+2"])
 
     def test_a_refusal_leaks_no_workspace(self) -> None:
-        pattern = "orbit-analysis-session-*"
-        before = set(Path(tempfile.gettempdir()).glob(pattern))
+        created = track_session_workspaces(self)
 
         self._assert_refused(str(self.secret))
 
-        self.assertEqual(set(Path(tempfile.gettempdir()).glob(pattern)) - before, set())
+        # Refused before a workspace is created, so `created` is normally
+        # empty; the assertion still holds if creation ever moves earlier.
+        self.assertEqual([path for path in created if path.exists()], [])
 
     # --- explicit command parity ----------------------------------------
     def test_explicit_analysis_may_still_name_an_outside_path(self) -> None:

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -17,6 +17,7 @@ if str(SRC) not in sys.path:
 
 from orbit.backend.base import ChatResult, Message
 from orbit.runtime import ChatRuntime
+from orbit.runtime import analysis_runtime
 from orbit.runtime.analysis_runtime import ANALYSIS_AUTONOMY_ENV, ANALYSIS_TOOL_NAME, AnalysisRuntime
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.sessions import SessionStore
@@ -36,6 +37,36 @@ from orbit.terminal.repl import Repl
 # automatic-recognition mission; the pin is updated only alongside the
 # prewarm requalification that a changed route prompt forces.
 ROUTE_PROMPT_SHA256 = "d38e293a1d8fc0efb5371cff08bb5870ffc4faa6b96b889ff2af54ba2b66a38d"
+
+
+def track_session_workspaces(test) -> list[Path]:
+    """Record the session workspaces created from here on.
+
+    Listing the shared temp root before and after reads state this process
+    does not own: another Orbit run creating a workspace between the two
+    samples lands in the difference and fails the test for a directory it
+    never created. `tempfile.gettempdir()` is resolved once per process, so
+    redirecting `TMPDIR` does not separate the two runs either.
+
+    Wrapping the call `AnalysisWorkspace.create` actually makes yields the
+    exact paths this test caused to exist, which no other process can add to.
+    """
+    created: list[Path] = []
+    real = analysis_runtime.tempfile.mkdtemp
+
+    def recording(*args, **kwargs):
+        path = real(*args, **kwargs)
+        # Recorded by the name the call actually produced rather than by the
+        # `prefix` keyword: `mkdtemp` also takes it positionally, and reading
+        # the argument would silently miss such a call.
+        if Path(path).name.startswith("orbit-analysis-session-"):
+            created.append(Path(path))
+        return path
+
+    patcher = mock.patch.object(analysis_runtime.tempfile, "mkdtemp", recording)
+    patcher.start()
+    test.addCleanup(patcher.stop)
+    return created
 
 
 class ScriptedBackend:
@@ -217,7 +248,8 @@ class EnterAnalysisTest(ModeTestBase):
         self.assertIs(repl.analysis, first)
 
     def test_failed_open_leaves_no_workspace_behind(self) -> None:
-        before = set(Path(tempfile.gettempdir()).glob("orbit-analysis-session-*"))
+        created = track_session_workspaces(self)
+
         with self.assertRaises(AnalysisModeError):
             open_analysis_session(
                 "/nonexistent/zzz.js",
@@ -225,8 +257,13 @@ class EnterAnalysisTest(ModeTestBase):
                 workdir=self.tmp,
                 evidence_store_factory=lambda root: EvidenceStore(root=root / "evidence"),
             )
-        after = set(Path(tempfile.gettempdir()).glob("orbit-analysis-session-*"))
-        self.assertEqual(before, after)
+
+        # This open refuses while resolving the target, before a workspace is
+        # created, so `created` is expected to be empty. The assertion is kept
+        # over tracked paths rather than asserted as "nothing was created":
+        # if resolution ever moves after creation, the workspace appears here
+        # and must still be gone.
+        self.assertEqual([path for path in created if path.exists()], [])
 
 
 class AnalysisDispatchTest(ModeTestBase):
@@ -459,16 +496,20 @@ class LifecycleTest(ModeTestBase):
         self.assertTrue(workspace_root.exists())
 
     def test_no_workspace_leaks_across_a_full_cycle(self) -> None:
-        pattern = "orbit-analysis-session-*"
-        before = set(Path(tempfile.gettempdir()).glob(pattern))
+        created = track_session_workspaces(self)
         repl = self.repl()
         self.run_command(repl, f"/analysis {self.artifact}")
         self.run_prompt(repl, "continue")
         self.run_command(repl, "/chat")
         with contextlib.redirect_stdout(io.StringIO()):
             repl._finish_interactive_session(0)
-        after = set(Path(tempfile.gettempdir()).glob(pattern))
-        self.assertEqual(before, after)
+
+        self.assertTrue(created, "the cycle must have opened a session workspace")
+        self.assertEqual(
+            [path for path in created if path.exists()],
+            [],
+            "finishing the session must remove the workspace it opened",
+        )
 
 
 class PersistenceTest(ModeTestBase):


### PR DESCRIPTION
Six tests failed intermittently when two Orbit test runs overlapped, for
directories neither test created.

## What changes

- **Fixes false failures caused by cross-process observation of shared temp
  state.** Each test listed the shared temp root before and after an operation
  and asserted the difference was empty. A concurrent Orbit run creating a
  directory under the same prefix between the two samples landed in that
  difference. Reproduced deterministically: with a second process churning
  `orbit-analysis-program-*` / `orbit-analysis-work-*`, the original tests
  give **2 failed, 42 passed**; two concurrent copies of the three files fail
  in **both** processes.
- **Tests now track only resources created by their own operation.** Each
  wraps the constructor the module under test actually calls and records the
  exact paths it returns, then asserts those paths are gone. That is narrower
  *and* stronger than a global glob: it distinguishes a directory that was
  cleaned up from one that merely never appeared, and no other process can add
  to it.
- **Cleanup assertions remain active**, and were verified against real leaks
  rather than assumed. Neutralising all four `cleanup()` calls in
  `analysis_sandbox.py` (success and error paths), and separately the
  workspace close, still fails these tests. One test is *stronger* than
  before: it recreates a path the action genuinely owned instead of an
  unrelated directory.
- **Concurrent pytest runs no longer interfere.** Five concurrent rounds, both
  processes **295 passed, exit 0** every time, against a baseline control that
  fails in both.
- **No production behaviour changed.** Zero files under `src/`.

## Why not TMPDIR

Redirecting `TMPDIR` does **not** isolate these tests. `tempfile.gettempdir()`
is resolved once per process and cached, so two runs keep writing into the same
root regardless of what the environment says at any later point. An earlier
attempt to isolate that way was answering a different question, and its clean
result was not evidence of isolation.

## Scope

**Tests only.** This changes what the tests look at; it does **not** change
Orbit's own temp cleanup behaviour, which is unchanged and still asserted.

Where a code path refuses before any workspace is created, the assertion is
kept over tracked paths rather than restated as "nothing was created" — so it
still catches a regression that moves creation earlier. Those sites say so
explicitly rather than reading as though a cleanup had been observed.

## Verification

Affected files serial **295 passed**; temp/cleanup-focused selection **93
passed + 1 skip**; concurrent qualification **5 rounds, 295/295, exit 0 both
processes**; owned-prefix leak check **0** from a clean slate; full suite
**3053 passed + 1 environment skip**, real exit code 0. compileall and
`git diff --check` clean.

Mutations caught: reverting to a global glob, using the wrong Orbit prefix, a
tracker that records nothing, and a genuine production leak. Python bytecode
caches were cleared around every mutation — `.pyc` invalidation is
timestamp+size, so a same-second restore can otherwise execute stale bytecode.
