### PR TITLE
fix(native): preserve profile chat templates with self-MTP

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -1432,13 +1432,27 @@ class NativeLlamaClient:
             thinking=thinking,
             prompt=prompt,
         ) if self._final_prefix_experiment_eligible(final_prefix_experiment) else None
+        # Whether MTP may be requested for THIS call is a runtime question:
+        # does a usable MTP session actually exist? `profile.mtp_supported`
+        # answers a different one -- whether the profile participates in the
+        # EXTERNAL-DRAFT architecture -- and is False for a single-GGUF
+        # self-MTP artifact such as Ornith. Gating admission on it meant a
+        # correctly constructed self-MTP session was never admitted here, so
+        # every request decoded normally with drafted/accepted/draft-calls all
+        # zero while the session still reported itself enabled.
+        #
+        # The predicate below is the SAME one the completion gate uses, so
+        # admission and execution cannot disagree. It is architecture-neutral:
+        # both constructors set the runtime and the flag on success, so
+        # external-draft and self-MTP are admitted alike without being
+        # conflated. Both are required: a failed reset clears the flag while
+        # leaving the runtime referenced, and a stale flag can outlive a
+        # freed session.
         allow_mtp = (
             not tools
             and route_anchor_segments is None
-            and (
-                getattr(self, "model_profile", None) is None
-                or getattr(self, "model_profile").mtp_supported
-            )
+            and self._persistent_mtp_runtime is not None
+            and self._session.mtp_enabled
         )
         if final_prefix_segments is not None:
             allow_mtp = False
@@ -2311,7 +2325,9 @@ class NativeLlamaClient:
             self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
             return None
 
-        mtp_prompt = _prepare_mtp_prompt(prompt, thinking=thinking)
+        mtp_prompt = _prepare_mtp_prompt(
+            prompt, thinking=thinking, profile=getattr(self, "model_profile", None)
+        )
         try:
             # The persistent shim's request-boundary reuse can leave target/draft
             # state that fails the next target suffix prefill. Resetting here
@@ -4325,13 +4341,57 @@ def _trim_at_stop(content: str, stops: tuple[str, ...]) -> str:
     return content[:first]
 
 
-def _prepare_mtp_prompt(prompt: str, *, thinking: bool = False) -> str:
-    stripped = prompt.lstrip()
-    if stripped.startswith("<bos>") or "<|turn>" in prompt:
-        if thinking:
-            return prompt
-        return _strip_thinking_prompt(prompt)
-    return render_gemma4_chat([{"role": "user", "content": prompt}], thinking=thinking)
+def _prepare_mtp_prompt(
+    prompt: str, *, thinking: bool = False, profile: NativeModelProfile | None = None
+) -> str:
+    """Prepare an ALREADY-RENDERED prompt for the MTP path.
+
+    `complete_prompt` is handed a prompt that `apply_chat_template` has already
+    rendered with the profile's own renderer, so MTP must not reinterpret that
+    text as chat-message content. MTP is inference behaviour; it does not own
+    chat templating.
+
+    Which family's contract applies is decided by the verified profile, never by
+    looking for markers in the prompt. Prompt text is data: a user can type
+    "<bos>" or "<|turn>" in a message, and a profile whose template lives in the
+    GGUF produces neither. Sniffing for them sent every non-Gemma4 prompt into
+    `render_gemma4_chat`, which wrapped the whole rendered prompt as the content
+    of a fresh user turn -- so the model received a Gemma4 envelope around
+    foreign markup and generated scaffolding instead of an answer.
+
+    Only the Orbit-side Gemma4 renderer appends a thought-channel suffix that a
+    non-thinking MTP request has to drop, so that strip is gated on that
+    renderer owning the prompt. Everything else passes through untouched.
+    """
+    if getattr(profile, "uses_native_chat_bridge", False):
+        # The profile's own template already rendered this prompt. Orbit does
+        # not own it and must not re-render it.
+        return prompt
+    if not _is_gemma4_rendered(prompt):
+        # A raw, unrendered prompt -- what the low-level `complete()` API
+        # accepts. Only the Gemma4 renderer is Orbit's to apply, and reaching
+        # here means no bridge-backed profile claimed this prompt, so the
+        # long-standing Gemma4 envelope still applies. In production
+        # `model_profile` is always resolved before the MTP session is built
+        # (`_initialize_model_profile` precedes
+        # `_initialize_persistent_mtp_session` in `load`), so `None` here means
+        # an unloaded client, where this preserves prior behaviour.
+        return render_gemma4_chat([{"role": "user", "content": prompt}], thinking=thinking)
+    if thinking:
+        return prompt
+    return _strip_thinking_prompt(prompt)
+
+
+def _is_gemma4_rendered(prompt: str) -> bool:
+    """Whether this text already carries the Orbit-side Gemma4 envelope.
+
+    Used ONLY to tell a rendered Gemma4 prompt from a raw one WITHIN the Gemma4
+    contract, never to decide which family a prompt belongs to -- that comes
+    from the profile. A profile whose template lives in the GGUF returns before
+    this is consulted, so a user quoting these markers cannot redirect
+    rendering.
+    """
+    return prompt.lstrip().startswith("<bos>") or "<|turn>" in prompt
 
 
 def _canonical_greedy_sampler_hash() -> str:

