### PR TITLE
feat(runtime): add analysis completion shadow gate

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -55,6 +55,15 @@ from orbit.runtime.analysis_sandbox import (
     scratch_baseline,
 )
 from orbit.runtime.evidence import EvidenceRecord, EvidenceStore, final_card
+from orbit.runtime.completion_shadow import (
+    ANALYSIS_COMPLETION_SHADOW_PHASE,
+    VERIFIER_MAX_TOKENS,
+    ShadowLedger,
+    build_snapshot,
+    evaluate_completion_shadow,
+    scheduled_actions,
+    shadow_enabled,
+)
 from orbit.runtime.evidence_authority import active_records, evaluate_standing
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
@@ -511,6 +520,10 @@ class AutonomousRunResult:
     cancelled: bool = False
     replans: int = 0
     final_report: "AnalysisReport | None" = None
+    # Diagnostics only. Nothing in the loop reads this back, and its verifier
+    # calls are deliberately absent from `model_calls`: a shadow observation
+    # must not consume the budget that bounds the investigation.
+    completion_shadow: ShadowLedger | None = None
 
     @property
     def last_step(self) -> AnalysisStepResult | None:
@@ -1007,6 +1020,8 @@ class AnalysisRuntime:
         stop_reason = STOP_MAX_MODEL_CALLS
         cancelled = False
         final_report: "AnalysisReport | None" = None
+        shadow = ShadowLedger() if shadow_enabled() else None
+        shadow_due = scheduled_actions()
 
         while True:
             if model_calls >= max_model_calls:
@@ -1052,6 +1067,15 @@ class AnalysisRuntime:
             records.append(record)
             if on_step is not None:
                 on_step(step, record)
+
+            # Observational only, and placed here deliberately: after the step
+            # is committed and before any stop decision, so the shadow sees
+            # exactly the state a real gate would have seen -- while every
+            # `break` below remains reachable regardless of what it says.
+            if shadow is not None and shadow_due(actions):
+                shadow.observations.append(
+                    self._observe_completion_shadow(actions, analyst_message)
+                )
 
             if record.classification == COMPLETE:
                 stop_reason = STOP_COMPLETE
@@ -1178,7 +1202,69 @@ class AnalysisRuntime:
             cancelled=cancelled,
             replans=replans,
             final_report=final_report,
+            completion_shadow=shadow,
         )
+
+    def _observe_completion_shadow(self, actions: int, request: str):
+        """One shadow checkpoint. Never raises, never affects the run.
+
+        The verifier call is issued tools-free under its own phase. Both
+        matter: the phase means the backend is asked for no rolling anchor, so
+        the analysis checkpoint is neither replaced nor consulted, and
+        `tools=[]` with thinking off keeps the prompt-cache transition a
+        qualified one, which is what preserves that checkpoint across the
+        detour. Diverging on either would drop the next step to a cold prefill.
+
+        One cost is real and bounded: the reset does drop the ANALYSIS *prewarm*
+        prefix, which is invalidated unconditionally rather than under the
+        preserve flag. It buys nothing back here, because the rolling
+        checkpoint holds this session's own tokens and is never shorter, so the
+        prewarm stands down whenever rolling can serve the prompt. It would
+        matter only to a cold step, and the earliest checkpoint fires after the
+        analysis is already warm.
+        """
+        from orbit.runtime.completion_shadow import ShadowObservation
+
+        try:
+            records = active_records(list(self.evidence_store.records.values()))
+            active_ids = {
+                str(getattr(record, "evidence_id", "") or "") for record in records
+            }
+            snapshot = build_snapshot(
+                request=request,
+                records=records,
+                load_raw=self.evidence_store.load_raw,
+            )
+
+            def ask(instruction: str, rendered: str):
+                messages = [
+                    {"role": "system", "content": instruction},
+                    {"role": "user", "content": rendered},
+                ]
+                with model_call_context(
+                    phase=ANALYSIS_COMPLETION_SHADOW_PHASE, tools_mode="off"
+                ):
+                    return self.backend.chat(
+                        messages,
+                        temperature=0,
+                        max_tokens=VERIFIER_MAX_TOKENS,
+                        tools=[],
+                    )
+
+            return evaluate_completion_shadow(
+                action=actions,
+                snapshot=snapshot,
+                ask=ask,
+                active_evidence_ids=active_ids,
+                reattest=self.evidence_store.reattest_exact,
+            )
+        except BaseException as exc:  # noqa: BLE001 - diagnostics must not end a run
+            return ShadowObservation(
+                action=actions,
+                snapshot_digest="",
+                would_stop=False,
+                blocked_by=f"shadow_error: {type(exc).__name__}",
+            )
 
     @staticmethod
     def _final_question(stop_reason: str) -> str:

