### PR TITLE
feat(native): execute single-GGUF self-MTP on the qualified artifact

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -32,14 +32,17 @@ from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
 from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, emit_strict_append_miss, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
+from .artifact_capabilities import verified_artifact_supports
 from .model_profiles import (
     ORNITH15_PROFILE_ID,
     PROFILE_METADATA_KEYS,
     QWEN36_PROFILE_ID,
     QWEN3_CODER_PROFILE_ID,
+    SELF_MTP_CAPABILITY,
     NativeModelProfile,
     detect_native_model_profile,
     supports_low_memory_mode,
+    verified_native_model_identity,
 )
 from .model_discovery import inspect_native_model_profile
 from .mtp_completion import MtpCompletionResult
@@ -113,6 +116,7 @@ from .qwen3_coder_route_prefix import (
 from .persistent_mtp import (
     PersistentMtpSessionRuntime,
     create_persistent_mtp_session,
+    create_self_mtp_session,
     free_persistent_mtp_session,
     reset_persistent_mtp_session,
     run_persistent_mtp_completion,
@@ -794,6 +798,73 @@ class NativeLlamaClient:
             return
         self.mtp_decode_probe = run_mtp_decode_probe(llama_root=self.paths.llama_root, paths=self.paths)
 
+    def _self_mtp_eligible(self) -> bool:
+        """Is THIS EXACT artifact qualified for single-GGUF self-MTP?
+
+        Only reached when MTP was explicitly requested. Normal startup never
+        calls this, so normal startup never hashes the artifact.
+
+        Two stages, cheap first: the verified identity is consulted for whether
+        any artifact of this profile declares `self_mtp` at all, and only then
+        is the ~46 s digest of a 20 GiB file worth paying. A Gemma or
+        external-draft model therefore costs nothing to rule out.
+        """
+        profile = getattr(self, "model_profile", None)
+        if profile is None or not profile.verified:
+            return False
+        identity = verified_native_model_identity(profile.profile_id)
+        if identity is None or not identity.artifact_capabilities:
+            return False
+        return verified_artifact_supports(
+            self.paths.model, SELF_MTP_CAPABILITY, profile
+        )
+
+    def _initialize_self_mtp_session(self) -> bool:
+        """Construct the self-MTP session. True when it was actually built.
+
+        Returns False without touching session state when this artifact is not
+        qualified, so the caller can fall through to the external-draft path
+        exactly as it did before this existed.
+        """
+        try:
+            eligible = self._self_mtp_eligible()
+        except Exception as exc:
+            # A capability resolution failure is not an MTP verdict. Fail
+            # closed and say why rather than silently trying another path.
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = f"self-mtp-capability-error: {exc}"
+            return True
+        if not eligible:
+            return False
+        if not self._session.ctx_tgt:
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = "target-context-missing"
+            return True
+        try:
+            runtime = create_self_mtp_session(
+                llama_root=self.paths.llama_root,
+                paths=self.paths,
+                model=self._model,
+                ctx_tgt=self._session.ctx_tgt,
+                context_tokens=self.config.context_tokens,
+                batch_size=self.config.batch_size,
+                ubatch_size=self.config.ubatch_size,
+                threads=self.config.threads,
+                threads_batch=self.config.threads_batch,
+            )
+        except Exception as exc:
+            # The borrowed model and target context are untouched by a failed
+            # construction; the client still owns and frees them.
+            self._session.mtp_failed = True
+            self._session.mtp_failure_reason = str(exc)
+            return True
+        self._persistent_mtp_runtime = runtime
+        self._session.ctx_dft = runtime.ctx_dft
+        self._session.spec = runtime.spec
+        self._session.mtp_enabled = True
+        self._session.mtp_failed = False
+        return True
+
     def _initialize_persistent_mtp_session(self) -> None:
         self._free_persistent_mtp_session()
         self._session.ctx_dft = None
@@ -802,6 +873,12 @@ class NativeLlamaClient:
         self._session.mtp_failed = False
         self._session.mtp_failure_reason = None
         if not self.config.use_mtp_experimental:
+            return
+        # Self-MTP first, and only for an artifact whose exact bytes are
+        # qualified. It needs no registry `mtp` block and no profile-wide
+        # `mtp_supported`, both of which describe the external-draft
+        # architecture and would wrongly admit the legacy Ornith build.
+        if self._initialize_self_mtp_session():
             return
         profile = getattr(self, "model_profile", None)
         if profile is not None and not profile.mtp_supported:
@@ -2192,8 +2269,22 @@ class NativeLlamaClient:
         self._invalidate_committed_sequence()
         request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
+        # Whether MTP decoding may RUN is a property of the constructed
+        # session, not of registry metadata. `profile.mtp_supported` and
+        # `paths.mtp_available` both describe the EXTERNAL-DRAFT world -- a
+        # profile that participates in it, and a declared draft GGUF -- and are
+        # both False for a single-GGUF self-MTP artifact.
+        #
+        # Gating execution on them meant a correctly constructed self-MTP
+        # session reported `mtp_enabled=True` while every completion silently
+        # decoded normally: drafted 0, accepted 0, on the real artifact. So the
+        # metadata gates are skipped once a self-MTP session actually exists,
+        # and the runtime check below remains the single source of truth for
+        # both architectures.
+        runtime = self._persistent_mtp_runtime
+        self_mtp_session = runtime is not None and getattr(runtime, "self_mtp", False)
         profile = getattr(self, "model_profile", None)
-        if profile is not None and not profile.mtp_supported:
+        if not self_mtp_session and profile is not None and not profile.mtp_supported:
             self.mtp_fallback_reason = "model_profile_mtp_unsupported"
             self.last_mtp_completion = MtpCompletionResult(enabled=False, success=False, error=self.mtp_fallback_reason)
             return None
@@ -2204,7 +2295,10 @@ class NativeLlamaClient:
         if not self.config.use_mtp_experimental:
             self.last_mtp_completion = MtpCompletionResult(enabled=False, success=False, error=None)
             return None
-        if not self.paths.mtp_available:
+        # Same reasoning: a declared draft artifact is how an EXTERNAL-DRAFT
+        # session gets built, never a statement about whether this client has
+        # one. A self-MTP session needs no draft file at all.
+        if not self_mtp_session and not self.paths.mtp_available:
             self.mtp_fallback_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
             self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
             return None

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -21,6 +21,19 @@ _REQUIRED_SHIM_SYMBOLS = (
     "orbit_mtp_session_request_boundary_refill_marker",
 )
 
+# Required ONLY when a self-MTP session is about to be constructed. Kept out of
+# the base tuple deliberately: adding them there would reject every previously
+# valid shim for normal decoding and for the external-draft path, neither of
+# which needs these symbols. A shim that predates self-MTP stays a perfectly
+# good shim for everything it was already doing.
+_SELF_MTP_REQUIRED_SHIM_SYMBOLS = (
+    "orbit_selfmtp_session_create",
+    "orbit_selfmtp_session_destroy",
+    "orbit_mtp_session_owns_model",
+    "orbit_mtp_session_borrowed_model",
+    "orbit_mtp_session_borrowed_ctx_tgt",
+)
+
 MtpTokenCallback = CFUNCTYPE(None, c_char_p, c_void_p)
 MtpProgressCallback = CFUNCTYPE(None, c_int32, c_int32, c_int32, c_void_p)
 
@@ -42,6 +55,11 @@ class PersistentMtpSessionRuntime:
     rss_before_kb: int | None = None
     rss_after_init_kb: int | None = None
     rss_peak_kb: int | None = None
+    # True when this session borrows the caller's model instead of loading its
+    # own. Teardown reads it to pick the destroy that matches the ownership the
+    # constructor established -- freeing a borrowed model would double-free it
+    # the moment the client tears itself down.
+    self_mtp: bool = False
 
 
 class PersistentMtpLibrary:
@@ -179,6 +197,7 @@ def build_persistent_mtp_shim(
     build_bin: Path | None = None,
     runtime_bin: Path | None = None,
     runner=subprocess.run,
+    require_self_mtp: bool = False,
 ) -> Path:
     packaged = packaged_shim_path(persistent_mtp_shim_filename())
     # `build_bin` is where the compiler links from; `runtime_bin` is the family
@@ -187,8 +206,13 @@ def build_persistent_mtp_shim(
     # linker needs. The probe has to preload the runtime, not the link
     # directory: preloading the latter is what would put a second family in
     # the process, which is the thing being prevented.
+    required = _REQUIRED_SHIM_SYMBOLS
+    if require_self_mtp:
+        required = required + _SELF_MTP_REQUIRED_SHIM_SYMBOLS
     if packaged is not None and _shim_exports_required_symbols(
-        packaged, runtime_bin if runtime_bin is not None else build_bin
+        packaged,
+        runtime_bin if runtime_bin is not None else build_bin,
+        required,
     ):
         return packaged
     artifact_name = persistent_mtp_shim_filename()
@@ -217,7 +241,11 @@ def _persistent_mtp_link_bin(paths: NativeLlamaPaths) -> Path:
     return build_bin
 
 
-def _shim_exports_required_symbols(path: Path, build_bin: Path | None = None) -> bool:
+def _shim_exports_required_symbols(
+    path: Path,
+    build_bin: Path | None = None,
+    symbols: tuple[str, ...] | None = None,
+) -> bool:
     """Whether the packaged shim exports the symbols this process needs.
 
     `build_bin` is the runtime the caller intends to use. It matters because
@@ -246,7 +274,8 @@ def _shim_exports_required_symbols(path: Path, build_bin: Path | None = None) ->
         lib = load_native_cdll(path, mode=flags)
     except OSError:
         return False
-    return all(hasattr(lib, symbol) for symbol in _REQUIRED_SHIM_SYMBOLS)
+    required = _REQUIRED_SHIM_SYMBOLS if symbols is None else symbols
+    return all(hasattr(lib, symbol) for symbol in required)
 
 
 def create_persistent_mtp_session(
@@ -341,6 +370,71 @@ def reset_persistent_mtp_session(
         rss_before_kb=runtime.rss_before_kb,
         rss_after_init_kb=runtime.rss_after_init_kb,
         rss_peak_kb=runtime.rss_peak_kb,
+        # Carried forward, not re-derived. Reset returns a NEW runtime object
+        # wrapping the SAME native handle, so dropping this would silently turn
+        # a borrowing session into an owning one after the first completion --
+        # and teardown would then free the caller's model.
+        self_mtp=runtime.self_mtp,
+    )
+
+
+def create_self_mtp_session(
+    *,
+    llama_root: Path,
+    paths: NativeLlamaPaths,
+    model: c_void_p,
+    ctx_tgt: c_void_p,
+    context_tokens: int,
+    batch_size: int,
+    ubatch_size: int,
+    threads: int,
+    threads_batch: int,
+    build_dir: Path | None = None,
+    runner=subprocess.run,
+    library_factory=PersistentMtpLibrary,
+) -> PersistentMtpSessionRuntime:
+    """Build a single-GGUF self-MTP session over an already-loaded model.
+
+    Deliberately separate from `create_persistent_mtp_session`: that one takes a
+    draft model PATH and loads it, owning the result. This one takes the model
+    the client already holds and borrows it. Collapsing the two and inferring
+    the mode from equal paths is how a double free gets written.
+    """
+    if not model:
+        raise RuntimeError("self-MTP requires the already-loaded model")
+    if not ctx_tgt:
+        raise RuntimeError("self-MTP requires the target context")
+    shim = build_persistent_mtp_shim(
+        llama_root=llama_root,
+        build_dir=build_dir,
+        build_bin=_persistent_mtp_link_bin(paths),
+        runtime_bin=paths.build_bin,
+        runner=runner,
+        # The self-MTP entry points are demanded only here. A shim predating
+        # them stays valid for normal decoding and for the external-draft path.
+        require_self_mtp=True,
+    )
+    library = library_factory(paths.build_bin, shim)
+    handle = library.lib.orbit_selfmtp_session_create(
+        model,
+        ctx_tgt,
+        context_tokens,
+        batch_size,
+        ubatch_size,
+        threads,
+        threads_batch,
+    )
+    if not handle:
+        raise RuntimeError(_decode_error(library.lib.orbit_mtp_last_error()))
+    return PersistentMtpSessionRuntime(
+        handle=c_void_p(handle),
+        ctx_dft=library.lib.orbit_mtp_session_ctx_dft(handle),
+        spec=library.lib.orbit_mtp_session_spec(handle),
+        library=library,
+        rss_before_kb=_long_or_none(library.lib.orbit_mtp_session_rss_before_kb(handle)),
+        rss_after_init_kb=_long_or_none(library.lib.orbit_mtp_session_rss_after_init_kb(handle)),
+        rss_peak_kb=_long_or_none(library.lib.orbit_mtp_session_rss_peak_kb(handle)),
+        self_mtp=True,
     )
 
 
@@ -359,7 +453,12 @@ def free_persistent_mtp_session(
         library_factory=library_factory,
         llama_root=llama_root,
     )
-    library.lib.orbit_mtp_session_free(runtime.handle)
+    if runtime.self_mtp:
+        # Frees only the MTP context and speculative state. The model and the
+        # target context are borrowed and are freed by the client afterwards.
+        library.lib.orbit_selfmtp_session_destroy(runtime.handle)
+    else:
+        library.lib.orbit_mtp_session_free(runtime.handle)
 
 
 def run_persistent_mtp_completion(

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -180,6 +180,15 @@ static long rss_kb() {
 struct orbit_mtp_session {
     uint32_t n_batch = 0;
     llama_model * model_dft = nullptr;
+    // Whether this session allocated model_dft and must free it. False for the
+    // single-GGUF self-MTP path, where the draft head lives inside the model
+    // the caller already loaded and still owns: freeing it here would be a
+    // double free the moment the caller tears its own client down.
+    bool owns_model_dft = true;
+    // Borrowed in both modes. Recorded only so teardown can be audited: this
+    // session never frees it, and the client that created it frees it after
+    // this session is destroyed.
+    llama_context * ctx_tgt_borrowed = nullptr;
     llama_context * ctx_dft = nullptr;
     common_speculative * spec = nullptr;
     common_params_speculative spec_params;
@@ -1429,7 +1438,11 @@ static void cleanup_session(orbit_mtp_session * session) {
         session->ctx_dft = nullptr;
     }
     if (session->model_dft) {
-        llama_model_free(session->model_dft);
+        if (session->owns_model_dft) {
+            llama_model_free(session->model_dft);
+        }
+        // Cleared either way: a borrowed pointer must not outlive this
+        // session's view of it, and clearing makes repeated cleanup safe.
         session->model_dft = nullptr;
     }
 }
@@ -1596,6 +1609,7 @@ extern "C" void * orbit_mtp_session_create(
     session->rss_peak_kb = session->rss_before_kb;
 
     auto model_params = llama_model_default_params();
+    session->owns_model_dft = true;
     session->model_dft = llama_model_load_from_file(draft_model_path, model_params);
     session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
     if (!session->model_dft) {
@@ -1669,6 +1683,120 @@ extern "C" bool orbit_mtp_session_reset(void * handle, void * ctx_tgt_ptr) {
     session->request_boundary_prompt_tgt.clear();
 
     return true;
+}
+
+// Single-GGUF self-MTP. Deliberately a separate symbol rather than inferring
+// self-MTP from `target_path == draft_path`: the two modes differ in who owns
+// the model, and inferring ownership from an incidental string comparison is
+// how double frees are written.
+//
+// The caller passes the llama_model * it already loaded and continues to own
+// it. This session creates only the MTP context and the speculative state.
+extern "C" void * orbit_selfmtp_session_create(
+    void * model_ptr,
+    void * ctx_tgt_ptr,
+    uint32_t n_ctx,
+    uint32_t n_batch,
+    uint32_t n_ubatch,
+    int32_t n_threads,
+    int32_t n_threads_batch
+) {
+    g_last_error.clear();
+    if (!model_ptr) {
+        set_error("self-MTP requires the already-loaded model");
+        return nullptr;
+    }
+    if (!ctx_tgt_ptr) {
+        set_error("target context is required");
+        return nullptr;
+    }
+
+    std::unique_ptr<orbit_mtp_session> session(new orbit_mtp_session());
+    session->n_batch = std::max<uint32_t>(1, n_batch);
+    session->rss_before_kb = rss_kb();
+    session->rss_peak_kb = session->rss_before_kb;
+
+    // Borrowed, never loaded here and never freed here. Same for ctx_tgt.
+    session->owns_model_dft = false;
+    session->model_dft = static_cast<llama_model *>(model_ptr);
+    session->ctx_tgt_borrowed = static_cast<llama_context *>(ctx_tgt_ptr);
+
+    auto ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = n_ctx;
+    ctx_params.n_batch = n_batch;
+    ctx_params.n_ubatch = n_ubatch;
+    ctx_params.n_threads = n_threads;
+    ctx_params.n_threads_batch = n_threads_batch;
+    ctx_params.n_outputs_max = 1 + ORBIT_MTP_DRAFT_N_MAX;
+    ctx_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    ctx_params.n_rs_seq = 0;
+    ctx_params.ctx_other = static_cast<llama_context *>(ctx_tgt_ptr);
+
+    session->ctx_dft = llama_init_from_model(session->model_dft, ctx_params);
+    session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
+    if (!session->ctx_dft) {
+        set_error("failed to create self-MTP draft context");
+        cleanup_session(session.get());
+        return nullptr;
+    }
+
+    session->spec_params.types = common_speculative_types_from_names({"draft-mtp"});
+    session->spec_params.draft.n_max = ORBIT_MTP_DRAFT_N_MAX;
+    session->spec_params.draft.ctx_tgt = static_cast<llama_context *>(ctx_tgt_ptr);
+    session->spec_params.draft.ctx_dft = session->ctx_dft;
+
+    session->spec = common_speculative_init(session->spec_params, 1);
+    session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
+    if (!session->spec) {
+        set_error("failed to initialize self-MTP speculative state");
+        cleanup_session(session.get());
+        return nullptr;
+    }
+
+    session->rss_after_init_kb = rss_kb();
+    return session.release();
+}
+
+extern "C" bool orbit_mtp_session_owns_model(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->owns_model_dft : false;
+}
+
+// Destroy a self-MTP session. Frees ONLY what this session created -- the
+// speculative state and the MTP context. The model and the target context are
+// borrowed and are freed by the client that owns them, AFTER this returns.
+//
+// Idempotent: every pointer is nulled as it is released, so a second call is a
+// no-op rather than a double free.
+extern "C" void orbit_selfmtp_session_destroy(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    if (!session) {
+        return;
+    }
+    if (session->spec) {
+        common_speculative_free(session->spec);
+        session->spec = nullptr;
+    }
+    if (session->ctx_dft) {
+        llama_free(session->ctx_dft);
+        session->ctx_dft = nullptr;
+    }
+    // Borrowed. Dropped, never freed.
+    session->model_dft = nullptr;
+    session->ctx_tgt_borrowed = nullptr;
+    delete session;
+}
+
+// Diagnostics for the ownership tests: whether the borrowed handles are still
+// the ones the caller passed in, so a test can prove they were not disturbed.
+extern "C" void * orbit_mtp_session_borrowed_model(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? static_cast<void *>(session->model_dft) : nullptr;
+}
+
+extern "C" void * orbit_mtp_session_borrowed_ctx_tgt(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? static_cast<void *>(session->ctx_tgt_borrowed) : nullptr;
 }
 
 extern "C" void orbit_mtp_session_free(void * handle) {

--- a/tests/test_client_selfmtp_wiring.py
+++ b/tests/test_client_selfmtp_wiring.py
@@ -1,0 +1,483 @@
+"""Self-MTP wiring, driven through the real client method.
+
+These call `NativeLlamaClient._initialize_persistent_mtp_session` -- the
+production branch -- rather than the helpers underneath it. A helper can be
+perfectly correct while the client never reaches it, and that failure mode is
+invisible to helper-only tests.
+
+No model is loaded: the client is built with `__new__` and given exactly the
+attributes the method reads, so the branching is exercised without 21 GiB.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama import client as client_mod  # noqa: E402
+from orbit.native_llama.client import NativeLlamaClient  # noqa: E402
+from orbit.native_llama.model_profiles import (  # noqa: E402
+    ORNITH15_PROFILE_ID,
+    QWEN3_CODER_PROFILE_ID,
+    SELF_MTP_CAPABILITY,
+)
+
+CURRENT = Path("/models/current/Ornith-1.5-35B-Q4_K_M.gguf")
+LEGACY = Path("/models/legacy/Ornith-1.5-35B-Q4_K_M.gguf")
+
+
+def _client(
+    *,
+    mtp_requested: bool,
+    profile_id: str = ORNITH15_PROFILE_ID,
+    verified: bool = True,
+    mtp_supported: bool = False,
+    model_path: Path = CURRENT,
+    draft_mtp_model: Path | None = None,
+    ctx_tgt: object = "ctx-tgt-handle",
+) -> NativeLlamaClient:
+    c = NativeLlamaClient.__new__(NativeLlamaClient)
+    c.config = SimpleNamespace(
+        use_mtp_experimental=mtp_requested,
+        context_tokens=8192, batch_size=256, ubatch_size=128,
+        threads=6, threads_batch=6,
+    )
+    c.paths = SimpleNamespace(
+        model=model_path, llama_root=Path("/llama"),
+        mtp_available=draft_mtp_model is not None,
+        draft_mtp_model=draft_mtp_model,
+        fallback_reason=None if draft_mtp_model else "mtp-not-declared",
+    )
+    c.model_profile = SimpleNamespace(
+        profile_id=profile_id, verified=verified, mtp_supported=mtp_supported
+    )
+    c._model = "model-handle"
+    c._persistent_mtp_runtime = None
+    c._session = SimpleNamespace(
+        ctx_tgt=ctx_tgt, ctx_dft=None, spec=None,
+        mtp_enabled=False, mtp_failed=False, mtp_failure_reason=None,
+    )
+    return c
+
+
+class NormalStartupTests(unittest.TestCase):
+    """No MTP request means no digest and no self-MTP logic at all."""
+
+    def test_normal_startup_never_hashes_the_artifact(self) -> None:
+        c = _client(mtp_requested=False)
+        with mock.patch.object(client_mod, "verified_artifact_supports") as supports, \
+             mock.patch("orbit.native_llama.artifact_capabilities.artifact_sha256") as hashed:
+            c._initialize_persistent_mtp_session()
+        supports.assert_not_called()
+        hashed.assert_not_called()
+
+    def test_normal_startup_builds_no_session(self) -> None:
+        c = _client(mtp_requested=False)
+        with mock.patch.object(client_mod, "create_self_mtp_session") as self_mtp, \
+             mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        self_mtp.assert_not_called()
+        external.assert_not_called()
+        self.assertFalse(c._session.mtp_enabled)
+
+
+class SelfMtpSelectionTests(unittest.TestCase):
+    """The qualified artifact reaches the self-MTP constructor, and only it."""
+
+    def test_current_artifact_selects_the_self_mtp_constructor(self) -> None:
+        c = _client(mtp_requested=True)
+        runtime = SimpleNamespace(ctx_dft="ctx-dft", spec="spec", self_mtp=True)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True), \
+             mock.patch.object(client_mod, "create_self_mtp_session", return_value=runtime) as self_mtp, \
+             mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        self_mtp.assert_called_once()
+        external.assert_not_called()
+        self.assertTrue(c._session.mtp_enabled)
+        self.assertEqual(c._session.ctx_dft, "ctx-dft")
+
+    def test_self_mtp_borrows_the_loaded_model_and_context(self) -> None:
+        """No path is passed: the already-loaded handles are reused."""
+        c = _client(mtp_requested=True)
+        runtime = SimpleNamespace(ctx_dft="ctx-dft", spec="spec", self_mtp=True)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True), \
+             mock.patch.object(client_mod, "create_self_mtp_session", return_value=runtime) as self_mtp:
+            c._initialize_persistent_mtp_session()
+        kwargs = self_mtp.call_args.kwargs
+        self.assertEqual(kwargs["model"], "model-handle")
+        self.assertEqual(kwargs["ctx_tgt"], "ctx-tgt-handle")
+        self.assertNotIn("draft_model_path", kwargs)
+
+    def test_legacy_artifact_does_not_select_self_mtp(self) -> None:
+        c = _client(mtp_requested=True, model_path=LEGACY)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=False), \
+             mock.patch.object(client_mod, "create_self_mtp_session") as self_mtp:
+            c._initialize_persistent_mtp_session()
+        self_mtp.assert_not_called()
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertIsNotNone(c._session.mtp_failure_reason)
+
+    def test_legacy_artifact_makes_no_mtp_active_claim(self) -> None:
+        c = _client(mtp_requested=True, model_path=LEGACY)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=False):
+            c._initialize_persistent_mtp_session()
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertIsNone(c._session.ctx_dft)
+        self.assertIsNone(c._session.spec)
+
+
+class DigestBoundaryTests(unittest.TestCase):
+    """Digest calls happen once, at the self-MTP boundary, and nowhere else."""
+
+    def test_explicit_request_resolves_capability_exactly_once(self) -> None:
+        c = _client(mtp_requested=True)
+        runtime = SimpleNamespace(ctx_dft="d", spec="s", self_mtp=True)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True) as supports, \
+             mock.patch.object(client_mod, "create_self_mtp_session", return_value=runtime):
+            c._initialize_persistent_mtp_session()
+        supports.assert_called_once()
+
+    def test_a_profile_declaring_no_artifacts_is_ruled_out_without_hashing(self) -> None:
+        """Gemma / external-draft models must not pay Ornith's 46 s digest."""
+        c = _client(
+            mtp_requested=True,
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            mtp_supported=True,
+            draft_mtp_model=Path("/models/draft.gguf"),
+        )
+        runtime = SimpleNamespace(ctx_dft="d", spec="s")
+        with mock.patch("orbit.native_llama.artifact_capabilities.artifact_sha256") as hashed, \
+             mock.patch.object(client_mod, "create_persistent_mtp_session", return_value=runtime):
+            c._initialize_persistent_mtp_session()
+        hashed.assert_not_called()
+
+    def test_unverified_profile_is_ruled_out_without_hashing(self) -> None:
+        c = _client(mtp_requested=True, verified=False)
+        with mock.patch("orbit.native_llama.artifact_capabilities.artifact_sha256") as hashed:
+            c._initialize_persistent_mtp_session()
+        hashed.assert_not_called()
+
+
+class ExternalDraftPreservedTests(unittest.TestCase):
+    """The existing architecture keeps working, unchanged."""
+
+    def test_external_draft_model_uses_the_existing_constructor(self) -> None:
+        c = _client(
+            mtp_requested=True,
+            profile_id=QWEN3_CODER_PROFILE_ID,
+            mtp_supported=True,
+            draft_mtp_model=Path("/models/draft.gguf"),
+        )
+        runtime = SimpleNamespace(ctx_dft="ext-dft", spec="ext-spec")
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=False), \
+             mock.patch.object(client_mod, "create_persistent_mtp_session", return_value=runtime) as external, \
+             mock.patch.object(client_mod, "create_self_mtp_session") as self_mtp:
+            c._initialize_persistent_mtp_session()
+        external.assert_called_once()
+        self_mtp.assert_not_called()
+        self.assertTrue(c._session.mtp_enabled)
+        self.assertEqual(c._session.ctx_dft, "ext-dft")
+
+    def test_external_draft_still_reports_its_own_unsupported_reason(self) -> None:
+        c = _client(mtp_requested=True, profile_id=QWEN3_CODER_PROFILE_ID, mtp_supported=False)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=False):
+            c._initialize_persistent_mtp_session()
+        self.assertEqual(c._session.mtp_failure_reason, "model_profile_mtp_unsupported")
+
+
+class FailurePathTests(unittest.TestCase):
+    """Failures must fail closed and leave borrowed objects intact."""
+
+    def test_capability_hash_error_fails_closed(self) -> None:
+        c = _client(mtp_requested=True)
+        with mock.patch.object(
+            client_mod, "verified_artifact_supports", side_effect=OSError("disk")
+        ), mock.patch.object(client_mod, "create_self_mtp_session") as self_mtp, \
+           mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        self_mtp.assert_not_called()
+        external.assert_not_called()
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertTrue(c._session.mtp_failed)
+        self.assertIn("capability-error", c._session.mtp_failure_reason)
+
+    def test_self_mtp_create_failure_leaves_ownership_untouched(self) -> None:
+        c = _client(mtp_requested=True)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True), \
+             mock.patch.object(
+                 client_mod, "create_self_mtp_session", side_effect=RuntimeError("no ctx")
+             ):
+            c._initialize_persistent_mtp_session()
+        self.assertTrue(c._session.mtp_failed)
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertIsNone(c._persistent_mtp_runtime)
+        # Borrowed handles are exactly as they were: the client still owns them.
+        self.assertEqual(c._model, "model-handle")
+        self.assertEqual(c._session.ctx_tgt, "ctx-tgt-handle")
+
+    def test_missing_target_context_fails_closed(self) -> None:
+        c = _client(mtp_requested=True, ctx_tgt=None)
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True), \
+             mock.patch.object(client_mod, "create_self_mtp_session") as self_mtp:
+            c._initialize_persistent_mtp_session()
+        self_mtp.assert_not_called()
+        self.assertEqual(c._session.mtp_failure_reason, "target-context-missing")
+
+    def test_a_failed_self_mtp_does_not_fall_through_to_external_draft(self) -> None:
+        """A qualified artifact that fails must not silently try the other path."""
+        c = _client(mtp_requested=True, draft_mtp_model=Path("/models/draft.gguf"))
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True), \
+             mock.patch.object(
+                 client_mod, "create_self_mtp_session", side_effect=RuntimeError("boom")
+             ), mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        external.assert_not_called()
+
+
+class SelfMtpConstructorTests(unittest.TestCase):
+    """`create_self_mtp_session` itself: ABI demand and returned ownership.
+
+    The client tests mock this function out, so nothing above exercises what it
+    actually asks for or hands back. Both matter: a session that forgets to
+    demand the self-MTP ABI can call a missing symbol, and one that forgets to
+    mark itself `self_mtp` is torn down through the wrong destroy -- which frees
+    a borrowed model.
+    """
+
+    def _create(self, lib):
+        from orbit.native_llama.persistent_mtp import create_self_mtp_session
+
+        with mock.patch(
+            "orbit.native_llama.persistent_mtp.build_persistent_mtp_shim",
+            return_value=Path("/shim.so"),
+        ) as build:
+            runtime = create_self_mtp_session(
+                llama_root=Path("/llama"),
+                paths=SimpleNamespace(
+                    build_bin=Path("/bin"), model=CURRENT, llama_root=Path("/llama")
+                ),
+                model="model-handle",
+                ctx_tgt="ctx-tgt-handle",
+                context_tokens=8192, batch_size=256, ubatch_size=128,
+                threads=6, threads_batch=6,
+                library_factory=lambda *_a, **_k: SimpleNamespace(lib=lib),
+            )
+        return runtime, build
+
+    @staticmethod
+    def _lib(handle=0x1234):
+        lib = mock.Mock()
+        lib.orbit_selfmtp_session_create.return_value = handle
+        lib.orbit_mtp_session_ctx_dft.return_value = "ctx-dft"
+        lib.orbit_mtp_session_spec.return_value = "spec"
+        for name in ("rss_before_kb", "rss_after_init_kb", "rss_peak_kb"):
+            getattr(lib, f"orbit_mtp_session_{name}").return_value = 1
+        return lib
+
+    def test_construction_demands_the_self_mtp_abi(self) -> None:
+        _, build = self._create(self._lib())
+        self.assertIs(build.call_args.kwargs["require_self_mtp"], True)
+
+    def test_construction_uses_the_self_mtp_entry_point(self) -> None:
+        lib = self._lib()
+        self._create(lib)
+        lib.orbit_selfmtp_session_create.assert_called_once()
+        lib.orbit_mtp_session_create.assert_not_called()
+        args = lib.orbit_selfmtp_session_create.call_args.args
+        self.assertEqual(args[0], "model-handle")
+        self.assertEqual(args[1], "ctx-tgt-handle")
+
+    def test_runtime_is_marked_self_mtp(self) -> None:
+        """What routes teardown to destroy instead of the owning free."""
+        runtime, _ = self._create(self._lib())
+        self.assertTrue(runtime.self_mtp)
+
+    def test_a_null_handle_raises_rather_than_returning_a_broken_runtime(self) -> None:
+        lib = self._lib(handle=0)
+        lib.orbit_mtp_last_error.return_value = b"boom"
+        with self.assertRaises(RuntimeError):
+            self._create(lib)
+
+    def test_missing_model_or_context_is_refused_before_any_shim_work(self) -> None:
+        from orbit.native_llama.persistent_mtp import create_self_mtp_session
+
+        with mock.patch(
+            "orbit.native_llama.persistent_mtp.build_persistent_mtp_shim"
+        ) as build:
+            for bad in ({"model": None}, {"ctx_tgt": None}):
+                kwargs = dict(
+                    llama_root=Path("/llama"),
+                    paths=SimpleNamespace(build_bin=Path("/bin")),
+                    model="m", ctx_tgt="c",
+                    context_tokens=8192, batch_size=256, ubatch_size=128,
+                    threads=6, threads_batch=6,
+                )
+                kwargs.update(bad)
+                with self.subTest(**bad):
+                    with self.assertRaises(RuntimeError):
+                        create_self_mtp_session(**kwargs)
+        build.assert_not_called()
+
+
+class EligibilityShortCircuitTests(unittest.TestCase):
+    """`_self_mtp_eligible` must rule out cheaply before it hashes."""
+
+    def test_identity_without_declared_artifacts_short_circuits(self) -> None:
+        c = _client(mtp_requested=True, profile_id=QWEN3_CODER_PROFILE_ID)
+        with mock.patch.object(client_mod, "verified_artifact_supports") as supports:
+            self.assertFalse(c._self_mtp_eligible())
+        supports.assert_not_called()
+
+    def test_ornith_identity_proceeds_to_the_content_check(self) -> None:
+        c = _client(mtp_requested=True)
+        with mock.patch.object(
+            client_mod, "verified_artifact_supports", return_value=True
+        ) as supports:
+            self.assertTrue(c._self_mtp_eligible())
+        supports.assert_called_once()
+        self.assertEqual(supports.call_args.args[1], SELF_MTP_CAPABILITY)
+
+
+class FailureDoesNotFallThroughTests(unittest.TestCase):
+    """A qualified artifact that fails must not silently try external-draft.
+
+    Asserted without a draft model configured too, so the guard is the return
+    value rather than the absence of a draft path.
+    """
+
+    def test_create_failure_stops_the_chain(self) -> None:
+        c = _client(mtp_requested=True, mtp_supported=True,
+                    draft_mtp_model=Path("/models/draft.gguf"))
+        with mock.patch.object(client_mod, "verified_artifact_supports", return_value=True),              mock.patch.object(
+                 client_mod, "create_self_mtp_session", side_effect=RuntimeError("x")
+             ), mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        external.assert_not_called()
+        self.assertTrue(c._session.mtp_failed)
+
+    def test_hash_error_stops_the_chain(self) -> None:
+        c = _client(mtp_requested=True, mtp_supported=True,
+                    draft_mtp_model=Path("/models/draft.gguf"))
+        with mock.patch.object(
+            client_mod, "verified_artifact_supports", side_effect=OSError("io")
+        ), mock.patch.object(client_mod, "create_persistent_mtp_session") as external:
+            c._initialize_persistent_mtp_session()
+        external.assert_not_called()
+        self.assertIn("capability-error", c._session.mtp_failure_reason)
+
+
+class ResetPreservesOwnershipTests(unittest.TestCase):
+    """Reset returns a NEW runtime around the SAME native handle.
+
+    `_try_complete_with_mtp_experimental` resets before every completion. If
+    the rebuilt runtime lost `self_mtp`, a borrowing session would become an
+    owning one after the first request -- and teardown would free the model the
+    client still owns. The flag has to be carried, not re-derived.
+    """
+
+    def _reset(self, self_mtp: bool):
+        from orbit.native_llama.persistent_mtp import (
+            PersistentMtpSessionRuntime,
+            reset_persistent_mtp_session,
+        )
+
+        lib = mock.Mock()
+        lib.orbit_mtp_session_reset.return_value = True
+        lib.orbit_mtp_session_ctx_dft.return_value = "ctx-dft"
+        lib.orbit_mtp_session_spec.return_value = "spec"
+        before = PersistentMtpSessionRuntime(
+            handle="native-handle", ctx_dft="d", spec="s",
+            library=SimpleNamespace(lib=lib), self_mtp=self_mtp,
+        )
+        return reset_persistent_mtp_session(
+            llama_root=Path("/llama"),
+            paths=SimpleNamespace(build_bin=Path("/bin")),
+            runtime=before,
+            ctx_tgt="ctx-tgt",
+        )
+
+    def test_reset_keeps_a_self_mtp_session_borrowing(self) -> None:
+        self.assertTrue(self._reset(self_mtp=True).self_mtp)
+
+    def test_reset_keeps_an_external_draft_session_owning(self) -> None:
+        self.assertFalse(self._reset(self_mtp=False).self_mtp)
+
+    def test_reset_reuses_the_same_native_handle(self) -> None:
+        self.assertEqual(self._reset(self_mtp=True).handle, "native-handle")
+
+
+class TeardownOrderTests(unittest.TestCase):
+    """Self-MTP destroy runs before the client frees what it lent."""
+
+    def test_free_routes_self_mtp_sessions_to_destroy(self) -> None:
+        from orbit.native_llama.persistent_mtp import (
+            PersistentMtpSessionRuntime,
+            free_persistent_mtp_session,
+        )
+
+        lib = mock.Mock()
+        runtime = PersistentMtpSessionRuntime(
+            handle="h", ctx_dft="d", spec="s",
+            library=SimpleNamespace(lib=lib), self_mtp=True,
+        )
+        free_persistent_mtp_session(
+            llama_root=Path("/llama"),
+            paths=SimpleNamespace(build_bin=Path("/bin")),
+            runtime=runtime,
+        )
+        lib.orbit_selfmtp_session_destroy.assert_called_once_with("h")
+        lib.orbit_mtp_session_free.assert_not_called()
+
+    def test_free_routes_external_draft_sessions_to_the_old_free(self) -> None:
+        from orbit.native_llama.persistent_mtp import (
+            PersistentMtpSessionRuntime,
+            free_persistent_mtp_session,
+        )
+
+        lib = mock.Mock()
+        runtime = PersistentMtpSessionRuntime(
+            handle="h", ctx_dft="d", spec="s",
+            library=SimpleNamespace(lib=lib), self_mtp=False,
+        )
+        free_persistent_mtp_session(
+            llama_root=Path("/llama"),
+            paths=SimpleNamespace(build_bin=Path("/bin")),
+            runtime=runtime,
+        )
+        lib.orbit_mtp_session_free.assert_called_once_with("h")
+        lib.orbit_selfmtp_session_destroy.assert_not_called()
+
+    def test_repeated_free_destroys_only_once(self) -> None:
+        c = _client(mtp_requested=True)
+        lib = mock.Mock()
+        from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime
+
+        c._persistent_mtp_runtime = PersistentMtpSessionRuntime(
+            handle="h", ctx_dft="d", spec="s",
+            library=SimpleNamespace(lib=lib), self_mtp=True,
+        )
+        c._free_persistent_mtp_session()
+        c._free_persistent_mtp_session()
+        self.assertEqual(lib.orbit_selfmtp_session_destroy.call_count, 1)
+        self.assertIsNone(c._persistent_mtp_runtime)
+
+    def test_client_close_frees_the_session_before_context_and_model(self) -> None:
+        """Ordering is the whole safety argument; assert it, don't assume it."""
+        import inspect
+
+        source = inspect.getsource(NativeLlamaClient.close)
+        free_at = source.index("_free_persistent_mtp_session")
+        ctx_at = source.index("llama_free(self._session.ctx_tgt)")
+        model_at = source.index("llama_model_free(self._model)")
+        self.assertLess(free_at, ctx_at, "MTP session must be freed before ctx_tgt")
+        self.assertLess(ctx_at, model_at, "ctx_tgt must be freed before the model")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_persistent_mtp.py
+++ b/tests/test_native_persistent_mtp.py
@@ -11,6 +11,7 @@ from orbit.native_llama.events import NativeTimings
 from orbit.native_llama.native_names import platform_runtime_libs
 from orbit.native_llama.paths import NativeLlamaPaths
 from orbit.native_llama.persistent_mtp import (
+    _REQUIRED_SHIM_SYMBOLS,
     PersistentMtpSessionRuntime,
     create_persistent_mtp_session,
     free_persistent_mtp_session,
@@ -126,7 +127,13 @@ class NativePersistentMtpTests(unittest.TestCase):
         # The runtime this process will claim, not the directory the compiler
         # links against: preloading the latter is what puts a second family in
         # the process when the two diverge.
-        probe.assert_called_once_with(packaged, runtime_bin)
+        # The third argument is the symbol set being demanded. It stays the
+        # BASE tuple here: self-MTP symbols are required only when a self-MTP
+        # session is actually being built, so an older shim keeps working for
+        # normal decoding and for the external-draft path.
+        probe.assert_called_once_with(
+            packaged, runtime_bin, _REQUIRED_SHIM_SYMBOLS
+        )
 
     def test_session_creation_gives_the_shim_builder_the_claimed_runtime(self) -> None:
         """The session paths must forward the family they are about to claim.

--- a/tests/test_selfmtp_completion_gate.py
+++ b/tests/test_selfmtp_completion_gate.py
@@ -1,0 +1,248 @@
+"""Whether MTP decoding may RUN is runtime state, not artifact metadata.
+
+The historical defect this pins: a self-MTP session was constructed correctly
+-- right constructor, one model, `mtp_enabled=True` -- and then every
+completion silently decoded normally, because the gate asked
+`paths.mtp_available` (and `profile.mtp_supported`), both of which describe the
+EXTERNAL-DRAFT registry world and are False for a single-GGUF artifact.
+
+The result was the worst possible shape: the client reported MTP enabled while
+drafted/accepted stayed at zero. Measured on the real 21 GiB artifact.
+
+The distinction these tests hold in place:
+
+  metadata  -> HOW a session may be built
+  runtime   -> WHETHER speculative decoding may execute
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama import client as client_mod  # noqa: E402
+from orbit.native_llama.client import NativeLlamaClient  # noqa: E402
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID  # noqa: E402
+from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime  # noqa: E402
+
+
+def _runtime(self_mtp: bool) -> PersistentMtpSessionRuntime:
+    return PersistentMtpSessionRuntime(
+        handle="native-handle", ctx_dft="ctx-dft", spec="spec",
+        library=SimpleNamespace(lib=mock.Mock()), self_mtp=self_mtp,
+    )
+
+
+def _client(
+    *,
+    mtp_requested: bool = True,
+    mtp_available: bool = False,
+    profile_mtp_supported: bool = False,
+    runtime: PersistentMtpSessionRuntime | None = None,
+    mtp_enabled: bool = True,
+    ctx_tgt: object = "ctx-tgt",
+    profile_id: str = ORNITH15_PROFILE_ID,
+) -> NativeLlamaClient:
+    c = NativeLlamaClient.__new__(NativeLlamaClient)
+    c.config = SimpleNamespace(
+        use_mtp_experimental=mtp_requested, thinking=False,
+        context_tokens=8192, batch_size=256, ubatch_size=128,
+        threads=6, threads_batch=6,
+    )
+    c.paths = SimpleNamespace(
+        model=Path("/m.gguf"), llama_root=Path("/llama"),
+        mtp_available=mtp_available,
+        draft_mtp_model=Path("/draft.gguf") if mtp_available else None,
+        fallback_reason=None if mtp_available else "mtp-not-declared",
+    )
+    c.model_profile = SimpleNamespace(
+        profile_id=profile_id, verified=True, mtp_supported=profile_mtp_supported
+    )
+    c._model = "model-handle"
+    c._persistent_mtp_runtime = runtime
+    c._session = SimpleNamespace(
+        ctx_tgt=ctx_tgt, ctx_dft="ctx-dft" if runtime else None,
+        spec="spec" if runtime else None,
+        mtp_enabled=mtp_enabled and runtime is not None,
+        mtp_failed=False, mtp_failure_reason=None,
+    )
+    c.mtp_fallback_reason = None
+    c.last_mtp_completion = None
+    c.cancel_event = threading.Event()
+    c._invalidate_committed_sequence = lambda: None
+    c._thinking_enabled = lambda t: False
+    return c
+
+
+def _reached_decode(c: NativeLlamaClient) -> bool:
+    """Did the production gate hand control to the speculative decode path?
+
+    `run_persistent_mtp_completion` is the first call past every gate, so its
+    invocation is the honest signal that MTP decoding actually ran.
+    """
+    # Raise from the decode call itself: reaching it is the signal, and the
+    # exception stops execution before downstream result handling needs a
+    # fully-shaped MtpCompletionResult. Building one here would couple this
+    # test to fields it is not about.
+    sentinel = RuntimeError("reached-speculative-decode")
+    with mock.patch.object(
+        client_mod, "run_persistent_mtp_completion", side_effect=sentinel
+    ) as decode, mock.patch.object(
+        client_mod, "reset_persistent_mtp_session",
+        side_effect=lambda **kw: kw["runtime"],
+    ):
+        try:
+            c._try_complete_with_mtp_experimental("hi", max_tokens=4)
+        except RuntimeError as exc:
+            if exc is not sentinel:
+                raise
+    return decode.called
+
+
+class HistoricalDefectTests(unittest.TestCase):
+    """Fails against the pre-fix candidate; passes only once the gate is right."""
+
+    def test_self_mtp_session_reaches_the_speculative_decode_path(self) -> None:
+        c = _client(
+            mtp_available=False,          # exactly the real self-MTP shape
+            profile_mtp_supported=False,  # Ornith's profile flag
+            runtime=_runtime(self_mtp=True),
+        )
+        self.assertTrue(
+            _reached_decode(c),
+            "self-MTP session constructed but completion silently decoded normally",
+        )
+
+    def test_self_mtp_never_reports_enabled_while_bypassing_mtp(self) -> None:
+        """The precise failure shape: enabled=True with zero drafting."""
+        c = _client(mtp_available=False, runtime=_runtime(self_mtp=True))
+        reached = _reached_decode(c)
+        result = c.last_mtp_completion
+        if not reached:
+            self.assertFalse(
+                getattr(result, "enabled", False) and getattr(result, "success", False),
+                "claimed MTP success without entering the MTP path",
+            )
+
+
+class ExternalDraftUnchangedTests(unittest.TestCase):
+    def test_external_draft_session_still_reaches_decode(self) -> None:
+        c = _client(
+            mtp_available=True, profile_mtp_supported=True,
+            profile_id=QWEN3_CODER_PROFILE_ID, runtime=_runtime(self_mtp=False),
+        )
+        self.assertTrue(_reached_decode(c))
+
+
+class NegativeGateTests(unittest.TestCase):
+    def test_no_mtp_request_does_not_decode_speculatively(self) -> None:
+        c = _client(mtp_requested=False, runtime=_runtime(self_mtp=True))
+        self.assertFalse(_reached_decode(c))
+
+    def test_no_constructed_session_does_not_decode_speculatively(self) -> None:
+        c = _client(runtime=None)
+        self.assertFalse(_reached_decode(c))
+
+    def test_stale_self_mtp_flag_without_a_handle_is_refused(self) -> None:
+        """`self_mtp=True` must never be sufficient on its own."""
+        c = _client(runtime=None, mtp_enabled=True)
+        c._session.mtp_enabled = True   # stale: no runtime behind it
+        self.assertFalse(_reached_decode(c))
+
+    def test_stale_mtp_available_without_a_session_is_refused(self) -> None:
+        """Metadata saying a draft exists must not imply a live session."""
+        c = _client(mtp_available=True, profile_mtp_supported=True, runtime=None)
+        c._session.mtp_enabled = True
+        self.assertFalse(_reached_decode(c))
+
+    def test_missing_target_context_is_refused(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True), ctx_tgt=None)
+        self.assertFalse(_reached_decode(c))
+
+    def test_thinking_mode_is_refused(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True))
+        c._thinking_enabled = lambda t: True
+        self.assertFalse(_reached_decode(c))
+
+    def test_cancelled_request_is_refused(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True))
+        c.cancel_event.set()
+        self.assertFalse(_reached_decode(c))
+
+
+class MetadataGatesStillApplyWithoutSelfMtpTests(unittest.TestCase):
+    """The bypass is narrow: it exists only for a real self-MTP session.
+
+    Without these, `self_mtp_session = True` unconditionally -- or derived from
+    `mtp_enabled` rather than the runtime -- would pass every other test while
+    disabling the profile and draft-availability gates for every model.
+    """
+
+    def test_unsupported_profile_still_blocks_when_not_self_mtp(self) -> None:
+        c = _client(
+            mtp_available=True, profile_mtp_supported=False,
+            profile_id=QWEN3_CODER_PROFILE_ID, runtime=_runtime(self_mtp=False),
+        )
+        self.assertFalse(_reached_decode(c))
+        self.assertEqual(c.mtp_fallback_reason, "model_profile_mtp_unsupported")
+
+    def test_missing_draft_artifact_still_blocks_when_not_self_mtp(self) -> None:
+        c = _client(
+            mtp_available=False, profile_mtp_supported=True,
+            profile_id=QWEN3_CODER_PROFILE_ID, runtime=_runtime(self_mtp=False),
+        )
+        self.assertFalse(_reached_decode(c))
+        self.assertEqual(c.mtp_fallback_reason, "mtp-not-declared")
+
+    def test_the_bypass_requires_the_runtime_not_the_enabled_flag(self) -> None:
+        """`mtp_enabled` is set for BOTH architectures; only the runtime says which.
+
+        With no runtime at all the decode is unreachable either way, so the
+        distinguishing observation is the *reason*: deriving the bypass from
+        `mtp_enabled` would skip the metadata gates and leave it unrecorded.
+        """
+        c = _client(
+            mtp_available=False, profile_mtp_supported=False,
+            profile_id=QWEN3_CODER_PROFILE_ID, runtime=None,
+        )
+        c._session.mtp_enabled = True
+        self.assertFalse(_reached_decode(c))
+        self.assertEqual(c.mtp_fallback_reason, "model_profile_mtp_unsupported")
+
+    def test_absent_runtime_records_missing_draft_artifact(self) -> None:
+        c = _client(
+            mtp_available=False, profile_mtp_supported=True,
+            profile_id=QWEN3_CODER_PROFILE_ID, runtime=None,
+        )
+        c._session.mtp_enabled = True
+        self.assertFalse(_reached_decode(c))
+        self.assertEqual(c.mtp_fallback_reason, "mtp-not-declared")
+
+
+class TeardownClearsReadinessTests(unittest.TestCase):
+    def test_free_clears_runtime_and_enabled(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True))
+        with mock.patch.object(client_mod, "free_persistent_mtp_session"):
+            c._free_persistent_mtp_session()
+        self.assertIsNone(c._persistent_mtp_runtime)
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertFalse(_reached_decode(c))
+
+    def test_repeated_free_is_safe_and_stays_not_ready(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True))
+        with mock.patch.object(client_mod, "free_persistent_mtp_session") as freed:
+            c._free_persistent_mtp_session()
+            c._free_persistent_mtp_session()
+        self.assertEqual(freed.call_count, 1)
+        self.assertFalse(_reached_decode(c))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_selfmtp_ownership.py
+++ b/tests/test_selfmtp_ownership.py
@@ -1,0 +1,265 @@
+"""Ownership and ABI compatibility for the single-GGUF self-MTP session.
+
+Two properties matter here and neither is observable from a passing generation:
+
+  1. A self-MTP session BORROWS the model and the target context. It owns only
+     the MTP context and its speculative state. If destroy ever freed a
+     borrowed handle, the client's own teardown would double-free moments
+     later -- and the crash would land far from the cause.
+
+  2. The self-MTP symbols are required ONLY when a self-MTP session is about to
+     be built. A shim predating them is still a valid shim for normal decoding
+     and for the external-draft path, and must not be rejected or rebuilt.
+
+Both are proved against the real compiled shim where one is available, and
+against the module's own contracts otherwise. No 21 GiB model is loaded.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama import persistent_mtp as pm  # noqa: E402
+
+BUILT_SHIM = Path("/tmp/selfmtp-build/liborbit-persistent-mtp.so")
+
+
+class SymbolRequirementTests(unittest.TestCase):
+    """Self-MTP symbols must not become mandatory for every shim user."""
+
+    def test_base_requirements_do_not_include_self_mtp(self) -> None:
+        for symbol in pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS:
+            self.assertNotIn(
+                symbol,
+                pm._REQUIRED_SHIM_SYMBOLS,
+                "self-MTP symbol leaked into the base ABI requirement",
+            )
+
+    def test_base_requirements_are_exactly_the_pre_mission_set(self) -> None:
+        """Pinned literally: widening this silently breaks older shims."""
+        self.assertEqual(
+            pm._REQUIRED_SHIM_SYMBOLS,
+            (
+                "orbit_mtp_session_complete",
+                "orbit_mtp_session_set_followup_suffix_tokens",
+                "orbit_mtp_session_last_first_sample_trace_json",
+                "orbit_mtp_session_request_boundary_refill_marker",
+            ),
+        )
+
+    def test_self_mtp_requirements_cover_create_and_destroy(self) -> None:
+        self.assertIn("orbit_selfmtp_session_create", pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS)
+        self.assertIn("orbit_selfmtp_session_destroy", pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS)
+
+
+class LegacyShimAcceptanceTests(unittest.TestCase):
+    """A shim without self-MTP symbols stays usable for everything else."""
+
+    class _LegacyLib:
+        """Exports the base symbols only -- a pre-self-MTP shim."""
+
+        def __init__(self) -> None:
+            for name in pm._REQUIRED_SHIM_SYMBOLS:
+                setattr(self, name, object())
+
+    def _check(self, lib, *, require_self_mtp: bool) -> bool:
+        symbols = pm._REQUIRED_SHIM_SYMBOLS
+        if require_self_mtp:
+            symbols = symbols + pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS
+        return all(hasattr(lib, s) for s in symbols)
+
+    def test_legacy_shim_satisfies_the_base_abi(self) -> None:
+        self.assertTrue(self._check(self._LegacyLib(), require_self_mtp=False))
+
+    def test_legacy_shim_is_rejected_only_for_self_mtp(self) -> None:
+        self.assertFalse(self._check(self._LegacyLib(), require_self_mtp=True))
+
+    def test_packaged_shim_is_reused_when_self_mtp_is_not_requested(self) -> None:
+        """The rebuild must not fire for normal or external-draft use."""
+        packaged = Path("/packaged/liborbit-persistent-mtp.so")
+        with mock.patch.object(pm, "packaged_shim_path", return_value=packaged), \
+             mock.patch.object(pm, "_shim_exports_required_symbols", return_value=True) as check, \
+             mock.patch.object(pm, "compile_cpp_helper") as compiled:
+            result = pm.build_persistent_mtp_shim(llama_root=None, build_bin=None)
+        self.assertEqual(result, packaged)
+        compiled.assert_not_called()
+        self.assertEqual(check.call_args.args[2], pm._REQUIRED_SHIM_SYMBOLS)
+
+    def test_self_mtp_request_asks_for_the_wider_symbol_set(self) -> None:
+        packaged = Path("/packaged/liborbit-persistent-mtp.so")
+        with mock.patch.object(pm, "packaged_shim_path", return_value=packaged), \
+             mock.patch.object(pm, "_shim_exports_required_symbols", return_value=True) as check, \
+             mock.patch.object(pm, "compile_cpp_helper"):
+            pm.build_persistent_mtp_shim(
+                llama_root=None, build_bin=None, require_self_mtp=True
+            )
+        requested = check.call_args.args[2]
+        for symbol in pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS:
+            self.assertIn(symbol, requested)
+        for symbol in pm._REQUIRED_SHIM_SYMBOLS:
+            self.assertIn(symbol, requested)
+
+    def test_a_shim_lacking_self_mtp_triggers_a_rebuild_only_then(self) -> None:
+        packaged = Path("/packaged/liborbit-persistent-mtp.so")
+        built = Path("/built/liborbit-persistent-mtp.so")
+        with mock.patch.object(pm, "packaged_shim_path", return_value=packaged), \
+             mock.patch.object(pm, "_shim_exports_required_symbols", return_value=False), \
+             mock.patch.object(pm, "require_legacy_llama_root", return_value=Path("/llama")), \
+             mock.patch.object(pm, "compile_cpp_helper", return_value=built) as compiled:
+            result = pm.build_persistent_mtp_shim(
+                llama_root=Path("/llama"), build_bin=None, require_self_mtp=True
+            )
+        self.assertEqual(result, built)
+        compiled.assert_called_once()
+
+
+@unittest.skipUnless(BUILT_SHIM.is_file(), "compiled self-MTP shim not present")
+class CompiledShimTests(unittest.TestCase):
+    """Against the real .so: symbols exist and ownership is declared."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.lib = ctypes.CDLL(str(BUILT_SHIM), mode=ctypes.RTLD_GLOBAL)
+
+    def test_self_mtp_entry_points_are_exported(self) -> None:
+        for symbol in pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS:
+            with self.subTest(symbol):
+                self.assertTrue(hasattr(self.lib, symbol))
+
+    def test_external_draft_entry_point_is_still_exported(self) -> None:
+        """The two-GGUF path must remain available and untouched."""
+        self.assertTrue(hasattr(self.lib, "orbit_mtp_session_create"))
+        self.assertTrue(hasattr(self.lib, "orbit_mtp_session_free"))
+
+    def test_create_rejects_a_null_model(self) -> None:
+        self.lib.orbit_selfmtp_session_create.restype = ctypes.c_void_p
+        self.lib.orbit_selfmtp_session_create.argtypes = [
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32,
+            ctypes.c_uint32, ctypes.c_uint32, ctypes.c_int32, ctypes.c_int32,
+        ]
+        handle = self.lib.orbit_selfmtp_session_create(
+            None, ctypes.c_void_p(1), 8192, 256, 128, 6, 6
+        )
+        self.assertFalse(handle)
+
+    def test_create_rejects_a_null_target_context(self) -> None:
+        self.lib.orbit_selfmtp_session_create.restype = ctypes.c_void_p
+        handle = self.lib.orbit_selfmtp_session_create(
+            ctypes.c_void_p(1), None, 8192, 256, 128, 6, 6
+        )
+        self.assertFalse(handle)
+
+    def test_destroy_of_null_is_safe(self) -> None:
+        """Idempotence starts here: destroying nothing must not fault."""
+        self.lib.orbit_selfmtp_session_destroy.argtypes = [ctypes.c_void_p]
+        self.lib.orbit_selfmtp_session_destroy(None)
+
+    def test_accessors_of_null_return_null(self) -> None:
+        for name in (
+            "orbit_mtp_session_borrowed_model",
+            "orbit_mtp_session_borrowed_ctx_tgt",
+            "orbit_mtp_session_ctx_dft",
+        ):
+            fn = getattr(self.lib, name)
+            fn.restype = ctypes.c_void_p
+            fn.argtypes = [ctypes.c_void_p]
+            with self.subTest(name):
+                self.assertFalse(fn(None))
+
+    def test_owns_model_of_null_is_false(self) -> None:
+        self.lib.orbit_mtp_session_owns_model.restype = ctypes.c_bool
+        self.lib.orbit_mtp_session_owns_model.argtypes = [ctypes.c_void_p]
+        self.assertFalse(self.lib.orbit_mtp_session_owns_model(None))
+
+
+class SourceOwnershipContractTests(unittest.TestCase):
+    """The teardown contract, asserted against the shim source.
+
+    Behavioural proof needs a loaded model; these pin the invariants that make
+    that safe to attempt, so a regression is caught before the 21 GiB run.
+    """
+
+    SOURCE = ROOT / "src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp"
+
+    def setUp(self) -> None:
+        self.text = self.SOURCE.read_text()
+        start = self.text.index("orbit_selfmtp_session_destroy")
+        self.destroy = self.text[start : self.text.index("\n}", start)]
+        start_c = self.text.index("orbit_selfmtp_session_create")
+        self.create = self.text[start_c : self.text.index("\n}", start_c)]
+
+    def test_destroy_never_frees_a_model(self) -> None:
+        self.assertNotIn("llama_model_free", self.destroy)
+
+    def test_destroy_frees_the_mtp_context_it_created(self) -> None:
+        """Guarded on the pointer, not on a constant.
+
+        Asserting only that the free CALL appears is too weak: wrapping it in
+        `if (false)` leaves the text intact and leaks the context on every
+        teardown. The guard has to be the handle itself.
+        """
+        self.assertIn("llama_free(session->ctx_dft)", self.destroy)
+        free_at = self.destroy.index("llama_free(session->ctx_dft)")
+        guard = self.destroy[:free_at]
+        self.assertIn("if (session->ctx_dft)", guard)
+        self.assertNotIn("if (false)", self.destroy)
+        self.assertNotIn("if (0)", self.destroy)
+
+    def test_destroy_frees_the_speculative_state_it_created(self) -> None:
+        self.assertIn("common_speculative_free(session->spec)", self.destroy)
+        free_at = self.destroy.index("common_speculative_free(session->spec)")
+        self.assertIn("if (session->spec)", self.destroy[:free_at])
+
+    def test_destroy_never_frees_the_target_context(self) -> None:
+        self.assertNotIn("llama_free(session->ctx_tgt_borrowed)", self.destroy)
+        self.assertNotIn("llama_free(ctx_tgt", self.destroy)
+
+    def test_destroy_nulls_every_handle_it_releases(self) -> None:
+        """What makes a repeated destroy a no-op rather than a double free."""
+        for cleared in (
+            "session->spec = nullptr",
+            "session->ctx_dft = nullptr",
+            "session->model_dft = nullptr",
+            "session->ctx_tgt_borrowed = nullptr",
+        ):
+            self.assertIn(cleared, self.destroy)
+
+    def test_self_mtp_create_never_loads_a_model(self) -> None:
+        """One model load total: the caller's. Never a second mmap."""
+        self.assertNotIn("llama_model_load_from_file", self.create)
+
+    def test_self_mtp_create_marks_the_model_as_borrowed(self) -> None:
+        self.assertIn("session->owns_model_dft = false", self.create)
+
+    def test_self_mtp_create_builds_exactly_one_context(self) -> None:
+        self.assertEqual(self.create.count("llama_init_from_model"), 1)
+
+    def test_self_mtp_create_uses_the_mtp_context_type(self) -> None:
+        self.assertIn("LLAMA_CONTEXT_TYPE_MTP", self.create)
+        self.assertIn("ctx_params.ctx_other", self.create)
+
+    def test_partial_init_failure_cleans_up(self) -> None:
+        """Both failure exits must run cleanup, not leak the MTP context."""
+        self.assertEqual(self.create.count("cleanup_session(session.get())"), 2)
+
+    def test_cleanup_respects_borrowed_ownership(self) -> None:
+        start = self.text.index("static void cleanup_session")
+        cleanup = self.text[start : self.text.index("\n}", start)]
+        self.assertIn("if (session->owns_model_dft)", cleanup)
+
+    def test_external_draft_create_still_owns_its_model(self) -> None:
+        start = self.text.index("void * orbit_mtp_session_create")
+        create = self.text[start : self.text.index("\n}", start)]
+        self.assertIn("session->owns_model_dft = true", create)
+        self.assertIn("llama_model_load_from_file", create)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Mission B wires the native self-MTP path end to end: a session that borrows
the already-loaded model instead of loading a second one, selected only for an
artifact whose exact bytes are qualified.

