### PR TITLE
fix(terminal): separate and preserve the completed progress line

### DIFF
--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -387,6 +387,10 @@ class Repl:
                 # would be told actions ran and given no evidence id to cite or
                 # re-attest.
                 def show(step, record) -> None:
+                    # The wait line is still being redrawn in place. End it
+                    # first, or this block lands on the same row and the
+                    # elapsed duration is overwritten instead of kept.
+                    renderer.settle_progress_line()
                     block = format_analysis_step(
                         step, prose_already_shown=renderer.rendered_visible_text
                     )

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -444,6 +444,11 @@ class Repl:
             renderer.finish(interrupted=True)
             self._close_analysis()
             raise
+        # A guided step prints its block after the renderer has stopped, so
+        # it asks for the finished progress line to be kept rather than
+        # settling over a live one.
+        if run is None:
+            renderer.keep_progress_line()
         renderer.finish()
         # The renderer already showed the prose if the backend streamed it;
         # the final block then carries only what streaming could not: action

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -159,6 +159,11 @@ class StreamRenderer:
         self._start_time = time.monotonic()
         self._first_delta = False
         self._progress = None
+        # Restarting resets the rest of the line state, so it resets this too.
+        # A settle suspends ticks for the caller's print; leaving them
+        # suspended across a restart would freeze the live line for the whole
+        # next segment.
+        self._suspend_ticks = False
         if not self._interactive or not self._started:
             return
         self._timer_active = True

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -75,6 +75,13 @@ class StreamRenderer:
         self._thinking_dim_open = False
         self._phase_label: str | None = None
         self._activity_kind = "model"
+        # The last generation line drawn in place, kept so it can be committed
+        # to the transcript instead of erased. The wait line is written with a
+        # bare `\r` and no newline, so whatever prints next lands on the same
+        # row; and clearing it takes the elapsed duration with it. Generation
+        # only -- a prefill or "working" tick is scaffolding the analyst does
+        # not need once the step is over.
+        self._settled_line: str | None = None
 
     def start(self) -> None:
         self._started = True
@@ -143,6 +150,26 @@ class StreamRenderer:
         self._timer_active = True
         self._thread = threading.Thread(target=self._run_wait_timer, daemon=True)
         self._thread.start()
+
+    def settle_progress_line(self) -> None:
+        """Commit the live generation line before printing something else.
+
+        A caller that prints while the timer is still running -- an autonomous
+        run rendering each completed step -- would otherwise land on the row
+        the wait line is redrawing, because that line carries no newline of
+        its own. Calling this first ends the line properly and keeps the
+        elapsed duration on screen. Safe to call when nothing is pending.
+        """
+        if self._settled_line is None:
+            return
+        self._commit_wait_line()
+        if self._timer_active:
+            # The line was committed; the timer keeps ticking for the next
+            # phase and must start a fresh one rather than overwrite it.
+            self._start_new_wait_line()
+
+    def _start_new_wait_line(self) -> None:
+        self._progress = None
 
     def progress(self, update: StreamProgress | WorkProgress) -> None:
         self._progress = update
@@ -227,8 +254,34 @@ class StreamRenderer:
             self._thread.join(timeout=1)
         self._thread = None
         self._timer_active = False
+        if self._settled_line is not None:
+            self._commit_wait_line()
+            return
         if clear:
             self._clear_wait_line()
+
+    def _commit_wait_line(self) -> None:
+        """Leave the finished generation line standing, set apart above and below.
+
+        The live line is drawn with `\r` and no newline so each tick can
+        overwrite the last. That is right while it is still moving, and wrong
+        the moment it stops: the next thing printed lands on the same row, and
+        clearing it instead loses the elapsed duration the analyst was
+        watching accumulate. Committing it writes the newline the redraw loop
+        deliberately omitted.
+
+        A blank line above separates it from the evidence or prose it follows;
+        one below separates it from the `action:` line that comes next. Both
+        are plain newlines, so the separation holds where colour does not --
+        a pipe, `NO_COLOR`, `TERM=dumb`.
+        """
+        line = self._settled_line
+        self._settled_line = None
+        if line is None:
+            return
+        # Overwrite the in-place copy rather than adding a second one.
+        print("\r" + _pad_to_terminal_width(""), end="", flush=True)
+        print(f"\r\n{dim(line)}\n", flush=True)
 
     def _run_wait_timer(self) -> None:
         while not self._stop.is_set():
@@ -244,8 +297,10 @@ class StreamRenderer:
             if self._progress is not None and self._progress.phase == "generation" and _valid_metric(progress_elapsed)
             else elapsed
         )
-        line = dim(_fit_activity_line(self._activity_kind, detail, format_elapsed(shown_elapsed)))
-        print(f"\r{_pad_to_terminal_width(line)}", end="", flush=True)
+        fitted = _fit_activity_line(self._activity_kind, detail, format_elapsed(shown_elapsed))
+        if self._progress is not None and self._progress.phase == "generation":
+            self._settled_line = fitted
+        print(f"\r{_pad_to_terminal_width(dim(fitted))}", end="", flush=True)
 
     @staticmethod
     def _clear_wait_line() -> None:

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -82,6 +82,15 @@ class StreamRenderer:
         # only -- a prefill or "working" tick is scaffolding the analyst does
         # not need once the step is over.
         self._settled_line: str | None = None
+        # Held for every write to the wait-line row. The timer thread redraws
+        # that row while the main thread may be committing or clearing it;
+        # without this a redraw can land between a commit and the print that
+        # follows, putting an unterminated line back under the caller's output
+        # -- the exact collision this class exists to prevent.
+        self._line_lock = threading.Lock()
+        # Set while a caller is printing after a settle, so the timer does not
+        # draw a new line underneath that output.
+        self._suspend_ticks = False
 
     def start(self) -> None:
         self._started = True