--- a/src/orbit/runtime/completion_shadow.py
+++ b/src/orbit/runtime/completion_shadow.py
@@ -1,0 +1,372 @@
+"""Observational completion verification for autonomous ANALYSIS.
+
+Shadow mode only. Nothing here may stop, shorten, or otherwise steer a run:
+the loop asks this module what it *would* do and then ignores the answer. That
+is the whole contract, and it is why the module owns no state the loop reads
+back and returns a value the loop only records.
+
+The mechanism is two asymmetric tool-free checks over one content-addressed
+snapshot of the ACTIVE evidence. Verifier A asks whether the request is already
+satisfied; only if A says COMPLETE does verifier B, which never sees A's
+verdict, look for a reason stopping would be premature. `WOULD_STOP` requires
+both to agree, both to parse strictly, and every referenced evidence id to
+still exist, be ACTIVE, and re-attest.
+
+Every ambiguity resolves to "continue". A malformed verdict, a stale reference,
+a snapshot mismatch, or any exception is not a weak yes -- it is a no.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Sequence
+
+# Distinct from `analysis_step` and `analysis_report` for the same reason those
+# two are distinct from each other: the backend keys its rolling checkpoints by
+# the phase the caller declares. A verifier that borrowed the step phase would
+# ask for the analysis anchor and could replace it; declaring its own phase
+# means it requests no anchor at all and the analysis lineage is untouched.
+ANALYSIS_COMPLETION_SHADOW_PHASE = "analysis_completion_shadow"
+
+SHADOW_ENV = "ORBIT_ANALYSIS_COMPLETION_SHADOW"
+
+# Bounded so a verifier prompt cannot grow with the session. The snapshot is a
+# projection for a yes/no question, not a report context: it carries what was
+# asked and what is currently established, and nothing about how the analysis
+# got there.
+MAX_SNAPSHOT_RECORDS = 12
+MAX_SNAPSHOT_CHARS_PER_RECORD = 600
+MAX_SNAPSHOT_ARTIFACTS = 16
+
+# Short by construction. Both verifiers answer in one or two lines, and a long
+# generation here is a cost paid against a run that is not going to stop.
+VERIFIER_MAX_TOKENS = 64
+
+_EVIDENCE_ID_RE = re.compile(r"\bev_[0-9a-f]{12}_[0-9a-f]{16}\b")
+
+
+def shadow_enabled(env: dict[str, str] | None = None) -> bool:
+    """Whether shadow verification runs at all. Off unless explicitly enabled."""
+    source = os.environ if env is None else env
+    return source.get(SHADOW_ENV, "").strip() == "1"
+
+
+def scheduled_actions(schedule: str = "after4every2") -> Callable[[int], bool]:
+    """Deterministic checkpoint schedules. No adaptive behaviour by design."""
+    table = {
+        "after3every2": (3, 2),
+        "after4every2": (4, 2),
+        "after4every3": (4, 3),
+    }
+    if schedule not in table:
+        raise ValueError(f"unknown shadow schedule: {schedule}")
+    start, stride = table[schedule]
+
+    def due(actions: int) -> bool:
+        return actions >= start and (actions - start) % stride == 0
+
+    return due
+
+
+@dataclass(frozen=True)
+class CompletionSnapshot:
+    """What both verifiers see, and the hash that proves they saw the same thing."""
+
+    request: str
+    evidence: tuple[tuple[str, str], ...]
+    artifacts: tuple[str, ...]
+    digest: str
+
+    def render(self) -> str:
+        lines = [f"REQUEST: {self.request}", "", "ESTABLISHED EVIDENCE:"]
+        for evidence_id, text in self.evidence:
+            lines.append(f"[{evidence_id}] {text}")
+        if self.artifacts:
+            lines.extend(("", "ARTIFACTS:"))
+            lines.extend(f"- {handle}" for handle in self.artifacts)
+        return "\n".join(lines)
+
+
+def build_snapshot(
+    *,
+    request: str,
+    records: Sequence[Any],
+    load_raw: Callable[[str], str | None],
+) -> CompletionSnapshot:
+    """The smallest bounded projection of ACTIVE evidence sufficient to judge.
+
+    `records` must already be the ACTIVE view: this does not decide standing,
+    it reads it. Feeding superseded records here would let a corrected value
+    and the value it replaced argue with each other inside one prompt.
+    """
+    evidence: list[tuple[str, str]] = []
+    artifacts: list[str] = []
+    for record in records[-MAX_SNAPSHOT_RECORDS:]:
+        evidence_id = str(getattr(record, "evidence_id", "") or "")
+        if not evidence_id:
+            continue
+        raw = load_raw(evidence_id) or ""
+        evidence.append((evidence_id, raw[:MAX_SNAPSHOT_CHARS_PER_RECORD]))
+        metadata = getattr(record, "metadata", None) or {}
+        for artifact in metadata.get("artifacts") or []:
+            handle = str(artifact.get("handle") or "")
+            if handle and handle not in artifacts:
+                artifacts.append(handle)
+    artifacts = artifacts[:MAX_SNAPSHOT_ARTIFACTS]
+    payload = json.dumps(
+        {"request": request, "evidence": evidence, "artifacts": artifacts},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return CompletionSnapshot(
+        request=request,
+        evidence=tuple(evidence),
+        artifacts=tuple(artifacts),
+        digest=digest,
+    )
+
+
+VERIFIER_A_INSTRUCTION = (
+    "You judge whether an analysis request has already been materially "
+    "satisfied by the evidence below.\n"
+    "Answer on one line, exactly one of:\n"
+    "COMPLETE evidence: <evidence ids that establish it>\n"
+    "CONTINUE missing: <one concrete material unresolved requirement>\n"
+    "Answer with nothing else."
+)
+
+VERIFIER_B_INSTRUCTION = (
+    "You look for one material requirement of the request that the evidence "
+    "below does NOT yet establish, and that would make it premature to stop.\n"
+    "Answer on one line, exactly one of:\n"
+    "GAP missing: <one concrete unresolved requirement>\n"
+    "NO_GAP\n"
+    "Answer with nothing else."
+)
+
+
+@dataclass(frozen=True)
+class VerifierVerdict:
+    """A parsed verifier answer. `ok` is false for anything not strictly parsed."""
+
+    ok: bool
+    decision: str
+    detail: str = ""
+    evidence_ids: tuple[str, ...] = ()
+    raw: str = ""
+
+
+def parse_verifier_a(text: str) -> VerifierVerdict:
+    """Strict. Anything that is not an unambiguous COMPLETE reads as CONTINUE.
+
+    Two properties do the work, and both were holes once. The verdict word is
+    matched on a word boundary, so `COMPLETELY unsure` is not a completion.
+    And the contradiction check reads the WHOLE answer, not its first line: the
+    evidence ids are harvested from the whole answer, so a later line saying
+    `CONTINUE` has to be able to disqualify it too.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return VerifierVerdict(False, "CONTINUE", "empty verifier output", raw=stripped)
+    whole = stripped.upper()
+    says_continue = re.search(r"\bCONTINUE\b", whole) is not None
+    head = stripped.splitlines()[0].strip()
+    if re.match(r"\s*CONTINUE\b", head, re.IGNORECASE):
+        return VerifierVerdict(True, "CONTINUE", head[len("CONTINUE"):].strip(), raw=stripped)
+    # An answer naming both verdicts is ambiguous however it is arranged, and
+    # the conservative reading of an ambiguous answer is the one that keeps going.
+    if re.match(r"\s*COMPLETE\b", head, re.IGNORECASE) and not says_continue:
+        return VerifierVerdict(
+            True,
+            "COMPLETE",
+            head[len("COMPLETE"):].strip(),
+            evidence_ids=tuple(dict.fromkeys(_EVIDENCE_ID_RE.findall(stripped))),
+            raw=stripped,
+        )
+    return VerifierVerdict(False, "CONTINUE", "unparsed verifier output", raw=stripped)
+
+
+def parse_verifier_b(text: str) -> VerifierVerdict:
+    """Strict, and asymmetric: only a clean NO_GAP clears the way.
+
+    `NO_GAP` must be the entire answer. A challenger that clears the way and
+    then describes a gap anyway -- on the same line or a later one, in any
+    case -- has found a gap, and the trailing prose is the finding rather than
+    decoration. `NO_GAPS` is not the token either.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return VerifierVerdict(False, "GAP", "empty verifier output", raw=stripped)
+    if re.fullmatch(r"\s*NO_GAP\s*\.?\s*", stripped, re.IGNORECASE):
+        return VerifierVerdict(True, "NO_GAP", raw=stripped)
+    head = stripped.splitlines()[0].strip()
+    if re.match(r"\s*GAP\b", head, re.IGNORECASE):
+        return VerifierVerdict(True, "GAP", head[len("GAP"):].strip(), raw=stripped)
+    # Anything else -- including a NO_GAP that kept talking -- is not a clean
+    # clearance, so it reads as a gap.
+    return VerifierVerdict(False, "GAP", "unparsed verifier output", raw=stripped)
+
+
+@dataclass
+class ShadowObservation:
+    """One checkpoint's result. Diagnostics only; the loop never acts on it."""
+
+    action: int
+    snapshot_digest: str
+    verifier_a: str | None = None
+    verifier_b: str | None = None
+    would_stop: bool = False
+    blocked_by: str | None = None
+    calls: int = 0
+    prompt_tokens: int = 0
+    output_tokens: int = 0
+    wall_seconds: float = 0.0
+
+    def as_log_fields(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "snapshot": self.snapshot_digest[:16],
+            "verifier_a": self.verifier_a,
+            "verifier_b": self.verifier_b,
+            "would_stop": self.would_stop,
+            "blocked_by": self.blocked_by,
+            "calls": self.calls,
+            "prompt_tokens": self.prompt_tokens,
+            "output_tokens": self.output_tokens,
+            "wall_seconds": round(self.wall_seconds, 3),
+        }
+
+
+@dataclass
+class ShadowLedger:
+    """Verifier accounting, deliberately separate from the loop's own budget."""
+
+    observations: list[ShadowObservation] = field(default_factory=list)
+
+    @property
+    def calls(self) -> int:
+        return sum(item.calls for item in self.observations)
+
+    @property
+    def prompt_tokens(self) -> int:
+        return sum(item.prompt_tokens for item in self.observations)
+
+    @property
+    def output_tokens(self) -> int:
+        return sum(item.output_tokens for item in self.observations)
+
+    @property
+    def wall_seconds(self) -> float:
+        return sum(item.wall_seconds for item in self.observations)
+
+    @property
+    def would_stop_actions(self) -> list[int]:
+        return [item.action for item in self.observations if item.would_stop]
+
+
+def evaluate_completion_shadow(
+    *,
+    action: int,
+    snapshot: CompletionSnapshot,
+    ask: Callable[[str, str], Any],
+    active_evidence_ids: set[str],
+    reattest: Callable[[str], object | None],
+) -> ShadowObservation:
+    """Run the two-stage check and report what it *would* have done.
+
+    `ask(instruction, snapshot_text)` performs one tool-free model call and
+    returns an object exposing `content` and, optionally, token counts. It is
+    injected so the loop owns the call and this module owns only the policy.
+    """
+    observation = ShadowObservation(action=action, snapshot_digest=snapshot.digest)
+    started = time.monotonic()
+
+    def account(response: Any) -> str:
+        observation.calls += 1
+        observation.prompt_tokens += int(getattr(response, "prompt_tokens", 0) or 0)
+        observation.output_tokens += int(getattr(response, "completion_tokens", 0) or 0)
+        return str(getattr(response, "content", "") or "")
+
+    try:
+        # Rendered inside the guard, not before it: the outer caller absorbs a
+        # failure here anyway, but a diagnostic should contain its own.
+        rendered = snapshot.render()
+        verdict_a = parse_verifier_a(account(ask(VERIFIER_A_INSTRUCTION, rendered)))
+        observation.verifier_a = verdict_a.decision
+        if not verdict_a.ok:
+            observation.blocked_by = "verifier_a_unparsed"
+            return observation
+        if verdict_a.decision != "COMPLETE":
+            # B is the expensive half and only ever asked about a proposed
+            # completion. A run that is still going never pays for it.
+            observation.blocked_by = "verifier_a_continue"
+            return observation
+
+        # A completion that cites nothing is not checkable, and an uncheckable
+        # claim is exactly what the re-attestation gate exists to refuse. This
+        # is also what keeps that gate on the passing path rather than only on
+        # the failing ones.
+        if not verdict_a.evidence_ids:
+            observation.blocked_by = "verifier_a_cited_no_evidence"
+            return observation
+
+        # Checked before B is asked: a COMPLETE resting on evidence that no
+        # longer stands is already disqualified, and asking B would spend a
+        # call to arrive at the same answer.
+        for evidence_id in verdict_a.evidence_ids:
+            if evidence_id not in active_evidence_ids:
+                observation.blocked_by = "referenced_evidence_not_active"
+                return observation
+            if reattest(evidence_id) is None:
+                observation.blocked_by = "referenced_evidence_reattest_failed"
+                return observation
+
+        # B is handed the same snapshot text and nothing else. It cannot see
+        # A's verdict, A's cited ids, or that A ran at all -- otherwise the
+        # challenge collapses into agreement with the thing it exists to test.
+        verdict_b = parse_verifier_b(account(ask(VERIFIER_B_INSTRUCTION, rendered)))
+        observation.verifier_b = verdict_b.decision
+        if not verdict_b.ok:
+            observation.blocked_by = "verifier_b_unparsed"
+            return observation
+        if verdict_b.decision != "NO_GAP":
+            observation.blocked_by = "verifier_b_gap"
+            return observation
+
+        observation.would_stop = True
+        return observation
+    except BaseException as exc:  # noqa: BLE001 - a failed verifier must never end a run
+        # BaseException, not Exception, and specifically for KeyboardInterrupt:
+        # the loop guards Ctrl-C around its own step only, so an interrupt
+        # raised here would unwind past `run_autonomous` to a caller holding a
+        # pre-run checkpoint and delete the history and provenance of every
+        # completed step. A diagnostic must not be able to destroy the run it
+        # is observing.
+        observation.blocked_by = f"verifier_error: {type(exc).__name__}"
+        observation.would_stop = False
+        return observation
+    finally:
+        observation.wall_seconds = time.monotonic() - started
+
+
+__all__ = [
+    "ANALYSIS_COMPLETION_SHADOW_PHASE",
+    "SHADOW_ENV",
+    "VERIFIER_MAX_TOKENS",
+    "CompletionSnapshot",
+    "ShadowLedger",
+    "ShadowObservation",
+    "VerifierVerdict",
+    "build_snapshot",
+    "evaluate_completion_shadow",
+    "parse_verifier_a",
+    "parse_verifier_b",
+    "scheduled_actions",
+    "shadow_enabled",
+]

