### PR TITLE
fix(evaluation): decide absence against the artifact, not the narrative

### DIFF
--- a/scripts/evaluation/score_completion_shadow.py
+++ b/scripts/evaluation/score_completion_shadow.py
@@ -33,6 +33,7 @@ INDETERMINATE, which is the conservative reading.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sys
@@ -50,14 +51,74 @@ class FindingResult:
     detail: str = ""
 
 
-def evaluate_finding(spec: dict, text: str) -> FindingResult:
-    """One deterministic predicate. No interpretation, no similarity."""
+# What a predicate is allowed to inspect.
+#
+#   SOURCE_FACT           a positive/negative fact about the immutable artifact
+#   DERIVED_FACT          established only after deterministic analysis
+#   ARTIFACT_FACT         a fact about an artifact analysis produced
+#   NEGATIVE_SOURCE_FACT  an absence property of the source
+#
+# The distinction is not decorative. A NEGATIVE_SOURCE_FACT decided by searching
+# cumulative narrative is unsound: an analysis step that *explains* the artifact
+# makes no network call has to name the calls it does not make, and the moment
+# it does, the absence predicate fails against its own explanation. Under
+# append-only state that makes COMPLETE -> INCOMPLETE reachable from commentary
+# alone, which is exactly what happened to `no_dangerous_capability`.
+#
+# So absence is evaluated against the source bytes, never the narrative.
+PREDICATE_SCOPES = {
+    "literal_all": "DERIVED_FACT",
+    "literal_any": "DERIVED_FACT",
+    "regex": "DERIVED_FACT",
+    "absent_all": "NEGATIVE_SOURCE_FACT",
+    "unscorable": "UNSCORABLE",
+}
+
+
+def predicate_scope(spec: dict) -> str:
+    """Scope of one predicate, per-spec first and `kind` as the fallback.
+
+    Keying on `kind` alone would force every absence predicate onto source
+    bytes, including a legitimate absence-of-DERIVED-fact ("analysis never
+    reported an unresolved gap"), where the token by construction never appears
+    and the finding would silently self-satisfy. No such predicate exists in the
+    oracle today, so this is a latent hazard rather than a live bug -- but the
+    override is one line and the failure mode is invisible.
+    """
+    declared = spec.get("scope")
+    if declared:
+        return declared if declared in set(PREDICATE_SCOPES.values()) else "UNKNOWN"
+    return PREDICATE_SCOPES.get(spec["kind"], "UNKNOWN")
+
+
+def evaluate_finding(
+    spec: dict, text: str, *, source_text: str | None = None
+) -> FindingResult:
+    """One deterministic predicate. No interpretation, no similarity.
+
+    `text` is the cumulative evidence narrative. `source_text` is the immutable
+    artifact. A NEGATIVE_SOURCE_FACT is decided against `source_text` and
+    refuses to be scored without it, rather than silently falling back to the
+    narrative and reintroducing the anti-monotonicity this exists to prevent.
+    """
     kind = spec["kind"]
     fid = spec["id"]
     if kind == "unscorable":
         return FindingResult(fid, False, True, spec.get("comment", ""))
 
+    if predicate_scope(spec) == "NEGATIVE_SOURCE_FACT":
+        if source_text is None:
+            return FindingResult(
+                fid, False, True,
+                "negative source predicate requires the artifact source",
+            )
+        text = source_text
+
     # A forbidden value can never satisfy a finding, even if it looks close.
+    # Note for whoever first writes an `absent_all` carrying a `forbidden` list:
+    # this reads whichever text won the scope routing above, so on a negative
+    # source fact it inspects source bytes rather than the narrative. No
+    # predicate combines the two today.
     # This is what keeps a superseded value from passing as authoritative.
     forbidden = [v for v in spec.get("forbidden", []) if v.lower() in text.lower()]
 
@@ -97,10 +158,18 @@ class CheckpointScore:
         return "COMPLETE" if not self.missing else "INCOMPLETE"
 
 
-def score_text(oracle: dict, text: str, action: int) -> CheckpointScore:
+def score_text(
+    oracle: dict, text: str, action: int, *, source_text: str | None = None
+) -> CheckpointScore:
+    """Score one state. `source_text` is required for negative source facts.
+
+    Without it a NEGATIVE_SOURCE_FACT scores UNSCORABLE rather than being
+    decided against the narrative -- refusing to answer beats answering from
+    the wrong evidence.
+    """
     score = CheckpointScore(action=action, required_total=len(oracle["required_findings"]))
     for spec in oracle["required_findings"]:
