### PR TITLE
docs(release): prepare v0.0.1-rc37

### DIFF
--- a/docs/releases/v0.0.1-rc37.md
+++ b/docs/releases/v0.0.1-rc37.md
@@ -1,0 +1,92 @@
+# v0.0.1-rc37
+
+A substantial UX and stability release over rc36. Most of the work is in what
+the terminal shows during an analysis, in how the native libraries are isolated,
+and in documentation; the analysis runtime itself is largely unchanged.
+
+Qualified production code: `6dfa37453bafb4e18380dcdd4f55df3ad82c7c4f`
+
+## Highlights
+
+- **Autonomous ANALYSIS can be switched from inside a session.** `/autonomous`
+  shows the current state, `/autonomous on` and `/autonomous off` change it
+  without restarting Orbit. The setting belongs to the running process: it
+  survives `/chat` ↔ `/analysis` transitions and is not persisted globally, so
+  a new `orbit` starts guided again. `/help` lists it with the other commands.
+- **Intermediate ANALYSIS output is readable.** Each step's action, evidence
+  preview and artifacts are rendered as they happen instead of arriving as one
+  block at the end, so an autonomous run can be followed while it runs.
+- **The progress line is separated and keeps its elapsed time.** The completed
+  `analysis · generating · … · 1m 54s` line now stands on its own row, with a
+  blank line above and below, and the duration is preserved rather than erased
+  when the line finishes.
+- **The final report is separated from Orbit's own telemetry.** The grounded
+  report and the run summary no longer share a line, so the model's conclusion
+  is not mixed with call counts and timings.
+- **Stronger terminal sanitization.** Tool labels are sanitized before display,
+  and a final report that arrives without streaming is sanitized on that path
+  too — previously it was safe only when the backend happened to stream it.
+- **Native library isolation.** When an artifact and the libraries it links
+  against share the vendored tree, the RUNPATH is written `$ORIGIN`-relative, so
+  copying that tree keeps it valid instead of pinning it to the build machine's
+  paths. An out-of-tree build still gets an absolute entry, deliberately: it
+  names one specific runtime rather than implying the two travel together. The
+  mtmd multimodal path and the MTP probe are both held to the runtime family
+  they claim, so a mismatched runtime is refused instead of being loaded. This
+  is an isolation and refusal improvement; it is not a claim that every native
+  crash mode is resolved.
+- **More reliable test isolation.** Analysis temporary resources are owned and
+  released per test, which removes a shared-temp flake in the suite.
+- **Refreshed first-run documentation.** The README leads with the models it
+  supports, then requirements, then a numbered first run. The introduction no
+  longer enumerates model names, and `/autonomous` is documented as the normal
+  way to switch, with `ORBIT_ANALYSIS_AUTONOMOUS=1` mentioned only as optional
+  startup configuration.
+- **Ornith 1.5 35B-A3B has a complete Supported Models row.** Measured with the
+  qualification harness in this repository at `ctx=8192`, 6 threads,
+  batch/ubatch 256/128 on the reference CPU-only system: prefill ~29.0 tok/s,
+  generation ~8.3 tok/s, tools-on chat ~36.8 s cold / ~8.4 s warm, tool + final
+  ~49.0 s, peak RAM ~35.8 GiB. Methodology, raw per-run values and reproduction
+  steps are in [the benchmark record](../benchmarks/ornith-1.5-35b-a3b.md).
+
+## Known limitations
+
+- **Autonomous ANALYSIS remains opt-in and off by default.** It is opt-in for
+  cost rather than correctness: a step that measures something new counts as
+  progress whether or not the measurement was worth making, so a simple
+  artifact can still attract many actions and consume the full action budget.
+- **Performance figures are measurements on one CPU-only system**, not
+  universal model performance. They move with hardware, configuration, cache
+  state and workload — tools-on chat in particular is dominated by
+  route-prefix cache state rather than model speed, which is why it is quoted
+  in both cold and warm states.
+- **Only the Ornith row is auditable under the current harness.** The Gemma,
+  Qwen 3.6 and Qwen3-Coder rows predate it and could not be reproduced from
+  data kept in this repository; they are marked indicative in the README until
+  they are re-measured.
+- **The final ANALYSIS telemetry line mixes two scopes.** `model calls`,
+  `actions` and elapsed time are run-wide, while `in`, `eval` and `cache`
+  describe the last analysis step only. It is not a measure of cache reuse
+  across the whole run.
+- ANALYSIS rolling KV reuse was verified live on this baseline and is healthy.
+- Eager ANALYSIS prewarm is opt-in
+  (`ORBIT_ORNITH_ANALYSIS_PREFIX_PREWARM=1`).
+- Exact-prefix reuse is per profile; a profile without support for a given
+  lineage falls back to ordinary cold behaviour rather than failing.
+- Linux x86_64 CPU-only is the qualified platform. There is no GPU path.
+
+## Verification
+
+Full suite: 3136 tests, exit code 0, 1 skip, on a tree with the native runtime
+already built. The skip is `test_upstream_template_hash_resolves_contract`
+(`model not present`), a pre-existing environment skip that needs a GGUF absent
+from a clean checkout.
+
+The vendored native libraries are gitignored, so a bare clone that has not run
+`scripts/build_native.py` yields a different result: twelve native tests skip
+for a missing runtime, and `test_process_rejects_a_second_runtime_family` errors
+on the absent library rather than skipping, because it lacks the guard its
+sibling native tests have. That is a test-harness gap, not a product defect.
+
+`compileall` and `git diff --check` are clean. No production code changed in
+release preparation.