--- a/tests/test_analysis_anchor_preservation.py
+++ b/tests/test_analysis_anchor_preservation.py
@@ -1,0 +1,74 @@
+"""The ANALYSIS rolling checkpoint must survive a tools-free detour.
+
+Production already does this -- `_ensure_prompt_cache_mode` treats
+`tools:thinking=off` <-> `chat:thinking=off` as a qualified transition and
+preserves both Ornith lineages -- but nothing pinned it for the *analysis*
+slot. The route slot has `test_full_turn_cycle_keeps_the_checkpoint_alive`;
+this is the missing counterpart.
+
+It is load-bearing for any tools-free call made between two analysis steps:
+lose it and the next step falls to a cold prefill instead of restoring.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID
+
+
+class _Profile:
+    verified = True
+    profile_id = ORNITH15_PROFILE_ID
+
+
+class _Session:
+    prompt_cache_mode: str | None = None
+
+
+def _client(current_mode: str) -> tuple[NativeLlamaClient, dict]:
+    client = NativeLlamaClient.__new__(NativeLlamaClient)
+    client.model_profile = _Profile()
+    client._session = _Session()
+    client._session.prompt_cache_mode = current_mode
+    captured: dict = {}
+    client.reset_session_state = lambda **kwargs: captured.update(kwargs)
+    return client, captured
+
+
+class AnalysisAnchorSurvivesToolFreeDetourTests(unittest.TestCase):
+    def test_step_to_tool_free_call_preserves_the_checkpoint(self) -> None:
+        client, captured = _client("tools:thinking=off")
+        client._ensure_prompt_cache_mode("chat:thinking=off")
+        self.assertTrue(
+            captured.get("preserve_ornith_rolling_route_checkpoint"),
+            "a tools-free call between analysis steps must not discard the anchor",
+        )
+
+    def test_tool_free_call_back_to_step_preserves_the_checkpoint(self) -> None:
+        client, captured = _client("chat:thinking=off")
+        client._ensure_prompt_cache_mode("tools:thinking=off")
+        self.assertTrue(captured.get("preserve_ornith_rolling_route_checkpoint"))
+
+    def test_thinking_transition_is_still_destructive(self) -> None:
+        # The preservation is narrow on purpose. A verifier that turned
+        # thinking on would silently cost the next step a full prefill.
+        client, captured = _client("tools:thinking=off")
+        client._ensure_prompt_cache_mode("chat:thinking=on")
+        self.assertFalse(captured.get("preserve_ornith_rolling_route_checkpoint"))
+
+    def test_multimodal_transition_is_still_destructive(self) -> None:
+        client, captured = _client("tools:thinking=off")
+        client._ensure_prompt_cache_mode("multimodal:thinking=off")
+        self.assertFalse(captured.get("preserve_ornith_rolling_route_checkpoint"))
+
+    def test_preservation_requires_the_verified_ornith_profile(self) -> None:
+        client, captured = _client("tools:thinking=off")
+        client.model_profile.verified = False
+        client._ensure_prompt_cache_mode("chat:thinking=off")
+        self.assertFalse(captured.get("preserve_ornith_rolling_route_checkpoint"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_completion_shadow.py
+++ b/tests/test_completion_shadow.py
@@ -1,0 +1,301 @@
+"""Shadow completion gate: it must observe, and never decide."""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+from typing import Any
+
+from orbit.runtime.completion_shadow import (
+    SHADOW_ENV,
+    CompletionSnapshot,
+    ShadowLedger,
+    build_snapshot,
+    evaluate_completion_shadow,
+    parse_verifier_a,
+    parse_verifier_b,
+    scheduled_actions,
+    shadow_enabled,
+)
+
+
+@dataclass
+class _Response:
+    content: str
+    prompt_tokens: int = 100
+    completion_tokens: int = 8
+
+
+@dataclass
+class _Record:
+    evidence_id: str
+    metadata: dict
+
+
+def _snapshot(digest: str = "d" * 64) -> CompletionSnapshot:
+    return CompletionSnapshot(
+        request="extract the C2", evidence=(("ev_a", "seen"),), artifacts=(), digest=digest
+    )
+
+
+def _run(answers, *, active=("ev_000000000000_0000000000000000",), reattest_ok=True):
+    """Drive the gate with scripted verifier answers."""
+    seen: list[str] = []
+
+    def ask(instruction: str, rendered: str):
+        seen.append(instruction)
+        return _Response(answers[len(seen) - 1])
+
+    observation = evaluate_completion_shadow(
+        action=4,
+        snapshot=_snapshot(),
+        ask=ask,
+        active_evidence_ids=set(active),
+        reattest=(lambda _id: "raw" if reattest_ok else None),
+    )
+    return observation, seen
+
+
+class ScheduleTests(unittest.TestCase):
+    def test_default_is_off(self) -> None:
+        self.assertFalse(shadow_enabled({}))
+        self.assertFalse(shadow_enabled({SHADOW_ENV: "0"}))
+        self.assertFalse(shadow_enabled({SHADOW_ENV: "true"}))
+
+    def test_explicit_opt_in(self) -> None:
+        self.assertTrue(shadow_enabled({SHADOW_ENV: "1"}))
+
+    def test_schedules_are_deterministic(self) -> None:
+        due = scheduled_actions("after4every2")
+        self.assertEqual([a for a in range(1, 13) if due(a)], [4, 6, 8, 10, 12])
+
+    def test_unknown_schedule_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            scheduled_actions("adaptive")
+
+
+class ParsingTests(unittest.TestCase):
+    def test_complete_parses_and_collects_ids(self) -> None:
+        verdict = parse_verifier_a(
+            "COMPLETE evidence: ev_271d2d4de64d_752e09e7c1a2673a"
+        )
+        self.assertTrue(verdict.ok)
+        self.assertEqual(verdict.decision, "COMPLETE")
+        self.assertEqual(verdict.evidence_ids, ("ev_271d2d4de64d_752e09e7c1a2673a",))
+
+    def test_continue_parses(self) -> None:
+        verdict = parse_verifier_a("CONTINUE missing: the decoded URL")
+        self.assertTrue(verdict.ok)
+        self.assertEqual(verdict.decision, "CONTINUE")
+
+    def test_ambiguous_answer_is_continue(self) -> None:
+        # Naming both words is not a completion, however it is phrased.
+        for text in ("COMPLETE but CONTINUE checking", "maybe complete", "", "   "):
+            with self.subTest(text=text):
+                self.assertEqual(parse_verifier_a(text).decision, "CONTINUE")
+
+    def test_b_requires_clean_no_gap(self) -> None:
+        self.assertEqual(parse_verifier_b("NO_GAP").decision, "NO_GAP")
+        self.assertTrue(parse_verifier_b("NO_GAP").ok)
+        for text in ("GAP missing: the C2 host", "", "unsure", "NO_GAP missing: x"):
+            with self.subTest(text=text):
+                verdict = parse_verifier_b(text)
+                self.assertNotEqual((verdict.ok, verdict.decision), (True, "NO_GAP"))
+
+
+class ParserInvariantTests(unittest.TestCase):
+    """The gate's redundancy rests on this: an unparsed verdict is never
+    affirmative. If a parser ever returned `ok=False` alongside COMPLETE or
+    NO_GAP, the `ok` checks in the gate would be the only thing standing
+    between a malformed answer and a WOULD_STOP."""
+
+    CASES = (
+        "COMPLETE", "CONTINUE", "NO_GAP", "GAP", "banana", "", "   ",
+        "complete", "Complete", "COMPLETE CONTINUE", "COMPLETE\nCONTINUE",
+        "xx COMPLETE", "NO_GAP missing: x", "COMPLETE evidence: ev_a",
+    )
+
+    def test_unparsed_a_is_never_complete(self) -> None:
+        for text in self.CASES:
+            with self.subTest(text=text):
+                verdict = parse_verifier_a(text)
+                if not verdict.ok:
+                    self.assertNotEqual(verdict.decision, "COMPLETE")
+
+    def test_unparsed_b_is_never_no_gap(self) -> None:
+        for text in self.CASES:
+            with self.subTest(text=text):
+                verdict = parse_verifier_b(text)
+                if not verdict.ok:
+                    self.assertNotEqual(verdict.decision, "NO_GAP")
+
+
+class GateTests(unittest.TestCase):
+    def test_complete_citing_nothing_is_refused(self) -> None:
+        # An uncheckable completion is not a completion: with no cited id the
+        # re-attestation gate has nothing to verify.
+        observation, seen = _run(["COMPLETE", "NO_GAP"])
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "verifier_a_cited_no_evidence")
+        self.assertEqual(len(seen), 1, "B must not be paid for an uncited claim")
+
+    def test_complete_and_no_gap_would_stop(self) -> None:
+        observation, seen = _run(["COMPLETE evidence: ev_000000000000_0000000000000000", "NO_GAP"])
+        self.assertTrue(observation.would_stop)
+        self.assertIsNone(observation.blocked_by)
+        self.assertEqual(len(seen), 2)
+
+    def test_a_continue_never_calls_b(self) -> None:
+        observation, seen = _run(["CONTINUE missing: the payload"])
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(len(seen), 1)
+        self.assertIsNone(observation.verifier_b)
+        self.assertEqual(observation.blocked_by, "verifier_a_continue")
+
+    def test_b_gap_blocks(self) -> None:
+        observation, _ = _run(["COMPLETE evidence: ev_000000000000_0000000000000000", "GAP missing: the C2"])
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "verifier_b_gap")
+
+    def test_malformed_a_blocks(self) -> None:
+        observation, seen = _run(["banana"])
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(len(seen), 1)
+
+    def test_malformed_b_blocks(self) -> None:
+        observation, _ = _run(["COMPLETE evidence: ev_000000000000_0000000000000000", "banana"])
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "verifier_b_unparsed")
+
+    def test_b_cannot_see_a_verdict(self) -> None:
+        seen: list[str] = []
+
+        def ask(instruction: str, rendered: str):
+            seen.append(instruction + "||" + rendered)
+            return _Response("COMPLETE evidence: ev_000000000000_0000000000000000" if len(seen) == 1 else "NO_GAP")
+
+        evaluate_completion_shadow(
+            action=4,
+            snapshot=_snapshot(),
+            ask=ask,
+            active_evidence_ids={"ev_000000000000_0000000000000000"},
+            reattest=lambda _id: "raw",
+        )
+        self.assertNotIn("COMPLETE", seen[1])
+        self.assertNotIn("verifier_a", seen[1].lower())
+
+    def test_both_verifiers_see_the_same_snapshot(self) -> None:
+        rendered: list[str] = []
+
+        def ask(instruction: str, text: str):
+            rendered.append(text)
+            return _Response("COMPLETE evidence: ev_000000000000_0000000000000000" if len(rendered) == 1 else "NO_GAP")
+
+        evaluate_completion_shadow(
+            action=4,
+            snapshot=_snapshot(),
+            ask=ask,
+            active_evidence_ids={"ev_000000000000_0000000000000000"},
+            reattest=lambda _id: "raw",
+        )
+        self.assertEqual(rendered[0], rendered[1])
+
+    def test_stale_evidence_reference_blocks(self) -> None:
+        observation, seen = _run(
+            ["COMPLETE evidence: ev_111111111111_2222222222222222", "NO_GAP"],
+            active=("ev_000000000000_0000000000000000",),
+        )
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "referenced_evidence_not_active")
+        self.assertEqual(len(seen), 1, "B must not be paid for a dead reference")
+
+    def test_failed_reattest_blocks(self) -> None:
+        observation, _ = _run(
+            ["COMPLETE evidence: ev_000000000000_0000000000000000", "NO_GAP"],
+            reattest_ok=False,
+        )
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "referenced_evidence_reattest_failed")
+
+    def test_keyboard_interrupt_is_contained(self) -> None:
+        """Ctrl-C during a verifier must not escape into the loop.
+
+        The loop guards KeyboardInterrupt around its own step only, so an
+        interrupt raised here would unwind past `run_autonomous` to a caller
+        holding a pre-run checkpoint and delete the history and provenance of
+        every completed step. Enabling a diagnostic must not create a window
+        in which Ctrl-C is destructive.
+        """
+
+        def ask(instruction: str, rendered: str):
+            raise KeyboardInterrupt()
+
+        observation = evaluate_completion_shadow(
+            action=4,
+            snapshot=_snapshot(),
+            ask=ask,
+            active_evidence_ids=set(),
+            reattest=lambda _id: "raw",
+        )
+        self.assertFalse(observation.would_stop)
+        self.assertEqual(observation.blocked_by, "verifier_error: KeyboardInterrupt")
+
+    def test_system_exit_is_contained(self) -> None:
+        def ask(instruction: str, rendered: str):
+            raise SystemExit(1)
+
+        observation = evaluate_completion_shadow(
+            action=4,
+            snapshot=_snapshot(),
+            ask=ask,
+            active_evidence_ids=set(),
+            reattest=lambda _id: "raw",
+        )
+        self.assertFalse(observation.would_stop)
+
+    def test_verifier_exception_blocks(self) -> None:
+        def ask(instruction: str, rendered: str):
+            raise RuntimeError("backend down")
+
+        observation = evaluate_completion_shadow(
+            action=4,
+            snapshot=_snapshot(),
+            ask=ask,
+            active_evidence_ids={"ev_000000000000_0000000000000000"},
+            reattest=lambda _id: "raw",
+        )
+        self.assertFalse(observation.would_stop)
+        self.assertTrue(observation.blocked_by.startswith("verifier_error"))
+
+
+class SnapshotTests(unittest.TestCase):
+    def test_snapshot_is_content_addressed(self) -> None:
+        records = [_Record("ev_a", {"artifacts": [{"handle": "/w/x.txt"}]})]
+        one = build_snapshot(request="r", records=records, load_raw=lambda _i: "text")
+        two = build_snapshot(request="r", records=records, load_raw=lambda _i: "text")
+        three = build_snapshot(request="r", records=records, load_raw=lambda _i: "other")
+        self.assertEqual(one.digest, two.digest)
+        self.assertNotEqual(one.digest, three.digest)
+        self.assertIn("/w/x.txt", one.render())
+
+    def test_snapshot_is_bounded(self) -> None:
+        records = [_Record(f"ev_{i}", {}) for i in range(50)]
+        snapshot = build_snapshot(
+            request="r", records=records, load_raw=lambda _i: "x" * 5000
+        )
+        self.assertLessEqual(len(snapshot.evidence), 12)
+        self.assertTrue(all(len(text) <= 600 for _id, text in snapshot.evidence))
+
+
+class AccountingTests(unittest.TestCase):
+    def test_ledger_sums_separately_from_the_loop(self) -> None:
+        observation, _ = _run(["COMPLETE evidence: ev_000000000000_0000000000000000", "NO_GAP"])
+        ledger = ShadowLedger(observations=[observation])
+        self.assertEqual(ledger.calls, 2)
+        self.assertEqual(ledger.prompt_tokens, 200)
+        self.assertEqual(ledger.output_tokens, 16)
+        self.assertEqual(ledger.would_stop_actions, [4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_completion_shadow_integration.py
+++ b/tests/test_completion_shadow_integration.py
@@ -1,0 +1,400 @@
+"""The shadow gate inside a real autonomous run: it must change nothing."""
+
+from __future__ import annotations
+
+import secrets
+import unittest
+from unittest import mock
+
+from orbit.runtime.completion_shadow import SHADOW_ENV, ShadowObservation
+
+from tests.test_analysis_autonomous import AutonomousTestBase, emit
+from tests.test_analysis_runtime import prose_response, tool_response
+
+
+def _script():
+    """Four productive steps then prose, so a run reaches the shadow schedule."""
+    return [
+        tool_response(emit("one")),
+        tool_response(emit("two")),
+        tool_response(emit("three")),
+        tool_response(emit("four")),
+        tool_response(emit("five")),
+        prose_response("done"),
+    ]
+
+
+class _CountingBackend:
+    """Serves the loop from a script and the verifier from its own answers.
+
+    Kept separate so verifier traffic can never be mistaken for a loop call:
+    the loop path is `chat_stream` with tools, the verifier path is `chat`
+    with `tools == []`.
+    """
+
+    def __init__(self, responses, verifier_answers=None):
+        self._responses = list(responses)
+        self.calls = 0
+        self.tool_modes: list[object] = []
+        self._verifier = list(verifier_answers or [])
+        self.verifier_calls = 0
+
+    def chat(self, messages, *, temperature, max_tokens, tools=None):
+        self.tool_modes.append(tools)
+        if tools == []:
+            from orbit.backend.base import ChatResult
+
+            self.verifier_calls += 1
+            answer = self._verifier.pop(0) if self._verifier else "CONTINUE missing: x"
+            return ChatResult(
+                content=answer,
+                model="m",
+                finish_reason="stop",
+                tool_calls=[],
+                prompt_tokens=50,
+                completion_tokens=4,
+                cached_tokens=0,
+                prompt_tokens_per_second=None,
+                generation_tokens_per_second=None,
+            )
+        if self.calls >= len(self._responses):
+            raise AssertionError("loop invoked more times than scripted")
+        response = self._responses[self.calls]
+        self.calls += 1
+        return response
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                    on_delta=None, on_progress=None):
+        response = self.chat(
+            messages, temperature=temperature, max_tokens=max_tokens, tools=tools
+        )
+        if on_delta is not None and response.content:
+            on_delta(response.content)
+        return response
+
+
+def _trajectory(run):
+    """Everything about a run that the shadow is forbidden to influence."""
+    return {
+        "stop_reason": run.stop_reason,
+        "model_calls": run.model_calls,
+        "actions": run.actions_executed,
+        "steps": len(run.steps),
+        "replans": run.replans,
+        "classifications": [record.classification for record in run.progress],
+        # The content half of the id, not the whole id: the prefix is a
+        # uuid4, so two runs never share it whatever the shadow does. The
+        # digest is what says the same evidence was produced.
+        "evidence_digests": [
+            step.evidence.evidence_id.split("_")[-1]
+            for step in run.steps
+            if step.evidence is not None
+        ],
+        "report": (run.final_report.text if run.final_report else None),
+    }
+
+
+class ShadowIsObservationalTests(AutonomousTestBase):
+    def test_default_off_runs_no_verifier(self) -> None:
+        backend = _CountingBackend(_script())
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop(SHADOW_ENV, None)
+            run = self.runtime(backend).run_autonomous("go", finalize=False)
+        self.assertIsNone(run.completion_shadow)
+        self.assertNotIn([], backend.tool_modes)
+
+    def test_shadow_on_off_trajectories_are_identical(self) -> None:
+        import os
+
+        results = {}
+        for label, env in (("off", {}), ("on", {SHADOW_ENV: "1"})):
+            with self.subTest(shadow=label):
+                base = AutonomousTestBase("run")
+                base.setUp()
+                self.addCleanup(base._dir.cleanup)
+                backend = _CountingBackend(
+                    _script(),
+                    verifier_answers=["CONTINUE missing: the payload"] * 12,
+                )
+                with mock.patch.dict("os.environ", env, clear=False):
+                    if not env:
+                        os.environ.pop(SHADOW_ENV, None)
+                    run = base.runtime(backend).run_autonomous("go", finalize=False)
+                results[label] = _trajectory(run)
+        self.assertEqual(results["off"], results["on"])
+
+    def test_would_stop_does_not_stop_the_run(self) -> None:
+        import os
+
+        from orbit.runtime.completion_shadow import ShadowObservation
+
+        backend = _CountingBackend(_script())
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            # Forced rather than scripted: a real COMPLETE must now cite live
+            # evidence, and this test is about the loop ignoring the verdict,
+            # not about how the verdict was reached.
+            with mock.patch(
+                "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                side_effect=lambda **kw: ShadowObservation(
+                    action=kw["action"],
+                    snapshot_digest=secrets.token_hex(32),
+                    would_stop=True,
+                ),
+            ):
+                run = self.runtime(backend).run_autonomous("go", finalize=False)
+        shadow = run.completion_shadow
+        self.assertIsNotNone(shadow)
+        self.assertTrue(shadow.would_stop_actions, "the fixture must reach WOULD_STOP")
+        # The run ended for its own reason, never because the shadow said stop.
+        self.assertNotEqual(run.stop_reason, "would_stop")
+        self.assertEqual(run.actions_executed, 5)
+
+    def test_verifier_calls_are_outside_the_loop_budget(self) -> None:
+        import os
+
+        backend = _CountingBackend(
+            _script(), verifier_answers=["CONTINUE missing: the payload"] * 12
+        )
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            run = self.runtime(backend).run_autonomous("go", finalize=False)
+        shadow = run.completion_shadow
+        self.assertGreater(shadow.calls, 0)
+        loop_calls = sum(1 for tools in backend.tool_modes if tools != [])
+        # The load-bearing one: the loop's own budget counts loop calls and
+        # nothing else, however many verifier calls the shadow made.
+        self.assertEqual(run.model_calls, loop_calls)
+
+    def test_verifier_calls_are_tool_free(self) -> None:
+        import os
+
+        backend = _CountingBackend(
+            _script(), verifier_answers=["CONTINUE missing: the payload"] * 12
+        )
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            self.runtime(backend).run_autonomous("go", finalize=False)
+        self.assertIn([], backend.tool_modes)
+
+    def test_shadow_failure_does_not_end_the_run(self) -> None:
+        import os
+
+        backend = _CountingBackend(_script())
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            # Patched at the import site: `analysis_runtime` bound the name at
+            # module load, so patching the source module would not take effect
+            # and the test would pass without exercising anything.
+            with mock.patch(
+                "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                side_effect=RuntimeError("verifier exploded"),
+            ):
+                run = self.runtime(backend).run_autonomous("go", finalize=False)
+        self.assertEqual(run.actions_executed, 5)
+        self.assertTrue(
+            all(not item.would_stop for item in run.completion_shadow.observations)
+        )
+
+
+def _long_script(n: int = 13):
+    """Enough productive steps to pass every checkpoint up to the hard bound."""
+    return [tool_response(emit(f"s{i}")) for i in range(n)] + [prose_response("done")]
+
+
+class ActiveStopIsUnreachableTests(AutonomousTestBase):
+    """The central safety property, asserted behaviourally rather than by grep.
+
+    A source scan for `would_stop` is evaded by `getattr(obs, "would_" + "stop")`
+    or by a helper the scan does not read, and a short fixture is evaded by
+    gating the stop above its action count. Forcing every checkpoint to say
+    stop, and running to the hard bound, is evaded by neither: any branch that
+    acts on the verdict changes the trajectory here.
+    """
+
+    def test_forced_would_stop_at_every_checkpoint_changes_nothing(self) -> None:
+        import os
+
+        from orbit.runtime.completion_shadow import ShadowObservation
+
+        # The digest is realistic and unpredictable, never a fixed sentinel: a
+        # stop conditioned on `snapshot_digest != "forced"` would otherwise
+        # truncate real runs while passing this very test.
+        def always_stop(**kwargs):
+            return ShadowObservation(
+                action=kwargs["action"],
+                snapshot_digest=secrets.token_hex(32),
+                verifier_a="COMPLETE",
+                verifier_b="NO_GAP",
+                would_stop=True,
+            )
+
+        trajectories = {}
+        for label, env in (("off", {}), ("on", {SHADOW_ENV: "1"})):
+            base = AutonomousTestBase("run")
+            base.setUp()
+            self.addCleanup(base._dir.cleanup)
+            backend = _CountingBackend(_long_script())
+            with mock.patch.dict("os.environ", env, clear=False):
+                if not env:
+                    os.environ.pop(SHADOW_ENV, None)
+                with mock.patch(
+                    "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                    side_effect=always_stop,
+                ):
+                    run = base.runtime(backend).run_autonomous("go", finalize=False)
+            trajectories[label] = _trajectory(run)
+            if label == "on":
+                self.assertTrue(
+                    run.completion_shadow.would_stop_actions,
+                    "the fixture must actually reach WOULD_STOP checkpoints",
+                )
+        self.assertEqual(trajectories["off"], trajectories["on"])
+
+    def test_forced_would_stop_reaches_the_action_bound(self) -> None:
+        """Guards the guard: if the fixture stopped early the test above would
+        compare two short runs and prove nothing."""
+        import os
+
+        from orbit.runtime.completion_shadow import ShadowObservation
+
+        backend = _CountingBackend(_long_script())
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            with mock.patch(
+                "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                side_effect=lambda **kw: ShadowObservation(
+                    action=kw["action"],
+                    snapshot_digest=secrets.token_hex(32),
+                    would_stop=True,
+                ),
+            ):
+                run = self.runtime(backend).run_autonomous("go", finalize=False)
+        self.assertGreaterEqual(run.actions_executed, 8)
+        self.assertGreaterEqual(len(run.completion_shadow.would_stop_actions), 3)
+
+
+class ShadowWiringTests(unittest.TestCase):
+    def test_loop_never_branches_on_would_stop(self) -> None:
+        """A cheap first line only. `ActiveStopIsUnreachableTests` is the real one."""
+        import inspect
+
+        from orbit.runtime import analysis_runtime
+
+        source = inspect.getsource(analysis_runtime.AnalysisRuntime.run_autonomous)
+        self.assertIn("_observe_completion_shadow", source)
+        self.assertNotIn("would_stop", source)
+
+    def test_observation_reads_only_active_evidence(self) -> None:
+        """The runtime call site, not just `build_snapshot`, must filter.
+
+        Passing the raw store here would hand a verifier a value the analysis
+        has already retracted -- the exact failure rc36 fixed for reports.
+        """
+        import inspect
+
+        from orbit.runtime import analysis_runtime
+
+        source = inspect.getsource(
+            analysis_runtime.AnalysisRuntime._observe_completion_shadow
+        )
+        self.assertIn("active_records(", source)
+        self.assertNotIn(
+            "records = list(self.evidence_store.records.values())", source
+        )
+
+    def test_verifier_declares_its_own_phase(self) -> None:
+        import inspect
+
+        from orbit.runtime import analysis_runtime
+
+        source = inspect.getsource(
+            analysis_runtime.AnalysisRuntime._observe_completion_shadow
+        )
+        self.assertIn("ANALYSIS_COMPLETION_SHADOW_PHASE", source)
+        self.assertIn("tools=[]", source)
+        self.assertIn('tools_mode="off"', source)
+        self.assertNotIn("ANALYSIS_STEP_PHASE", source)
+
+
+class SnapshotUsesActiveEvidenceOnlyTests(unittest.TestCase):
+    """A superseded record must never reach a verifier.
+
+    Replayed against the preserved store from the rc36 finalization failure,
+    which contains a genuine artifact rewrite: an earlier `ioc_report.txt`
+    naming `gibuyuy37v2v.top` and its correction naming `gibuzuy37v2v.top`.
+    Handing both to a verifier would ask it to judge completion against a
+    value the analysis had already retracted.
+    """
+
+    # Resolved relative to the repo rather than hard-coded to one machine, and
+    # skipped cleanly when the preserved archive is not present -- it lives
+    # outside the repository by convention, so most checkouts will not have it.
+    CHECKPOINT = (
+        "RECOVERED-finalization-failure-run-20260825-021057/evidence-store/evidence"
+    )
+
+    def setUp(self) -> None:
+        import os
+        from pathlib import Path
+
+        root = Path(
+            os.environ.get(
+                "ORBIT_CHECKPOINT_ROOT",
+                Path(__file__).resolve().parents[2] / "orbit-checkpoints",
+            )
+        )
+        store = root / self.CHECKPOINT
+        if not store.is_dir():
+            self.skipTest("preserved evidence store not present")
+        self.STORE = str(store)
+        from orbit.runtime.evidence import EvidenceStore
+
+        self.store = EvidenceStore(root=Path(self.STORE))
+        self.store.load_index()
+
+    def test_superseded_record_is_excluded_from_the_snapshot(self) -> None:
+        from orbit.runtime.completion_shadow import build_snapshot
+        from orbit.runtime.evidence_authority import active_records
+
+        every = list(self.store.records.values())
+        active = active_records(every)
+        self.assertLess(len(active), len(every), "fixture must contain a supersession")
+
+        superseded = {
+            record.evidence_id for record in every
+        } - {record.evidence_id for record in active}
+
+        snapshot = build_snapshot(
+            request="extract the C2 and artifacts",
+            records=active,
+            load_raw=self.store.load_raw,
+        )
+        rendered = snapshot.render()
+        for evidence_id in superseded:
+            self.assertNotIn(evidence_id, rendered)
+
+    def test_snapshot_over_all_records_would_leak_the_retracted_version(self) -> None:
+        # Pins why the ACTIVE view is load-bearing rather than cosmetic: built
+        # over every record, the snapshot carries the superseded evidence id.
+        from orbit.runtime.completion_shadow import build_snapshot
+        from orbit.runtime.evidence_authority import active_records
+
+        every = list(self.store.records.values())
+        active_ids = {record.evidence_id for record in active_records(every)}
+        superseded = [r for r in every if r.evidence_id not in active_ids]
+        self.assertTrue(superseded)
+
+        naive = build_snapshot(
+            request="extract the C2 and artifacts",
+            records=every,
+            load_raw=self.store.load_raw,
+        )
+        correct = build_snapshot(
+            request="extract the C2 and artifacts",
+            records=active_records(every),
+            load_raw=self.store.load_raw,
+        )
+        self.assertNotEqual(naive.digest, correct.digest)
+        self.assertIn(superseded[0].evidence_id, naive.render())
+        self.assertNotIn(superseded[0].evidence_id, correct.render())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## SHADOW ONLY — this cannot stop an analysis

A conservative completion gate that runs in **shadow mode only**. The autonomous ANALYSIS loop asks, at a fixed schedule, whether the request already looks satisfied — and then ignores the answer. The point is to find out whether that question can be answered reliably *before* anything is allowed to act on it.

### Required statements

| | |
|---|---|
| **SHADOW ONLY** | yes — `WOULD_STOP` is diagnostic and nothing reads it back |
| **Default** | **OFF**, behind `ORBIT_ANALYSIS_COMPLETION_SHADOW=1` |
| **Can it stop an analysis?** | **No.** Forcing `would_stop=True` at every checkpoint past the hard bound leaves the trajectory byte-identical to shadow-off |
| **Autonomous model-call budget** | verifier calls are accounted separately and **never** enter `model_calls` |
| **ANALYSIS rolling checkpoint** | verifier state **cannot** replace or consult it |
| **Effectiveness claim** | **none made** |
| **Premature-stop rate** | **not measurable** from the current historical corpus |
| **Active completion** | **NOT AUTHORIZED** |

### How it works

Two asymmetric tool-free checks over one content-addressed snapshot of the **ACTIVE** evidence. Verifier A judges coverage; only if A says `COMPLETE` does verifier B — which never sees A's verdict, cited ids, or that A ran — look for a reason stopping would be premature.

`WOULD_STOP` requires: A=COMPLETE ∧ both strictly parsed ∧ ≥1 cited evidence id ∧ every cited id ACTIVE ∧ every cited id re-attests ∧ B=NO_GAP ∧ no exception (including `BaseException`). Any ambiguity, malformed verdict, stale reference or error resolves to *continue*.

### Why the verifier cannot perturb the rolling KV

The verifier declares its own phase `analysis_completion_shadow` with `tools=[]` and thinking off. Both halves matter:

1. `_analysis_rolling_anchor_requested` returns True only for `analysis_step`, so **no anchor is requested** — capture and replace are unreachable.
2. `tools=[]` + thinking off lands on `chat:thinking=off`, a **qualified transition**, so `preserve_ornith_rolling_route_checkpoint=True`: invalidation is skipped and the `reset_generation` bump suppressed.

Restore reads the serialized checkpoint blob via `llama_state_seq_set_data`, so a dirty live context is irrelevant. Verified live in both directions; thinking-on and multimodal are shown to destroy it, which is why the shape is pinned.

**Known bounded cost:** the detour drops the 384-token ANALYSIS *prewarm*, which is invalidated unconditionally. It changes no measured reuse — the rolling checkpoint is never shorter, so the prewarm already stands down, and checkpoints never fire before the analysis is warm. Documented in the code.

### Why no effectiveness claim

The replay corpus cannot measure premature-stop risk. The one staged-discovery trajectory (C2 recovered late) archived route cards (~171 chars) rather than evidence text, so its action boundaries are unreconstructable without a forbidden long malware re-run. The one complete evidence store dumped the full plaintext at its first action, so every stop point is trivially safe there. Shipping this OFF is how that corpus gets built.

### Scope

Production change is **86 insertions, 0 deletions** in one file. With the flag off, `shadow is None` and the hook is a single false condition.

Also pins an invariant this design depends on that **nothing pinned before**: a qualified prompt-cache transition preserves the *ANALYSIS* rolling checkpoint, not just the route one.

### Verification

- 39 new tests; focused suites (completion-shadow, anchor, autonomous ANALYSIS, rolling-KV, prewarm/prefix) **all exit 0**
- full suite **3180 tests, exit 0, 1 pre-existing environment skip** (`test_upstream_template_hash_resolves_contract`, 'model not present')
- `compileall`, `git diff --check`, `git diff --cached --check` all clean
- 13 mutants: **12 caught, 1 proven equivalent** and pinned by an invariant test

### Independent review

Two rounds. Round 1 returned **MERGE SAFE: NO** with 3 BLOCKERs — all real, all reproduced before fixing:

- an active stop wired via `getattr(obs, "would_" + "stop")` gated at `actions >= 8` passed the entire suite, defeating both the source grep and the short fixtures. Replaced with a behavioural invariant that forces WOULD_STOP at every checkpoint past the hard bound; it catches all five of the reviewer's evasion attempts, including a non-`break` variant that merely shrank a budget.
- `KeyboardInterrupt` escaped the shadow into a caller holding a pre-run checkpoint, which would delete the history of every completed step. Now contained via `BaseException`.
- seven parser leaks, including `COMPLETELY unsure` reading as COMPLETE and `NO_GAP gap missing: the C2 host` clearing the way.

Round 2: **MERGE SAFE: YES**, BLOCKER 0 / MAJOR 0 / MINOR 0.
