### PR TITLE
feat(runtime): record completion snapshot fidelity

### DIFF
--- a/scripts/evaluation/backfill_snapshot_fidelity.py
+++ b/scripts/evaluation/backfill_snapshot_fidelity.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Reconstruct snapshot fidelity for an already-collected corpus. No inference.
+
+The corpus preserves both the bounded snapshot the verifiers saw and the
+EvidenceStore it was drawn from, so fidelity is recoverable after the fact by
+comparing them. That is the whole point of having persisted both.
+
+Read-only: the corpus is never written to.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from orbit.runtime.completion_shadow import (  # noqa: E402
+    MAX_SNAPSHOT_ARTIFACTS,
+    MAX_SNAPSHOT_CHARS_PER_RECORD,
+    MAX_SNAPSHOT_RECORDS,
+    MAX_SNAPSHOT_REQUEST_CHARS,
+)
+from orbit.runtime.completion_shadow_ledger import read_ledger  # noqa: E402
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+
+
+def reconstruct(checkpoint: dict, store: EvidenceStore) -> dict:
+    """Fidelity of one persisted checkpoint, from the corpus alone."""
+    reasons: list[str] = []
+    truncated = []
+    for entry in checkpoint.get("snapshot_evidence", []):
+        evidence_id = entry.get("evidence_id", "")
+        included = entry.get("text", "")
+        authoritative = store.load_raw(evidence_id) or ""
+        if len(included) < len(authoritative):
+            truncated.append({
+                "evidence_id": evidence_id,
+                "authoritative_chars": len(authoritative),
+                "included_chars": len(included),
+            })
+    if truncated:
+        reasons.append("record_content_truncated")
+
+    included_records = len(checkpoint.get("snapshot_evidence", []))
+    if included_records >= MAX_SNAPSHOT_RECORDS:
+        # At the cap the snapshot cannot show whether more existed; the run's
+        # own record count is the only evidence, and it is not per-checkpoint.
+        reasons.append("record_count_cap_reached")
+
+    included_artifacts = len(checkpoint.get("snapshot_artifacts", []))
+    if included_artifacts >= MAX_SNAPSHOT_ARTIFACTS:
+        reasons.append("artifact_count_cap_reached")
+    if len(checkpoint.get("request", "")) >= MAX_SNAPSHOT_REQUEST_CHARS:
+        reasons.append("request_cap_reached")
+
+    return {
+        "action": checkpoint["action"],
+        "lossless": not reasons,
+        "reasons": reasons,
+        "active_records_included": included_records,
+        "truncated_record_count": len(truncated),
+        "truncated_records": truncated[:8],
+        "artifacts_included": included_artifacts,
+    }
+
+
+def main(argv: list[str]) -> int:
+    corpus = Path(argv[1])
+    out: dict = {"corpus": str(corpus), "runs": {}}
+    for label in ("A", "B", "C"):
+        d = corpus / "runs" / label
+        if not (d / "completion-shadow.jsonl").exists():
+            continue
+        ledger = read_ledger(d / "completion-shadow.jsonl")
+        store = EvidenceStore(root=d / "evidence")
+        store.load_index()
+        rows = [reconstruct(cp, store) for cp in ledger.checkpoints]
+        out["runs"][label] = rows
+        print(f"\n[{label}]  {len(store.records)} records in store")
+        print(f"{'act':>4} {'fidelity':>9} {'incl':>5} {'trunc':>6} {'arts':>5}  reasons")
+        for r in rows:
+            print(f"{r['action']:>4} {('LOSSLESS' if r['lossless'] else 'LOSSY'):>9} "
+                  f"{r['active_records_included']:>5} {r['truncated_record_count']:>6} "
+                  f"{r['artifacts_included']:>5}  {','.join(r['reasons'])}")
+    if len(argv) > 2:
+        Path(argv[2]).write_text(json.dumps(out, indent=2))
+    total = sum(len(v) for v in out["runs"].values())
+    lossy = sum(1 for v in out["runs"].values() for r in v if not r["lossless"])
+    print(f"\nTOTAL: {total} checkpoints, {lossy} LOSSY, {total-lossy} LOSSLESS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/orbit/runtime/completion_shadow.py
+++ b/src/orbit/runtime/completion_shadow.py
@@ -85,6 +85,68 @@ def scheduled_actions(schedule: str = "after4every2") -> Callable[[int], bool]:
 
 
 @dataclass(frozen=True)
+class TruncatedRecord:
+    """One record that reached the verifiers shorter than it really is."""
+
+    evidence_id: str
+    authoritative_chars: int
+    included_chars: int
+
+
+@dataclass(frozen=True)
+class CompletionSnapshotFidelity:
+    """Whether the snapshot is the whole of its canonical input, or less.
+
+    Side-band only: this never reaches a verifier and never changes a byte of
+    what they are shown. It exists because a verdict reached on a truncated
+    view is not evidence about the verifier -- it is evidence about the view.
+    Without this the two are indistinguishable after the fact.
+
+    "Lossless" is deliberately hard to earn: every ACTIVE record the contract
+    selected must be present, whole, with every artifact handle and the full
+    request. Anything less is lossy with a stated reason. Nothing here infers
+    that an omission was harmless -- that judgement is exactly what this
+    refuses to make.
+    """
+
+    lossless: bool
+    reasons: tuple[str, ...] = ()
+    request_truncated: bool = False
+    request_authoritative_chars: int = 0
+    request_included_chars: int = 0
+    active_records_total: int = 0
+    active_records_included: int = 0
+    omitted_record_count: int = 0
+    truncated_records: tuple[TruncatedRecord, ...] = ()
+    artifacts_total: int = 0
+    artifacts_included: int = 0
+    omitted_artifact_count: int = 0
+
+    def as_log_fields(self) -> dict[str, object]:
+        return {
+            "lossless": self.lossless,
+            "reasons": list(self.reasons),
+            "request_truncated": self.request_truncated,
+            "request_authoritative_chars": self.request_authoritative_chars,
+            "request_included_chars": self.request_included_chars,
+            "active_records_total": self.active_records_total,
+            "active_records_included": self.active_records_included,
+            "omitted_record_count": self.omitted_record_count,
+            "truncated_records": [
+                {
+                    "evidence_id": r.evidence_id,
+                    "authoritative_chars": r.authoritative_chars,
+                    "included_chars": r.included_chars,
+                }
+                for r in self.truncated_records
+            ],
+            "artifacts_total": self.artifacts_total,
+            "artifacts_included": self.artifacts_included,
+            "omitted_artifact_count": self.omitted_artifact_count,
+        }
+
+
+@dataclass(frozen=True)
 class CompletionSnapshot:
     """What both verifiers see, and the hash that proves they saw the same thing."""
 
@@ -92,6 +154,9 @@ class CompletionSnapshot:
     evidence: tuple[tuple[str, str], ...]
     artifacts: tuple[str, ...]
     digest: str
+    # Describes the snapshot; is not part of it. `digest` still covers exactly
+    # the model-visible bytes, so adding this cannot move a hash.
+    fidelity: "CompletionSnapshotFidelity | None" = None
 
     def render(self) -> str:
         lines = [f"REQUEST: {self.request}", "", "ESTABLISHED EVIDENCE:"]
@@ -117,19 +182,77 @@ def build_snapshot(
     """
     evidence: list[tuple[str, str]] = []
     artifacts: list[str] = []
-    for record in records[-MAX_SNAPSHOT_RECORDS:]:
+    truncated: list[TruncatedRecord] = []
+    selected = records[-MAX_SNAPSHOT_RECORDS:]
+    for record in selected:
         evidence_id = str(getattr(record, "evidence_id", "") or "")
         if not evidence_id:
             continue
         raw = load_raw(evidence_id) or ""
-        evidence.append((evidence_id, raw[:MAX_SNAPSHOT_CHARS_PER_RECORD]))
+        excerpt = raw[:MAX_SNAPSHOT_CHARS_PER_RECORD]
+        evidence.append((evidence_id, excerpt))
+        if len(excerpt) < len(raw):
+            truncated.append(TruncatedRecord(evidence_id, len(raw), len(excerpt)))
         metadata = getattr(record, "metadata", None) or {}
         for artifact in metadata.get("artifacts") or []:
             handle = str(artifact.get("handle") or "")
             if handle and handle not in artifacts:
                 artifacts.append(handle)
+
+    # Handles are gathered only from the records that survived the count cap,
+    # so an evicted record takes its artifacts with it. Counting the whole
+    # ACTIVE view separately is what keeps that cascade visible instead of
+    # letting it read as "there were only this many".
+    all_handles: list[str] = []
+    for record in records:
+        metadata = getattr(record, "metadata", None) or {}
+        for artifact in metadata.get("artifacts") or []:
+            handle = str(artifact.get("handle") or "")
+            if handle and handle not in all_handles:
+                all_handles.append(handle)
+
+    artifacts_before_cap = len(artifacts)
     artifacts = artifacts[:MAX_SNAPSHOT_ARTIFACTS]
-    request = (request or "")[:MAX_SNAPSHOT_REQUEST_CHARS]
+    full_request = request or ""
+    request = full_request[:MAX_SNAPSHOT_REQUEST_CHARS]
+
+    reasons: list[str] = []
+    omitted_records = max(0, len(records) - len(selected))
+    if omitted_records:
+        reasons.append("record_count_cap")
+    # A selected record that produced no entry was dropped for its own reason
+    # -- no usable evidence id -- and dropping it silently would let a snapshot
+    # missing a record still call itself whole. Counted separately from the
+    # count cap because the cause, and any fix, are different.
+    unusable_records = len(selected) - len(evidence)
+    if unusable_records:
+        reasons.append("record_unusable")
+    if truncated:
+        reasons.append("record_content_truncated")
+    if len(artifacts) < artifacts_before_cap:
+        reasons.append("artifact_count_cap")
+    if len(all_handles) > len(artifacts):
+        # Either the cap fired or an evicted record carried handles; both mean
+        # the verifiers were shown fewer artifacts than the analysis holds.
+        if "artifact_count_cap" not in reasons:
+            reasons.append("artifact_omitted_with_record")
+    if len(request) < len(full_request):
+        reasons.append("request_truncated")
+
+    fidelity = CompletionSnapshotFidelity(
+        lossless=not reasons,
+        reasons=tuple(reasons),
+        request_truncated=len(request) < len(full_request),
+        request_authoritative_chars=len(full_request),
+        request_included_chars=len(request),
+        active_records_total=len(records),
+        active_records_included=len(evidence),
+        omitted_record_count=omitted_records + unusable_records,
+        truncated_records=tuple(truncated),
+        artifacts_total=len(all_handles),
+        artifacts_included=len(artifacts),
+        omitted_artifact_count=max(0, len(all_handles) - len(artifacts)),
+    )
     payload = json.dumps(
         {"request": request, "evidence": evidence, "artifacts": artifacts},
         ensure_ascii=False,
@@ -141,6 +264,7 @@ def build_snapshot(
         evidence=tuple(evidence),
         artifacts=tuple(artifacts),
         digest=digest,
+        fidelity=fidelity,
     )
 
 
@@ -244,6 +368,7 @@ class ShadowObservation:
     # which is what the historical corpus lacked; the raw answers are bounded
     # excerpts kept for parser audit, never a transcript.
     snapshot: "CompletionSnapshot | None" = None
+    snapshot_fidelity: "CompletionSnapshotFidelity | None" = None
     verifier_a_evidence_ids: tuple[str, ...] = ()
     verifier_a_detail: str = ""
     verifier_b_detail: str = ""
@@ -307,7 +432,10 @@ def evaluate_completion_shadow(
     injected so the loop owns the call and this module owns only the policy.
     """
     observation = ShadowObservation(
-        action=action, snapshot_digest=snapshot.digest, snapshot=snapshot
+        action=action,
+        snapshot_digest=snapshot.digest,
+        snapshot=snapshot,
+        snapshot_fidelity=getattr(snapshot, "fidelity", None),
     )
     started = time.monotonic()
 
@@ -368,6 +496,16 @@ def evaluate_completion_shadow(
             observation.blocked_by = "verifier_b_gap"
             return observation
 
+        # Last gate, and deliberately last: a verdict reached on a partial view
+        # says nothing about whether the analysis is done. Refusing here is not
+        # a judgement that something material was lost -- it is a refusal to
+        # guess either way, which is the same conservatism every other gate
+        # applies.
+        fidelity = getattr(snapshot, "fidelity", None)
+        if fidelity is not None and not fidelity.lossless:
+            observation.blocked_by = "snapshot_lossy"
+            return observation
+
         observation.would_stop = True
         return observation
     except BaseException as exc:  # noqa: BLE001 - a failed verifier must never end a run
@@ -391,8 +529,10 @@ __all__ = [
     "SHADOW_ENV",
     "VERIFIER_MAX_TOKENS",
     "CompletionSnapshot",
+    "CompletionSnapshotFidelity",
     "ShadowLedger",
     "ShadowObservation",
+    "TruncatedRecord",
     "VerifierVerdict",
     "build_snapshot",
     "evaluate_completion_shadow",

--- a/src/orbit/runtime/completion_shadow_ledger.py
+++ b/src/orbit/runtime/completion_shadow_ledger.py
@@ -138,6 +138,15 @@ class ShadowLedgerWriter:
             "verifier_prompt_tokens": observation.prompt_tokens,
             "verifier_output_tokens": observation.output_tokens,
             "verifier_wall_seconds": round(observation.wall_seconds, 3),
+            # Additive: a v1 reader ignores it and a v1 ledger simply has no
+            # fidelity, which reads as unknown rather than lossless. Bumping
+            # the schema would have invalidated an expensive corpus that is
+            # still perfectly valid for everything it does record.
+            "snapshot_fidelity": (
+                observation.snapshot_fidelity.as_log_fields()
+                if getattr(observation, "snapshot_fidelity", None) is not None
+                else None
+            ),
             **fields,
         }
         return self._append(payload)
@@ -167,6 +176,28 @@ class LedgerReadResult:
     def complete(self) -> bool:
         """A run that never wrote its final record did not finish normally."""
         return self.run_final is not None
+
+    @property
+    def lossy_actions(self) -> tuple[int, ...]:
+        """Checkpoints whose snapshot was not the whole of its input.
+
+        A checkpoint with no fidelity record is not counted: an older ledger
+        that predates the field is unknown, not lossless.
+        """
+        return tuple(
+            int(item["action"])
+            for item in self.checkpoints
+            if isinstance(item.get("snapshot_fidelity"), dict)
+            and item["snapshot_fidelity"].get("lossless") is False
+        )
+
+    @property
+    def fidelity_unknown_actions(self) -> tuple[int, ...]:
+        return tuple(
+            int(item["action"])
+            for item in self.checkpoints
+            if not isinstance(item.get("snapshot_fidelity"), dict)
+        )
 
     @property
     def would_stop_actions(self) -> tuple[int, ...]:

--- a/tests/test_completion_shadow_ledger.py
+++ b/tests/test_completion_shadow_ledger.py
@@ -309,6 +309,67 @@ class WriterTests(unittest.TestCase):
         self.assertEqual(len(stored["snapshot_artifacts"]), MAX_SNAPSHOT_ARTIFACTS)
         self.assertEqual(verify_snapshot_hashes(read_ledger(self.path)), ())
 
+    def test_fidelity_is_persisted_and_readable(self) -> None:
+        from orbit.runtime.completion_shadow import build_snapshot as bs
+
+        class _Rec:
+            evidence_id = "ev_a"
+            metadata: dict = {}
+
+        lossy = bs(request="r", records=[_Rec()], load_raw=lambda _i: "x" * 5000)
+        obs = _observation(4)
+        obs.snapshot = lossy
+        obs.snapshot_fidelity = lossy.fidelity
+        obs.snapshot_digest = lossy.digest
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(obs)
+
+        record = read_ledger(self.path).checkpoints[0]
+        stored = record["snapshot_fidelity"]
+        self.assertFalse(stored["lossless"])
+        self.assertIn("record_content_truncated", stored["reasons"])
+        self.assertEqual(stored["truncated_records"][0]["authoritative_chars"], 5000)
+        self.assertEqual(stored["truncated_records"][0]["included_chars"], 600)
+
+    def test_reader_reports_lossy_and_unknown_separately(self) -> None:
+        from orbit.runtime.completion_shadow import build_snapshot as bs
+
+        class _Rec:
+            evidence_id = "ev_a"
+            metadata: dict = {}
+
+        lossy = bs(request="r", records=[_Rec()], load_raw=lambda _i: "x" * 5000)
+        with_fid = _observation(4)
+        with_fid.snapshot, with_fid.snapshot_fidelity = lossy, lossy.fidelity
+        without = _observation(6)  # older shape: no fidelity recorded
+
+        writer = ShadowLedgerWriter(self.path)
+        writer.write_checkpoint(with_fid)
+        writer.write_checkpoint(without)
+
+        result = read_ledger(self.path)
+        self.assertEqual(result.lossy_actions, (4,))
+        self.assertEqual(result.fidelity_unknown_actions, (6,),
+                         "a ledger predating fidelity is unknown, never lossless")
+        self.assertNotIn(6, result.lossy_actions,
+                         "unknown fidelity must not be reported as lossy either")
+
+    def test_a_lossless_record_is_not_counted_lossy(self) -> None:
+        from orbit.runtime.completion_shadow import build_snapshot as bs
+
+        class _Rec:
+            evidence_id = "ev_a"
+            metadata: dict = {}
+
+        clean = bs(request="r", records=[_Rec()], load_raw=lambda _i: "short")
+        self.assertTrue(clean.fidelity.lossless)
+        obs = _observation(8)
+        obs.snapshot, obs.snapshot_fidelity = clean, clean.fidelity
+        ShadowLedgerWriter(self.path).write_checkpoint(obs)
+        result = read_ledger(self.path)
+        self.assertEqual(result.lossy_actions, ())
+        self.assertEqual(result.fidelity_unknown_actions, ())
+
     def test_request_is_bounded_in_the_snapshot(self) -> None:
         from orbit.runtime.completion_shadow import MAX_SNAPSHOT_REQUEST_CHARS
 

--- a/tests/test_completion_snapshot_fidelity.py
+++ b/tests/test_completion_snapshot_fidelity.py
@@ -1,0 +1,190 @@
+"""Snapshot fidelity: does the verifier see the whole of its input, or less."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from orbit.runtime.completion_shadow import (
+    MAX_SNAPSHOT_ARTIFACTS,
+    MAX_SNAPSHOT_CHARS_PER_RECORD,
+    MAX_SNAPSHOT_RECORDS,
+    MAX_SNAPSHOT_REQUEST_CHARS,
+    CompletionSnapshot,
+    build_snapshot,
+    evaluate_completion_shadow,
+)
+
+
+class _Record:
+    def __init__(self, evidence_id: str, artifacts=()) -> None:
+        self.evidence_id = evidence_id
+        self.metadata = {"artifacts": [{"handle": h} for h in artifacts]}
+
+
+def _snapshot(records, raw, request="r"):
+    return build_snapshot(request=request, records=records, load_raw=lambda _i: raw)
+
+
+class LosslessTests(unittest.TestCase):
+    def test_everything_fits_is_lossless(self) -> None:
+        s = _snapshot([_Record("ev_a")], "short")
+        self.assertTrue(s.fidelity.lossless)
+        self.assertEqual(s.fidelity.reasons, ())
+        self.assertEqual(s.fidelity.active_records_total, 1)
+        self.assertEqual(s.fidelity.active_records_included, 1)
+
+    def test_record_exactly_at_the_cap_is_lossless(self) -> None:
+        # The boundary is the interesting case: equal is not truncated.
+        s = _snapshot([_Record("ev_a")], "x" * MAX_SNAPSHOT_CHARS_PER_RECORD)
+        self.assertTrue(s.fidelity.lossless)
+        self.assertEqual(s.fidelity.truncated_records, ())
+
+
+class LossyTests(unittest.TestCase):
+    def test_one_char_over_the_cap_is_lossy(self) -> None:
+        s = _snapshot([_Record("ev_a")], "x" * (MAX_SNAPSHOT_CHARS_PER_RECORD + 1))
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("record_content_truncated", s.fidelity.reasons)
+        t = s.fidelity.truncated_records[0]
+        self.assertEqual(t.authoritative_chars, MAX_SNAPSHOT_CHARS_PER_RECORD + 1)
+        self.assertEqual(t.included_chars, MAX_SNAPSHOT_CHARS_PER_RECORD)
+
+    def test_omitted_record_is_lossy_and_counted(self) -> None:
+        records = [_Record(f"ev_{i}") for i in range(MAX_SNAPSHOT_RECORDS + 3)]
+        s = _snapshot(records, "short")
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("record_count_cap", s.fidelity.reasons)
+        self.assertEqual(s.fidelity.omitted_record_count, 3)
+        self.assertEqual(s.fidelity.active_records_included, MAX_SNAPSHOT_RECORDS)
+
+    def test_artifact_overflow_is_lossy(self) -> None:
+        handles = [f"/w/{i}" for i in range(MAX_SNAPSHOT_ARTIFACTS + 5)]
+        s = _snapshot([_Record("ev_a", handles)], "short")
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("artifact_count_cap", s.fidelity.reasons)
+        self.assertEqual(s.fidelity.omitted_artifact_count, 5)
+
+    def test_artifact_lost_with_an_evicted_record_is_reported(self) -> None:
+        # The cascade: a handle can vanish because its record was evicted,
+        # which is a different reason from the artifact cap firing.
+        records = [_Record("ev_old", ["/w/gone"])] + [
+            _Record(f"ev_{i}") for i in range(MAX_SNAPSHOT_RECORDS)
+        ]
+        s = _snapshot(records, "short")
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("artifact_omitted_with_record", s.fidelity.reasons)
+        self.assertEqual(s.fidelity.artifacts_total, 1)
+        self.assertEqual(s.fidelity.artifacts_included, 0)
+
+    def test_a_record_dropped_for_a_missing_id_is_lossy(self) -> None:
+        """A record can be skipped for its own reason, not just a cap.
+
+        Without this the snapshot would be one record short and still call
+        itself whole, which is the one thing `lossless` must never do.
+        """
+        s = _snapshot([_Record(""), _Record("ev_a")], "short")
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("record_unusable", s.fidelity.reasons)
+        self.assertEqual(s.fidelity.omitted_record_count, 1)
+        self.assertEqual(s.fidelity.active_records_total, 2)
+        self.assertEqual(s.fidelity.active_records_included, 1)
+
+    def test_request_truncation_is_lossy(self) -> None:
+        s = _snapshot([_Record("ev_a")], "short", "q" * (MAX_SNAPSHOT_REQUEST_CHARS + 1))
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("request_truncated", s.fidelity.reasons)
+        self.assertTrue(s.fidelity.request_truncated)
+
+    def test_multiple_simultaneous_reasons(self) -> None:
+        records = [_Record(f"ev_{i}") for i in range(MAX_SNAPSHOT_RECORDS + 2)]
+        s = _snapshot(records, "x" * 5000, "q" * (MAX_SNAPSHOT_REQUEST_CHARS + 1))
+        self.assertFalse(s.fidelity.lossless)
+        for reason in ("record_count_cap", "record_content_truncated", "request_truncated"):
+            self.assertIn(reason, s.fidelity.reasons)
+
+
+class ModelVisibleBytesUnchangedTests(unittest.TestCase):
+    def test_fidelity_does_not_alter_the_snapshot_or_its_hash(self) -> None:
+        """Fidelity describes the snapshot; it must not be part of it."""
+        one = _snapshot([_Record("ev_a")], "x" * 5000)
+        two = _snapshot([_Record("ev_a")], "x" * 5000)
+        self.assertEqual(one.digest, two.digest)
+        self.assertEqual(one.render(), two.render())
+        # The rendered text is what the verifiers read; nothing from fidelity
+        # may appear in it.
+        for token in ("lossless", "truncated", "authoritative_chars", "fidelity"):
+            self.assertNotIn(token, one.render())
+
+    def test_digest_is_stable_against_a_known_value(self) -> None:
+        # Pins that adding fidelity did not move the hash for a fixed input.
+        s = build_snapshot(request="r", records=[_Record("ev_a")], load_raw=lambda _i: "text")
+        import hashlib
+        import json
+
+        expected = hashlib.sha256(
+            json.dumps(
+                {"request": "r", "evidence": [["ev_a", "text"]], "artifacts": []},
+                ensure_ascii=False, sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(s.digest, expected)
+
+
+class FidelityGateTests(unittest.TestCase):
+    LIVE = "ev_000000000000_0000000000000000"
+
+    def _run(self, snapshot):
+        answers = [f"COMPLETE evidence: {self.LIVE}", "NO_GAP"]
+        seen: list[str] = []
+
+        class _R:
+            def __init__(self, text):
+                self.content = text
+                self.prompt_tokens = 10
+                self.completion_tokens = 2
+
+        def ask(_i, _r):
+            seen.append(_i)
+            return _R(answers[len(seen) - 1])
+
+        return evaluate_completion_shadow(
+            action=4, snapshot=snapshot, ask=ask,
+            active_evidence_ids={self.LIVE}, reattest=lambda _i: "raw",
+        )
+
+    def test_lossless_snapshot_permits_would_stop(self) -> None:
+        obs = self._run(_snapshot([_Record("ev_a")], "short"))
+        self.assertTrue(obs.would_stop)
+        self.assertIsNone(obs.blocked_by)
+
+    def test_lossy_snapshot_forces_would_stop_false(self) -> None:
+        obs = self._run(_snapshot([_Record("ev_a")], "x" * 5000))
+        self.assertFalse(obs.would_stop)
+        self.assertEqual(obs.blocked_by, "snapshot_lossy")
+
+    def test_absent_fidelity_does_not_fabricate_a_block(self) -> None:
+        # A snapshot built without fidelity (an older path) is not treated as
+        # lossy; it is simply not gated, which is the pre-existing behaviour.
+        obs = self._run(CompletionSnapshot("r", (("ev_a", "t"),), (), "d" * 64))
+        self.assertTrue(obs.would_stop)
+
+    def test_gate_runs_after_the_existing_gates(self) -> None:
+        # A lossy snapshot whose verifiers disagree is still blocked by the
+        # disagreement, not silently relabelled.
+        answers = ["CONTINUE missing: x"]
+
+        class _R:
+            content = answers[0]
+            prompt_tokens = 10
+            completion_tokens = 2
+
+        obs = evaluate_completion_shadow(
+            action=4, snapshot=_snapshot([_Record("ev_a")], "x" * 5000),
+            ask=lambda _i, _r: _R(), active_evidence_ids=set(), reattest=lambda _i: "raw",
+        )
+        self.assertEqual(obs.blocked_by, "verifier_a_continue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The corpus proved the verifiers were judged on incomplete input

Verifier A declared an analysis COMPLETE while the evidence that would have contradicted it sat in the store, past the 600-character excerpt each record gets. A was not wrong about what it saw — it was **shown less than the analysis knew**. This records whether a snapshot is the whole of its canonical input, so verifier behaviour can be separated from input completeness.

### Lossy transforms inventoried

| # | Transform | Bound | Reason code |
|---|---|---:|---|
| 1 | ACTIVE record count cap | 12 | `record_count_cap` |
| 2 | **per-record character cap** | **600** | `record_content_truncated` |
| 3 | artifact handle cap | 16 | `artifact_count_cap` |
| 4 | request cap | 2000 | `request_truncated` |
| 5 | *cascade* — handles gathered only from included records | — | `artifact_omitted_with_record` |

(5) falls out of (1) and is reported separately, because the two imply different fixes.

### Guarantees

| | |
|---|---|
| Model-visible snapshot changed | **NO** — byte-identical; a test asserts no fidelity token appears in `render()` |
| `snapshot_sha256` semantics changed | **NO** — still hashes exactly what the verifiers read; pinned against a known digest |
| Verifier prompts / schedule changed | **NO** |
| Autonomous behaviour changed | **NO** |
| Shadow default | **OFF** |
| Active completion | **NOT AUTHORIZED** |

### New conservative gate (shadow only)

`lossless == false` → `WOULD_STOP = false`, `blocked_by = snapshot_lossy`. Evaluated **last**, so an existing disagreement is still reported as itself rather than relabelled.

### Ledger: additive, old corpus stays valid

A v1 ledger has no fidelity, which reads as **unknown** — never as lossless. `lossy_actions` and `fidelity_unknown_actions` are reported separately, and a test pins that an unknown record is not counted lossy.

### Offline backfill of the collected corpus — no inference

**All 13 checkpoints are LOSSY. Zero lossless.**

```
[A] 4 LOSSY (2/8 truncated) · 6 LOSSY (6/12) · 8 LOSSY (10/12)
[B] 4,6,8,10,12 all LOSSY
[C] 4 LOSSY (7/8 truncated) · 6,8,10,12 all LOSSY
```

Deterministic proof for run C action 4: only **8** records exist, so the 12-record window evicted nothing. **6 of those 8 carry the hidden-launch evidence in their authoritative text; 0 carry it in the snapshot.** Cause: the 600-char per-record cap.

### Consequence — this weakens my own earlier conclusions

| | before | after |
|---|---|---|
| A | 3 TRUE_COMPLETE, 5 FALSE_COMPLETE, 5 INDETERMINATE | **13 UNTRUSTED_LOSSY** |
| B | 3 FALSE_GAP, 5 TRUE_GAP, 5 INDETERMINATE | **13 UNTRUSTED_LOSSY** |

The five false completes that motivated this work are now input-untrusted, and run A's action-4 checkpoint — which I had cited as evidence of B being over-conservative — is lossy too, so it cannot support that claim either. **Neither verifier has been measured on a single lossless checkpoint.**

### WOULD_STOP replay

| Policy | WOULD_STOP | False stops |
|---|---:|---:|
| Without fidelity gate | 0/13 | 0 |
| With fidelity gate | 0/13 | 0 |

The gate changes nothing on this corpus — every checkpoint was already blocked by verifier B. It is structural insurance, not a fix for an observed failure.

### Cost

Fidelity construction is **0.084 ms/checkpoint** total (the *marginal* cost over base is ~0.024 ms), against ~137 s of verifier inference.

Ledger records grow by **~1262-1623 B**. Measured against the real corpus, whose checkpoint lines average **8061 B**, that is **+16 to +20%** — not the +63% an earlier draft of this description claimed, which used an invented ~2100 B denominator matching no record type in the corpus. The field is bounded by construction: `truncated_records` cannot exceed `MAX_SNAPSHOT_RECORDS` (12), so it caps at ~1.6 KB.

### Verification

28 focused tests; full suite **3250, exit 0, 1 skip — on a tree with the native runtime built**. The vendored `.so` files are gitignored, so a bare clone instead sees 15 environment skips and one failure in `test_process_rejects_a_second_runtime_family`; both reproduce identically at base `13911c3` and are unrelated to this change.

**10/10 mutants caught.** Two gaps were found and closed during review: unknown-fidelity-read-as-lossy, and a **false-LOSSLESS hole** where a record skipped for a missing `evidence_id` was dropped silently while fidelity still reported `lossless=True` — now a distinct `record_unusable` reason. `compileall` and `git diff --check` clean.