--- a/tests/test_mtp_prompt_contract.py
+++ b/tests/test_mtp_prompt_contract.py
@@ -1,0 +1,258 @@
+"""Who owns chat templating on the MTP path.
+
+`complete_prompt` receives a prompt that `apply_chat_template` has ALREADY
+rendered using the profile's own renderer. For a profile whose template lives in
+the GGUF (renderer "llama.cpp-jinja"), that is the model's official template.
+
+The defect these cover: `_prepare_mtp_prompt` decided which family a prompt
+belonged to by sniffing for Gemma4 markers in the prompt TEXT. An Ornith prompt
+contains none of them, so it fell through to `render_gemma4_chat`, which wrapped
+the already-rendered prompt as the *content of a new user message*. The model was
+handed a Gemma4 envelope containing Ornith markup as literal text, and generated
+scaffolding instead of an answer.
+
+Prompt text is data. It is not evidence of which model produced it, and a user
+can type any of those markers. Family dispatch must come from the verified
+profile, so these tests pin behaviour by profile rather than by prompt content.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from orbit.native_llama.chat_template import render_gemma4_chat
+from orbit.native_llama.client import _prepare_mtp_prompt, _strip_thinking_prompt
+
+# An officially rendered Ornith prompt: qwen-style markers from the GGUF template.
+ORNITH_RENDERED = "<|im_start|>user\nReply exactly: ORBIT_D1_OK<|im_end|>\n<|im_start|>assistant\n"
+
+FOREIGN_MARKERS = ("<bos>", "<|turn>", "<|channel>", "<turn|>", "<channel|>")
+
+
+class _Profile:
+    def __init__(self, renderer: str) -> None:
+        self.renderer = renderer
+        self.verified = True
+        self.mtp_supported = False
+
+    @property
+    def uses_native_chat_bridge(self) -> bool:
+        return self.renderer == "llama.cpp-jinja"
+
+
+GEMMA4 = _Profile("orbit-gemma4")
+JINJA = _Profile("llama.cpp-jinja")
+
+
+class HistoricalDefectTests(unittest.TestCase):
+    """Reproduces the exact Ornith corruption. No model required."""
+
+    def test_ornith_rendered_prompt_is_not_re_rendered(self) -> None:
+        out = _prepare_mtp_prompt(ORNITH_RENDERED, thinking=False, profile=JINJA)
+        self.assertEqual(
+            out,
+            ORNITH_RENDERED,
+            "an already-rendered profile prompt must reach MTP unchanged",
+        )
+
+    def test_no_foreign_template_markers_are_introduced(self) -> None:
+        out = _prepare_mtp_prompt(ORNITH_RENDERED, thinking=False, profile=JINJA)
+        for marker in FOREIGN_MARKERS:
+            self.assertNotIn(
+                marker, out, f"Orbit introduced a foreign template marker: {marker}"
+            )
+
+    def test_ornith_prompt_is_not_wrapped_as_user_content(self) -> None:
+        """The failure mode was nesting the whole prompt inside a new user turn."""
+        out = _prepare_mtp_prompt(ORNITH_RENDERED, thinking=False, profile=JINJA)
+        self.assertFalse(out.startswith("<bos>"))
+        self.assertEqual(out.count("<|im_start|>user"), 1)
+
+
+class Gemma4ByteEquivalenceTests(unittest.TestCase):
+    """Captured from the pre-fix implementation; must not drift."""
+
+    def test_thinking_off_strips_the_thought_suffix(self) -> None:
+        rendered = render_gemma4_chat([{"role": "user", "content": "HELLO"}], thinking=False)
+        self.assertEqual(
+            _prepare_mtp_prompt(rendered, thinking=False, profile=GEMMA4),
+            "<bos><|turn>user\nHELLO<turn|>\n",
+        )
+
+    def test_thinking_on_passes_through(self) -> None:
+        rendered = render_gemma4_chat([{"role": "user", "content": "HELLO"}], thinking=True)
+        self.assertEqual(
+            _prepare_mtp_prompt(rendered, thinking=True, profile=GEMMA4), rendered
+        )
+
+    def test_multiturn_matches_prefix_characterization(self) -> None:
+        rendered = render_gemma4_chat(
+            [
+                {"role": "user", "content": "A"},
+                {"role": "assistant", "content": "B"},
+                {"role": "user", "content": "C"},
+            ],
+            thinking=False,
+        )
+        self.assertEqual(
+            _prepare_mtp_prompt(rendered, thinking=False, profile=GEMMA4),
+            "<bos><|turn>user\nA<turn|>\n<|turn>model\nB<turn|>\n<|turn>user\nC<turn|>\n",
+        )
+
+
+class MarkerSpoofingTests(unittest.TestCase):
+    """Prompt text must never decide which family's contract applies."""
+
+    def test_gemma_markers_inside_a_jinja_prompt_do_not_switch_family(self) -> None:
+        spoofed = (
+            "<|im_start|>user\nExplain what <bos><|turn>model means"
+            "<|im_end|>\n<|im_start|>assistant\n"
+        )
+        self.assertEqual(
+            _prepare_mtp_prompt(spoofed, thinking=False, profile=JINJA),
+            spoofed,
+            "a user quoting Gemma4 markers must not be re-rendered as Gemma4",
+        )
+
+    def test_gemma_thought_suffix_quoted_by_a_user_is_not_stripped(self) -> None:
+        suffix = "<|turn>model\n<|channel>thought\n<channel|>"
+        spoofed = f"<|im_start|>user\nliteral: {suffix}<|im_end|>\n<|im_start|>assistant\n"
+        self.assertEqual(
+            _prepare_mtp_prompt(spoofed, thinking=False, profile=JINJA), spoofed
+        )
+
+    def test_absent_profile_still_does_not_re_render_a_rendered_prompt(self) -> None:
+        """An unloaded client must not wrap an already-rendered prompt.
+
+        `model_profile` is None only before `load()` resolves it; in production
+        it is always set before the MTP session exists. Even so, a prompt that
+        already carries an envelope must not gain a second one.
+        """
+        gemma_rendered = render_gemma4_chat(
+            [{"role": "user", "content": "HELLO"}], thinking=True
+        )
+        self.assertEqual(
+            _prepare_mtp_prompt(gemma_rendered, thinking=True, profile=None),
+            gemma_rendered,
+        )
+
+
+class BridgeProfileNeverStripsTests(unittest.TestCase):
+    """A bridge-rendered prompt must survive even if it *ends* like Gemma4.
+
+    Without this, applying `_strip_thinking_prompt` to bridge profiles is
+    undetectable: ordinary Ornith prompts do not end with the Gemma4 thought
+    suffix, so the strip is a silent no-op on them.
+    """
+
+    GEMMA_SUFFIX = "<|turn>model\n<|channel>thought\n<channel|>"
+
+    def test_bridge_prompt_ending_in_gemma_suffix_is_untouched(self) -> None:
+        prompt = f"<|im_start|>user\nquote: {self.GEMMA_SUFFIX}"
+        self.assertTrue(prompt.endswith(self.GEMMA_SUFFIX))
+        self.assertEqual(
+            _prepare_mtp_prompt(prompt, thinking=False, profile=JINJA),
+            prompt,
+            "a bridge-owned prompt must never have the Gemma4 suffix stripped",
+        )
+
+    def test_bridge_prompt_ending_in_gemma_suffix_untouched_with_thinking(self) -> None:
+        prompt = f"<|im_start|>assistant\n{self.GEMMA_SUFFIX}"
+        self.assertEqual(
+            _prepare_mtp_prompt(prompt, thinking=True, profile=JINJA), prompt
+        )
+
+
+class CallSitePassesProfileTests(unittest.TestCase):
+    """The real call site must hand the resolved profile to the helper.
+
+    Without this, dropping `profile=` at client.py's call site is invisible:
+    every helper-level test supplies the profile explicitly.
+    """
+
+    def test_try_complete_passes_the_resolved_profile(self) -> None:
+        from ctypes import c_void_p
+        from unittest.mock import patch
+        from orbit.native_llama import client as client_mod
+        from orbit.native_llama.client import NativeLlamaClient
+        from orbit.native_llama.session_state import NativeSessionState
+
+        seen: dict[str, object] = {}
+        real = client_mod._prepare_mtp_prompt
+
+        def spy(prompt, *, thinking=False, profile=None):
+            seen["profile"] = profile
+            seen["out"] = real(prompt, thinking=thinking, profile=profile)
+            raise _Stop()
+
+        c = NativeLlamaClient.__new__(NativeLlamaClient)
+        c.model_profile = JINJA
+        c._session = NativeSessionState(session_id="cs")
+        c._session.ctx_tgt = c_void_p(0x1)
+        c._session.mtp_enabled = True
+        # A self-MTP runtime, as Ornith has: the completion gate's metadata
+        # check is bypassed for it, so execution reaches the prompt helper.
+        c._persistent_mtp_runtime = type("R", (), {"self_mtp": True})()
+        c.config = type("C", (), {"use_mtp_experimental": True})()
+        c.paths = type("P", (), {"mtp_available": False, "fallback_reason": None})()
+        c.cancel_event = type("E", (), {"is_set": lambda self: False})()
+        c.mtp_fallback_reason = None
+        c.last_mtp_completion = None
+
+        with patch.object(client_mod, "_prepare_mtp_prompt", spy), \
+             patch.object(NativeLlamaClient, "_thinking_enabled", lambda self, v: False), \
+             patch.object(NativeLlamaClient, "_invalidate_committed_sequence", lambda self: None):
+            try:
+                c._try_complete_with_mtp_experimental(ORNITH_RENDERED, max_tokens=8)
+            except _Stop:
+                pass
+
+        self.assertIs(
+            seen.get("profile"), JINJA,
+            "the call site must pass the resolved profile, not None",
+        )
+        self.assertEqual(seen.get("out"), ORNITH_RENDERED)
+
+
+class _Stop(Exception):
+    pass
+
+
+class StripThinkingPromptTests(unittest.TestCase):
+    """Direct coverage for the previously untested helper."""
+
+    def test_strips_only_the_exact_gemma4_suffix(self) -> None:
+        rendered = render_gemma4_chat([{"role": "user", "content": "X"}], thinking=False)
+        self.assertTrue(rendered.endswith("<|turn>model\n<|channel>thought\n<channel|>"))
+        self.assertEqual(
+            _strip_thinking_prompt(rendered),
+            rendered[: -len("<|turn>model\n<|channel>thought\n<channel|>")],
+        )
+
+    def test_leaves_a_jinja_prompt_untouched(self) -> None:
+        self.assertEqual(_strip_thinking_prompt(ORNITH_RENDERED), ORNITH_RENDERED)
+
+    def test_leaves_unrelated_text_untouched(self) -> None:
+        self.assertEqual(_strip_thinking_prompt("no markers here"), "no markers here")
+
+
+class RenderOwnershipTests(unittest.TestCase):
+    def test_prepare_is_idempotent_for_jinja_profiles(self) -> None:
+        once = _prepare_mtp_prompt(ORNITH_RENDERED, thinking=False, profile=JINJA)
+        twice = _prepare_mtp_prompt(once, thinking=False, profile=JINJA)
+        self.assertEqual(once, twice)
+
+    def test_prepare_is_idempotent_for_gemma4(self) -> None:
+        rendered = render_gemma4_chat([{"role": "user", "content": "HELLO"}], thinking=False)
+        once = _prepare_mtp_prompt(rendered, thinking=False, profile=GEMMA4)
+        twice = _prepare_mtp_prompt(once, thinking=False, profile=GEMMA4)
+        self.assertEqual(once, twice)
+
+    def test_jinja_prompt_never_grows(self) -> None:
+        """Re-rendering can only add envelope; passthrough cannot."""
+        out = _prepare_mtp_prompt(ORNITH_RENDERED, thinking=False, profile=JINJA)
+        self.assertLessEqual(len(out), len(ORNITH_RENDERED))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -444,6 +444,14 @@ class NativeMtpExperimentalTests(unittest.TestCase):
     def test_complete_chat_keeps_mtp_enabled_for_final_from_tool_history(self, _mocked_lib) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
         client.apply_chat_template = mock.Mock(return_value="prompt")
