### PR TITLE
feat(native): qualify self-MTP by exact artifact content, not by profile

### DIFF
--- a/src/orbit/native_llama/artifact_capabilities.py
+++ b/src/orbit/native_llama/artifact_capabilities.py
@@ -1,0 +1,85 @@
+"""What one exact GGUF is qualified to do, as distinct from what its profile supports.
+
+Discovery answers "which model is this?" from GGUF metadata, cheaply. This
+module answers a different question -- "is *these bytes* qualified for X?" --
+and it has to, because two builds of the same model share every metadata field
+discovery reads. The current and legacy Ornith artifacts have the same
+architecture, the same `general.name`, the same chat template and the same 753
+tensors; only ~20 blk.40 weights differ. Nothing short of content identity can
+separate them.
+
+So capability is keyed on the SHA-256 of the file's bytes. That costs a full
+read of a 20 GiB file (measured ~46 s), which is why it is never done during
+discovery and only ever on an explicit query.
+
+Everything about ARTIFACT STATE fails closed: an unknown digest, an unverified
+profile, a missing file or an unreadable one all yield "not qualified". Caller
+bugs are deliberately not absorbed -- an unhashable `capability` argument, or a
+non-OSError fault while hashing, propagates rather than being reported as a
+policy decision. Silently answering "not qualified" for a defect would hide it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from orbit.native_llama.model_profiles import (
+    NativeModelProfile,
+    artifact_capability_map,
+    verified_native_model_identity,
+)
+
+_CHUNK = 1024 * 1024
+
+
+def artifact_sha256(path: Path) -> str:
+    """SHA-256 of the file's bytes. No caching: correctness over cleverness.
+
+    Deliberately not memoised. A cache keyed on path or on (size, mtime) can be
+    defeated by an in-place replacement that preserves both, and the failure
+    mode is an unqualified artifact inheriting a qualified verdict. Orbit has
+    no existing primitive with invalidation strong enough to carry that risk,
+    so the honest answer is to pay the read.
+    """
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verified_artifact_capabilities(
+    path: Path,
+    profile: NativeModelProfile | None,
+) -> frozenset[str]:
+    """Capabilities this exact artifact is qualified for. Empty when unsure.
+
+    `profile` is the already-resolved discovery result, passed in rather than
+    recomputed: this module must not become a second way to identify a model.
+    A profile that is absent or unverified short-circuits before any hashing,
+    so the expensive path is only reached for a model Orbit already trusts.
+    """
+    if profile is None or not profile.verified:
+        return frozenset()
+    identity = verified_native_model_identity(profile.profile_id)
+    if identity is None or not identity.artifact_capabilities:
+        return frozenset()
+    # Only now is the digest worth computing: this profile has *some* artifact
+    # qualified for *something*, so the bytes decide which.
+    try:
+        digest = artifact_sha256(Path(path))
+    except OSError:
+        # Unreadable, vanished, or a directory. Not qualified, not an error --
+        # the caller's normal path must keep working without capabilities.
+        return frozenset()
+    return frozenset(artifact_capability_map(identity).get(digest, frozenset()))
+
+
+def verified_artifact_supports(
+    path: Path,
+    capability: str,
+    profile: NativeModelProfile | None,
+) -> bool:
+    """Is this exact artifact qualified for `capability`?"""
+    return capability in verified_artifact_capabilities(path, profile)

--- a/src/orbit/native_llama/model_profiles.py
+++ b/src/orbit/native_llama/model_profiles.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
+from types import MappingProxyType
 from typing import Mapping
 
 
@@ -136,17 +137,61 @@ _VERIFIED_TEMPLATE_HISTORY_SERIALIZATION = {
 }
 
 
+# Capabilities a specific ARTIFACT is qualified for, as opposed to what its
+# profile supports. The distinction is the whole point: two GGUFs can share a
+# profile, a model name and an architecture and still differ in what they are
+# qualified to do -- the current and legacy Ornith builds are exactly that
+# case, identical in every metadata field discovery reads.
+#
+# `self_mtp` means "this exact artifact is qualified to drive llama.cpp's
+# single-GGUF NextN self-speculative decoding". It is deliberately NOT
+# `NativeModelProfile.mtp_supported`, which gates the external-draft MTP path
+# and is a property of the profile.
+SELF_MTP_CAPABILITY = "self_mtp"
+
+# Current official Ornith 1.5 35B-A3B Q4_K_M build. Its blk.40 NextN weights
+# differ from the legacy local build; only this one is qualified.
+ORNITH15_CURRENT_ARTIFACT_SHA256 = (
+    "42739874cc2ccfdb8523b23fbe52e29b2a7555c8176737ca9ca0b5d59859d41f"
+)
+
+
 @dataclass(frozen=True)
 class VerifiedNativeModelIdentity:
     profile_id: str
     model_name: str
     architecture: str
+    # sha256 -> frozenset of capability names. Keyed by content, never by path
+    # or basename, so the same bytes qualify under any filename and a renamed
+    # impostor never does. Empty by default: an artifact earns capabilities by
+    # being listed, so an unknown digest fails closed without a special case.
+    # Stored as a frozenset of (digest, capabilities) pairs rather than a
+    # mapping, because the field has to be BOTH hashable and compared.
+    #
+    # A mappingproxy delegates hashing to the dict it wraps, so keeping it here
+    # made the frozen record unhashable. Excluding it with `compare=False`
+    # restored the hash but collapsed equality: two identities differing only
+    # in which artifact they qualify became interchangeable, and a
+    # legacy-qualified record would silently overwrite a current-qualified one
+    # used as a dict key -- the very substitution this module exists to
+    # prevent, relocated from the digest lookup into record identity.
+    #
+    # A frozenset of pairs has neither problem: hashable, and it distinguishes.
+    # `artifact_capability_map()` reads it back as a mapping.
+    artifact_capabilities: frozenset[tuple[str, frozenset[str]]] = frozenset()
 
 
 VERIFIED_NATIVE_MODEL_IDENTITIES = (
     VerifiedNativeModelIdentity(GEMMA4_PROFILE_ID, GEMMA4_VERIFIED_MODEL_NAME, "gemma4"),
     VerifiedNativeModelIdentity(QWEN36_PROFILE_ID, QWEN36_VERIFIED_MODEL_NAME, "qwen35moe"),
-    VerifiedNativeModelIdentity(ORNITH15_PROFILE_ID, ORNITH15_VERIFIED_MODEL_NAME, "qwen35moe"),
+    VerifiedNativeModelIdentity(
+        ORNITH15_PROFILE_ID,
+        ORNITH15_VERIFIED_MODEL_NAME,
+        "qwen35moe",
+        frozenset(
+            {(ORNITH15_CURRENT_ARTIFACT_SHA256, frozenset({SELF_MTP_CAPABILITY}))}
+        ),
+    ),
     VerifiedNativeModelIdentity(QWEN38_PROFILE_ID, QWEN38_VERIFIED_MODEL_NAME, "qwen35"),
     VerifiedNativeModelIdentity(
         QWEN3_CODER_PROFILE_ID,
@@ -154,6 +199,13 @@ VERIFIED_NATIVE_MODEL_IDENTITIES = (
         "qwen3moe",
     ),
 )
+
+
+def artifact_capability_map(
+    identity: VerifiedNativeModelIdentity,
+) -> Mapping[str, frozenset[str]]:
+    """Read the stored pairs back as a digest -> capabilities mapping."""
+    return MappingProxyType(dict(identity.artifact_capabilities))
 
 
 def verified_native_model_identity(profile_id: str) -> VerifiedNativeModelIdentity | None:

--- a/tests/test_artifact_capabilities.py
+++ b/tests/test_artifact_capabilities.py
@@ -1,0 +1,460 @@
+"""Exact-artifact capability identity.
+
+The property under test is that capability follows CONTENT, never the path.
+Two Ornith builds share their profile, model name, architecture and chat
+template; only their bytes differ. Anything keyed on a filename would qualify
+the wrong one.
+
+Small fixtures with injected digests do the work. One integration test hashes a
+real file end to end so the wiring is not merely mocked.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama import artifact_capabilities as ac  # noqa: E402
+from orbit.native_llama.model_profiles import (  # noqa: E402
+    ORNITH15_CURRENT_ARTIFACT_SHA256,
+    artifact_capability_map,
+    ORNITH15_PROFILE_ID,
+    SELF_MTP_CAPABILITY,
+    VERIFIED_NATIVE_MODEL_IDENTITIES,
+    VerifiedNativeModelIdentity,
+    verified_native_model_identity,
+)
+
+LEGACY_SHA = "ca6ea26329c88b78ffd90a85163be2e746c2fafd1024f56db47e499f117f9a7f"
+
+
+def _profile(profile_id: str = ORNITH15_PROFILE_ID, verified: bool = True):
+    """The fields `verified_artifact_capabilities` actually reads."""
+    return mock.Mock(profile_id=profile_id, verified=verified)
+
+
+class SchemaTests(unittest.TestCase):
+    def test_only_ornith_declares_an_artifact_capability(self) -> None:
+        declaring = [
+            i.profile_id for i in VERIFIED_NATIVE_MODEL_IDENTITIES if i.artifact_capabilities
+        ]
+        self.assertEqual(declaring, [ORNITH15_PROFILE_ID])
+
+    def test_current_sha_maps_to_self_mtp(self) -> None:
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        self.assertEqual(
+            artifact_capability_map(identity)[ORNITH15_CURRENT_ARTIFACT_SHA256],
+            frozenset({SELF_MTP_CAPABILITY}),
+        )
+
+    def test_legacy_sha_is_absent_from_the_table(self) -> None:
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        self.assertNotIn(LEGACY_SHA, artifact_capability_map(identity))
+
+    def test_exactly_one_digest_is_qualified(self) -> None:
+        """The table is an allowlist of one, not "the current one plus others".
+
+        Asserting only that a couple of known-bad digests are absent would let
+        any additional entry slip in. What matters is the size of the set.
+        """
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        self.assertEqual(
+            list(artifact_capability_map(identity)), [ORNITH15_CURRENT_ARTIFACT_SHA256]
+        )
+
+    def test_no_profile_qualifies_more_than_the_digests_it_declares(self) -> None:
+        for identity in VERIFIED_NATIVE_MODEL_IDENTITIES:
+            with self.subTest(identity.profile_id):
+                for digest in artifact_capability_map(identity):
+                    self.assertEqual(len(digest), 64, "keys must be sha256 hex")
+                    self.assertEqual(digest, digest.lower())
+
+    def test_capability_sets_are_immutable(self) -> None:
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        with self.assertRaises(AttributeError):
+            identity.artifact_capabilities.add(("x", frozenset({"y"})))
+        with self.assertRaises(TypeError):
+            artifact_capability_map(identity)["x"] = frozenset({"y"})
+
+    def test_identities_without_capabilities_default_to_empty(self) -> None:
+        blank = VerifiedNativeModelIdentity("p", "m", "a")
+        self.assertEqual(dict(artifact_capability_map(blank)), {})
+
+
+class EligibilityTests(unittest.TestCase):
+    """Digest-driven verdicts, with the hash injected so no 20 GiB is read."""
+
+    def _supports(self, digest: str, profile=None) -> bool:
+        with mock.patch.object(ac, "artifact_sha256", return_value=digest):
+            return ac.verified_artifact_supports(
+                Path("/nonexistent.gguf"),
+                SELF_MTP_CAPABILITY,
+                profile if profile is not None else _profile(),
+            )
+
+    def test_current_artifact_is_eligible(self) -> None:
+        self.assertTrue(self._supports(ORNITH15_CURRENT_ARTIFACT_SHA256))
+
+    def test_legacy_artifact_is_not_eligible(self) -> None:
+        self.assertFalse(self._supports(LEGACY_SHA))
+
+    def test_unknown_artifact_is_not_eligible(self) -> None:
+        self.assertFalse(self._supports("00" * 32))
+
+    def test_unverified_profile_is_not_eligible(self) -> None:
+        self.assertFalse(
+            self._supports(ORNITH15_CURRENT_ARTIFACT_SHA256, _profile(verified=False))
+        )
+
+    def test_absent_profile_is_not_eligible(self) -> None:
+        self.assertFalse(
+            ac.verified_artifact_supports(
+                Path("/nonexistent.gguf"), SELF_MTP_CAPABILITY, None
+            )
+        )
+
+    def test_other_profile_is_not_eligible_even_with_the_current_digest(self) -> None:
+        """The digest alone must not qualify an artifact under another profile."""
+        self.assertFalse(
+            self._supports(
+                ORNITH15_CURRENT_ARTIFACT_SHA256, _profile("orbit-qwen38-native-v1")
+            )
+        )
+
+    def test_digest_lookup_is_case_sensitive(self) -> None:
+        """hexdigest() emits lowercase; nothing may normalise around that.
+
+        Latent rather than live, but a lookup that lowercases (or uppercases)
+        its key widens the allowlist by exactly the set of digests that differ
+        only in case -- a silent relaxation of an exact-match guarantee.
+        """
+        self.assertFalse(self._supports(ORNITH15_CURRENT_ARTIFACT_SHA256.upper()))
+
+    def test_non_oserror_failures_are_not_swallowed(self) -> None:
+        """The narrow `except OSError` is deliberate: a bug must surface.
+
+        Widening it to `except Exception` would turn a programming error into
+        a silent "not qualified", which reads as a policy decision rather than
+        the defect it is.
+        """
+        with mock.patch.object(ac, "artifact_sha256", side_effect=TypeError("bug")):
+            with self.assertRaises(TypeError):
+                ac.verified_artifact_supports(
+                    Path("/x.gguf"), SELF_MTP_CAPABILITY, _profile()
+                )
+
+    def test_unknown_capability_name_fails_closed(self) -> None:
+        with mock.patch.object(
+            ac, "artifact_sha256", return_value=ORNITH15_CURRENT_ARTIFACT_SHA256
+        ):
+            self.assertFalse(
+                ac.verified_artifact_supports(
+                    Path("/x.gguf"), "teleportation", _profile()
+                )
+            )
+
+
+class ContentNotPathTests(unittest.TestCase):
+    """Section 4: capability follows the bytes, under any name or link."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="artifact-caps-"))
+        self.addCleanup(self._cleanup)
+        self.payload = b"pretend GGUF bytes\n"
+        self.real = self.tmp / "Ornith-1.5-35B-Q4_K_M.gguf"
+        self.real.write_bytes(self.payload)
+        self.digest = ac.artifact_sha256(self.real)
+        # Qualify these exact bytes under the Ornith profile for the test.
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        self.patched = VerifiedNativeModelIdentity(
+            identity.profile_id,
+            identity.model_name,
+            identity.architecture,
+            frozenset({(self.digest, frozenset({SELF_MTP_CAPABILITY}))}),
+        )
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _supports(self, path: Path) -> bool:
+        with mock.patch.object(
+            ac, "verified_native_model_identity", return_value=self.patched
+        ):
+            return ac.verified_artifact_supports(path, SELF_MTP_CAPABILITY, _profile())
+
+    def test_original_path_qualifies(self) -> None:
+        self.assertTrue(self._supports(self.real))
+
+    def test_renamed_file_still_qualifies(self) -> None:
+        renamed = self.tmp / "totally-different-name.bin"
+        renamed.write_bytes(self.payload)
+        self.assertTrue(self._supports(renamed))
+
+    def test_symlink_to_the_artifact_qualifies(self) -> None:
+        link = self.tmp / "link.gguf"
+        link.symlink_to(self.real)
+        self.assertTrue(self._supports(link))
+
+    def test_same_name_wrong_bytes_does_not_qualify(self) -> None:
+        """The impostor case: correct filename, different content."""
+        other = self.tmp / "impostor"
+        other.mkdir()
+        impostor = other / "Ornith-1.5-35B-Q4_K_M.gguf"
+        impostor.write_bytes(self.payload + b"tampered")
+        self.assertEqual(impostor.name, self.real.name)
+        self.assertFalse(self._supports(impostor))
+
+    def test_one_flipped_byte_does_not_qualify(self) -> None:
+        near = self.tmp / "near.gguf"
+        near.write_bytes(self.payload[:-1] + b"X")
+        self.assertFalse(self._supports(near))
+
+    def test_missing_file_fails_closed(self) -> None:
+        self.assertFalse(self._supports(self.tmp / "absent.gguf"))
+
+    def test_directory_fails_closed(self) -> None:
+        self.assertFalse(self._supports(self.tmp))
+
+    def test_unreadable_file_fails_closed(self) -> None:
+        locked = self.tmp / "locked.gguf"
+        locked.write_bytes(self.payload)
+        locked.chmod(0o000)
+        self.addCleanup(locked.chmod, 0o644)
+        if os.geteuid() == 0:
+            self.skipTest("root ignores file permissions")
+        self.assertFalse(self._supports(locked))
+
+
+class WholeFileIsHashedTests(unittest.TestCase):
+    """The digest must cover every byte, not just the first chunk.
+
+    Every other fixture here is a few dozen bytes -- under `_CHUNK` -- so a
+    truncated read would hash them entirely and no test would notice. That is
+    exactly the bug this module exists to prevent: the CURRENT and LEGACY
+    Ornith artifacts share ~20 GiB of identical prefix and differ only in
+    trailing blk.40 weights, so a first-chunk-only digest would hand LEGACY
+    the CURRENT verdict.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+
+        self.tmp = Path(tempfile.mkdtemp(prefix="whole-file-hash-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        # Shared prefix strictly larger than one read chunk, then a divergent
+        # tail -- the CURRENT/LEGACY shape in miniature.
+        prefix = b"\xa5" * (ac._CHUNK + 4096)
+        self.a = self.tmp / "a.gguf"
+        self.b = self.tmp / "b.gguf"
+        self.a.write_bytes(prefix + b"TAIL-A")
+        self.b.write_bytes(prefix + b"TAIL-B")
+
+    def test_files_sharing_a_chunk_sized_prefix_hash_differently(self) -> None:
+        self.assertGreater(self.a.stat().st_size, ac._CHUNK)
+        self.assertEqual(
+            self.a.read_bytes()[: ac._CHUNK], self.b.read_bytes()[: ac._CHUNK]
+        )
+        self.assertNotEqual(ac.artifact_sha256(self.a), ac.artifact_sha256(self.b))
+
+    def test_a_tail_only_difference_changes_the_verdict(self) -> None:
+        """End to end: the impostor must not inherit the qualified verdict."""
+        identity = VerifiedNativeModelIdentity(
+            ORNITH15_PROFILE_ID,
+            "Ornith-1.5-35B",
+            "qwen35moe",
+            frozenset({(ac.artifact_sha256(self.a), frozenset({SELF_MTP_CAPABILITY}))}),
+        )
+        with mock.patch.object(
+            ac, "verified_native_model_identity", return_value=identity
+        ):
+            self.assertTrue(
+                ac.verified_artifact_supports(self.a, SELF_MTP_CAPABILITY, _profile())
+            )
+            self.assertFalse(
+                ac.verified_artifact_supports(self.b, SELF_MTP_CAPABILITY, _profile())
+            )
+
+    def test_digest_matches_a_whole_file_reference_hash(self) -> None:
+        import hashlib
+
+        self.assertEqual(
+            ac.artifact_sha256(self.a),
+            hashlib.sha256(self.a.read_bytes()).hexdigest(),
+        )
+
+
+class IdentityRecordTests(unittest.TestCase):
+    """The identity record must stay hashable and frozen."""
+
+    def test_identities_remain_hashable(self) -> None:
+        for identity in VERIFIED_NATIVE_MODEL_IDENTITIES:
+            with self.subTest(identity.profile_id):
+                self.assertIsInstance(hash(identity), int)
+        self.assertEqual(len(set(VERIFIED_NATIVE_MODEL_IDENTITIES)),
+                         len(VERIFIED_NATIVE_MODEL_IDENTITIES))
+
+    def test_identities_are_usable_as_dict_keys(self) -> None:
+        mapping = {i: i.profile_id for i in VERIFIED_NATIVE_MODEL_IDENTITIES}
+        self.assertEqual(len(mapping), len(VERIFIED_NATIVE_MODEL_IDENTITIES))
+
+    def test_identities_differing_only_in_capabilities_are_distinct(self) -> None:
+        """Capabilities must participate in equality, not just live alongside it.
+
+        Excluding them (compare=False) restores hashability but collapses
+        equality, and a legacy-qualified record then silently overwrites a
+        current-qualified one used as a dict key -- the substitution this
+        module exists to prevent, moved from the digest lookup into record
+        identity.
+        """
+        current = VerifiedNativeModelIdentity(
+            "p", "m", "a", frozenset({("aa" * 32, frozenset({SELF_MTP_CAPABILITY}))})
+        )
+        legacy = VerifiedNativeModelIdentity(
+            "p", "m", "a", frozenset({("bb" * 32, frozenset({SELF_MTP_CAPABILITY}))})
+        )
+        none = VerifiedNativeModelIdentity("p", "m", "a")
+        self.assertNotEqual(current, legacy)
+        self.assertNotEqual(current, none)
+        self.assertEqual(len({current, legacy, none}), 3)
+        keyed = {current: "current", legacy: "legacy"}
+        self.assertEqual(keyed[current], "current", "legacy overwrote current")
+
+    def test_value_equality_holds_for_identical_records(self) -> None:
+        """`eq=False` would silently switch this to identity comparison."""
+        caps = frozenset({("aa" * 32, frozenset({SELF_MTP_CAPABILITY}))})
+        self.assertEqual(
+            VerifiedNativeModelIdentity("p", "m", "a", caps),
+            VerifiedNativeModelIdentity("p", "m", "a", caps),
+        )
+        self.assertEqual(
+            VerifiedNativeModelIdentity("p", "m", "a"),
+            VerifiedNativeModelIdentity("p", "m", "a"),
+        )
+
+    def test_identity_is_frozen(self) -> None:
+        identity = verified_native_model_identity(ORNITH15_PROFILE_ID)
+        with self.assertRaises(Exception):
+            identity.profile_id = "mutated"
+
+
+class DiscoveryDoesNotHashTests(unittest.TestCase):
+    """Normal discovery must not acquire a 20 GiB hashing cost."""
+
+    def test_model_discovery_module_never_hashes_artifacts(self) -> None:
+        from orbit.native_llama import model_discovery
+
+        source = Path(model_discovery.__file__).read_text()
+        self.assertNotIn("artifact_sha256", source)
+        self.assertNotIn("artifact_capabilities", source)
+
+    def test_model_profiles_module_does_not_hash_artifacts(self) -> None:
+        from orbit.native_llama import model_profiles
+
+        source = Path(model_profiles.__file__).read_text()
+        self.assertNotIn("artifact_sha256(", source)
+
+    def test_capability_query_short_circuits_before_hashing(self) -> None:
+        """A profile with no declared artifacts never reaches the hash."""
+        with mock.patch.object(ac, "artifact_sha256") as hashed:
+            ac.verified_artifact_supports(
+                Path("/x.gguf"), SELF_MTP_CAPABILITY, _profile("orbit-qwen38-native-v1")
+            )
+            hashed.assert_not_called()
+
+    def test_capability_query_does_hash_when_it_must(self) -> None:
+        with mock.patch.object(ac, "artifact_sha256", return_value="00" * 32) as hashed:
+            ac.verified_artifact_supports(Path("/x.gguf"), SELF_MTP_CAPABILITY, _profile())
+            hashed.assert_called_once()
+
+
+class ExternalDraftUntouchedTests(unittest.TestCase):
+    """Existing external-draft MTP semantics must be unchanged."""
+
+    def test_ornith_mtp_supported_is_false_without_any_fixture(self) -> None:
+        """Machine-independent: no checkpoint, no captured JSON, no skip.
+
+        The JSON-backed test below is stronger but skips where the checkpoint
+        is absent -- and with it skipped, flipping this flag left the whole
+        suite green. The external-draft guarantee needs an anchor that cannot
+        skip.
+        """
+        import inspect
+
+        from orbit.native_llama import model_profiles
+
+        source = inspect.getsource(model_profiles)
+        start = source.index("if ornith15_identity:")
+        end = source.index("return NativeModelProfile", start)
+        end = source.index(")", source.index("template_source", end))
+        block = source[start:end]
+        self.assertIn("mtp_supported=False", block)
+        self.assertNotIn("mtp_supported=True", block)
+
+    def test_ornith_profile_mtp_supported_stays_false(self) -> None:
+        """`mtp_supported` gates external-draft MTP and must not absorb self_mtp.
+
+        Asserted against the shipped profile table rather than a hand-built
+        metadata dict: Ornith detection requires twelve exact fields plus the
+        official template hash, and a fixture that drifts from those would
+        silently stop testing Ornith at all.
+        """
+        import json
+
+        from orbit.native_llama.model_profiles import detect_native_model_profile
+
+        captured = Path(
+            "/home/guelfoweb/LAB/orbit-checkpoints/"
+            "ornith-new-mtp-qualification-20260828/gguf_metadata_old_vs_new.json"
+        )
+        if not captured.is_file():
+            self.skipTest("captured Ornith GGUF metadata not present")
+        meta = json.loads(captured.read_text())["new"]["meta"]
+        profile = detect_native_model_profile(meta, meta["tokenizer.chat_template"])
+        self.assertEqual(profile.profile_id, ORNITH15_PROFILE_ID)
+        self.assertTrue(profile.verified)
+        self.assertFalse(profile.mtp_supported)
+
+    def test_registry_mtp_block_semantics_unchanged(self) -> None:
+        from orbit.native_llama.model_registry import load_registry
+
+        ornith = [m for m in load_registry() if "ornith" in m.id][0]
+        self.assertIsNone(ornith.mtp)
+
+
+class RealFileIntegrationTests(unittest.TestCase):
+    """One end-to-end hash, so the wiring is not only mocked."""
+
+    def test_real_file_digest_drives_the_verdict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "artifact.gguf"
+            path.write_bytes(b"orbit self-mtp capability integration fixture")
+            digest = ac.artifact_sha256(path)
+            identity = VerifiedNativeModelIdentity(
+                ORNITH15_PROFILE_ID,
+                "Ornith-1.5-35B",
+                "qwen35moe",
+                frozenset({(digest, frozenset({SELF_MTP_CAPABILITY}))}),
+            )
+            with mock.patch.object(
+                ac, "verified_native_model_identity", return_value=identity
+            ):
+                self.assertTrue(
+                    ac.verified_artifact_supports(path, SELF_MTP_CAPABILITY, _profile())
+                )
+                path.write_bytes(b"different bytes entirely")
+                self.assertFalse(
+                    ac.verified_artifact_supports(path, SELF_MTP_CAPABILITY, _profile())
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Mission A of 3. Deterministic only: no inference, no native wiring, no CLI change, no policy. **No caller yet — this is the primitive.**

## Why content identity is unavoidable

The current and legacy Ornith artifacts are indistinguishable by everything discovery reads — same architecture, same `general.name` (`Ornith-1.5-35B`), same chat-template hash, same 753 tensors. Only ~20 `blk.40` weights differ, and those are precisely the NextN weights that decide self-MTP qualification. Nothing short of hashing the bytes can separate them.

## Schema

`VerifiedNativeModelIdentity` gains one optional field: a frozenset of `(sha256, capabilities)` pairs. Only Ornith populates it, mapping the current artifact to `{self_mtp}`. This follows the module's own precedent — `_VERIFIED_TEMPLATE_HISTORY_SERIALIZATION` is already a SHA256-keyed capability table — rather than adding a second registry.

`self_mtp` is deliberately **not** `NativeModelProfile.mtp_supported`, which gates the external-draft path and stays `False` for Ornith.

### Why pairs and not a mapping

The field must be **both hashable and compared**. A `mappingproxy` delegates hashing to its wrapped dict, so keeping one here made the frozen record unhashable. Excluding it with `compare=False` restored the hash but collapsed equality — two identities qualifying *different* artifacts became interchangeable, and a legacy-qualified record would silently overwrite a current-qualified one used as a dict key. That is the substitution this module exists to prevent, relocated from the digest lookup into record identity. A frozenset of pairs has neither problem.

## Digest strategy: no cache, by measurement

SHA-256 of the 20.2 GiB artifact: **46.2 s**. A cache was permitted only with proven invalidation, and none exists — a `(path, size, mtime)` key is defeated by an in-place replacement preserving both, and the failure mode is an unqualified artifact inheriting a qualified verdict.

**Discovery pays nothing**: instrumented `discover_models()` hashes **2 bytes** total.

## Verified end to end on the real artifacts

```
CURRENT (42739874…)  self_mtp -> True
LEGACY  (ca6ea263…)  self_mtp -> False
```

Artifact *state* fails closed (unknown digest, unverified/absent profile, missing, unreadable, directory, symlink loop, uppercase digest). Caller *bugs* propagate rather than being reported as a policy decision.

## Qualification

- 40 tests in the new file; 108 across four focused suites
- Full suite **3388, exit 0**, 1 pre-existing skip
- **19 mutants, all caught**

Two review rounds. Round 1 (2 MAJOR) found the unhashability regression and — more seriously — that every fixture was smaller than one read chunk, so replacing the chunked loop with a single `read(_CHUNK)` left the whole suite green. That is the truncation bug that would hand LEGACY the CURRENT verdict; it is now pinned by a fixture sharing a `_CHUNK + 4096` prefix and differing only in the tail. Round 2 (MERGE SAFE: YES, 2 MINOR) found that my first fix had introduced a quieter trap than the one it solved; both minors are now closed and mutation-covered.