-        result = evaluate_finding(spec, text)
+        result = evaluate_finding(spec, text, source_text=source_text)
         if result.unscorable:
             score.unscorable.append(result.id)
         elif result.satisfied:
@@ -213,7 +282,58 @@ def load_run(corpus: Path, label: str) -> dict:
     cumulative = "\n".join(
         (store.load_raw(r.evidence_id) or "") for r in store.records.values()
     )
-    return {"label": label, "run": run, "ledger": ledger, "cumulative": cumulative}
+    # The immutable artifact, for NEGATIVE_SOURCE_FACT predicates. Absence is a
+    # property of the source, and scoring it against the narrative is the defect
+    # the predicate scopes exist to prevent. A corpus that preserved no artifact
+    # yields None, and such findings then score UNSCORABLE rather than guessed.
+    #
+    # Bound to its recorded hash, exactly as the ledger is. The artifact is now
+    # load-bearing for absence, so accepting unverified bytes here would let a
+    # swapped or rewritten file score confidently against the wrong source --
+    # and a `final_report.txt` picked up as "the artifact" would reintroduce
+    # narrative scoring through a different door, which is the whole defect.
+    artifacts = sorted(d.glob("artifact.*"))
+    if len(artifacts) > 1:
+        raise SystemExit(
+            f"[{label}] {len(artifacts)} artifact.* files; cannot choose a source"
+        )
+    source_text = None
+    if artifacts:
+        # A directory named artifact.* is a refusal like any other, not an
+        # uncaught IsADirectoryError from three frames down.
+        if not artifacts[0].is_file():
+            raise SystemExit(f"[{label}] {artifacts[0].name} is not a regular file")
+        raw = artifacts[0].read_bytes()
+        expected = str(run.get("artifact_sha256_before") or "")
+        # An absent or empty recorded hash is a refusal, not a waiver. Skipping
+        # verification when the corpus records nothing would make the guard's
+        # strength depend on the data it is guarding: a hash-less run would
+        # accept arbitrary bytes as "the immutable artifact", and absence
+        # scored against a narrative-shaped file is the original defect.
+        if not expected:
+            raise SystemExit(
+                f"[{label}] artifact present but run.json records no "
+                "artifact_sha256_before; cannot vouch for the source bytes"
+            )
+        actual = hashlib.sha256(raw).hexdigest()
+        if actual != expected:
+            raise SystemExit(
+                f"[{label}] artifact hash mismatch: {actual} != {expected}; "
+                "refusing to score absence against unverified bytes"
+            )
+        # Absence over nothing is vacuously true, so an empty artifact would
+        # satisfy every absent_all. Authentic bytes or not, that is not a
+        # judgement worth making silently.
+        if not raw.strip():
+            raise SystemExit(
+                f"[{label}] artifact is empty; absence predicates would be "
+                "vacuously satisfied"
+            )
+        source_text = raw.decode(errors="replace")
+    return {
+        "label": label, "run": run, "ledger": ledger,
+        "cumulative": cumulative, "source_text": source_text,
+    }
 
 
 def snapshot_text(checkpoint: dict) -> str:
@@ -242,8 +362,10 @@ def score_corpus(corpus: Path, oracles: dict) -> dict:
         oracle = oracles["samples"][label]
         rows = []
         for cp in data["ledger"].checkpoints:
-            snap = score_text(oracle, snapshot_text(cp), cp["action"])
-            cum = score_text(oracle, data["cumulative"], cp["action"])
+            snap = score_text(oracle, snapshot_text(cp), cp["action"],
+                              source_text=data["source_text"])
+            cum = score_text(oracle, data["cumulative"], cp["action"],
+                             source_text=data["source_text"])
             skipped = bool(cp.get("verification_skipped"))
             a_class = classify_a(
                 cp["verifier_a"], snap.oracle_complete, bool(snap.unscorable),

--- a/tests/test_completion_shadow_scorer.py
+++ b/tests/test_completion_shadow_scorer.py
@@ -47,9 +47,23 @@ class PredicateTests(unittest.TestCase):
         self.assertFalse(evaluate_finding(spec, "gamma").satisfied)
 
     def test_absent_all_is_inverted(self) -> None:
+        """Inverted, and scored against source bytes rather than narrative.
+
+        Absence is a property of the artifact. Deciding it from cumulative
+        narrative let an analysis step that *explains* the artifact makes no
+        such call introduce the token and unsatisfy the finding.
+        """
         spec = {"id": "x", "kind": "absent_all", "values": ["eval("]}
-        self.assertTrue(evaluate_finding(spec, "safe code").satisfied)
-        self.assertFalse(evaluate_finding(spec, "eval(payload)").satisfied)
+        self.assertTrue(
+            evaluate_finding(spec, "narrative", source_text="safe code").satisfied
+        )
+        self.assertFalse(
+            evaluate_finding(spec, "narrative", source_text="eval(payload)").satisfied
+        )
+
+    def test_absent_all_without_source_is_unscorable(self) -> None:
+        spec = {"id": "x", "kind": "absent_all", "values": ["eval("]}
+        self.assertTrue(evaluate_finding(spec, "safe code").unscorable)
 
     def test_regex_is_bounded_not_semantic(self) -> None:
         spec = {"id": "x", "kind": "regex", "pattern": r"(?i)Get-Date"}
@@ -128,7 +142,16 @@ class VerifierClassificationTests(unittest.TestCase):
         self.assertEqual(classify_b("NO_GAP", False, False), "B_FALSE_NO_GAP")
 
     def test_b_not_called_when_a_continued(self) -> None:
-        self.assertEqual(classify_b(None, False, False), "B_NOT_CALLED")
+        """B's absence is read from `blocked_by`, not from a bare missing verdict.
+
+        A_CONTINUE means B was deliberately never asked -- the gate's own cost
+        control. Without that reason, a missing verdict is a failed verifier.
+        """
+        self.assertEqual(
+            classify_b(None, False, False, blocked_by="verifier_a_continue"),
+            "B_NOT_CALLED",
+        )
+        self.assertEqual(classify_b(None, False, False), "B_ERRORED")
 
     def test_indeterminate_dominates(self) -> None:
         self.assertEqual(classify_a("COMPLETE", False, True), "A_INDETERMINATE")

--- a/tests/test_lossless_ac_scoring.py
+++ b/tests/test_lossless_ac_scoring.py
@@ -23,6 +23,7 @@ from score_completion_shadow import (  # noqa: E402
     classify_b,
     classify_gap,
     evaluate_finding,
+    predicate_scope,
     score_corpus,
     score_text,
 )
@@ -40,6 +41,15 @@ def _checkpoint(label: str, action: int) -> dict:
 
     led = read_ledger(CORPUS / f"runs/{label}/completion-shadow.jsonl")
     return next(c for c in led.checkpoints if c["action"] == action)
+
+
+def _source(label: str) -> str:
+    """The immutable artifact bytes, for negative source predicates."""
+    for name in ("artifact.js", "artifact.ps1"):
+        path = CORPUS / f"runs/{label}/{name}"
+        if path.exists():
+            return path.read_text(errors="replace")
+    raise AssertionError(f"no preserved artifact for run {label}")
 
 
 def _text(checkpoint: dict) -> str:
@@ -94,7 +104,8 @@ class CorpusPresent(unittest.TestCase):
 
 class RunAScoringTests(CorpusPresent):
     def test_a4_is_oracle_complete(self) -> None:
-        score = score_text(ORACLES["A"], _text(_checkpoint("A", 4)), 4)
+        score = score_text(ORACLES["A"], _text(_checkpoint("A", 4)), 4,
+                           source_text=_source("A"))
         self.assertEqual(score.state, "COMPLETE")
         self.assertEqual(score.missing, [])
 
@@ -238,7 +249,8 @@ class CounterfactualTests(CorpusPresent):
         for label in ("A", "C"):
             with self.subTest(run=label):
                 score = score_text(
-                    ORACLES[label], _text(_checkpoint(label, 4)), 4
+                    ORACLES[label], _text(_checkpoint(label, 4)), 4,
+                    source_text=_source(label),
                 )
                 self.assertEqual(score.state, "COMPLETE")
 
@@ -419,27 +431,38 @@ class SyntheticCorpusTests(unittest.TestCase):
         self.assertEqual(row["b_class"], "B_INDETERMINATE")
 
 
-class AntiMonotonicFindingTests(unittest.TestCase):
-    """Guards the guard: `lost` must be able to fire, or asserting it is empty
-    proves nothing."""
+class NegativeSourceFactTests(unittest.TestCase):
+    """A negative source fact is a property of the artifact, not the narrative.
+
+    These previously pinned the opposite -- that appended text could unsatisfy
+    an absence predicate. That was the defect: an analysis step explaining that
+    the artifact makes no network call has to name the calls it does not make,
+    and the predicate then failed against its own explanation.
+    """
 
     SPEC = {"id": "no_dangerous_capability", "kind": "absent_all",
             "values": ["require(", "eval("]}
+    SOURCE = "function greet(name) { console.log(name); }"
 
-    def test_absent_all_is_lost_when_the_capability_appears_later(self) -> None:
-        early = "function greet(name) { console.log(name); }"
-        later = early + "\nrequire('child_process')"
-        self.assertTrue(evaluate_finding(self.SPEC, early).satisfied)
-        self.assertFalse(evaluate_finding(self.SPEC, later).satisfied)
+    def test_scope_is_negative_source_fact(self) -> None:
+        self.assertEqual(predicate_scope(self.SPEC), "NEGATIVE_SOURCE_FACT")
 
-    def test_such_a_finding_could_never_appear_as_gained(self) -> None:
-        """Which is exactly why the one-directional filter was insufficient."""
-        early = "clean"
-        later = "clean require("
-        gained = evaluate_finding(self.SPEC, later).satisfied and not evaluate_finding(self.SPEC, early).satisfied
-        lost = evaluate_finding(self.SPEC, early).satisfied and not evaluate_finding(self.SPEC, later).satisfied
-        self.assertFalse(gained)
-        self.assertTrue(lost)
+    def test_narrative_naming_the_capability_cannot_unsatisfy_it(self) -> None:
+        narrative = self.SOURCE + "\nNote: the file never calls require( or eval("
+        result = evaluate_finding(self.SPEC, narrative, source_text=self.SOURCE)
+        self.assertTrue(result.satisfied)
+
+    def test_it_is_still_false_when_the_source_really_contains_it(self) -> None:
+        source = self.SOURCE + "\nrequire('child_process')"
+        self.assertFalse(
+            evaluate_finding(self.SPEC, "clean narrative", source_text=source).satisfied
+        )
+
+    def test_without_source_it_is_unscorable_not_guessed(self) -> None:
+        """Refusing to answer beats answering from the wrong evidence."""
+        result = evaluate_finding(self.SPEC, self.SOURCE)
+        self.assertTrue(result.unscorable)
+        self.assertFalse(result.satisfied)
 
 
 class VerifierBAbsenceTests(unittest.TestCase):
@@ -692,10 +715,11 @@ class PredicateSemanticsTests(unittest.TestCase):
         self.assertFalse(evaluate_finding(spec, "neither").satisfied)
 
     def test_absent_all_rejects_any_present_value(self) -> None:
+        """Scored against source bytes: absence is a property of the artifact."""
         spec = dict(self.MULTI, kind="absent_all")
-        self.assertTrue(evaluate_finding(spec, "neither here").satisfied)
-        self.assertFalse(evaluate_finding(spec, "alpha here").satisfied)
-        self.assertFalse(evaluate_finding(spec, "beta here").satisfied)
+        self.assertTrue(evaluate_finding(spec, "", source_text="neither here").satisfied)
+        self.assertFalse(evaluate_finding(spec, "", source_text="alpha here").satisfied)
+        self.assertFalse(evaluate_finding(spec, "", source_text="beta here").satisfied)
 
 
 class IntegrityRefusalTests(unittest.TestCase):

--- a/tests/test_oracle_monotonicity.py
+++ b/tests/test_oracle_monotonicity.py
@@ -1,0 +1,405 @@
+"""The completion oracle must be monotonic under append-only analysis state.
+
+A completion oracle exists to answer "is the request satisfied yet?". If
+appending evidence can *unsatisfy* it, the question has no stable answer and
+nothing built on it can be qualified.
+
+The defect these tests pin was real and observed: `no_dangerous_capability` is
+an absence property of the artifact, but was decided by searching the cumulative
+evidence narrative. An analysis step explaining that the file makes no network
+call has to name the calls it does not make -- and the predicate then failed
+against its own explanation. On a real captured trajectory the oracle went
+COMPLETE at action 1 and INCOMPLETE at actions 2-5, with no evidence lost.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "evaluation"))
+
+from score_completion_shadow import (  # noqa: E402
+    PREDICATE_SCOPES,
+    evaluate_finding,
+    predicate_scope,
+    score_text,
+)
+
+ORACLES = json.loads(
+    (ROOT / "scripts/evaluation/completion_shadow_oracles.json").read_text()
+)
+AUTHENTIC = Path(
+    "/home/guelfoweb/LAB/orbit-checkpoints/INVALID-authentic-capture-20260828/authentic_states"
+)
+
+
+class PredicateScopeTests(unittest.TestCase):
+    """Every predicate must declare what it is allowed to inspect."""
+
+    def test_every_kind_in_use_has_a_scope(self) -> None:
+        for sample in ORACLES["samples"].values():
+            for spec in sample["required_findings"]:
+                with self.subTest(spec["id"]):
+                    self.assertIn(spec["kind"], PREDICATE_SCOPES)
+                    self.assertNotEqual(predicate_scope(spec), "UNKNOWN")
+
+    def test_absence_predicates_are_negative_source_facts(self) -> None:
+        for sample in ORACLES["samples"].values():
+            for spec in sample["required_findings"]:
+                if spec["kind"] == "absent_all":
+                    self.assertEqual(predicate_scope(spec), "NEGATIVE_SOURCE_FACT")
+
+    def test_a_spec_may_declare_a_derived_absence(self) -> None:
+        """Absence of a DERIVED fact must not be forced onto source bytes."""
+        spec = {"id": "no_gap_reported", "kind": "absent_all",
+                "values": ["UNRESOLVED"], "scope": "DERIVED_FACT"}
+        self.assertEqual(predicate_scope(spec), "DERIVED_FACT")
+        # Scored against the narrative, as a derived fact should be.
+        self.assertFalse(evaluate_finding(spec, "UNRESOLVED gap remains").satisfied)
+        self.assertTrue(evaluate_finding(spec, "all questions answered").satisfied)
+
+    def test_an_unrecognised_declared_scope_is_unknown(self) -> None:
+        spec = {"id": "x", "kind": "absent_all", "values": ["y"], "scope": "MADE_UP"}
+        self.assertEqual(predicate_scope(spec), "UNKNOWN")
+
+    def test_a_negative_source_fact_refuses_the_narrative(self) -> None:
+        """Without source bytes it is unscorable, never guessed from prose."""
+        spec = {"id": "x", "kind": "absent_all", "values": ["require("]}
+        result = evaluate_finding(spec, "clean narrative")
+        self.assertTrue(result.unscorable)
+        self.assertFalse(result.satisfied)
+
+    def test_negative_fact_ignores_every_forbidden_data_source(self) -> None:
+        """Narrative, later evidence and the final report are all excluded.
+
+        Constructed rather than corpus-derived on purpose: this corpus's report
+        happens not to name the forbidden tokens, so it cannot demonstrate the
+        property. The adversarial case is the one that matters.
+        """
+        spec = {"id": "x", "kind": "absent_all", "values": ["fetch(", "eval("]}
+        source = "function greet(n){ console.log(n); }"
+        forbidden_sources = {
+            "cumulative narrative": "The artifact never calls fetch( or eval(.",
+            "later evidence prose": "Step 4 confirmed absence of eval( usage.",
+            "final report text": "## Findings\nNo fetch( or eval( is present.",
+        }
+        for where, text in forbidden_sources.items():
+            with self.subTest(where):
+                result = evaluate_finding(spec, text, source_text=source)
+                self.assertTrue(
+                    result.satisfied,
+                    f"{where} was allowed to unsatisfy a negative source fact",
+                )
+
+    def test_the_same_text_would_have_broken_the_old_scoring(self) -> None:
+        """Guards the guard: these strings really are hostile to the old rule."""
+        values = ["fetch(", "eval("]
+        narrative = "The artifact never calls fetch( or eval(."
+        old_rule = not any(v.lower() in narrative.lower() for v in values)
+        self.assertFalse(old_rule)
+
+    def test_positive_predicates_still_read_the_narrative(self) -> None:
+        """Derived facts are established BY analysis, so narrative is correct."""
+        spec = {"id": "x", "kind": "literal_all", "values": ["FOUND"]}
+        self.assertTrue(evaluate_finding(spec, "the analysis FOUND it").satisfied)
+
+
+class ScorerSuppliesSourceTests(unittest.TestCase):
+    """The scorer must hand the artifact to negative source predicates.
+
+    Fail-closed is right, but a scorer that never supplies the source turns
+    every run INDETERMINATE -- correct in principle, useless in practice, and
+    it silently erased a previously-merged COMPLETE conclusion.
+    """
+
+    CORPUS = Path(
+        "/home/guelfoweb/LAB/orbit-checkpoints/completion-shadow-lossless-ac-20260827-175528"
+    )
+
+    def setUp(self) -> None:
+        if not self.CORPUS.is_dir():
+            self.skipTest("preserved corpus not present")
+
+    def test_load_run_carries_the_immutable_artifact(self) -> None:
+        from score_completion_shadow import load_run
+
+        data = load_run(self.CORPUS, "A")
+        self.assertIsNotNone(data["source_text"])
+        self.assertIn("function greet", data["source_text"])
+
+    def test_run_a_scores_complete_not_indeterminate(self) -> None:
+        """The regression this guards: absent source made every row INDETERMINATE."""
+        from score_completion_shadow import score_corpus
+
+        oracles = json.loads(
+            (ROOT / "scripts/evaluation/completion_shadow_oracles.json").read_text()
+        )
+        rows = score_corpus(self.CORPUS, oracles)["runs"]["A"]["checkpoints"]
+        for row in rows:
+            with self.subTest(action=row["action"]):
+                self.assertEqual(row["snapshot_state"], "COMPLETE")
+                # Cumulative gets its own assertion: source can be threaded to
+                # one call and not the other, and only this catches that.
+                self.assertEqual(row["cumulative_state"], "COMPLETE")
+                self.assertEqual(row["a_class"], "A_TRUE_COMPLETE")
+
+
+class NoNarrativeFallbackTests(unittest.TestCase):
+    """score_text must not quietly substitute the narrative for missing source.
+
+    `source_text or text` looks harmless and reintroduces the whole defect:
+    with no artifact preserved, absence would once again be decided against the
+    analyst's own commentary.
+    """
+
+    SPEC = {
+        "required_findings": [
+            {"id": "no_cap", "kind": "absent_all", "values": ["fetch("]},
+        ]
+    }
+
+    def test_missing_source_is_unscorable_not_narrative_scored(self) -> None:
+        clean = "the artifact does not call anything unusual"
+        score = score_text(self.SPEC, clean, 0)
+        self.assertEqual(score.unscorable, ["no_cap"])
+        self.assertEqual(score.state, "INDETERMINATE")
+
+    def test_hostile_narrative_still_unscorable_without_source(self) -> None:
+        """Text naming the token must not flip it either way when source is absent."""
+        hostile = "the artifact never calls fetch( at all"
+        score = score_text(self.SPEC, hostile, 0)
+        self.assertEqual(score.unscorable, ["no_cap"])
+        self.assertNotIn("no_cap", score.missing)
+
+    def test_absent_source_never_reaches_the_predicate_at_all(self) -> None:
+        """Directly pins the guard, not just its consequence.
+
+        A mutant that keeps `text = source_text` when source exists but deletes
+        the None-guard leaves absence decided against narrative in exactly the
+        case where no artifact was preserved. Asserting the returned reason
+        catches that; asserting only the satisfied/missing split does not.
+        """
+        spec = {"id": "no_cap", "kind": "absent_all", "values": ["fetch("]}
+        result = evaluate_finding(spec, "text mentioning fetch( freely")
+        self.assertTrue(result.unscorable)
+        self.assertIn("source", result.detail.lower())
+
+    def test_with_source_it_becomes_scorable_again(self) -> None:
+        hostile = "the artifact never calls fetch( at all"
+        score = score_text(self.SPEC, hostile, 0, source_text="function greet(){}")
+        self.assertEqual(score.unscorable, [])
+        self.assertEqual(score.state, "COMPLETE")
+
+
+class SourceProvenanceTests(unittest.TestCase):
+    """Which bytes count as "the source" is itself load-bearing.
+
+    Absence is now decided against the artifact, so accepting the wrong file --
+    above all `final_report.txt`, the narrative-like text whose exclusion is the
+    entire point -- would reintroduce the defect through a different door.
+    """
+
+    CORPUS = Path(
+        "/home/guelfoweb/LAB/orbit-checkpoints/completion-shadow-lossless-ac-20260827-175528"
+    )
+
+    def setUp(self) -> None:
+        if not self.CORPUS.is_dir():
+            self.skipTest("preserved corpus not present")
+        self.tmp = Path(tempfile.mkdtemp(prefix="source-prov-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        shutil.copytree(self.CORPUS, self.tmp / "corpus")
+        self.corpus = self.tmp / "corpus"
+
+    def test_source_is_the_artifact_not_the_report(self) -> None:
+        from score_completion_shadow import load_run
+
+        data = load_run(self.corpus, "A")
+        report = (self.corpus / "runs/A/final_report.txt").read_text()
+        self.assertNotEqual(data["source_text"], report)
+        self.assertEqual(
+            data["source_text"],
+            (self.corpus / "runs/A/artifact.js").read_text(),
+        )
+
+    def test_a_tampered_artifact_refuses_to_score(self) -> None:
+        from score_completion_shadow import load_run
+
+        path = self.corpus / "runs/A/artifact.js"
+        path.write_text(path.read_text() + "\n// appended\n")
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def test_an_artifact_swapped_for_the_report_refuses_to_score(self) -> None:
+        """The exact substitution that would resurrect narrative scoring."""
+        from score_completion_shadow import load_run
+
+        report = (self.corpus / "runs/A/final_report.txt").read_text()
+        (self.corpus / "runs/A/artifact.js").write_text(report)
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def test_ambiguous_artifacts_refuse_to_score(self) -> None:
+        """Two candidates means no defensible choice, so make none."""
+        from score_completion_shadow import load_run
+
+        (self.corpus / "runs/A/artifact.txt").write_text("decoy")
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def _blank_hash(self) -> None:
+        run = self.corpus / "runs/A/run.json"
+        data = json.loads(run.read_text())
+        data["artifact_sha256_before"] = ""
+        run.write_text(json.dumps(data))
+
+    def test_a_corpus_recording_no_hash_refuses_to_score(self) -> None:
+        """The guard must not weaken itself when the corpus vouches for nothing.
+
+        This defect lived in corpus SHAPE, not in code, so no source mutation
+        expresses it: `if expected and ...` silently verified nothing whenever
+        the field was blank.
+        """
+        from score_completion_shadow import load_run
+
+        self._blank_hash()
+        with self.assertRaises(SystemExit) as caught:
+            load_run(self.corpus, "A")
+        # The REASON matters, not just the raise. Without the explicit guard a
+        # blank hash still trips the mismatch branch by accident -- same
+        # outcome here, but it would waive verification anywhere the recorded
+        # hash is blank AND the comparison is later loosened.
+        self.assertIn("records no", str(caught.exception))
+
+    def test_a_blank_hash_cannot_launder_the_final_report(self) -> None:
+        """The swap test only bit because the hash was intact; close that door."""
+        from score_completion_shadow import load_run
+
+        report = (self.corpus / "runs/A/final_report.txt").read_text()
+        (self.corpus / "runs/A/artifact.js").write_text(report)
+        self._blank_hash()
+        with self.assertRaises(SystemExit) as caught:
+            load_run(self.corpus, "A")
+        self.assertIn("records no", str(caught.exception))
+
+    def test_an_empty_artifact_refuses_even_with_a_matching_hash(self) -> None:
+        """Absence over nothing is vacuously true; refuse rather than pass."""
+        import hashlib
+
+        from score_completion_shadow import load_run
+
+        path = self.corpus / "runs/A/artifact.js"
+        path.write_text("")
+        run = self.corpus / "runs/A/run.json"
+        data = json.loads(run.read_text())
+        data["artifact_sha256_before"] = hashlib.sha256(b"").hexdigest()
+        run.write_text(json.dumps(data))
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def test_the_whole_hash_is_compared_not_a_prefix(self) -> None:
+        """A truncated comparison is weaker than it looks; pin the full digest."""
+        import hashlib
+
+        from score_completion_shadow import load_run
+
+        path = self.corpus / "runs/A/artifact.js"
+        real = path.read_bytes()
+        digest = hashlib.sha256(real).hexdigest()
+        run = self.corpus / "runs/A/run.json"
+        data = json.loads(run.read_text())
+        # Same first 16 hex chars, different tail: only a full comparison fails.
+        data["artifact_sha256_before"] = digest[:16] + ("0" * 48)
+        run.write_text(json.dumps(data))
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def test_a_directory_artifact_refuses_cleanly(self) -> None:
+        from score_completion_shadow import load_run
+
+        path = self.corpus / "runs/A/artifact.js"
+        path.unlink()
+        path.mkdir()
+        with self.assertRaises(SystemExit):
+            load_run(self.corpus, "A")
+
+    def test_the_unmodified_corpus_still_loads(self) -> None:
+        """Guards the guard: the refusals above must not be unconditional."""
+        from score_completion_shadow import load_run
+
+        self.assertIsNotNone(load_run(self.corpus, "A")["source_text"])
+
+
+class MonotonicityInvariantTests(unittest.TestCase):
+    """COMPLETE -> INCOMPLETE must be unreachable without supersession."""
+
+    LEGAL = {
+        ("INCOMPLETE", "INCOMPLETE"),
+        ("INCOMPLETE", "COMPLETE"),
+        ("COMPLETE", "COMPLETE"),
+    }
+
+    def _trajectory(self, label: str, source: Path) -> list[str]:
+        states = sorted(AUTHENTIC.glob(f"{label}_action*"))
+        if not states:
+            self.skipTest("authentic capture not present")
+        source_text = source.read_text(errors="replace")
+        out = []
+        for state in states:
+            index = json.loads((state / "evidence" / "index.json").read_text())
+            text = "\n".join(
+                (state / "evidence" / f"{eid}.txt").read_text(errors="replace")
+                for eid in index
+                if (state / "evidence" / f"{eid}.txt").exists()
+            )
+            out.append(
+                score_text(ORACLES["samples"][label], text, 0, source_text=source_text).state
+            )
+        return out
+
+    def test_trivial_trajectory_never_regresses(self) -> None:
+        """The exact trajectory that exhibited the defect."""
+        states = self._trajectory("A", ROOT / "workdir/samples/trivial_greeting_demo.js")
+        self.assertGreaterEqual(len(states), 2, "need a transition to test")
+        for i in range(1, len(states)):
+            with self.subTest(step=i, transition=(states[i - 1], states[i])):
+                self.assertIn((states[i - 1], states[i]), self.LEGAL)
+
+    def test_powershell_trajectory_never_regresses(self) -> None:
+        states = self._trajectory("C", ROOT / "workdir/samples/peXF7I6W.ps1")
+        for i in range(1, len(states)):
+            with self.subTest(step=i, transition=(states[i - 1], states[i])):
+                self.assertIn((states[i - 1], states[i]), self.LEGAL)
+
+    def test_the_defect_is_actually_gone_not_merely_untested(self) -> None:
+        """Guards the guard: the old scoring really did regress here."""
+        states = sorted(AUTHENTIC.glob("A_action*"))
+        if len(states) < 2:
+            self.skipTest("authentic capture not present")
+        spec = [
+            s for s in ORACLES["samples"]["A"]["required_findings"]
+            if s["id"] == "no_dangerous_capability"
+        ][0]
+        later = states[1]
+        index = json.loads((later / "evidence" / "index.json").read_text())
+        narrative = "\n".join(
+            (later / "evidence" / f"{eid}.txt").read_text(errors="replace")
+            for eid in index
+            if (later / "evidence" / f"{eid}.txt").exists()
+        )
+        # Old behaviour: absence decided against narrative -> fails.
+        old = not any(v.lower() in narrative.lower() for v in spec["values"])
+        self.assertFalse(old, "expected the historical defect to be reproducible")
+        # New behaviour: decided against source -> holds.
+        source = (ROOT / "workdir/samples/trivial_greeting_demo.js").read_text()
+        self.assertTrue(evaluate_finding(spec, narrative, source_text=source).satisfied)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Evaluation-only. No changes under `src/`.

## The defect

`no_dangerous_capability` asserts that the artifact performs no network or
process-creation call. It was evaluated against the **cumulative evidence
narrative** — so an analysis step explaining that the file makes no such call
had to name the calls it does not make, and the predicate then failed against
its own explanation.

On a real captured trajectory the oracle read COMPLETE at action 1 and
INCOMPLETE at actions 2–5, **with no evidence lost**. That makes
`COMPLETE → INCOMPLETE` reachable from commentary alone, and a completion
oracle whose answer can be revoked by appended prose cannot qualify anything.

## The fix

Predicates now declare what they may inspect — `SOURCE_FACT`, `DERIVED_FACT`,
`ARTIFACT_FACT`, `NEGATIVE_SOURCE_FACT` — with an optional per-spec override so
a legitimate absence-of-*derived*-fact is not forced onto source bytes and made
to self-satisfy. A negative source fact is decided against the artifact, and is
UNSCORABLE without it: refusing to answer beats answering from the wrong
evidence.

Supplying the artifact makes it load-bearing, so it is bound like the ledger
already is. `load_run` refuses on ambiguity, on a missing or blank recorded
hash, on hash mismatch, on a non-file, and on empty bytes (absence over nothing
is vacuously true). Without the blank-hash refusal the guard's strength would
depend on the data it guards, and a `final_report.txt` accepted as "the
artifact" would reintroduce narrative scoring through a different door.

## Result

`COMPLETE → INCOMPLETE` flips on the real trajectory: **1 → 0**. Both preserved
corpora reproduce their baseline scoring output exactly.

## Qualification

- **20/20 mutations caught**
- 105 focused tests; full suite **3348, exit 0**, 1 pre-existing skip
- Two independent review rounds; every BLOCKER/MAJOR closed

Five defects surfaced along the way — three found by review, two by me:
`score_corpus` never supplying source (silently turning a previously-merged
COMPLETE into INDETERMINATE); `source_text or text` surviving as a
plausible-looking fallback; `final_report.txt` substitutable as the artifact;
cumulative source threading untested; and a blank recorded hash waiving
verification entirely. The last lived in *corpus shape* rather than code, so no
source mutation expressed it.

Two stale expectations are corrected alongside: one pinned the pre-fix absence
behaviour, and `test_b_not_called_when_a_continued` was **already failing at
baseline**, left behind by the merged `B_ERRORED` change.