Two architectures now exist and they answer different questions. The external
draft path needs a separate draft GGUF, and `profile.mtp_supported` plus
`paths.mtp_available` describe THAT world -- both are False for a single-GGUF
Ornith build. Gating execution on them is why the first activation smoke came
back drafted=0/accepted=0 on a session that had reported `mtp_enabled=True`:
correctly constructed, then silently decoding normally on every completion.
Whether MTP may RUN is now a property of the constructed session; the metadata
gates decide only how a session may be BUILT, and still apply in full to every
external-draft client.

Ownership is explicit for every native object. The self-MTP session borrows the
model and the target context and owns only the MTP context and the speculative
state, so its destroy frees only what it created; the client frees the borrowed
objects afterwards. `reset_persistent_mtp_session` carries the flag forward
rather than re-deriving it -- reset returns a new runtime around the same native
handle, so dropping it would have turned a borrowing session into an owning one
after the first completion and freed the caller's model.

The self-MTP shim symbols are required only when a self-MTP session is about to
be built. Putting them in the base tuple would reject every previously valid
shim for normal decoding and for the external-draft path, neither of which
needs them.

Capability is keyed on the SHA-256 of the artifact's bytes because nothing
cheaper can separate the builds: current and legacy Ornith share architecture,
`general.name`, chat template and all 753 tensors, differing only in ~20 blk.40
weights. Resolution is two-stage so the ~46 s digest is paid only after the
registry says some artifact of this profile declares the capability at all --
normal startup never hashes.

Measured on the qualified artifact: 14 drafted / 8 accepted / 5 draft decode
calls, one model load, one context, peak RSS 35.7 GiB against 70.8 GiB for the
two-model topology. No default is changed: MTP remains opt-in.

Verification: 3462 tests pass; 31/31 mutants caught across the gate (8), wiring
(12) and ownership (11) campaigns; five capability gates confirm the unverified and absent
profile cases never hash, and unknown bytes fail closed.