### PR TITLE
docs: refresh README for current UX; add Ornith benchmark evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,24 @@
 # Orbit
 
-Orbit is a small Python-first local runtime for Gemma 4 26B-A4B, verified Qwen 3.6 35B-A3B, and verified Qwen3-Coder 30B-A3B profiles on CPU-only machines. The primary path is the native `orbit server` backend, using vendored llama.cpp/ggml libraries built and loaded by Orbit. It does not require an external `llama-server` process for normal use.
+Orbit is a small Python-first local AI runtime designed for CPU-only machines. It
+supports a limited set of compatible and verified models, listed in
+[Supported Models](#supported-models) below. The primary path is the native Orbit
+server backend, using vendored llama.cpp/ggml libraries built and loaded by
+Orbit. It does not require an external `llama-server` process for normal use.
 
-Orbit stays model-driven. The runtime enforces safety, size, timeout, context, and tool-contract boundaries, but the model decides whether to answer directly or use exposed tools.
-
-Linux is the main target environment. macOS may work. Windows is not a target.
+Orbit stays model-driven: the runtime enforces safety, size, timeout, context and
+tool-contract boundaries; the model decides whether to answer directly or reach
+for a tool. Linux x86_64 CPU-only is the qualified platform.
 
 <p align="center">
   <img src="docs/orbit-cli.png" alt="Orbit CLI" width="900">
 </p>
 
-## Supported Models
-
-| Model | Prefill | Generation | Tools-on chat | Tool + final | Peak RAM |
-|---|---:|---:|---:|---:|---:|
-| [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
-| [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
-| [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
-| [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) | — | — | — | — | — |
-
-NUC10 Intel Core i7-10710U (6 cores / 12 threads) with 64 GB RAM, no GPU
-Linux, llama.cpp b9551, ctx=8192, 6 threads, batch/ubatch 256/128, Flash Attention AUTO, thinking off, and MTP off.
-
-Ornith 1.5 35B-A3B is the verified profile the analysis workflow was qualified on. Its row is empty
-because it has not been measured under the warm steady-state chat protocol used for the other rows.
-Expect memory in the same range as the other 35B-A3B profile.
-
-Chat and tool latencies are warm steady-state medians after one excluded warm-up. Prefill measures evaluated tokens only and excludes cache benefit. These are not universal performance claims; actual results vary with CPU, memory bandwidth, quantization, backend build, and workload.
-
-`orbit server --low-memory` is an opt-in mode supported only for the verified Qwen3-Coder 30B-A3B profile. Default behavior is unchanged and CPU repacking remains enabled unless this flag is specified. On the documented NUC10, peak RSS was approximately 31.3 GiB by default and 18.3 GiB in low-memory mode, a 41.6% reduction, with weighted prefill approximately 13.9% slower and decode approximately 1% slower. 24 GB RAM is the recommended practical minimum for a complete host; 20 GiB was qualified only as a process-memory limit and is not a general host recommendation.
-
-## Chat and Analysis
-
-Orbit has two workflows. Chat is the default and is unchanged: you ask, the model
-answers, and it may use the exposed tools.
-
-Analysis is for inspecting one local artifact in an isolated workspace. Start it
-explicitly, or let Orbit route to it when a request is clearly about analysing a
-file:
-
-```
-/analysis path/to/artifact
-/report            # answer from the evidence already collected, running nothing
-/chat              # back to normal chat
-```
-
-An analysis step is deliberately narrow. The model writes a short Python program,
-Orbit runs it in a sandbox with no network and a read-only copy of the artifact,
-and the output is recorded in an evidence store with its provenance. One model
-call performs at most one action, and control returns to you after each step, so
-you steer by typing the next instruction — `continue` included.
-
-Everything the model derives stays inside the session workspace. Full outputs
-remain re-attestable in the evidence store; only bounded excerpts are shown to
-the model.
-
-### Autonomous continuation (opt-in)
-
-By default an analysis advances one step at a time and waits for you. With
-
-```bash
-ORBIT_ANALYSIS_AUTONOMOUS=1 orbit
-```
-
-Orbit continues by itself while each step produces verifiably new evidence,
-stopping when the model finishes, when progress stalls, or at a hard bound of 12
-actions. Every ending except a cancellation produces one grounded report from the
-evidence collected.
-
-This mode is off by default. It is opt-in for cost rather than for
-correctness: a step that measures something new counts as progress whether or
-not the measurement was worth making, so an artifact with little to derive can
-still attract many actions. Whether that trade is worthwhile is a judgement for
-the operator. Ctrl-C stops a run immediately.
-
 ## Requirements
 
-- Python 3.11 or newer
-- Linux recommended
-- CMake for building the vendored native libraries
+- Python 3.11 or newer, on Linux
+- CMake, to build the vendored native libraries
+- Enough RAM for the model you choose (24 GB practical minimum)
 
 ## Install
 
@@ -97,72 +37,157 @@ Build the vendored native libraries if they are not already present:
 python3 scripts/build_native.py
 ```
 
-Inspect the host and review the recommended server configuration:
+To inspect the host and see a recommended configuration:
 
 ```bash
 scripts/suggest-server-profile.sh
 ```
 
-## Limitations
+## First run
 
-- Linux x86_64 CPU-only is the qualified platform. macOS may work; Windows is not
-  a target. There is no GPU path.
-- Analysis runs one artifact per session, and the sandbox has no network.
-- Autonomous continuation is opt-in and may perform unnecessary work on trivial
-  artifacts (see above).
-- Eager capture of the analysis prefix at startup is opt-in
-  (`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1`); by default the prefix is captured
-  lazily by the first analysis step, which costs that step and benefits every
-  later one.
-- Analysis features are qualified on the verified Ornith 1.5 profile. Other
-  verified profiles fall back to ordinary cold behaviour rather than failing.
-
-## Quick Start
-
-Start the native server and select an available verified model:
+**1. Start the server** in one terminal. It loads the model and stays running:
 
 ```bash
-orbit server
+orbit server --ctx 16384 --batch 256 --ubatch 128
 ```
 
-The default context is 8192 tokens, equivalent to:
+`--ctx` sets the context window and the largest input that fits in one model
+call. Larger contexts need more memory, mostly for the KV cache; if a document
+does not fit, Orbit reports the minimum required.
 
-```bash
-orbit server --ctx 8192
-```
-
-`--ctx` controls the server context window and the maximum input that can fit
-in one model call. To use a larger context:
-
-```bash
-orbit server --ctx 19456
-```
-
-For Qwen3-Coder with low-memory mode and a larger context:
-
-```bash
-orbit server --ctx 19456 --low-memory
-```
-
-To select a model explicitly:
-
-```bash
-orbit server --model /path/to/model.gguf --ctx 19456
-```
-
-`/max-tokens` controls maximum response length only; it does not enlarge the
-context. If a full document does not fit, Orbit reports the minimum required
-context and suggests a suitable `--ctx`. Larger contexts require additional
-memory, mainly for the KV cache.
-
-In another terminal:
+**2. Start the CLI** in another terminal:
 
 ```bash
 orbit
 ```
 
-For a one-shot request:
+**3. Chat.** The default mode — ask a question, get an answer. The model may use
+the exposed tools on its own.
+
+**4. Analyse a file.** Orbit routes to ANALYSIS by itself when a request is
+clearly about inspecting a local artifact:
+
+```
+analyze ~/samples/loader.js and tell me what it reads from disk
+```
+
+You can also enter it explicitly, and leave the same way:
+
+```
+/analysis path/to/artifact    # start an analysis
+/report                       # answer from evidence already collected, running nothing
+/chat                         # back to normal chat
+```
+
+**5. Choose how analysis advances.** By default each step returns to you. To let
+a run continue on its own:
+
+```
+/autonomous on     # or: /autonomous off, or /autonomous to see the current setting
+```
+
+`/help` lists every command.
+
+Other server flags: `--low-memory`, and `--model /path/to/model.gguf` to pick a
+file explicitly. Without `--ctx` the default is 8192. For one shot without the
+interactive session:
 
 ```bash
 orbit --workdir workdir --think off "hi, how are you?"
 ```
+
+## Chat and Analysis
+
+**ANALYSIS** inspects one local artifact in an isolated workspace. The model
+writes a short Python program, Orbit runs it in a sandbox with no network and a
+read-only copy of the artifact, and the output is recorded with its provenance.
+One model call performs at most one action, and everything derived stays in the
+session workspace. Reports are plain text.
+
+### Guided vs autonomous
+
+ANALYSIS is **guided by default**: it advances one step at a time and control
+returns to you after each, so you steer by typing the next instruction —
+`continue` included.
+
+Switch at any time, without restarting Orbit:
+
+```
+/autonomous          # show the current state
+/autonomous on       # continue automatically
+/autonomous off      # back to guided
+```
+
+The setting belongs to the running CLI process. It survives `/chat` ↔
+`/analysis` transitions within that session, and is not persisted globally — a
+new `orbit` starts guided again.
+
+**Autonomous** continues by itself while each step produces verifiably new
+evidence, stopping on completion, when progress stalls, or at a hard bound of 12
+actions. Every ending but a cancellation produces one grounded report. Ctrl-C
+stops a run immediately.
+
+It is off by default, and opt-in for cost rather than correctness: a step that
+measures something new counts as progress whether or not the measurement was
+worth making, so an artifact with little to derive can still attract many
+actions. Whether that trade is worthwhile is the operator's call.
+
+## Supported Models
+
+| Model | Prefill | Generation | Tools-on chat | Tool + final | Peak RAM |
+|---|---:|---:|---:|---:|---:|
+| [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
+| [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
+| [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
+| [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) | — | — | — | — | — |
+
+Measured on a NUC10 Intel Core i7-10710U (6 cores / 12 threads), 64 GB RAM, no
+GPU; Linux, llama.cpp b9551, `ctx=8192`, 6 threads, batch/ubatch 256/128, Flash
+Attention AUTO, thinking off, MTP off.
+
+Chat and tool latencies are warm steady-state medians after one excluded
+warm-up; prefill counts evaluated tokens only. **These are measurements on that
+one system, not universal model performance** — results vary with hardware,
+context, cache reuse and workload.
+
+**Ornith 1.5 35B-A3B** is verified, and the profile the ANALYSIS workflow is
+qualified on. It has not been run under the chat protocol above, so it has no
+comparable row there. Measured on the same system under the ANALYSIS workload,
+at `--ctx 16384`, quantization Q4_K_M:
+
+| Metric | Measured |
+|---|---|
+| Prefill (cold, no cache reuse) | 21–33 tok/s (n=5, median 31.8) |
+| Generation | ~5–10 tok/s (n=22 derived, median 5.9) |
+
+Prefill counts only calls with no reuse, so it matches the definition above.
+Generation is derived from wall clock minus prefill — a looser bound than a
+dedicated decode benchmark. Peak RAM is not stated because it was never
+measured. Methodology and per-call figures:
+[docs/benchmarks/ornith-1.5-35b-a3b.md](docs/benchmarks/ornith-1.5-35b-a3b.md).
+
+`--low-memory` is supported only for Qwen3-Coder 30B-A3B. On the system above it
+cut peak RSS from ~31.3 to ~18.3 GiB, costing ~13.9% on prefill and ~1% on
+decode.
+
+## Limitations
+
+- Linux x86_64 CPU-only is the qualified platform. macOS may work; Windows is
+  not a target. There is no GPU path.
+- Analysis handles one artifact per session, and the sandbox has no network.
+- Autonomous analysis is opt-in and may do unnecessary work on trivial
+  artifacts (see above).
+- Analysis is qualified on the Ornith 1.5 profile. Other verified profiles fall
+  back to ordinary cold behaviour rather than failing.
+- The analysis prefix is captured lazily by the first analysis step, which costs
+  that step and benefits every later one. Eager capture at startup is opt-in.
+
+## Configuration
+
+Behaviour is controlled by CLI flags and in-session commands. Two environment
+variables are supported for startup configuration only:
+
+- `ORBIT_ANALYSIS_AUTONOMOUS=1` — start with autonomous analysis already on.
+  `/autonomous on` is the normal way; this only helps a scripted start.
+- `ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1` — capture the analysis prefix eagerly
+  at startup instead of lazily on first use.

--- a/docs/benchmarks/ornith-1.5-35b-a3b.md
+++ b/docs/benchmarks/ornith-1.5-35b-a3b.md
@@ -117,7 +117,8 @@ Measured 2026-08-24 against served commit `98049a9`.
 ### Prefix cache reuse
 
 The clearest result on this profile. Across one 13-call autonomous analysis run,
-per-call KV reuse rises as the run accumulates context:
+per-call KV reuse rises as the run accumulates context (selected calls; the
+totals below are over all 13):
 
 | Call | Reused | Evaluated | Reuse |
 |---:|---:|---:|---:|
@@ -171,9 +172,9 @@ Per-call `prefill_ms` on calls that **did** reuse cache is not usable as a
 prefill-throughput figure. The timer starts before the prefix reuse and restore
 work, while the token count excludes reused tokens, so restore overhead lands in
 the denominator but not the numerator. That systematically depresses the rate:
-medians of 14.6 tok/s (n=13) and 18.3 tok/s (n=9) across two runs, against
-21–33 tok/s on cold calls — a spread that reflects the metric's definition, not
-the hardware.
+across the two runs, the reuse-affected calls median 14.4 tok/s (n=11) and
+17.5 tok/s (n=7), against 21–33 tok/s on cold calls — a spread that reflects
+the metric's definition, not the hardware.
 
 This is why the published range is drawn from zero-reuse calls only.
 

--- a/docs/benchmarks/ornith-1.5-35b-a3b.md
+++ b/docs/benchmarks/ornith-1.5-35b-a3b.md
@@ -1,0 +1,203 @@
+# Ornith 1.5 35B-A3B — measurements on the reference system
+
+What has actually been measured for this profile, where each number came from,
+and — just as importantly — what has **not** been measured.
+
+Everything below is a measurement on one machine. It is not a claim about the
+model in general: results move with CPU, memory bandwidth, quantization,
+backend build, and workload.
+
+## Why this profile is measured separately
+
+The other rows in the README table are warm steady-state medians from a
+controlled *chat* benchmark: one excluded warm-up, three measured repetitions, a
+fixed long-prefill fixture, at `ctx=8192` with 6 threads.
+
+**No Ornith run has been made under that protocol.** Every measurement here
+comes from the *analysis* workflow at `ctx=16384` with 12 threads. Reporting
+those numbers inside the chat table would imply a comparability that does not
+exist, so the README gives this profile its own table with its own stated basis
+instead.
+
+Within that basis the figures are sound. The prefill numbers below count only
+calls with **no cache reuse**, which makes them comparable to the README's
+"evaluated tokens only, excludes cache benefit" definition; the reuse-affected
+numbers are excluded and explained under
+[Prefill on reuse calls](#prefill-on-reuse-calls-not-comparable).
+
+## Model specification
+
+Properties of the model file, not of Orbit.
+
+| Property | Value |
+|---|---|
+| Repository | [ornith-ai/Ornith-1.5-35B-A3B-GGUF](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) |
+| File | `Ornith-1.5-35B-Q4_K_M.gguf` |
+| Quantization | Q4_K_M (4.89 BPW) |
+| File size | 20.21 GiB |
+| Parameters | 35.51 B (35B-A3B) |
+| Architecture | `qwen35moe`, 256 experts, 8 active |
+| Training context | 262144 |
+
+Source: `print_info` lines 54–136 of the run log listed under
+[Evidence sources](#evidence-sources).
+
+## Reference hardware
+
+| Property | Value |
+|---|---|
+| CPU | Intel Core i7-10710U (NUC10), 6 cores / 12 threads |
+| RAM | 64 GB |
+| GPU | none (`gpu_layers = 0`) |
+| OS | Linux x86_64 |
+| llama.cpp build | b9551 |
+
+## Orbit configuration used for these measurements
+
+| Setting | Value |
+|---|---|
+| Context | 16384 |
+| Batch / ubatch | 256 / 128 |
+| Threads | 12 (generation and batch) |
+| Flash Attention | `auto` |
+| Thinking | off |
+
+```bash
+orbit server --ctx 16384 --batch 256 --ubatch 128
+```
+
+Note this differs from the README table's benchmark configuration
+(`ctx=8192`, 6 threads), which is one reason the numbers are not interchangeable.
+
+## Measured values
+
+### Prefill, cold calls only — the published range
+
+Calls that evaluated their prompt with **zero** reused tokens, so no restore work
+sits inside the timing window. These are the samples behind the README's
+`21–33 tok/s (n=5, median 31.8)`:
+
+| Source | Evaluated tokens | Prefill |
+|---|---:|---:|
+| `/report` measurement | 5526 | 32.9 tok/s |
+| autonomous run A, call 1 | 604 | 31.8 tok/s |
+| autonomous run A, final call | 9613 | 21.0 tok/s |
+| autonomous run B, call 1 | 604 | 31.9 tok/s |
+| autonomous run B, final call | 8419 | 23.2 tok/s |
+
+n = 5, min 21.0, max 32.9, median 31.8. The two lower values are the largest
+prompts, which is the expected shape rather than noise.
+
+### Generation — the published range
+
+Derived as output tokens ÷ (wall clock − prefill) over every call with at least
+20 output tokens: **n = 22, median 5.9 tok/s**, spanning 1.8–9.9 with a single
+low outlier at 1.8; excluding it, 4.8–9.9. The README states `~5–10 tok/s`.
+
+This is a **looser bound than a dedicated decode benchmark**: the denominator
+includes any non-decode overhead in the call. The one directly measured decode
+figure, 8.1 tok/s from the `/report` call below, falls inside the derived range,
+which is the cross-check that makes the range publishable.
+
+### Single `/report` call
+
+One model call, measured end to end. **n = 1** — recorded here because it is
+real and directly measured, not because one sample is a benchmark.
+
+| Metric | Value |
+|---|---|
+| Prompt tokens | 5526 evaluated, 0 cached |
+| Output tokens | 886 |
+| Prefill | 32.9 tok/s |
+| Decode | 8.1 tok/s |
+| Wall clock | 277.1 s (168.1 s to first token) |
+
+Measured 2026-08-24 against served commit `98049a9`.
+
+### Prefix cache reuse
+
+The clearest result on this profile. Across one 13-call autonomous analysis run,
+per-call KV reuse rises as the run accumulates context:
+
+| Call | Reused | Evaluated | Reuse |
+|---:|---:|---:|---:|
+| 1 | 0 | 604 | 0.0% |
+| 2 | 604 | 2,337 | 20.5% |
+| 3 | 2,941 | 2,957 | 49.9% |
+| 4 | 5,898 | 1,285 | 82.1% |
+| 6 | 8,616 | 824 | 91.3% |
+| 10 | 12,227 | 443 | 96.5% |
+| 12 | 14,736 | 594 | 96.1% |
+| 13 | 0 | 9,613 | 0.0% |
+
+Run totals: **95,799 reused / 24,943 evaluated = 79.3% overall**, with per-call
+reuse peaking near 96%. Call 13 opens a fresh report context and so starts cold
+again — the reset is expected, not a regression. Token accounting was exact on
+every call.
+
+Read the aggregate carefully: 79.3% is the whole run including its cold start;
+~96% is the *steady-state peak*, not an average.
+
+### ANALYSIS prefix prewarm
+
+Descriptive timings, **n = 1** each, for the opt-in
+`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1` startup capture:
+
+- capture cost: 11.0 s of startup prefill, 73,736,684 bytes resident
+- with it on, a first analysis step restored 384 of 588 prompt tokens and its
+  prefill fell from 18.2 s to 6.0 s
+
+Reuse itself is on by default and free — the first analysis step captures the
+checkpoint on its way past. The environment variable only decides whether that
+capture is paid eagerly at startup instead.
+
+## Not measured
+
+Stated explicitly so nobody infers a number that does not exist:
+
+- **Peak RAM / RSS.** No resident-memory measurement exists for this profile.
+  The 20.21 GiB file size and the mapped model buffer are not RSS, and the
+  other 35B-A3B profile's figure must not be carried over.
+- **Warm steady-state chat throughput**, tools-on chat latency, and tool+final
+  latency — the chat-protocol columns. No data of any kind; the throughput
+  figures above are the analysis workload, not that protocol.
+- **Flash Attention resolved value.** The log records `auto`, never what it
+  resolved to.
+- **MTP state.** Absent from the evidence; absent is not the same as off.
+
+### Prefill on reuse calls, not comparable
+
+Per-call `prefill_ms` on calls that **did** reuse cache is not usable as a
+prefill-throughput figure. The timer starts before the prefix reuse and restore
+work, while the token count excludes reused tokens, so restore overhead lands in
+the denominator but not the numerator. That systematically depresses the rate:
+medians of 14.6 tok/s (n=13) and 18.3 tok/s (n=9) across two runs, against
+21–33 tok/s on cold calls — a spread that reflects the metric's definition, not
+the hardware.
+
+This is why the published range is drawn from zero-reuse calls only.
+
+## Evidence sources
+
+All paths relative to the qualification checkpoint archive, which is kept
+outside the repository.
+
+| What | Source |
+|---|---|
+| `/report` call | `report-performance-baseline-20260824-022942/artifacts/measurement.json` |
+| Served commit | `report-performance-baseline-20260824-022942/artifacts/served_commit.txt` |
+| Cache reuse, per call | `analysis-autonomous-final-20260824-202440/evidence/fullrun-qualification.json` |
+| Model spec, runtime config | `analysis-autonomous-progress-20260824-190424/evidence/fullrun.ABORTED-infra-kill.log` |
+| Prewarm timings | `AGENTS.md` |
+| Qualification status | `docs/releases/v0.0.1-rc34.md`, `docs/releases/v0.0.1-rc35.md` |
+
+Two log files in the archive — `fullrun-budget.log` and
+`fullrun-qualification.log` — are byte-identical. They are one run, and counting
+them twice would double the sample.
+
+## Reproducing a publishable row
+
+To fill the README row properly, run the protocol the other rows use — one
+excluded warm-up and three measured repetitions against the fixed long-prefill
+fixture, at `ctx=8192` with 6 threads — and capture peak RSS alongside it. See
+`docs/QWEN3_CODER_QUALIFICATION.md` for the procedure.


### PR DESCRIPTION
## What

Refreshes `README.md` to describe Orbit as it works today, restructured around what a first-time user actually does. Adds `docs/benchmarks/ornith-1.5-35b-a3b.md` so every published number is auditable.

**Docs only. No production change.**

## Introduction

No longer enumerates model names — `Supported Models` is the single authoritative list.

## First run

One numbered flow: start the server, start the CLI, chat, let routing reach ANALYSIS, choose guided or autonomous. Quick Start used to sit at the bottom, so a first reader met the performance table before learning how to start anything.

## Autonomous continuation

The previous README documented this **only** as `ORBIT_ANALYSIS_AUTONOMOUS=1 orbit`, and never mentioned that `/autonomous` exists. It now leads with the interactive commands:

```
/autonomous          # show the current state
/autonomous on       # continue automatically
/autonomous off      # back to guided
```

Verified against production rather than assumed: `autonomous_analysis` is a `Repl` instance field set once at init and mutated only by `/autonomous`, and neither `_handle_chat_command` nor the analysis command resets it — so "belongs to the running process, survives `/chat` ↔ `/analysis`, not persisted globally" is accurate. Default remains **off**. The environment variable is documented as startup configuration only.

## Supported Models — the Ornith row

The row was empty. It is now completed with evidence recovered from qualification checkpoints, **in its own table rather than the chat-benchmark row**, because Ornith has never been run under that protocol (the other rows are warm steady-state chat medians at `ctx=8192`/6 threads; all Ornith evidence is the ANALYSIS workload at `ctx=16384`/12 threads).

| Metric | Measured |
|---|---|
| Prefill (cold, no cache reuse) | 21–33 tok/s (n=5, median 31.8) |
| Generation | ~5–10 tok/s (n=22 derived, median 5.9) |

Why these are defensible:

- **Prefill** counts only calls with **zero** reused tokens, so no restore work sits in the timing window — that matches the chat table's "evaluated tokens only, excludes cache benefit" definition. Reuse-affected calls are excluded and the reason is documented.
- **Generation** is derived from wall clock minus prefill and is labelled as the looser bound it is. The one directly measured decode figure (8.1 tok/s) falls inside the derived range, which is the cross-check that makes the range publishable.
- **Peak RAM is omitted** because it was never measured. It is not inferred from file size, mapped buffer, or the other 35B-A3B profile.

What was deliberately **not** published, having been checked and rejected: the single `/report` sample as a headline benchmark (n=1); medians from reuse-affected prefill (metric-definition mismatch, ~2.7x spread); and any figure from treating `fullrun-budget.log` and `fullrun-qualification.log` as two runs — they are byte-identical, one run.

Cache-reuse percentages are kept out of the model table; they are a workload/session property, not intrinsic model speed.

## Content cleanup

Removed or corrected: env-var-only autonomous docs; the empty Ornith row; Quick Start's position; duplicated context/server explanations; an overlapping limitations bullet. No stale rc references, no internal jargon (EvidenceStore internals, family guards, KV identities, PR history), no Markdown-final-report claims.

## Quality gate

| | Before | After |
|---|---:|---:|
| Words | 1016 | 1123 (+10.5%) |
| Sections | 8 | 7 |

The overage is the Ornith evidence table; prose elsewhere was cut to compensate.

## Verification

- All four model links return **200**; `docs/orbit-cli.png` and `docs/QWEN3_CODER_QUALIFICATION.md` exist
- Every command checked against `command_registry.py`; every server flag against `orbit server --help`
- `--ctx` default 8192 confirmed at `native_server/app.py:1138`; 12-action bound at `analysis_runtime.py:243`; Q4_K_M at `model_profiles.py:55`
- Every published number cross-checked against the benchmark doc and its source
