### PR TITLE
build(native): make llama provenance reproducible

### DIFF
--- a/scripts/llama_provenance_v2.py
+++ b/scripts/llama_provenance_v2.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Reproducible Orbit patchset attestation (orbit-patchset-v2).
+
+The legacy `patchset_sha256` in LLAMA_PROVENANCE.json was produced by a packaging
+pipeline that is not available here, and no candidate algorithm reproduces its
+recorded values. It is preserved as an imported historical attestation: this tool
+never recomputes, reinterprets, or validates it.
+
+V2 is additive. It records `patchset_algorithm` and `patchset_v2_sha256`
+alongside the legacy fields, so existing readers and the bridge identity chain
+are unaffected.
+
+The V2 hash binds the actual patch content: for every vendored file that differs
+from the pinned upstream commit (or is absent upstream), both the upstream and
+the vendored SHA-256 are recorded.
+
+  canonical object : [{"path", "upstream_sha256"|null, "vendored_sha256"}]
+  ordering         : sorted by path
+  encoding         : json.dumps(..., separators=(",", ":")), UTF-8, no newline
+  hashing          : sha256 over raw file bytes; no newline normalization
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ALGORITHM = "orbit-patchset-v2"
+
+# Mirrors the exclusion filter used by source_tree_sha256 so the two views of the
+# vendored tree cannot drift apart.
+EXCLUDED_PARTS = {".git", "build", "__pycache__"}
+EXCLUDED_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _vendored_files(root: Path) -> list[str]:
+    out: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if EXCLUDED_PARTS.intersection(relative.parts):
+            continue
+        if path.suffix in EXCLUDED_SUFFIXES:
+            continue
+        out.append(relative.as_posix())
+    return sorted(out)
+
+
+def _upstream_blob(upstream_root: Path, commit: str, relative: str) -> bytes | None:
+    """Read a file from the pinned upstream commit.
+
+    Reads through `git show <commit>:<path>` so a dirty upstream working tree
+    cannot influence the attestation.
+    """
+    completed = subprocess.run(
+        ["git", "-C", str(upstream_root), "show", f"{commit}:{relative}"],
+        capture_output=True,
+    )
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def build_patchset(upstream_root: Path, vendored_root: Path, commit: str) -> list[dict]:
+    """The canonical V2 object: every vendored file that diverges from upstream."""
+    entries: list[dict] = []
+    for relative in _vendored_files(vendored_root):
+        vendored = (vendored_root / relative).read_bytes()
+        upstream = _upstream_blob(upstream_root, commit, relative)
+        if upstream is not None and upstream == vendored:
+            continue
+        entries.append(
+            {
+                "path": relative,
+                "upstream_sha256": _sha256_bytes(upstream) if upstream is not None else None,
+                "vendored_sha256": _sha256_bytes(vendored),
+            }
+        )
+    entries.sort(key=lambda entry: entry["path"])
+    return entries
+
+
+def canonical_bytes(entries: list[dict]) -> bytes:
+    return json.dumps(entries, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def patchset_v2_sha256(entries: list[dict]) -> str:
+    return _sha256_bytes(canonical_bytes(entries))
+
+
+def _load_manifest(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve(args: argparse.Namespace) -> tuple[dict, Path, Path, str, list[dict]]:
+    manifest_path = args.manifest
+    manifest = _load_manifest(manifest_path)
+    commit = args.upstream_commit or manifest["upstream_commit"]
+    entries = build_patchset(args.upstream_root, args.vendored_root, commit)
+    return manifest, manifest_path, args.vendored_root, commit, entries
+
+
+def cmd_generate(args: argparse.Namespace) -> int:
+    manifest, manifest_path, _, _, entries = _resolve(args)
+    digest = patchset_v2_sha256(entries)
+    declared = [entry["path"] for entry in entries]
+
+    manifest["patched_paths"] = declared
+    manifest["patchset_algorithm"] = ALGORITHM
+    manifest["patchset_v2_sha256"] = digest
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    print(f"patchset_algorithm : {ALGORITHM}")
+    print(f"patchset_v2_sha256 : {digest}")
+    print(f"patched_paths      : {len(declared)}")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    manifest, _, _, _, entries = _resolve(args)
+    digest = patchset_v2_sha256(entries)
+    declared = list(manifest.get("patched_paths") or [])
+    computed = [entry["path"] for entry in entries]
+
+    problems: list[str] = []
+    if manifest.get("patchset_algorithm") != ALGORITHM:
+        problems.append(
+            f"patchset_algorithm is {manifest.get('patchset_algorithm')!r}, expected {ALGORITHM!r}"
+        )
+    if manifest.get("patchset_v2_sha256") != digest:
+        problems.append(
+            f"patchset_v2_sha256 mismatch:\n"
+            f"    manifest {manifest.get('patchset_v2_sha256')}\n"
+            f"    computed {digest}"
+        )
+    duplicates = sorted({path for path in declared if declared.count(path) > 1})
+    if duplicates:
+        # `_from_payload` also rejects these at load time; catching them here too
+        # keeps `check` self-sufficient rather than relying on a second reader.
+        problems.append(f"duplicate declared patched paths: {duplicates}")
+    if sorted(declared) != computed:
+        missing = sorted(set(computed) - set(declared))
+        extra = sorted(set(declared) - set(computed))
+        if missing:
+            problems.append(f"vendored files differ from upstream but are undeclared: {missing}")
+        if extra:
+            problems.append(f"declared patched paths that do not differ from upstream: {extra}")
+        if not missing and not extra:
+            problems.append("declared patched paths do not match the derived set")
+
+    if problems:
+        for problem in problems:
+            print(f"provenance v2 check FAILED: {problem}", file=sys.stderr)
+        return 1
+    print(f"provenance v2 check OK ({len(computed)} patched paths, {digest})")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    root = Path(__file__).resolve().parents[1]
+    default_vendored = root / "src/orbit/native_llama/vendor/source/llama.cpp"
+    default_manifest = root / "src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "check"))
+    parser.add_argument("--upstream-root", type=Path, default=Path.home() / "LAB/llama.cpp")
+    parser.add_argument("--vendored-root", type=Path, default=default_vendored)
+    parser.add_argument("--manifest", type=Path, default=default_manifest)
+    parser.add_argument("--upstream-commit", default=None)
+    args = parser.parse_args(argv)
+
+    if not args.vendored_root.is_dir():
+        print(f"vendored root not found: {args.vendored_root}", file=sys.stderr)
+        return 2
+    if not (args.upstream_root / ".git").exists():
+        print(f"upstream git checkout not found: {args.upstream_root}", file=sys.stderr)
+        return 2
+    if not args.manifest.is_file():
+        print(f"manifest not found: {args.manifest}", file=sys.stderr)
+        return 2
+
+    return cmd_generate(args) if args.command == "generate" else cmd_check(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
+++ b/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
@@ -69,5 +69,7 @@
     "tools/mtmd/mtmd-helper.cpp",
     "vendor/cpp-httplib/LICENSE",
     "vendor/miniaudio/miniaudio.h"
-  ]
+  ],
+  "patchset_algorithm": "orbit-patchset-v2",
+  "patchset_v2_sha256": "7d470bdd8f0eb73f738b66f14f70b59f457408b464429e0b9237b85570ede3bd"
 }

