### PR TITLE
feat(native): expose self-MTP pending-state diagnostics

### DIFF
--- a/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
+++ b/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
@@ -2,7 +2,7 @@
   "format": 1,
   "upstream_commit": "379ac6673b5cd75c7b4e07d1521c50f1e093878c",
   "upstream_tag": "b9551",
-  "source_tree_sha256": "28cde4325d775b95daf396defaea6abeeaef53b9e713b89a2d7d4a3e1e19b0a4",
+  "source_tree_sha256": "e78615ff6dbe019a1a0d03d2e72f2bca90f9a5d03ccaaad5902d3e6cc5831b78",
   "patchset_sha256": "aa3bb3d637ea963320df82dd588a0a85982936c192b7629d424daba0d1604441",
   "omitted_upstream_path_count": 1509,
   "omitted_upstream_paths_sha256": "93f225c176ba65acdb282c231f5c309fff45180746e88ba69028936bff8db485",
@@ -11,6 +11,7 @@
     "common/chat-auto-parser-helpers.cpp",
     "common/chat.h",
     "common/speculative.cpp",
+    "common/speculative.h",
     "common/unicode.cpp",
     "ggml/include/ggml-cpu.h",
     "ggml/src/ggml-backend-dl.h",
@@ -71,5 +72,5 @@
     "vendor/miniaudio/miniaudio.h"
   ],
   "patchset_algorithm": "orbit-patchset-v2",
-  "patchset_v2_sha256": "7d470bdd8f0eb73f738b66f14f70b59f457408b464429e0b9237b85570ede3bd"
+  "patchset_v2_sha256": "8789a825b004ab5bc345e94dae04cc181072131dd64b5acaa2be8cc6469a0598"
 }