@@ -160,19 +169,24 @@ class StreamRenderer:
         its own. Calling this first ends the line properly and keeps the
         elapsed duration on screen. Safe to call when nothing is pending.
         """
-        if self._settled_line is None:
-            return
-        self._commit_wait_line()
-        if self._timer_active:
-            # The line was committed; the timer keeps ticking for the next
-            # phase and must start a fresh one rather than overwrite it.
-            self._start_new_wait_line()
-
-    def _start_new_wait_line(self) -> None:
-        self._progress = None
+        with self._line_lock:
+            if self._settled_line is None:
+                return
+            self._commit_wait_line()
+            self._progress = None
+            # Silence the timer for the caller's print. Serialising the two
+            # writers is not enough on its own: a tick that lands after the
+            # commit draws a fresh unterminated line, and the caller's output
+            # then collides with that one instead. The timer is restarted by
+            # the next `progress()` or `event()`, as it is after any pause.
+            self._suspend_ticks = True
 
     def progress(self, update: StreamProgress | WorkProgress) -> None:
-        self._progress = update
+        with self._line_lock:
+            # Published together: releasing the timer before the new progress
+            # is in place would let a tick draw from the previous step's.
+            self._progress = update
+            self._suspend_ticks = False
         if self._interactive and self._started and not self._first_delta:
             self._render_wait_line()
 
@@ -254,11 +268,22 @@ class StreamRenderer:
             self._thread.join(timeout=1)
         self._thread = None
         self._timer_active = False
-        if self._settled_line is not None:
-            self._commit_wait_line()
-            return
-        if clear:
-            self._clear_wait_line()
+        # Taken after the join above, so the timer thread is already gone and
+        # cannot be holding it.
+        with self._line_lock:
+            # Only a line the caller is finished with gets committed. Once
+            # prose has started streaming the progress line has been
+            # superseded by the answer itself, and `write()` asks for it to be
+            # erased -- committing it there would put a generating row above
+            # every CHAT reply.
+            if self._settled_line is not None and not self._first_delta:
+                self._commit_wait_line()
+                return
+            # Dropped rather than kept: a line abandoned mid-stream must not
+            # surface later as though it had just finished.
+            self._settled_line = None
+            if clear:
+                self._clear_wait_line()
 
     def _commit_wait_line(self) -> None:
         """Leave the finished generation line standing, set apart above and below.
@@ -289,6 +314,12 @@ class StreamRenderer:
             self._stop.wait(self.interval)
 
     def _render_wait_line(self) -> None:
+        with self._line_lock:
+            if self._suspend_ticks:
+                return
+            self._render_wait_line_locked()
+
+    def _render_wait_line_locked(self) -> None:
         elapsed = time.monotonic() - self._start_time
         detail = self._progress_activity_detail() or self._phase_label or "working"
         progress_elapsed = getattr(self._progress, "elapsed_seconds", None)

--- a/src/orbit/terminal/streaming.py
+++ b/src/orbit/terminal/streaming.py
@@ -91,6 +91,11 @@ class StreamRenderer:
         # Set while a caller is printing after a settle, so the timer does not
         # draw a new line underneath that output.
         self._suspend_ticks = False
+        # Whether a caller has asked for the finished line to be kept. Commit
+        # only on request: the renderer cannot infer the intent from what has
+        # streamed, because a turn that only calls a tool sends no prose at
+        # all and would otherwise look identical to one that finished.
+        self._commit_pending = False
 
     def start(self) -> None:
         self._started = True
@@ -172,6 +177,7 @@ class StreamRenderer:
         with self._line_lock:
             if self._settled_line is None:
                 return
+            self._commit_pending = False
             self._commit_wait_line()
             self._progress = None
             # Silence the timer for the caller's print. Serialising the two
@@ -180,6 +186,15 @@ class StreamRenderer:
             # then collides with that one instead. The timer is restarted by
             # the next `progress()` or `event()`, as it is after any pause.
             self._suspend_ticks = True
+
+    def keep_progress_line(self) -> None:
+        """Ask for the finished generation line to be kept when the timer stops.
+
+        For a caller that ends the step through `finish()` rather than by
+        printing over a live line: a guided analysis writes its block after
+        the renderer has already stopped.
+        """
+        self._commit_pending = True
 
     def progress(self, update: StreamProgress | WorkProgress) -> None:
         with self._line_lock:
@@ -276,11 +291,13 @@ class StreamRenderer:
             # superseded by the answer itself, and `write()` asks for it to be
             # erased -- committing it there would put a generating row above
             # every CHAT reply.
-            if self._settled_line is not None and not self._first_delta:
+            if self._commit_pending and self._settled_line is not None:
+                self._commit_pending = False
                 self._commit_wait_line()
                 return
             # Dropped rather than kept: a line abandoned mid-stream must not
             # surface later as though it had just finished.
+            self._commit_pending = False
             self._settled_line = None
             if clear:
                 self._clear_wait_line()

--- a/tests/test_progress_line_separation.py
+++ b/tests/test_progress_line_separation.py
@@ -92,6 +92,8 @@ class ProgressLineHarness(unittest.TestCase):
                 if interactive:
                     renderer._render_wait_line()
                 if via_finish:
+                    # What a guided step does: ask for the line, then stop.
+                    renderer.keep_progress_line()
                     renderer.finish()
                 else:
                     renderer.settle_progress_line()
@@ -198,8 +200,12 @@ class ActionOutcomeTests(ProgressLineHarness):
 
 
 class BothCompletionPathsTests(ProgressLineHarness):
