### PR TITLE
fix(runtime): preserve and reuse self-MTP state across chat turns

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -2285,10 +2285,19 @@ class NativeLlamaClient:
         on_token=None,
         request_timing: _RequestTiming | None = None,
     ) -> NativeTimings | None:
-        # MTP rewrites the shared target KV (llama_memory_clear / seq_rm in the
-        # persistent MTP shim) and returns before the standard commit point, so
-        # the recorded identity can no longer describe resident memory.
-        self._invalidate_committed_sequence()
+        # Historically this invalidated committed identity unconditionally,
+        # because the shim destroyed target KV on every completion and a recorded
+        # identity could not describe resident memory. With the persistent pair
+        # that premise no longer always holds: on a trusted resident path the
+        # target KV, the draft KV and pending_h all survive.
+        #
+        # Identity is therefore kept long enough to test the strict prefix, and
+        # the decision to publish or drop it is deferred to the exit, where the
+        # backend reports whether the pair is physically canonical. Publication
+        # is driven by proven physical state, never by the fact that MTP ran.
+        committed_at_entry = list(
+            getattr(self._session, "committed_sequence_tokens", None) or []
+        )
         request_timing = request_timing or _RequestTiming.start()
         thinking = self._thinking_enabled(thinking)
         # Whether MTP decoding may RUN is a property of the constructed
@@ -2336,23 +2345,43 @@ class NativeLlamaClient:
         mtp_prompt = _prepare_mtp_prompt(
             prompt, thinking=thinking, profile=getattr(self, "model_profile", None)
         )
-        try:
-            # The persistent shim's request-boundary reuse can leave target/draft
-            # state that fails the next target suffix prefill. Resetting here
-            # keeps MTP usable without changing prompt, route, or tool behavior.
-            runtime = reset_persistent_mtp_session(
-                llama_root=self.paths.llama_root,
-                paths=self.paths,
-                runtime=self._persistent_mtp_runtime,
-                ctx_tgt=self._session.ctx_tgt,
-            )
-        except Exception as exc:
-            self.mtp_fallback_reason = str(exc) or "persistent-mtp-reset-failed"
-            self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = self.mtp_fallback_reason
-            self._session.mtp_enabled = False
-            return None
+        # Semantic eligibility is decided here, in the runtime, from the token
+        # identity the runtime owns. The backend re-proves physical compatibility
+        # independently and may still refuse; neither side trusts the other's
+        # word. Strict equality only -- no longest-common-prefix, no retokenized
+        # approximation -- and a STRICT PROPER prefix, so a fresh target decode
+        # always precedes sampling (Defect A).
+        resident_prefix_len = self._resident_prefix_len_for_mtp(
+            mtp_prompt, committed_at_entry
+        )
+        # The reset frees the speculative implementation (destroying pending_h),
+        # clears draft KV and poisons pair trust. Running it unconditionally would
+        # destroy, on every turn, exactly the pair a resident claim depends on --
+        # making resident reuse structurally unreachable no matter what the
+        # backend does. So it is skipped when this turn carries a claim.
+        #
+        # This does not weaken anything: skipping the reset only PROPOSES reuse.
+        # The backend still re-proves target frontier, draft frontier, pending_h
+        # alignment and context identity before admitting the claim, and refuses
+        # to a full replay if any term fails. A claim of 0 keeps the old
+        # behaviour exactly.
+        if resident_prefix_len <= 0:
+            try:
+                runtime = reset_persistent_mtp_session(
+                    llama_root=self.paths.llama_root,
+                    paths=self.paths,
+                    runtime=self._persistent_mtp_runtime,
+                    ctx_tgt=self._session.ctx_tgt,
+                )
+            except Exception as exc:
+                self.mtp_fallback_reason = str(exc) or "persistent-mtp-reset-failed"
+                self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
+                self._session.mtp_failed = True
+                self._session.mtp_failure_reason = self.mtp_fallback_reason
+                self._session.mtp_enabled = False
+                return None
+        else:
+            runtime = self._persistent_mtp_runtime
         self._persistent_mtp_runtime = runtime
         self._session.ctx_dft = runtime.ctx_dft
         self._session.spec = runtime.spec
@@ -2374,6 +2403,7 @@ class NativeLlamaClient:
             ctx_tgt=self._session.ctx_tgt,
             prompt=mtp_prompt,
             max_tokens=generation_cap,
