### PR TITLE
feat(runtime): persist completion shadow observations

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -64,6 +64,10 @@ from orbit.runtime.completion_shadow import (
     scheduled_actions,
     shadow_enabled,
 )
+from orbit.runtime.completion_shadow_ledger import (
+    ShadowLedgerWriter,
+    ledger_path_for_evidence_root,
+)
 from orbit.runtime.evidence_authority import active_records, evaluate_standing
 from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
@@ -1022,6 +1026,25 @@ class AnalysisRuntime:
         final_report: "AnalysisReport | None" = None
         shadow = ShadowLedger() if shadow_enabled() else None
         shadow_due = scheduled_actions()
+        # Created only when the shadow runs: with the flag off this does no
+        # filesystem work at all, not even a stat.
+        shadow_ledger = None
+        if shadow is not None:
+            # Creation is guarded too: resolving the path reads the store, and
+            # a run must survive a ledger that cannot be opened at all.
+            try:
+                shadow_ledger = ShadowLedgerWriter(
+                    ledger_path_for_evidence_root(self.evidence_store.root)
+                )
+                shadow_ledger.write_run_start(
+                    request=analyst_message,
+                    schedule="after4every2",
+                    max_actions=max_actions,
+                    soft_max_actions=soft_max_actions,
+                    max_model_calls=max_model_calls,
+                )
+            except Exception:  # noqa: BLE001 - diagnostics never end a run
+                shadow_ledger = None
 
         while True:
             if model_calls >= max_model_calls:
@@ -1073,9 +1096,15 @@ class AnalysisRuntime:
             # exactly the state a real gate would have seen -- while every
             # `break` below remains reachable regardless of what it says.
             if shadow is not None and shadow_due(actions):
-                shadow.observations.append(
-                    self._observe_completion_shadow(actions, analyst_message)
-                )
+                observation = self._observe_completion_shadow(actions, analyst_message)
+                shadow.observations.append(observation)
+                if shadow_ledger is not None:
+                    # The writer swallows its own I/O failures; this guards the
+                    # serialization around them for the same reason.
+                    try:
+                        shadow_ledger.write_checkpoint(observation)
+                    except Exception:  # noqa: BLE001 - diagnostics never end a run
+                        shadow_ledger.failures.append("checkpoint_serialization_failed")
 
             if record.classification == COMPLETE:
                 stop_reason = STOP_COMPLETE
@@ -1193,6 +1222,30 @@ class AnalysisRuntime:
             else:
                 model_calls += final_report.model_calls
 
+        if shadow_ledger is not None:
+            # Written last, so its absence is how a reader tells a killed run
+            # from a finished one. Linking the ledger to the outcome is the
+            # whole point: a WOULD_STOP at action N only means something
+            # beside what the run went on to find.
+            #
+            # Guarded as a whole rather than trusting the writer's own guard:
+            # building the final snapshot reads the store, and a diagnostic
+            # must not be able to fail a run that has already completed.
+            try:
+                self._write_shadow_final(
+                    shadow_ledger,
+                    shadow,
+                    request=analyst_message,
+                    stop_reason=stop_reason,
+                    actions=actions,
+                    model_calls=model_calls,
+                    cancelled=cancelled,
+                    replans=replans,
+                    final_report=final_report,
+                )
+            except Exception:  # noqa: BLE001 - diagnostics must not end a run
+                pass
+
         return AutonomousRunResult(
             steps=tuple(steps),
             progress=tuple(records),
@@ -1203,6 +1256,50 @@ class AnalysisRuntime:
             replans=replans,
             final_report=final_report,
             completion_shadow=shadow,
+        )
+
+    def _write_shadow_final(
+        self,
+        ledger,
+        shadow,
+        *,
+        request: str,
+        stop_reason: str,
+        actions: int,
+        model_calls: int,
+        cancelled: bool,
+        replans: int,
+        final_report,
+    ) -> None:
+        """Link the checkpoint ledger to what the run actually produced."""
+        final_active = active_records(list(self.evidence_store.records.values()))
+        final_snapshot = build_snapshot(
+            request=request,
+            records=final_active,
+            load_raw=self.evidence_store.load_raw,
+        )
+        ledger.write_run_final(
+            stop_reason=stop_reason,
+            actions_executed=actions,
+            model_calls=model_calls,
+            cancelled=cancelled,
+            replans=replans,
+            final_report_produced=final_report is not None,
+            final_evidence_ids=[
+                str(getattr(record, "evidence_id", "")) for record in final_active
+            ],
+            final_artifacts=list(final_snapshot.artifacts),
+            final_snapshot_sha256=final_snapshot.digest,
+            final_snapshot_evidence=[
+                {"evidence_id": evidence_id, "text": text}
+                for evidence_id, text in final_snapshot.evidence
+            ],
+            request=final_snapshot.request,
+            shadow_verifier_calls=shadow.calls,
+            shadow_verifier_prompt_tokens=shadow.prompt_tokens,
+            shadow_verifier_output_tokens=shadow.output_tokens,
+            shadow_verifier_wall_seconds=round(shadow.wall_seconds, 3),
+            ledger_write_failures=list(ledger.failures),
         )
 
     def _observe_completion_shadow(self, actions: int, request: str):

--- a/src/orbit/runtime/completion_shadow.py
+++ b/src/orbit/runtime/completion_shadow.py
@@ -42,10 +42,21 @@ SHADOW_ENV = "ORBIT_ANALYSIS_COMPLETION_SHADOW"
 MAX_SNAPSHOT_RECORDS = 12
 MAX_SNAPSHOT_CHARS_PER_RECORD = 600
 MAX_SNAPSHOT_ARTIFACTS = 16
