### PR TITLE
test(evaluation): score completion shadow corpus

### DIFF
--- a/scripts/evaluation/completion_shadow_oracles.json
+++ b/scripts/evaluation/completion_shadow_oracles.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "note": "Evaluator-only. Never loaded by Orbit runtime, backend, EvidenceStore, terminal or the completion gate. Predicates are deterministic: literal or bounded regex over persisted snapshot text, evidence ids, or artifact handles. No LLM interpretation, no semantic similarity.",
+  "samples": {
+    "A": {
+      "artifact": "trivial_greeting_demo.js",
+      "artifact_sha256": "dc3043129234f3f2b96393978fc41b6b9b41bfbd3c2cae02e4025e82cfdb02d1",
+      "conclusion": "benign",
+      "required_findings": [
+        {"id": "greet_function", "kind": "literal_any", "values": ["function greet", "greet(name)"]},
+        {"id": "hardcoded_array", "kind": "literal_any", "values": ["\"Ada\"", "'Ada'", "Ada"]},
+        {"id": "stdout_only", "kind": "literal_any", "values": ["console.log"]},
+        {"id": "no_dangerous_capability", "kind": "absent_all",
+         "values": ["XMLHttpRequest", "WScript.Shell", "ActiveXObject", "eval(", "require(", "fetch("],
+         "comment": "No network, filesystem, process creation or dynamic code in the artifact content."}
+      ]
+    },
+    "B": {
+      "artifact": "suspicious_dropper_demo.js",
+      "artifact_sha256": "ac7aea71beb9494fcaac015ef0cf7072fc2a208c23d8e0c6241de9f69013b3f9",
+      "conclusion": "benign demo, inert as written",
+      "required_findings": [
+        {"id": "dropper_structure_present", "kind": "regex", "pattern": "(?i)(ActiveXObject|WScript|XMLHTTP|ADODB)"},
+        {"id": "inert_url_data", "kind": "regex", "pattern": "(?i)https?://"},
+        {"id": "no_real_execution", "kind": "unscorable",
+         "comment": "Requires reasoning about reachability of the dropper path. Not deterministically decidable from persisted snapshot text."}
+      ]
+    },
+    "C": {
+      "artifact": "peXF7I6W.ps1",
+      "artifact_sha256": "5eba3e4538cffbde5d39ba81eb4ed85e9c9cc6065e036503073a43a9478f405d",
+      "conclusion": "malicious PowerShell dropper/downloader",
+      "required_findings": [
+        {"id": "c2_domain", "kind": "literal_all", "values": ["gibuzuy37v2v.top"],
+         "forbidden": ["gibuyuy37v2v.top"],
+         "comment": "Stale-evidence guard: only the authoritative gibuzuy37v2v.top may satisfy this finding. NOTE: on the 20260827 corpus the superseded spelling gibuyuy37v2v.top appears in no evidence file, so this guard was never exercised by that data -- it is unit-tested, not corpus-proven. The guard is advisory: a forbidden value annotates detail and does not veto an otherwise satisfied finding, so a record quoting the stale value beside the correct one still satisfies, which is the correction-record case."},
+        {"id": "c2_uri_tag", "kind": "literal_all", "values": ["?s=mints13"]},
+        {"id": "download_execute", "kind": "regex", "pattern": "(?i)\\biex\\b|invoke-expression"},
+        {"id": "curl_fetch", "kind": "regex", "pattern": "(?i)curl"},
+        {"id": "dropper_path", "kind": "regex", "pattern": "(?i)Users..?Public..?Documents"},
+        {"id": "hidden_launch", "kind": "regex", "pattern": "(?i)(windowstyle\\s+hidden|-w\\s+hidden|hidden)"},
+        {"id": "logic_bomb", "kind": "regex", "pattern": "(?i)Get-Date[^\\n]{0,120}(\\+|-gt|-lt|-ge|-le|AddMinutes|Add\\()", "comment": "Get-Date alone is a timestamp; the oracle requires the arithmetic/comparison that makes it a logic bomb."},
+        {"id": "cleanup_targets", "kind": "regex", "pattern": "(?i)APPDATA"}
+      ]
+    }
+  }
+}

