### PR TITLE
fix(terminal): sanitize tool labels before display

### DIFF
--- a/src/orbit/terminal/tool_events.py
+++ b/src/orbit/terminal/tool_events.py
@@ -68,20 +68,31 @@ def format_tool_call_event(name: str, args: str) -> str:
             parsed = {}
         check = parsed.get("check") if isinstance(parsed, dict) else None
         if isinstance(check, str):
-            return f"› Artifact  verify published artifact · {check}"
-    detail = f"  {args}" if args else ""
-    return f"› {display_tool_name(name)}{detail}"
+            return f"› Artifact  verify published artifact · {_normalize_inline(check)}"
+    # Nothing above recognised the tool, so neither the name nor the argument
+    # string has been through a parser that would have dropped control bytes.
+    detail = f"  {_normalize_inline(args)}" if args else ""
+    return f"› {_normalize_inline(display_tool_name(name))}{detail}"
 
 
 def format_tool_activity_label(name: str, args: str) -> str:
+    """One short line naming what is running, for the waiting indicator.
+
+    Every branch returns model- or tool-authored text, and the caller prints it
+    on a line that begins with a carriage return. Left raw, an escape sequence
+    in a command or URL could move the cursor or erase that line and write over
+    Orbit's own status row. `_normalize_inline` is the same boundary the other
+    formatters use, and it is idempotent, so a value that arrives already
+    sanitized is not escaped twice.
+    """
     if name == "exec_shell_full_command":
-        return _command_from_args(args) or name
+        return _normalize_inline(_command_from_args(args) or name)
     if name == "fetch_url":
-        return _url_from_args(args) or name
+        return _normalize_inline(_url_from_args(args) or name)
     if name == "list_directory":
         path, _recursive = _list_directory_from_args(args)
-        return path or name
-    return display_tool_name(name)
+        return _normalize_inline(path or name)
+    return _normalize_inline(display_tool_name(name))
 
 
 def format_tool_result_event(name: str, chars: int, source: str | None = None, content: str | None = None) -> str:

--- a/tests/test_terminal_activity_sanitization.py
+++ b/tests/test_terminal_activity_sanitization.py
@@ -1,0 +1,191 @@
+"""Sanitization of the tool labels that share a line with Orbit's own output.
+
+Three formatting paths returned model- or tool-authored text without passing
+it through the terminal boundary: the waiting indicator's activity label, the
+fallback used when no branch recognises a tool, and the `verify_artifact`
+check field. Everything else in this module already went through
+`_normalize_inline`.
+
+The activity label is the sharpest of the three. It is printed on a line that
+begins with a carriage return, so an escape sequence in a command or URL could
+erase that line and write over Orbit's own status row: the terminal would show
+a row that looks like Orbit's and says whatever the tool wanted.
+
+These tests assert on the returned string. What reaches the terminal is that
+string, and the printing site adds only styling.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from orbit.terminal.tool_events import (
+    format_tool_activity_label,
+    format_tool_call_event,
+)
+
+
+# Anything in the control range that a terminal acts on rather than shows.
+# Vertical tab, form feed, NEL and the Unicode separators are included because
+# `str.splitlines` treats them as line breaks: left intact they can forge a row.
+CONTROL_BYTES = (
+    "\x1b",      # ESC -- CSI/OSC introducer
+    "\x9b",      # 8-bit CSI
+    "\x07",      # BEL
+    "\r",        # CR -- the line-overwrite primitive
+    "\x0b",      # VT
+    "\x0c",      # FF
+    "\x85",      # NEL
+    "\u2028",    # LINE SEPARATOR
+    "\u2029",    # PARAGRAPH SEPARATOR
+    "\x00",      # NUL
+    "\x08",      # BS
+)
+
+HOSTILE = (
+    "start \x1b[2J\x1b[H erase \x1b]0;title\x07 osc \r overwrite "
+    "\x0b\x0c\x85\u2028\u2029 breaks \x00\x08 end"
+)
+
+
+def rendered_paths(payload: str) -> dict[str, str]:
+    """Every formatter branch that can carry untrusted text, keyed by name."""
+    return {
+        "activity/shell": format_tool_activity_label(
+            "exec_shell_full_command", json.dumps({"command": payload})
+        ),
+        "activity/url": format_tool_activity_label(
+            "fetch_url", json.dumps({"url": payload})
+        ),
+        "activity/list_directory": format_tool_activity_label(
+            "list_directory", json.dumps({"path": payload})
+        ),
+        "activity/tool_name": format_tool_activity_label(payload, "{}"),
+        "call/unknown_args": format_tool_call_event("some_unknown_tool", payload),
+        "call/unknown_name": format_tool_call_event(payload, ""),
+        "call/verify_check": format_tool_call_event(
+            "verify_artifact", json.dumps({"check": payload})
+        ),
+    }
+
+
+class ControlSequenceTests(unittest.TestCase):
+    """No path may hand the terminal something it will act on."""
+
+    def assert_inert(self, label: str, rendered: str) -> None:
+        for char in CONTROL_BYTES:
+            self.assertNotIn(
+                char, rendered, f"{label}: {char!r} reached the terminal"
+            )
+        self.assertNotIn("\n", rendered, f"{label}: rendered more than one line")
+
+    def test_no_path_emits_a_control_sequence(self) -> None:
+        for label, rendered in rendered_paths(HOSTILE).items():
+            with self.subTest(path=label):
+                self.assert_inert(label, rendered)
+
+    def test_each_control_byte_individually(self) -> None:
+        """One at a time, so a failure names the byte that got through."""
+        for char in CONTROL_BYTES:
+            for label, rendered in rendered_paths(f"a{char}b").items():
+                with self.subTest(path=label, char=repr(char)):
+                    self.assert_inert(label, rendered)
+
+    def test_a_forged_status_row_cannot_be_written(self) -> None:
+        """CR is what lets injected text overwrite Orbit's own row.
+
+        The waiting indicator prints its line starting with a carriage return.
+        If a payload's own CR survived, everything after it would land at
+        column zero and replace what Orbit had written there.
+        """
+        payload = "harmless\r› Exec  rm -rf /   "
+
+        for label, rendered in rendered_paths(payload).items():
+            with self.subTest(path=label):
+                self.assertNotIn("\r", rendered)
+                # The text is still shown -- it is just no longer a cursor move.
+                self.assertIn("Exec", rendered)
+
+
+class ContentPreservationTests(unittest.TestCase):
+    """Sanitizing must not cost ordinary content."""
+
+    def test_printable_text_survives(self) -> None:
+        for label, rendered in rendered_paths("ls -la /tmp").items():
+            with self.subTest(path=label):
+                self.assertIn("ls -la /tmp", rendered)
+
+    def test_unicode_survives(self) -> None:
+        payload = "café — 日本語 ✓ αβγ Ω 🎯 ünïcödé"
+        for label, rendered in rendered_paths(payload).items():
+            with self.subTest(path=label):
+                self.assertIn(payload, rendered)
+
+    def test_windows_paths_and_backslashes_survive(self) -> None:
+        payload = r"C:\Users\analyst\Desktop\sample.exe"
+        for label, rendered in rendered_paths(payload).items():
+            with self.subTest(path=label):
+                self.assertIn(payload, rendered)
+
+    def test_urls_survive_intact(self) -> None:
+        payload = "https://example.com/a?b=1&c=2#frag"
+        self.assertIn(
+            payload,
+            format_tool_activity_label("fetch_url", json.dumps({"url": payload})),
+        )
+
+    def test_hostile_input_keeps_its_readable_text(self) -> None:
+        """Escaping is not deletion: the words are still there to read."""
+        for label, rendered in rendered_paths(HOSTILE).items():
+            with self.subTest(path=label):
+                for word in ("start", "erase", "overwrite", "breaks", "end"):
+                    self.assertIn(word, rendered)
+
+
+class IdempotenceTests(unittest.TestCase):
+    """An already-sanitized value must not be escaped a second time."""
+
+    def test_a_sanitized_value_gains_no_second_layer_of_escapes(self) -> None:
+        """Passing a value through twice must not escape it again.
+
+        Whitespace still collapses on a second pass -- that is what these
+        single-line labels are for -- so the property under test is the escape
+        count, not string equality. A value that gained a layer each time it
+        crossed the boundary would slowly turn into its own transcript.
+        """
+        for label, once in rendered_paths(HOSTILE).items():
+            with self.subTest(path=label):
+                twice = format_tool_activity_label(once, "{}")
+                self.assertEqual(
+                    once.count("\\x"),
+                    twice.count("\\x"),
+                    "a sanitized value was escaped again",
+                )
+                self.assertNotIn("\\\\x", twice)
+
+    def test_the_boundary_helper_is_idempotent(self) -> None:
+        from orbit.terminal.tool_events import _normalize_inline
+
+        once = _normalize_inline(HOSTILE)
+
+        self.assertEqual(once, _normalize_inline(once))
+
+
+class UnrecognisedToolTests(unittest.TestCase):
+    """The fallback carries two untrusted values, not one."""
+
+    def test_both_the_name_and_the_arguments_are_sanitized(self) -> None:
+        rendered = format_tool_call_event("evil\x1b[2Jtool", "arg\x07value")
+
+        self.assertNotIn("\x1b", rendered)
+        self.assertNotIn("\x07", rendered)
+        self.assertIn("tool", rendered)
+        self.assertIn("value", rendered)
+
+    def test_a_recognised_tool_still_renders_normally(self) -> None:
+        rendered = format_tool_call_event(
+            "exec_shell_full_command", json.dumps({"command": "ls -la"})
+        )
+
+        self.assertEqual(rendered, "› Read  ls -la")


### PR DESCRIPTION
Three formatting paths handed model- or tool-authored text to the terminal
without the sanitization every other formatter in the module already applied.

## The paths

Three named paths, **seven** entry points — the activity label has four
sources, and the unknown-tool fallback carries both the argument string and
the tool name:

| path | entry points |
|---|---|
| `format_tool_activity_label` | shell command, url, list_directory path, tool display name |
| unknown-tool fallback in `format_tool_call_event` | raw `args`, raw tool name |
| `verify_artifact` check field | `check` |

Measured on the previous revision, **all seven** leaked ESC, BEL, CR, vertical
tab, form feed, NEL and U+2028/U+2029.

## Why the activity label mattered most

It reaches a real terminal write with only `.strip()` applied: `set_activity`
stores it, then `_render_wait_line` does `print(f"\r{...}", end="",
flush=True)`. Because that line already begins with a carriage return, an
injected CR or ESC could erase it and write over Orbit's own status row — the
terminal would show a row that looks like Orbit's and says whatever the tool
wanted. That is row forgery, not cosmetic noise.

## The fix

Each of the seven goes through `_normalize_inline`, the boundary that already
wraps `sanitize_terminal_text`. **No new helper, no new dependency**, nothing
outside `src/orbit/terminal/`.

- **Idempotent** — a value that arrives already sanitized is not escaped
  again.
- **Escapes rather than deletes** — ordinary text, Unicode, Windows paths,
  URLs and shell commands survive byte for byte.
- **Rendering only** — no evidence, history, stored tool result or
  model-facing message is touched. The escaping happens where text is
  displayed, not where it is kept.

## Verification

New tests fail **4 of 12** against the previous revision and pass 12/12 with
the fix. **All seven** `_normalize_inline` call sites were mutated
individually; every one is caught.

Fuzz: 20,000 random hostile payloads × 7 paths = **140,000 renders, zero
control-byte or newline leaks, zero exceptions**.

Independent review reproduced this and went further: an exhaustive sweep of
every codepoint in `0x0–0x11000` plus astral slices (~73k codepoints × 11
branches) found **zero leaks**; a 300k-iteration fuzz pushed through the real
downstream pipeline (`_fit_activity_line` → `_pad_to_terminal_width` → `dim()`
→ the actual `print`) found **zero**; ten end-to-end row-forgery attack classes
produced **zero forgeries**. A differential on benign input is **byte-identical
to baseline**, including `› Read  ls -la`, and shows exactly seven changed
outputs on hostile input — nothing was opportunistically sanitized.

Suites: new sanitization **12**, terminal sanitization **27**, tool
event/rendering **116**, terminal/command **100**, CHAT/routing **251**,
ANALYSIS guided+autonomous **120**, full suite **3065 passed + 1 environment
skip**, real exit code 0. compileall and `git diff --check` clean. Zero files
changed under `runtime/`, `backend/` or `native_llama/`.

## Not addressed

`theme.py` escapes zero-width joiners because `str.isprintable()` is false for
U+200D, so ZWJ emoji display escaped. **Pre-existing**, not introduced here,
and arguably correct — the same rule escapes U+202E, a real filename-spoofing
vector. Out of scope for this PR.