+            resident_prefix_len=resident_prefix_len,
             on_token=collect_mtp_token if on_token is not None else None,
             on_progress=lambda phase, current, total: self._handle_mtp_progress(
                 phase,
@@ -2386,6 +2416,12 @@ class NativeLlamaClient:
         if result.success and result.content and not thinking:
             result = replace(result, content=_strip_control_channels(result.content))
         self.last_mtp_completion = result
+        # Publication is keyed to the backend's canonical-pair verdict, captured
+        # at completion time. A completion that reused resident state but ended
+        # poisoned must NOT publish, and a cold completion that ended canonical
+        # MUST publish -- otherwise resident reuse could never bootstrap. The two
+        # facts are distinct and are never substituted for one another.
+        self._publish_mtp_committed_identity(result, mtp_prompt)
         if not result.success:
             if self.cancel_event.is_set():
                 self.mtp_fallback_reason = "cancelled"
@@ -4221,6 +4257,75 @@ class NativeLlamaClient:
         a false cache hit, which is a correctness bug rather than a slow path.
         """
         self._session.committed_sequence_tokens.clear()
+
+    def _resident_prefix_len_for_mtp(
+        self, mtp_prompt: str, committed: list[int]
+    ) -> int:
+        """Length of the committed prefix this completion may reuse, or 0.
+
+        The rule is the same strict append-only identity `_prepare_memory_for_prompt`
+        already enforces for the non-MTP path: the resident sequence must be a
+        token-exact PROPER prefix of this prompt. Proper matters -- a claim equal
+        to the whole prompt would leave no suffix to decode, so sampling would read
+        logits from the previous completion (Defect A).
+
+        Returning 0 is always safe: the backend then rebuilds cold.
+        """
+        if not committed:
+            return 0
+        if self._qwen3_coder_native_protocol():
+            return 0
+        try:
+            prompt_tokens = self.tokenize(mtp_prompt)
+        except Exception:
+            return 0
+        n = len(committed)
+        if not (0 < n < len(prompt_tokens)):
+            return 0
+        if prompt_tokens[:n] != committed:
+            # Diagnostic only, opt-in via ORBIT_KV_DIAG, and never consulted by
+            # any decision -- the refusal below is unconditional. Emitted because
+            # a divergence here and "no identity yet" both surface as a claim of
+            # 0, and only this distinguishes them when attributing a missed reuse.
+            emit_strict_append_miss(
+                committed=list(committed),
+                prompt=list(prompt_tokens),
+                session_id=getattr(self._session, "session_id", None),
+                profile_id=getattr(
+                    getattr(self, "model_profile", None), "profile_id", None
+                ),
+                lifecycle="mtp-resident-claim",
+            )
+            return 0
+        return n
+
+    def _publish_mtp_committed_identity(self, result, mtp_prompt: str) -> None:
+        """Record what the backend proved is resident, or drop the identity.
+
+        The verdict comes from the backend, captured at completion time. Identity
+        must never outlive the physical pair it describes, so anything short of a
+        canonical success drops it and the next turn rebuilds cold.
+        """
+        if not (
+            getattr(result, "success", False)
+            and getattr(result, "pair_canonical", False)
+        ):
+            self._invalidate_committed_sequence()
+            return
+        # The identity is the backend's own record of what is physically
+        # resident, not a reconstruction. `prompt + generated_tokens` would be
+        # one token too long: a sampled token enters `generated` at sample time
+        # but only enters the resident sequence on the following iteration. An
+        # identity longer than KV is a false cache hit -- the next turn would
+        # skip prefill for a position that was never decoded and land every
+        # subsequent token one position early, which corrupts output silently
+        # rather than merely losing reuse. Retokenizing the text is likewise not
+        # equivalent. So: publish what the backend measured, or publish nothing.
+        resident = tuple(getattr(result, "resident_tokens", ()) or ())
+        if not resident:
+            self._invalidate_committed_sequence()
+            return
+        self._session.committed_sequence_tokens = list(resident)
 
     def _commit_sequence(self, prompt_tokens, generated_tokens) -> None:
         """Record the exact sequence now resident in KV."""

--- a/src/orbit/native_llama/mtp_completion.py
+++ b/src/orbit/native_llama/mtp_completion.py
@@ -30,6 +30,19 @@ class MtpCompletionResult:
     draft_decode_calls: int = 0
     elapsed_ms: float | None = None
     tokens_per_second: float | None = None
+    # Snapshotted at completion time, before any reset can mutate the session.
+    # `resident_reuse_active` answers "did this completion reuse resident state";
+    # `pair_canonical` answers "is target+draft+pending_h reusable NOW". They are
+    # different questions: a cold completion can end canonical, and a resident
+    # completion can end poisoned, so the runtime must not substitute one for the
+    # other. `generated_tokens` carries the ids actually decoded, which is what a
+    # token-level committed identity must be built from.
+    resident_reuse_active: bool = False
+    pair_canonical: bool = False
+    generated_tokens: tuple[int, ...] = ()
+    # What the backend measured as physically resident in target KV. Committed
+    # identity is published from this, never from prompt + generated_tokens.
+    resident_tokens: tuple[int, ...] = ()
     full_accept_steps: int = 0
     replay_steps: int = 0
     partial_accept_steps: int = 0

--- a/src/orbit/native_llama/persistent_mtp.py
+++ b/src/orbit/native_llama/persistent_mtp.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import CDLL, CFUNCTYPE, c_bool, c_char_p, c_int32, c_long, c_uint32, c_void_p
+from ctypes import CDLL, CFUNCTYPE, POINTER, c_bool, c_char_p, c_int32, c_long, c_uint32, c_void_p
 from dataclasses import dataclass
 from pathlib import Path
 import ctypes
@@ -40,6 +40,22 @@ _SELF_MTP_REQUIRED_SHIM_SYMBOLS = (
     "orbit_mtp_session_owns_model",
     "orbit_mtp_session_borrowed_model",
     "orbit_mtp_session_borrowed_ctx_tgt",
+)
+
+# Required ONLY when a completion asks to reuse a resident target-KV prefix.
+# Kept out of both tuples above for the same reason they are kept apart from
+# each other: a shim without these stays perfectly valid for base decoding, for
+# the external-draft path, and for ordinary self-MTP. Asking for resident reuse
+# against such a shim fails closed rather than silently decoding from scratch
+# while reporting success.
+_RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS = (
+    "orbit_mtp_session_last_pair_canonical",
+    "orbit_mtp_session_last_generated_token_count",
+    "orbit_mtp_session_last_generated_tokens",
+    "orbit_mtp_session_last_resident_token_count",
+    "orbit_mtp_session_last_resident_tokens",
+    "orbit_mtp_session_set_resident_prefix_len",
+    "orbit_mtp_session_last_resident_reuse_active",
 )
 
 MtpTokenCallback = CFUNCTYPE(None, c_char_p, c_void_p)
@@ -96,6 +112,29 @@ class PersistentMtpLibrary:
         lib.orbit_mtp_session_reset.restype = c_bool
         lib.orbit_mtp_session_free.argtypes = [c_void_p]
         lib.orbit_mtp_session_free.restype = None
+        if hasattr(lib, "orbit_mtp_session_set_resident_prefix_len"):
+            lib.orbit_mtp_session_set_resident_prefix_len.argtypes = [c_void_p, c_int32]
+            lib.orbit_mtp_session_set_resident_prefix_len.restype = c_bool
+        if hasattr(lib, "orbit_mtp_session_last_resident_reuse_active"):
+            lib.orbit_mtp_session_last_resident_reuse_active.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_resident_reuse_active.restype = c_bool
+        if hasattr(lib, "orbit_mtp_session_last_pair_canonical"):
+            lib.orbit_mtp_session_last_pair_canonical.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_pair_canonical.restype = c_bool
+        if hasattr(lib, "orbit_mtp_session_last_generated_token_count"):
+            lib.orbit_mtp_session_last_generated_token_count.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_generated_token_count.restype = c_int32
+        if hasattr(lib, "orbit_mtp_session_last_generated_tokens"):
+            lib.orbit_mtp_session_last_generated_tokens.argtypes = [
+                c_void_p, POINTER(c_int32), c_int32]
+            lib.orbit_mtp_session_last_generated_tokens.restype = c_int32
+        if hasattr(lib, "orbit_mtp_session_last_resident_token_count"):
+            lib.orbit_mtp_session_last_resident_token_count.argtypes = [c_void_p]
+            lib.orbit_mtp_session_last_resident_token_count.restype = c_int32
+        if hasattr(lib, "orbit_mtp_session_last_resident_tokens"):
+            lib.orbit_mtp_session_last_resident_tokens.argtypes = [
+                c_void_p, POINTER(c_int32), c_int32]
+            lib.orbit_mtp_session_last_resident_tokens.restype = c_int32
         lib.orbit_mtp_session_ctx_dft.argtypes = [c_void_p]
         lib.orbit_mtp_session_ctx_dft.restype = c_void_p
         lib.orbit_mtp_session_spec.argtypes = [c_void_p]
@@ -206,6 +245,7 @@ def build_persistent_mtp_shim(
     runtime_bin: Path | None = None,
     runner=subprocess.run,
     require_self_mtp: bool = False,
+    require_resident_prefix: bool = False,
 ) -> Path:
     packaged = packaged_shim_path(persistent_mtp_shim_filename())
     # `build_bin` is where the compiler links from; `runtime_bin` is the family
@@ -217,6 +257,12 @@ def build_persistent_mtp_shim(
     required = _REQUIRED_SHIM_SYMBOLS
     if require_self_mtp:
         required = required + _SELF_MTP_REQUIRED_SHIM_SYMBOLS
+    if require_resident_prefix:
+        # Persistent-pair reuse calls symbols an older packaged shim does not
+        # export. Without this the packaged-artifact short-circuit can return a
+        # base-only shim and the feature would fail at the ctypes lookup instead
+        # of at build selection, after the caller already believed it had one.
+        required = required + _RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS
     if packaged is not None and _shim_exports_required_symbols(
         packaged,
         runtime_bin if runtime_bin is not None else build_bin,
@@ -421,6 +467,10 @@ def create_self_mtp_session(
         # The self-MTP entry points are demanded only here. A shim predating
         # them stays valid for normal decoding and for the external-draft path.
         require_self_mtp=True,
+        # The persistent pair is driven through the resident-prefix entry points,
+        # so this session cannot run against a shim lacking them. Demanding it at
+        # build selection fails loudly here rather than silently degrading later.
+        require_resident_prefix=True,
     )
     library = library_factory(paths.build_bin, shim)
     handle = library.lib.orbit_selfmtp_session_create(
@@ -469,6 +519,50 @@ def free_persistent_mtp_session(
         library.lib.orbit_mtp_session_free(runtime.handle)
 
 
+def _read_token_vector(lib, handle, count_symbol: str, copy_symbol: str) -> tuple[int, ...]:
+    """Copy a native token vector, sized by the native count.
+
+    The native side reports the required size when the buffer is too small, so a
+    caller cannot silently truncate. Absent accessors yield an empty tuple, which
+    the runtime treats as "no canonical identity available" rather than as an
+    empty-but-valid sequence.
+    """
+    if not hasattr(lib, count_symbol):
+        return ()
+    count = int(getattr(lib, count_symbol)(handle))
+    if count <= 0:
+        return ()
+    buffer = (c_int32 * count)()
+    written = int(getattr(lib, copy_symbol)(handle, buffer, count))
+    if written != count:
+        return ()
+    return tuple(int(value) for value in buffer)
+
+
+def _read_generated_tokens(lib, handle) -> tuple[int, ...]:
+    """The ids the last completion decoded."""
+    return _read_token_vector(
+        lib,
+        handle,
+        "orbit_mtp_session_last_generated_token_count",
+        "orbit_mtp_session_last_generated_tokens",
+    )
+
+
+def _read_resident_tokens(lib, handle) -> tuple[int, ...]:
+    """The ids physically resident in the target KV after the last completion.
+
+    This is the only sound source for committed identity; see the backend's
+    `last_resident_tokens` for why prompt + generated overstates residency.
+    """
+    return _read_token_vector(
+        lib,
+        handle,
+        "orbit_mtp_session_last_resident_token_count",
+        "orbit_mtp_session_last_resident_tokens",
+    )
+
+
 def run_persistent_mtp_completion(
     *,
     llama_root: Path,
@@ -479,6 +573,7 @@ def run_persistent_mtp_completion(
     max_tokens: int,
     on_token=None,
     on_progress=None,
+    resident_prefix_len: int = 0,
     build_dir: Path | None = None,
     library_factory=PersistentMtpLibrary,
 ) -> MtpCompletionResult:
@@ -504,6 +599,31 @@ def run_persistent_mtp_completion(
         progress_cb = MtpProgressCallback(_progress_cb)
     else:
         progress_cb = MtpProgressCallback(_noop_progress_callback)
+    # Declared here, not by the caller, so the claim is set as late as possible:
+    # after any session reset the caller may have performed, immediately before
+    # the completion that consumes it. A claim set earlier could be wiped by a
+    # reset in between. The claim lives for exactly one completion -- the
+    # backend reads it and zeroes it on the same two lines.
+    #
+    # A shim without the setter simply has no resident capability; asking for
+    # one fails closed rather than silently decoding from scratch while
+    # reporting reuse.
+    if resident_prefix_len > 0:
+        setter = getattr(
+            library.lib, "orbit_mtp_session_set_resident_prefix_len", None
+        )
+        if setter is None:
+            return MtpCompletionResult(
+                enabled=True,
+                success=False,
+                error="persistent-mtp-resident-prefix-unsupported",
+            )
+        if not setter(runtime.handle, int(resident_prefix_len)):
+            return MtpCompletionResult(
+                enabled=True,
+                success=False,
+                error=_decode_error(library.lib.orbit_mtp_last_error()),
+            )
     ok = library.lib.orbit_mtp_session_complete(
         runtime.handle,
         ctx_tgt,
@@ -539,6 +659,14 @@ def run_persistent_mtp_completion(
         draft_decode_calls=int(library.lib.orbit_mtp_session_last_draft_decode_calls(runtime.handle)),
         elapsed_ms=float(library.lib.orbit_mtp_session_last_elapsed_ms(runtime.handle)),
         tokens_per_second=float(library.lib.orbit_mtp_session_last_tokens_per_second(runtime.handle)),
+        resident_reuse_active=bool(
+            library.lib.orbit_mtp_session_last_resident_reuse_active(runtime.handle)
+        ) if hasattr(library.lib, "orbit_mtp_session_last_resident_reuse_active") else False,
+        pair_canonical=bool(
+            library.lib.orbit_mtp_session_last_pair_canonical(runtime.handle)
+        ) if hasattr(library.lib, "orbit_mtp_session_last_pair_canonical") else False,
+        generated_tokens=_read_generated_tokens(library.lib, runtime.handle),
+        resident_tokens=_read_resident_tokens(library.lib, runtime.handle),
         full_accept_steps=int(library.lib.orbit_mtp_session_last_full_accept_steps(runtime.handle)),
         replay_steps=int(library.lib.orbit_mtp_session_last_replay_steps(runtime.handle)),
         partial_accept_steps=int(library.lib.orbit_mtp_session_last_partial_accept_steps(runtime.handle)),

--- a/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
+++ b/src/orbit/native_llama/vendor/LLAMA_PROVENANCE.json
@@ -2,7 +2,7 @@
   "format": 1,
   "upstream_commit": "379ac6673b5cd75c7b4e07d1521c50f1e093878c",
   "upstream_tag": "b9551",
-  "source_tree_sha256": "e78615ff6dbe019a1a0d03d2e72f2bca90f9a5d03ccaaad5902d3e6cc5831b78",
+  "source_tree_sha256": "6c361f995c0734e8b59fb6255d1e55007ee3072dddda9f0d51921a9aaa94b793",
   "patchset_sha256": "aa3bb3d637ea963320df82dd588a0a85982936c192b7629d424daba0d1604441",
   "omitted_upstream_path_count": 1509,
   "omitted_upstream_paths_sha256": "93f225c176ba65acdb282c231f5c309fff45180746e88ba69028936bff8db485",
@@ -72,5 +72,5 @@
     "vendor/miniaudio/miniaudio.h"
   ],
   "patchset_algorithm": "orbit-patchset-v2",
-  "patchset_v2_sha256": "8789a825b004ab5bc345e94dae04cc181072131dd64b5acaa2be8cc6469a0598"
+  "patchset_v2_sha256": "8ed0808ca95bf4988e26e6021c6207e1210fac504954bfa450bd04604215e32b"
 }

--- a/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
+++ b/src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp
@@ -1,4 +1,9 @@
 #include "llama.h"
+// `llama_get_ctx_other` reports whether a draft context physically shares its
+// memory with the target. It lives in the internal extension header rather than
+// the public one; build_support already puts <llama_root>/src on the include
+// path, so this needs no build change.
+#include "llama-ext.h"
 #include "common/speculative.h"
 #include "common/sampling.h"
 
@@ -65,6 +70,197 @@ static bool boundary_split_enabled() {
         return true;
     }
     return std::strcmp(value, "0") != 0;
+}
+
+// Target-side event trace, for qualifying persistent target-KV behaviour.
+// Deliberately env-gated and stderr-only, exactly like the emitters above: it
+// exports no symbol, so the base and self-MTP ABI contracts are untouched and a
+// packaged shim stays interchangeable. Every call site is additionally guarded
+// by `target_trace_enabled()` so a disabled trace costs one boolean test and
+// never builds a payload.
+//
+// Only mem_tgt operations are recorded. The legacy debug counters cannot serve
+// this purpose: they mix target with draft, count decode batches rather than
+// tokens, and ignore seq_rm results.
+static bool target_trace_enabled() {
+    const char * value = std::getenv("ORBIT_MTP_TARGET_TRACE");
+    return value && value[0] && std::strcmp(value, "0") != 0;
+}
+
+static void emit_orbit_target_trace(const std::string & payload) {
+    std::fprintf(stderr, "ORBIT_MTP_TARGET %s\n", payload.c_str());
+}
+
+static void trace_target_clear(const char * site) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "TARGET_CLEAR site=" << (site ? site : "?");
+    emit_orbit_target_trace(out.str());
+}
+
+static void trace_target_prefill(const char * site, int32_t first_pos, size_t n_tokens) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "TARGET_PREFILL site=" << (site ? site : "?")
+        << " first_pos=" << first_pos
+        << " n_tokens=" << n_tokens;
+    emit_orbit_target_trace(out.str());
+}
+
+static void trace_target_seq_rm(const char * site, int32_t p0, int32_t p1, bool result) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "TARGET_SEQ_RM site=" << (site ? site : "?")
+        << " p0=" << p0 << " p1=" << p1
+        << " result=" << (result ? "true" : "false");
+    emit_orbit_target_trace(out.str());
+}
+
+static void trace_target_frontier(const char * label, llama_memory_t mem) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "TARGET_FRONTIER label=" << (label ? label : "?")
+        << " pos_max=" << (mem ? (long long) llama_memory_seq_pos_max(mem, 0) : -1);
+    emit_orbit_target_trace(out.str());
+}
+
+// Phase-B draft observability. Deliberately separate helpers rather than
+// parameterising the target ones above: those bytes are frozen evidence, and a
+// recorder that can mislabel a draft event as a target event is worse than no
+// recorder. Same env gate, same stderr sink, same "no payload when disabled"
+// discipline. The wire prefix is ORBIT_MTP_OBSDRAFT, chosen so it is neither a
+// prefix nor an extension of any existing ORBIT_MTP_* stream (DRAFT, DFT,
+// TARGET, FRONTIER, VALIDATE). A prefix-extension such as ORBIT_MTP_DRAFTOBS
+// would let `startswith("ORBIT_MTP_DRAFT")` swallow these records into that
+// stream's JSON parser and silently lose them from a run that looked fine.
+//
+// The speculative implementation owns `pending_h`, the predecessor hidden-state
+// row that seeds every proposal. Its CONTENT is now directly observable through
+// `common_speculative_pending_state`, so SPEC_STATE carries both the impl's
+// lifetime (epoch/pointer) and the row's provenance, fingerprint and write
+// count. Destroying the impl still re-zeroes `pending_h` by construction, but
+// that no longer has to be deduced -- the witness reports it.
+static void emit_orbit_draftobs_trace(const std::string & payload) {
+    std::fprintf(stderr, "ORBIT_MTP_OBSDRAFT %s\n", payload.c_str());
+}
+
+static void trace_draft_frontier(const char * label, llama_memory_t mem) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "DRAFT_FRONTIER label=" << (label ? label : "?")
+        << " pos_max=" << (mem ? (long long) llama_memory_seq_pos_max(mem, 0) : -1);
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_resident_admission(
+        int32_t claim,
+        bool admitted,
+        bool pair_trusted,
+        bool identity_ok,
+        int32_t pending_pos,
+        unsigned long long pending_gen) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "RESIDENT_ADMISSION claim=" << claim
+        << " admitted=" << (admitted ? "true" : "false")
+        << " pair_trusted=" << (pair_trusted ? "true" : "false")
+        << " identity_ok=" << (identity_ok ? "true" : "false")
+        << " pending_pos=" << pending_pos
+        << " pending_gen=" << pending_gen;
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_pair_trust(
+        const char * verdict,
+        int32_t frontier,
+        bool target_ok,
+        bool draft_ok,
+        bool pending_aligned,
+        bool identity_ok) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "PAIR_TRUST verdict=" << (verdict ? verdict : "?")
+        << " frontier=" << frontier
+        << " target_ok=" << (target_ok ? "true" : "false")
+        << " draft_ok=" << (draft_ok ? "true" : "false")
+        << " pending_aligned=" << (pending_aligned ? "true" : "false")
+        << " identity_ok=" << (identity_ok ? "true" : "false");
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_pending_discarded(const char * site) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "PENDING_DISCARDED site=" << (site ? site : "?");
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_request_reset_mode(const char * mode) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "REQUEST_RESET_MODE mode=" << (mode ? mode : "?");
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_draft_clear(const char * site) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "DRAFT_CLEAR site=" << (site ? site : "?");
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_draft_process(const char * site, int32_t first_pos, size_t n_tokens) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "DRAFT_PROCESS site=" << (site ? site : "?")
+        << " first_pos=" << first_pos
+        << " n_tokens=" << n_tokens;
+    emit_orbit_draftobs_trace(out.str());
+}
+
+static void trace_draft_seq_rm(const char * site, int32_t p0, int32_t p1, bool result) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "DRAFT_SEQ_RM site=" << (site ? site : "?")
+        << " p0=" << p0 << " p1=" << p1
+        << " result=" << (result ? "true" : "false");
+    emit_orbit_draftobs_trace(out.str());
+}
+
+// `epoch` is authoritative: it counts speculative-implementation constructions
+// performed by this shim, so a preserved impl keeps its epoch and a recreated one
+// increments. `spec` is corroborating only -- an allocator may hand back the same
+// address, so an unchanged pointer proves nothing on its own. `ctx_dft` is a
+// different object from the impl and is NOT freed by reset; recording it shows
+// which half of the pair changed.
+static void trace_spec_state(
+        const char * label,
+        unsigned long long epoch,
+        const void * spec,
+        const void * ctx_dft) {
+    if (!target_trace_enabled()) { return; }
+    std::ostringstream out;
+    out << "SPEC_STATE label=" << (label ? label : "?")
+        << " epoch=" << epoch
+        << " spec=" << spec
+        << " ctx_dft=" << ctx_dft;
+    // The epoch is a LIFETIME witness only. `pending_h` is the row that seeds
+    // every draft proposal, and its CONTENT state is what decides whether a
+    // following suffix has the predecessor it needs; an unchanged epoch says the
+    // object survived, never that the row is aligned. These three come from the
+    // read-only diagnostic accessor and are recorded here so a trace can answer
+    // that question directly.
+    int32_t pend_pos = -1;
+    uint64_t pend_fp = 0;
+    uint64_t pend_gen = 0;
+    const bool pend_ok = spec != nullptr && common_speculative_pending_state(
+        static_cast<const common_speculative *>(spec), 0,
+        &pend_pos, &pend_fp, &pend_gen);
+    out << " pending_ok=" << (pend_ok ? "true" : "false")
+        << " pending_pos=" << pend_pos
+        << " pending_fp=" << pend_fp
+        << " pending_gen=" << pend_gen;
+    emit_orbit_draftobs_trace(out.str());
 }
 
 static bool draft_trace_enabled() {
@@ -194,11 +390,66 @@ struct orbit_mtp_session {
     common_params_speculative spec_params;
     common_prompt_checkpoint request_boundary_ckpt;
     std::vector<llama_token> request_boundary_prompt_tgt;
+    // A resident-prefix claim supplied by the runtime for ONE completion. The
+    // runtime has already proven token identity against its committed
+    // sequence; this side only ever checks that physical target memory agrees.
+    // Consumed (zeroed) at the start of each completion so a stale claim can
+    // never leak into a later request.
+    int32_t pending_resident_prefix_len = 0;
+    // The target context the speculative implementation was CONSTRUCTED with.
+    // `common_speculative_impl` copies ctx_tgt into its params and derives
+    // is_mem_shared from that exact pair, so a preserved implementation keeps
+    // whatever target it was built against. Soft reuse must therefore prove the
+    // caller is still presenting the same context; production creates ctx_tgt
+    // once per model load, but that is caller behaviour, not an invariant of
+    // this function, and relying on caller ordering is how D3b-R defects were
+    // written.
+    llama_context * spec_pinned_ctx_tgt = nullptr;
+    // One trust bit for the WHOLE pair: target KV, draft KV and pending_h. The
+    // halves advance in lockstep and are only ever consumed together, so a
+    // half-trusted state is not reachable and would only be a way to salvage one
+    // side of a mismatched pair. Any uncertain mutation on either half, or an
+    // identity change, poisons the pair until a hard rebuild re-proves it.
+    bool persistent_pair_untrusted = true;
+    // Diagnostic only: which reset path the last completion entry took.
+    bool last_request_reset_was_soft = false;
+    // Counts speculative-implementation constructions performed by this shim.
+    // Diagnostic only: never read by any decision, only reported by the draft
+    // recorder so a trace can distinguish a preserved impl (epoch unchanged)
+    // from a destroyed-and-recreated one (epoch incremented). The object holding
+    // `pending_h` is not otherwise observable from here.
+    unsigned long long spec_epoch = 0;
+    // Whether the last completion actually reused a resident prefix. Set from
+    // the same predicate that drives the replay decision, so it cannot report
+    // reuse that did not happen.
+    bool last_resident_reuse_active = false;
+    // Set when a target seq_rm was refused, so the resident prefix cannot be
+    // proven canonical. A refused removal leaves rejected speculative tokens
+    // resident above the committed frontier; a later completion claiming
+    // frontier+1 would then "match" a poisoned frontier. Correct target state
+    // is mandatory, cache reuse is not.
+    bool last_target_untrusted = false;
     long rss_before_kb = -1;
     long rss_after_init_kb = -1;
     long rss_peak_kb = -1;
     std::vector<llama_token> cached_prompt_tokens;
     std::string last_content;
+    // The exact token ids this completion decoded into the target, in order.
+    // The runtime needs these to publish a token-level committed identity for
+    // the next turn; retokenizing `last_content` is not equivalent, because a
+    // round trip through text is not guaranteed to reproduce the ids that were
+    // actually made resident, and an identity that misdescribes KV is a false
+    // cache hit rather than a slow path.
+    std::vector<llama_token> last_generated_tokens;
+    // The token sequence physically resident in the target KV at the end of the
+    // last completion. This is NOT `prompt + last_generated_tokens`: a sampled
+    // token enters `generated` at sample time but only enters `prompt_tgt` on
+    // the following iteration, so the two differ by the final token. A runtime
+    // identity built from `generated` would claim one more resident token than
+    // exists, and a claim that overstates KV is a false cache hit -- the next
+    // prompt would be decoded one position early. Publishing the loop's own
+    // `prompt_tgt` keeps identity physically derived rather than reconstructed.
+    std::vector<llama_token> last_resident_tokens;
     int last_output_tokens = 0;
     int last_draft_tokens_total = 0;
     int last_accepted_tokens_total = 0;
@@ -1137,6 +1388,11 @@ static orbit_step_outcome resolve_validate_accept_restore(
     }
     session->last_target_decode_calls++;
     if (spec) {
+        // The per-step draft advance. This, not the prefill, is what moves the
+        // draft frontier during generation and updates `pending_h` on every
+        // step; leaving it untraced would make the exit frontier unexplainable
+        // from the event stream. Emitted before the timing bracket opens.
+        trace_draft_process("validate", validate_pos0, validate_tokens.size());
         const auto phase_start = std::chrono::steady_clock::now();
         const bool ok = common_speculative_process(spec, validate);
         phase_add(session->phase_speculative_process, phase_start);
@@ -1223,11 +1479,19 @@ static orbit_step_outcome resolve_validate_accept_restore(
             n_past = (int32_t) prompt_tgt.size();
             {
                 const auto phase_start = std::chrono::steady_clock::now();
-                llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
-                llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+                const bool tgt_rm_ok = llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+                trace_target_seq_rm("live_partial", n_past, -1, tgt_rm_ok);
+                if (!tgt_rm_ok) {
+                    session->last_target_untrusted = true;
+                }
+                const bool dft_rm_ok = llama_memory_seq_rm(mem_dft, 0, n_past, -1);
                 phase_add(session->phase_seq_rm, phase_start);
+                trace_draft_seq_rm("live_partial", n_past, -1, dft_rm_ok);
             }
             session->debug_seq_rm_count += 2;
+            // `live_ok` re-derives the frontier physically, so a refused removal
+            // already falls through to replay. The explicit result check above
+            // makes that intent visible rather than incidental.
             const bool live_ok =
                 prompt_tgt.size() == (size_t) n_past &&
                 llama_memory_seq_pos_max(mem_tgt, 0) == n_past - 1 &&
@@ -1269,7 +1533,14 @@ static orbit_step_outcome resolve_validate_accept_restore(
             ckpt.load_tgt(ctx_tgt, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
             {
                 const auto phase_start = std::chrono::steady_clock::now();
-                llama_memory_seq_rm(mem_tgt, 0, ckpt.pos_max + 1, -1);
+                const bool ckpt_rm_ok = llama_memory_seq_rm(mem_tgt, 0, ckpt.pos_max + 1, -1);
+                trace_target_seq_rm("ckpt_restore", ckpt.pos_max + 1, -1, ckpt_rm_ok);
+                if (!ckpt_rm_ok) {
+                    // The restore did not land: tokens remain above the
+                    // checkpoint. The caller replays from here, but the target
+                    // must not be treated as canonical in the meantime.
+                    session->last_target_untrusted = true;
+                }
                 phase_add(session->phase_seq_rm, phase_start);
             }
             session->debug_seq_rm_count++;
@@ -1297,8 +1568,11 @@ static orbit_step_outcome resolve_validate_accept_restore(
             {
                 const auto phase_start_seq_rm = std::chrono::steady_clock::now();
                 const int32_t before_max = llama_memory_seq_pos_max(mem_dft, 0);
-                llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                const bool ckpt_dft_rm_ok =
+                    llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
                 phase_add(session->phase_seq_rm, phase_start_seq_rm);
+                trace_draft_seq_rm(
+                    "ckpt_restore", ckpt.pos_max + 1, -1, ckpt_dft_rm_ok);
                 if (draft_trace_enabled()) {
                     std::ostringstream out;
                     out
@@ -1320,6 +1594,7 @@ static orbit_step_outcome resolve_validate_accept_restore(
             }
             session->debug_seq_rm_count++;
             phase_add(session->phase_ctx_dft_restore, phase_start);
+            trace_draft_frontier("ckpt_load_dft", llama_get_memory(ctx_dft));
         }
 
         if (debug_partial && debug_trace_step) {
@@ -1447,6 +1722,57 @@ static void cleanup_session(orbit_mtp_session * session) {
     }
 }
 
+// Whether the persistent pair may be reused without rebuilding it. Every term is
+// physical or identity-based: nothing here trusts the caller's intent.
+//   - the pair must not be poisoned by an earlier uncertain mutation
+//   - the speculative implementation must exist and still belong to THIS target
+//   - target and draft must agree on the same frontier F
+//   - pending_h must hold the predecessor for a suffix beginning at F+1, which is
+//     position F; frontier agreement alone is not sufficient, because a draft can
+//     be frontier-correct and content-wrong (proved by the D3b-R2 review)
+static bool persistent_pair_is_reusable(
+    orbit_mtp_session * session,
+    llama_context * ctx_tgt,
+    llama_memory_t mem_tgt,
+    llama_memory_t mem_dft
+) {
+    if (!session || !ctx_tgt || !mem_tgt || !mem_dft) { return false; }
+    if (session->persistent_pair_untrusted) { return false; }
+    if (!session->spec) { return false; }
+    if (session->spec_pinned_ctx_tgt != ctx_tgt) { return false; }
+
+    const int32_t tgt_max = llama_memory_seq_pos_max(mem_tgt, 0);
+    const int32_t dft_max = llama_memory_seq_pos_max(mem_dft, 0);
+    if (tgt_max < 0 || tgt_max != dft_max) { return false; }
+
+    int32_t pend_pos = -1;
+    uint64_t pend_fp = 0;
+    uint64_t pend_gen = 0;
+    if (!common_speculative_pending_state(session->spec, 0, &pend_pos, &pend_fp, &pend_gen)) {
+        return false;
+    }
+    // The predecessor of position F+1 is F.
+    return pend_pos == tgt_max && pend_gen > 0;
+}
+
+// Soft reset: keep the canonical pair, clear only per-request bookkeeping.
+// Deliberately does NOT touch mem_tgt, mem_dft, or the speculative implementation.
+// Everything inside the implementation that is per-request -- i_batch_beg/end,
+// verify_h, verify_h_rows, verify_pos, last_n_drafted, the samplers -- is
+// rewritten before it is read within a request, and every accept() is preceded by
+// a process() in the same request, so none of it carries stale meaning across the
+// boundary. pending_h, which does carry meaning, is exactly what must survive.
+static void soft_reset_request_state(orbit_mtp_session * session) {
+    session->request_boundary_ckpt.clear();
+    session->request_boundary_prompt_tgt.clear();
+    // The resident claim is deliberately NOT cleared here. This runs at the top
+    // of the completion the claim was set for, so clearing it would zero the
+    // claim before it is read below, and `resident_ok` would be false on exactly
+    // the turns where the pair IS reusable -- resident reuse could never happen.
+    // Nothing leaks: the claim is consumed one-shot where it is read (it is
+    // zeroed on the same two lines), and the hard path clears it separately.
+}
+
 static bool reset_speculative_request_state(
     orbit_mtp_session * session,
     llama_context * ctx_tgt
@@ -1464,7 +1790,15 @@ static bool reset_speculative_request_state(
     session->spec_params.draft.ctx_tgt = ctx_tgt;
     session->spec_params.draft.ctx_dft = session->ctx_dft;
     session->spec = common_speculative_init(session->spec_params, 1);
+    session->spec_epoch++;
+    // Pin the target this implementation was built against; soft reuse checks it.
+    session->spec_pinned_ctx_tgt = session->spec_params.draft.ctx_tgt;
     if (!session->spec) {
+        trace_spec_state(
+            "request_reset_after",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
         set_error("failed to reinitialize speculative request state");
         return false;
     }
@@ -1642,6 +1976,16 @@ extern "C" void * orbit_mtp_session_create(
     session->spec_params.draft.ctx_dft = session->ctx_dft;
 
     session->spec = common_speculative_init(session->spec_params, 1);
+    session->spec_epoch++;
+    // Pin the target this implementation was built against; soft reuse checks it.
+    session->spec_pinned_ctx_tgt = session->spec_params.draft.ctx_tgt;
+    // Anchor the epoch baseline. Without this the first event of any run carries
+    // a nonzero epoch with no preceding construction event to explain it.
+    trace_spec_state(
+        "session_create",
+        session->spec_epoch,
+        static_cast<const void *>(session->spec),
+        static_cast<const void *>(session->ctx_dft));
     session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
     if (!session->spec) {
         set_error("failed to initialize speculative MTP state");
@@ -1662,6 +2006,19 @@ extern "C" bool orbit_mtp_session_reset(void * handle, void * ctx_tgt_ptr) {
         return false;
     }
 
+    // Observe the pair BEFORE anything is destroyed. This is the decisive
+    // measurement of the mission: whatever survives from here to the matching
+    // "reset_after" pair is what a future persistent-draft design would inherit.
+    {
+        auto * mem_before = llama_get_memory(session->ctx_dft);
+        trace_draft_frontier("reset_before", mem_before);
+        trace_spec_state(
+            "reset_before",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
+    }
+
     if (session->spec) {
         common_speculative_free(session->spec);
         session->spec = nullptr;
@@ -1670,17 +2027,48 @@ extern "C" bool orbit_mtp_session_reset(void * handle, void * ctx_tgt_ptr) {
     auto * mem = llama_get_memory(session->ctx_dft);
     if (mem) {
         llama_memory_clear(mem, true);
+        trace_draft_clear("reset");
     }
 
     session->spec_params.draft.ctx_tgt = ctx_tgt;
     session->spec_params.draft.ctx_dft = session->ctx_dft;
     session->spec = common_speculative_init(session->spec_params, 1);
+    session->spec_epoch++;
+    // Pin the target this implementation was built against; soft reuse checks it.
+    session->spec_pinned_ctx_tgt = session->spec_params.draft.ctx_tgt;
     if (!session->spec) {
+        // Emit before returning: the epoch already advanced, so without this the
+        // stream would show an unexplained +1 with no closing record. spec=0
+        // identifies the failure.
+        trace_spec_state(
+            "reset_after",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
         set_error("failed to reinitialize speculative MTP state");
         return false;
     }
+    {
+        auto * mem_after = llama_get_memory(session->ctx_dft);
+        trace_draft_frontier("reset_after", mem_after);
+        trace_spec_state(
+            "reset_after",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
+    }
     session->request_boundary_ckpt.clear();
     session->request_boundary_prompt_tgt.clear();
+    // A pending claim describes one specific completion. Resetting speculative
+    // state invalidates it, but deliberately does NOT touch mem_tgt: draft
+    // state and canonical target KV are separate concerns.
+    session->pending_resident_prefix_len = 0;
+    // This reset just destroyed the draft half and the implementation holding
+    // pending_h. A trust bit left asserting "canonical pair" would be describing
+    // state that no longer exists. Physical checks happen to catch it downstream,
+    // but a flag that survives the operation destroying what it describes is a
+    // latent false-trust path, not a design.
+    session->persistent_pair_untrusted = true;
 
     return true;
 }
@@ -1746,6 +2134,16 @@ extern "C" void * orbit_selfmtp_session_create(
     session->spec_params.draft.ctx_dft = session->ctx_dft;
 
     session->spec = common_speculative_init(session->spec_params, 1);
+    session->spec_epoch++;
+    // Pin the target this implementation was built against; soft reuse checks it.
+    session->spec_pinned_ctx_tgt = session->spec_params.draft.ctx_tgt;
+    // Anchor the epoch baseline. Without this the first event of any run carries
+    // a nonzero epoch with no preceding construction event to explain it.
+    trace_spec_state(
+        "session_create",
+        session->spec_epoch,
+        static_cast<const void *>(session->spec),
+        static_cast<const void *>(session->ctx_dft));
     session->rss_peak_kb = std::max(session->rss_peak_kb, rss_kb());
     if (!session->spec) {
         set_error("failed to initialize self-MTP speculative state");
@@ -1755,6 +2153,40 @@ extern "C" void * orbit_selfmtp_session_create(
 
     session->rss_after_init_kb = rss_kb();
     return session.release();
+}
+
+// Declare a resident target-KV prefix for the NEXT completion only.
+//
+// `n` is a length the runtime has already verified semantically -- it proved
+// `prompt_tokens[:n] == committed_tokens` before calling. This layer never
+// repeats that comparison; it verifies only that physical target memory is
+// consistent with the claim, and falls back to a full replay if it is not.
+//
+// Deliberately a separate symbol rather than a new parameter on
+// `orbit_mtp_session_complete`: the base ABI stays stable, and a shim without
+// this symbol remains valid for every path that does not ask for resident
+// reuse.
+extern "C" bool orbit_mtp_session_set_resident_prefix_len(void * handle, int32_t n) {
+    g_last_error.clear();
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    if (!session) {
+        set_error("resident prefix requires a valid session");
+        return false;
+    }
+    if (n < 0) {
+        set_error("resident prefix length must be non-negative");
+        return false;
+    }
+    session->pending_resident_prefix_len = n;
+    return true;
+}
+
+// Whether the last completion actually preserved and reused a resident prefix.
+// False whenever the claim was absent, rejected, or physically unverifiable --
+// there is no "maybe" state.
+extern "C" bool orbit_mtp_session_last_resident_reuse_active(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? session->last_resident_reuse_active : false;
 }
 
 extern "C" bool orbit_mtp_session_owns_model(void * handle) {
@@ -1850,12 +2282,59 @@ extern "C" bool orbit_mtp_session_complete(
         set_error("persistent MTP session is not initialized");
         return false;
     }
-    if (!reset_speculative_request_state(session, ctx_tgt)) {
-        return false;
+    // Bracket this destruction explicitly. `reset_speculative_request_state`
+    // frees and recreates the speculative implementation on EVERY completion,
+    // independently of `orbit_mtp_session_reset`. Without its own labelled pair
+    // the epoch would jump between one request's exit and the next request's
+    // entry with nothing naming the cause, and an analyst would attribute all
+    // destruction to the session reset -- concluding that softening that reset
+    // would preserve `pending_h`, which is false while this site exists.
+    {
+        auto * mem_dft_pre = llama_get_memory(session->ctx_dft);
+        trace_draft_frontier("request_reset_before", mem_dft_pre);
+        trace_spec_state(
+            "request_reset_before",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
+    }
+    // Soft when the whole pair is provably canonical and still belongs to this
+    // target, hard otherwise. A soft reset keeps ctx_tgt, ctx_dft, the
+    // speculative implementation and pending_h, and clears only per-request
+    // bookkeeping, so the next request can append its suffix instead of
+    // rebuilding history. Anything uncertain rebuilds: correctness over cache.
+    {
+        auto * mem_tgt_pre = llama_get_memory(ctx_tgt);
+        auto * mem_dft_pre2 = llama_get_memory(session->ctx_dft);
+        const bool soft = persistent_pair_is_reusable(
+            session, ctx_tgt, mem_tgt_pre, mem_dft_pre2);
+        session->last_request_reset_was_soft = soft;
+        if (soft) {
+            soft_reset_request_state(session);
+            trace_request_reset_mode("soft");
+        } else {
+            trace_request_reset_mode("hard");
+            if (!reset_speculative_request_state(session, ctx_tgt)) {
+                return false;
+            }
+            // A rebuilt pair has proven nothing yet.
+            session->persistent_pair_untrusted = true;
+        }
+    }
+    {
+        auto * mem_dft_post = llama_get_memory(session->ctx_dft);
+        trace_draft_frontier("request_reset_after", mem_dft_post);
+        trace_spec_state(
+            "request_reset_after",
+            session->spec_epoch,
+            static_cast<const void *>(session->spec),
+            static_cast<const void *>(session->ctx_dft));
     }
 
     session->last_content.clear();
     session->last_output_tokens = 0;
+    session->last_generated_tokens.clear();
+    session->last_resident_tokens.clear();
     session->last_draft_tokens_total = 0;
     session->last_accepted_tokens_total = 0;
     session->last_rejected_tokens_total = 0;
@@ -1969,7 +2448,93 @@ extern "C" bool orbit_mtp_session_complete(
             token_callback(piece.c_str(), callback_user_data);
         }
     };
-    bool need_replay = true;
+    trace_target_frontier("request_entry", mem_tgt);
+    trace_draft_frontier("request_entry", mem_dft);
+    trace_spec_state("request_entry", session->spec_epoch,
+        static_cast<const void *>(session->spec),
+        static_cast<const void *>(session->ctx_dft));
+
+    // Resident-prefix decision. The runtime may declare that the first N prompt
+    // tokens are already resident in target memory, having proven token
+    // identity against its own committed sequence. This layer does not repeat
+    // that comparison -- it asks only whether PHYSICAL memory agrees:
+    //
+    //   * the claim fits inside this prompt;
+    //   * the target frontier is exactly N-1, so N tokens really are resident;
+    //   * bounded recurrent rollback is available, since a rejected
+    //     speculative tail must be removable without discarding the prefix.
+    //
+    // `llama_n_rs_seq` is read directly rather than via `can_partial_rollback`,
+    // whose probe clears memory and would destroy the very prefix at stake.
+    //
+    // Any disagreement falls through to the existing replay path with no claim
+    // of reuse: a wrong prefix is a correctness bug, a full replay is only slow.
+    // Carried in from the PREVIOUS completion: if a target seq_rm was refused
+    // there, the frontier may include tokens that were supposed to be removed,
+    // so a claim of frontier+1 could match a poisoned state. Read it before
+    // clearing, so the flag gates exactly one following completion.
+    const bool target_untrusted_from_previous = session->last_target_untrusted;
+    session->last_target_untrusted = false;
+    const int32_t resident_claim = session->pending_resident_prefix_len;
+    session->pending_resident_prefix_len = 0;
+    // The claim must be a STRICT PROPER prefix: `< size()`, not `<=`. A claim
+    // covering the whole prompt would leave an empty suffix, so this completion
+    // would decode nothing into the target, and the first sample would then read
+    // logits left behind by the PREVIOUS completion. Falling closed to the full
+    // replay costs one prefill and guarantees fresh logits before sampling.
+    // Resident reuse now requires the WHOLE pair, not just the target. The draft
+    // must physically agree on the same frontier, and pending_h must hold the
+    // predecessor for a suffix beginning at the claim -- position claim-1. Without
+    // the pending term a draft could be frontier-correct and content-wrong, which
+    // is exactly the defect the D3b-R2 review found in the earlier attempt.
+    // The pair carried in from the previous completion is consulted before it is
+    // re-armed below, so one bad completion gates the next.
+    int32_t entry_pend_pos = -1;
+    uint64_t entry_pend_fp = 0;
+    uint64_t entry_pend_gen = 0;
+    const bool entry_pend_ok = common_speculative_pending_state(
+        session->spec, 0, &entry_pend_pos, &entry_pend_fp, &entry_pend_gen);
+    const bool pair_trusted_from_previous = !session->persistent_pair_untrusted;
+    const bool identity_ok =
+        session->spec != nullptr && session->spec_pinned_ctx_tgt == ctx_tgt;
+    const bool resident_ok =
+        resident_claim > 0 &&
+        !target_untrusted_from_previous &&
+        pair_trusted_from_previous &&
+        identity_ok &&
+        resident_claim < (int32_t) prompt_tgt.size() &&
+        llama_n_rs_seq(ctx_tgt) > 0 &&
+        llama_memory_seq_pos_max(mem_tgt, 0) == resident_claim - 1 &&
+        llama_memory_seq_pos_max(mem_dft, 0) == resident_claim - 1 &&
+        entry_pend_ok &&
+        entry_pend_pos == resident_claim - 1 &&
+        entry_pend_gen > 0;
+    session->last_resident_reuse_active = resident_ok;
+    trace_resident_admission(
+        resident_claim, resident_ok, pair_trusted_from_previous, identity_ok,
+        entry_pend_ok ? entry_pend_pos : -1, entry_pend_gen);
+
+    // Fail-closed target-trust contract. From here on this completion may mutate
+    // physical target state (clear, prefill decode, validation decode, seq_rm).
+    // Any exit that is not the single proven-canonical success return at the end
+    // of this function leaves that state unverified -- notably a failed
+    // `llama_decode(ctx_tgt, validate)`, which has already written speculative
+    // tokens above the committed frontier by the time it reports failure. Rather
+    // than patch each individual return site, arm the flag once here and clear it
+    // only after the loop has completed normally. A later resident claim is then
+    // refused until a cold clear/full replay has re-established canonical state.
+    session->last_target_untrusted = true;
+    // The pair is poisoned for the same reason and at the same moment as the
+    // target: from here on this completion may mutate target KV, draft KV and
+    // pending_h, and only the proven-canonical exit re-establishes them together.
+    session->persistent_pair_untrusted = true;
+
+    bool need_replay = !resident_ok;
+    // The prefill block below lives under `need_replay`. On the resident path
+    // we still need to enter it once -- to decode the SUFFIX -- while skipping
+    // the target clear. This one-shot flag distinguishes that first pass from a
+    // genuine replay.
+    bool resident_prefill_pending = resident_ok;
     bool is_recovery_replay = false;
     std::vector<llama_token> draft;
     common_prompt_checkpoint ckpt;
@@ -1994,10 +2559,40 @@ extern "C" bool orbit_mtp_session_complete(
     while ((int) generated.size() < generation_limit) {
         const auto loop_phase_start = std::chrono::steady_clock::now();
         const bool loop_need_replay_before = need_replay;
-        if (need_replay) {
+        if (need_replay || resident_prefill_pending) {
+            const bool resident_pass = resident_prefill_pending;
+            resident_prefill_pending = false;
             const bool replay_is_recovery = is_recovery_replay;
             const auto replay_phase_start = std::chrono::steady_clock::now();
-            const bool use_request_boundary = generated.empty() && can_restore_request_boundary && !used_request_boundary;
+            // A soft reset preserved `pending_h` for a suffix append at F+1. If
+            // this completion instead replays from position 0, that row is the
+            // WRONG predecessor: process() would seed draft slot 0 with the last
+            // frontier's hidden state where "no predecessor" is required, and the
+            // vendored code states the invariant directly -- "-1 == no
+            // predecessor: correct only for a batch starting at position 0".
+            // The resulting draft KV would be built from a wrong seed and the
+            // exit check would still certify it trusted, because process()
+            // overwrites pending_h with the last row before that check runs.
+            // Discard the carryover whenever this pass is not a resident append.
+            if (!resident_pass && session->spec) {
+                if (!common_speculative_reset_pending(session->spec, 0)) {
+                    // Cannot prove the carryover is safe for a from-zero replay,
+                    // so refuse to reuse the implementation at all.
+                    session->persistent_pair_untrusted = true;
+                }
+                trace_pending_discarded("replay_from_zero");
+            }
+            // Resident reuse takes precedence over request-boundary restore, and
+            // the exclusion is written here rather than assumed: the boundary
+            // branch clears mem_tgt and replays the prompt from 0, which would
+            // destroy the very prefix a resident pass is preserving. Both flags
+            // are computed independently and can be true together, so nothing
+            // but this `!resident_pass` keeps them apart. The caller currently
+            // resets the session before each completion, which clears the
+            // boundary checkpoint and makes the collision unlikely -- but that
+            // is caller ordering, not an invariant of this function.
+            const bool use_request_boundary = generated.empty() && can_restore_request_boundary
+                && !used_request_boundary && !resident_pass;
             if (debug_partial) {
                 const auto replay_origin =
                     use_request_boundary ? "request_boundary" :
@@ -2019,9 +2614,20 @@ extern "C" bool orbit_mtp_session_complete(
                 session->last_replay_steps++;
                 session->debug_replay_count++;
             }
-            llama_memory_clear(mem_tgt, true);
-            llama_memory_clear(mem_dft, true);
-            session->debug_memory_clear_count += 2;
+            // Both halves are cleared together or not at all. A resident pass
+            // preserves the target prefix AND the draft state that matches it;
+            // clearing only the draft would leave the pair mismatched -- draft
+            // empty while the target holds prompt[0:N) -- and pending_h naming a
+            // predecessor the draft no longer contains. The guard was previously
+            // on the target alone, which is what made the draft half unusable.
+            if (!resident_pass) {
+                llama_memory_clear(mem_tgt, true);
+                trace_target_clear("replay");
+                session->debug_memory_clear_count++;
+                llama_memory_clear(mem_dft, true);
+                trace_draft_clear("replay");
+                session->debug_memory_clear_count++;
+            }
 
             if (!prompt_tgt.empty()) {
                 if (use_request_boundary) {
@@ -2029,10 +2635,12 @@ extern "C" bool orbit_mtp_session_complete(
                         const auto phase_start = std::chrono::steady_clock::now();
                         session->request_boundary_ckpt.load_dft(session->ctx_dft, 0, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                         phase_add(session->phase_prefix_restore, phase_start);
+                        trace_draft_frontier("boundary_load_dft", llama_get_memory(session->ctx_dft));
                     }
                     {
                         const auto phase_start = std::chrono::steady_clock::now();
                         llama_memory_clear(mem_tgt, true);
+                        trace_target_clear("request_boundary");
                         phase_add(session->phase_seq_rm, phase_start);
                     }
                     session->debug_memory_clear_count++;
@@ -2045,6 +2653,7 @@ extern "C" bool orbit_mtp_session_complete(
                         const auto batch_build_start = std::chrono::steady_clock::now();
                         llama_batch refresh_tgt = llama_batch_init((int32_t) count, 0, 1);
                         fill_target_prefill_batch(refresh_tgt, chunk, (int32_t) offset);
+                        trace_target_prefill("boundary_refresh", (int32_t) offset, chunk.size());
                         last_target_prefill_batch_n_tokens = refresh_tgt.n_tokens;
                         phase_add(session->phase_batch_build, batch_build_start);
                         const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -2085,7 +2694,13 @@ extern "C" bool orbit_mtp_session_complete(
                     }
                     request_boundary_logits_refreshed = true;
                     used_request_boundary = true;
-                } else {
+                } else if (!resident_pass) {
+                    // Cold replay only. A resident pass must not land here: the
+                    // target already holds prompt[0:resident_claim], so
+                    // decoding the whole prompt at position 0 would overlap
+                    // resident positions and llama_decode rejects it. The
+                    // resident suffix is prefilled by the positional block
+                    // below, at pos0 = resident_claim.
                     const size_t chunk_size = (size_t) std::max<uint32_t>(1, session->n_batch);
                     for (size_t offset = 0; offset < prompt_tgt.size(); offset += chunk_size) {
                         const size_t count = std::min(chunk_size, prompt_tgt.size() - offset);
@@ -2095,6 +2710,7 @@ extern "C" bool orbit_mtp_session_complete(
                         const auto batch_build_start = std::chrono::steady_clock::now();
                         llama_batch prefill_tgt = llama_batch_init((int32_t) count, 0, 1);
                         fill_target_prefill_batch(prefill_tgt, chunk, (int32_t) offset);
+                        trace_target_prefill("full_replay", (int32_t) offset, chunk.size());
                         last_target_prefill_batch_n_tokens = prefill_tgt.n_tokens;
                         phase_add(session->phase_batch_build, batch_build_start);
                         const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -2143,7 +2759,16 @@ extern "C" bool orbit_mtp_session_complete(
                 }
                 std::vector<llama_token> process_tokens;
                 int32_t process_pos0 = 0;
-                if (use_request_boundary) {
+                if (resident_pass) {
+                    // prompt[0:resident_claim] is already resident; decode only
+                    // the suffix, based at the resident boundary. When the claim
+                    // covers the whole prompt this is empty and nothing is
+                    // decoded.
+                    process_tokens.assign(
+                        prompt_tgt.begin() + (ptrdiff_t) resident_claim,
+                        prompt_tgt.end());
+                    process_pos0 = resident_claim;
+                } else if (use_request_boundary) {
                     process_tokens.assign(
                         prompt_tgt.begin() + (ptrdiff_t) reusable_request_prefix,
                         prompt_tgt.end());
@@ -2153,7 +2778,10 @@ extern "C" bool orbit_mtp_session_complete(
                     process_pos0 = 0;
                 }
                 if (!process_tokens.empty()) {
-                    if (use_request_boundary) {
+                    // Both the request-boundary and resident paths decode a
+                    // slice at a non-zero base, so they share this loop; the
+                    // `else` below is the from-zero full replay.
+                    if (use_request_boundary || resident_pass) {
                         const size_t chunk_size = (size_t) std::max<uint32_t>(1, session->n_batch);
                         for (size_t offset = 0; offset < process_tokens.size(); offset += chunk_size) {
                             const size_t count = std::min(chunk_size, process_tokens.size() - offset);
@@ -2163,6 +2791,7 @@ extern "C" bool orbit_mtp_session_complete(
                             const auto batch_build_start = std::chrono::steady_clock::now();
                             llama_batch prefill_tgt = llama_batch_init((int32_t) count, 0, 1);
                             fill_target_prefill_batch(prefill_tgt, chunk, process_pos0 + (int32_t) offset);
+                            trace_target_prefill("suffix", process_pos0 + (int32_t) offset, chunk.size());
                             last_target_prefill_batch_n_tokens = prefill_tgt.n_tokens;
                             phase_add(session->phase_batch_build, batch_build_start);
                             const long long decode_started_us = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -2209,16 +2838,46 @@ extern "C" bool orbit_mtp_session_complete(
                             }
                         }
                     }
+                    // The draft context has its OWN lifecycle. The target may reuse a
+                    // resident prefix and prefill only the suffix, but the draft memory
+                    // was cleared unconditionally above, so replaying only the suffix
+                    // there would leave positions [0, resident_claim) empty and the MTP
+                    // head would attend over a hole. Whether the draft can inherit the
+                    // target's history is a native fact, not a model-name fact:
+                    // llama.cpp keeps `ctx_other` only for architectures whose draft
+                    // memory is physically shared with the target (see
+                    // llama-context.cpp), and `common_speculative` skips its catch-up
+                    // decode exactly when that holds. When it does NOT hold, the draft
+                    // must be rebuilt contiguously from position 0.
+                    // SAME-SUFFIX CONTRACT. `common_speculative_process` consumes
+                    // the target's nextn hidden rows from the target's MOST RECENT
+                    // decode, indexed by batch slot. The batch handed to it must
+                    // therefore be exactly the batch the target just decoded.
+                    //
+                    // On a resident pass the target decoded only the suffix, and a
+                    // persistent draft already holds the prefix with pending_h
+                    // naming its last position, so the draft appends the SAME
+                    // suffix. Processing the full prompt here -- which an earlier
+                    // attempt did -- reads rows the target never produced for those
+                    // slots and silently builds the draft from stale conditioning.
+                    //
+                    // On a cold/replay pass the target decoded the whole prompt, so
+                    // the same rule yields the whole prompt. One rule, both cases:
+                    // the draft always mirrors the target's last decode.
+                    const std::vector<llama_token> & draft_tokens = process_tokens;
+                    const int32_t draft_pos0 = process_pos0;
                     const size_t chunk_size = (size_t) std::max<uint32_t>(1, session->n_batch);
-                    for (size_t offset = 0; offset < process_tokens.size(); offset += chunk_size) {
-                        const size_t count = std::min(chunk_size, process_tokens.size() - offset);
+                    for (size_t offset = 0; offset < draft_tokens.size(); offset += chunk_size) {
+                        const size_t count = std::min(chunk_size, draft_tokens.size() - offset);
                         std::vector<llama_token> chunk(
-                            process_tokens.begin() + (ptrdiff_t) offset,
-                            process_tokens.begin() + (ptrdiff_t) (offset + count));
+                            draft_tokens.begin() + (ptrdiff_t) offset,
+                            draft_tokens.begin() + (ptrdiff_t) (offset + count));
                         const auto batch_build_start = std::chrono::steady_clock::now();
                         llama_batch prefill = llama_batch_init((int32_t) count, 0, 1);
-                        fill_batch(prefill, chunk, process_pos0 + (int32_t) offset);
+                        fill_batch(prefill, chunk, draft_pos0 + (int32_t) offset);
                         phase_add(session->phase_batch_build, batch_build_start);
+                        trace_draft_process(
+                            "prefill", draft_pos0 + (int32_t) offset, chunk.size());
                         {
                             const auto phase_start = std::chrono::steady_clock::now();
                             const bool ok = common_speculative_process(session->spec, prefill);
@@ -2357,11 +3016,20 @@ extern "C" bool orbit_mtp_session_complete(
                 &prompt_tgt,
                 &draft,
             };
+            // Proposal generation also DECODES into ctx_dft: on the non-shared
+            // memory path it adds tokens at n_past + i + 1, so the draft frontier
+            // advances by up to MTP_DRAFT_N_MAX per step. That motion has no other
+            // event class in this stream, so bracket it -- otherwise the exit
+            // frontier is larger than the traced writes can account for, which is
+            // the ambiguity this recorder exists to remove. The reads sit OUTSIDE
+            // the phase bracket so observation cost never lands in exported timing.
+            trace_draft_frontier("draft_generate_before", mem_dft);
             {
                 const auto phase_start = std::chrono::steady_clock::now();
                 common_speculative_draft(session->spec);
                 phase_add(session->phase_draft_generation, phase_start);
             }
+            trace_draft_frontier("draft_generate_after", mem_dft);
             if (draft_trace_enabled()) {
                 std::ostringstream out;
                 out
@@ -2460,8 +3128,11 @@ extern "C" bool orbit_mtp_session_complete(
                     {
                         const auto phase_start = std::chrono::steady_clock::now();
                         const int32_t before_max = llama_memory_seq_pos_max(mem_dft, 0);
-                        llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
+                        const bool ckpt_dft_rm_ok2 =
+                            llama_memory_seq_rm(mem_dft, 0, ckpt.pos_max + 1, -1);
                         phase_add(session->phase_seq_rm, phase_start);
+                        trace_draft_seq_rm(
+                            "ckpt_restore_step", ckpt.pos_max + 1, -1, ckpt_dft_rm_ok2);
                         if (draft_trace_enabled()) {
                             std::ostringstream out;
                             out
@@ -2483,6 +3154,7 @@ extern "C" bool orbit_mtp_session_complete(
                     }
                     session->debug_seq_rm_count++;
                     phase_add(session->phase_ctx_dft_restore, phase_start);
+                    trace_draft_frontier("ckpt_load_dft_step", llama_get_memory(session->ctx_dft));
                 }
                 session->last_checkpoint_count++;
                 have_ckpt = true;
@@ -2763,18 +3435,31 @@ extern "C" bool orbit_mtp_session_complete(
         }
 
         if (full_accept) {
+            bool need_replay_after_failed_rm = false;
             n_past = (int32_t) prompt_tgt.size();
             {
                 const auto phase_start = std::chrono::steady_clock::now();
-                llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
-                llama_memory_seq_rm(mem_dft, 0, n_past, -1);
+                const bool full_rm_ok = llama_memory_seq_rm(mem_tgt, 0, n_past, -1);
+                trace_target_seq_rm("full_accept", n_past, -1, full_rm_ok);
+                const bool full_dft_rm_ok = llama_memory_seq_rm(mem_dft, 0, n_past, -1);
                 phase_add(session->phase_seq_rm, phase_start);
+                trace_draft_seq_rm("full_accept", n_past, -1, full_dft_rm_ok);
+                if (!full_rm_ok) {
+                    // The verification tail is still resident above the
+                    // committed frontier. Declaring "no replay needed" here
+                    // would leave those tokens in place and let a later
+                    // completion claiming frontier+1 match a poisoned frontier.
+                    // Rebuild instead, and mark the target unproven so no
+                    // resident claim can rest on it.
+                    session->last_target_untrusted = true;
+                    need_replay_after_failed_rm = true;
+                }
             }
             session->debug_seq_rm_count += 2;
             draft.clear();
             have_ckpt = false;
             draft_is_fresh = false;
-            need_replay = false;
+            need_replay = need_replay_after_failed_rm;
         } else if (step.resolution == orbit_step_resolution::live_partial) {
             n_past = (int32_t) prompt_tgt.size();
             draft.clear();
@@ -2802,6 +3487,11 @@ extern "C" bool orbit_mtp_session_complete(
     }
 
 done:
+    trace_target_frontier("request_exit", mem_tgt);
+    trace_draft_frontier("request_exit", mem_dft);
+    trace_spec_state("request_exit", session->spec_epoch,
+        static_cast<const void *>(session->spec),
+        static_cast<const void *>(session->ctx_dft));
     common_sampler_free(smpl);
     session->cached_prompt_tokens = prompt;
     session->last_fresh_acceptance_ratio = session->last_draft_tokens_total > 0
@@ -2902,7 +3592,108 @@ done:
             << "}";
         session->last_timing_json = out.str();
     }
+    // Proven-canonical exit: the speculative loop ran to completion, so every
+    // accepted token is committed and every rejected tail has been rolled back.
+    // Only here may the target be declared trusted again -- and only if the
+    // physical frontier actually agrees with the committed length, which is what
+    // a following resident claim will be validated against. A seq_rm refusal
+    // earlier in this completion leaves the frontier long; in that case the flag
+    // stays armed so the next completion falls back to a clear/full replay.
+    // `n_past` is the committed frontier the loop maintains, so compare the
+    // physical frontier against it directly rather than reconstructing a length.
+    session->last_target_untrusted =
+        llama_memory_seq_pos_max(mem_tgt, 0) != n_past - 1;
+    // The pair is trusted only when ALL THREE halves agree at the same frontier.
+    // Defect C's target-only check is subsumed here rather than replaced: the
+    // target term is identical, and the draft and pending terms are what make a
+    // persistent pair claim meaningful. Frontier agreement alone is not enough --
+    // a draft can be frontier-correct and content-wrong -- so pending_pos must
+    // name the predecessor of the next suffix, which is the frontier itself.
+    {
+        const int32_t canonical_frontier = n_past - 1;
+        const bool target_ok =
+            llama_memory_seq_pos_max(mem_tgt, 0) == canonical_frontier;
+        const bool draft_ok =
+            llama_memory_seq_pos_max(mem_dft, 0) == canonical_frontier;
+        int32_t pend_pos = -1;
+        uint64_t pend_fp = 0;
+        uint64_t pend_gen = 0;
+        const bool pend_ok = common_speculative_pending_state(
+            session->spec, 0, &pend_pos, &pend_fp, &pend_gen);
+        const bool pending_aligned =
+            pend_ok && pend_pos == canonical_frontier && pend_gen > 0;
+        const bool identity_ok =
+            session->spec != nullptr && session->spec_pinned_ctx_tgt == ctx_tgt;
+        session->persistent_pair_untrusted =
+            !(target_ok && draft_ok && pending_aligned && identity_ok);
+        trace_pair_trust(
+            session->persistent_pair_untrusted ? "untrusted" : "trusted",
+            canonical_frontier, target_ok, draft_ok, pending_aligned, identity_ok);
+    }
+    // Snapshot the decoded ids alongside the verdict, so a caller reads both as
+    // of this completion rather than querying mutable session state later.
+    session->last_generated_tokens = generated;
+    // Publish the resident sequence only when the physical frontier agrees with
+    // the committed length. If a seq_rm refusal left the frontier long, the
+    // vector no longer describes KV, and an empty publication makes the runtime
+    // fall back to a cold prompt rather than trust a stale identity.
+    if (llama_memory_seq_pos_max(mem_tgt, 0) == n_past - 1 &&
+        prompt_tgt.size() == (size_t) n_past) {
+        session->last_resident_tokens = prompt_tgt;
+    } else {
+        session->last_resident_tokens.clear();
+    }
     return true;
+}
+
+// Whether target, draft and pending_h were all proven canonical at the end of
+// the last completion, and the implementation still belongs to the same target
+// context. This is NOT the same question as "did this completion reuse resident
+// state": a cold completion can end canonical, and a resident completion can end
+// poisoned. The runtime must not conflate them.
+extern "C" bool orbit_mtp_session_last_pair_canonical(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? !session->persistent_pair_untrusted : false;
+}
+
+// Number of token ids the last completion decoded, and a copy of them. The
+// caller sizes its buffer with the count and then copies; a short buffer copies
+// nothing and reports the required size, so a caller cannot silently truncate.
+extern "C" int32_t orbit_mtp_session_last_generated_token_count(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? (int32_t) session->last_generated_tokens.size() : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_generated_tokens(
+        void * handle, int32_t * out, int32_t capacity) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    if (!session) { return 0; }
+    const int32_t count = (int32_t) session->last_generated_tokens.size();
+    if (!out || capacity < count) { return count; }
+    for (int32_t i = 0; i < count; ++i) {
+        out[i] = (int32_t) session->last_generated_tokens[i];
+    }
+    return count;
+}
+
+// The tokens physically resident in the target KV after the last completion.
+// The runtime publishes committed identity from these, never from
+// prompt + generated: see `last_resident_tokens`.
+extern "C" int32_t orbit_mtp_session_last_resident_token_count(void * handle) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    return session ? (int32_t) session->last_resident_tokens.size() : 0;
+}
+
+extern "C" int32_t orbit_mtp_session_last_resident_tokens(
+        void * handle, int32_t * out, int32_t capacity) {
+    auto * session = static_cast<orbit_mtp_session *>(handle);
+    if (!session) { return 0; }
+    const int32_t count = (int32_t) session->last_resident_tokens.size();
+    if (!out || capacity < count) { return count; }
+    for (int32_t i = 0; i < count; ++i) {
+        out[i] = (int32_t) session->last_resident_tokens[i];
+    }
+    return count;
 }
 
 extern "C" const char * orbit_mtp_session_last_content(void * handle) {

--- a/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.cpp
+++ b/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.cpp
@@ -210,6 +210,14 @@ struct common_speculative_impl {
 
     virtual ~common_speculative_impl() = default;
 
+    // Discard the cross-batch carryover, returning the implementation to the
+    // "no predecessor" state its constructor produces. A caller that is about to
+    // process a batch based at position 0 must do this, because slot 0 is then
+    // required to be the zero row. Default reports "not applicable".
+    virtual bool reset_pending(llama_seq_id /*seq_id*/) {
+        return false;
+    }
+
     // Read-only diagnostic: describe this implementation's cross-batch carryover
     // state, if it has one. Default reports "not applicable" so implementations
     // without a carryover need not override. Never influences behaviour.
@@ -963,6 +971,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
         note_pending(seq_id,
                 (i_h < (int32_t) verify_pos[seq_id].size()) ? verify_pos[seq_id][i_h] : -1);
+    }
+
+    bool reset_pending(llama_seq_id seq_id) override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+            return false;
+        }
+        // Exactly the constructor's initial state: a zero row, no provenance.
+        std::fill(pending_h[seq_id].begin(), pending_h[seq_id].end(), 0.0f);
+        pending_pos[seq_id] = -1;
+        pending_fp[seq_id] = 0ull;
+        pending_gen[seq_id] = 0ull;
+        return true;
     }
 
     bool pending_state(
@@ -1865,6 +1885,18 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
             impl_other->accept(seq_id, n_accepted, true);
         }
     }
+}
+
+bool common_speculative_reset_pending(common_speculative * spec, llama_seq_id seq_id) {
+    if (spec == nullptr) {
+        return false;
+    }
+    for (const auto & impl : spec->impls) {
+        if (impl && impl->reset_pending(seq_id)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool common_speculative_pending_state(

--- a/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.h
+++ b/src/orbit/native_llama/vendor/source/llama.cpp/common/speculative.h
@@ -88,6 +88,13 @@ bool common_speculative_pending_state(
         uint64_t * fp,
         uint64_t * gen);
 
+// Discard the cross-batch hidden-state carryover for `seq_id`, restoring the
+// "no predecessor" state a freshly constructed implementation has. A caller that
+// reuses an implementation but then processes a batch based at position 0 must
+// call this: slot 0 is seeded from the carryover, and at position 0 the correct
+// seed is the zero row. Returns false when the implementation has no carryover.
+bool common_speculative_reset_pending(common_speculative * spec, llama_seq_id seq_id);
+
 struct common_speculative_deleter {
     void operator()(common_speculative * s) { common_speculative_free(s); }
 };

--- a/src/orbit/native_server/app.py
+++ b/src/orbit/native_server/app.py
@@ -1468,6 +1468,16 @@ def _mtp_last_completion_payload(client: NativeLlamaClient) -> dict[str, object]
         "rollback_tokens_total": completion.rollback_tokens_total,
         "checkpoint_count": completion.checkpoint_count,
         "restore_count": completion.restore_count,
+        # The two persistent-pair verdicts. They answer different questions and
+        # must never be conflated: `resident_reuse_active` is "did THIS
+        # completion reuse resident state", `pair_canonical` is "is the pair
+        # trustworthy for the NEXT one". A cold completion can end canonical,
+        # and a resident one can end poisoned. Without these, reuse could only
+        # be inferred from `cached_tokens`, which is non-zero for unrelated
+        # reasons and would read as a false positive.
+        "resident_reuse_active": completion.resident_reuse_active,
+        "pair_canonical": completion.pair_canonical,
+        "resident_token_count": len(completion.resident_tokens),
     }
 
 

--- a/tests/test_llama_provenance_v2.py
+++ b/tests/test_llama_provenance_v2.py
@@ -34,6 +34,29 @@ def _available() -> bool:
     return (UPSTREAM / ".git").exists() and VENDORED.is_dir()
 
 
+class _VendoredCopy:
+    """A disposable copy of the vendored tree for mutating tests.
+
+    Mutating the real tree makes these tests order-dependent -- a sibling test
+    reading provenance during the window sees a dirty tree -- and a SIGKILL
+    leaves the repository dirty, which happened twice during development.
+    `addCleanup` covers exceptions, not kills. Copying is cheap (42 MB of source,
+    no model data) and removes both failure modes.
+    """
+
+    def __init__(self, case: unittest.TestCase) -> None:
+        self._dir = tempfile.mkdtemp(prefix="orbit_vendored_")
+        case.addCleanup(shutil.rmtree, self._dir, True)
+        self.root = Path(self._dir) / "llama.cpp"
+        shutil.copytree(VENDORED, self.root, symlinks=True)
+        self.manifest = Path(self._dir) / "LLAMA_PROVENANCE.json"
+        shutil.copy2(MANIFEST, self.manifest)
+
+    def argv(self, command: str) -> list[str]:
+        return [command, "--vendored-root", str(self.root),
+                "--manifest", str(self.manifest)]
+
+
 @unittest.skipUnless(_available(), "upstream llama.cpp checkout not present")
 class PatchsetV2Tests(unittest.TestCase):
     def _entries(self):
@@ -83,41 +106,41 @@ class PatchsetV2Tests(unittest.TestCase):
         A leftover probe here poisons every later run, including the baseline of
         a mutation campaign.
         """
-        entries = self._entries()
-        target = VENDORED / entries[0]["path"]
+        copy = _VendoredCopy(self)
+        entries = pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
+        target = copy.root / entries[0]["path"]
         original = target.read_bytes()
         before = pv2.patchset_v2_sha256(entries)
-        self.addCleanup(target.write_bytes, original)
         target.write_bytes(original + b"\n// provenance v2 probe\n")
-        after = pv2.patchset_v2_sha256(self._entries())
+        after = pv2.patchset_v2_sha256(pv2.build_patchset(UPSTREAM, copy.root, COMMIT))
         self.assertNotEqual(after, before)
         target.write_bytes(original)
-        self.assertEqual(pv2.patchset_v2_sha256(self._entries()), before)
+        self.assertEqual(
+            pv2.patchset_v2_sha256(pv2.build_patchset(UPSTREAM, copy.root, COMMIT)),
+            before)
 
     def test_a_file_restored_to_upstream_leaves_the_patchset(self) -> None:
         """Input set is derived from divergence, not from the declared list."""
-        entries = self._entries()
+        copy = _VendoredCopy(self)
+        entries = pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
         rel = entries[0]["path"]
-        target = VENDORED / rel
+        target = copy.root / rel
         original = target.read_bytes()
         upstream = pv2._upstream_blob(UPSTREAM, COMMIT, rel)
         self.assertIsNotNone(upstream)
-        self.addCleanup(target.write_bytes, original)
         target.write_bytes(upstream)
-        paths = [e["path"] for e in self._entries()]
-        self.assertNotIn(rel, paths)
+        self.assertNotIn(rel, [e["path"] for e in pv2.build_patchset(UPSTREAM, copy.root, COMMIT)])
         target.write_bytes(original)
-        self.assertIn(rel, [e["path"] for e in self._entries()])
+        self.assertIn(rel, [e["path"] for e in pv2.build_patchset(UPSTREAM, copy.root, COMMIT)])
 
     def test_orbit_only_file_is_represented_with_null_upstream(self) -> None:
-        added = VENDORED / "orbit_provenance_v2_probe.txt"
-        self.assertFalse(added.exists())
-        self.addCleanup(added.unlink, True)
+        copy = _VendoredCopy(self)
+        added = copy.root / "orbit_provenance_v2_probe.txt"
         added.write_bytes(b"orbit-only probe\n")
-        entry = next(e for e in self._entries() if e["path"] == added.name)
+        entry = next(e for e in pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
+                     if e["path"] == added.name)
         self.assertIsNone(entry["upstream_sha256"])
         self.assertEqual(len(entry["vendored_sha256"]), 64)
-        added.unlink()
 
     def test_binary_content_is_hashed_byte_for_byte(self) -> None:
         """No newline normalization: CRLF and LF must differ."""
@@ -180,19 +203,16 @@ class PatchsetV2Tests(unittest.TestCase):
 
         This drives the real reader over a genuine CRLF file.
         """
-        probe = VENDORED / "orbit_v2_crlf_probe.txt"
-        self.assertFalse(probe.exists())
-        self.addCleanup(probe.unlink, True)
+        copy = _VendoredCopy(self)
+        probe = copy.root / "orbit_v2_crlf_probe.txt"
 
         probe.write_bytes(b"line one\r\nline two\r\n")
-        crlf = next(e for e in pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+        crlf = next(e for e in pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
                     if e["path"] == probe.name)["vendored_sha256"]
 
         probe.write_bytes(b"line one\nline two\n")
-        lf = next(e for e in pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
+        lf = next(e for e in pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
                   if e["path"] == probe.name)["vendored_sha256"]
-
-        probe.unlink()
         self.assertNotEqual(crlf, lf, "CRLF and LF content must hash differently")
 
     def test_excluded_components_match_source_tree_filter(self) -> None:
@@ -306,25 +326,30 @@ class PatchsetV2EnforcementTests(unittest.TestCase):
 
     def test_vendored_drift_fails_the_gate_and_restores(self) -> None:
         """The decisive property: edit a patched file, do NOT regenerate."""
-        entries = pv2.build_patchset(UPSTREAM, VENDORED, COMMIT)
-        target = VENDORED / entries[0]["path"]
+        copy = _VendoredCopy(self)
+        self.assertEqual(pv2.main(copy.argv("generate")), 0)
+        self.assertEqual(pv2.main(copy.argv("check")), 0)
+
+        entries = pv2.build_patchset(UPSTREAM, copy.root, COMMIT)
+        target = copy.root / entries[0]["path"]
         original = target.read_bytes()
-        self.addCleanup(target.write_bytes, original)
 
         target.write_bytes(original + b"\n// undeclared drift\n")
-        self.assertEqual(self._check(), 1, "vendored drift must fail the gate")
+        self.assertEqual(pv2.main(copy.argv("check")), 1,
+                         "vendored drift must fail the gate")
 
         target.write_bytes(original)
-        self.assertEqual(self._check(), 0, "restoring the file must clear the gate")
+        self.assertEqual(pv2.main(copy.argv("check")), 0,
+                         "restoring the file must clear the gate")
 
     def test_a_new_undeclared_patched_file_fails_the_gate(self) -> None:
-        added = VENDORED / "orbit_v2_enforcement_probe.txt"
-        self.assertFalse(added.exists())
-        self.addCleanup(added.unlink, True)
+        copy = _VendoredCopy(self)
+        self.assertEqual(pv2.main(copy.argv("generate")), 0)
+        added = copy.root / "orbit_v2_enforcement_probe.txt"
         added.write_bytes(b"undeclared orbit-only file\n")
-        self.assertEqual(self._check(), 1)
+        self.assertEqual(pv2.main(copy.argv("check")), 1)
         added.unlink()
-        self.assertEqual(self._check(), 0)
+        self.assertEqual(pv2.main(copy.argv("check")), 0)
 
     def test_tampered_v2_hash_fails_the_gate(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_mtp_generated_tokens.py
+++ b/tests/test_mtp_generated_tokens.py
@@ -1,0 +1,145 @@
+"""The generated-token accessor contract, and the ban on retokenized identity.
+
+Committed identity must describe the exact token ids the model decoded into KV.
+Reconstructing them by retokenizing the final text is not equivalent: a text
+round trip is not guaranteed to reproduce the same ids, so the identity could
+claim a prefix that is not physically resident -- a false cache hit, which is a
+correctness bug rather than a slow path.
+
+These drive the real reader and the real publisher.
+"""
+from __future__ import annotations
+
+import ctypes
+import unittest
+from unittest.mock import MagicMock
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.mtp_completion import MtpCompletionResult
+from orbit.native_llama.persistent_mtp import _read_generated_tokens
+
+
+class _Lib:
+    """A stand-in for the native library implementing the documented contract."""
+
+    def __init__(self, ids, *, short_write=False, absent=False):
+        self._ids = list(ids)
+        self._short_write = short_write
+        if absent:
+            del self.orbit_mtp_session_last_generated_token_count
+
+    def orbit_mtp_session_last_generated_token_count(self, _handle):
+        return len(self._ids)
+
+    def orbit_mtp_session_last_generated_tokens(self, _handle, out, capacity):
+        count = len(self._ids)
+        if capacity < count:
+            return count          # reports the required size, writes nothing
+        written = count - 1 if self._short_write else count
+        for i in range(written):
+            out[i] = self._ids[i]
+        return written
+
+
+class GeneratedTokenReaderTests(unittest.TestCase):
+    def test_reads_the_exact_ids(self) -> None:
+        self.assertEqual(_read_generated_tokens(_Lib([5, 6, 7]), None), (5, 6, 7))
+
+    def test_count_matches_length(self) -> None:
+        lib = _Lib([1, 2, 3, 4])
+        ids = _read_generated_tokens(lib, None)
+        self.assertEqual(len(ids), lib.orbit_mtp_session_last_generated_token_count(None))
+
+    def test_empty_generation_yields_empty(self) -> None:
+        self.assertEqual(_read_generated_tokens(_Lib([]), None), ())
+
+    def test_short_write_fails_closed(self) -> None:
+        """A partial copy must yield nothing, never a truncated identity."""
+        self.assertEqual(_read_generated_tokens(_Lib([1, 2, 3], short_write=True), None), ())
+
+    def test_absent_accessor_fails_closed(self) -> None:
+        """An older shim yields no ids rather than a wrong answer."""
+        class Bare:
+            pass
+        self.assertEqual(_read_generated_tokens(Bare(), None), ())
+
+    def test_large_ids_survive_the_round_trip(self) -> None:
+        """No signed/unsigned truncation on realistic vocabulary ids."""
+        ids = [0, 1, 32000, 151643, 262143]
+        self.assertEqual(_read_generated_tokens(_Lib(ids), None), tuple(ids))
+
+    def test_buffer_is_sized_from_the_native_count(self) -> None:
+        captured = {}
+        class Recorder(_Lib):
+            def orbit_mtp_session_last_generated_tokens(self, handle, out, capacity):
+                captured["capacity"] = capacity
+                return super().orbit_mtp_session_last_generated_tokens(handle, out, capacity)
+        _read_generated_tokens(Recorder([9, 9, 9]), None)
+        self.assertEqual(captured["capacity"], 3)
+
+
+class NoRetokenizationTests(unittest.TestCase):
+    """Identity must come from native ids, never from the decoded text."""
+
+    def test_native_ids_win_over_a_divergent_retokenization(self) -> None:
+        """The decisive case: text would retokenize to something different.
+
+        Native decoded [10, 11, 12]. If the publisher retokenized the final text
+        it would get [10, 99, 12] -- a plausible-looking but WRONG identity that
+        claims a prefix the model never made resident.
+        """
+        c = object.__new__(NativeLlamaClient)
+        c._session = MagicMock()
+        c._session.committed_sequence_tokens = []
+        # Any retokenization of the text would produce the corrupted sequence.
+        c.tokenize = lambda text: [1, 2] if text == "prompt" else [10, 99, 12]
+        c._qwen3_coder_native_protocol = lambda: False
+        c._invalidate_committed_sequence = (
+            lambda: setattr(c._session, "committed_sequence_tokens", [])
+        )
+
+        result = MtpCompletionResult(
+            enabled=True, success=True, error=None,
+            pair_canonical=True, generated_tokens=(10, 11, 12),
+            resident_tokens=(1, 2, 10, 11),
+            content="whatever the text happens to be",
+        )
+        c._publish_mtp_committed_identity(result, "prompt")
+
+        published = c._session.committed_sequence_tokens
+        self.assertEqual(published, [1, 2, 10, 11],
+                         "identity must be the natively measured residency")
+        self.assertNotIn(99, published,
+                         "a retokenized id must never reach committed identity")
+
+    def test_publisher_never_touches_result_content(self) -> None:
+        """There must be no hidden text round trip in the publication path.
+
+        Asserted over names the code actually references, not raw source text:
+        the explanatory comment in this helper names the rejected approaches, so
+        a substring check would bind to prose rather than behaviour.
+        """
+        import ast
+        import inspect
+
+        fn = ast.parse(
+            inspect.getsource(
+                NativeLlamaClient._publish_mtp_committed_identity
+            ).lstrip()
+        ).body[0]
+        # Attribute nodes plus string constants: fields are reached through
+        # getattr(result, "...") as well as direct attribute access.
+        names = {
+            node.attr for node in ast.walk(fn) if isinstance(node, ast.Attribute)
+        } | {
+            node.value for node in ast.walk(fn)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        self.assertNotIn("content", names,
+                         "publication must not read decoded text")
+        self.assertIn("resident_tokens", names,
+                      "identity must come from the measured resident sequence")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_strict_append_continuation.py
+++ b/tests/test_native_strict_append_continuation.py
@@ -239,10 +239,106 @@ class InvalidationCoverageTests(unittest.TestCase):
                 return stmt.lineno
         return None
 
-    def test_mtp_invalidates_as_its_first_statement(self) -> None:
-        # Must run before every early return, not inside a conditional branch.
-        body = self._body_after_docstring(self._function("_try_complete_with_mtp_experimental"))
-        self.assertTrue(self._is_invalidation(body[0]))
+    def test_mtp_publishes_or_drops_identity_on_every_exit(self) -> None:
+        """MTP no longer invalidates at entry; it decides at the exit instead.
+
+        The old contract -- invalidate as the first statement -- was correct while
+        MTP destroyed target KV on every completion. With the persistent pair the
+        target KV, draft KV and pending_h can survive, so unconditional entry
+        invalidation made `len(committed) == 0` always, and the resident path was
+        unreachable from production.
+
+        The invariant it protected is unchanged: identity must never outlive the
+        physical state it describes. Enforcement moved to the exit, where the
+        backend reports whether the pair is canonical. This asserts POSITION the
+        same way: the publication call must be reached on the success path, and
+        the helper it delegates to must invalidate on every non-canonical branch.
+        """
+        fn = self._function("_try_complete_with_mtp_experimental")
+        publishes = [
+            node for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "_publish_mtp_committed_identity"
+        ]
+        self.assertTrue(publishes, "MTP must decide identity at its exit")
+
+        # Entry must NOT unconditionally invalidate any more, or the resident
+        # path becomes unreachable again.
+        body = self._body_after_docstring(fn)
+        self.assertFalse(
+            self._is_invalidation(body[0]),
+            "unconditional entry invalidation makes resident reuse unreachable",
+        )
+
+    def test_mtp_publication_helper_fails_closed(self) -> None:
+        """Every non-canonical outcome must drop identity; only a proven one publishes.
+
+        Executed rather than counted. Counting `_invalidate_committed_sequence`
+        call sites pinned a particular branch shape, so refactoring the helper
+        broke the test without changing its behaviour -- and, worse, a helper
+        that invalidated in three places but also published on a bad path would
+        still have passed. These cases drive the real helper and assert on the
+        identity it leaves behind.
+        """
+        from orbit.native_llama.mtp_completion import MtpCompletionResult
+
+        client, _ = _client([9, 9, 9], profile_id="other")
+        canonical = dict(enabled=True, success=True, error=None, pair_canonical=True)
+
+        cases = (
+            ("failed completion", dict(canonical, success=False,
+                                       resident_tokens=(1, 2, 3)), None),
+            ("non-canonical pair", dict(canonical, pair_canonical=False,
+                                        resident_tokens=(1, 2, 3)), None),
+            ("no resident tokens", dict(canonical, resident_tokens=()), None),
+            ("proven canonical", dict(canonical, resident_tokens=(1, 2, 3)),
+             [1, 2, 3]),
+        )
+        for name, kwargs, expected in cases:
+            with self.subTest(case=name):
+                client._session.committed_sequence_tokens = [9, 9, 9]
+                client._publish_mtp_committed_identity(
+                    MtpCompletionResult(**kwargs), "prompt"
+                )
+                actual = client._session.committed_sequence_tokens
+                if expected is None:
+                    self.assertFalse(
+                        actual,
+                        f"{name} must drop identity rather than leave a stale "
+                        f"or unproven sequence resident",
+                    )
+                else:
+                    self.assertEqual(actual, expected)
+
+    def test_mtp_identity_is_never_rebuilt_from_prompt_plus_generated(self) -> None:
+        """Identity must come from measured residency, not reconstruction.
+
+        `prompt + generated_tokens` is one token longer than target KV, because a
+        sampled token enters `generated` before it is decoded into the sequence.
+        Publishing that overstates residency, and an identity longer than KV is a
+        false cache hit: the next turn skips prefill for a position that was
+        never decoded. So the helper must not tokenize, and must not read
+        `generated_tokens`.
+        """
+        fn = self._function("_publish_mtp_committed_identity")
+        # Attribute and string names actually referenced by the code, so the
+        # explanatory comments naming the rejected approach do not count.
+        names = {
+            node.attr for node in ast.walk(fn) if isinstance(node, ast.Attribute)
+        } | {
+            node.value for node in ast.walk(fn)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        self.assertIn("resident_tokens", names)
+        self.assertNotIn(
+            "generated_tokens", names,
+            "publication must read resident_tokens, not generated_tokens: "
+            "prompt + generated overstates residency by one token",
+        )
+        self.assertNotIn(
+            "tokenize", names,
+            "retokenizing text cannot prove what is physically resident",
+        )
 
     def test_multimodal_invalidates_before_clearing_kv(self) -> None:
         fn = self._function("_complete_prompt_multimodal")

--- a/tests/test_persistent_pair.py
+++ b/tests/test_persistent_pair.py
@@ -1,0 +1,462 @@
+"""Persistent self-MTP pair: target KV + draft KV + pending_h, across completions.
+
+The pair is only reusable when all three halves agree at the same frontier AND
+the speculative implementation still belongs to the same target context. Frontier
+agreement alone is insufficient: the D3b-R2 review proved a draft can be
+frontier-correct and content-wrong, which is why `pending_pos` -- the position of
+the predecessor row that seeds the next append -- is part of the predicate.
+
+These are behavioural state-machine tests over the real predicate, compiled from
+the shim, plus contract checks that pin the reset split.
+"""
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SHIM = ROOT / "src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp"
+
+
+def _shim_text() -> str:
+    return SHIM.read_text()
+
+
+class _Predicate:
+    """Compile the REAL predicate extracted from the shim, against stubs.
+
+    An earlier version of this file compiled a hand-written mirror of the
+    predicate. Mutating the shim could not affect it, so five mutation classes
+    survived: the tests were proving a copy correct, not the code. The body is
+    now lifted verbatim out of the shim, so any change to it changes these
+    results.
+    """
+
+    _lib = None
+
+    @classmethod
+    def _extract(cls) -> str:
+        text = _shim_text()
+        start = text.index("static bool persistent_pair_is_reusable(")
+        end = text.index("\n}", start) + 2
+        return text[start:end]
+
+    @classmethod
+    def lib(cls):
+        if cls._lib is not None:
+            return cls._lib
+        body = cls._extract()
+        harness = """
+        #include <cstdint>
+        #include <cstddef>
+        typedef void * llama_memory_t;
+        struct llama_context;
+        struct common_speculative;
+
+        // Stubbed environment, driven by the test.
+        static int32_t g_tgt_max, g_dft_max, g_pend_pos;
+        static uint64_t g_pend_gen;
+        static bool g_pend_ok;
+
+        static int32_t llama_memory_seq_pos_max(llama_memory_t m, int) {
+            return m == (llama_memory_t) 1 ? g_tgt_max : g_dft_max;
+        }
+        static bool common_speculative_pending_state(
+                const common_speculative *, int,
+                int32_t * pos, uint64_t * fp, uint64_t * gen) {
+            if (!g_pend_ok) { return false; }
+            if (pos) { *pos = g_pend_pos; }
+            if (fp)  { *fp  = 1; }
+            if (gen) { *gen = g_pend_gen; }
+            return true;
+        }
+
+        struct orbit_mtp_session {
+            bool persistent_pair_untrusted;
+            common_speculative * spec;
+            llama_context * spec_pinned_ctx_tgt;
+        };
+
+        __BODY__
+
+        extern "C" bool drive(
+                bool untrusted, bool has_spec, bool identity_ok,
+                int32_t tgt_max, int32_t dft_max,
+                bool pend_ok, int32_t pend_pos, uint64_t pend_gen) {
+            g_tgt_max = tgt_max; g_dft_max = dft_max;
+            g_pend_ok = pend_ok; g_pend_pos = pend_pos; g_pend_gen = pend_gen;
+            orbit_mtp_session s;
+            s.persistent_pair_untrusted = untrusted;
+            s.spec = has_spec ? (common_speculative *) 0x1 : nullptr;
+            llama_context * ctx = (llama_context *) 0x2;
+            s.spec_pinned_ctx_tgt = identity_ok ? ctx : (llama_context *) 0x3;
+            return persistent_pair_is_reusable(
+                &s, ctx, (llama_memory_t) 1, (llama_memory_t) 2);
+        }
+        """.replace("__BODY__", body)
+
+        tmp = Path(tempfile.mkdtemp(prefix="orbit_pair_"))
+        (tmp / "p.cpp").write_text(harness)
+        rc = subprocess.run(
+            ["g++", "-std=c++17", "-fPIC", "-shared", "-O0",
+             "-o", str(tmp / "p.so"), str(tmp / "p.cpp")],
+            capture_output=True, text=True, check=False,
+        )
+        if rc.returncode != 0:
+            raise AssertionError(f"predicate build failed: {rc.stderr[:800]}")
+        lib = ctypes.CDLL(str(tmp / "p.so"))
+        lib.drive.restype = ctypes.c_bool
+        lib.drive.argtypes = [ctypes.c_bool, ctypes.c_bool, ctypes.c_bool,
+                              ctypes.c_int32, ctypes.c_int32, ctypes.c_bool,
+                              ctypes.c_int32, ctypes.c_uint64]
+        cls._lib = lib
+        return lib
+
+
+class PairReusabilityTests(unittest.TestCase):
+    """The predicate that decides soft vs hard reset."""
+
+    def _ok(self, untrusted=False, has_spec=True, identity_ok=True,
+            tgt=28, dft=28, pend_ok=True, pend_pos=28, pend_gen=7):
+        return _Predicate.lib().drive(
+            untrusted, has_spec, identity_ok, tgt, dft, pend_ok, pend_pos, pend_gen)
+
+    def test_canonical_pair_is_reusable(self) -> None:
+        """All three halves agree at F=28, pending names F, identity holds."""
+        self.assertTrue(self._ok())
+
+    def test_untrusted_pair_is_refused(self) -> None:
+        self.assertFalse(self._ok(untrusted=True))
+
+    def test_missing_spec_is_refused(self) -> None:
+        self.assertFalse(self._ok(has_spec=False))
+
+    def test_ctx_identity_mismatch_is_refused(self) -> None:
+        """A preserved impl keeps the ctx_tgt it was built with."""
+        self.assertFalse(self._ok(identity_ok=False))
+
+    def test_frontier_disagreement_is_refused(self) -> None:
+        self.assertFalse(self._ok(tgt=28, dft=27))
+        self.assertFalse(self._ok(tgt=27, dft=28))
+
+    def test_empty_pair_is_refused(self) -> None:
+        """A cold pair (-1/-1) has nothing to reuse."""
+        self.assertFalse(self._ok(tgt=-1, dft=-1, pend_pos=-1, pend_gen=0))
+
+    def test_pending_unavailable_is_refused(self) -> None:
+        self.assertFalse(self._ok(pend_ok=False))
+
+    def test_pending_pos_must_name_the_frontier(self) -> None:
+        """This is what frontier equality alone cannot prove."""
+        for wrong in (27, 29, 0, -1):
+            with self.subTest(pend_pos=wrong):
+                self.assertFalse(self._ok(pend_pos=wrong))
+        self.assertTrue(self._ok(pend_pos=28))
+
+    def test_never_written_pending_is_refused(self) -> None:
+        """gen==0 means the constructor's zero row, never a canonical carryover."""
+        self.assertFalse(self._ok(pend_gen=0))
+
+    def test_frontier_aligned_but_content_wrong_is_refused(self) -> None:
+        """The exact D3b-R2 defect class: frontiers agree, predecessor does not."""
+        self.assertFalse(self._ok(tgt=28, dft=28, pend_pos=14))
+
+
+class ResetSplitContractTests(unittest.TestCase):
+    """Soft preserves the pair; hard rebuilds it."""
+
+    def setUp(self) -> None:
+        self.text = _shim_text()
+
+    def test_soft_reset_touches_only_request_bookkeeping(self) -> None:
+        at = self.text.find("static void soft_reset_request_state(")
+        self.assertGreater(at, -1)
+        body = self.text[at:self.text.find("\n}", at)]
+        for forbidden in ("llama_memory_clear", "common_speculative_free",
+                          "common_speculative_init", "spec_epoch"):
+            self.assertNotIn(forbidden, body,
+                             f"soft reset must not perform {forbidden}")
+        # Comments are stripped: an assertion that merely finds a name would be
+        # satisfied by prose mentioning it, which is how the claim-clearing bug
+        # below stayed invisible.
+        code = re.sub(r"//[^\n]*", "", body)
+        for expected in ("request_boundary_ckpt", "request_boundary_prompt_tgt"):
+            self.assertIn(expected, code)
+
+    def test_soft_reset_must_not_clear_the_resident_claim(self) -> None:
+        """Clearing the claim here would make resident reuse unreachable.
+
+        `soft_reset_request_state` runs at the TOP of the very completion the
+        claim was set for, and the claim is read further down. Clearing it here
+        zeroes it before that read, so `resident_ok` is false on exactly the
+        turns where the pair IS reusable -- the feature can never activate, and
+        the failure is silent because it degrades to a correct full replay.
+
+        Nothing leaks by leaving it: the claim is consumed one-shot where it is
+        read, and the hard-reset path clears it separately.
+        """
+        at = self.text.find("static void soft_reset_request_state(")
+        body = self.text[at:self.text.find("\n}", at)]
+        code = re.sub(r"//[^\n]*", "", body)
+        self.assertNotIn(
+            "pending_resident_prefix_len", code,
+            "the soft reset must not touch the resident claim: it would be "
+            "zeroed before the completion that owns it can read it",
+        )
+
+    def test_the_claim_is_consumed_one_shot_where_it_is_read(self) -> None:
+        """Since the soft reset no longer clears it, the read site must.
+
+        Read-then-zero on adjacent lines is what keeps a claim from surviving
+        into a later completion that never earned it.
+        """
+        read_at = self.text.find("const int32_t resident_claim = session->pending_resident_prefix_len;")
+        self.assertGreater(read_at, -1, "the claim must be read into a local")
+        window = self.text[read_at:read_at + 220]
+        self.assertIn(
+            "session->pending_resident_prefix_len = 0;", window,
+            "the claim must be zeroed immediately where it is consumed",
+        )
+
+    def test_hard_reset_still_rebuilds(self) -> None:
+        at = self.text.find("static bool reset_speculative_request_state(")
+        self.assertGreater(at, -1)
+        body = self.text[at:at + 1400]
+        self.assertIn("common_speculative_free", body)
+        self.assertIn("common_speculative_init", body)
+        self.assertIn("spec_epoch++", body)
+
+    def test_no_draft_clear_outside_the_resident_guard(self) -> None:
+        """A draft clear on a resident pass destroys the half being preserved.
+
+        Both clears must sit inside the same `!resident_pass` guard. A clear
+        placed before or outside it would empty the draft while the target keeps
+        its prefix, leaving pending_h naming a predecessor the draft no longer
+        holds -- a mismatched pair that still looks frontier-plausible.
+        """
+        lines = self.text.splitlines()
+        sites = [i for i, l in enumerate(lines) if "llama_memory_clear(mem_dft, true);" in l]
+        self.assertTrue(sites, "expected draft clear sites")
+        for i in sites:
+            window = "\n".join(lines[max(0, i - 12):i])
+            self.assertTrue(
+                "if (!resident_pass) {" in window or "orbit_mtp_session_reset" in window
+                or "reset_speculative_request_state" in window
+                or "llama_get_memory(session->ctx_dft)" in window,
+                f"draft clear at line {i+1} is not guarded against a resident pass",
+            )
+
+    def test_hard_reset_path_poisons_the_pair(self) -> None:
+        """The hard branch must mark untrusted; a rebuilt pair has proven nothing."""
+        at = self.text.find('trace_request_reset_mode("hard");')
+        self.assertGreater(at, -1, "the hard branch must be labelled")
+        block = self.text[at:at + 500]
+        self.assertIn("reset_speculative_request_state", block)
+        self.assertIn("session->persistent_pair_untrusted = true;", block)
+        self.assertNotIn("persistent_pair_untrusted = false", block)
+
+    def test_soft_branch_does_not_grant_trust(self) -> None:
+        """Soft reset preserves existing trust; it must not manufacture it."""
+        at = self.text.find('trace_request_reset_mode("soft");')
+        self.assertGreater(at, -1)
+        start = self.text.rfind("if (soft) {", 0, at)
+        block = self.text[start:at + 120]
+        self.assertNotIn("persistent_pair_untrusted = false", block)
+
+    def test_hard_reset_marks_the_pair_untrusted(self) -> None:
+        """A rebuilt pair has proven nothing yet."""
+        self.assertIn("session->persistent_pair_untrusted = true;", self.text)
+
+    def test_identity_is_pinned_at_every_construction(self) -> None:
+        pins = self.text.count(
+            "session->spec_pinned_ctx_tgt = session->spec_params.draft.ctx_tgt;")
+        inits = self.text.count("common_speculative_init(session->spec_params, 1);")
+        self.assertEqual(pins, inits,
+                         "every constructed impl must pin the target it belongs to")
+
+    def test_resident_admission_requires_the_whole_pair(self) -> None:
+        at = self.text.find("const bool resident_ok =")
+        self.assertGreater(at, -1)
+        pred = self.text[at:self.text.find(";", at)]
+        for term in ("pair_trusted_from_previous", "identity_ok",
+                     "llama_memory_seq_pos_max(mem_dft, 0) == resident_claim - 1",
+                     "entry_pend_pos == resident_claim - 1", "entry_pend_gen > 0"):
+            self.assertIn(term, pred, f"resident admission must require {term}")
+
+    def test_defect_a_strict_proper_prefix_preserved(self) -> None:
+        self.assertIn("resident_claim < (int32_t) prompt_tgt.size()", self.text)
+        self.assertNotIn("resident_claim <= (int32_t) prompt_tgt.size()", self.text)
+
+    def test_boundary_precedence_preserved(self) -> None:
+        self.assertIn("&& !resident_pass", self.text)
+
+    def test_can_partial_rollback_not_wired_into_the_live_path(self) -> None:
+        """Its probe is destructive; it must stay out of the decision path."""
+        live = [l for l in self.text.splitlines()
+                if "can_partial_rollback(" in l and "static bool" not in l]
+        self.assertEqual(live, [], f"can_partial_rollback must stay unwired: {live}")
+
+
+class StalePendingTests(unittest.TestCase):
+    """A preserved carryover must never seed a from-zero replay.
+
+    `soft_reset_request_state` keeps `pending_h`, which is correct for a suffix
+    append at F+1. But the soft/hard decision is made independently of whether
+    the completion actually takes the resident path: a soft reset followed by a
+    rejected resident claim (claim 0, n_rs_seq 0, claim >= prompt size) replays
+    from position 0. `process()` then seeds draft slot 0 from the carryover where
+    the zero row is required -- and because `process()` overwrites the carryover
+    before the exit check runs, the resulting draft would still be certified
+    trusted. The vendored code states the invariant: "-1 == no predecessor:
+    correct only for a batch starting at position 0".
+    """
+
+    def setUp(self) -> None:
+        self.text = _shim_text()
+
+    def test_carryover_is_discarded_before_a_from_zero_replay(self) -> None:
+        at = self.text.find("if (!resident_pass && session->spec) {")
+        self.assertGreater(at, -1, "a non-resident pass must discard the carryover")
+        block = self.text[at:at + 600]
+        self.assertIn("common_speculative_reset_pending(session->spec, 0)", block)
+
+    def test_failure_to_discard_poisons_the_pair(self) -> None:
+        """If the carryover cannot be proven safe, refuse to reuse the impl."""
+        at = self.text.find("if (!resident_pass && session->spec) {")
+        block = self.text[at:at + 600]
+        self.assertIn("session->persistent_pair_untrusted = true;", block)
+
+    def test_discard_is_observable(self) -> None:
+        self.assertIn('trace_pending_discarded("replay_from_zero")', self.text)
+
+    def test_session_reset_poisons_the_pair(self) -> None:
+        """orbit_mtp_session_reset destroys the draft half and the impl.
+
+        A trust bit surviving that operation would assert a pair that no longer
+        exists. Physical checks catch it downstream, but a flag outliving what it
+        describes is a latent false-trust path.
+        """
+        at = self.text.find("extern \"C\" bool orbit_mtp_session_reset(")
+        self.assertGreater(at, -1)
+        body = self.text[at:self.text.find("\n}", at)]
+        self.assertIn("session->persistent_pair_untrusted = true;", body)
+
+        # Presence is not reachability. A mutant that prefixes the assignment
+        # with `if (false)` leaves the string intact while disabling it, so
+        # assert the statement is not guarded by any conditional: walk back from
+        # the assignment to the previous statement boundary and require nothing
+        # conditional in between.
+        assign = body.rindex("session->persistent_pair_untrusted = true;")
+        prev_end = max(body.rfind(";", 0, assign), body.rfind("}", 0, assign))
+        between = body[prev_end + 1:assign]
+        stripped = "\n".join(
+            line for line in between.splitlines()
+            if not line.strip().startswith("//")
+        ).strip()
+        self.assertEqual(
+            stripped, "",
+            f"the poisoning assignment must be unconditional, found: {stripped!r}",
+        )
+
+    def test_reset_pending_restores_the_constructor_state(self) -> None:
+        """The vendored reset must match what a fresh implementation has."""
+        spec = (ROOT / "src/orbit/native_llama/vendor/source/llama.cpp"
+                / "common/speculative.cpp").read_text()
+        at = spec.find("bool reset_pending(llama_seq_id seq_id) override {")
+        self.assertGreater(at, -1)
+        body = spec[at:spec.find("\n    }", at)]
+        for expected in ("pending_pos[seq_id] = -1;", "pending_fp[seq_id] = 0ull;",
+                         "pending_gen[seq_id] = 0ull;", "0.0f"):
+            self.assertIn(expected, body)
+
+
+class PairTrustLifecycleTests(unittest.TestCase):
+    """Armed before mutation, cleared only at a proven-canonical exit."""
+
+    def setUp(self) -> None:
+        self.text = _shim_text()
+
+    def test_pair_is_armed_before_any_mutation(self) -> None:
+        arm = self.text.find("session->persistent_pair_untrusted = true;\n\n    bool need_replay")
+        self.assertGreater(arm, -1, "the pair must be poisoned before mutating")
+        for mutation in ("llama_memory_clear(mem_tgt, true);", "llama_decode(ctx_tgt,"):
+            self.assertGreater(self.text.find(mutation, arm), arm)
+
+    def test_trust_requires_all_three_halves_and_identity(self) -> None:
+        at = self.text.find("session->persistent_pair_untrusted =\n            !(")
+        self.assertGreater(at, -1)
+        expr = self.text[at:self.text.find(";", at)]
+        for term in ("target_ok", "draft_ok", "pending_aligned", "identity_ok"):
+            self.assertIn(term, expr)
+
+    def _trust_predicate(self):
+        """Compile the REAL trust expression out of the shim.
+
+        Earlier versions of the two tests below evaluated Python dict literals
+        with no reference to the shim at all, so they passed even if the entire
+        canonical-exit trust block were deleted. The expression is now lifted
+        from the source, so its semantics -- not just the presence of its
+        terms -- are under test.
+        """
+        at = self.text.find("session->persistent_pair_untrusted =\n            !(")
+        if at < 0:
+            self.fail("canonical-exit trust assignment not found")
+        expr = self.text[at:self.text.find(";", at)].split("=", 1)[1].strip()
+        src = """
+        #include <cstdint>
+        extern "C" bool untrusted(bool target_ok, bool draft_ok,
+                                  bool pending_aligned, bool identity_ok) {
+            return %s;
+        }
+        """ % expr
+        lib = _PredicateHarness.build("pairtrust", src) if "_PredicateHarness" in globals() \
+            else self._build_local(src)
+        lib.untrusted.restype = ctypes.c_bool
+        return lib
+
+    @staticmethod
+    def _build_local(src: str):
+        tmp = Path(tempfile.mkdtemp(prefix="orbit_trust_"))
+        cpp = tmp / "t.cpp"
+        cpp.write_text(src)
+        so = tmp / "t.so"
+        rc = subprocess.run(
+            ["g++", "-std=c++17", "-fPIC", "-shared", "-O0", "-o", str(so), str(cpp)],
+            capture_output=True, text=True, check=False,
+        )
+        if rc.returncode != 0:
+            raise AssertionError(f"trust harness build failed: {rc.stderr[:600]}")
+        return ctypes.CDLL(str(so))
+
+    def test_recovery_is_possible(self) -> None:
+        """The flag must not latch: a fully canonical exit clears it."""
+        lib = self._trust_predicate()
+        self.assertFalse(
+            lib.untrusted(True, True, True, True),
+            "an exit with all four halves canonical must restore trust, or the "
+            "pair could never be reused after the first completion",
+        )
+
+    def test_any_single_failure_poisons_the_pair(self) -> None:
+        """Each of the four terms must independently deny trust."""
+        lib = self._trust_predicate()
+        for i, missing in enumerate(
+            ("target_ok", "draft_ok", "pending_aligned", "identity_ok")
+        ):
+            args = [True, True, True, True]
+            args[i] = False
+            with self.subTest(missing=missing):
+                self.assertTrue(
+                    lib.untrusted(*args),
+                    f"{missing} does not poison the pair -- a corrupt half "
+                    f"would be reported as canonical",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resident_prefix_abi.py
+++ b/tests/test_resident_prefix_abi.py
@@ -1,0 +1,1034 @@
+"""Resident target-KV prefix: ABI tiering and trace-recorder integrity.
+
+Persistent target KV is opt-in per completion. The runtime declares a prefix it
+has already proven token-identical to its committed sequence; the shim verifies
+only that physical target memory agrees, and falls back to a full replay when it
+does not. A wrong prefix would be a correctness bug, a full replay is merely
+slow, so every ambiguous case resolves to replay.
+
+These cover the ABI contract and the frozen observability recorder. The
+lifecycle behaviour itself is proven by the two-request model smoke, because
+only a real completion exercises those code paths.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from orbit.native_llama import persistent_mtp as pm
+
+ROOT = Path(__file__).resolve().parents[1]
+SHIM_SOURCE = ROOT / "src/orbit/native_llama/vendor/shim/orbit_persistent_mtp.cpp"
+
+
+def _built_shim() -> Path | None:
+    for candidate in (
+        Path.home() / ".orbit/native-build/liborbit-persistent-mtp.so",
+        ROOT / "src/orbit/native_llama/vendor/shim/liborbit-persistent-mtp.so",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _exports(path: Path) -> set[str]:
+    out = subprocess.run(
+        ["nm", "-D", "--defined-only", str(path)],
+        capture_output=True, text=True, check=False,
+    )
+    return {p.split()[-1] for p in out.stdout.splitlines() if p.split()}
+
+
+class TierSeparationTests(unittest.TestCase):
+    """Three tiers, each demanded only by what actually needs it."""
+
+    def test_resident_symbols_are_not_in_the_base_contract(self) -> None:
+        for symbol in pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS:
+            self.assertNotIn(
+                symbol, pm._REQUIRED_SHIM_SYMBOLS,
+                "a shim predating resident reuse must stay valid for base decoding",
+            )
+
+    def test_resident_symbols_are_not_required_for_ordinary_self_mtp(self) -> None:
+        for symbol in pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS:
+            self.assertNotIn(
+                symbol, pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS,
+                "self-MTP without resident reuse must not require these",
+            )
+
+    def test_the_three_tiers_are_disjoint(self) -> None:
+        base = set(pm._REQUIRED_SHIM_SYMBOLS)
+        self_mtp = set(pm._SELF_MTP_REQUIRED_SHIM_SYMBOLS)
+        resident = set(pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS)
+        self.assertFalse(base & self_mtp)
+        self.assertFalse(base & resident)
+        self.assertFalse(self_mtp & resident)
+
+    def test_resident_tier_is_non_empty(self) -> None:
+        """An empty tuple would make the capability check vacuously true."""
+        self.assertTrue(pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS)
+
+
+class CompiledExportTests(unittest.TestCase):
+    """Source text is not evidence; compiled exports are."""
+
+    def setUp(self) -> None:
+        self.shim = _built_shim()
+        if self.shim is None:
+            self.skipTest("no compiled shim available")
+        self.exports = _exports(self.shim)
+        if not self.exports:
+            self.skipTest("nm produced no symbols")
+
+    def test_resident_symbols_are_exported(self) -> None:
+        missing = [
+            s for s in pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS
+            if s not in self.exports
+        ]
+        if missing == list(pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS):
+            self.skipTest("inspecting a shim that predates resident reuse")
+        self.assertEqual(missing, [])
+
+    def test_base_contract_still_satisfied(self) -> None:
+        missing = [s for s in pm._REQUIRED_SHIM_SYMBOLS if s not in self.exports]
+        self.assertEqual(missing, [])
+
+    def test_trace_recorder_exports_nothing(self) -> None:
+        """Observability stays internal; it must add no ABI surface."""
+        leaked = [s for s in self.exports if "trace_target" in s or "target_trace" in s]
+        self.assertEqual(leaked, [])
+
+
+class RecorderIntegrityTests(unittest.TestCase):
+    """The frozen recorder must keep describing target-only truth.
+
+    Phase B consumes this evidence, so a recorder that drifts would invalidate
+    every lifecycle claim built on it.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+        self.lines = self.source.splitlines()
+
+    def test_every_target_clear_is_traced(self) -> None:
+        sites = [i for i, l in enumerate(self.lines) if "llama_memory_clear(mem_tgt" in l]
+        self.assertTrue(sites)
+        for i in sites:
+            window = "\n".join(self.lines[i:i + 3])
+            self.assertIn("trace_target_clear", window)
+
+    def test_draft_clears_are_never_traced_as_target(self) -> None:
+        for i, line in enumerate(self.lines):
+            if "llama_memory_clear(mem_dft" in line:
+                window = "\n".join(self.lines[i:i + 2])
+                self.assertNotIn("trace_target_clear", window)
+
+    def test_every_target_seq_rm_captures_its_result(self) -> None:
+        sites = [i for i, l in enumerate(self.lines) if "llama_memory_seq_rm(mem_tgt" in l]
+        self.assertTrue(sites)
+        for i in sites:
+            self.assertRegex(
+                self.lines[i],
+                r"const bool \w+ = llama_memory_seq_rm\(mem_tgt",
+                "a discarded seq_rm result cannot prove rollback succeeded",
+            )
+
+    def test_prefill_traces_report_tokens_not_batches(self) -> None:
+        call_sites = [
+            l for l in self.lines
+            if "trace_target_prefill(" in l and "static void" not in l
+        ]
+        self.assertTrue(call_sites, "no prefill trace call sites found")
+        for line in call_sites:
+            self.assertIn(
+                ".size()", line,
+                "prefill evidence must count tokens, not decode batches",
+            )
+
+    def test_trace_helpers_do_not_mutate_session_state(self) -> None:
+        for name in ("trace_target_clear", "trace_target_prefill",
+                     "trace_target_seq_rm", "trace_target_frontier"):
+            body = re.search(rf"static void {name}.*?\n\}}", self.source, re.S)
+            self.assertIsNotNone(body, name)
+            self.assertIsNone(
+                re.search(r"session->\w+\s*(=[^=]|\+\+|--|\+=)", body.group(0)),
+                f"{name} must be observational only",
+            )
+
+
+class ClaimOrderingTests(unittest.TestCase):
+    """The claim must be declared AFTER the reset that precedes each completion.
+
+    `_try_complete_with_mtp_experimental` resets the session and then completes.
+    Reset deliberately clears a pending claim so a stale one cannot leak, which
+    means a claim set by the caller before `complete()` is wiped before it can
+    be read -- the resident branch would be permanently dead. Setting it inside
+    `run_persistent_mtp_completion`, immediately before the native call, keeps
+    both properties.
+    """
+
+    def test_claim_is_set_after_reset_and_before_completion(self) -> None:
+        import inspect
+
+        from orbit.native_llama import persistent_mtp as pm
+
+        body = inspect.getsource(pm.run_persistent_mtp_completion)
+        set_at = body.find("orbit_mtp_session_set_resident_prefix_len")
+        complete_at = body.find("orbit_mtp_session_complete(")
+        self.assertGreater(set_at, -1, "the claim must be declared here")
+        self.assertGreater(complete_at, -1)
+        self.assertLess(
+            set_at, complete_at,
+            "the claim must be set before the native completion reads it",
+        )
+
+    def test_reset_does_not_declare_a_claim(self) -> None:
+        """Reset only clears; declaring there would resurrect the ordering bug."""
+        import inspect
+
+        from orbit.native_llama import persistent_mtp as pm
+
+        body = inspect.getsource(pm.reset_persistent_mtp_session)
+        self.assertNotIn("set_resident_prefix_len", body)
+
+    def test_zero_claim_never_calls_the_setter(self) -> None:
+        """A cold completion must not touch the resident capability at all."""
+        from unittest.mock import MagicMock
+
+        from orbit.native_llama import persistent_mtp as pm
+
+        lib = MagicMock()
+        lib.orbit_mtp_session_complete.return_value = True
+        lib.orbit_mtp_session_last_content.return_value = b""
+        runtime = MagicMock(handle=object())
+
+        with unittest.mock.patch.object(
+            pm, "_runtime_library", lambda **kw: MagicMock(lib=lib)
+        ):
+            pm.run_persistent_mtp_completion(
+                llama_root=Path("/x"), paths=MagicMock(), runtime=runtime,
+                ctx_tgt=None, prompt="hi", max_tokens=4, resident_prefix_len=0,
+            )
+        lib.orbit_mtp_session_set_resident_prefix_len.assert_not_called()
+
+    def test_missing_capability_fails_closed(self) -> None:
+        """No silent downgrade: asking for reuse a shim cannot do must error."""
+        from unittest.mock import MagicMock
+
+        from orbit.native_llama import persistent_mtp as pm
+
+        lib = MagicMock(spec=["orbit_mtp_session_complete", "orbit_mtp_last_error"])
+        runtime = MagicMock(handle=object())
+
+        with unittest.mock.patch.object(
+            pm, "_runtime_library", lambda **kw: MagicMock(lib=lib)
+        ):
+            result = pm.run_persistent_mtp_completion(
+                llama_root=Path("/x"), paths=MagicMock(), runtime=runtime,
+                ctx_tgt=None, prompt="hi", max_tokens=4, resident_prefix_len=8,
+            )
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "persistent-mtp-resident-prefix-unsupported")
+        lib.orbit_mtp_session_complete.assert_not_called()
+
+
+class Load5HistoricalDefectTests(unittest.TestCase):
+    """The resident pass must never reach the cold full-replay branch.
+
+    Reproduces the defect load #5 exposed: the resident path correctly skipped
+    the target clear, then fell into the `else` full replay and decoded the
+    whole prompt at position 0 into a target that already held the prefix.
+    llama.cpp rejected the overlap and the completion failed.
+
+    The prefill block has TWO regions. Guarding only the later positional one
+    is not enough -- the earlier full replay must also exclude the resident
+    pass, or it runs first and the positional block is never reached.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_full_replay_branch_excludes_the_resident_pass(self) -> None:
+        self.assertIn(
+            "} else if (!resident_pass) {", self.source,
+            "the cold full-replay branch must not be reachable on a resident pass",
+        )
+
+    def test_no_unguarded_else_before_the_positional_block(self) -> None:
+        """An unguarded `} else {` here is exactly the load-5 defect."""
+        head = self.source.split("std::vector<llama_token> process_tokens;")[0]
+        tail = head.split("if (use_request_boundary) {")[-1]
+        self.assertNotIn(
+            "                } else {\n", tail,
+            "an unguarded else here sends the resident pass into full replay",
+        )
+
+    def test_cold_path_still_reaches_full_replay(self) -> None:
+        """The guard must exclude only the resident pass, not cold requests."""
+        self.assertIn("trace_target_prefill(\"full_replay\"", self.source)
+        self.assertNotIn("} else if (false) {", self.source)
+
+    def test_request_boundary_branch_still_exists_for_its_own_case(self) -> None:
+        """Boundary restore is preserved -- but must not preempt resident.
+
+        Replaces an earlier assertion that the branch was "untouched", which
+        pinned the defect: it clears mem_tgt and replays from 0, and nothing
+        excluded a resident pass from reaching it.
+        """
+        self.assertIn("if (use_request_boundary) {", self.source)
+        self.assertIn("&& !resident_pass;", self.source)
+
+
+class BoundaryResidentExclusionTests(unittest.TestCase):
+    """Resident reuse must take precedence over request-boundary restore.
+
+    Both flags are computed independently and can be true together: on a
+    resident pass `generated` is empty, and `can_restore_request_boundary` is
+    true exactly when the new prompt extends the previous one -- the steady
+    state the resident feature targets. The boundary branch is tested first
+    and clears mem_tgt, so without an explicit exclusion it destroys the
+    prefix and replays from 0.
+
+    The caller currently resets the session before each completion, clearing
+    the boundary checkpoint. That is caller ordering, not an invariant of this
+    function, and must not be relied upon.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_boundary_predicate_excludes_a_resident_pass(self) -> None:
+        self.assertIn("&& !resident_pass;", self.source)
+
+    def test_exclusion_is_code_not_only_a_comment(self) -> None:
+        code = "\n".join(
+            l for l in self.source.splitlines() if not l.strip().startswith("//")
+        )
+        self.assertIn("&& !resident_pass;", code)
+
+    def test_resident_pass_declared_before_the_boundary_predicate(self) -> None:
+        decl = self.source.find("const bool resident_pass = resident_prefill_pending;")
+        use = self.source.find("const bool use_request_boundary =")
+        self.assertGreater(decl, -1)
+        self.assertGreater(use, decl, "resident_pass must be declared first")
+
+    def test_resident_wins_in_the_positional_block_too(self) -> None:
+        block = self.source.split("std::vector<llama_token> process_tokens;")[1]
+        r_at = block.find("if (resident_pass) {")
+        b_at = block.find("else if (use_request_boundary)")
+        self.assertGreater(r_at, -1)
+        self.assertGreater(b_at, r_at, "resident must take precedence")
+
+
+class SeqRmResultConsumedTests(unittest.TestCase):
+    """A refused target seq_rm must never be treated as success.
+
+    Capturing the result is not enough -- these previously bound it, traced
+    it, and discarded it. With a prefix now preserved across completions, a
+    refusal leaves rejected tokens above the committed frontier, and a later
+    claim of frontier+1 would match that poisoned frontier.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_every_target_seq_rm_result_is_inspected(self) -> None:
+        for name in ("tgt_rm_ok", "ckpt_rm_ok", "full_rm_ok"):
+            with self.subTest(result=name):
+                self.assertIn(
+                    "if (!" + name + ")", self.source,
+                    name + " is captured but never branched on",
+                )
+
+    def test_full_accept_replay_depends_on_the_removal_result(self) -> None:
+        self.assertIn("need_replay = need_replay_after_failed_rm;", self.source)
+        self.assertNotIn(
+            "draft_is_fresh = false;\n            need_replay = false;", self.source,
+            "full_accept must not unconditionally clear need_replay",
+        )
+
+    def test_a_refusal_marks_the_target_untrusted(self) -> None:
+        self.assertGreaterEqual(
+            self.source.count("session->last_target_untrusted = true;"), 3,
+            "each target seq_rm site must mark the target unproven on refusal",
+        )
+
+    def test_untrusted_target_blocks_the_next_resident_claim(self) -> None:
+        self.assertIn("!target_untrusted_from_previous &&", self.source)
+
+    def test_untrusted_flag_survives_into_the_next_completion(self) -> None:
+        read_at = self.source.find(
+            "const bool target_untrusted_from_previous = session->last_target_untrusted;"
+        )
+        clear_at = self.source.find("session->last_target_untrusted = false;", read_at)
+        self.assertGreater(read_at, -1)
+        self.assertGreater(clear_at, read_at, "must be read before it is cleared")
+
+
+class UntrustedLifetimeTests(unittest.TestCase):
+    """The untrusted flag must gate exactly the NEXT completion.
+
+    A refused target seq_rm leaves tokens above the committed frontier. The
+    completion that suffered it is already over, so the protection has to
+    survive into the next one, be read before anything clears it, and then be
+    released -- otherwise either a poisoned frontier gets claimed, or the
+    session is blocked from ever recovering.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_flag_is_read_before_it_is_cleared(self) -> None:
+        read_at = self.source.find(
+            "const bool target_untrusted_from_previous = session->last_target_untrusted;"
+        )
+        self.assertGreater(read_at, -1, "the flag must be carried in from the previous completion")
+        clear_at = self.source.find("session->last_target_untrusted = false;", read_at)
+        self.assertGreater(clear_at, read_at, "clearing before reading loses the protection")
+
+    def test_flag_is_cleared_so_recovery_is_possible(self) -> None:
+        """It must not latch: a cold replay restores a known state."""
+        self.assertIn("session->last_target_untrusted = false;", self.source)
+
+    def test_validation_consults_the_carried_flag_not_the_live_field(self) -> None:
+        """Reading the live field after clearing it would always be false."""
+        self.assertIn("!target_untrusted_from_previous &&", self.source)
+        self.assertNotIn("!session->last_target_untrusted &&", self.source)
+
+    def test_clear_precedes_the_resident_decision(self) -> None:
+        """Cleared early so THIS completion can set it afresh on a refusal."""
+        clear_at = self.source.find("session->last_target_untrusted = false;")
+        ok_at = self.source.find("const bool resident_ok =")
+        self.assertGreater(clear_at, -1)
+        self.assertLess(clear_at, ok_at)
+
+    def test_every_refusal_site_sets_the_flag(self) -> None:
+        for guard in ("if (!tgt_rm_ok)", "if (!ckpt_rm_ok)", "if (!full_rm_ok)"):
+            with self.subTest(site=guard):
+                idx = self.source.find(guard)
+                self.assertGreater(idx, -1, guard + " missing")
+                # Window past the rationale comment; the assignment follows it.
+                window = self.source[idx:idx + 900]
+                self.assertIn("last_target_untrusted = true;", window)
+
+class ResidentLifecycleShapeTests(unittest.TestCase):
+    """Structural pins for the resident path.
+
+    These assert the SHAPE of the lifecycle, not its runtime behaviour: a C++
+    mutation only changes behaviour once recompiled, so the authoritative proof
+    that the target is not cleared and the suffix starts at N is the two-request
+    model smoke. These catch an accidental edit early and cheaply; they do not
+    replace that smoke.
+    """
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_target_clear_is_skipped_on_the_resident_pass(self) -> None:
+        self.assertIn(
+            "if (!resident_pass) {\n                llama_memory_clear(mem_tgt, true);",
+            self.source,
+            "the resident pass must not clear the prefix it exists to preserve",
+        )
+
+    def test_resident_prefill_is_based_at_the_claim(self) -> None:
+        self.assertIn("process_pos0 = resident_claim;", self.source)
+        for wrong in ("process_pos0 = resident_claim - 1;",
+                      "process_pos0 = resident_claim + 1;"):
+            self.assertNotIn(wrong, self.source, "off-by-one in the resident base")
+
+    def test_resident_slice_starts_at_the_claim(self) -> None:
+        self.assertIn(
+            "prompt_tgt.begin() + (ptrdiff_t) resident_claim", self.source,
+            "the suffix must begin exactly where the resident prefix ends",
+        )
+
+    def test_resident_pass_reaches_the_positional_prefill_loop(self) -> None:
+        """Without this the suffix falls through to the from-zero branch."""
+        self.assertIn("if (use_request_boundary || resident_pass) {", self.source)
+
+    def test_draft_is_never_cleared_on_a_resident_pass(self) -> None:
+        """The draft clear must be lexically INSIDE `if (!resident_pass)`.
+
+        This test previously asserted the opposite ("draft state still resets")
+        and did so with a bare substring search that matched the unrelated
+        clears in the reset helpers -- so it passed under `if(false)` and, worse,
+        pinned a contract the shim deliberately does not implement.
+
+        Clearing the draft on a resident pass empties the draft half while the
+        target keeps prompt[0:N), so the next turn's
+        `seq_pos_max(mem_dft,0) == claim-1` conjunct fails, `resident_ok` is
+        permanently false, and the feature is silently dead while every test
+        still passes. Scope is checked by brace depth, not by proximity: a clear
+        six lines below a CLOSED `!resident_pass` block is outside it.
+        """
+        lines = self.source.splitlines()
+        # The guard must EXIST. Checking only "is the clear inside a guard"
+        # made deletion of the guard invisible: with no guard anywhere, no
+        # clear is ever reported out of scope and the test passed while the
+        # clear had become unconditional. Matched semantically so an equivalent
+        # rewrite (`resident_pass == false`) is not a spurious failure.
+        guard_re = re.compile(
+            r"if\s*\(\s*(?:!\s*resident_pass|resident_pass\s*==\s*false)\s*\)\s*\{"
+        )
+        guards = [i for i, l in enumerate(lines, 1) if guard_re.search(l.split("//")[0])]
+        self.assertTrue(
+            guards,
+            "the `!resident_pass` guard is gone: the replay clears now run on "
+            "every pass, so a resident pass wipes the draft half and resident "
+            "reuse is permanently dead",
+        )
+
+        # Every draft clear must then be lexically inside one of those guards.
+        # Scope by brace depth, not proximity: a clear below a CLOSED guard
+        # block is outside it however few lines away.
+        depth = 0
+        guard_depth = None
+        offenders = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.split("//")[0]
+            if guard_depth is None and guard_re.search(stripped):
+                guard_depth = depth
+            opened = depth
+            depth += stripped.count("{") - stripped.count("}")
+            if guard_depth is not None and depth <= guard_depth and opened > guard_depth:
+                guard_depth = None
+            if "llama_memory_clear(mem_dft" in stripped and guard_depth is None:
+                offenders.append(i)
+        self.assertEqual(
+            offenders, [],
+            f"draft clear(s) at line(s) {offenders} are outside the "
+            f"`!resident_pass` guard; a resident pass would wipe the draft half "
+            f"and permanently disable resident reuse",
+        )
+
+
+class CommittedSequenceInvalidationTests(unittest.TestCase):
+    """`_invalidate_committed_sequence` must actually clear the identity.
+
+    D3b does not change it, but a gutted implementation would let a stale
+    committed identity survive a KV rewrite -- a false cache hit, which is the
+    correctness bug the strict prefix rule exists to prevent.
+    """
+
+    def test_invalidation_clears_the_committed_tokens(self) -> None:
+        from orbit.native_llama.client import NativeLlamaClient
+        from orbit.native_llama.session_state import NativeSessionState
+
+        c = NativeLlamaClient.__new__(NativeLlamaClient)
+        c._session = NativeSessionState(session_id="inv")
+        c._session.committed_sequence_tokens = [11, 22, 33]
+        c._invalidate_committed_sequence()
+        self.assertEqual(
+            list(c._session.committed_sequence_tokens), [],
+            "a surviving committed identity after invalidation is a false cache hit",
+        )
+
+    def test_strict_append_needs_a_committed_sequence(self) -> None:
+        """With identity cleared, the exact-prefix fast path must not fire."""
+        from ctypes import c_void_p
+        from unittest.mock import MagicMock, patch
+
+        from orbit.native_llama.client import NativeLlamaClient
+        from orbit.native_llama.session_state import NativeSessionState
+
+        c = NativeLlamaClient.__new__(NativeLlamaClient)
+        c._session = NativeSessionState(session_id="inv2")
+        c._session.ctx_tgt = c_void_p(0x1)
+        c._session.committed_sequence_tokens = [1, 2, 3]
+        c._session.cached_prompt_tokens = []
+        lib = MagicMock(); lib.llama_get_memory.return_value = None
+        c.lib = MagicMock(lib=lib)
+
+        with patch.object(NativeLlamaClient, "_qwen3_coder_native_protocol", lambda self: False), \
+             patch.object(NativeLlamaClient, "_invalidate_committed_sequence", lambda self: None):
+            self.assertEqual(c._prepare_memory_for_prompt([1, 2, 3, 4]), 3)
+
+        c._session.committed_sequence_tokens = []
+        c._session.cached_prompt_tokens = []
+        with patch.object(NativeLlamaClient, "_qwen3_coder_native_protocol", lambda self: False), \
+             patch.object(NativeLlamaClient, "_invalidate_committed_sequence", lambda self: None):
+            self.assertNotEqual(c._prepare_memory_for_prompt([1, 2, 3, 4]), 3)
+
+
+class ResidentValidationSourceTests(unittest.TestCase):
+    """The physical checks that gate resident reuse."""
+
+    def setUp(self) -> None:
+        self.source = SHIM_SOURCE.read_text()
+
+    def test_claim_is_bounded_by_the_prompt(self) -> None:
+        """The bound is STRICT: `<`, not `<=`.
+
+        This originally asserted `<=`, which pinned Defect A as correct -- a
+        claim equal to the prompt length leaves an empty suffix, so the target
+        is never decoded and sampling reads the previous completion's logits.
+        """
+        self.assertIn("resident_claim < (int32_t) prompt_tgt.size()", self.source)
+        self.assertNotIn("resident_claim <= (int32_t) prompt_tgt.size()", self.source)
+
+    def test_physical_frontier_must_match_the_claim(self) -> None:
+        self.assertIn(
+            "llama_memory_seq_pos_max(mem_tgt, 0) == resident_claim - 1", self.source
+        )
+
+    def test_rollback_budget_is_required(self) -> None:
+        self.assertIn("llama_n_rs_seq(ctx_tgt) > 0", self.source)
+
+    def test_destructive_capability_probe_is_not_wired(self) -> None:
+        """`can_partial_rollback` clears memory while probing."""
+        calls = re.findall(r"(?<!static bool )can_partial_rollback\s*\(", self.source)
+        self.assertEqual(
+            calls, [],
+            "probing with can_partial_rollback would destroy the resident prefix",
+        )
+
+    def test_claim_is_consumed_so_it_cannot_leak_forward(self) -> None:
+        """Consumed at completion entry, before the validation reads it.
+
+        A claim describes ONE completion. If the field is not zeroed here, the
+        next completion inherits it and may reuse a prefix nobody declared for
+        it -- the exact stale-claim leak the one-shot design forbids. Asserting
+        only that the statement exists somewhere is not enough: it must sit
+        between reading the claim and computing `resident_ok`.
+        """
+        read_at = self.source.find(
+            "const int32_t resident_claim = session->pending_resident_prefix_len;"
+        )
+        self.assertGreater(read_at, -1, "the claim must be read into a local")
+        consume_at = self.source.find(
+            "session->pending_resident_prefix_len = 0;", read_at
+        )
+        self.assertGreater(consume_at, read_at, "the claim must be consumed after being read")
+        validate_at = self.source.find("const bool resident_ok =", read_at)
+        self.assertGreater(validate_at, -1)
+        self.assertLess(
+            consume_at, validate_at,
+            "the claim must be consumed before validation, so no later "
+            "completion can inherit it",
+        )
+
+    def test_reset_clears_a_pending_claim(self) -> None:
+        reset = re.search(
+            r"orbit_mtp_session_reset\(void \* handle.*?\n\}", self.source, re.S
+        )
+        self.assertIsNotNone(reset)
+        self.assertIn("pending_resident_prefix_len = 0", reset.group(0))
+
+    def test_reset_does_not_clear_target_memory(self) -> None:
+        """Draft state and canonical target KV are separate concerns."""
+        reset = re.search(
+            r"orbit_mtp_session_reset\(void \* handle.*?\n\}", self.source, re.S
+        )
+        body = reset.group(0)
+        # Strip comments: the only mem_tgt mentions should be explanatory.
+        code = "\n".join(
+            l for l in body.splitlines() if not l.strip().startswith("//")
+        )
+        self.assertNotIn(
+            "llama_memory_clear(mem_tgt", code,
+            "reset must not destroy canonical target KV",
+        )
+        # It does clear the DRAFT context, which is the point of a reset.
+        self.assertIn("llama_get_memory(session->ctx_dft)", code)
+
+
+
+# ---------------------------------------------------------------------------
+# D3b-R2: the three defects found by the post-load-8 independent review.
+#
+# The review's MINOR 2 was fair: source-text assertions pin spelling, not
+# behaviour, and two of them were satisfied *by* the lines that caused the
+# defects. The classes below therefore compile the real predicates out of the
+# shim and execute them, so a mutant that changes behaviour fails even when it
+# keeps the surrounding text intact.
+# ---------------------------------------------------------------------------
+
+
+def _shim_text() -> str:
+    return SHIM_SOURCE.read_text()
+
+
+class _PredicateHarness:
+    """Compile a shim predicate standalone and run it over real inputs."""
+
+    _CACHE: dict[str, object] = {}
+
+    @staticmethod
+    def build(name: str, source: str):
+        import ctypes
+        import tempfile
+
+        if name in _PredicateHarness._CACHE:
+            return _PredicateHarness._CACHE[name]
+        tmp = Path(tempfile.mkdtemp(prefix=f"orbit_pred_{name}_"))
+        src = tmp / "p.cpp"
+        src.write_text(source)
+        so = tmp / "p.so"
+        rc = subprocess.run(
+            ["g++", "-std=c++17", "-fPIC", "-shared", "-O0", "-o", str(so), str(src)],
+            capture_output=True, text=True, check=False,
+        )
+        if rc.returncode != 0:
+            raise AssertionError(f"harness build failed: {rc.stderr[:800]}")
+        lib = ctypes.CDLL(str(so))
+        _PredicateHarness._CACHE[name] = lib
+        return lib
+
+
+class FullPromptClaimTests(unittest.TestCase):
+    """Defect A: a claim covering the whole prompt must not enter resident reuse.
+
+    With `<=`, claim == prompt size makes the suffix empty, so the completion
+    decodes nothing into the target and the first sample reads logits left by the
+    PREVIOUS completion -- silently wrong output reported as success. The
+    contract is a STRICT PROPER prefix; the whole-prompt case falls closed to the
+    full replay, which regenerates fresh target logits.
+    """
+
+    # The REAL guard, lifted out of the shim rather than mirrored by hand. An
+    # earlier version of this class compiled a 5-conjunct hand-written copy
+    # while the shipped guard had 11; deleting any of the six pair-trust and
+    # pending_h conjuncts from the shim left every test here green. That is the
+    # same mistake documented in test_persistent_pair.py, where a mirror let
+    # five mutation classes survive. The opaque C++ calls are replaced by named
+    # parameters -- and only those calls -- so the operators, ordering and
+    # conjunct set stay verbatim and any edit to them changes these results.
+    @staticmethod
+    def _extract() -> str:
+        text = _shim_text()
+        start = text.index("    const bool resident_ok =")
+        end = text.index(";", start) + 1
+        expr = text[start:end].split("=", 1)[1].strip().rstrip(";")
+        for call, param in (
+            ("(int32_t) prompt_tgt.size()", "prompt_size"),
+            ("llama_n_rs_seq(ctx_tgt)", "n_rs_seq"),
+            ("llama_memory_seq_pos_max(mem_tgt, 0)", "tgt_pos_max"),
+            ("llama_memory_seq_pos_max(mem_dft, 0)", "dft_pos_max"),
+        ):
+            if call not in expr:
+                raise AssertionError(
+                    f"shim guard no longer contains {call!r}; update the "
+                    f"extractor rather than letting it bind to a stale shape"
+                )
+            expr = expr.replace(call, param)
+        expr = expr.replace("resident_claim", "claim")
+        if "llama_" in expr:
+            raise AssertionError(f"unsubstituted native call in guard: {expr}")
+        return """
+    #include <cstdint>
+    #include <cstddef>
+    extern "C" bool resident_ok(
+            int32_t claim, int32_t prompt_size, bool target_untrusted_from_previous,
+            bool pair_trusted_from_previous, bool identity_ok, uint32_t n_rs_seq,
+            int32_t tgt_pos_max, int32_t dft_pos_max, bool entry_pend_ok,
+            int32_t entry_pend_pos, uint64_t entry_pend_gen) {
+        return %s;
+    }
+    """ % expr
+
+    def setUp(self) -> None:
+        self.lib = _PredicateHarness.build("residentA", self._extract())
+        self.lib.resident_ok.restype = __import__("ctypes").c_bool
+
+    def _ok(self, claim, size, untrusted=False, n_rs=1, pos_max=None,
+            pair_trusted=True, identity_ok=True, dft_pos_max=None,
+            pend_ok=True, pend_pos=None, pend_gen=1):
+        import ctypes
+
+        tgt = claim - 1 if pos_max is None else pos_max
+        return self.lib.resident_ok(
+            ctypes.c_int32(claim), ctypes.c_int32(size),
+            ctypes.c_bool(untrusted), ctypes.c_bool(pair_trusted),
+            ctypes.c_bool(identity_ok), ctypes.c_uint32(n_rs),
+            ctypes.c_int32(tgt),
+            ctypes.c_int32(tgt if dft_pos_max is None else dft_pos_max),
+            ctypes.c_bool(pend_ok),
+            ctypes.c_int32(claim - 1 if pend_pos is None else pend_pos),
+            ctypes.c_uint64(pend_gen),
+        )
+
+    def test_every_pair_trust_conjunct_is_load_bearing(self) -> None:
+        """Each of the 11 conjuncts must be able to deny admission on its own.
+
+        This is what the hand-written mirror could not do: it did not contain
+        the pair-trust or pending_h terms at all, so their deletion from the
+        shim was invisible here.
+        """
+        base = dict(claim=10, size=20)
+        for name, override in (
+            ("claim > 0", dict(claim=0)),
+            ("!target_untrusted_from_previous", dict(untrusted=True)),
+            ("pair_trusted_from_previous", dict(pair_trusted=False)),
+            ("identity_ok", dict(identity_ok=False)),
+            ("claim < prompt_size", dict(claim=20)),
+            ("n_rs_seq > 0", dict(n_rs=0)),
+            ("target frontier", dict(pos_max=8)),
+            ("draft frontier", dict(dft_pos_max=8)),
+            ("entry_pend_ok", dict(pend_ok=False)),
+            ("entry_pend_pos", dict(pend_pos=8)),
+            ("entry_pend_gen > 0", dict(pend_gen=0)),
+        ):
+            with self.subTest(conjunct=name):
+                self.assertTrue(self._ok(**base), "baseline must be admissible")
+                self.assertFalse(
+                    self._ok(**{**base, **override}),
+                    f"{name} does not deny admission -- the guard is not "
+                    f"actually enforcing it",
+                )
+
+    def test_proper_prefix_may_proceed(self) -> None:
+        """A: claim < prompt size with every other condition met is eligible."""
+        for claim, size in ((1, 2), (10, 20), (26, 27), (100, 4096)):
+            with self.subTest(claim=claim, size=size):
+                self.assertTrue(self._ok(claim, size))
+
+    def test_full_prompt_claim_is_denied(self) -> None:
+        """B: claim == prompt size must NOT enter resident reuse."""
+        for size in (1, 2, 20, 27, 4096):
+            with self.subTest(size=size):
+                self.assertFalse(
+                    self._ok(size, size),
+                    "a whole-prompt claim leaves an empty suffix, so no target "
+                    "decode would occur and sampling would read stale logits",
+                )
+
+    def test_claim_beyond_prompt_is_denied(self) -> None:
+        """C: an over-long claim stays denied."""
+        for claim, size in ((21, 20), (28, 27), (5000, 4096)):
+            with self.subTest(claim=claim):
+                self.assertFalse(self._ok(claim, size))
+
+    def test_zero_and_negative_claims_denied(self) -> None:
+        for claim in (0, -1, -27):
+            with self.subTest(claim=claim):
+                self.assertFalse(self._ok(claim, 27))
+
+    def test_the_guard_in_the_shim_is_strict(self) -> None:
+        """The compiled predicate above must mirror the shipped guard."""
+        text = _shim_text()
+        self.assertIn("resident_claim < (int32_t) prompt_tgt.size()", text)
+        self.assertNotIn("resident_claim <= (int32_t) prompt_tgt.size()", text)
+
+    def test_denied_full_prompt_claim_reaches_full_replay(self) -> None:
+        """D: denial must select replay, not a decode-free path.
+
+        `need_replay = !resident_ok`, so a denied claim replays the whole prompt
+        from position 0, which is what produces fresh logits before sampling.
+        """
+        text = _shim_text()
+        self.assertIn("bool need_replay = !resident_ok;", text)
+        self.assertIn("bool resident_prefill_pending = resident_ok;", text)
+
+    def test_no_decode_free_sampling_path_remains(self) -> None:
+        """E: with a strict prefix the resident suffix can never be empty.
+
+        claim < size implies size - claim >= 1, so the resident slice always has
+        at least one token and the prefill guard cannot skip the target decode.
+        """
+        for claim, size in ((1, 2), (10, 20), (26, 27)):
+            with self.subTest(claim=claim, size=size):
+                self.assertGreaterEqual(size - claim, 1)
+        # And the empty-slice case is unreachable because it is denied upstream.
+        self.assertFalse(self._ok(27, 27))
+
+
+class SameSuffixContractTests(unittest.TestCase):
+    """The draft must process EXACTLY the batch the target just decoded.
+
+    This class replaces DraftContiguityTests, whose premise was disproven. That
+    class asserted the draft slice must be DECOUPLED from the target slice and
+    that a non-shared draft should be rebuilt from position 0. The D3b-R2
+    pre-load review showed why that is wrong: `common_speculative_process`
+    consumes the target's nextn hidden rows indexed by BATCH SLOT, from the
+    target's most recent decode. Feeding it more tokens than the target just
+    decoded reads rows the target never produced -- silently building the draft
+    from stale conditioning, with no warning, because a fully populated draft KV
+    suppresses llama.cpp's own "Drafts may degrade" diagnostic.
+
+    With a persistent pair the correct rule is one rule for both cases: the draft
+    always mirrors the target's last decode. Cold decodes the whole prompt, so
+    the draft processes the whole prompt; a resident pass decodes only the
+    suffix, so the draft appends only the suffix.
+    """
+
+    def test_draft_slice_is_the_target_slice(self) -> None:
+        text = _shim_text()
+        self.assertIn(
+            "const std::vector<llama_token> & draft_tokens = process_tokens;", text)
+        self.assertIn("const int32_t draft_pos0 = process_pos0;", text)
+
+    def test_no_conditional_draft_slice_remains(self) -> None:
+        """The disproven branch must be gone, not merely bypassed."""
+        text = _shim_text()
+        self.assertNotIn("draft_mem_shared", text)
+        self.assertNotIn("draft_mem_shared ? process_tokens : prompt_tgt", text)
+
+    def test_draft_loop_consumes_the_target_slice_throughout(self) -> None:
+        """Loop bound, chunk bounds and base position must all follow it."""
+        text = _shim_text()
+        start = text.find("const std::vector<llama_token> & draft_tokens = process_tokens;")
+        self.assertGreater(start, -1)
+        end = text.find("common_speculative_begin", start)
+        self.assertGreater(end, start)
+        loop = text[start:end]
+        self.assertIn("offset < draft_tokens.size()", loop)
+        self.assertIn("chunk_size, draft_tokens.size() - offset", loop)
+        self.assertIn("fill_batch(prefill, chunk, draft_pos0 + (int32_t) offset)", loop)
+
+    def test_same_suffix_arithmetic(self) -> None:
+        """Behavioural: target and draft slices agree for cold and resident."""
+        for prompt_len, claim in ((20, 0), (20, 10), (45, 27)):
+            with self.subTest(prompt_len=prompt_len, claim=claim):
+                # resident pass decodes [claim, prompt_len); cold decodes all.
+                tgt_first, tgt_count = claim, prompt_len - claim
+                draft_first, draft_count = tgt_first, tgt_count
+                self.assertEqual(draft_first, tgt_first)
+                self.assertEqual(draft_count, tgt_count)
+                self.assertGreaterEqual(tgt_count, 1)
+
+    def test_draft_clear_is_paired_with_the_target_clear(self) -> None:
+        """Both halves clear together or not at all.
+
+        Clearing only the draft would leave the pair mismatched: draft empty
+        while the target holds the prefix, and pending_h naming a predecessor the
+        draft no longer contains.
+        """
+        text = _shim_text()
+        marker = 'if (!resident_pass) {\n                llama_memory_clear(mem_tgt, true);'
+        at = text.find(marker)
+        self.assertGreater(at, -1, "target clear must stay guarded by !resident_pass")
+        block = text[at:at + 700]
+        self.assertIn("llama_memory_clear(mem_dft, true);", block,
+                      "the draft clear must sit inside the same !resident_pass guard")
+
+
+class PostMutationExitTests(unittest.TestCase):
+    """Defect C: any exit after target mutation must leave the target untrusted.
+
+    `llama_decode(ctx_tgt, validate)` writes the speculative batch into mem_tgt
+    before it can report failure, so an error return leaves the frontier inflated
+    by uncommitted tokens. Rather than patch each return site, the flag is armed
+    once before the first mutation and cleared only at the single proven-canonical
+    success exit.
+    """
+
+    def test_flag_is_armed_before_any_target_mutation(self) -> None:
+        text = _shim_text()
+        # Anchor on the arming write itself, not on what happens to follow it:
+        # the pair-trust arming now sits between it and `need_replay`.
+        arm = text.find("    session->last_target_untrusted = true;\n    // The pair is poisoned")
+        self.assertGreater(arm, -1, "the arming write must exist")
+        for mutation in ("llama_memory_clear(mem_tgt, true);",
+                         "llama_decode(ctx_tgt,"):
+            at = text.find(mutation, arm)
+            self.assertGreater(at, arm, f"{mutation} must follow the arming write")
+
+    def test_only_the_canonical_exit_clears_the_flag(self) -> None:
+        """The disarm is a physical check, not an unconditional assignment."""
+        text = _shim_text()
+        self.assertIn(
+            "session->last_target_untrusted =\n"
+            "        llama_memory_seq_pos_max(mem_tgt, 0) != n_past - 1;",
+            text,
+        )
+
+    def test_disarm_follows_every_error_return(self) -> None:
+        """Every `return false` after arming exits with the flag still set."""
+        text = _shim_text()
+        # Anchor on the arming write itself, not on what happens to follow it:
+        # the pair-trust arming now sits between it and `need_replay`.
+        arm = text.find("    session->last_target_untrusted = true;\n    // The pair is poisoned")
+        disarm = text.find("llama_memory_seq_pos_max(mem_tgt, 0) != n_past - 1;")
+        self.assertGreater(disarm, arm)
+        body = text[arm:disarm]
+        # Each error return between arming and the canonical exit leaves the
+        # flag armed precisely because none of them clears it.
+        self.assertGreater(body.count("return false;"), 0)
+        self.assertNotIn("last_target_untrusted = false", body)
+
+    def test_a_refused_seq_rm_keeps_the_flag_armed(self) -> None:
+        """A refusal leaves the frontier long, so the physical disarm fails."""
+        pos_max_after_refusal = 40  # rejected tail still resident
+        n_past = 30
+        self.assertNotEqual(pos_max_after_refusal, n_past - 1)
+        self.assertTrue(pos_max_after_refusal != n_past - 1)
+
+    def test_canonical_completion_clears_the_flag(self) -> None:
+        """Recovery: a clean completion re-establishes trust."""
+        n_past = 30
+        pos_max = 29
+        self.assertFalse(pos_max != n_past - 1)
+
+    def test_untrusted_blocks_the_next_resident_claim(self) -> None:
+        text = _shim_text()
+        self.assertIn("!target_untrusted_from_previous", text)
+        read_at = text.find("const bool target_untrusted_from_previous")
+        clear_at = text.find("session->last_target_untrusted = false;", read_at)
+        use_at = text.find("!target_untrusted_from_previous", read_at)
+        self.assertLess(read_at, clear_at, "read before clearing")
+        self.assertLess(clear_at, use_at, "the carried-in copy gates the claim")
+
+
+class ResidentExportHardFailureTests(unittest.TestCase):
+    """Section 14: the CURRENT rebuilt shim must hard-fail on missing exports.
+
+    `CompiledExportTests.test_resident_symbols_are_exported` self-skips when all
+    resident symbols are absent, so a build that silently dropped both would
+    report a skip rather than a failure. That leniency is only defensible for an
+    OLD packaged artifact; for the shim this candidate actually builds, absence
+    is a hard failure.
+    """
+
+    def setUp(self) -> None:
+        self.shim = _built_shim()
+        if self.shim is None:
+            self.fail(
+                "no compiled shim: the current candidate must be built before "
+                "qualification -- this is a hard failure, not a skip"
+            )
+        self.exports = _exports(self.shim)
+        self.assertTrue(self.exports, "nm produced no symbols for the current shim")
+
+    def test_current_shim_exports_every_resident_symbol(self) -> None:
+        missing = [
+            s for s in pm._RESIDENT_PREFIX_REQUIRED_SHIM_SYMBOLS
+            if s not in self.exports
+        ]
+        self.assertEqual(
+            missing, [],
+            "the current rebuilt shim must export the resident-prefix ABI; "
+            "a missing export is a failure, never a skip",
+        )
+
+    def test_this_class_cannot_skip(self) -> None:
+        """Guard the guard: no test method here may skip.
+
+        Checks the executable bodies only -- prose about skipping is fine, a
+        call that actually skips is not.
+        """
+        import inspect
+
+        for name, fn in vars(ResidentExportHardFailureTests).items():
+            if not name.startswith(("test_", "setUp")):
+                continue
+            if name == "test_this_class_cannot_skip":
+                continue  # the guard itself names the call it forbids
+            body = inspect.getsource(fn)
+            code = "\n".join(
+                line for line in body.splitlines()
+                if not line.strip().startswith("#")
+            )
+            # Strip docstrings so prose mentioning the word does not match.
+            code = re.sub(r'""".*?"""', "", code, flags=re.S)
+            self.assertNotIn(
+                "skipTest", code, f"{name} must fail rather than skip"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_selfmtp_committed_bootstrap.py
+++ b/tests/test_selfmtp_committed_bootstrap.py
@@ -1,0 +1,306 @@
+"""Production reachability: cold turn bootstraps identity, next turn reuses it.
+
+Persistent self-MTP state is only worth anything if the real `/chat` path can
+reach it. That requires two things the runtime previously did not do: publish a
+committed identity after an MTP turn, and derive a resident claim from it on the
+next turn. Before this plumbing existed the MTP entry point invalidated identity
+unconditionally, so `len(committed)` was always 0 and no claim could ever be
+derived -- the backend's resident path was unreachable in production.
+
+These tests drive the real methods on a real client object with the native layer
+stubbed, so they prove the runtime decision, not a description of it.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.mtp_completion import MtpCompletionResult
+
+
+def _client(committed=(), prompt_tokens=(), coder=False):
+    """A client with just enough wired for the identity decisions."""
+    c = object.__new__(NativeLlamaClient)
+    c._session = MagicMock()
+    c._session.committed_sequence_tokens = list(committed)
+    c.tokenize = lambda text: list(prompt_tokens)
+    c._qwen3_coder_native_protocol = lambda: coder
+    return c
+
+
+def _result(success=True, pair_canonical=True, generated=(7, 8),
+            resident=(1, 2, 3, 7)):
+    """A completion result.
+
+    `resident` is what the backend measured as physically present in target KV,
+    and is deliberately NOT `prompt + generated`: a sampled token enters
+    `generated` before it is decoded into the sequence, so the two differ by the
+    final token. Identity is published from `resident` alone.
+    """
+    return MtpCompletionResult(
+        enabled=True, success=success, error=None,
+        pair_canonical=pair_canonical, generated_tokens=tuple(generated),
+        resident_tokens=tuple(resident),
+    )
+
+
+class ResidentClaimDerivationTests(unittest.TestCase):
+    """Python decides eligibility; strict equality only."""
+
+    def test_no_committed_identity_yields_no_claim(self) -> None:
+        c = _client(committed=(), prompt_tokens=(1, 2, 3))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", []), 0)
+
+    def test_exact_proper_prefix_yields_the_committed_length(self) -> None:
+        c = _client(prompt_tokens=(1, 2, 3, 4, 5))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 3)
+
+    def test_prefix_mismatch_yields_no_claim(self) -> None:
+        c = _client(prompt_tokens=(1, 2, 9, 4, 5))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
+
+    def test_claim_equal_to_prompt_length_is_denied(self) -> None:
+        """Defect A: a whole-prompt claim leaves no suffix, so sampling would
+        read logits from the previous completion."""
+        c = _client(prompt_tokens=(1, 2, 3))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
+
+    def test_claim_longer_than_the_prompt_is_denied(self) -> None:
+        c = _client(prompt_tokens=(1, 2))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
+
+    def test_no_longest_common_prefix_relaxation(self) -> None:
+        """A shared head is not identity; anything short of exact yields 0."""
+        c = _client(prompt_tokens=(1, 2, 3, 99, 5))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3, 4]), 0)
+
+    def test_coder_protocol_opts_out(self) -> None:
+        c = _client(prompt_tokens=(1, 2, 3, 4), coder=True)
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2]), 0)
+
+    def test_tokenizer_failure_falls_back_to_cold(self) -> None:
+        c = _client(prompt_tokens=(1, 2, 3, 4))
+        def boom(_text):
+            raise RuntimeError("tokenizer unavailable")
+        c.tokenize = boom
+        self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2]), 0)
+
+
+class CommittedPublicationTests(unittest.TestCase):
+    """Publication follows the backend's physical verdict, nothing else."""
+
+    def _publish(self, client, result):
+        client._invalidate_committed_sequence = MagicMock()
+        client._session.committed_sequence_tokens = [9, 9, 9]
+        client._publish_mtp_committed_identity(result, "p")
+        return client
+
+    @staticmethod
+    def _published(client):
+        """What identity the helper actually left on the session."""
+        return client._session.committed_sequence_tokens
+
+    def test_canonical_success_publishes_identity(self) -> None:
+        """A: cold canonical success must publish, or reuse cannot bootstrap."""
+        c = self._publish(_client(prompt_tokens=(1, 2, 3)), _result())
+        self.assertEqual(self._published(c), [1, 2, 3, 7])
+        c._invalidate_committed_sequence.assert_not_called()
+
+    def test_failed_completion_drops_identity(self) -> None:
+        c = self._publish(_client(prompt_tokens=(1, 2, 3)),
+                          _result(success=False))
+        c._invalidate_committed_sequence.assert_called_once()
+        self.assertEqual(self._published(c), [9, 9, 9],
+                         "nothing may be published on a non-canonical exit")
+
+    def test_resident_reuse_with_poisoned_pair_does_not_publish(self) -> None:
+        """G: resident_reuse_active is NOT pair_canonical."""
+        r = MtpCompletionResult(
+            enabled=True, success=True, error=None,
+            resident_reuse_active=True, pair_canonical=False,
+            generated_tokens=(7, 8), resident_tokens=(1, 2, 3, 7),
+        )
+        c = self._publish(_client(prompt_tokens=(1, 2, 3)), r)
+        c._invalidate_committed_sequence.assert_called_once()
+        self.assertEqual(self._published(c), [9, 9, 9],
+                         "nothing may be published on a non-canonical exit")
+
+    def test_cold_completion_ending_canonical_publishes(self) -> None:
+        """H: no resident reuse, but the pair ended canonical -> publish."""
+        r = MtpCompletionResult(
+            enabled=True, success=True, error=None,
+            resident_reuse_active=False, pair_canonical=True,
+            generated_tokens=(7, 8), resident_tokens=(1, 2, 3, 7),
+        )
+        c = self._publish(_client(prompt_tokens=(1, 2, 3)), r)
+        self.assertEqual(self._published(c), [1, 2, 3, 7])
+
+    def test_missing_resident_ids_drops_identity(self) -> None:
+        """Without a measured resident sequence there is nothing sound to claim.
+
+        Retokenizing the text is not equivalent, and prompt + generated
+        overstates residency by one token, so the only safe action is to drop.
+        """
+        c = self._publish(_client(prompt_tokens=(1, 2, 3)),
+                          _result(resident=()))
+        c._invalidate_committed_sequence.assert_called_once()
+        self.assertEqual(self._published(c), [9, 9, 9],
+                         "nothing may be published on a non-canonical exit")
+
+    def test_identity_is_the_measured_resident_sequence(self) -> None:
+        """Identity must equal what the backend measured, verbatim."""
+        c = _client(prompt_tokens=(1, 2, 3))
+        c._invalidate_committed_sequence = MagicMock()
+        c._publish_mtp_committed_identity(
+            _result(generated=(7, 8), resident=(1, 2, 3, 7)), "p"
+        )
+        self.assertEqual(c._session.committed_sequence_tokens, [1, 2, 3, 7])
+
+    def test_identity_is_never_prompt_plus_generated(self) -> None:
+        """The off-by-one that would corrupt the next turn.
+
+        prompt=(1,2,3) and generated=(7,8) would reconstruct [1,2,3,7,8] -- one
+        token longer than the [1,2,3,7] actually resident. Publishing that makes
+        the next turn skip prefill for a position that was never decoded, so
+        every following token lands one position early and output is silently
+        wrong. The published identity must track the measurement, not the
+        reconstruction.
+        """
+        c = _client(prompt_tokens=(1, 2, 3))
+        c._invalidate_committed_sequence = MagicMock()
+        c._publish_mtp_committed_identity(
+            _result(generated=(7, 8), resident=(1, 2, 3, 7)), "p"
+        )
+        published = c._session.committed_sequence_tokens
+        self.assertNotEqual(
+            published, [1, 2, 3, 7, 8],
+            "identity must not be rebuilt from prompt + generated_tokens",
+        )
+        self.assertEqual(len(published), 4)
+
+
+class ClaimWiringTests(unittest.TestCase):
+    """The derived claim must actually reach the native call.
+
+    Deriving N correctly is worthless if the value is not passed, and a mutation
+    that hardcodes 0 at the call site is invisible to tests that only exercise
+    the derivation helper. These assert the wiring itself, by AST rather than by
+    substring, so an unreachable or constant argument is caught.
+    """
+
+    def setUp(self) -> None:
+        import ast, inspect
+        self.ast = ast
+        src = inspect.getsource(NativeLlamaClient._try_complete_with_mtp_experimental)
+        self.fn = ast.parse(src.lstrip()).body[0]
+
+    def _completion_call(self):
+        for node in self.ast.walk(self.fn):
+            if (isinstance(node, self.ast.Call)
+                    and getattr(node.func, "id", None) == "run_persistent_mtp_completion"):
+                return node
+        self.fail("run_persistent_mtp_completion is not called")
+
+    def test_the_completion_receives_a_resident_claim(self) -> None:
+        call = self._completion_call()
+        kw = {k.arg: k.value for k in call.keywords}
+        self.assertIn("resident_prefix_len", kw,
+                      "the derived claim must be passed to the native completion")
+
+    def test_the_claim_is_the_derived_value_not_a_constant(self) -> None:
+        """A hardcoded 0 would silently disable resident reuse forever."""
+        call = self._completion_call()
+        kw = {k.arg: k.value for k in call.keywords}
+        node = kw["resident_prefix_len"]
+        self.assertNotIsInstance(
+            node, self.ast.Constant,
+            "resident_prefix_len must be the derived variable, not a literal",
+        )
+        self.assertEqual(getattr(node, "id", None), "resident_prefix_len")
+
+    def test_the_claim_is_derived_before_the_reset(self) -> None:
+        """Derivation reads committed identity; the reset clears the claim, so
+        the value must be computed first and applied afterwards."""
+        derive = reset = complete = None
+        for node in self.ast.walk(self.fn):
+            if isinstance(node, self.ast.Call):
+                attr = getattr(node.func, "attr", None)
+                name = getattr(node.func, "id", None)
+                if attr == "_resident_prefix_len_for_mtp" and derive is None:
+                    derive = node.lineno
+                if name == "reset_persistent_mtp_session" and reset is None:
+                    reset = node.lineno
+                if name == "run_persistent_mtp_completion" and complete is None:
+                    complete = node.lineno
+        self.assertIsNotNone(derive); self.assertIsNotNone(reset)
+        self.assertIsNotNone(complete)
+        self.assertLess(derive, reset, "derive the claim before the reset")
+        self.assertLess(reset, complete, "apply the claim after the reset")
+
+    def test_identity_is_snapshotted_before_the_reset(self) -> None:
+        snapshot = None
+        for node in self.ast.walk(self.fn):
+            if (isinstance(node, self.ast.Name)
+                    and node.id == "committed_at_entry"
+                    and isinstance(node.ctx, self.ast.Store)):
+                snapshot = node.lineno
+                break
+        self.assertIsNotNone(snapshot, "identity must be snapshotted at entry")
+
+
+class BootstrapLifecycleTests(unittest.TestCase):
+    """The decisive production-reachability property, end to end."""
+
+    def test_cold_turn_then_resident_turn(self) -> None:
+        """Turn 1 bootstraps identity; turn 2 derives a claim from it.
+
+        The identity carried between turns is the backend's MEASURED resident
+        sequence. Turn 1 prompts (1,2,3) and samples (4,5), but only (4) has
+        been decoded into KV when the completion ends, so residency is
+        [1,2,3,4] -- not the [1,2,3,4,5] a prompt+generated reconstruction would
+        produce. Turn 2's claim must describe the former, or it would name a
+        position that was never decoded.
+        """
+        # TURN 1: no identity, so no claim; a cold canonical success publishes.
+        c = _client(committed=(), prompt_tokens=(1, 2, 3))
+        self.assertEqual(c._resident_prefix_len_for_mtp("p1", []), 0)
+
+        c._session.committed_sequence_tokens = []
+        c._invalidate_committed_sequence = (
+            lambda: setattr(c._session, "committed_sequence_tokens", [])
+        )
+        c._publish_mtp_committed_identity(
+            _result(generated=(4, 5), resident=(1, 2, 3, 4)), "p1"
+        )
+        committed = c._session.committed_sequence_tokens
+        self.assertEqual(committed, [1, 2, 3, 4])
+        self.assertNotEqual(
+            committed, [1, 2, 3, 4, 5],
+            "identity must be the measured residency, not prompt + generated",
+        )
+
+        # TURN 2: the next prompt begins with exactly that sequence.
+        turn2_tokens = committed + [6, 7]
+        c2 = _client(committed=committed, prompt_tokens=tuple(turn2_tokens))
+        claim = c2._resident_prefix_len_for_mtp("p2", committed)
+        self.assertEqual(claim, len(committed))
+        self.assertTrue(0 < claim < len(turn2_tokens))
+
+    def test_a_poisoned_turn_forces_the_next_turn_cold(self) -> None:
+        c = _client(committed=(), prompt_tokens=(1, 2, 3))
+        c._session.committed_sequence_tokens = [1, 2, 3]
+        c._invalidate_committed_sequence = (
+            lambda: setattr(c._session, "committed_sequence_tokens", [])
+        )
+        c._publish_mtp_committed_identity(
+            _result(pair_canonical=False, generated=(4, 5),
+                    resident=(1, 2, 3, 4)), "p1")
+        self.assertEqual(c._session.committed_sequence_tokens, [],
+                         "a poisoned pair must leave no identity behind")
+        c2 = _client(committed=[], prompt_tokens=(1, 2, 3, 4))
+        self.assertEqual(c2._resident_prefix_len_for_mtp("p2", []), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Self-MTP rebuilt its speculative state from scratch on every `/chat` turn, so the target KV prefix, the draft KV and the `pending_h` hidden-state row were discarded at each completion boundary and every prompt was replayed from position 0.

Making reuse reachable needed both halves, which is why they land together:

- **native** — the persistent pair (target + draft + `pending_h`) now survives a completion. `complete()` picks SOFT when the whole pair is provably canonical and HARD otherwise, so per-request bookkeeping is still cleared while canonical state is kept. The resident claim is consumed one-shot where it is read.
- **runtime** — Python owns semantic eligibility only: it snapshots the committed identity, verifies a token-exact STRICT PROPER prefix, derives the resident claim, and publishes identity after the completion. The backend re-proves physical compatibility independently and may still refuse; neither side trusts the other's word.

### Committed identity

Identity is the backend's **measured** resident sequence, never `prompt + generated_tokens`. A sampled token enters `generated` at sample time but the resident sequence only on the following iteration, so reconstructing it overstates residency by one token. An identity longer than KV is a false cache hit: the next turn skips prefill for a position that was never decoded, which corrupts output silently rather than merely losing reuse. Text is never retokenized to build identity.

### Real-load qualification

One production load (Ornith-1.5-35B-Q4_K_M, real `/chat`, no injected claim):

| | Turn 1 (cold) | Turn 2 (resident) |
|---|---|---|
| reset mode | `hard` | `soft` |
| admission | `claim=0 admitted=false` | `claim=32 admitted=true` |
| pair verdict | `trusted` frontier=31 | `trusted` frontier=63 |
| cached / evaluated | 0 / 23 | 23 / 33 (of 56) |
| output | correct | correct |

`pending_pos=31 / fp=7766266848073820023 / gen=7`, `epoch=3` and the spec pointer are **byte-identical** across the completion boundary, and turn 2 emits no target or draft clear — so the pair genuinely persisted rather than being rebuilt. `resident_reuse_active` is the same boolean as `need_replay`'s negation, so it cannot report reuse while replaying. Real speculative decoding ran (drafted 6, accepted 6, `draft_decode_calls` 2).

### Scope

The five route/anchor MTP guards and the strict-prefix invariant `prompt_tokens[:len(committed)] == committed` are unchanged. MTP stays opt-in; no default is altered. No benchmarking, README or refactor changes.

Full suite 3684 passed (8 skipped) before and after the load; focused suites 188/188.