--- a/scripts/evaluation/score_completion_shadow.py
+++ b/scripts/evaluation/score_completion_shadow.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Deterministic offline scorer for the completion-shadow corpus.
+
+Evaluation only. Reads a preserved corpus read-only, scores each persisted
+checkpoint against an evaluator-only oracle, and reports what the two verifiers
+got right and wrong. It performs no inference: there is no backend, no client,
+and no network here, and a test asserts as much.
+
+Two views of "what was established" are scored separately, because they answer
+different questions:
+
+  snapshot   -- exactly what the verifiers were shown at that checkpoint. This
+                is what A and B can fairly be judged against.
+  cumulative -- everything the analysis had established by then, from the
+                EvidenceStore. This is what "was the analysis actually
+                complete" means, and it is not what the verifiers saw.
+
+The two views diverge for two independent reasons, and they call for different
+fixes, so they are worth keeping apart:
+
+  * per-record truncation -- each record enters the snapshot as a 600-character
+    excerpt (MAX_SNAPSHOT_CHARS_PER_RECORD). This is the dominant effect and it
+    bites from the very first checkpoint: in this corpus, at action 4 of the
+    PowerShell run, six of eight records carry the hidden-launch evidence in
+    their full text and none carry it inside the excerpt.
+  * window eviction -- at most MAX_SNAPSHOT_RECORDS (12) records are carried,
+    so older evidence drops out later in a run. Real, but it cannot explain a
+    checkpoint that holds only eight records.
+
+An oracle finding that cannot be decided from persisted text is UNSCORABLE, and
+a sample with an unscorable required finding is never declared complete: it is
+INDETERMINATE, which is the conservative reading.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCHEDULE = (4, 6, 8, 10, 12)
+
+
+@dataclass(frozen=True)
+class FindingResult:
+    id: str
+    satisfied: bool
+    unscorable: bool
+    detail: str = ""
+
+
+def evaluate_finding(spec: dict, text: str) -> FindingResult:
+    """One deterministic predicate. No interpretation, no similarity."""
+    kind = spec["kind"]
+    fid = spec["id"]
+    if kind == "unscorable":
+        return FindingResult(fid, False, True, spec.get("comment", ""))
+
+    # A forbidden value can never satisfy a finding, even if it looks close.
+    # This is what keeps a superseded value from passing as authoritative.
+    forbidden = [v for v in spec.get("forbidden", []) if v.lower() in text.lower()]
+
+    if kind == "literal_all":
+        hit = all(v.lower() in text.lower() for v in spec["values"])
+    elif kind == "literal_any":
+        hit = any(v.lower() in text.lower() for v in spec["values"])
+    elif kind == "absent_all":
+        hit = not any(v.lower() in text.lower() for v in spec["values"])
+    elif kind == "regex":
+        hit = re.search(spec["pattern"], text) is not None
+    else:
+        return FindingResult(fid, False, True, f"unknown predicate kind {kind!r}")
+
+    detail = f"forbidden present: {forbidden}" if forbidden else ""
+    return FindingResult(fid, bool(hit), False, detail)
+
+
+@dataclass
+class CheckpointScore:
+    action: int
+    required_total: int
+    satisfied: list = field(default_factory=list)
+    missing: list = field(default_factory=list)
+    unscorable: list = field(default_factory=list)
+
+    @property
+    def oracle_complete(self) -> bool:
+        # Never complete while anything required is unscorable: an undecided
+        # requirement is treated as unmet, not waved through.
+        return not self.missing and not self.unscorable
+
+    @property
+    def state(self) -> str:
+        if self.unscorable:
+            return "INDETERMINATE"
+        return "COMPLETE" if not self.missing else "INCOMPLETE"
+
+
+def score_text(oracle: dict, text: str, action: int) -> CheckpointScore:
+    score = CheckpointScore(action=action, required_total=len(oracle["required_findings"]))
+    for spec in oracle["required_findings"]:
+        result = evaluate_finding(spec, text)
+        if result.unscorable:
+            score.unscorable.append(result.id)
+        elif result.satisfied:
+            score.satisfied.append(result.id)
+        else:
+            score.missing.append(result.id)
+    return score
+
+
+def classify_a(verdict: str, oracle_complete: bool, indeterminate: bool) -> str:
+    if indeterminate:
+        return "A_INDETERMINATE"
+    if verdict == "COMPLETE":
+        return "A_TRUE_COMPLETE" if oracle_complete else "A_FALSE_COMPLETE"
+    return "A_TRUE_CONTINUE" if not oracle_complete else "A_FALSE_CONTINUE"
+
+
+def classify_b(verdict: str | None, oracle_complete: bool, indeterminate: bool) -> str:
+    if verdict is None:
+        return "B_NOT_CALLED"
+    if indeterminate:
+        return "B_INDETERMINATE"
+    if verdict == "GAP":
+        return "B_TRUE_GAP" if not oracle_complete else "B_FALSE_GAP"
+    return "B_TRUE_NO_GAP" if oracle_complete else "B_FALSE_NO_GAP"
+
+
+def classify_gap(detail: str, score: CheckpointScore) -> str:
+    """Is B's stated omission a real material one, or already satisfied?
+
+    Decided against the oracle's own findings, never against B's prose meaning:
+    the prose records what B claimed, and treating it as ground truth would let
+    the thing under test grade itself.
+
+    The consequence is worth stating plainly, because the label is easy to
+    over-read. `NON_MATERIAL_OR_ALREADY_SATISFIED` means only "the oracle's
+    required findings were all present when B objected". It does not mean B was
+    incoherent. B may have raised a real process objection -- an artifact whose
+    contents were never displayed, a path that does not obviously correspond to
+    the requested one -- that this oracle simply does not encode, because the
+    oracle scores material findings about the artifact rather than the shape of
+    the report. Whether such objections *should* be material is a policy
+    question this scorer deliberately does not answer.
+    """
+    if not detail:
+        return "UNSCORABLE"
+    if score.unscorable:
+        return "UNSCORABLE"
+    if score.missing:
+        return "MATERIAL_AND_REAL"
+    return "NON_MATERIAL_OR_ALREADY_SATISFIED"
+
+
+def load_run(corpus: Path, label: str) -> dict:
+    """Read one preserved run. Corpus is opened read-only and never written."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+    from orbit.runtime.completion_shadow_ledger import read_ledger, verify_snapshot_hashes
+    from orbit.runtime.evidence import EvidenceStore
+
+    d = corpus / "runs" / label
+    run = json.loads((d / "run.json").read_text())
+    ledger = read_ledger(d / "completion-shadow.jsonl")
+    if ledger.malformed_lines or ledger.unsupported_versions:
+        raise SystemExit(f"[{label}] corrupt ledger; refusing to score")
+    mismatched = verify_snapshot_hashes(ledger)
+    if mismatched:
+        raise SystemExit(f"[{label}] snapshot hash mismatch at actions {mismatched}; refusing to score")
+
+    store = EvidenceStore(root=d / "evidence")
+    store.load_index()
+    cumulative = "\n".join(
+        (store.load_raw(r.evidence_id) or "") for r in store.records.values()
+    )
+    return {"label": label, "run": run, "ledger": ledger, "cumulative": cumulative}
+
+
+def snapshot_text(checkpoint: dict) -> str:
+    return "\n".join(e.get("text", "") for e in checkpoint.get("snapshot_evidence", []))
+
+
+def score_corpus(corpus: Path, oracles: dict) -> dict:
+    report = {"runs": {}, "schedule": list(SCHEDULE)}
+    for label in ("A", "B", "C"):
+        data = load_run(corpus, label)
+        oracle = oracles["samples"][label]
+        rows = []
+        for cp in data["ledger"].checkpoints:
+            snap = score_text(oracle, snapshot_text(cp), cp["action"])
+            cum = score_text(oracle, data["cumulative"], cp["action"])
+            a_class = classify_a(cp["verifier_a"], snap.oracle_complete, bool(snap.unscorable))
+            b_class = classify_b(cp["verifier_b"], snap.oracle_complete, bool(snap.unscorable))
+            rows.append({
+                "action": cp["action"],
+                "required_total": snap.required_total,
+                "snapshot_satisfied": snap.satisfied,
+                "snapshot_missing": snap.missing,
+                "unscorable": snap.unscorable,
+                "snapshot_state": snap.state,
+                "cumulative_state": cum.state,
+                "cumulative_missing": cum.missing,
+                "verifier_a": cp["verifier_a"],
+                "verifier_b": cp["verifier_b"],
+                "would_stop": cp["would_stop"],
+                "a_class": a_class,
+                "b_class": b_class,
+                "b_gap_materiality": classify_gap(cp.get("verifier_b_detail", ""), snap),
+                "b_detail": cp.get("verifier_b_detail", "")[:160],
+                "verifier_calls": cp["verifier_calls"],
+                "verifier_wall_seconds": cp["verifier_wall_seconds"],
+                "verifier_prompt_tokens": cp["verifier_prompt_tokens"],
+                "verifier_output_tokens": cp["verifier_output_tokens"],
+            })
+        report["runs"][label] = {
+            "artifact": data["run"]["artifact"],
+            "artifact_sha256": data["run"]["artifact_sha256_before"],
+            "stop_reason": data["run"]["stop_reason"],
+            "actions_executed": data["run"]["actions_executed"],
+            "model_calls": data["run"]["model_calls"],
+            "wall_seconds": data["run"]["wall_seconds"],
+            "shadow": data["run"]["shadow"],
+            "checkpoints": rows,
+        }
+    return report
+
+
+def main(argv: list[str]) -> int:
+    corpus = Path(argv[1])
+    oracles = json.loads(Path(argv[2]).read_text())
+    report = score_corpus(corpus, oracles)
+    out = Path(argv[3]) if len(argv) > 3 else None
+    if out:
+        out.write_text(json.dumps(report, indent=2, ensure_ascii=False))
+    for label, r in report["runs"].items():
+        print(f"\n=== RUN {label}  {r['artifact']}  actions={r['actions_executed']} "
+              f"stop={r['stop_reason']}")
+        print(f"{'act':>4} {'snapshot':>13} {'cumulative':>12} {'A':>9} {'B':>5} "
+              f"{'WOULD':>6} {'a_class':>18} {'b_class':>14} {'gap':>34}")
+        for c in r["checkpoints"]:
+            print(f"{c['action']:>4} {c['snapshot_state']:>13} {c['cumulative_state']:>12} "
+                  f"{str(c['verifier_a']):>9} {str(c['verifier_b']):>5} {str(c['would_stop']):>6} "
+                  f"{c['a_class']:>18} {c['b_class']:>14} {c['b_gap_materiality']:>34}")
+            if c["snapshot_missing"]:
+                print(f"       snapshot missing: {c['snapshot_missing']}")
+            if c["cumulative_missing"]:
+                print(f"       cumulative missing: {c['cumulative_missing']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_completion_shadow_scorer.py
+++ b/tests/test_completion_shadow_scorer.py
@@ -1,0 +1,202 @@
+"""Deterministic scorer for the completion-shadow corpus.
+
+Evaluation-only code. These tests pin the predicates and the conservative
+rules, and assert the scorer cannot reach a model.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "evaluation"))
+
+from score_completion_shadow import (  # noqa: E402
+    CheckpointScore,
+    classify_a,
+    classify_b,
+    classify_gap,
+    evaluate_finding,
+    score_text,
+)
+
+ORACLES = json.loads(
+    (Path(__file__).resolve().parents[1]
+     / "scripts/evaluation/completion_shadow_oracles.json").read_text()
+)
+
+
+class PredicateTests(unittest.TestCase):
+    def test_literal_present_and_absent(self) -> None:
+        spec = {"id": "x", "kind": "literal_all", "values": ["curl"]}
+        self.assertTrue(evaluate_finding(spec, "uses curl -useb").satisfied)
+        self.assertFalse(evaluate_finding(spec, "uses wget").satisfied)
+
+    def test_literal_all_needs_every_value(self) -> None:
+        # Pins `all` rather than `any`: a multi-value requirement is not met by
+        # one of its parts, which is what makes a conjunctive finding meaningful.
+        spec = {"id": "x", "kind": "literal_all", "values": ["alpha", "beta"]}
+        self.assertTrue(evaluate_finding(spec, "alpha and beta").satisfied)
+        self.assertFalse(evaluate_finding(spec, "alpha only").satisfied)
+        self.assertFalse(evaluate_finding(spec, "beta only").satisfied)
+
+    def test_literal_any_needs_only_one(self) -> None:
+        spec = {"id": "x", "kind": "literal_any", "values": ["alpha", "beta"]}
+        self.assertTrue(evaluate_finding(spec, "beta only").satisfied)
+        self.assertFalse(evaluate_finding(spec, "gamma").satisfied)
+
+    def test_absent_all_is_inverted(self) -> None:
+        spec = {"id": "x", "kind": "absent_all", "values": ["eval("]}
+        self.assertTrue(evaluate_finding(spec, "safe code").satisfied)
+        self.assertFalse(evaluate_finding(spec, "eval(payload)").satisfied)
+
+    def test_regex_is_bounded_not_semantic(self) -> None:
+        spec = {"id": "x", "kind": "regex", "pattern": r"(?i)Get-Date"}
+        self.assertTrue(evaluate_finding(spec, "$t = Get-Date").satisfied)
+        self.assertFalse(evaluate_finding(spec, "the current time").satisfied)
+
+    def test_unknown_kind_is_unscorable_not_guessed(self) -> None:
+        result = evaluate_finding({"id": "x", "kind": "vibes"}, "anything")
+        self.assertTrue(result.unscorable)
+        self.assertFalse(result.satisfied)
+
+
+class StaleEvidenceTrapTests(unittest.TestCase):
+    """The superseded domain must never satisfy the authoritative finding."""
+
+    SPEC = next(
+        f for f in ORACLES["samples"]["C"]["required_findings"] if f["id"] == "c2_domain"
+    )
+
+    def test_wrong_domain_alone_does_not_satisfy(self) -> None:
+        self.assertFalse(evaluate_finding(self.SPEC, "C2 is gibuyuy37v2v.top").satisfied)
+
+    def test_correct_domain_satisfies(self) -> None:
+        self.assertTrue(evaluate_finding(self.SPEC, "C2 is gibuzuy37v2v.top").satisfied)
+
+    def test_correction_record_still_satisfies(self) -> None:
+        # A record that quotes the error in order to correct it is authoritative.
+        text = "report said gibuyuy37v2v.top but the correct value is gibuzuy37v2v.top"
+        result = evaluate_finding(self.SPEC, text)
+        self.assertTrue(result.satisfied)
+        self.assertIn("forbidden present", result.detail)
+
+    def test_neither_domain_does_not_satisfy(self) -> None:
+        self.assertFalse(evaluate_finding(self.SPEC, "no domain here").satisfied)
+
+
+class CompletenessTests(unittest.TestCase):
+    ORACLE = {"required_findings": [
+        {"id": "one", "kind": "literal_all", "values": ["alpha"]},
+        {"id": "two", "kind": "literal_all", "values": ["beta"]},
+    ]}
+
+    def test_all_present_is_complete(self) -> None:
+        s = score_text(self.ORACLE, "alpha and beta", 4)
+        self.assertTrue(s.oracle_complete)
+        self.assertEqual(s.state, "COMPLETE")
+
+    def test_one_missing_is_incomplete(self) -> None:
+        s = score_text(self.ORACLE, "alpha only", 4)
+        self.assertFalse(s.oracle_complete)
+        self.assertEqual(s.missing, ["two"])
+
+    def test_unscorable_required_finding_forces_indeterminate(self) -> None:
+        oracle = {"required_findings": [
+            {"id": "one", "kind": "literal_all", "values": ["alpha"]},
+            {"id": "two", "kind": "unscorable"},
+        ]}
+        s = score_text(oracle, "alpha", 4)
+        self.assertEqual(s.state, "INDETERMINATE")
+        self.assertFalse(s.oracle_complete, "an undecided requirement is never complete")
+
+
+class VerifierClassificationTests(unittest.TestCase):
+    def test_a_false_complete_detected(self) -> None:
+        self.assertEqual(classify_a("COMPLETE", False, False), "A_FALSE_COMPLETE")
+
+    def test_a_true_complete_and_continue(self) -> None:
+        self.assertEqual(classify_a("COMPLETE", True, False), "A_TRUE_COMPLETE")
+        self.assertEqual(classify_a("CONTINUE", False, False), "A_TRUE_CONTINUE")
+        self.assertEqual(classify_a("CONTINUE", True, False), "A_FALSE_CONTINUE")
+
+    def test_b_false_gap_detected(self) -> None:
+        self.assertEqual(classify_b("GAP", True, False), "B_FALSE_GAP")
+
+    def test_b_false_no_gap_detected(self) -> None:
+        self.assertEqual(classify_b("NO_GAP", False, False), "B_FALSE_NO_GAP")
+
+    def test_b_not_called_when_a_continued(self) -> None:
+        self.assertEqual(classify_b(None, False, False), "B_NOT_CALLED")
+
+    def test_indeterminate_dominates(self) -> None:
+        self.assertEqual(classify_a("COMPLETE", False, True), "A_INDETERMINATE")
+        self.assertEqual(classify_b("GAP", False, True), "B_INDETERMINATE")
+
+
+class GapMaterialityTests(unittest.TestCase):
+    def test_real_gap_when_findings_missing(self) -> None:
+        s = CheckpointScore(action=4, required_total=2, missing=["two"])
+        self.assertEqual(classify_gap("missing: the C2", s), "MATERIAL_AND_REAL")
+
+    def test_gap_against_complete_oracle_is_not_material(self) -> None:
+        s = CheckpointScore(action=4, required_total=2, satisfied=["one", "two"])
+        self.assertEqual(
+            classify_gap("missing: something", s), "NON_MATERIAL_OR_ALREADY_SATISFIED"
+        )
+
+    def test_unscorable_gap_is_not_guessed(self) -> None:
+        s = CheckpointScore(action=4, required_total=1, unscorable=["one"])
+        self.assertEqual(classify_gap("missing: x", s), "UNSCORABLE")
+        self.assertEqual(classify_gap("", CheckpointScore(4, 1)), "UNSCORABLE")
+
+
+class ScorerIsOfflineTests(unittest.TestCase):
+    def test_scorer_makes_no_network_connection(self) -> None:
+        """Behavioural, not a substring scan.
+
+        Importing the EvidenceStore transitively pulls in the backend module,
+        so a source scan cannot establish this. Blocking the socket layer and
+        scoring the real corpus can.
+        """
+        import socket
+        from unittest import mock
+
+        corpus = Path("/home/guelfoweb/LAB/orbit-checkpoints"
+                      "/completion-shadow-corpus-20260827-103458")
+        if not corpus.is_dir():
+            self.skipTest("corpus not present")
+        from score_completion_shadow import score_corpus
+
+        def refuse(*_a, **_k):
+            raise AssertionError("scorer attempted a network connection")
+
+        import urllib.request
+
+        with mock.patch.object(socket.socket, "connect", refuse), \
+             mock.patch.object(socket.socket, "connect_ex", refuse), \
+             mock.patch.object(socket, "create_connection", refuse), \
+             mock.patch.object(socket, "getaddrinfo", refuse), \
+             mock.patch.object(urllib.request, "urlopen", refuse):
+            report = score_corpus(corpus, ORACLES)
+        self.assertEqual(sorted(report["runs"]), ["A", "B", "C"])
+
+    def test_scorer_never_imports_a_backend_or_network(self) -> None:
+        source = (Path(__file__).resolve().parents[1]
+                  / "scripts/evaluation/score_completion_shadow.py").read_text()
+        for forbidden in ("requests", "urllib", "httpx", "socket",
+                          "LlamaServerBackend", "complete_chat", "chat_stream",
+                          "NativeLlamaClient", "openai"):
+            self.assertNotIn(forbidden, source, f"scorer must not reach {forbidden}")
+
+    def test_oracles_are_evaluator_only(self) -> None:
+        # Nothing under src/ may load the oracle manifest.
+        root = Path(__file__).resolve().parents[1] / "src"
+        hits = [p for p in root.rglob("*.py")
+                if "completion_shadow_oracles" in p.read_text(errors="ignore")]
+        self.assertEqual(hits, [], "oracle must never enter runtime")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Evaluation only — no inference, no runtime change