--- a/tests/test_llama_provenance_v2.py
+++ b/tests/test_llama_provenance_v2.py
@@ -1,0 +1,361 @@
+"""Provenance V2: a locally reproducible attestation of the Orbit patchset.
+
+The legacy `patchset_sha256` came from a packaging pipeline that no longer exists
+here; 121 candidate algorithms failed to reproduce either of its two historical
+values. It is preserved as an imported attestation and must never be recomputed
+or reinterpreted. V2 is additive and locally reproducible.
+
+These tests exercise the real generator against real trees and real mutations,
+not source text.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import llama_provenance_v2 as pv2  # noqa: E402
+
+UPSTREAM = Path.home() / "LAB/llama.cpp"
+VENDORED = ROOT / "src/orbit/native_llama/vendor/source/llama.cpp"
+MANIFEST = ROOT / "src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json"
+COMMIT = json.loads(MANIFEST.read_text())["upstream_commit"]
+
+
+def _available() -> bool:
+    return (UPSTREAM / ".git").exists() and VENDORED.is_dir()
+
+
+@unittest.skipUnless(_available(), "upstream llama.cpp checkout not present")
+class PatchsetV2Tests(unittest.TestCase):
+    def _entries(self):
+        return pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+
+    def test_generation_is_deterministic(self) -> None:
+        a = pv2.patchset_v2_sha256(self._entries())
+        b = pv2.patchset_v2_sha256(self._entries())
+        self.assertEqual(a, b)
+
+    def test_input_set_equals_declared_patched_paths(self) -> None:
+        """The derived set must be exactly what the manifest declares.
+
+        Proven in the recovery mission at both historical commits (60/60, 62/62).
+        """
+        declared = sorted(json.loads(MANIFEST.read_text())["patched_paths"])
+        computed = sorted(e["path"] for e in self._entries())
+        self.assertEqual(computed, declared)
+
+    def test_entries_are_sorted_by_path(self) -> None:
+        paths = [e["path"] for e in self._entries()]
+        self.assertEqual(paths, sorted(paths))
+
+    def test_canonical_encoding_is_compact_and_unterminated(self) -> None:
+        blob = pv2.canonical_bytes(self._entries())
+        self.assertNotIn(b", ", blob)
+        self.assertNotIn(b'": ', blob)
+        self.assertFalse(blob.endswith(b"\n"))
+        self.assertEqual(blob[:1], b"[")
+
+    def test_empty_patchset_matches_the_existing_sentinel(self) -> None:
+        from orbit.native_llama.llama_provenance import EMPTY_PATCHSET_SHA256
+
+        self.assertEqual(pv2.patchset_v2_sha256([]), EMPTY_PATCHSET_SHA256)
+
+    def test_every_entry_binds_both_sides(self) -> None:
+        for e in self._entries():
+            self.assertIsInstance(e["vendored_sha256"], str)
+            self.assertEqual(len(e["vendored_sha256"]), 64)
+            self.assertTrue(e["upstream_sha256"] is None or len(e["upstream_sha256"]) == 64)
+
+    def test_hash_changes_when_a_patched_file_changes_and_reverts(self) -> None:
+        """Content sensitivity, then exact restoration.
+
+        Restoration is registered as a cleanup rather than a `finally`, so the
+        vendored tree is repaired even if the process is interrupted mid-test.
+        A leftover probe here poisons every later run, including the baseline of
+        a mutation campaign.
+        """
+        entries = self._entries()
+        target = VENDORED / entries[0]["path"]
+        original = target.read_bytes()
+        before = pv2.patchset_v2_sha256(entries)
+        self.addCleanup(target.write_bytes, original)
+        target.write_bytes(original + b"\n// provenance v2 probe\n")
+        after = pv2.patchset_v2_sha256(self._entries())
+        self.assertNotEqual(after, before)
+        target.write_bytes(original)
+        self.assertEqual(pv2.patchset_v2_sha256(self._entries()), before)
+
+    def test_a_file_restored_to_upstream_leaves_the_patchset(self) -> None:
+        """Input set is derived from divergence, not from the declared list."""
+        entries = self._entries()
+        rel = entries[0]["path"]
+        target = VENDORED / rel
+        original = target.read_bytes()
+        upstream = pv2._upstream_blob(UPSTREAM, COMMIT, rel)
+        self.assertIsNotNone(upstream)
+        self.addCleanup(target.write_bytes, original)
+        target.write_bytes(upstream)
+        paths = [e["path"] for e in self._entries()]
+        self.assertNotIn(rel, paths)
+        target.write_bytes(original)
+        self.assertIn(rel, [e["path"] for e in self._entries()])
+
+    def test_orbit_only_file_is_represented_with_null_upstream(self) -> None:
+        added = VENDORED / "orbit_provenance_v2_probe.txt"
+        self.assertFalse(added.exists())
+        self.addCleanup(added.unlink, True)
+        added.write_bytes(b"orbit-only probe\n")
+        entry = next(e for e in self._entries() if e["path"] == added.name)
+        self.assertIsNone(entry["upstream_sha256"])
+        self.assertEqual(len(entry["vendored_sha256"]), 64)
+        added.unlink()
+
+    def test_binary_content_is_hashed_byte_for_byte(self) -> None:
+        """No newline normalization: CRLF and LF must differ."""
+        a = [{"path": "x", "upstream_sha256": None, "vendored_sha256": pv2._sha256_bytes(b"a\r\nb")}]
+        b = [{"path": "x", "upstream_sha256": None, "vendored_sha256": pv2._sha256_bytes(b"a\nb")}]
+        self.assertNotEqual(pv2.patchset_v2_sha256(a), pv2.patchset_v2_sha256(b))
+
+    def test_path_rename_changes_the_hash(self) -> None:
+        entries = self._entries()
+        renamed = [dict(e) for e in entries]
+        renamed[0]["path"] = renamed[0]["path"] + ".renamed"
+        renamed.sort(key=lambda e: e["path"])
+        self.assertNotEqual(pv2.patchset_v2_sha256(renamed), pv2.patchset_v2_sha256(entries))
+
+    def test_upstream_side_participates_in_the_hash(self) -> None:
+        entries = self._entries()
+        tweaked = [dict(e) for e in entries]
+        tweaked[0]["upstream_sha256"] = "0" * 64
+        self.assertNotEqual(pv2.patchset_v2_sha256(tweaked), pv2.patchset_v2_sha256(entries))
+
+    def test_declared_order_does_not_matter(self) -> None:
+        entries = self._entries()
+        shuffled = list(reversed(entries))
+        self.assertEqual(
+            pv2.patchset_v2_sha256(sorted(shuffled, key=lambda e: e["path"])),
+            pv2.patchset_v2_sha256(entries),
+        )
+
+    def test_entries_are_sorted_independently_of_walk_order(self) -> None:
+        """The explicit sort must not rely on `_vendored_files` already sorting.
+
+        Mutation P1 (removing `entries.sort`) survived because the walker returns
+        sorted paths, making the sort a no-op TODAY. It is still load-bearing:
+        it pins ordering independently of the walker. This test removes the
+        coupling by feeding an unsorted walk.
+        """
+        real = pv2._vendored_files
+
+        def shuffled(root):
+            return list(reversed(real(root)))
+
+        with unittest.mock.patch.object(pv2, "_vendored_files", shuffled):
+            entries = pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+        paths = [e["path"] for e in entries]
+        self.assertEqual(paths, sorted(paths), "build_patchset must sort its own output")
+        self.assertEqual(
+            pv2.patchset_v2_sha256(entries),
+            pv2.patchset_v2_sha256(pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)),
+            "walk order must not change the attestation",
+        )
+
+    def test_crlf_only_change_is_detected(self) -> None:
+        """Line-ending normalization must never be introduced.
+
+        Mutation P9 (normalizing CRLF->LF on read) survived only because no
+        ATTESTABLE vendored file currently contains CRLF -- the 11 that do are
+        all __pycache__/.pyc, which the filter excludes. A future vendored file
+        with CRLF would then let a line-ending-only edit produce an identical
+        hash, so an undeclared modification would pass the gate.
+
+        This drives the real reader over a genuine CRLF file.
+        """
+        probe = VENDORED / "orbit_v2_crlf_probe.txt"
+        self.assertFalse(probe.exists())
+        self.addCleanup(probe.unlink, True)
+
+        probe.write_bytes(b"line one\r\nline two\r\n")
+        crlf = next(e for e in pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+                    if e["path"] == probe.name)["vendored_sha256"]
+
+        probe.write_bytes(b"line one\nline two\n")
+        lf = next(e for e in pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+                  if e["path"] == probe.name)["vendored_sha256"]
+
+        probe.unlink()
+        self.assertNotEqual(crlf, lf, "CRLF and LF content must hash differently")
+
+    def test_excluded_components_match_source_tree_filter(self) -> None:
+        self.assertEqual(pv2.EXCLUDED_PARTS, {".git", "build", "__pycache__"})
+        self.assertEqual(pv2.EXCLUDED_SUFFIXES, {".pyc", ".pyo"})
+
+    def test_missing_vendored_root_fails_closed(self) -> None:
+        rc = pv2.main(["check", "--vendored-root", "/nonexistent/vendored"])
+        self.assertEqual(rc, 2)
+
+    def test_missing_upstream_checkout_fails_closed(self) -> None:
+        rc = pv2.main(["check", "--upstream-root", "/nonexistent/upstream"])
+        self.assertEqual(rc, 2)
+
+    def test_check_fails_on_a_manifest_without_v2_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            payload = json.loads(MANIFEST.read_text())
+            payload.pop("patchset_algorithm", None)
+            payload.pop("patchset_v2_sha256", None)
+            copy.write_text(json.dumps(payload))
+            rc = pv2.main(["check", "--manifest", str(copy)])
+            self.assertEqual(rc, 1)
+
+    def test_generate_then_check_roundtrips(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            shutil.copy2(MANIFEST, copy)
+            self.assertEqual(pv2.main(["generate", "--manifest", str(copy)]), 0)
+            self.assertEqual(pv2.main(["check", "--manifest", str(copy)]), 0)
+            written = json.loads(copy.read_text())
+            self.assertEqual(written["patchset_algorithm"], "orbit-patchset-v2")
+            self.assertEqual(len(written["patchset_v2_sha256"]), 64)
+
+    def test_legacy_fields_are_never_recomputed_or_removed(self) -> None:
+        """V2 must not touch the imported attestation."""
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            shutil.copy2(MANIFEST, copy)
+            before = json.loads(copy.read_text())
+            pv2.main(["generate", "--manifest", str(copy)])
+            after = json.loads(copy.read_text())
+            for key in ("patchset_sha256", "source_tree_sha256",
+                        "omitted_upstream_paths_sha256", "omitted_upstream_path_count",
+                        "upstream_commit", "upstream_tag", "format"):
+                self.assertEqual(after[key], before[key], f"V2 modified legacy field {key}")
+
+    def test_v2_digest_differs_from_the_legacy_digest(self) -> None:
+        """Guards against silently aliasing the two attestations."""
+        legacy = json.loads(MANIFEST.read_text())["patchset_sha256"]
+        self.assertNotEqual(pv2.patchset_v2_sha256(self._entries()), legacy)
+
+    def test_dirty_upstream_worktree_cannot_affect_the_attestation(self) -> None:
+        """BEHAVIOURAL: dirty an attested upstream file, digest must not move.
+
+        This previously asserted on `inspect.getsource` text, which would keep
+        passing through a refactor that kept the substring but read the working
+        tree anyway. It now proves the property instead of describing it.
+        """
+        entries = pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+        before = pv2.patchset_v2_sha256(entries)
+
+        target = UPSTREAM / entries[0]["path"]
+        if not target.is_file():
+            self.skipTest("attested path not present in the upstream worktree")
+        original = target.read_bytes()
+        self.addCleanup(target.write_bytes, original)
+
+        target.write_bytes(original + b"\n// upstream worktree drift probe\n")
+        after = pv2.patchset_v2_sha256(pv2.build_patchset(UPSTREAM, VENDORED, COMMIT))
+        target.write_bytes(original)
+
+        self.assertEqual(after, before,
+                         "upstream working-tree edits must not affect the attestation")
+
+    def test_duplicate_declared_paths_fail_the_gate(self) -> None:
+        """A malformed declared list must not be blessed by `check`."""
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            payload = json.loads(MANIFEST.read_text())
+            payload["patched_paths"] = payload["patched_paths"] + [payload["patched_paths"][0]]
+            copy.write_text(json.dumps(payload))
+            self.assertEqual(pv2.main(["check", "--manifest", str(copy)]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+@unittest.skipUnless(_available(), "upstream llama.cpp checkout not present")
+class PatchsetV2EnforcementTests(unittest.TestCase):
+    """V2 must be a GATE, not a note in a file.
+
+    The legacy `source_tree_sha256` is already enforced: `load_llama_provenance`
+    raises on drift and `test_vendored_provenance_matches_current_source_tree`
+    fails. V2 needs the same automatic property, so vendored drift cannot reach a
+    green suite merely because someone forgot to run a command by hand.
+
+    Every check here drives the REAL verifier (`pv2.main(["check", ...])`), never
+    a reimplementation of its algorithm.
+    """
+
+    def _check(self, manifest: Path | None = None) -> int:
+        argv = ["check"]
+        if manifest is not None:
+            argv += ["--manifest", str(manifest)]
+        return pv2.main(argv)
+
+    def test_current_tree_passes_the_gate(self) -> None:
+        self.assertEqual(self._check(), 0)
+
+    def test_vendored_drift_fails_the_gate_and_restores(self) -> None:
+        """The decisive property: edit a patched file, do NOT regenerate."""
+        entries = pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+        target = VENDORED / entries[0]["path"]
+        original = target.read_bytes()
+        self.addCleanup(target.write_bytes, original)
+
+        target.write_bytes(original + b"\n// undeclared drift\n")
+        self.assertEqual(self._check(), 1, "vendored drift must fail the gate")
+
+        target.write_bytes(original)
+        self.assertEqual(self._check(), 0, "restoring the file must clear the gate")
+
+    def test_a_new_undeclared_patched_file_fails_the_gate(self) -> None:
+        added = VENDORED / "orbit_v2_enforcement_probe.txt"
+        self.assertFalse(added.exists())
+        self.addCleanup(added.unlink, True)
+        added.write_bytes(b"undeclared orbit-only file\n")
+        self.assertEqual(self._check(), 1)
+        added.unlink()
+        self.assertEqual(self._check(), 0)
+
+    def test_tampered_v2_hash_fails_the_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            payload = json.loads(MANIFEST.read_text())
+            payload["patchset_v2_sha256"] = "0" * 64
+            copy.write_text(json.dumps(payload))
+            self.assertEqual(self._check(copy), 1)
+
+    def test_tampered_patched_path_membership_fails_the_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            payload = json.loads(MANIFEST.read_text())
+            payload["patched_paths"] = payload["patched_paths"][:-1]
+            copy.write_text(json.dumps(payload))
+            self.assertEqual(self._check(copy), 1)
+
+    def test_wrong_algorithm_name_fails_the_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            copy = Path(td) / "m.json"
+            payload = json.loads(MANIFEST.read_text())
+            payload["patchset_algorithm"] = "orbit-patchset-v1"
+            copy.write_text(json.dumps(payload))
+            self.assertEqual(self._check(copy), 1)
+
+    def test_check_never_mutates_the_manifest(self) -> None:
+        before = MANIFEST.read_bytes()
+        self._check()
+        self.assertEqual(MANIFEST.read_bytes(), before)
+
+    def test_legacy_attestation_is_untouched_by_the_gate(self) -> None:
+        payload = json.loads(MANIFEST.read_text())
+        self.assertEqual(len(payload["patchset_sha256"]), 64)
+        self.assertNotEqual(payload["patchset_sha256"], payload.get("patchset_v2_sha256"))


### PR DESCRIPTION
The vendored llama.cpp tree is pinned by `LLAMA_PROVENANCE.json`. Its `patchset_sha256` was produced by a packaging pipeline that is no longer available here, and no candidate algorithm reproduces its recorded values, so vendored changes could not be attested at all.

**That field is left exactly as it is.** It stays an imported historical attestation: nothing here recomputes, reinterprets or validates it, and no code path can write it. It was never guessed or regenerated.

Alongside it this adds a locally reproducible attestation, `patchset_algorithm` and `patchset_v2_sha256`. Both are additive: the manifest parser requires `format == 1` and ignores unknown keys, and the mtmd/chat bridges keep baking the legacy hash, so bridge identities and the family-integrity chain are untouched and need no rebuild.

## What the digest binds

Patch content, not filenames. For every vendored file that differs from the pinned upstream commit, or is absent upstream, it records the path with both the upstream and vendored SHA-256, sorted by path, encoded as compact JSON with no trailing newline, hashed over raw bytes with no newline normalization. Upstream bytes are read through `git show <commit>:<path>`, so a dirty upstream worktree cannot influence the result.

The 62 patched paths are derived from actual upstream-vs-vendored divergence and cross-checked against the declared list rather than trusted. The same derivation reproduces the declared list exactly at both historical manifest states.

## Enforcement

`scripts/llama_provenance_v2.py check` verifies without mutating anything. The enforcement tests drive that verifier directly, so vendored drift fails automatically rather than waiting for someone to remember a command: a content edit, an added or deleted file, a tampered digest, a duplicated or dropped path, or a wrong algorithm name each fail the gate, and restoring the tree clears it.

## Verification

- 32 provenance tests, full suite 3622 passing
- 16/16 mutants caught; the two initial survivors were investigated rather than dismissed, one proven equivalent and re-targeted, one found to be a real CRLF gap and closed
- independent review recomputed the digest from scratch and matched, derived 62 paths independently, and confirmed every legacy field byte-identical

No persistent-draft or reset-lifecycle changes are included.