-    def test_the_guided_path_settles_through_finish(self) -> None:
-        """A guided step ends at `finish()`, not at an explicit settle."""
+    def test_the_guided_path_keeps_its_line_through_finish(self) -> None:
+        """A guided step asks for the line, then ends at `finish()`.
+
+        It prints its block after the renderer has stopped, so it has no live
+        line to settle over -- it requests the keep instead.
+        """
         lines = self.run_step(via_finish=True)
         index = next(i for i, line in enumerate(lines) if "generating" in line)
         self.assertEqual(lines[index - 1], "")
@@ -344,6 +350,31 @@ class ProductionWiringTests(unittest.TestCase):
             show.index("settle_progress_line()"),
             show.index("print("),
             "the settle must come before the first print, not after",
+        )
+
+    def test_the_guided_path_asks_to_keep_its_line(self) -> None:
+        """A guided step prints after `finish()`, so it must request the keep.
+
+        Every guided test drives `keep_progress_line()` itself, which proves
+        the renderer honours a request and nothing about whether production
+        makes one. Removing the call would leave those tests green while the
+        guided progress line silently disappeared again.
+        """
+        import inspect
+
+        from orbit.terminal import repl as repl_module
+
+        source = inspect.getsource(repl_module.Repl._ask_analysis)
+
+        self.assertIn(
+            "keep_progress_line()",
+            source,
+            "the guided path must ask for its finished line to be kept",
+        )
+        self.assertLess(
+            source.index("keep_progress_line()"),
+            source.rindex("renderer.finish()"),
+            "the request must come before the renderer stops",
         )
 
     def test_the_seam_is_safe_when_nothing_is_pending(self) -> None:
@@ -493,3 +524,71 @@ class TimerInterferenceTests(ProgressLineHarness):
         lines = self.run_step(steps=2)
         rendered = [line for line in lines if "generating" in line]
         self.assertEqual(len(rendered), 2, "the second step drew no progress line")
+
+
+class ToolCallPresentationTests(ProgressLineHarness):
+    """A CHAT turn that only calls a tool must gain nothing either.
+
+    Tool-call tokens never reach `write()` -- the native protocol delivers
+    them as tool_call events, not deltas -- while the same model call still
+    emits generation progress per token. A renderer that infers "the caller
+    is finished" from streamed prose therefore sees a tool turn as a finished
+    step, and commits a progress row above every tool call. That is why the
+    commit is requested explicitly rather than deduced.
+    """
+
+    def tool_turn(self) -> list[str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.start()
+            renderer.progress(generation(2.0, tokens=12))
+            renderer._render_wait_line()
+            renderer.event("tool: read_file(path=a.js)")
+        return screen(buffer.getvalue())
+
+    def test_a_tool_call_gains_no_progress_row(self) -> None:
+        lines = self.tool_turn()
+        self.assertFalse(
+            any("generating" in line for line in lines),
+            "a committed progress row appeared above a CHAT tool call",
+        )
+
+    def test_the_tool_event_is_the_first_thing_printed(self) -> None:
+        lines = self.tool_turn()
+        self.assertEqual(lines[0], "tool: read_file(path=a.js)")
+
+    def test_a_turn_with_no_prose_at_all_gains_nothing(self) -> None:
+        """`finish()` with neither prose nor a request keeps nothing."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.start()
+            renderer.progress(generation(2.0, tokens=2))
+            renderer._render_wait_line()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(
+            any("generating" in line for line in lines),
+            "a silent turn committed a progress row",
+        )
+
+    def test_an_unrequested_line_cannot_surface_from_a_later_stop(self) -> None:
+        """An abandoned line must not be committed by a subsequent request."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.start()
+            renderer.progress(generation(2.0, tokens=7))
+            renderer._render_wait_line()
+            renderer.event("tool: read_file(path=a.js)")
+            # A later step asks to keep its own line; the abandoned one is gone.
+            renderer.keep_progress_line()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(
+            any("7 tok" in line for line in lines),
+            "an abandoned line resurfaced on a later request",
+        )

--- a/tests/test_progress_line_separation.py
+++ b/tests/test_progress_line_separation.py
@@ -405,3 +405,91 @@ class MultiStepStateTests(ProgressLineHarness):
             1,
             "the finished step was committed twice",
         )