A deterministic offline scorer for the completion-shadow corpus. It answers, without a single model call, whether verifier A and verifier B were each right at every checkpoint, and when an analysis was actually complete.

| | |
|---|---|
| Production code changed | **none** — `git diff --stat 8db8d2f -- src/` is empty |
| Can it call an LLM? | **No** — proven behaviourally, sockets blocked while scoring the real corpus |
| Oracle location | evaluator-only; nothing under `src/` reads it |
| Corpus | opened **read-only**, byte-unchanged after scoring (105/105 hashes) |
| Predicates | literal / bounded regex / exact id / explicit `unscorable` — no similarity |
| Active completion | **NOT AUTHORIZED** |

### Two views, deliberately separate

The **snapshot** view is exactly what the verifiers were shown — the only fair basis for grading them. The **cumulative** view is everything the analysis had established. They diverge, and that gap is itself the headline finding.

### Conservatism is structural

A required finding that cannot be decided from persisted text is `UNSCORABLE`, and a sample carrying one is never declared complete — it is `INDETERMINATE`. A `forbidden` value annotates but never satisfies a finding, so a superseded record cannot pass as authoritative.

### What it establishes on the collected corpus

- A said `COMPLETE` at **13/13** checkpoints and was wrong at **5** of them
- B blocked **every** one — `B_FALSE_NO_GAP = 0`
- An **A-only** gate would have made **2 false stops on 3 runs**
- The current **A+B** gate: **0 false stops, 0 stops** — safe, currently unproductive
- Run A was oracle-complete at action 4 but ran to 9 — one genuine missed opportunity

