### PR TITLE
fix(runtime): require lossless completion snapshots

### DIFF
--- a/scripts/evaluation/measure_snapshot_capacity.py
+++ b/scripts/evaluation/measure_snapshot_capacity.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""What would a LOSSLESS completion snapshot actually cost, in exact tokens?
+
+Zero inference. The GGUF is opened vocab-only -- no weight tensors are
+allocated -- so this measures the real tokenizer without ever running the
+model. Character estimates are not used anywhere: the question is how many
+tokens the verifier prompt would really be, and only the tokenizer knows.
+
+Reads the preserved corpus read-only and reconstructs, for each persisted
+checkpoint, the snapshot that Orbit *would* have built had nothing been
+truncated or omitted.
+"""
+from __future__ import annotations
+
+import ctypes
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama.bindings import LlamaLibrary  # noqa: E402
+from orbit.runtime.completion_shadow import (  # noqa: E402
+    VERIFIER_A_INSTRUCTION,
+    VERIFIER_B_INSTRUCTION,
+    CompletionSnapshot,
+)
+from orbit.runtime.completion_shadow_ledger import read_ledger  # noqa: E402
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+
+MODEL = ROOT / "models/ornith-ai--Ornith-1.5-35B-A3B-GGUF/Ornith-1.5-35B-Q4_K_M.gguf"
+BUILD = ROOT / "src/orbit/native_llama/vendor/build/llama.cpp/bin"
+BUDGETS = (1024, 2048, 4096, 6144, 8192, 12288)
+
+
+class VocabTokenizer:
+    """Exact tokenization with no weights loaded and no inference possible."""
+
+    def __init__(self, build_bin: Path, model_path: Path) -> None:
+        self._binding = LlamaLibrary(build_bin)
+        lib = self._binding.lib
+        lib.llama_backend_init()
+        params = lib.llama_model_default_params()
+        params.vocab_only = True
+        params.use_mmap = True
+        self._model = lib.llama_model_load_from_file(str(model_path).encode(), params)
+        if not self._model:
+            raise RuntimeError("vocab-only load failed")
+        self._vocab = lib.llama_model_get_vocab(self._model)
+        self._lib = lib
+
+    def count(self, text: str) -> int:
+        data = text.encode("utf-8")
+        cap = len(data) + 64
+        out = (ctypes.c_int32 * cap)()
+        n = self._lib.llama_tokenize(
+            self._vocab, data, len(data), out, cap, False, False
+        )
+        if n < 0:
+            raise RuntimeError("tokenization overflow")
+        return int(n)
+
+    def close(self) -> None:
+        self._lib.llama_model_free(self._model)
+
+
+def full_snapshot(checkpoint: dict, store: EvidenceStore, request: str) -> CompletionSnapshot:
+    """The snapshot the contract would produce with nothing dropped."""
+    evidence = tuple(
+        (e["evidence_id"], store.load_raw(e["evidence_id"]) or "")
+        for e in checkpoint.get("snapshot_evidence", [])
+    )
+    return CompletionSnapshot(
+        request=request,
+        evidence=evidence,
+        artifacts=tuple(checkpoint.get("snapshot_artifacts", [])),
+        digest="",
+    )
+
+
+def bounded_snapshot(checkpoint: dict, request: str) -> CompletionSnapshot:
+    return CompletionSnapshot(
+        request=request,
+        evidence=tuple(
+            (e["evidence_id"], e.get("text", ""))
+            for e in checkpoint.get("snapshot_evidence", [])
+        ),
+        artifacts=tuple(checkpoint.get("snapshot_artifacts", [])),
+        digest="",
+    )
+
+
+def main(argv: list[str]) -> int:
+    corpus = Path(argv[1])
+    tok = VocabTokenizer(BUILD, MODEL)
+    # The verifier prompt is instruction + snapshot; both must fit the budget.
+    overhead = max(tok.count(VERIFIER_A_INSTRUCTION), tok.count(VERIFIER_B_INSTRUCTION))
+    print(f"verifier instruction overhead: {overhead} tokens (larger of A/B)\n")
+
+    rows = []
+    for label in ("A", "B", "C"):
+        d = corpus / "runs" / label
+        ledger = read_ledger(d / "completion-shadow.jsonl")
+        store = EvidenceStore(root=d / "evidence")
+        store.load_index()
+        for cp in ledger.checkpoints:
+            request = cp.get("request", "")
+            full = full_snapshot(cp, store, request)
+            bounded = bounded_snapshot(cp, request)
+            full_text, bounded_text = full.render(), bounded.render()
+            full_tokens = tok.count(full_text)
+            largest = max(
+                (tok.count(text) for _i, text in full.evidence), default=0
+            )
+            rows.append({
+                "run": label,
+                "action": cp["action"],
+                "records": len(full.evidence),
+                "artifacts": len(full.artifacts),
+                "bounded_chars": len(bounded_text),
+                "full_chars": len(full_text),
+                "bounded_tokens": tok.count(bounded_text),
+                "full_tokens": full_tokens,
+                "largest_record_tokens": largest,
+                "prompt_tokens_if_lossless": full_tokens + overhead,
+            })
+    tok.close()
+
+    print(f"{'run':>4}{'act':>5}{'recs':>6}{'arts':>6}{'bounded_tok':>13}{'full_tok':>10}"
+          f"{'delta':>8}{'largest':>9}{'prompt':>8}  " + "".join(f"{b//1024}K".rjust(6) for b in BUDGETS))
+    for r in rows:
+        fits = "".join(
+            ("yes" if r["prompt_tokens_if_lossless"] <= b else "-").rjust(6) for b in BUDGETS
+        )
+        print(f"{r['run']:>4}{r['action']:>5}{r['records']:>6}{r['artifacts']:>6}"
+              f"{r['bounded_tokens']:>13}{r['full_tokens']:>10}"
+              f"{r['full_tokens']-r['bounded_tokens']:>8}{r['largest_record_tokens']:>9}"
+              f"{r['prompt_tokens_if_lossless']:>8}  {fits}")
+
+    print(f"\n{'budget':>8}{'lossless / 13':>16}")
+    for b in BUDGETS:
+        n = sum(1 for r in rows if r["prompt_tokens_if_lossless"] <= b)
+        print(f"{b:>8}{f'{n} / 13':>16}")
+
+    if len(argv) > 2:
+        Path(argv[2]).write_text(json.dumps(
+            {"instruction_overhead_tokens": overhead, "budgets": list(BUDGETS), "rows": rows},
+            indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -59,7 +59,9 @@ from orbit.runtime.completion_shadow import (
     ANALYSIS_COMPLETION_SHADOW_PHASE,
     VERIFIER_MAX_TOKENS,
     ShadowLedger,
+    build_lossless_snapshot,
     build_snapshot,
+    snapshot_fits_budget,
     evaluate_completion_shadow,
     scheduled_actions,
     shadow_enabled,
@@ -73,6 +75,10 @@ from orbit.runtime.kv_diag import model_call_context
 from orbit.runtime.tool_calls import tool_call_id
 
 ANALYSIS_TOOL_NAME = "execute_analysis"
+
+class _TokenCountUnavailable(RuntimeError):
+    """The backend could not tokenize, so the completion budget is unverifiable."""
+
 
 # The phase this runtime declares around its one model call. It names a kind of
 # call, not a mode: the backend uses it the way it already uses "route", to know
@@ -1327,7 +1333,7 @@ class AnalysisRuntime:
             active_ids = {
                 str(getattr(record, "evidence_id", "") or "") for record in records
             }
-            snapshot = build_snapshot(
+            snapshot = build_lossless_snapshot(
                 request=request,
                 records=records,
                 load_raw=self.evidence_store.load_raw,
@@ -1348,12 +1354,30 @@ class AnalysisRuntime:
                         tools=[],
                     )
 
+            # Exact tokens from the model's own tokenizer. If the backend
+            # cannot supply them the checkpoint is skipped rather than
+            # estimated: an estimate wrong in the permissive direction would
+            # put an oversized prompt in front of a verifier, which is the one
+            # outcome the budget exists to prevent.
+            def count_tokens(text: str) -> int:
+                counted = self.backend.count_text_tokens(text)
+                if counted is None:
+                    raise _TokenCountUnavailable()
+                return int(counted.tokens)
+
+            try:
+                fits, total = snapshot_fits_budget(snapshot, count_tokens)
+            except _TokenCountUnavailable:
+                fits, total = False, None
+
             return evaluate_completion_shadow(
                 action=actions,
                 snapshot=snapshot,
                 ask=ask,
                 active_evidence_ids=active_ids,
                 reattest=self.evidence_store.reattest_exact,
+                fits_budget=fits,
+                snapshot_tokens=total,
             )
         except BaseException as exc:  # noqa: BLE001 - diagnostics must not end a run
             return ShadowObservation(

--- a/src/orbit/runtime/completion_shadow.py
+++ b/src/orbit/runtime/completion_shadow.py
@@ -52,6 +52,43 @@ MAX_SNAPSHOT_REQUEST_CHARS = 2000
 # generation here is a cost paid against a run that is not going to stop.
 VERIFIER_MAX_TOKENS = 64
 
+# The whole verifier prompt -- instruction plus snapshot -- must fit this, or
+# the checkpoint is skipped rather than trimmed. A verdict reached on a partial
+# view says nothing about whether the analysis is done, so asking for one is
+# worse than not asking: it spends a model call to obtain an answer that cannot
+# be interpreted.
+#
+# 6144 measured, not chosen. Against the collected corpus, tokenised with the
+# qualified Ornith vocabulary, the full lossless prompt for every checkpoint
+# is: 2014, 2155, 3009, 3132, 3229, 3486, 3581, 3738, 3932, 4724, 4777, 5016,
+# 6374. This admits twelve of the thirteen and skips only the largest.
+#
+# The budget exists to bound lossless verification, and for no other purpose.
+# It is not a proxy for how hard an artifact is to analyse: snapshot size is a
+# token count, and reading it as an analytical signal would smuggle in exactly
+# the kind of heuristic this design refuses. Sizing it here so that both simple
+# and complex checkpoints can be verified is deliberate -- a budget that only
+# admitted the small ones would leave the interesting half unmeasured.
+#
+# With a 64-token generation allowance the worst case is 6208 tokens, 37.9% of
+# the qualified 16384 context, leaving 10176 tokens of headroom.
+COMPLETION_SNAPSHOT_TOKEN_BUDGET = 6144
+
+# The chat template wraps each message in role markers before anything reaches
+# the model, and those tokens are in neither the instruction nor the snapshot.
+# Measured 37 on the qualified Ornith template, via `llama_chat_apply_template`
+# on the real two-message verifier exchange: the rendered prompt costs 37 more
+# tokens than the instruction and snapshot do on their own. A hand-written
+# ChatML skeleton gives 38, and the couple of tokens between them are boundary
+# merges -- which is why the authoritative number comes from the renderer the
+# model actually uses rather than from a reconstructed string.
+#
+# Carried at 64 rather than the measured value so a template revision cannot
+# silently make the budget describe less than the prompt it bounds. A model
+# whose wrapper exceeded 64 would under-budget, which is why the headroom below
+# the context is kept large.
+CHAT_TEMPLATE_OVERHEAD_TOKENS = 64
+
 # What a persisted verifier answer may occupy. Enough to audit a parse verdict
 # after the fact; far too little to become a transcript. The verifiers are
 # instructed to answer in one line, so anything past this is already a protocol
@@ -166,6 +203,94 @@ class CompletionSnapshot:
             lines.extend(("", "ARTIFACTS:"))
             lines.extend(f"- {handle}" for handle in self.artifacts)
         return "\n".join(lines)
+
+
+def build_lossless_snapshot(
+    *,
+    request: str,
+    records: Sequence[Any],
+    load_raw: Callable[[str], str | None],
+) -> CompletionSnapshot:
+    """The complete canonical snapshot: every ACTIVE record, whole.
+
+    Nothing is trimmed to make it fit. Whether it *does* fit is decided
+    afterwards against the token budget, and a snapshot that does not fit is
+    skipped rather than shortened -- the caller never receives a partial view
+    to reason about.
+    """
+    evidence: list[tuple[str, str]] = []
+    artifacts: list[str] = []
+    unusable = 0
+    for record in records:
+        evidence_id = str(getattr(record, "evidence_id", "") or "")
+        if not evidence_id:
+            unusable += 1
+            continue
+        evidence.append((evidence_id, load_raw(evidence_id) or ""))
+        metadata = getattr(record, "metadata", None) or {}
+        for artifact in metadata.get("artifacts") or []:
+            handle = str(artifact.get("handle") or "")
+            if handle and handle not in artifacts:
+                artifacts.append(handle)
+
+    full_request = request or ""
+    reasons: tuple[str, ...] = ("record_unusable",) if unusable else ()
+    fidelity = CompletionSnapshotFidelity(
+        lossless=not reasons,
+        reasons=reasons,
+        request_truncated=False,
+        request_authoritative_chars=len(full_request),
+        request_included_chars=len(full_request),
+        active_records_total=len(records),
+        active_records_included=len(evidence),
+        omitted_record_count=unusable,
+        truncated_records=(),
+        artifacts_total=len(artifacts),
+        artifacts_included=len(artifacts),
+        omitted_artifact_count=0,
+    )
+    payload = json.dumps(
+        {"request": full_request, "evidence": evidence, "artifacts": artifacts},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return CompletionSnapshot(
+        request=full_request,
+        evidence=tuple(evidence),
+        artifacts=tuple(artifacts),
+        digest=hashlib.sha256(payload.encode("utf-8")).hexdigest(),
+        fidelity=fidelity,
+    )
+
+
+def snapshot_fits_budget(
+    snapshot: CompletionSnapshot,
+    count_tokens: Callable[[str], int],
+    *,
+    budget: int = COMPLETION_SNAPSHOT_TOKEN_BUDGET,
+) -> tuple[bool, int]:
+    """Exact tokens for the whole verifier prompt, and whether it fits.
+
+    Counted with the model's own tokenizer rather than estimated: an estimate
+    that is wrong in the permissive direction would put an oversized prompt in
+    front of the verifier, which is the one outcome the budget exists to
+    prevent.
+
+    Three parts are counted, because all three are sent: the snapshot, the
+    larger of the two instructions, and the chat template's own wrapper. The
+    wrapper is easy to forget -- it is in neither string -- but it is real, and
+    leaving it out would make the budget describe something narrower than the
+    prompt it is supposed to bound.
+    """
+    largest_instruction = max(
+        count_tokens(VERIFIER_A_INSTRUCTION), count_tokens(VERIFIER_B_INSTRUCTION)
+    )
+    total = (
+        count_tokens(snapshot.render())
+        + largest_instruction
+        + CHAT_TEMPLATE_OVERHEAD_TOKENS
+    )
+    return total <= budget, total
 
 
 def build_snapshot(
@@ -369,6 +494,8 @@ class ShadowObservation:
     # excerpts kept for parser audit, never a transcript.
     snapshot: "CompletionSnapshot | None" = None
     snapshot_fidelity: "CompletionSnapshotFidelity | None" = None
+    snapshot_tokens: int | None = None
+    verification_skipped: bool = False
     verifier_a_evidence_ids: tuple[str, ...] = ()
     verifier_a_detail: str = ""
     verifier_b_detail: str = ""
@@ -387,6 +514,8 @@ class ShadowObservation:
             "prompt_tokens": self.prompt_tokens,
             "output_tokens": self.output_tokens,
             "wall_seconds": round(self.wall_seconds, 3),
+            "snapshot_tokens": self.snapshot_tokens,
+            "verification_skipped": self.verification_skipped,
         }
 
 
@@ -424,6 +553,8 @@ def evaluate_completion_shadow(
     ask: Callable[[str, str], Any],
     active_evidence_ids: set[str],
     reattest: Callable[[str], object | None],
+    fits_budget: bool = True,
+    snapshot_tokens: int | None = None,
 ) -> ShadowObservation:
     """Run the two-stage check and report what it *would* have done.
 