--- a/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.cpp
+++ b/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.cpp
@@ -210,6 +210,15 @@ struct common_speculative_impl {
 
     virtual ~common_speculative_impl() = default;
 
+    // Read-only diagnostic: describe this implementation's cross-batch carryover
+    // state, if it has one. Default reports "not applicable" so implementations
+    // without a carryover need not override. Never influences behaviour.
+    virtual bool pending_state(
+            llama_seq_id /*seq_id*/,
+            int32_t * /*pos*/, uint64_t * /*fp*/, uint64_t * /*gen*/) const {
+        return false;
+    }
+
     virtual void begin(llama_seq_id seq_id, const llama_tokens & prompt) = 0;
 
     virtual bool process(const llama_batch & batch) = 0;
@@ -485,6 +494,44 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     // call to pair with, so it's stashed here until that next call fires.
     std::vector<std::vector<float>> pending_h;   // [n_seq][n_embd]
 
+    // --- read-only diagnostic metadata for pending_h (no behavioural effect) ---
+    // pending_h alone is unobservable from outside this translation unit, so a
+    // caller cannot tell a canonical carryover from a freshly-zeroed one, nor
+    // which absolute position it was derived from. These fields record exactly
+    // that, written at the same three places pending_h itself is written. They
+    // are never read by any decision here.
+    //   pending_pos : absolute token position whose hidden row pending_h holds,
+    //                 or -1 when pending_h is the constructor's zero row.
+    //   pending_fp  : order-sensitive fingerprint of the row bytes, so two rows
+    //                 can be compared for identity without exposing the tensor.
+    //   pending_gen : increments on every pending_h write; distinguishes "same
+    //                 object, pending_h changed" from "object untouched".
+    std::vector<int32_t>  pending_pos;
+    std::vector<uint64_t> pending_fp;
+    std::vector<uint64_t> pending_gen;
+
+    // Positions of the batch slots seen by the most recent process() call, so
+    // accept() can name the absolute position of the row it selects.
+    std::vector<std::vector<int32_t>> verify_pos;
+
+    static uint64_t fingerprint_row(const float * row, int32_t n) {
+        // FNV-1a over the raw row bytes. Order-sensitive, so a shifted or
+        // reordered row does not collide with the original.
+        uint64_t h = 1469598103934665603ull;
+        const unsigned char * p = reinterpret_cast<const unsigned char *>(row);
+        for (size_t i = 0; i < (size_t) n * sizeof(float); ++i) {
+            h ^= (uint64_t) p[i];
+            h *= 1099511628211ull;
+        }
+        return h;
+    }
+
+    void note_pending(llama_seq_id seq_id, int32_t pos) {
+        pending_pos[seq_id] = pos;
+        pending_fp[seq_id] = fingerprint_row(pending_h[seq_id].data(), n_embd);
+        pending_gen[seq_id]++;
+    }
+
     std::vector<int32_t> i_batch_beg;
     std::vector<int32_t> i_batch_end;
 
@@ -557,6 +604,11 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
 
         pending_h.assign(n_seq, std::vector<float>(n_embd, 0.0f));
+        // -1 == "no predecessor": correct only for a batch starting at position 0.
+        pending_pos.assign(n_seq, -1);
+        pending_fp.assign(n_seq, 0ull);
+        pending_gen.assign(n_seq, 0ull);
+        verify_pos.assign(n_seq, std::vector<int32_t>());
 
         i_batch_beg.assign(n_seq, -1);
         i_batch_end.assign(n_seq, -1);
@@ -686,6 +738,13 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             verify_h_rows[seq_id] = n_rows;
             verify_h[seq_id].resize((size_t) n_rows * n_embd);
 
+            // Absolute position of each captured row, so accept() can name the
+            // provenance of whichever row it later selects.
+            verify_pos[seq_id].resize((size_t) n_rows);
+            for (int32_t i = 0; i < n_rows; ++i) {
+                verify_pos[seq_id][i] = batch_in.pos[i_batch_beg[seq_id] + i];
+            }
+
             for (int32_t i = 0; i < n_rows; ++i) {
                 const float * h = llama_get_embeddings_nextn_ith(ctx_tgt, i_batch_beg[seq_id] + i);
                 std::memcpy(verify_h[seq_id].data() + (size_t) i * n_embd, h, row_bytes);
@@ -693,6 +752,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             std::memcpy(pending_h[seq_id].data(),
                     verify_h[seq_id].data() + (size_t) (n_rows - 1) * n_embd, row_bytes);
+            note_pending(seq_id, verify_pos[seq_id][n_rows - 1]);
         }
 
         return true;
@@ -901,6 +961,20 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         const int32_t i_h = std::min<int32_t>(n_accepted, n_rows - 1);
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
         std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
+        note_pending(seq_id,
+                (i_h < (int32_t) verify_pos[seq_id].size()) ? verify_pos[seq_id][i_h] : -1);
+    }
+
+    bool pending_state(
+            llama_seq_id seq_id,
+            int32_t * pos, uint64_t * fp, uint64_t * gen) const override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+            return false;
+        }
+        if (pos) { *pos = pending_pos[seq_id]; }
+        if (fp)  { *fp  = pending_fp[seq_id];  }
+        if (gen) { *gen = pending_gen[seq_id]; }
+        return true;
     }
 
     bool need_embd() const override {
@@ -1791,6 +1865,25 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
             impl_other->accept(seq_id, n_accepted, true);
         }
     }