Crucially it also shows *why* A was wrong: the deciding evidence was **truncated out of its input** by the per-record 600-char snapshot excerpt, not absent from the analysis. At action 4 only 8 records existed, so this is not window eviction — 6 of those 8 carry the hidden-launch evidence in full text and none within the excerpt.

### Honesty guards

- **Wall savings reported as not exactly measurable** — per-step normal timing is not in the corpus; no average is presented as a decision input
- Overhead stated against the **normal-only baseline** (34.4%), not as a fraction of the shadow-inclusive total
- The stale-domain guard is described as **unit-tested, not corpus-proven** — that spelling appears in no evidence file
- `n=13` from 3 runs, one class excluded; the 5 false completes are correlated checkpoints from **one** run, not 5 independent observations

### Verification

25 focused tests; full suite **3232, exit 0**, 1 pre-existing environment skip; `compileall` and `git diff --check` clean. **11/11 mutants caught** (one, `literal_all`→`any`, initially survived and the gap was closed).

### Independent review

**MERGE SAFE: YES**, BLOCKER 0 / MAJOR 0. The reviewer independently ran 14 mutants (14/14 caught) and proved the no-network property by blocking sockets. Two MAJORs were raised and both fixed: an overhead denominator error (25.6% → 34.4%) and a misattributed mechanism (window eviction → per-record truncation).