@@ -437,7 +568,17 @@ def evaluate_completion_shadow(
         snapshot=snapshot,
         snapshot_fidelity=getattr(snapshot, "fidelity", None),
     )
+    observation.snapshot_tokens = snapshot_tokens
     started = time.monotonic()
+
+    # Checked before anything is asked, and before the timer matters: a
+    # snapshot that does not fit is not shortened to make it fit, so there is
+    # no view to put in front of a verifier. Spending a call here would buy an
+    # answer that cannot be interpreted either way.
+    if not fits_budget:
+        observation.blocked_by = "snapshot_too_large"
+        observation.verification_skipped = True
+        return observation
 
     def account(response: Any) -> str:
         observation.calls += 1
@@ -527,6 +668,8 @@ __all__ = [
     "MAX_PERSISTED_RAW_CHARS",
     "MAX_SNAPSHOT_REQUEST_CHARS",
     "SHADOW_ENV",
+    "CHAT_TEMPLATE_OVERHEAD_TOKENS",
+    "COMPLETION_SNAPSHOT_TOKEN_BUDGET",
     "VERIFIER_MAX_TOKENS",
     "CompletionSnapshot",
     "CompletionSnapshotFidelity",
@@ -534,7 +677,9 @@ __all__ = [
     "ShadowObservation",
     "TruncatedRecord",
     "VerifierVerdict",
+    "build_lossless_snapshot",
     "build_snapshot",
+    "snapshot_fits_budget",
     "evaluate_completion_shadow",
     "parse_verifier_a",
     "parse_verifier_b",

--- a/src/orbit/runtime/completion_shadow_ledger.py
+++ b/src/orbit/runtime/completion_shadow_ledger.py
@@ -33,6 +33,8 @@ from pathlib import Path
 from typing import Any, Iterator
 from uuid import uuid4
 
+from orbit.runtime.completion_shadow import COMPLETION_SNAPSHOT_TOKEN_BUDGET
+
 # Bumped when a reader could otherwise misread an older file. Readers must
 # refuse a version they do not know rather than guess at its shape.
 LEDGER_SCHEMA_VERSION = 1
@@ -142,6 +144,9 @@ class ShadowLedgerWriter:
             # fidelity, which reads as unknown rather than lossless. Bumping
             # the schema would have invalidated an expensive corpus that is
             # still perfectly valid for everything it does record.
+            "snapshot_tokens": observation.snapshot_tokens,
+            "token_budget": COMPLETION_SNAPSHOT_TOKEN_BUDGET,
+            "verification_skipped": bool(observation.verification_skipped),
             "snapshot_fidelity": (
                 observation.snapshot_fidelity.as_log_fields()
                 if getattr(observation, "snapshot_fidelity", None) is not None

--- a/tests/test_completion_shadow_integration.py
+++ b/tests/test_completion_shadow_integration.py
@@ -63,6 +63,17 @@ class _CountingBackend:
         self.calls += 1
         return response
 
+    def count_text_tokens(self, text: str):
+        """A deterministic stand-in for the model tokenizer.
+
+        Whole-word counting, not the real vocabulary: these tests are about the
+        budget mechanism, not about token fidelity, and a fixture that returned
+        None would make every checkpoint skip and hide the behaviour under test.
+        """
+        from orbit.backend.base import TokenCount
+
+        return TokenCount(tokens=len(text.split()), context_tokens=16384)
+
     def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
                     on_delta=None, on_progress=None):
         response = self.chat(

--- a/tests/test_completion_snapshot_budget.py
+++ b/tests/test_completion_snapshot_budget.py
@@ -1,0 +1,246 @@
+"""Token-budgeted lossless snapshots: fit exactly, or do not ask at all."""
+
+from __future__ import annotations
+
+import unittest
+
+from orbit.runtime.completion_shadow import (
+    COMPLETION_SNAPSHOT_TOKEN_BUDGET,
+    VERIFIER_A_INSTRUCTION,
+    VERIFIER_B_INSTRUCTION,
+    VERIFIER_MAX_TOKENS,
+    CompletionSnapshot,
+    build_lossless_snapshot,
+    evaluate_completion_shadow,
+    snapshot_fits_budget,
+)
+
+
+class _Record:
+    def __init__(self, evidence_id: str, artifacts=()) -> None:
+        self.evidence_id = evidence_id
+        self.metadata = {"artifacts": [{"handle": h} for h in artifacts]}
+
+
+def _words(text: str) -> int:
+    return len(text.split())
+
+
+class LosslessConstructionTests(unittest.TestCase):
+    def test_no_record_content_is_truncated(self) -> None:
+        huge = "x" * 100_000
+        s = build_lossless_snapshot(
+            request="r", records=[_Record("ev_a")], load_raw=lambda _i: huge
+        )
+        self.assertEqual(s.evidence[0][1], huge)
+        self.assertTrue(s.fidelity.lossless)
+        self.assertEqual(s.fidelity.truncated_records, ())
+
+    def test_no_record_is_omitted_to_fit(self) -> None:
+        records = [_Record(f"ev_{i}") for i in range(60)]
+        s = build_lossless_snapshot(request="r", records=records, load_raw=lambda _i: "t")
+        self.assertEqual(len(s.evidence), 60)
+        self.assertEqual(s.fidelity.omitted_record_count, 0)
+        self.assertTrue(s.fidelity.lossless)
+
+    def test_no_artifact_is_omitted_to_fit(self) -> None:
+        handles = [f"/w/{i}" for i in range(50)]
+        s = build_lossless_snapshot(
+            request="r", records=[_Record("ev_a", handles)], load_raw=lambda _i: "t"
+        )
+        self.assertEqual(len(s.artifacts), 50)
+        self.assertEqual(s.fidelity.omitted_artifact_count, 0)
+
+    def test_request_is_included_whole(self) -> None:
+        request = "q" * 50_000
+        s = build_lossless_snapshot(
+            request=request, records=[_Record("ev_a")], load_raw=lambda _i: "t"
+        )
+        self.assertEqual(s.request, request)
+        self.assertFalse(s.fidelity.request_truncated)
+
+    def test_an_unusable_record_is_still_reported(self) -> None:
+        s = build_lossless_snapshot(
+            request="r", records=[_Record(""), _Record("ev_a")], load_raw=lambda _i: "t"
+        )
+        self.assertFalse(s.fidelity.lossless)
+        self.assertIn("record_unusable", s.fidelity.reasons)
+
+
+class BudgetBoundaryTests(unittest.TestCase):
+    """Off-by-one at the budget is the failure that would matter."""
+
+    def _sized(self, total_tokens: int):
+        """Build a snapshot whose counted prompt is exactly `total_tokens`.
+
+        The template wrapper is part of that total, so it is subtracted here
+        too -- otherwise these boundary tests would be measuring a different
+        quantity from the one the budget actually bounds.
+        """
+        from orbit.runtime.completion_shadow import CHAT_TEMPLATE_OVERHEAD_TOKENS
+
+        snapshot = CompletionSnapshot("r", (("ev_a", "t"),), (), "d" * 64)
+        overhead = max(_words(VERIFIER_A_INSTRUCTION), _words(VERIFIER_B_INSTRUCTION))
+        body = total_tokens - overhead - CHAT_TEMPLATE_OVERHEAD_TOKENS
+
+        def count(text: str) -> int:
+            return body if text == snapshot.render() else _words(text)
+
+        return snapshot, count
+
+    def test_exactly_at_budget_fits(self) -> None:
+        snapshot, count = self._sized(COMPLETION_SNAPSHOT_TOKEN_BUDGET)
+        fits, total = snapshot_fits_budget(snapshot, count)
+        self.assertTrue(fits)
+        self.assertEqual(total, COMPLETION_SNAPSHOT_TOKEN_BUDGET)
+
+    def test_one_token_over_budget_does_not_fit(self) -> None:
+        snapshot, count = self._sized(COMPLETION_SNAPSHOT_TOKEN_BUDGET + 1)
+        fits, total = snapshot_fits_budget(snapshot, count)
+        self.assertFalse(fits)
+        self.assertEqual(total, COMPLETION_SNAPSHOT_TOKEN_BUDGET + 1)
+
+    def test_one_token_under_budget_fits(self) -> None:
+        snapshot, count = self._sized(COMPLETION_SNAPSHOT_TOKEN_BUDGET - 1)
+        self.assertTrue(snapshot_fits_budget(snapshot, count)[0])
+
+    def test_instruction_is_counted_not_only_the_snapshot(self) -> None:
+        # Budgeting the snapshot alone would let the real prompt exceed it.
+        from orbit.runtime.completion_shadow import CHAT_TEMPLATE_OVERHEAD_TOKENS
+
+        snapshot = CompletionSnapshot("r", (("ev_a", "t"),), (), "d" * 64)
+        _fits, total = snapshot_fits_budget(snapshot, _words)
+        self.assertEqual(
+            total,
+            _words(snapshot.render())
+            + max(_words(VERIFIER_A_INSTRUCTION), _words(VERIFIER_B_INSTRUCTION))
+            + CHAT_TEMPLATE_OVERHEAD_TOKENS,
+            "the counted prompt must be snapshot + instruction + template wrapper",
+        )
+
+
+class SkipInvariantTests(unittest.TestCase):
+    """VERIFIER CALLED => SNAPSHOT LOSSLESS AND WITHIN BUDGET."""
+
+    def _observe(self, *, fits: bool):
+        calls: list[str] = []
+
+        class _R:
+            content = "COMPLETE evidence: ev_000000000000_0000000000000000"
+            prompt_tokens = 10
+            completion_tokens = 2
+
+        def ask(instruction, _rendered):
+            calls.append(instruction)
+            return _R()
+
+        obs = evaluate_completion_shadow(
+            action=4,
+            snapshot=build_lossless_snapshot(
+                request="r", records=[_Record("ev_a")], load_raw=lambda _i: "t"
+            ),
+            ask=ask,
+            active_evidence_ids={"ev_000000000000_0000000000000000"},
+            reattest=lambda _i: "raw",
+            fits_budget=fits,
+            snapshot_tokens=999,
+        )
+        return obs, calls
+
+    def test_oversized_snapshot_calls_no_verifier_at_all(self) -> None:
+        obs, calls = self._observe(fits=False)
+        self.assertEqual(calls, [], "neither A nor B may be asked")
+        self.assertEqual(obs.blocked_by, "snapshot_too_large")
+        self.assertTrue(obs.verification_skipped)
+        self.assertEqual(obs.calls, 0)
+
+    def test_skipped_verification_cannot_would_stop(self) -> None:
+        obs, _ = self._observe(fits=False)
+        self.assertFalse(obs.would_stop)
+
+    def test_b_is_not_called_when_a_is_skipped(self) -> None:
+        obs, calls = self._observe(fits=False)
+        self.assertIsNone(obs.verifier_a)
+        self.assertIsNone(obs.verifier_b)
+        self.assertEqual(len(calls), 0)
+
+    def test_within_budget_runs_the_verifier(self) -> None:
+        obs, calls = self._observe(fits=True)
+        self.assertGreaterEqual(len(calls), 1)
+        self.assertFalse(obs.verification_skipped)
+        self.assertNotEqual(obs.blocked_by, "snapshot_too_large")
+
+    def test_snapshot_tokens_are_recorded_either_way(self) -> None:
+        for fits in (True, False):
+            with self.subTest(fits=fits):
+                obs, _ = self._observe(fits=fits)
+                self.assertEqual(obs.snapshot_tokens, 999)
+
+
+class RuntimeWiringTests(unittest.TestCase):
+    """The call site must build losslessly and must not estimate tokens.
+
+    Both were mutants that survived a behavioural-only suite: the fixture
+    tokenizer is generous enough that a truncating builder still fits, and an
+    estimating fallback still produces a number. Pinning the call site is what
+    catches them.
+    """
+
+    def _source(self) -> str:
+        import inspect
+
+        from orbit.runtime import analysis_runtime
+
+        return inspect.getsource(analysis_runtime.AnalysisRuntime._observe_completion_shadow)
+
+    def test_observation_builds_the_lossless_snapshot(self) -> None:
+        source = self._source()
+        self.assertIn("build_lossless_snapshot(", source)
+        self.assertNotIn("snapshot = build_snapshot(", source)
+
+    def test_token_count_failure_is_never_estimated(self) -> None:
+        # Comments are stripped first: the word "estimate" appears in the
+        # prose explaining why estimating is forbidden, and matching that
+        # would be checking the documentation rather than the code.
+        import ast
+
+        source = self._source()
+        self.assertIn("_TokenCountUnavailable", source)
+        self.assertIn("count_text_tokens", source)
+        import textwrap
+
+        code = ast.unparse(ast.parse(textwrap.dedent(source)))
+        for estimate in ("len(text) // 4", "len(text)//4", "// 3.5", "* 0.25"):
+            self.assertNotIn(estimate, code, "the budget must never be estimated")
+
+    def test_unavailable_tokenizer_skips_rather_than_guesses(self) -> None:
+        from orbit.runtime.completion_shadow import evaluate_completion_shadow as run
+
+        calls: list[str] = []
+        obs = run(
+            action=4,
+            snapshot=build_lossless_snapshot(
+                request="r", records=[_Record("ev_a")], load_raw=lambda _i: "t"
+            ),
+            ask=lambda i, _r: calls.append(i),
+            active_evidence_ids=set(),
+            reattest=lambda _i: "raw",
+            fits_budget=False,
+            snapshot_tokens=None,
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(obs.blocked_by, "snapshot_too_large")
+        self.assertIsNone(obs.snapshot_tokens)
+
+
+class ContextSafetyTests(unittest.TestCase):
+    def test_worst_case_prompt_plus_generation_fits_the_qualified_context(self) -> None:
+        # The budget bounds the whole prompt, so the worst case is fixed rather
+        # than dependent on any particular analysis.
+        worst = COMPLETION_SNAPSHOT_TOKEN_BUDGET + VERIFIER_MAX_TOKENS
+        self.assertLess(worst, 16384)
+        self.assertLess(worst, 16384 * 0.5, "leave the analysis most of its context")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Shadow only — the verifiers were judging a view that had already lost the answer

Each ACTIVE record reached the shadow verifiers as a 600-character excerpt. In the collected corpus **all 13 checkpoints were lossy**: at run C action 4 the hidden-launch evidence sat in six of the eight records and in **none** of the excerpts. A verdict reached on that view says nothing about the verifier that reached it.

This stops trimming. Build the whole canonical snapshot, count the entire verifier prompt with the model's own tokenizer, then decide — within budget the verifiers run on complete evidence; over budget the checkpoint is **skipped**, never shortened.

### The invariant

**`VERIFIER CALLED ⇒ SNAPSHOT LOSSLESS`**

Over budget → skip A, skip B, `WOULD_STOP = false`, `blocked_by = snapshot_too_large`.

### Required statements

| | |
|---|---|
| **Shadow only** | yes — default OFF, behind `ORBIT_ANALYSIS_COMPLETION_SHADOW=1` |
| **Active stop still impossible** | yes — `would_stop` is never read to steer the loop; a skipped checkpoint cannot set it |
| **6144 is a fixed verifier-prompt capacity bound** | yes — it bounds snapshot + instruction + template wrapper, not the snapshot alone |
| **Oversized snapshots skipped, never truncated** | yes — no per-record truncation, no record omission, no artifact omission |
| **Budget selection is evidence-based** | yes — measured token counts, **not** a sample-complexity heuristic |
| **Verifier A/B unchanged** | yes — prompts byte-identical |
| **Schedule unchanged** | yes — still 4, 6, 8, 10, 12 |

### Why 6144 — measured, not chosen

Tokenised with the qualified Ornith vocabulary (vocab-only load, zero inference), the full lossless prompt for each collected checkpoint:

```
2014  2155  3009  3132  3229  3486  3581  3738  3932  4724  4777  5016  6374
```

Coverage: **4096 → 9/13 · 6144 → 12/13 · 8192 → 13/13**. The budget admits twelve and skips the largest (run C action 6, over by 230).

The budget exists to bound lossless verification and for no other purpose. Snapshot size is a token count, **not** a measure of how hard an artifact is to analyse; reading it as the latter would smuggle in exactly the heuristic this design refuses. Sizing it so both simple and complex checkpoints can be verified is deliberate — a budget admitting only the small ones would leave the interesting half unmeasured.

### Token accounting

Three parts, because all three are sent: snapshot + larger instruction + **chat-template wrapper**. The wrapper is in neither string but is real — measured 36–38 tokens on this template, carried at 64 for headroom. Omitting it would have made the budget describe something narrower than the prompt it bounds; I found and fixed that during implementation.

Tokens come from the backend tokenizer or the checkpoint is skipped — **never estimated**. An estimate wrong in the permissive direction would put an oversized prompt in front of a verifier, the one outcome the budget exists to prevent.

### Context safety

Worst case = 6144 + 64 generation = **6208 tokens = 37.9% of the qualified 16384 context**, leaving 10176 headroom. The budget bounds the whole prompt by construction, so no checkpoint can exceed it.

### Verification

18 new tests; focused **127 PASS**; full suite **3268, exit 0**, 1 pre-existing environment skip; `compileall` and both diff-checks clean. **9/9 mutants caught**, including two that initially survived and needed call-site pinning: reverting to the truncating builder, and substituting an estimated token count.

### Independent review

**MERGE SAFE: YES**, BLOCKER 0 / MAJOR 0. The reviewer reproduced the token list byte-for-byte, killed 12 mutants of its own, and confirmed the invariant holds on every path it could construct. Two MINORs addressed: the template-overhead comment now states the measured 36–38 range, and the `count_chat_tokens` alternative is noted with its trade-off.

### What this does *not* claim

Nothing about whether A or B behave **better** on complete input. No lossless checkpoint has ever been observed, so that remains entirely unmeasured — which is what a fresh corpus would answer.