+}
+
+bool common_speculative_pending_state(
+        const common_speculative * spec,
+        llama_seq_id seq_id,
+        int32_t * pos,
+        uint64_t * fp,
+        uint64_t * gen) {
+    if (spec == nullptr) {
+        return false;
+    }
+    // Report the first implementation that maintains a carryover. Only the
+    // draft-MTP implementation does, so this is unambiguous in practice.
+    for (const auto & impl : spec->impls) {
+        if (impl && impl->pending_state(seq_id, pos, fp, gen)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void common_speculative_print_stats(const common_speculative * spec) {

--- a/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.h
+++ b/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.h
@@ -71,6 +71,23 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id, uint16_t
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec);
 
+// Read-only diagnostic describing the cross-batch hidden-state carryover the
+// speculative implementation holds for `seq_id`, if any.
+//   pos : absolute token position the carryover row was derived from, or -1 when
+//         it is the freshly-constructed zero row (i.e. "no predecessor").
+//   fp  : order-sensitive fingerprint of the row, for identity comparison
+//         without exposing tensor contents.
+//   gen : number of times the carryover has been written; distinguishes a
+//         surviving-but-updated state from an untouched one.
+// Returns false when the active implementation maintains no such state.
+// Has no effect on speculative behaviour.
+bool common_speculative_pending_state(
+        const common_speculative * spec,
+        llama_seq_id seq_id,
+        int32_t * pos,
+        uint64_t * fp,
+        uint64_t * gen);
+
 struct common_speculative_deleter {
     void operator()(common_speculative * s) { common_speculative_free(s); }
 };

--- a/tests/test_mtmd_bridge_abi.py
+++ b/tests/test_mtmd_bridge_abi.py
@@ -36,7 +36,9 @@ class MtmdBridgeAbiTests(unittest.TestCase):
         self.assertEqual(provenance.upstream_tag, EXPECTED_TAG)
         self.assertEqual(provenance.source_tree_sha256, source_tree_sha256(BUNDLED_SOURCE_ROOT))
         self.assertEqual(len(provenance.patchset_sha256), 64)
-        self.assertEqual(len(provenance.patched_paths), 62)
+        # 63 since the pending-state diagnostic patched common/speculative.h;
+        # the count is derived by the provenance generator, not hand-maintained.
+        self.assertEqual(len(provenance.patched_paths), 63)
 
     def test_cmake_build_metadata_uses_vendor_not_parent_git(self) -> None:
         arguments = _cmake_provenance_args(BUNDLED_SOURCE_ROOT)


### PR DESCRIPTION
For single-GGUF self-MTP the draft context does not share memory with the target, so valid draft state is a pair: the draft KV, and `pending_h` — the hidden-state row inside `common_speculative` that seeds every draft proposal. `pending_h` lives in one translation unit with no accessor, so a caller could not tell a canonical carryover from a freshly zeroed one, nor which absolute position it came from. Observing the draft frontier alone cannot answer that.

## What it records

Three values, written at the same three places `pending_h` itself is written (constructor, `process()`, `accept()`):

- `pending_pos` — the absolute token position the row came from, `-1` for the constructor's zero row
- `pending_fp` — an order-sensitive 64-bit fingerprint of the row
- `pending_gen` — a count of writes, distinguishing "object survived" from "pending_h unchanged"

`common_speculative_pending_state()` reads them back. The positions are taken from the same batch index the row was copied from, so a row and its recorded position cannot drift apart. A freshly constructed state reports position `-1`, generation `0` and fingerprint `0`, so it can never be mistaken for a canonical one.

## Safety

Purely additive — 93 and 17 insertions, zero deletions from the pristine upstream files. Nothing reads the new fields in a decision; they are diagnostic only, and no behavioural policy is added to llama.cpp. Only a 64-bit digest escapes, never tensor content. The accessor is `const` and null-safe, and implementations without a carryover return `false` through the base-class default.

## Provenance

Patching vendored llama.cpp changes `common/speculative.h`, so the manifest is regenerated: `source_tree_sha256` and `patchset_v2_sha256` are recomputed by their own shipped generators, and `patched_paths` grows 62 → 63 by derivation, not by hand.

The legacy `patchset_sha256` and the omitted-path fields are left byte-identical. They remain an imported attestation from a packaging pipeline that no longer exists locally, and nothing here recomputes or reinterprets them.

`libllama-common` and both bridges are rebuilt, and the packaged `vendor/lib` mirror synced, so the native family identities stay coherent.

## Verification

- 17/17 witness behavioural checks; 13/13 mutants caught
- full suite 3622 passing; family-integrity and RUNPATH suites clean
- independent review returned 0 BLOCKER / 0 MAJOR / 0 MINOR, having rederived the provenance formulas over 19 state-machine cases, recomputed both regenerated hashes from scratch, and verified every pinned library hash in both `vendor/build` and `vendor/lib`

No persistent-draft or reset-lifecycle changes are included.