+        # Admission is a runtime question, so this external-draft client needs a
+        # constructed session like its siblings. It previously passed on registry
+        # metadata alone, which admitted a client whose completion gate would
+        # then reject it as `persistent-mtp-uninitialized`. What this test is
+        # about -- tool history must not disable MTP -- is unchanged.
+        client._session.ctx_tgt = object()
+        client._session.mtp_enabled = True
+        client._persistent_mtp_runtime = object()
         expected = NativeTimings(
             prompt_tokens=10,
             output_tokens=2,

--- a/tests/test_selfmtp_chat_admission.py
+++ b/tests/test_selfmtp_chat_admission.py
@@ -1,0 +1,218 @@
+"""Production `/chat` admission for a constructed self-MTP runtime.
+
+The defect these cover: `complete_chat` derived `allow_mtp` from
+`profile.mtp_supported`, which describes the EXTERNAL-DRAFT architecture and is
+False for Ornith. A correctly constructed single-GGUF self-MTP session was
+therefore never admitted through the production chat path, and every request
+decoded normally with drafted/accepted/draft-calls all zero -- while `/props`
+still reported `mtp_enabled: true`.
+
+Admission must instead ask a runtime question: does a usable MTP session exist?
+That is architecture-neutral, so it admits external-draft and self-MTP alike
+without conflating them, and it is the SAME predicate the completion gate uses
+(client.py:2309), so admission and execution cannot disagree.
+
+These drive the real `complete_chat`, capturing the value it hands to
+`complete_prompt`, rather than asserting against a helper.
+"""
+
+from __future__ import annotations
+
+import unittest
+from ctypes import c_void_p
+from unittest.mock import patch
+
+from orbit.native_llama import client as client_mod
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID, QWEN3_CODER_PROFILE_ID
+from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime
+from orbit.native_llama.session_state import NativeSessionState
+
+
+class _Profile:
+    """Stands in for the resolved registry profile."""
+
+    def __init__(self, *, mtp_supported: bool, profile_id: str = ORNITH15_PROFILE_ID):
+        self.mtp_supported = mtp_supported
+        self.profile_id = profile_id
+        self.verified = True
+        self.uses_native_chat_bridge = False
+        self.thinking_supported = True
+        self.gemma_prefix_reuse_supported = False
+        self.route_prefix_reuse_supported = False
+        self.multimodal_supported = False
+        self.family = "qwen35moe"
+
+
+def _runtime(*, self_mtp: bool) -> PersistentMtpSessionRuntime:
+    return PersistentMtpSessionRuntime(
+        handle=c_void_p(0x1000),
+        ctx_dft=c_void_p(0x2000),
+        spec=c_void_p(0x3000),
+        library=object(),
+        self_mtp=self_mtp,
+    )
+
+
+def _client(
+    *,
+    runtime: PersistentMtpSessionRuntime | None,
+    mtp_enabled: bool,
+    mtp_supported: bool,
+    profile_id: str = ORNITH15_PROFILE_ID,
+) -> NativeLlamaClient:
+    c = NativeLlamaClient.__new__(NativeLlamaClient)
+    c.model_profile = _Profile(mtp_supported=mtp_supported, profile_id=profile_id)
+    c._persistent_mtp_runtime = runtime
+    c._session = NativeSessionState(session_id="d1")
+    c._session.mtp_enabled = mtp_enabled
+    c._session.ctx_tgt = c_void_p(0x4000)
+    c._final_prefix_status = type("S", (), {"last_used": False})()
+    c._media_marker = None
+    return c
+
+
+def admitted(c: NativeLlamaClient, *, tools=None, thinking=False) -> bool:
+    """Run the REAL complete_chat and report what it admitted.
+
+    `complete_prompt` is intercepted so nothing native is touched; the captured
+    `allow_mtp_experimental` is the production admission decision.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_complete_prompt(self, prompt, **kw):
+        seen["allow_mtp"] = kw.get("allow_mtp_experimental")
+        raise _Stop()
+
+    with patch.object(NativeLlamaClient, "complete_prompt", fake_complete_prompt), \
+         patch.object(NativeLlamaClient, "_thinking_enabled", lambda self, v: bool(thinking)), \
+         patch.object(NativeLlamaClient, "_ensure_prompt_cache_mode", lambda self, m: None), \
+         patch.object(NativeLlamaClient, "apply_chat_template", lambda self, *a, **k: "PROMPT"), \
+         patch.object(NativeLlamaClient, "_route_anchor_segments_for_prompt", lambda self, *a, **k: None), \
+         patch.object(NativeLlamaClient, "_final_prefix_segments_for_prompt", lambda self, *a, **k: None), \
+         patch.object(NativeLlamaClient, "_final_prefix_experiment_eligible", lambda self, v: False), \
+         patch.object(NativeLlamaClient, "_ornith_rolling_route_eligible", lambda self, **k: False), \
+         patch.object(NativeLlamaClient, "_ornith_rolling_analysis_eligible", lambda self, **k: False), \
+         patch.object(client_mod, "prepare_multimodal_messages", lambda m, media_marker=None: None):
+        try:
+            c.complete_chat([{"role": "user", "content": "hi"}], tools=tools)
+        except _Stop:
+            pass
+    return bool(seen.get("allow_mtp"))
+
+
+class _Stop(Exception):
+    pass
+
+
+class HistoricalDefectTests(unittest.TestCase):
+    """The exact Mission-C/diagnosis configuration."""
+
+    def test_constructed_self_mtp_is_admitted_despite_profile_metadata(self) -> None:
+        # CURRENT exact artifact, self-MTP runtime constructed, and the registry
+        # profile says mtp_supported=False because it describes external draft.
+        c = _client(runtime=_runtime(self_mtp=True), mtp_enabled=True, mtp_supported=False)
+        self.assertTrue(
+            admitted(c),
+            "a constructed self-MTP runtime must be admitted through production chat",
+        )
+
+
+class ArchitectureNeutralityTests(unittest.TestCase):
+    def test_external_draft_runtime_still_admitted(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=False), mtp_enabled=True, mtp_supported=True)
+        self.assertTrue(admitted(c))
+
+    def test_external_draft_admitted_even_if_profile_metadata_absent(self) -> None:
+        """Admission is a runtime question; it must not re-consult metadata."""
+        c = _client(runtime=_runtime(self_mtp=False), mtp_enabled=True, mtp_supported=False)
+        self.assertTrue(admitted(c))
+
+    def test_admission_does_not_depend_on_which_constructor_ran(self) -> None:
+        a = _client(runtime=_runtime(self_mtp=True), mtp_enabled=True, mtp_supported=False)
+        b = _client(runtime=_runtime(self_mtp=False), mtp_enabled=True, mtp_supported=False)
+        self.assertEqual(admitted(a), admitted(b))
+
+
+class NegativeAdmissionTests(unittest.TestCase):
+    def test_ordinary_client_without_mtp_denied(self) -> None:
+        c = _client(runtime=None, mtp_enabled=False, mtp_supported=False)
+        self.assertFalse(admitted(c))
+
+    def test_failed_construction_denied(self) -> None:
+        # Both constructors leave the runtime None when construction raises.
+        c = _client(runtime=None, mtp_enabled=False, mtp_supported=True)
+        self.assertFalse(admitted(c))
+
+    def test_stale_self_mtp_flag_without_runtime_denied(self) -> None:
+        c = _client(runtime=None, mtp_enabled=True, mtp_supported=False)
+        self.assertFalse(admitted(c))
+
+    def test_stale_runtime_after_reset_failure_denied(self) -> None:
+        """Reset failure clears mtp_enabled but leaves the runtime referenced.
+
+        Admitting on the handle alone would admit a request the completion gate
+        (client.py:2309) then rejects.
+        """
+        c = _client(runtime=_runtime(self_mtp=True), mtp_enabled=False, mtp_supported=False)
+        self.assertFalse(admitted(c))
+
+    def test_profile_metadata_true_without_session_denied(self) -> None:
+        c = _client(runtime=None, mtp_enabled=False, mtp_supported=True)
+        self.assertFalse(admitted(c))
+
+
+class UnchangedGateTests(unittest.TestCase):
+    """Admission must not widen the pre-existing non-MTP conditions."""
+
+    def test_tools_still_block_admission(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True), mtp_enabled=True, mtp_supported=False)
+        self.assertFalse(admitted(c, tools=[{"type": "function"}]))
+
+    def test_explicit_false_request_still_denied(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True), mtp_enabled=True, mtp_supported=False)
+        seen: dict[str, object] = {}
+
+        def fake_complete_prompt(self, prompt, **kw):
+            seen["allow_mtp"] = kw.get("allow_mtp_experimental")
+            raise _Stop()
+
+        with patch.object(NativeLlamaClient, "complete_prompt", fake_complete_prompt), \
+             patch.object(NativeLlamaClient, "_thinking_enabled", lambda self, v: False), \
+             patch.object(NativeLlamaClient, "_ensure_prompt_cache_mode", lambda self, m: None), \
+             patch.object(NativeLlamaClient, "apply_chat_template", lambda self, *a, **k: "P"), \
+             patch.object(NativeLlamaClient, "_route_anchor_segments_for_prompt", lambda self, *a, **k: None), \
+             patch.object(NativeLlamaClient, "_final_prefix_segments_for_prompt", lambda self, *a, **k: None), \
+             patch.object(NativeLlamaClient, "_final_prefix_experiment_eligible", lambda self, v: False), \
+             patch.object(NativeLlamaClient, "_ornith_rolling_route_eligible", lambda self, **k: False), \
+             patch.object(NativeLlamaClient, "_ornith_rolling_analysis_eligible", lambda self, **k: False), \
+             patch.object(client_mod, "prepare_multimodal_messages", lambda m, media_marker=None: None):
+            try:
+                c.complete_chat(
+                    [{"role": "user", "content": "hi"}], allow_mtp_experimental=False
+                )
+            except _Stop:
+                pass
+        self.assertFalse(bool(seen.get("allow_mtp")))
+
+
+class NoPerRequestHashingTests(unittest.TestCase):
+    """Admission must consume qualified runtime state, never re-hash 21 GiB."""
+
+    def test_admission_never_calls_artifact_digest(self) -> None:
+        c = _client(runtime=_runtime(self_mtp=True), mtp_enabled=True, mtp_supported=False)
+        import orbit.native_llama.artifact_capabilities as ac
+
+        calls: list[str] = []
+        real = ac.artifact_sha256
+        try:
+            ac.artifact_sha256 = lambda p: (calls.append(str(p)), real(p))[1]
+            for _ in range(5):
+                admitted(c)
+        finally:
+            ac.artifact_sha256 = real
+        self.assertEqual(calls, [], "admission must not hash the artifact per request")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two correctness defects kept the single-GGUF self-MTP path from working
through production chat. Neither is a performance change and none is claimed.

Request admission asked the wrong question. `complete_chat` derived
`allow_mtp` from `profile.mtp_supported`, which describes the EXTERNAL-DRAFT
architecture and is False for a single-GGUF artifact such as Ornith. A
correctly constructed self-MTP session was therefore never admitted: every
request decoded normally with drafted/accepted/draft-calls all zero, while the
session still reported itself enabled. Admission now asks whether a usable MTP
session exists, using the same predicate the completion gate uses so the two
cannot disagree. Both conjuncts are required: a completion-path reset failure
clears the flag while leaving the runtime referenced, and the flag alone can
outlive a freed session. It is architecture-neutral, so external-draft and
self-MTP are admitted alike without being conflated.

Prompt preparation then double-rendered. `_prepare_mtp_prompt` decided which
family a prompt belonged to by sniffing the prompt TEXT for Gemma4 markers.
`complete_prompt` receives a prompt `apply_chat_template` has ALREADY rendered
with the profile's own renderer, and a GGUF-templated prompt contains no Gemma4
markers, so it fell through to `render_gemma4_chat` -- which wrapped the whole
rendered prompt as the CONTENT of a fresh user turn. The model was handed a
Gemma4 envelope around foreign markup and emitted template scaffolding instead
of an answer.

Dispatch is now architectural rather than textual. A profile whose template
lives in the GGUF owns its prompt and it passes through untouched; raw prompts
from the low-level `complete()` API still get the Gemma4 envelope; Gemma4
rendered prompts keep the existing thinking-strip. Marker detection survives
only INSIDE the Gemma4 contract, to tell a rendered prompt from a raw one --
never as family authority, since a bridge-backed profile returns before markers
are consulted. Prompt text is data: a user can type `<bos>` or `<|turn>`, and
that must not redirect rendering. No model-name branching.

Gemma4 external-draft behaviour is byte-identical, verified against outputs
captured from the pre-fix implementation across thinking on/off, multi-turn and
a bare `<bos>` prompt.

Measured end to end on the qualified artifact through production `/chat`: the
prompt reaches native MTP byte-identical to what the profile rendered (same
SHA256, 95 chars in and out), the response is exactly the requested string with
no foreign markers, and speculative decoding genuinely executes. One model load,
35.6 GiB peak RSS, clean shutdown.

MTP remains opt-in; no default changed. Prompt-cache reuse under `--mtp` is a
separate, still-open issue and is untouched here: all five rolling-route anchor
guards and the strict committed-prefix invariant are unchanged.

Verification: 3492 tests pass; 11/11 mutants caught across prompt contract,
admission, Gemma4 equivalence, cache-guard and per-request-hashing sentinels;
independent review BLOCKER 0 / MAJOR 0.

---

This fixes correctness and activation compatibility. It is NOT a performance
change, and no performance improvement is claimed or measured. MTP remains
opt-in; no default is altered. Prompt-cache reuse under `--mtp` remains a
separate open issue, deliberately untouched here.