+# The request is bounded like everything else. It is operator-supplied rather
+# than hostile, but it is echoed into every checkpoint and the final record, so
+# leaving it unbounded would make "bounded by construction" untrue of the one
+# term an analyst can make arbitrarily long.
+MAX_SNAPSHOT_REQUEST_CHARS = 2000
 
 # Short by construction. Both verifiers answer in one or two lines, and a long
 # generation here is a cost paid against a run that is not going to stop.
 VERIFIER_MAX_TOKENS = 64
+
+# What a persisted verifier answer may occupy. Enough to audit a parse verdict
+# after the fact; far too little to become a transcript. The verifiers are
+# instructed to answer in one line, so anything past this is already a protocol
+# violation and the truncation is itself the finding.
+MAX_PERSISTED_RAW_CHARS = 400
 
 _EVIDENCE_ID_RE = re.compile(r"\bev_[0-9a-f]{12}_[0-9a-f]{16}\b")
 
@@ -118,6 +129,7 @@ def build_snapshot(
             if handle and handle not in artifacts:
                 artifacts.append(handle)
     artifacts = artifacts[:MAX_SNAPSHOT_ARTIFACTS]
+    request = (request or "")[:MAX_SNAPSHOT_REQUEST_CHARS]
     payload = json.dumps(
         {"request": request, "evidence": evidence, "artifacts": artifacts},
         ensure_ascii=False,
@@ -227,6 +239,16 @@ class ShadowObservation:
     prompt_tokens: int = 0
     output_tokens: int = 0
     wall_seconds: float = 0.0
+    # Recorded so a decision can be audited offline without rerunning
+    # inference. `snapshot` is the exact bounded projection both verifiers saw,
+    # which is what the historical corpus lacked; the raw answers are bounded
+    # excerpts kept for parser audit, never a transcript.
+    snapshot: "CompletionSnapshot | None" = None
+    verifier_a_evidence_ids: tuple[str, ...] = ()
+    verifier_a_detail: str = ""
+    verifier_b_detail: str = ""
+    verifier_a_raw: str = ""
+    verifier_b_raw: str = ""
 
     def as_log_fields(self) -> dict[str, object]:
         return {
@@ -284,7 +306,9 @@ def evaluate_completion_shadow(
     returns an object exposing `content` and, optionally, token counts. It is
     injected so the loop owns the call and this module owns only the policy.
     """
-    observation = ShadowObservation(action=action, snapshot_digest=snapshot.digest)
+    observation = ShadowObservation(
+        action=action, snapshot_digest=snapshot.digest, snapshot=snapshot
+    )
     started = time.monotonic()
 
     def account(response: Any) -> str:
@@ -299,6 +323,9 @@ def evaluate_completion_shadow(
         rendered = snapshot.render()
         verdict_a = parse_verifier_a(account(ask(VERIFIER_A_INSTRUCTION, rendered)))
         observation.verifier_a = verdict_a.decision
+        observation.verifier_a_evidence_ids = verdict_a.evidence_ids
+        observation.verifier_a_detail = verdict_a.detail[:MAX_PERSISTED_RAW_CHARS]
+        observation.verifier_a_raw = verdict_a.raw[:MAX_PERSISTED_RAW_CHARS]
         if not verdict_a.ok:
             observation.blocked_by = "verifier_a_unparsed"
             return observation
@@ -332,6 +359,8 @@ def evaluate_completion_shadow(
         # challenge collapses into agreement with the thing it exists to test.
         verdict_b = parse_verifier_b(account(ask(VERIFIER_B_INSTRUCTION, rendered)))
         observation.verifier_b = verdict_b.decision
+        observation.verifier_b_detail = verdict_b.detail[:MAX_PERSISTED_RAW_CHARS]
+        observation.verifier_b_raw = verdict_b.raw[:MAX_PERSISTED_RAW_CHARS]
         if not verdict_b.ok:
             observation.blocked_by = "verifier_b_unparsed"
             return observation
@@ -357,6 +386,8 @@ def evaluate_completion_shadow(
 
 __all__ = [
     "ANALYSIS_COMPLETION_SHADOW_PHASE",
+    "MAX_PERSISTED_RAW_CHARS",
+    "MAX_SNAPSHOT_REQUEST_CHARS",
     "SHADOW_ENV",
     "VERIFIER_MAX_TOKENS",
     "CompletionSnapshot",

--- a/src/orbit/runtime/completion_shadow_ledger.py
+++ b/src/orbit/runtime/completion_shadow_ledger.py
@@ -1,0 +1,325 @@
+"""Durable record of what the completion shadow saw and decided.
+
+Diagnostics, and nothing else. Every write is best-effort: a ledger that cannot
+be created or written must leave the analysis exactly as it would have been,
+because the alternative is a diagnostic that decides outcomes.
+
+The format is JSONL, one record per line, appended and flushed as it happens.
+That choice is about crash behaviour rather than speed: an atomic whole-file
+replace would keep the file consistent but would put every earlier observation
+at risk of the last write, and the observations are the expensive part -- each
+one cost a model call that will not be repeated. Append-only means a run killed
+mid-flight keeps everything it had already committed, and the missing final
+record is itself how a reader detects that it was killed.
+
+What is persisted is the exact bounded snapshot the verifiers were shown. The
+historical corpus failed precisely there: it kept evidence ids and hashes but
+not the content, so no later question could be answered without rerunning the
+analysis. Hashes prove integrity; they do not reconstruct what was judged.
+
+No raw sandbox output and no second copy of EvidenceStore. Verifier answers are
+kept as 400-character excerpts for parser audit, so if a verifier emits
+reasoning markup that markup can appear inside an excerpt -- bounded, never a
+transcript. The claim here is that nothing unbounded is persisted, not that a
+verifier's own words are filtered.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+# Bumped when a reader could otherwise misread an older file. Readers must
+# refuse a version they do not know rather than guess at its shape.
+LEDGER_SCHEMA_VERSION = 1
+
+LEDGER_FILENAME = "completion-shadow.jsonl"
+
+RECORD_RUN_START = "run_start"
+RECORD_CHECKPOINT = "checkpoint"
+RECORD_RUN_FINAL = "run_final"
+
+
+def ledger_path_for_evidence_root(root: Path) -> Path:
+    """Beside the evidence it describes, in Orbit's own session directory."""
+    return Path(root).parent / f"{Path(root).name}.{LEDGER_FILENAME}"
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    # Deterministic: sorted keys, no incidental whitespace, UTF-8 preserved.
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass
+class ShadowLedgerWriter:
+    """Append-only writer. Never raises into the caller.
+
+    `failures` is kept rather than logged away so a run can report that its
+    diagnostics were incomplete instead of a reader inferring completeness from
+    a file that simply stopped early.
+
+    Every record carries a `run_id`, because one analysis session can hold more
+    than one run and they share this file. Without it a finished run's final
+    record would make the next run -- killed halfway -- read as complete, which
+    is the one conclusion this ledger must never support.
+    """
+
+    path: Path
+    enabled: bool = True
+    run_id: str = ""
+    failures: list[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.failures is None:
+            self.failures = []
+        if not self.run_id:
+            self.run_id = uuid4().hex
+
+    def _append(self, payload: dict[str, Any]) -> bool:
+        if not self.enabled:
+            return False
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            line = _canonical(payload) + "\n"
+            # Flushed per record: an observation already paid for must not be
+            # lost to a buffer if the process dies during the next model call.
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+                handle.flush()
+                os.fsync(handle.fileno())
+            return True
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not end a run
+            # Deliberately not BaseException: a KeyboardInterrupt here is the
+            # operator stopping the CLI, and swallowing it to save a diagnostic
+            # would break ordinary interrupt semantics.
+            self.failures.append(f"{type(exc).__name__}: {exc}")
+            return False
+
+    def write_run_start(self, **fields: Any) -> bool:
+        return self._append(
+            {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "record": RECORD_RUN_START,
+                "run_id": self.run_id,
+                **fields,
+            }
+        )
+
+    def write_checkpoint(self, observation: Any, **fields: Any) -> bool:
+        snapshot = getattr(observation, "snapshot", None)
+        payload = {
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "record": RECORD_CHECKPOINT,
+            "run_id": self.run_id,
+            "action": observation.action,
+            "snapshot_sha256": observation.snapshot_digest,
+            "request": getattr(snapshot, "request", ""),
+            # The exact bounded projection the verifiers judged, not a
+            # reference to evidence that may be unreadable later.
+            "snapshot_evidence": [
+                {"evidence_id": evidence_id, "text": text}
+                for evidence_id, text in (getattr(snapshot, "evidence", ()) or ())
+            ],
+            "snapshot_artifacts": list(getattr(snapshot, "artifacts", ()) or ()),
+            "verifier_a": observation.verifier_a,
+            "verifier_a_evidence_ids": list(observation.verifier_a_evidence_ids),
+            "verifier_a_detail": observation.verifier_a_detail,
+            "verifier_a_raw": observation.verifier_a_raw,
+            "verifier_b": observation.verifier_b,
+            "verifier_b_detail": observation.verifier_b_detail,
+            "verifier_b_raw": observation.verifier_b_raw,
+            "would_stop": bool(observation.would_stop),
+            "blocked_by": observation.blocked_by,
+            "verifier_calls": observation.calls,
+            "verifier_prompt_tokens": observation.prompt_tokens,
+            "verifier_output_tokens": observation.output_tokens,
+            "verifier_wall_seconds": round(observation.wall_seconds, 3),
+            **fields,
+        }
+        return self._append(payload)
+
+    def write_run_final(self, **fields: Any) -> bool:
+        return self._append(
+            {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "record": RECORD_RUN_FINAL,
+                "run_id": self.run_id,
+                **fields,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class LedgerReadResult:
+    """What a ledger file contains, and whether it can be trusted."""
+
+    run_start: dict[str, Any] | None
+    checkpoints: tuple[dict[str, Any], ...]
+    run_final: dict[str, Any] | None
+    malformed_lines: tuple[int, ...]
+    unsupported_versions: tuple[int, ...]
+
+    @property
+    def complete(self) -> bool:
+        """A run that never wrote its final record did not finish normally."""
+        return self.run_final is not None
+
+    @property
+    def would_stop_actions(self) -> tuple[int, ...]:
+        return tuple(
+            int(item["action"]) for item in self.checkpoints if item.get("would_stop")
+        )
+
+    @property
+    def verifier_calls(self) -> int:
+        return sum(int(item.get("verifier_calls") or 0) for item in self.checkpoints)
+
+    @property
+    def verifier_wall_seconds(self) -> float:
+        return sum(float(item.get("verifier_wall_seconds") or 0.0) for item in self.checkpoints)
+
+    @property
+    def verifier_tokens(self) -> tuple[int, int]:
+        return (
+            sum(int(item.get("verifier_prompt_tokens") or 0) for item in self.checkpoints),
+            sum(int(item.get("verifier_output_tokens") or 0) for item in self.checkpoints),
+        )
+
+
+def _snapshot_digest(record: dict[str, Any]) -> str:
+    """Recompute the snapshot hash from the persisted projection.
+
+    Mirrors `build_snapshot` exactly. If the two ever drift, a stored decision
+    can no longer be tied to the content it was made from, so the reader
+    reports a mismatch rather than trusting the stored hash.
+    """
+    import hashlib
+
+    payload = json.dumps(
+        {
+            "request": record.get("request", ""),
+            "evidence": [
+                [item.get("evidence_id", ""), item.get("text", "")]
+                for item in record.get("snapshot_evidence") or []
+            ],
+            "artifacts": list(record.get("snapshot_artifacts") or []),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def verify_snapshot_hashes(result: LedgerReadResult) -> tuple[int, ...]:
+    """Actions whose persisted snapshot does not re-hash to its stored digest."""
+    return tuple(
+        int(record["action"])
+        for record in result.checkpoints
+        if _snapshot_digest(record) != record.get("snapshot_sha256")
+    )
+
+
+def read_ledger(path: Path) -> LedgerReadResult:
+    """Parse a ledger, tolerating truncation and refusing unknown versions.
+
+    A partially written last line is expected rather than exceptional: the
+    process may have been killed mid-write. It is reported, never interpreted.
+    """
+    run_start: dict[str, Any] | None = None
+    checkpoints: list[dict[str, Any]] = []
+    run_final: dict[str, Any] | None = None
+    malformed: list[int] = []
+    versions: list[int] = []
+    records_in_order: list[dict[str, Any]] = []
+    try:
+        lines = Path(path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    for number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            malformed.append(number)
+            continue
+        if not isinstance(payload, dict):
+            malformed.append(number)
+            continue
+        version = payload.get("schema_version")
+        if version != LEDGER_SCHEMA_VERSION:
+            if isinstance(version, int):
+                versions.append(version)
+            else:
+                malformed.append(number)
+            continue
+        kind = payload.get("record")
+        if kind in (RECORD_RUN_START, RECORD_CHECKPOINT, RECORD_RUN_FINAL):
+            records_in_order.append(payload)
+        if kind == RECORD_RUN_START:
+            run_start = payload
+        elif kind == RECORD_CHECKPOINT:
+            if "action" in payload:
+                checkpoints.append(payload)
+            else:
+                malformed.append(number)
+        elif kind == RECORD_RUN_FINAL:
+            run_final = payload
+        else:
+            malformed.append(number)
+    # One session can hold several runs in one file, so the result describes
+    # the most recent run rather than a blend of all of them. "Most recent"
+    # means the run whose record appears last: two genuinely concurrent runs
+    # sharing one file would leave the older one invisible here. That is the
+    # conservative direction -- it never reports a killed run as complete --
+    # and the sequential single-session case is the one this serves.
+    #
+    # The current run is identified by the newest id seen on ANY record, not by
+    # the newest `run_start`. A `run_start` can be lost on its own -- each
+    # record opens the file independently, so a transient ENOSPC can drop it
+    # while later writes succeed -- and keying off it would then credit the
+    # previous run's final record to this one, which is exactly the "killed run
+    # looks complete" conclusion this ledger must never support.
+    current = None
+    for item in reversed(records_in_order):
+        candidate = item.get("run_id")
+        if isinstance(candidate, str) and candidate:
+            current = candidate
+            break
+    if current is None:
+        # No record carries an id: the file predates them or is unattributable,
+        # so nothing may be credited to a specific run.
+        checkpoints = []
+        run_final = None
+        run_start = None
+    else:
+        checkpoints = [item for item in checkpoints if item.get("run_id") == current]
+        if run_final is not None and run_final.get("run_id") != current:
+            run_final = None
+        if run_start is not None and run_start.get("run_id") != current:
+            run_start = None
+    return LedgerReadResult(
+        run_start=run_start,
+        checkpoints=tuple(checkpoints),
+        run_final=run_final,
+        malformed_lines=tuple(malformed),
+        unsupported_versions=tuple(sorted(set(versions))),
+    )
+
+
+__all__ = [
+    "LEDGER_FILENAME",
+    "LEDGER_SCHEMA_VERSION",
+    "LedgerReadResult",
+    "RECORD_CHECKPOINT",
+    "RECORD_RUN_FINAL",
+    "RECORD_RUN_START",
+    "ShadowLedgerWriter",
+    "ledger_path_for_evidence_root",
+    "read_ledger",
+    "verify_snapshot_hashes",
+]

--- a/tests/test_completion_shadow_ledger.py
+++ b/tests/test_completion_shadow_ledger.py
@@ -1,0 +1,457 @@
+"""The shadow ledger: it must record faithfully and decide nothing."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.runtime.completion_shadow import (
+    SHADOW_ENV,
+    CompletionSnapshot,
+    ShadowObservation,
+    build_snapshot,
+)
+from orbit.runtime.completion_shadow_ledger import (
+    LEDGER_SCHEMA_VERSION,
+    ShadowLedgerWriter,
+    ledger_path_for_evidence_root,
+    read_ledger,
+    verify_snapshot_hashes,
+)
+
+from tests.test_analysis_autonomous import AutonomousTestBase
+from tests.test_completion_shadow_integration import (
+    _CountingBackend,
+    _long_script,
+    _script,
+    _trajectory,
+)
+
+
+def _observation(action: int, **kwargs) -> ShadowObservation:
+    snapshot = build_snapshot(
+        request="extract the C2",
+        records=[type("R", (), {"evidence_id": "ev_a", "metadata": {}})()],
+        load_raw=lambda _i: "the decoded url is http://example.invalid",
+    )
+    defaults = dict(
+        action=action,
+        snapshot_digest=snapshot.digest,
+        snapshot=snapshot,
+        verifier_a="CONTINUE",
+        calls=1,
+        prompt_tokens=120,
+        output_tokens=9,
+        wall_seconds=1.25,
+    )
+    defaults.update(kwargs)
+    return ShadowObservation(**defaults)
+
+
+class WriterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-ledger-")
+        self.addCleanup(self._dir.cleanup)
+        self.path = Path(self._dir.name) / "run.jsonl"
+
+    def test_one_checkpoint_writes_one_valid_record(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        self.assertTrue(writer.write_checkpoint(_observation(4)))
+        result = read_ledger(self.path)
+        self.assertEqual(len(result.checkpoints), 1)
+        self.assertEqual(result.checkpoints[0]["action"], 4)
+        self.assertEqual(result.malformed_lines, ())
+        self.assertEqual(verify_snapshot_hashes(result), ())
+
+    def test_snapshot_rehashes_exactly(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(_observation(4))
+        result = read_ledger(self.path)
+        # The persisted projection must reproduce the digest the verifiers saw,
+        # or a stored decision cannot be tied to what it was made from.
+        self.assertEqual(verify_snapshot_hashes(result), ())
+
+    def test_tampered_snapshot_is_detected(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(_observation(4))
+        raw = self.path.read_text(encoding="utf-8").splitlines()
+        payload = json.loads(raw[0])
+        payload["snapshot_evidence"][0]["text"] = "something else entirely"
+        self.path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        self.assertEqual(verify_snapshot_hashes(read_ledger(self.path)), (4,))
+
+    def test_verdicts_and_costs_are_preserved(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(
+            _observation(
+                6,
+                verifier_a="COMPLETE",
+                verifier_a_evidence_ids=("ev_a",),
+                verifier_b="NO_GAP",
+                would_stop=True,
+                calls=2,
+                prompt_tokens=300,
+                output_tokens=14,
+                wall_seconds=2.5,
+            )
+        )
+        record = read_ledger(self.path).checkpoints[0]
+        self.assertEqual(record["verifier_a"], "COMPLETE")
+        self.assertEqual(record["verifier_a_evidence_ids"], ["ev_a"])
+        self.assertEqual(record["verifier_b"], "NO_GAP")
+        self.assertTrue(record["would_stop"])
+        self.assertEqual(record["verifier_calls"], 2)
+        self.assertEqual(record["verifier_prompt_tokens"], 300)
+        self.assertEqual(record["verifier_output_tokens"], 14)
+
+    def test_continue_and_gap_records(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(
+            _observation(4, verifier_a="CONTINUE", verifier_a_detail="missing: the URL")
+        )
+        writer.write_checkpoint(
+            _observation(6, verifier_a="COMPLETE", verifier_b="GAP", blocked_by="verifier_b_gap")
+        )
+        result = read_ledger(self.path)
+        self.assertEqual([c["action"] for c in result.checkpoints], [4, 6])
+        self.assertEqual(result.would_stop_actions, ())
+        self.assertEqual(result.checkpoints[1]["blocked_by"], "verifier_b_gap")
+
+    def test_incomplete_run_is_detectable(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_run_start(request="r")
+        writer.write_checkpoint(_observation(4))
+        # No final record: the process died mid-run.
+        self.assertFalse(read_ledger(self.path).complete)
+
+    def test_truncated_last_line_keeps_earlier_records(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(_observation(4))
+        writer.write_checkpoint(_observation(6))
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write('{"schema_version": 1, "record": "checkpo')
+        result = read_ledger(self.path)
+        self.assertEqual(len(result.checkpoints), 2, "paid-for observations survive")
+        self.assertEqual(result.malformed_lines, (3,))
+        self.assertFalse(result.complete)
+
+    def test_a_finished_run_does_not_vouch_for_the_next_one(self) -> None:
+        """Two runs share one session file. A killed second run must not read
+        as complete because the first one finished."""
+        first = ShadowLedgerWriter(self.path)
+        first.write_run_start(request="run one")
+        first.write_run_final(stop_reason="done")
+
+        second = ShadowLedgerWriter(self.path)
+        second.write_run_start(request="run two")
+        second.write_checkpoint(_observation(4))
+
+        result = read_ledger(self.path)
+        self.assertFalse(result.complete, "the killed run is not complete")
+        self.assertEqual(result.run_start["request"], "run two")
+        self.assertEqual(len(result.checkpoints), 1, "only this run's checkpoints")
+
+        second.write_run_final(stop_reason="finished")
+        done = read_ledger(self.path)
+        self.assertTrue(done.complete)
+        self.assertEqual(done.run_final["stop_reason"], "finished")
+
+    def test_a_lost_run_start_does_not_inherit_the_previous_final(self) -> None:
+        """Each record opens the file on its own, so a transient failure can
+        drop `run_start` alone. Keying the scope off it would then credit the
+        previous run's final record to this one."""
+        first = ShadowLedgerWriter(self.path, run_id="A")
+        first.write_run_start(request="one")
+        first.write_run_final(stop_reason="complete", actions_executed=9)
+
+        second = ShadowLedgerWriter(self.path, run_id="B")
+        # `write_run_start` lost to a transient error; later writes succeed.
+        second.write_checkpoint(_observation(4))
+
+        result = read_ledger(self.path)
+        self.assertFalse(result.complete, "run B never finished")
+        self.assertIsNone(result.run_final, "run A's final must not vouch for B")
+        self.assertEqual([c["action"] for c in result.checkpoints], [4])
+
+    def test_records_without_a_run_id_are_unattributable(self) -> None:
+        # A file predating run ids, or otherwise unattributable: nothing may be
+        # credited to a specific run rather than guessing.
+        self.path.write_text(
+            json.dumps(
+                {"schema_version": LEDGER_SCHEMA_VERSION, "record": "run_final",
+                 "stop_reason": "complete"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        result = read_ledger(self.path)
+        self.assertFalse(result.complete)
+        self.assertIsNone(result.run_final)
+        self.assertEqual(result.checkpoints, ())
+
+    def test_checkpoints_are_scoped_to_their_own_run(self) -> None:
+        first = ShadowLedgerWriter(self.path)
+        first.write_run_start(request="one")
+        first.write_checkpoint(_observation(4))
+        first.write_checkpoint(_observation(6))
+        first.write_run_final(stop_reason="done")
+        second = ShadowLedgerWriter(self.path)
+        second.write_run_start(request="two")
+        second.write_checkpoint(_observation(8))
+        second.write_run_final(stop_reason="done")
+        result = read_ledger(self.path)
+        self.assertEqual([c["action"] for c in result.checkpoints], [8])
+
+    def test_unknown_schema_version_is_refused_not_guessed(self) -> None:
+        self.path.write_text(
+            json.dumps({"schema_version": 999, "record": "checkpoint", "action": 4}) + "\n",
+            encoding="utf-8",
+        )
+        result = read_ledger(self.path)
+        self.assertEqual(result.checkpoints, ())
+        self.assertEqual(result.unsupported_versions, (999,))
+
+    def test_verbose_answer_is_truncated_where_it_is_parsed(self) -> None:
+        """The bound must be enforced at the source, not merely asserted here.
+
+        Written so that removing the truncation in `evaluate_completion_shadow`
+        fails this test: the previous version compared against a limit it had
+        itself produced, and survived deleting the bound entirely.
+        """
+        from orbit.runtime.completion_shadow import (
+            MAX_PERSISTED_RAW_CHARS,
+            CompletionSnapshot,
+            evaluate_completion_shadow,
+        )
+
+        hostile = ("<think>" + "x" * 200 + "</think>") * 500
+
+        class _Response:
+            content = "CONTINUE missing: " + hostile
+            prompt_tokens = 10
+            completion_tokens = 4
+
+        observation = evaluate_completion_shadow(
+            action=4,
+            snapshot=CompletionSnapshot("r", (), (), "d" * 64),
+            ask=lambda _i, _r: _Response(),
+            active_evidence_ids=set(),
+            reattest=lambda _i: "raw",
+        )
+        self.assertLessEqual(len(observation.verifier_a_raw), MAX_PERSISTED_RAW_CHARS)
+        self.assertLessEqual(len(observation.verifier_a_detail), MAX_PERSISTED_RAW_CHARS)
+
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(observation)
+        record = read_ledger(self.path).checkpoints[0]
+        self.assertLessEqual(len(record["verifier_a_raw"]), MAX_PERSISTED_RAW_CHARS)
+
+    def test_verifier_b_answer_is_bounded_too(self) -> None:
+        from orbit.runtime.completion_shadow import (
+            MAX_PERSISTED_RAW_CHARS,
+            CompletionSnapshot,
+            evaluate_completion_shadow,
+        )
+
+        live = "ev_000000000000_0000000000000000"
+        answers = [f"COMPLETE evidence: {live}", "GAP missing: " + "y" * 100_000]
+
+        class _Response:
+            def __init__(self, text):
+                self.content = text
+                self.prompt_tokens = 10
+                self.completion_tokens = 4
+
+        seen: list[str] = []
+
+        def ask(_instruction, _rendered):
+            seen.append(_instruction)
+            return _Response(answers[len(seen) - 1])
+
+        observation = evaluate_completion_shadow(
+            action=4,
+            snapshot=CompletionSnapshot("r", (), (), "d" * 64),
+            ask=ask,
+            active_evidence_ids={live},
+            reattest=lambda _i: "raw",
+        )
+        self.assertEqual(observation.verifier_b, "GAP")
+        self.assertLessEqual(len(observation.verifier_b_raw), MAX_PERSISTED_RAW_CHARS)
+        self.assertLessEqual(len(observation.verifier_b_detail), MAX_PERSISTED_RAW_CHARS)
+
+    def test_artifact_handles_are_capped(self) -> None:
+        from orbit.runtime.completion_shadow import MAX_SNAPSHOT_ARTIFACTS
+
+        record = type(
+            "R",
+            (),
+            {
+                "evidence_id": "ev_a",
+                "metadata": {"artifacts": [{"handle": f"/w/{i}"} for i in range(600)]},
+            },
+        )()
+        snapshot = build_snapshot(
+            request="r", records=[record], load_raw=lambda _i: "text"
+        )
+        self.assertEqual(len(snapshot.artifacts), MAX_SNAPSHOT_ARTIFACTS)
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(
+            ShadowObservation(
+                action=4, snapshot_digest=snapshot.digest, snapshot=snapshot
+            )
+        )
+        stored = read_ledger(self.path).checkpoints[0]
+        self.assertEqual(len(stored["snapshot_artifacts"]), MAX_SNAPSHOT_ARTIFACTS)
+        self.assertEqual(verify_snapshot_hashes(read_ledger(self.path)), ())
+
+    def test_request_is_bounded_in_the_snapshot(self) -> None:
+        from orbit.runtime.completion_shadow import MAX_SNAPSHOT_REQUEST_CHARS
+
+        snapshot = build_snapshot(
+            request="q" * (MAX_SNAPSHOT_REQUEST_CHARS * 10),
+            records=[],
+            load_raw=lambda _i: "",
+        )
+        self.assertEqual(len(snapshot.request), MAX_SNAPSHOT_REQUEST_CHARS)
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(
+            ShadowObservation(
+                action=4, snapshot_digest=snapshot.digest, snapshot=snapshot
+            )
+        )
+        record = read_ledger(self.path).checkpoints[0]
+        self.assertEqual(len(record["request"]), MAX_SNAPSHOT_REQUEST_CHARS)
+        self.assertEqual(verify_snapshot_hashes(read_ledger(self.path)), ())
+
+    def test_write_failure_is_recorded_not_raised(self) -> None:
+        writer = ShadowLedgerWriter(Path("/proc/orbit-cannot-exist/run.jsonl"))
+        self.assertFalse(writer.write_checkpoint(_observation(4)))
+        self.assertTrue(writer.failures)
+
+    def test_serialization_failure_is_recorded_not_raised(self) -> None:
+        writer = ShadowLedgerWriter(self.path)
+
+        class Unserializable:
+            pass
+
+        self.assertFalse(writer.write_run_start(bad=Unserializable()))
+        self.assertTrue(writer.failures)
+
+    def test_keyboard_interrupt_is_not_swallowed(self) -> None:
+        # Ordinary CLI interrupt semantics matter more than a diagnostic line.
+        writer = ShadowLedgerWriter(self.path)
+        with mock.patch.object(Path, "open", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                writer.write_checkpoint(_observation(4))
+
+    def test_disabled_writer_writes_nothing(self) -> None:
+        writer = ShadowLedgerWriter(self.path, enabled=False)
+        self.assertFalse(writer.write_checkpoint(_observation(4)))
+        self.assertFalse(self.path.exists())
+
+    def test_records_are_deterministic(self) -> None:
+        # Same run id, same input, same bytes. The id itself is deliberately
+        # unique per run, so it is held fixed here rather than compared.
+        one = Path(self._dir.name) / "a.jsonl"
+        two = Path(self._dir.name) / "b.jsonl"
+        ShadowLedgerWriter(one, run_id="fixed").write_checkpoint(_observation(4))
+        ShadowLedgerWriter(two, run_id="fixed").write_checkpoint(_observation(4))
+        self.assertEqual(one.read_bytes(), two.read_bytes())
+
+    def test_each_writer_gets_its_own_run_id(self) -> None:
+        self.assertNotEqual(
+            ShadowLedgerWriter(self.path).run_id,
+            ShadowLedgerWriter(self.path).run_id,
+        )
+
+
+class InLoopLedgerTests(AutonomousTestBase):
+    def _ledger(self, runtime) -> Path:
+        return ledger_path_for_evidence_root(runtime.evidence_store.root)
+
+    def test_shadow_off_writes_nothing(self) -> None:
+        backend = _CountingBackend(_script())
+        runtime = self.runtime(backend)
+        os.environ.pop(SHADOW_ENV, None)
+        runtime.run_autonomous("go", finalize=False)
+        self.assertFalse(self._ledger(runtime).exists())
+
+    def test_run_writes_checkpoints_and_a_final_record(self) -> None:
+        backend = _CountingBackend(
+            _long_script(), verifier_answers=["CONTINUE missing: the payload"] * 12
+        )
+        runtime = self.runtime(backend)
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            run = runtime.run_autonomous("analyze this", finalize=False)
+        result = read_ledger(self._ledger(runtime))
+        self.assertIsNotNone(result.run_start)
+        self.assertTrue(result.checkpoints)
+        self.assertTrue(result.complete)
+        self.assertEqual(verify_snapshot_hashes(result), ())
+        self.assertEqual(result.run_final["stop_reason"], run.stop_reason)
+        self.assertEqual(result.run_final["actions_executed"], run.actions_executed)
+        self.assertEqual(result.run_final["model_calls"], run.model_calls)
+        self.assertEqual(result.verifier_calls, run.completion_shadow.calls)
+
+    def test_checkpoint_actions_match_the_schedule(self) -> None:
+        backend = _CountingBackend(
+            _long_script(), verifier_answers=["CONTINUE missing: x"] * 12
+        )
+        runtime = self.runtime(backend)
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            run = runtime.run_autonomous("go", finalize=False)
+        result = read_ledger(self._ledger(runtime))
+        self.assertEqual(
+            [c["action"] for c in result.checkpoints],
+            [o.action for o in run.completion_shadow.observations],
+        )
+
+    def test_ledger_failure_cannot_change_the_trajectory(self) -> None:
+        trajectories = {}
+        for label, broken in (("ok", False), ("broken", True)):
+            base = AutonomousTestBase("run")
+            base.setUp()
+            self.addCleanup(base._dir.cleanup)
+            backend = _CountingBackend(
+                _long_script(), verifier_answers=["CONTINUE missing: x"] * 12
+            )
+            runtime = base.runtime(backend)
+            with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+                if broken:
+                    with mock.patch.object(
+                        ShadowLedgerWriter, "_append", side_effect=OSError("disk full")
+                    ):
+                        run = runtime.run_autonomous("go", finalize=False)
+                else:
+                    run = runtime.run_autonomous("go", finalize=False)
+            trajectories[label] = _trajectory(run)
+        self.assertEqual(trajectories["ok"], trajectories["broken"])
+
+    def test_ledger_carries_no_model_facing_content(self) -> None:
+        backend = _CountingBackend(
+            _long_script(), verifier_answers=["CONTINUE missing: x"] * 12
+        )
+        runtime = self.runtime(backend)
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
+            runtime.run_autonomous("go", finalize=False)
+        # The claim this defends is that the ledger is write-only: it never
+        # re-enters a prompt. It deliberately does NOT claim reasoning markup
+        # is filtered out of a verifier's own answer -- that is bounded to 400
+        # characters, and `test_verbose_answer_is_truncated_where_it_is_parsed`
+        # is what pins the bound.
+        raw = self._ledger(runtime).read_text(encoding="utf-8")
+        self.assertTrue(raw)
+        for message in runtime.messages:
+            content = message.get("content")
+            if isinstance(content, str) and content:
+                self.assertNotIn("completion-shadow.jsonl", content)
+                self.assertNotIn("snapshot_sha256", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Diagnostics only — this cannot change an analysis outcome

The shadow gate spends a model call per checkpoint and then forgets what it saw. That is the same failure the historical corpus already has: evidence ids and hashes survived, the content did not, so no later question could be answered without rerunning the analysis. This persists enough to ask, months later, **"if checkpoint N said WOULD_STOP, what materially appeared after N?"** — offline, with no inference.

### Storage

`~/.orbit/sessions/<session>.evidence.completion-shadow.jsonl` — beside the evidence it describes, in Orbit's existing session directory. No new dependency, no database, no invented location.

JSONL, **schema version 1**, append + flush + fsync. Three record kinds: `run_start`, `checkpoint`, `run_final`.

Append-only rather than atomic whole-file replace, deliberately: the observations are the expensive part, and a run killed mid-flight should keep everything it already paid for. The missing final record is then how a reader tells a killed run from a finished one.

### What each checkpoint stores

The **exact bounded snapshot the verifiers judged** — not a reference to evidence that may be unreadable later — plus its SHA-256, the request, ACTIVE evidence ids, artifact handles, both verdicts, verifier A's cited ids and missing-requirement text, bounded raw answers for parser audit, `would_stop`, `blocked_by`, and the verifier's own call/token/wall cost.

The final record links the ledger to the outcome: stop reason, actions, model calls, final ACTIVE evidence, final artifacts, final snapshot + hash, whether a report was produced, and total shadow cost.

### Safety

| | |
|---|---|
| Can a ledger failure change the analysis? | **No.** Creation, every write, and the final-record build are each failure-isolated |
| Shadow OFF | **zero** filesystem work — not a stat, not a mkdir |
| Model calls added | **none** |
| Rolling KV | untouched |
| Verifier budget | still outside `model_calls` |
| `KeyboardInterrupt` | still propagates — ordinary CLI semantics beat saving a diagnostic line |
| Chain-of-thought | no *unbounded* reasoning persisted — verifier answers are kept as 400-char excerpts for parser audit, so short reasoning markup can appear inside one |
| Size | bounded by construction: ~10 KiB/checkpoint, ~60–120 KiB per 12-action run |

### Run scoping

Every record carries a `run_id`, because one session can hold several runs in one file. The reader scopes to the **newest id seen on any record**, not to the newest `run_start` — a `run_start` can be lost on its own (each record opens the file independently, so a transient ENOSPC drops it while later writes succeed), and keying off it would credit the previous run's final record to a run that was killed.

### Offline reader

`read_ledger` / `verify_snapshot_hashes`: schema validation, snapshot re-hashing, checkpoint enumeration, `would_stop` decisions, cost totals, and detection of incomplete or corrupt ledgers. **No false-stop scoring and no LLM evaluation** — that is the next mission, and it needs a corpus that does not exist yet.

### Verification

- **66 shadow+ledger tests**; full suite **3207, exit 0**, 1 pre-existing environment skip
- **15/15 ledger mutants caught**
- `compileall`, `git diff --check` clean

### Independent review

Returned **MERGE SAFE: YES**, 0 BLOCKER, after an 11-case failure-injection matrix, 4000 randomized digest-mirroring fuzz trials, and syscall-level verification that shadow OFF is inert.

Three findings were raised and all are fixed here:

- **I found one myself before the reviewer:** because the ledger path derives from the evidence root, a finished run's `run_final` made a *later, killed* run read as `complete=True`. Fixed with `run_id`.
- The reviewer then showed my fix had a second door — a **lost `run_start`** reached the same false-complete state. Reproduced and fixed by scoping off the newest id on any record.
- `test_bounded_raw_answers` was **vacuous**: deleting the truncation left the suite green. Rewritten to drive `evaluate_completion_shadow` with a hostile 100 KB answer and assert the real bound.
- The reviewer also noted `request` was the only unbounded term; now bounded, so "bounded by construction" is literally true.

### Not authorized by this PR

Shadow stays **default OFF**. No corpus collection. **No active completion.**

### Review round 2

Returned **MERGE SAFE: YES**, 0 BLOCKER / 0 MAJOR, after 9/9 failure injections, 23/23 run-scoping attacks, 4000 digest-fuzz trials, syscall-level shadow-OFF verification, and 25 independent mutants.

Three MINORs raised, all fixed here: the chain-of-thought claim was **overstated** (a bounded 400-char excerpt can contain reasoning markup — corrected in the table above, the module docstring, and the test that appeared to defend it); the verifier-B bounds and the artifact cap were enforced but **untested** (now pinned, and their mutants die); and the reader's newest-run-wins behaviour under genuinely concurrent runs is now documented as the conservative limitation it is.