+
+
+class ChatPresentationTests(ProgressLineHarness):
+    """CHAT must render exactly as it did before this change.
+
+    Native streaming reports generation progress per token, so a progress line
+    is always armed by the time the first delta arrives. Committing it there
+    would put a `model · generating · …` row and two blank lines above every
+    CHAT answer -- a regression in the one place this change was required not
+    to touch.
+    """
+
+    def chat_turn(self) -> list[str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.start()
+            renderer.progress(generation(0.0, tokens=1, rate=5.0))
+            renderer._render_wait_line()
+            renderer.write("The answer is 42.")
+            renderer.finish()
+            print()
+            print("~ 80 tok · 12s", flush=True)
+        return screen(buffer.getvalue())
+
+    def test_a_streamed_answer_gains_no_progress_row(self) -> None:
+        lines = self.chat_turn()
+        self.assertFalse(
+            any("generating" in line for line in lines),
+            "a committed progress row appeared above a CHAT answer",
+        )
+
+    def test_the_answer_is_the_first_thing_printed(self) -> None:
+        """No leading blank lines before the reply."""
+        lines = self.chat_turn()
+        self.assertEqual(lines[0], "The answer is 42.")
+
+    def test_an_abandoned_line_never_surfaces_later(self) -> None:
+        """A line dropped mid-stream must not be committed by a later stop."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.start()
+            renderer.progress(generation(114.0))
+            renderer._render_wait_line()
+            renderer.write("prose")
+            renderer.finish()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(any("generating" in line for line in lines))
+
+
+class TimerInterferenceTests(ProgressLineHarness):
+    """A tick must not draw a new line into the caller's print window.
+
+    Serialising the timer and the committing thread is not sufficient on its
+    own: a tick landing after the commit draws a fresh unterminated line, and
+    the caller's output then collides with that one instead.
+    """
+
+    def test_no_tick_lands_between_the_commit_and_the_next_print(self) -> None:
+        import time
+
+        collisions = 0
+        for _ in range(20):
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                renderer = StreamRenderer(interval=0.002, interactive=True)
+                renderer.set_activity("analysis")
+                renderer.start()
+                renderer.progress(generation(114.0))
+                renderer.settle_progress_line()
+                # The window `format_analysis_step` occupies in production.
+                time.sleep(0.02)
+                print("action: ok", flush=True)
+                renderer.finish()
+            for line in screen(buffer.getvalue()):
+                if ("generating" in line or "working" in line) and "action:" in line:
+                    collisions += 1
+
+        self.assertEqual(collisions, 0, "a timer tick collided with the caller's output")
+
+    def test_the_timer_resumes_for_the_following_step(self) -> None:
+        """Suspending ticks must not silence the rest of the run."""
+        lines = self.run_step(steps=2)
+        rendered = [line for line in lines if "generating" in line]
+        self.assertEqual(len(rendered), 2, "the second step drew no progress line")

--- a/tests/test_progress_line_separation.py
+++ b/tests/test_progress_line_separation.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import orbit.terminal.streaming as streaming_module
+from orbit.backend.base import StreamProgress
+from orbit.terminal.streaming import StreamRenderer
+
+
+def screen(raw: str) -> list[str]:
+    """Resolve a stream of terminal bytes the way a terminal would.
+
+    The wait line is redrawn with a bare carriage return, so the bytes on the
+    wire are not what the analyst reads. Asserting on the raw string would let
+    a line that is overwritten -- or one that collides with the next print --
+    pass as though it were visible. Applying `\\r` here means every assertion
+    below is about what actually ends up on screen.
+    """
+    raw = re.sub(r"\x1b\[[0-9;]*m", "", raw)
+    lines: list[str] = []
+    current = ""
+    for ch in raw:
+        if ch == "\n":
+            lines.append(current.rstrip())
+            current = ""
+        elif ch == "\r":
+            current = ""
+        else:
+            current += ch
+    lines.append(current.rstrip())
+    return lines
+
+
+def generation(elapsed: float, *, tokens: int = 552, rate: float = 4.8) -> StreamProgress:
+    return StreamProgress(
+        phase="generation",
+        current=tokens,
+        total=0,
+        percent=0,
+        tokens_per_second=rate,
+        elapsed_seconds=elapsed,
+    )
+
+
+class ProgressLineHarness(unittest.TestCase):
+    def setUp(self) -> None:
+        self._patches = [
+            mock.patch("orbit.terminal.streaming.is_tty", return_value=True),
+            mock.patch("orbit.terminal.streaming.supports_ansi", return_value=True),
+            mock.patch("orbit.terminal.theme.supports_ansi", return_value=True),
+        ]
+        for patcher in self._patches:
+            patcher.start()
+
+    def tearDown(self) -> None:
+        for patcher in reversed(self._patches):
+            patcher.stop()
+
+    def run_step(
+        self,
+        *,
+        elapsed: float = 114.0,
+        before: str | None = "raw: ev_91adbf966e59_dc809e8533424e29",
+        after: str | None = "action: ok",
+        steps: int = 1,
+        via_finish: bool = False,
+        interactive: bool = True,
+    ) -> list[str]:
+        """Drive one or more analysis steps and return the resulting screen."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=interactive)
+            renderer.set_activity("analysis")
+            if before:
+                print(before, flush=True)
+            renderer.start()
+            for _ in range(steps):
+                renderer.progress(generation(elapsed))
+                # One timer tick. The real timer thread would do this; calling
+                # it directly keeps the test free of sleeps.
+                if interactive:
+                    renderer._render_wait_line()
+                if via_finish:
+                    renderer.finish()
+                else:
+                    renderer.settle_progress_line()
+                if after:
+                    print(after, flush=True)
+        return screen(buffer.getvalue())
+
+
+class LiveToCompletedTests(ProgressLineHarness):
+    def test_the_completed_line_survives_the_next_print(self) -> None:
+        """The reported defect: the next line landed on the same row.
+
+        The wait line carries no newline of its own, so `action: ok` used to
+        be printed into the middle of it -- separated only by the padding
+        spaces, which read as one ragged line.
+        """
+        lines = self.run_step()
+
+        self.assertIn(
+            "analysis · generating · 552 tok · 4.8 tok/s · 1m 54s",
+            lines,
+            "the completed progress line must stand on a row of its own",
+        )
+        for line in lines:
+            self.assertNotIn(
+                "action: ok",
+                line if "generating" in line else "",
+                "action must not share the progress row",
+            )
+
+    def test_the_line_is_not_erased_on_completion(self) -> None:
+        """Clearing the line would take the elapsed duration with it."""
+        lines = self.run_step()
+        self.assertTrue(
+            any("generating" in line for line in lines),
+            "the progress line was cleared instead of committed",
+        )
+
+
+class VerticalSeparationTests(ProgressLineHarness):
+    def test_one_blank_line_before_and_after(self) -> None:
+        lines = self.run_step()
+        index = next(i for i, line in enumerate(lines) if "generating" in line)
+
+        self.assertEqual(lines[index - 1], "", "no blank line before the progress line")
+        self.assertEqual(lines[index + 1], "", "no blank line after the progress line")
+        self.assertIn("raw: ev_91adbf966e59_dc809e8533424e29", lines[index - 2])
+        self.assertIn("action: ok", lines[index + 2])
+
+    def test_no_duplicate_blank_lines(self) -> None:
+        """One blank line, not two. A ragged gap is its own defect."""
+        for steps in (1, 2, 3):
+            with self.subTest(steps=steps):
+                lines = self.run_step(steps=steps)
+                doubled = [
+                    i for i in range(len(lines) - 1) if lines[i] == "" and lines[i + 1] == ""
+                ]
+                self.assertEqual(doubled, [], f"duplicate blank lines at {doubled}")
+
+    def test_separation_holds_with_no_preceding_output(self) -> None:
+        lines = self.run_step(before=None)
+        index = next(i for i, line in enumerate(lines) if "generating" in line)
+        self.assertEqual(lines[index + 1], "")
+
+
+class ElapsedPreservationTests(ProgressLineHarness):
+    def test_minute_and_second_duration_is_kept(self) -> None:
+        """`1m 54s` is the whole point: it must not be lost at completion."""
+        lines = self.run_step(elapsed=114.0)
+        self.assertTrue(
+            any("1m 54s" in line for line in lines),
+            "the minute+second elapsed duration was lost",
+        )
+
+    def test_seconds_only_duration_is_kept(self) -> None:
+        lines = self.run_step(elapsed=42.0)
+        self.assertTrue(any("42s" in line for line in lines))
+
+    def test_a_range_of_durations_round_trips(self) -> None:
+        for elapsed, expected in ((0.0, "0s"), (9.0, "9s"), (59.0, "59s"), (60.0, "1m 0s"), (114.0, "1m 54s"), (3599.0, "59m 59s")):
+            with self.subTest(elapsed=elapsed):
+                lines = self.run_step(elapsed=elapsed)
+                self.assertTrue(
+                    any(line.endswith(expected) for line in lines),
+                    f"expected a line ending in {expected!r}",
+                )
+
+    def test_token_count_and_rate_are_kept(self) -> None:
+        """Presentation only: the accounting shown must be what was measured."""
+        lines = self.run_step()
+        line = next(line for line in lines if "generating" in line)
+        self.assertIn("552 tok", line)
+        self.assertIn("4.8 tok/s", line)
+
+
+class ActionOutcomeTests(ProgressLineHarness):
+    def test_every_action_outcome_is_separated(self) -> None:
+        for outcome in ("action: ok", "action: error | boom", "action: refused"):
+            with self.subTest(outcome=outcome):
+                lines = self.run_step(after=outcome)
+                index = next(i for i, line in enumerate(lines) if "generating" in line)
+                self.assertEqual(lines[index + 1], "")
+                self.assertIn(outcome, lines[index + 2])
+
+
+class BothCompletionPathsTests(ProgressLineHarness):
+    def test_the_guided_path_settles_through_finish(self) -> None:
+        """A guided step ends at `finish()`, not at an explicit settle."""
+        lines = self.run_step(via_finish=True)
+        index = next(i for i, line in enumerate(lines) if "generating" in line)
+        self.assertEqual(lines[index - 1], "")
+        self.assertEqual(lines[index + 1], "")
+        self.assertIn("1m 54s", lines[index])
+
+    def test_repeated_autonomous_steps_each_get_their_own_line(self) -> None:
+        lines = self.run_step(steps=3)
+        rendered = [line for line in lines if "generating" in line]
+        self.assertEqual(len(rendered), 3, "each completed step keeps its own line")
+        for line in rendered:
+            self.assertIn("1m 54s", line)
+
+
+class NonAnsiTests(ProgressLineHarness):
+    def test_separation_does_not_depend_on_colour(self) -> None:
+        """A pipe, `NO_COLOR` and `TERM=dumb` all lose `dim()`.
+
+        The blank lines and the line itself are plain text, so the separation
+        has to survive that. If it depended on escape codes it would collapse
+        exactly where a transcript is most often read back.
+        """
+        with mock.patch("orbit.terminal.theme.supports_ansi", return_value=False):
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                renderer = StreamRenderer(interval=999, interactive=True)
+                renderer.set_activity("analysis")
+                print("raw: ev_abc", flush=True)
+                renderer.start()
+                renderer.progress(generation(114.0))
+                renderer._render_wait_line()
+                renderer.settle_progress_line()
+                print("action: ok", flush=True)
+            raw = buffer.getvalue()
+
+        self.assertNotIn("\x1b", raw, "no escape codes should be emitted")
+        lines = screen(raw)
+        index = next(i for i, line in enumerate(lines) if "generating" in line)
+        self.assertEqual(lines[index - 1], "")
+        self.assertEqual(lines[index + 1], "")
+        self.assertIn("1m 54s", lines[index])
+
+    def test_a_non_interactive_stream_still_prints_no_progress_line(self) -> None:
+        """Unchanged behaviour: a pipe never gets the live line at all.
+
+        The fix must not start emitting progress rows into redirected output
+        that never had them.
+        """
+        lines = self.run_step(interactive=False)
+        self.assertFalse(
+            any("generating" in line for line in lines),
+            "a non-interactive stream must not gain a progress line",
+        )
+        self.assertIn("raw: ev_91adbf966e59_dc809e8533424e29", lines[0])
+        self.assertIn("action: ok", lines[1])
+
+
+class TerminalWidthTests(ProgressLineHarness):
+    def test_the_elapsed_duration_survives_a_narrow_terminal(self) -> None:
+        """Truncation trims the detail, never the duration."""
+        for columns in (40, 60, 80, 200):
+            with self.subTest(columns=columns):
+                with mock.patch.object(
+                    streaming_module, "_terminal_columns", return_value=columns
+                ):
+                    lines = self.run_step()
+                line = next(line for line in lines if "generating" in line)
+                self.assertTrue(
+                    line.endswith("1m 54s"),
+                    f"elapsed lost at {columns} columns: {line!r}",
+                )
+                self.assertLessEqual(len(line), columns, "the committed line overflowed")
+
+    def test_no_row_exceeds_the_terminal_width(self) -> None:
+        with mock.patch.object(streaming_module, "_terminal_columns", return_value=40):
+            lines = self.run_step()
+        for line in lines:
+            self.assertLessEqual(len(line), 40, f"row wider than the terminal: {line!r}")
+
+
+class NonGenerationPhaseTests(ProgressLineHarness):
+    def test_a_prefill_line_is_still_cleared(self) -> None:
+        """Only a finished generation is worth keeping.
+
+        Prefill and the bare "working" tick are scaffolding: committing them
+        would leave rows the analyst has no use for once the step is over.
+        """
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            renderer.start()
+            renderer.progress(
+                StreamProgress(
+                    phase="prefill",
+                    current=0,
+                    total=100,
+                    percent=10,
+                    evaluated_current=10,
+                    evaluated_total=100,
+                )
+            )
+            renderer._render_wait_line()
+            renderer.finish()
+            print("action: ok", flush=True)
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(
+            any("prefill" in line for line in lines),
+            "a prefill line should not be committed to the transcript",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ProductionWiringTests(unittest.TestCase):
+    """The autonomous step renderer must settle before it prints.
+
+    Every test above drives `settle_progress_line()` itself, which proves the
+    renderer behaves -- and proves nothing about whether production calls it.
+    Removing the call from `show()` leaves all of them passing while the
+    reported defect returns in full, so the wiring is asserted here directly.
+    """
+
+    def test_the_autonomous_step_renderer_settles_first(self) -> None:
+        import inspect
+
+        from orbit.terminal import repl as repl_module
+
+        source = inspect.getsource(repl_module.Repl._ask_analysis)
+        show = source[source.index("def show(") :]
+        show = show[: show.index("run = self.analysis.run_autonomous")]
+
+        self.assertIn(
+            "settle_progress_line()",
+            show,
+            "show() must end the live progress line before printing a step",
+        )
+        self.assertLess(
+            show.index("settle_progress_line()"),
+            show.index("print("),
+            "the settle must come before the first print, not after",
+        )
+
+    def test_the_seam_is_safe_when_nothing_is_pending(self) -> None:
+        """Called on every step, including ones that never drew a line."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.settle_progress_line()
+            renderer.settle_progress_line()
+
+        self.assertEqual(buffer.getvalue(), "", "settling nothing must print nothing")
+
+
+class MultiStepStateTests(ProgressLineHarness):
+    """Each committed step must carry its own counts, not the previous one's."""
+
+    def test_each_step_keeps_its_own_measurements(self) -> None:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            renderer.start()
+            for tokens, rate, elapsed in ((100, 4.0, 10.0), (200, 5.0, 20.0)):
+                renderer.progress(generation(elapsed, tokens=tokens, rate=rate))
+                renderer._render_wait_line()
+                renderer.settle_progress_line()
+                print("action: ok", flush=True)
+        lines = [line for line in screen(buffer.getvalue()) if "generating" in line]
+
+        self.assertEqual(len(lines), 2)
+        self.assertIn("100 tok", lines[0])
+        self.assertIn("10s", lines[0])
+        self.assertIn("200 tok", lines[1])
+        self.assertIn("20s", lines[1])
+
+    def test_a_tick_after_settling_does_not_recommit_stale_counts(self) -> None:
+        """A timer tick between steps must not repeat the finished line.
+
+        The timer keeps running after a step is committed. Without clearing
+        the progress state, the next tick would redraw -- and then commit --
+        the previous step's token count and duration as though they were new.
+        """
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            print("raw: ev_abc", flush=True)
+            renderer.start()
+            renderer.progress(generation(10.0, tokens=100, rate=4.0))
+            renderer._render_wait_line()
+            renderer.settle_progress_line()
+            print("action: ok", flush=True)
+            renderer._render_wait_line()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertEqual(
+            len([line for line in lines if "100 tok" in line]),
+            1,
+            "the finished step was committed twice",
+        )

--- a/tests/test_progress_line_separation.py
+++ b/tests/test_progress_line_separation.py
@@ -592,3 +592,120 @@ class ToolCallPresentationTests(ProgressLineHarness):
             any("7 tok" in line for line in lines),
             "an abandoned line resurfaced on a later request",
         )
+
+
+class CommitRequestInvariantTests(ProgressLineHarness):
+    """A request must not outlive the line it was made for.
+
+    `keep_progress_line()` can be called when nothing has settled yet. If the
+    flag survives the drop path, a later line -- one nobody asked to keep --
+    is committed instead. Production happens to call `keep` immediately before
+    `finish()`, which hides this; the invariant is asserted directly so a
+    reordering cannot reintroduce it.
+    """
+
+    def test_a_stale_request_does_not_commit_a_later_line(self) -> None:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            renderer.start()
+            renderer.keep_progress_line()
+            # Nothing has settled, so this takes the drop path.
+            renderer.event("tool: x")
+            renderer.progress(generation(99.0, tokens=9, rate=5.0))
+            renderer._render_wait_line()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(
+            any("generating" in line for line in lines),
+            "a stale keep request committed a line nobody asked for",
+        )
+
+    def test_a_request_is_consumed_by_the_commit_it_causes(self) -> None:
+        """One request keeps one line, not every line after it."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            renderer.start()
+            renderer.progress(generation(10.0, tokens=11))
+            renderer._render_wait_line()
+            renderer.keep_progress_line()
+            renderer.finish()
+            # A second segment nobody asked about.
+            renderer.progress(generation(20.0, tokens=22))
+            renderer._render_wait_line()
+            renderer.finish()
+        lines = screen(buffer.getvalue())
+
+        self.assertTrue(any("11 tok" in line for line in lines), "the kept line is missing")
+        self.assertFalse(
+            any("22 tok" in line for line in lines),
+            "the request leaked into a later line",
+        )
+
+
+class PhaseSelectionTests(ProgressLineHarness):
+    """Only a finished generation is worth keeping in the transcript."""
+
+    def test_a_prefill_line_is_not_committed_on_the_guided_path(self) -> None:
+        """A guided step that never generates must leave no scaffolding row.
+
+        `test_a_prefill_line_is_still_cleared` covers the plain stop; this
+        covers the requested one, which is the route the guided fix uses.
+        """
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer = StreamRenderer(interval=999, interactive=True)
+            renderer.set_activity("analysis")
+            renderer.start()
+            renderer.progress(
+                StreamProgress(
+                    phase="prefill",
+                    current=0,
+                    total=100,
+                    percent=10,
+                    evaluated_current=10,
+                    evaluated_total=100,
+                )
+            )
+            renderer._render_wait_line()
+            renderer.keep_progress_line()
+            renderer.finish()
+            print("action: ok", flush=True)
+        lines = screen(buffer.getvalue())
+
+        self.assertFalse(
+            any("prefill" in line for line in lines),
+            "a prefill row was committed to the transcript",
+        )
+
+
+class TimerRestartTests(ProgressLineHarness):
+    def test_a_restart_releases_suspended_ticks(self) -> None:
+        """Restarting the timer resets line state, this included.
+
+        A settle suspends ticks for the caller's print. If an `event()`
+        restarts the timer while they are still suspended, the live line stays
+        frozen for the whole next segment. Not reachable from today's single
+        settle caller, which passes no event callback -- asserted so that
+        wiring one in later cannot silently freeze the line.
+        """
+        renderer = StreamRenderer(interval=999, interactive=True)
+        renderer.set_activity("analysis")
+        renderer.start()
+        renderer.progress(generation(5.0))
+        renderer._render_wait_line()
+        renderer.settle_progress_line()
+        self.assertTrue(renderer._suspend_ticks, "settling should suspend ticks")
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            renderer._restart_timer()
+
+        self.assertFalse(
+            renderer._suspend_ticks,
+            "a restarted timer must not stay suspended",
+        )


### PR DESCRIPTION
## What

The ANALYSIS progress line is redrawn in place with a bare carriage return and no newline. That is correct while it is still moving and wrong the moment it stops: whatever printed next landed on the same row.

**Before**
```
raw: ev_91adbf966e59_dc809e8533424e29
analysis · generating · 552 tok · 4.8 tok/s · 1m 54s        action: ok
```

**After**
```
raw: ev_91adbf966e59_dc809e8533424e29

analysis · generating · 552 tok · 4.8 tok/s · 1m 54s

action: ok
```

## Root cause

`_render_wait_line` writes `\r` + padded text with `end=""`, so the line never terminates. Two consequences:

1. Anything printed while the timer is active collides with it. The autonomous path prints each completed step from `show()` mid-run, which is the reported case; the padding to terminal width is what produced the wide gap.
2. `_clear_wait_line()` erases the row, so the elapsed duration the analyst watched accumulate is lost at completion.

## Fix

`StreamRenderer` owns the wait line, so it settles it. `_commit_wait_line()` writes the newline the redraw loop omits, with one blank line above and one below. Only a **generation** line is committed — prefill and the bare `working` tick are scaffolding with no value once the step is over.

`settle_progress_line()` is the seam for a caller that prints while the timer still runs; the autonomous `show()` calls it first. A guided step already ends at `finish()` and needs no change.

## Guarantees

- **Presentation only.** Token accounting, timing calculation semantics, backend metrics, streaming protocol, ANALYSIS runtime, EvidenceStore, prompts, KV/prewarm, autonomous policy and CHAT presentation are all untouched.
- **Elapsed preserved** in every case, including a 40-column terminal where the detail truncates but the duration never does.
- **Visible without colour** — blank lines and plain text, so it holds under `NO_COLOR`, `TERM=dumb` and pipes.
- **Non-interactive output unchanged**: a redirected stream still gets no progress line at all.

## Tests

`tests/test_progress_line_separation.py`, 21 tests. The harness resolves `\r` and strips ANSI so assertions are about what a terminal actually shows, not the bytes on the wire.

Covered: live→completed transition · elapsed preserved (`0s`, `9s`, `59s`, `1m 0s`, `1m 54s`, `59m 59s`) · action ok/error/refused · evidence immediately before · no duplicate blank lines · repeated autonomous steps · guided path via `finish()` · TTY and NO_COLOR/non-ANSI · terminal widths 40/60/80/200 · prefill not committed · per-step counts not carried over · production wiring asserted directly.

Mutation testing — **7/7 caught**: drop both blank lines; drop trailing blank; double leading blank; never commit; commit prefill too; autonomous `show()` stops settling; stale progress not cleared after settle.

## Verification

- Focused (progress line, streaming, repl, workflow, tool events, final output, analysis runtime): **542 passed**, exit 0
- Full suite: **3119 passed, 1 environment skip**, exit 0, no crash markers
- `compileall` OK · `git diff --check` clean

---

## Review round 2 (ff70311)

The first review returned MERGE SAFE: NO with one BLOCKER and one MAJOR. Both are fixed; both were reproduced causally before being accepted.

**BLOCKER — CHAT regression.** `_stop_timer` checked the settled line *before* honouring its `clear` argument, so `write()` — which asks for the line to be erased when the first delta arrives — committed it instead. Native streaming reports generation progress per token, so the line was always armed by then, and every CHAT answer gained a `model · generating · …` row plus two blank lines above it. Confirmed against a clean baseline worktree: baseline renders 3 rows, the regressed build 6.

Now only a line the caller is finished with is committed (`and not self._first_delta`), and one abandoned mid-stream is dropped so it cannot surface from a later stop.

**MAJOR — timer race.** The proposed fix was a lock. **A lock alone does not work**, and I measured that: 60/60 collisions with the lock in place. Serialising the two writers is not sufficient, because a tick landing *after* the commit draws a fresh unterminated line and the caller's output then collides with that one instead.

The implemented fix suspends ticks for the caller's print window, released by the next `progress()` call, with `_progress` and `_suspend_ticks` published together under the lock so a tick cannot draw from the previous step's state. Result: **0/60** on the widened-window probe that previously failed 60/60, and 0/300 unwidened.

`progress()` releases the lock before calling `_render_wait_line()`, so there is no self-deadlock; verified with a live timer thread over 50 rapid updates.

**MINOR** — the `_start_new_wait_line` one-line indirection the review flagged is removed.

### Verification at ff70311

- 26 tests (5 new: CHAT presentation, abandoned-line, timer interference, resume)
- Mutations: **10/10 caught**, including restoring the BLOCKER, restoring the MAJOR, and ticks never resuming
- Focused battery: **560 passed**, exit 0
- Full suite: **3126 passed, 1 environment skip**, exit 0, no crash markers
- `compileall` OK · `git diff --check` clean

---

## Review round 3 (dbe93c6)

Round 2 found the CHAT fix incomplete: guarding on `_first_delta` covered streamed **prose** only. Tool-call tokens never reach `write()` — the native protocol delivers them as tool_call events — while the same model call still emits generation progress per token. So a CHAT turn that only called a tool was indistinguishable from a finished analysis step, and every tool call gained a `model · generating` row plus two blank lines. Reproduced before accepting:

```
before:                                    after:
|                                     |    |tool: read_file(path=a.js)|
|model · generating · 12 tok · 4.8 …  |
|                                     |
|tool: read_file(path=a.js)|
```

**The renderer cannot infer that intent from what streamed.** Callers now request the keep explicitly:

- `settle_progress_line()` — a caller printing over a live line (autonomous `show()`)
- `keep_progress_line()` — a guided step, which prints after the renderer has stopped

`_stop_timer` commits only when asked; a line nobody asked to keep is dropped.

Also adds the `event()` coverage whose absence let this through — no test in the file exercised the tool-call route.

### Verification at dbe93c6

- 31 tests. Mutations: BLOCKER-2 restored, reverting to the inferred guard, removing `keep_progress_line()` from the guided path, removing the settle from `show()`, neutering tick suspension, and dropping the tick release — **all caught**. One mutation (clearing `_commit_pending` on the drop path) is an **equivalent mutant**: after `event()`, `_settled_line` is already `None`, so the reset is defensive but unobservable.
- Focused battery: **565 passed**, exit 0
- Full suite: **3131 passed, 1 environment skip**, exit 0, no crash markers
- `compileall` OK · `git diff --check` clean
- Race re-measured at this commit: **0/60** widened-window, 0/300 unwidened

---

## Round 3 verdict and follow-up (c07058a)

Round 3 returned **MERGE SAFE: YES** on dbe93c6 (BLOCKER 0 / MAJOR 0), confirming both prior blockers resolved and CHAT byte-identical to baseline on all 12 routes it constructed, including the tool-call routes that defeated round 2.

It raised three MINORs. All three are now closed, and one deserves a correction on my part.

**My equivalence claim was wrong.** I had declared the `_commit_pending = False` reset on the drop path an equivalent mutant. The review refuted it, and I reproduced the refutation: calling `keep_progress_line()` while no line has settled leaves the flag set through the drop path, and a later stop then commits a line nobody asked for — the mutant emits `analysis · generating · 9 tok · 5.0 tok/s · 1m 39s`, HEAD emits nothing. It is unreachable today only because production calls `keep` immediately before `finish()`. That is a real invariant resting on call ordering, so it is now asserted directly rather than left to reasoning.

**Test gaps closed:** committing prefill lines on the requested path, and the stale-request invariant above.

**Latent trap closed:** `_restart_timer` reset every other piece of line state but left `_suspend_ticks` set, which would freeze the live line for a whole segment if an event callback were ever wired into the autonomous path. One line.

One review note to correct for the record: the gap it reported for removing `keep_progress_line()` from repl.py is already covered — `test_the_guided_path_asks_to_keep_its_line` was added in dbe93c6 itself and catches that mutation (verified: 1 failed).

### Verification at c07058a

- **35 tests**; mutations **7/7 caught**, including the two reported surviving and the one I wrongly called equivalent
- Focused battery (incl. `test_native_streaming.py`): **579 passed**, exit 0
- Race re-measured: **0/60** widened-window
- `compileall` OK · `git diff --check` clean
- No behaviour change on any reachable path; the only production edit is the one-line `_suspend_ticks` reset
