### PR TITLE
docs: complete the Ornith Supported Models row from measured benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,32 @@ for a tool. Linux x86_64 CPU-only is the qualified platform.
   <img src="docs/orbit-cli.png" alt="Orbit CLI" width="900">
 </p>
 
+## Supported Models
+
+| Model | Prefill | Generation | Tools-on chat | Tool + final | Peak RAM |
+|---|---:|---:|---:|---:|---:|
+| [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
+| [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
+| [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
+| [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) | ~29.0 tok/s | ~8.3 tok/s | ~36.8 s cold / ~8.4 s warm | ~49.0 s | ~35.8 GiB |
+
+**Performance figures are measurements on one CPU-only system**, not universal
+model performance — they vary with hardware, configuration, cache state and
+workload. The reference system is a NUC10 Intel Core i7-10710U (6 cores / 12
+threads), 64 GB RAM, no GPU; Linux, llama.cpp b9551, `ctx=8192`, 6 threads,
+batch/ubatch 256/128, thinking off.
+
+The Ornith row was measured with the qualification harness in this repository
+and every figure is reproducible from
+[its benchmark record](docs/benchmarks/ornith-1.5-35b-a3b.md). The first three
+rows predate that harness and could not be reproduced from any data kept in the
+repository; treat them as indicative until they are re-measured. Tools-on chat
+in particular is dominated by route-prefix cache state rather than model speed.
+
+`--low-memory` is supported only for Qwen3-Coder 30B-A3B. On the system above it
+cut peak RSS from ~31.3 to ~18.3 GiB, costing ~13.9% on prefill and ~1% on
+decode.
+
 ## Requirements
 
 - Python 3.11 or newer, on Linux
@@ -131,44 +157,6 @@ It is off by default, and opt-in for cost rather than correctness: a step that
 measures something new counts as progress whether or not the measurement was
 worth making, so an artifact with little to derive can still attract many
 actions. Whether that trade is worthwhile is the operator's call.
-
-## Supported Models
-
-| Model | Prefill | Generation | Tools-on chat | Tool + final | Peak RAM |
-|---|---:|---:|---:|---:|---:|
-| [Gemma 4 26B-A4B](https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF) | ~24.2 tok/s | ~7.1 tok/s | ~3.0 s | ~20.9 s | ~29.4 GiB |
-| [Qwen 3.6 35B-A3B](https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-GGUF) | ~31.8 tok/s | ~7.6 tok/s | ~6.1 s | ~23.8 s | ~36.4 GiB |
-| [Qwen3-Coder 30B-A3B](https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF) | ~26.0 tok/s | ~10.7 tok/s | ~3.0 s | ~18.4 s | ~31.3 GiB |
-| [Ornith 1.5 35B-A3B](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) | — | — | — | — | — |
-
-Measured on a NUC10 Intel Core i7-10710U (6 cores / 12 threads), 64 GB RAM, no
-GPU; Linux, llama.cpp b9551, `ctx=8192`, 6 threads, batch/ubatch 256/128, Flash
-Attention AUTO, thinking off, MTP off.
-
-Chat and tool latencies are warm steady-state medians after one excluded
-warm-up; prefill counts evaluated tokens only. **These are measurements on that
-one system, not universal model performance** — results vary with hardware,
-context, cache reuse and workload.
-
-**Ornith 1.5 35B-A3B** is verified, and the profile the ANALYSIS workflow is
-qualified on. It has not been run under the chat protocol above, so it has no
-comparable row there. Measured on the same system under the ANALYSIS workload,
-at `--ctx 16384`, quantization Q4_K_M:
-
-| Metric | Measured |
-|---|---|
-| Prefill (cold, no cache reuse) | 21–33 tok/s (n=5, median 31.8) |
-| Generation | ~5–10 tok/s (n=22 derived, median 5.9) |
-
-Prefill counts only calls with no reuse, so it matches the definition above.
-Generation is derived from wall clock minus prefill — a looser bound than a
-dedicated decode benchmark. Peak RAM is not stated because it was never
-measured. Methodology and per-call figures:
-[docs/benchmarks/ornith-1.5-35b-a3b.md](docs/benchmarks/ornith-1.5-35b-a3b.md).
-
-`--low-memory` is supported only for Qwen3-Coder 30B-A3B. On the system above it
-cut peak RSS from ~31.3 to ~18.3 GiB, costing ~13.9% on prefill and ~1% on
-decode.
 
 ## Limitations
 

--- a/docs/benchmarks/ornith-1.5-35b-a3b.json
+++ b/docs/benchmarks/ornith-1.5-35b-a3b.json
@@ -1,0 +1,274 @@
+{
+  "schema": "orbit-benchmark-results/1",
+  "model": {
+    "repository": "ornith-ai/Ornith-1.5-35B-A3B-GGUF",
+    "file": "Ornith-1.5-35B-Q4_K_M.gguf",
+    "quantization": "Q4_K_M",
+    "file_bytes": 21713462848,
+    "file_sha256": "ca6ea26329c88b78ffd90a85163be2e746c2fafd1024f56db47e499f117f9a7f",
+    "profile_id": "orbit-ornith15-native-v1",
+    "architecture": "qwen35moe",
+    "template_sha256": "f55f52930aa8bf44ab5cb85f99370fcc3c56e9a85640b812086d5330bce5d86b"
+  },
+  "orbit": {
+    "git_revision": "892cfad36453b55f28f0dcdd50aea7a36450f58e",
+    "backend": "orbit-native",
+    "llama_cpp_build_number": 9551,
+    "llama_cpp_build_commit": "379ac6673b5cd75c7b4e07d1521c50f1e093878c"
+  },
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "machine": "Intel NUC10i7FNH",
+    "physical_cores": 6,
+    "logical_cores": 12,
+    "ram_total_gb": 63,
+    "gpu": null,
+    "os": "Linux 7.0.0-30-generic x86_64"
+  },
+  "configuration": {
+    "ctx_size": 8192,
+    "threads": 6,
+    "threads_batch": 6,
+    "batch_size": 256,
+    "ubatch_size": 128,
+    "parallel_slots": 1,
+    "thinking": "off",
+    "mtp": "off",
+    "temperature": 0
+  },
+  "protocol": {
+    "harness": "scripts/orbit_qualify.py",
+    "fixtures": [
+      "chat_route_first (optimizations-v1)",
+      "pwd_route (core-v1)",
+      "pwd_final (core-v1)",
+      "json_artifact (core-v1)",
+      "existing_file_modification (workflows-v1)"
+    ],
+    "warmups_excluded": 1,
+    "measured_repetitions": 3,
+    "definitions": {
+      "prefill_tokens_per_second": "sum evaluated / sum per-call evaluated seconds; server timings.prompt_per_second; evaluated tokens only",
+      "generation_tokens_per_second": "sum output / sum per-call decode seconds; server timings.predicted_per_second",
+      "tools_on_chat": "wall of the tools-on fixture that routes to CHAT and executes no tool",
+      "tool_plus_final": "wall of the fixture that calls one tool then produces a final answer",
+      "peak_rss": "Linux VmHWM of the server PID; process lifetime including model load"
+    }
+  },
+  "raw_runs": [
+    {
+      "run": 1,
+      "model_calls": 14,
+      "prefill_tokens_per_second": 29.98,
+      "generation_tokens_per_second": 8.3,
+      "peak_rss_bytes": 38422634496,
+      "workloads": {
+        "chat_route_first": {
+          "wall_seconds": 6.79,
+          "cached_tokens": 768,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "pwd_route": {
+          "wall_seconds": 5.42,
+          "cached_tokens": 768,
+          "model_calls": 1,
+          "status": "PASS"
+        },
+        "pwd_final": {
+          "wall_seconds": 41.41,
+          "cached_tokens": 0,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "json_artifact": {
+          "wall_seconds": 161.05,
+          "cached_tokens": 0,
+          "model_calls": 4,
+          "status": "PASS"
+        },
+        "existing_file_modification": {
+          "wall_seconds": 272.53,
+          "cached_tokens": 0,
+          "model_calls": 5,
+          "status": "PASS"
+        }
+      }
+    },
+    {
+      "run": 2,
+      "model_calls": 15,
+      "prefill_tokens_per_second": 26.55,
+      "generation_tokens_per_second": 7.04,
+      "peak_rss_bytes": 38422634496,
+      "workloads": {
+        "chat_route_first": {
+          "wall_seconds": 32.53,
+          "cached_tokens": 0,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "pwd_route": {
+          "wall_seconds": 7.14,
+          "cached_tokens": 768,
+          "model_calls": 1,
+          "status": "PASS"
+        },
+        "pwd_final": {
+          "wall_seconds": 49.01,
+          "cached_tokens": 0,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "json_artifact": {
+          "wall_seconds": 189.8,
+          "cached_tokens": 0,
+          "model_calls": 4,
+          "status": "PASS"
+        },
+        "existing_file_modification": {
+          "wall_seconds": 328.84,
+          "cached_tokens": 0,
+          "model_calls": 6,
+          "status": "PASS"
+        }
+      }
+    },
+    {
+      "run": 3,
+      "model_calls": 15,
+      "prefill_tokens_per_second": 28.95,
+      "generation_tokens_per_second": 8.27,
+      "peak_rss_bytes": 38422634496,
+      "workloads": {
+        "chat_route_first": {
+          "wall_seconds": 37.82,
+          "cached_tokens": 0,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "pwd_route": {
+          "wall_seconds": 8.19,
+          "cached_tokens": 768,
+          "model_calls": 1,
+          "status": "PASS"
+        },
+        "pwd_final": {
+          "wall_seconds": 53.72,
+          "cached_tokens": 0,
+          "model_calls": 2,
+          "status": "PASS"
+        },
+        "json_artifact": {
+          "wall_seconds": 171.9,
+          "cached_tokens": 0,
+          "model_calls": 4,
+          "status": "PASS"
+        },
+        "existing_file_modification": {
+          "wall_seconds": 321.57,
+          "cached_tokens": 0,
+          "model_calls": 6,
+          "status": "PASS"
+        }
+      }
+    }
+  ],
+  "tools_on_chat_repetitions": [
+    {
+      "run": 1,
+      "wall_seconds": 6.79,
+      "cached_tokens": 768,
+      "cache_state": "warm",
+      "status": "PASS",
+      "route_call_wall_seconds": 5.56,
+      "route_call_evaluated_tokens": 172
+    },
+    {
+      "run": 2,
+      "wall_seconds": 32.53,
+      "cached_tokens": 0,
+      "cache_state": "cold",
+      "status": "PASS",
+      "route_call_wall_seconds": 31.03,
+      "route_call_evaluated_tokens": 940
+    },
+    {
+      "run": 3,
+      "wall_seconds": 37.82,
+      "cached_tokens": 0,
+      "cache_state": "cold",
+      "status": "PASS",
+      "route_call_wall_seconds": 35.81,
+      "route_call_evaluated_tokens": 940
+    },
+    {
+      "run": 4,
+      "wall_seconds": 36.84,
+      "cached_tokens": 0,
+      "cache_state": "cold",
+      "status": "PASS",
+      "route_call_wall_seconds": 35.05,
+      "route_call_evaluated_tokens": 940
+    },
+    {
+      "run": 5,
+      "wall_seconds": 10.01,
+      "cached_tokens": 768,
+      "cache_state": "warm",
+      "status": "PASS",
+      "route_call_wall_seconds": 8.08,
+      "route_call_evaluated_tokens": 172
+    }
+  ],
+  "published": {
+    "prefill_tokens_per_second": {
+      "value": 29.0,
+      "basis": "median of 3 run aggregates",
+      "runs": [
+        29.98,
+        26.55,
+        28.95
+      ]
+    },
+    "generation_tokens_per_second": {
+      "value": 8.3,
+      "basis": "median of 3 run aggregates",
+      "runs": [
+        8.3,
+        7.04,
+        8.27
+      ]
+    },
+    "tools_on_chat_seconds": {
+      "value_cold": 36.8,
+      "basis_cold": "median of 3 cold repetitions",
+      "runs_cold": [
+        32.53,
+        37.82,
+        36.84
+      ],
+      "value_warm": 8.4,
+      "basis_warm": "median of 2 warm (route prefix restored) repetitions",
+      "runs_warm": [
+        6.79,
+        10.01
+      ]
+    },
+    "tool_plus_final_seconds": {
+      "value": 49.0,
+      "basis": "median of 3 runs, all cold",
+      "runs": [
+        41.41,
+        49.01,
+        53.72
+      ]
+    },
+    "peak_rss_gib": {
+      "value": 35.8,
+      "basis": "server VmHWM, identical across all runs",
+      "bytes": 38422634496
+    },
+    "rounding": "median of measured values, rounded half-up to one decimal"
+  }
+}

--- a/docs/benchmarks/ornith-1.5-35b-a3b.md
+++ b/docs/benchmarks/ornith-1.5-35b-a3b.md
@@ -1,204 +1,175 @@
-# Ornith 1.5 35B-A3B — measurements on the reference system
+# Ornith 1.5 35B-A3B — Supported Models benchmark
 
-What has actually been measured for this profile, where each number came from,
-and — just as importantly — what has **not** been measured.
+Auditable source for the `Ornith 1.5 35B-A3B` row in the README
+[Supported Models](../../README.md#supported-models) table.
 
-Everything below is a measurement on one machine. It is not a claim about the
+Every number here is a measurement on one machine. It is not a claim about the
 model in general: results move with CPU, memory bandwidth, quantization,
-backend build, and workload.
+backend build, cache state, and workload.
 
-## Why this profile is measured separately
+Raw machine-readable results: [`ornith-1.5-35b-a3b.json`](ornith-1.5-35b-a3b.json).
 
-The other rows in the README table are warm steady-state medians from a
-controlled *chat* benchmark: one excluded warm-up, three measured repetitions, a
-fixed long-prefill fixture, at `ctx=8192` with 6 threads.
+## Reference system
 
-**No Ornith run has been made under that protocol.** Every measurement here
-comes from the *analysis* workflow at `ctx=16384` with 12 threads. Reporting
-those numbers inside the chat table would imply a comparability that does not
-exist, so the README gives this profile its own table with its own stated basis
-instead.
+| Property | Value |
+|---|---|
+| CPU | Intel Core i7-10710U (NUC10i7FNH), 6 cores / 12 threads |
+| RAM | 63 GiB |
+| GPU | none |
+| OS | Linux 7.0.0-30-generic x86_64 |
+| llama.cpp build | b9551 (`379ac66`) |
+| Orbit revision | `892cfad` |
 
-Within that basis the figures are sound. The prefill numbers below count only
-calls with **no cache reuse**, which makes them comparable to the README's
-"evaluated tokens only, excludes cache benefit" definition; the reuse-affected
-numbers are excluded and explained under
-[Prefill on reuse calls](#prefill-on-reuse-calls-not-comparable).
-
-## Model specification
-
-Properties of the model file, not of Orbit.
+## Model
 
 | Property | Value |
 |---|---|
 | Repository | [ornith-ai/Ornith-1.5-35B-A3B-GGUF](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF) |
-| File | `Ornith-1.5-35B-Q4_K_M.gguf` |
-| Quantization | Q4_K_M (4.89 BPW) |
-| File size | 20.21 GiB |
-| Parameters | 35.51 B (35B-A3B) |
-| Architecture | `qwen35moe`, 256 experts, 8 active |
-| Training context | 262144 |
+| File | `Ornith-1.5-35B-Q4_K_M.gguf`, 21,713,462,848 bytes (20.22 GiB) |
+| SHA-256 | `ca6ea26329c88b78ffd90a85163be2e746c2fafd1024f56db47e499f117f9a7f` |
+| Quantization | Q4_K_M |
+| Profile | `orbit-ornith15-native-v1`, architecture `qwen35moe` |
 
-Source: `print_info` lines 54–136 of the run log listed under
-[Evidence sources](#evidence-sources).
-
-## Reference hardware
-
-| Property | Value |
-|---|---|
-| CPU | Intel Core i7-10710U (NUC10), 6 cores / 12 threads |
-| RAM | 64 GB |
-| GPU | none (`gpu_layers = 0`) |
-| OS | Linux x86_64 |
-| llama.cpp build | b9551 |
-
-## Orbit configuration used for these measurements
-
-| Setting | Value |
-|---|---|
-| Context | 16384 |
-| Batch / ubatch | 256 / 128 |
-| Threads | 12 (generation and batch) |
-| Flash Attention | `auto` |
-| Thinking | off |
+## Configuration
 
 ```bash
-orbit server --ctx 16384 --batch 256 --ubatch 128
+orbit server --ctx 8192 --threads 6 --threads-batch 6 --batch 256 --ubatch 128 --think off
 ```
 
-Note this differs from the README table's benchmark configuration
-(`ctx=8192`, 6 threads), which is one reason the numbers are not interchangeable.
+`ctx=8192`, 6 generation and batch threads, batch/ubatch 256/128, one parallel
+slot, temperature 0, thinking off, MTP off.
+
+## Protocol
+
+Harness: `scripts/orbit_qualify.py` against a separately managed server, over
+the five qualification fixtures used for this table:
+
+| Workload | Fixture |
+|---|---|
+| tools-on chat | `chat_route_first` (`optimizations-v1`) |
+| pwd route | `pwd_route` (`core-v1`) |
+| tool + final | `pwd_final` (`core-v1`) |
+| artifact + verify | `json_artifact` (`core-v1`) |
+| existing-file modification | `existing_file_modification` (`workflows-v1`) |
+
+One excluded warm-up, then three measured repetitions. All 15 fixture
+executions passed, with identity, lifecycle and protocol gates clean.
+
+Column definitions, taken from the harness rather than the column names:
+
+- **Prefill** — `sum(evaluated) / sum(per-call evaluated seconds)` across every
+  call of every fixture, from the server's `timings.prompt_per_second`.
+  Evaluated tokens only, so cached tokens do not inflate it.
+- **Generation** — the same weighting on output tokens, from
+  `timings.predicted_per_second`.
+- **Tools-on chat** — wall time of the tools-on fixture that routes to CHAT and
+  executes no tool.
+- **Tool + final** — wall time of the fixture that calls one tool and then
+  produces a final answer.
+- **Peak RAM** — Linux `VmHWM` of the server process, whole lifetime including
+  model load.
 
 ## Measured values
 
-### Prefill, cold calls only — the published range
+### Aggregate rates, per repetition
 
-Calls that evaluated their prompt with **zero** reused tokens, so no restore work
-sits inside the timing window. These are the samples behind the README's
-`21–33 tok/s (n=5, median 31.8)`:
-
-| Source | Evaluated tokens | Prefill |
-|---|---:|---:|
-| `/report` measurement | 5526 | 32.9 tok/s |
-| autonomous run A, call 1 | 604 | 31.8 tok/s |
-| autonomous run A, final call | 9613 | 21.0 tok/s |
-| autonomous run B, call 1 | 604 | 31.9 tok/s |
-| autonomous run B, final call | 8419 | 23.2 tok/s |
-
-n = 5, min 21.0, max 32.9, median 31.8. The two lower values are the largest
-prompts, which is the expected shape rather than noise.
-
-### Generation — the published range
-
-Derived as output tokens ÷ (wall clock − prefill) over every call with at least
-20 output tokens: **n = 22, median 5.9 tok/s**, spanning 1.8–9.9 with a single
-low outlier at 1.8; excluding it, 4.8–9.9. The README states `~5–10 tok/s`.
-
-This is a **looser bound than a dedicated decode benchmark**: the denominator
-includes any non-decode overhead in the call. The one directly measured decode
-figure, 8.1 tok/s from the `/report` call below, falls inside the derived range,
-which is the cross-check that makes the range publishable.
-
-### Single `/report` call
-
-One model call, measured end to end. **n = 1** — recorded here because it is
-real and directly measured, not because one sample is a benchmark.
-
-| Metric | Value |
-|---|---|
-| Prompt tokens | 5526 evaluated, 0 cached |
-| Output tokens | 886 |
-| Prefill | 32.9 tok/s |
-| Decode | 8.1 tok/s |
-| Wall clock | 277.1 s (168.1 s to first token) |
-
-Measured 2026-08-24 against served commit `98049a9`.
-
-### Prefix cache reuse
-
-The clearest result on this profile. Across one 13-call autonomous analysis run,
-per-call KV reuse rises as the run accumulates context (selected calls; the
-totals below are over all 13):
-
-| Call | Reused | Evaluated | Reuse |
+| Run | Model calls | Prefill | Generation |
 |---:|---:|---:|---:|
-| 1 | 0 | 604 | 0.0% |
-| 2 | 604 | 2,337 | 20.5% |
-| 3 | 2,941 | 2,957 | 49.9% |
-| 4 | 5,898 | 1,285 | 82.1% |
-| 6 | 8,616 | 824 | 91.3% |
-| 10 | 12,227 | 443 | 96.5% |
-| 12 | 14,736 | 594 | 96.1% |
-| 13 | 0 | 9,613 | 0.0% |
+| 1 | 14 | 29.98 tok/s | 8.30 tok/s |
+| 2 | 15 | 26.55 tok/s | 7.04 tok/s |
+| 3 | 15 | 28.95 tok/s | 8.27 tok/s |
 
-Run totals: **95,799 reused / 24,943 evaluated = 79.3% overall**, with per-call
-reuse peaking near 96%. Call 13 opens a fresh report context and so starts cold
-again — the reset is expected, not a regression. Token accounting was exact on
-every call.
+Published: **~29.0 tok/s** prefill, **~8.3 tok/s** generation.
 
-Read the aggregate carefully: 79.3% is the whole run including its cold start;
-~96% is the *steady-state peak*, not an average.
+Every published figure is the median of its measured values, rounded
+half-up to one decimal: prefill 28.95 → 29.0, generation 8.27 → 8.3.
 
-### ANALYSIS prefix prewarm
+### Per-workload wall time
 
-Descriptive timings, **n = 1** each, for the opt-in
-`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1` startup capture:
+| Workload | Run 1 | Run 2 | Run 3 | Median |
+|---|---:|---:|---:|---:|
+| tools-on chat | 6.79 s | 32.53 s | 37.82 s | see below |
+| pwd route | 5.42 s | 7.14 s | 8.19 s | 7.14 s |
+| tool + final | 41.41 s | 49.01 s | 53.72 s | **49.01 s** |
+| artifact + verify | 161.05 s | 189.80 s | 171.90 s | 171.90 s |
+| existing-file modification | 272.53 s | 328.84 s | 321.57 s | 321.57 s |
 
-- capture cost: 11.0 s of startup prefill, 73,736,684 bytes resident
-- with it on, a first analysis step restored 384 of 588 prompt tokens and its
-  prefill fell from 18.2 s to 6.0 s
+Published: **~49.0 s** for tool + final.
 
-Reuse itself is on by default and free — the first analysis step captures the
-checkpoint on its way past. The environment variable only decides whether that
-capture is paid eagerly at startup instead.
+### Tools-on chat depends on route-prefix cache state
+
+This workload is bimodal, so it was repeated five times and the two states are
+reported separately rather than averaged together:
+
+| Run | Fixture wall | Route call | Cached tokens | State |
+|---:|---:|---:|---:|---|
+| 1 | 6.79 s | 5.56 s | 768 | warm |
+| 2 | 32.53 s | 31.03 s | 0 | cold |
+| 3 | 37.82 s | 35.81 s | 0 | cold |
+| 4 | 36.84 s | 35.05 s | 0 | cold |
+| 5 | 10.01 s | 8.08 s | 768 | warm |
+
+The workload is identical in every run — 940 input tokens, same output. Only
+the route-prefix checkpoint differs: restoring 768 tokens cuts the route call
+from a median of 35.05 s (cold, n=3) to 6.82 s (warm, n=2).
+
+Published: **~36.8 s cold** (median, n=3) **/ ~8.4 s warm** (median, n=2). Both
+states are given because a single number here says more about the cache than
+about the model.
+
+### Peak RAM
+
+`VmHWM` was **38,422,634,496 bytes = 35.78 GiB**, identical across all runs.
+Published: **~35.8 GiB**.
+
+## Comparability with the other rows
+
+The Ornith row was measured with the qualification harness in this repository,
+which is the only benchmark protocol the repository actually contains.
+
+The other three rows were published in `ba5c580` and **could not be reproduced
+from any data in this repository**. Their values do not appear in any surviving
+harness output, log, or result file — only in README revisions. They also differ
+substantially from the earlier `ff74ee3` values, most sharply on tools-on chat
+(Gemma 31.7 s → 3.0 s, Qwen 3.6 25.1 s → 6.1 s), while their Peak RAM figures
+are byte-identical across both tables — consistent with having been carried over
+rather than re-measured. The `ff74ee3` set is itself only partly traceable: 12 of
+its 15 cells match a recovered baseline document, but Qwen 3.6's tools-on chat
+(25.1 s vs 44.63 s) and tool + final (30.5 s vs 43.16 s) do not.
+
+The measurements above show why that column moves so much: it is dominated by
+route-prefix cache state, not by model speed. Combining the two sets silently
+would misrepresent both, so the README footnote marks rows 1–3 as unverified
+against the current harness.
+
+## Reproducing
+
+```bash
+orbit server --ctx 8192 --threads 6 --threads-batch 6 --batch 256 --ubatch 128 --think off &
+SRV=$!   # server PID, required for VmHWM
+
+python3 scripts/orbit_qualify.py --base-url http://127.0.0.1:12120 \
+  --profile orbit-ornith15-native-v1 --server-pid $SRV \
+  --fixtures qualification/fixtures/optimizations-v1.json --fixture chat_route_first \
+  --output run-chat.json
+python3 scripts/orbit_qualify.py --base-url http://127.0.0.1:12120 \
+  --profile orbit-ornith15-native-v1 --server-pid $SRV \
+  --fixtures qualification/fixtures/core-v1.json \
+  --fixture pwd_route --fixture pwd_final --fixture json_artifact \
+  --output run-core.json
+python3 scripts/orbit_qualify.py --base-url http://127.0.0.1:12120 \
+  --profile orbit-ornith15-native-v1 --server-pid $SRV \
+  --fixtures qualification/fixtures/workflows-v1.json \
+  --fixture existing_file_modification --output run-mod.json
+```
+
+Discard the first pass as a warm-up and repeat three times.
 
 ## Not measured
 
-Stated explicitly so nobody infers a number that does not exist:
-
-- **Peak RAM / RSS.** No resident-memory measurement exists for this profile.
-  The 20.21 GiB file size and the mapped model buffer are not RSS, and the
-  other 35B-A3B profile's figure must not be carried over.
-- **Warm steady-state chat throughput**, tools-on chat latency, and tool+final
-  latency — the chat-protocol columns. No data of any kind; the throughput
-  figures above are the analysis workload, not that protocol.
-- **Flash Attention resolved value.** The log records `auto`, never what it
-  resolved to.
-- **MTP state.** Absent from the evidence; absent is not the same as off.
-
-### Prefill on reuse calls, not comparable
-
-Per-call `prefill_ms` on calls that **did** reuse cache is not usable as a
-prefill-throughput figure. The timer starts before the prefix reuse and restore
-work, while the token count excludes reused tokens, so restore overhead lands in
-the denominator but not the numerator. That systematically depresses the rate:
-across the two runs, the reuse-affected calls median 14.4 tok/s (n=11) and
-17.5 tok/s (n=7), against 21–33 tok/s on cold calls — a spread that reflects
-the metric's definition, not the hardware.
-
-This is why the published range is drawn from zero-reuse calls only.
-
-## Evidence sources
-
-All paths relative to the qualification checkpoint archive, which is kept
-outside the repository.
-
-| What | Source |
-|---|---|
-| `/report` call | `report-performance-baseline-20260824-022942/artifacts/measurement.json` |
-| Served commit | `report-performance-baseline-20260824-022942/artifacts/served_commit.txt` |
-| Cache reuse, per call | `analysis-autonomous-final-20260824-202440/evidence/fullrun-qualification.json` |
-| Model spec, runtime config | `analysis-autonomous-progress-20260824-190424/evidence/fullrun.ABORTED-infra-kill.log` |
-| Prewarm timings | `AGENTS.md` |
-| Qualification status | `docs/releases/v0.0.1-rc34.md`, `docs/releases/v0.0.1-rc35.md` |
-
-Two log files in the archive — `fullrun-budget.log` and
-`fullrun-qualification.log` — are byte-identical. They are one run, and counting
-them twice would double the sample.
-
-## Reproducing a publishable row
-
-To fill the README row properly, run the protocol the other rows use — one
-excluded warm-up and three measured repetitions against the fixed long-prefill
-fixture, at `ctx=8192` with 6 threads — and capture peak RSS alongside it. See
-`docs/QWEN3_CODER_QUALIFICATION.md` for the procedure.
+- **Warm-only steady state.** Runs are a mix of cold and warm cache; only the
+  tools-on chat workload was repeated enough to separate the two.
+- **Flash Attention resolved value.** The configuration records `auto`, never
+  what it resolved to.
+- **`--low-memory`.** Not supported for this profile.
+- **TTFT.** The harness reports it as unavailable.

--- a/qualification/fixtures/core-v1.json
+++ b/qualification/fixtures/core-v1.json
@@ -7,7 +7,8 @@
       "profiles": [
         "orbit-gemma4-native-v1",
         "orbit-qwen36-native-v1",
-        "orbit-qwen3-coder-native-v1"
+        "orbit-qwen3-coder-native-v1",
+        "orbit-ornith15-native-v1"
       ],
       "request": {
         "prompt": "Reply with exactly ORBIT_QUALIFICATION_CHAT_OK and nothing else.",
@@ -26,7 +27,8 @@
       "profiles": [
         "orbit-gemma4-native-v1",
         "orbit-qwen36-native-v1",
-        "orbit-qwen3-coder-native-v1"
+        "orbit-qwen3-coder-native-v1",
+        "orbit-ornith15-native-v1"
       ],
       "request": {
         "prompt": "Determine the absolute current working directory using a local capability.",
@@ -48,7 +50,8 @@
       "profiles": [
         "orbit-gemma4-native-v1",
         "orbit-qwen36-native-v1",
-        "orbit-qwen3-coder-native-v1"
+        "orbit-qwen3-coder-native-v1",
+        "orbit-ornith15-native-v1"
       ],
       "request": {
         "prompt": "Run exactly the local shell command `pwd`, then answer with only its output.",
@@ -70,7 +73,8 @@
       "profiles": [
         "orbit-gemma4-native-v1",
         "orbit-qwen36-native-v1",
-        "orbit-qwen3-coder-native-v1"
+        "orbit-qwen3-coder-native-v1",
+        "orbit-ornith15-native-v1"
       ],
       "request": {
         "prompt": "Create qualification.json with this valid JSON integer, then verify the artifact:\n\n3141592653589793238462643383279502884197169399375105820974944592",

--- a/qualification/fixtures/optimizations-v1.json
+++ b/qualification/fixtures/optimizations-v1.json
@@ -4,7 +4,7 @@
     {
       "name": "chat_route_first",
       "capability": "tools",
-      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "request": {"prompt": "Say hello in one word.", "tools": true, "full_request": true},
       "expect": {"route": "CHAT", "finish_reason": "stop", "max_model_calls": 2},
       "parity": {"mode": "structural"}
@@ -12,7 +12,7 @@
     {
       "name": "pwd_route",
       "capability": "tools",
-      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "request": {"prompt": "Determine the absolute current working directory using a local capability.", "tools": true},
       "expect": {
         "route": "FILESYSTEM",
@@ -25,7 +25,7 @@
     {
       "name": "pwd_final",
       "capability": "tools",
-      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "request": {"prompt": "Run exactly the local shell command `pwd`, then answer with only its output.", "tools": true},
       "expect": {
         "tool_calls": [{"name": "exec_shell_full_command", "arguments": {"command": "pwd"}}],
@@ -38,7 +38,7 @@
     {
       "name": "chat_route_second",
       "capability": "tools",
-      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "request": {"prompt": "Who designed you? Answer briefly.", "tools": true, "full_request": true},
       "expect": {"route": "CHAT", "finish_reason": "stop", "max_model_calls": 2},
       "parity": {"mode": "structural"}

--- a/qualification/fixtures/workflows-v1.json
+++ b/qualification/fixtures/workflows-v1.json
@@ -4,7 +4,7 @@
     {
       "name": "bug_fix_and_test",
       "capability": "tools",
-      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "workspace": {
         "files": [
           {"path": "calculator.py", "content": "def add(left, right):\n    return left - right\n"},
@@ -37,7 +37,7 @@
     {
       "name": "existing_file_modification",
       "capability": "tools",
-      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "workspace": {
         "files": [
           {"path": "settings.ini", "content": "[service]\nmode=development\nretries=2\n"},
@@ -65,7 +65,7 @@
     {
       "name": "failed_command_recovery",
       "capability": "tools",
-      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1"],
+      "profiles": ["orbit-gemma4-native-v1", "orbit-qwen36-native-v1", "orbit-qwen3-coder-native-v1", "orbit-ornith15-native-v1"],
       "workspace": {
         "files": [
           {"path": "fallback.txt", "content": "RECOVERY_OK\n"},


### PR DESCRIPTION
Completes the `Ornith 1.5 35B-A3B` row in the README Supported Models table from real measurements, and restructures the section for a first-time reader.

## Published row

| Model | Prefill | Generation | Tools-on chat | Tool + final | Peak RAM |
|---|---:|---:|---:|---:|---:|
| Ornith 1.5 35B-A3B | ~29.0 tok/s | ~8.3 tok/s | ~36.8 s cold / ~8.4 s warm | ~49.0 s | ~35.8 GiB |

Measured with `scripts/orbit_qualify.py` at the configuration the table footnote states (`ctx=8192`, 6 threads, batch/ubatch 256/128, thinking off), on the reference NUC10 i7-10710U. One excluded warm-up, three measured repetitions over the same five fixtures the original table used. **All 15 fixture executions passed**, identity/lifecycle/protocol gates clean.

Column definitions were recovered from the harness rather than the column names: prefill/generation are token-weighted aggregates (`sum(tokens)/sum(tokens/rate)`, `schema.py:311-323`), Peak RAM is the server process `VmHWM`.

## Tools-on chat is reported in both cache states

The workload is bimodal. Same 940-token request, same output; only the route-prefix checkpoint differs:

| State | Route call | n |
|---|---:|---:|
| cold | median 35.05 s | 3 |
| warm (768 tokens restored) | median 6.82 s | 2 |

A single number in that column describes the cache, not the model, so both are given.

## The other three rows

Their values **could not be reproduced from any data kept in this repository** — they appear only in README revisions, with no surviving harness output. They also differ sharply from the earlier `ff74ee3` values (Gemma tools-on chat 31.7 s → 3.0 s; Qwen 3.6 25.1 s → 6.1 s), while their Peak RAM figures are byte-identical across both tables, consistent with carry-over rather than re-measurement.

The measurements here explain why that column moves so much. **Their numbers are left unchanged**; the footnote marks them indicative until re-measured. Re-measuring them was explicitly out of scope.

## Layout

- `## Supported Models` now precedes `## Requirements`
- the separate Ornith metric table is removed — one table carries every model
- no `—` left in the Ornith row; 1123 → 1057 words (−5.9%)

## Evidence

- `docs/benchmarks/ornith-1.5-35b-a3b.md` — hardware, model SHA-256, config, protocol, per-run raw values, reproduction commands, and what was not measured
- `docs/benchmarks/ornith-1.5-35b-a3b.json` — machine-readable raw results

## Verification

- full suite **3136 passed, 1 skip, exit 0**
- `git diff --stat -- src/` empty — **no production code touched**
- qualification fixtures gain only the Ornith profile id, no other field
- all four Hugging Face links return 200

## Independent review

An independent reviewer recomputed all five published values from the raw JSON with its own implementation of the weighting function: **all five match**. Verdict **MERGE SAFE: YES**, 0 BLOCKER / 0 MAJOR.

A first review raised three MINORs, all fixed; an exact remote review then found a real **BLOCKER** — prefill was published as ~29.0 tok/s while the median of the committed runs (29.98, 26.55, 28.95) is 28.95, which rounds half-up to **29.0**. Corrected in all three files, and the route-call timings behind the 35.05 s / 6.82 s figures are now committed to the JSON so every number in the record is derivable. The earlier MINORs were: two best-case figures in the evidence doc replaced with medians, the partial traceability of the `ff74ee3` set stated explicitly, and JSON indentation corrected. The reviewer's suggestion to show both cache states in the table cell itself was adopted.


A re-review of the corrected commit returned **MERGE SAFE: YES** (0 BLOCKER / 0 MAJOR) with one MINOR: the first correction truncated 28.95 to 28.9 while generation and peak RAM were rounded half-up, so the rule was inconsistent. All figures now follow one stated convention — median, rounded half-up to one decimal — written into both evidence files.