### PR DESCRIPTION
Release notes for `v0.0.1-rc37`. **Notes only — no production code, no version-file change.**

## Scope

12 commits since rc36 (`6b16e1a`): interactive `/autonomous` control, intermediate ANALYSIS output rendering, progress-line separation with elapsed time preserved, final report separated from Orbit telemetry, tool-label and non-streaming final-report sanitization, native `$ORIGIN` RUNPATH isolation, mtmd family guard, MTP probe family isolation, analysis temp-resource test isolation, README refresh, and the completed Ornith 1.5 35B-A3B Supported Models row.

The source version stays `0.0.1` and the RC number lives in the tag, matching rc32–rc36. `pyproject.toml` is untouched.

## Deliberately excluded

Evidence supersession shipped in **rc36** (`0753dc7`, already an ancestor of the rc36 tag), so it is **not** claimed here.

## Known limitations stated, not hidden

- autonomous ANALYSIS stays opt-in and can consume the full action budget on a simple artifact
- performance figures are measurements on one CPU-only system
- only the Ornith row is auditable under the current harness; the other three are marked indicative
- the final ANALYSIS telemetry line mixes run-wide counters with last-step `in`/`eval`/`cache`
- native isolation is described precisely — no claim that every native crash mode is resolved

## Verification

- focused groups (terminal, UX, sanitization, tool events, progress line, ANALYSIS guided/autonomous, routing, rolling KV, prewarm, prefix anchors, evidence authority, native family guard, MTP bridge, RUNPATH, temp cleanup, qualification): **all exit 0**
- full suite: **3136 tests, exit code 0, 1 skip**
- the skip is `test_upstream_template_hash_resolves_contract` (`model not present`) — pre-existing, needs a GGUF absent from a clean checkout, introduced before rc36
- `compileall` exit 0; `git diff --check` clean
- `git diff --stat 6dfa374 -- src/` empty

## Independent review

**MERGE SAFE: YES**, 0 BLOCKER / 0 MAJOR. The reviewer recomputed all five published Ornith metrics from the committed raw arrays (every one reproduces under the stated median/half-up convention), ran the suite independently (3136, exit 0, 1 skip), and confirmed the skip is environment-caused rather than a masked failure. One MINOR — a malformed short SHA in the `Qualified production code` line — was fixed before commit; the line now carries the bare full SHA, matching rc34–rc36 house style.

Tag target after merge will be the resulting `main` SHA.
