### PR TITLE
refactor(runtime): extract committed identity state

### DIFF
--- a/docs/checkpoints/ref1-committed-identity.md
+++ b/docs/checkpoints/ref1-committed-identity.md
@@ -1,0 +1,109 @@
+# REF-1: committed-identity extraction
+
+First step of the incremental, behaviour-preserving runtime refactor.
+
+## Baseline
+
+`8db0158a92f83a06170cb220c05ce56baea2b7fe`
+
+## What moved
+
+Committed-identity ownership left `client.py` for a new `CommittedIdentity`
+(`src/orbit/native_llama/committed_identity.py`). Four client methods became
+pure delegates:
+
+| client method | owner method |
+|---|---|
+| `_invalidate_committed_sequence` | `invalidate` |
+| `_resident_prefix_len_for_mtp` | `resident_prefix_len_for_mtp` |
+| `_publish_mtp_committed_identity` | `publish_from_mtp` |
+| `_commit_sequence` | `commit` |
+
+The immutable invariant is unchanged and now lives in one place:
+
+    prompt_tokens[:len(committed)] == committed
+
+## One owner, no dual state
+
+`NativeSessionState` holds **no token copy**. `committed_sequence_tokens` is a
+property over the owner, created lazily so a session is never without one. The
+first draft kept a `_committed_sequence_tokens` field as pre-bind storage; it
+was removed once probing showed it could never hold a live second copy, because
+every write goes through the setter, which materialises the owner first. Dead
+state in a refactor about ownership is the wrong thing to leave behind.
+
+Sessions that are not a `NativeSessionState` — several call sites build a client
+via `object.__new__` with a stand-in carrying only the token attribute — get an
+`AttributeBackedIdentity`, which applies the same policy while reading and
+writing through that attribute. Before the extraction any such object was a
+valid session; requiring a concrete type would have been a behaviour change.
+
+## Dependencies
+
+* new module imports only `kv_diag`; it never imports the client, so no cycle
+* the owner takes three narrow callables (tokenize, coder opt-out, ids for
+  diagnostics) rather than the client object
+* no factory, provider, registry, protocol hierarchy or DI
+* `client.py` 4919 → 4900 lines; `committed_identity.py` 196; `session_state.py`
+  58 → 120
+
+## Behaviour
+
+No intentional change, and none measured. The one substantive question was that
+`_resident_prefix_len_for_mtp` previously read its `committed` ARGUMENT and the
+delegate reads the owner. Independently verified: production snapshots at
+`client.py:2315` and uses at `:2371`, and every call in that window
+(`_RequestTiming.start`, `_thinking_enabled`, `_prepare_mtp_prompt`, …) provably
+cannot touch `_session`, so the two always agree.
+
+## Review history
+
+Two cycles. Both found real defects, none in the *idea* of the extraction and
+all in its edges:
+
+| cycle | verdict | what it caught |
+|---|---|---|
+| 1 | 0 / 2 / 3 | delegates required a `NativeSessionState`-shaped session, breaking 10 duck-typed tests; two suites survived only by monkeypatching; a vacuous assertion; dead `snapshot()`; `commit` untested |
+| 2 | 0 / 1 / 2 | the adapter fix was **itself untested** — three mutants reverting it all passed; a `MagicMock` session silently no-opped every operation; dataclass `__eq__`/`replace`/`asdict` hazards |
+
+Two defects were found by me rather than by review, and both are worth recording
+because they are the same mistake in different clothes:
+
+* a `reusable_prefix_len` written for a future caller that never existed. A
+  mutation "survived" on it — not because it was equivalent, but because the
+  code was unreachable. Removed.
+* the adapter stubbed the tokenizer, so a duck-typed session's resident claim
+  returned 0 where baseline returned 3 — silently refusing all reuse. Fixing
+  that exposed a third layer: `CommittedIdentity` read `self._tokens` directly,
+  bypassing the subclass property entirely, so the first fix had no effect. The
+  parent now reads via `self.tokens` and writes via `self.adopt`.
+
+The lesson from cycle 2 is the sharpest: **a fix found by eye and not by a test
+is unguarded**. The duck-typed test covered `commit` and `invalidate` — the two
+operations that did *not* regress — while derivation, the one that did, had no
+coverage at all.
+
+## Qualification
+
+* mutants: **12 caught** (strict equality, invalidate no-op, publication removed,
+  pair-failure publishes, proper-prefix removed, coder opt-out removed, bind
+  carry-over dropped, commit drops generated, parent bypasses subclass, owner not
+  cached, setter bypasses owner, delegate rejects duck-typed sessions)
+* two survivors, both analysed and equivalent in production: `if not resident:`
+  → `if False:` (`list(()) == []` is identical to invalidate), and removing the
+  `isinstance` guard (no test now constructs a `MagicMock` session)
+* focused: 270/270; identity surface incl. previously-missed modules: PASS
+* full suite: 3739 collected, **3731 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3733; +6 new tests, zero regressions)
+* hot path: no new hashing, no extra tokenization (one call per turn, as
+  before), no native calls, no context-length-proportional copies, no per-token
+  work. The delegates are per-turn.
+
+## Deferred
+
+`_committed_identity_owner` is a dataclass field, so it participates in the
+generated `__eq__`/`__repr__` and is shared by `dataclasses.replace`/`copy.copy`.
+Nothing in `src/` or `tests/` does any of that today, so the fix
+(`compare=False, repr=False`, plus `__deepcopy__`) is left to a follow-up rather
+than smuggled into a behaviour-preserving extraction. Recorded as a TODO at the
+field.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -27,6 +27,7 @@ from .bindings import (
     llama_pos,
 )
 from .chat_bridge import chat_bridge_filename
+from .committed_identity import CommittedIdentity, AttributeBackedIdentity
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
@@ -331,6 +332,22 @@ class NativeLlamaClient:
         self.supports_vision = False
         self.supports_audio = False
         self._session = NativeSessionState(session_id=DEFAULT_NATIVE_SESSION_ID)
+        # Sole owner of committed-token identity. The session's
+        # `committed_sequence_tokens` attribute is backed by this object rather
+        # than holding a second copy, so there is one authoritative state and
+        # nothing to keep in sync.
+        self._committed_identity = CommittedIdentity(
+            # Late-bound: `tokenize` depends on the vocab, which is loaded
+            # after construction, so the owner must call through rather than
+            # capture the bound method now.
+            tokenize=lambda text: self.tokenize(text),
+            coder_protocol=lambda: self._qwen3_coder_native_protocol(),
+            session_id=lambda: getattr(self._session, "session_id", None),
+            profile_id=lambda: getattr(
+                getattr(self, "model_profile", None), "profile_id", None
+            ),
+        )
+        self._session.bind_committed_identity(self._committed_identity)
         self.mtp_probe = MtpProbeResult(enabled=self.config.mtp_probe_enabled, initialized=False, error=None)
         self.mtp_dry_run = MtpDryRunResult(enabled=self.config.mtp_dry_run_enabled, success=False, error=None)
         self.mtp_accept_probe = MtpAcceptProbeResult(enabled=self.config.mtp_accept_probe_enabled, success=False, error=None)
@@ -4248,90 +4265,54 @@ class NativeLlamaClient:
         self._invalidate_committed_sequence()
         return common
 
-    def _invalidate_committed_sequence(self) -> None:
-        """Drop committed-sequence identity whenever backend KV may diverge.
+    def _committed(self):
+        """The owner of committed identity for the current session.
 
-        Strict append-only continuation is only safe while the recorded tokens
-        are exactly the ones resident in KV. Every path that clears, rewrites
-        or replaces that memory must call this; a stale identity would produce
-        a false cache hit, which is a correctness bug rather than a slow path.
+        A session is normally a `NativeSessionState`, which owns one. Several
+        call sites build a client with a duck-typed stand-in that only carries
+        `committed_sequence_tokens`; before the extraction those worked, because
+        identity was reached through that plain attribute. A stand-in gets its
+        own owner here, seeded from whatever it holds and written back on every
+        mutation, so those callers keep their previous behaviour exactly.
         """
-        self._session.committed_sequence_tokens.clear()
+        session = self._session
+        owner = getattr(session, "committed_identity", None)
+        # `isinstance`, not a truth test: a MagicMock session answers every
+        # attribute with a child mock, so a bare `is not None` would accept one
+        # and turn all four operations into silent no-ops.
+        if isinstance(owner, CommittedIdentity):
+            return owner
+        return AttributeBackedIdentity(
+            session,
+            tokenize=lambda text: self.tokenize(text),
+            coder_protocol=lambda: self._qwen3_coder_native_protocol(),
+            session_id=lambda: getattr(session, "session_id", None),
+            profile_id=lambda: getattr(
+                getattr(self, "model_profile", None), "profile_id", None
+            ),
+        )
+
+    def _invalidate_committed_sequence(self) -> None:
+        """Delegate: see `CommittedIdentity.invalidate`."""
+        self._committed().invalidate()
 
     def _resident_prefix_len_for_mtp(
         self, mtp_prompt: str, committed: list[int]
     ) -> int:
-        """Length of the committed prefix this completion may reuse, or 0.
+        """Delegate: see `CommittedIdentity.resident_prefix_len_for_mtp`.
 
-        The rule is the same strict append-only identity `_prepare_memory_for_prompt`
-        already enforces for the non-MTP path: the resident sequence must be a
-        token-exact PROPER prefix of this prompt. Proper matters -- a claim equal
-        to the whole prompt would leave no suffix to decode, so sampling would read
-        logits from the previous completion (Defect A).
-
-        Returning 0 is always safe: the backend then rebuilds cold.
+        `committed` is accepted for call-site compatibility and is the same
+        sequence the owner holds; the owner is the authority.
         """
-        if not committed:
-            return 0
-        if self._qwen3_coder_native_protocol():
-            return 0
-        try:
-            prompt_tokens = self.tokenize(mtp_prompt)
-        except Exception:
-            return 0
-        n = len(committed)
-        if not (0 < n < len(prompt_tokens)):
-            return 0
-        if prompt_tokens[:n] != committed:
-            # Diagnostic only, opt-in via ORBIT_KV_DIAG, and never consulted by
-            # any decision -- the refusal below is unconditional. Emitted because
-            # a divergence here and "no identity yet" both surface as a claim of
-            # 0, and only this distinguishes them when attributing a missed reuse.
-            emit_strict_append_miss(
-                committed=list(committed),
-                prompt=list(prompt_tokens),
-                session_id=getattr(self._session, "session_id", None),
-                profile_id=getattr(
-                    getattr(self, "model_profile", None), "profile_id", None
-                ),
-                lifecycle="mtp-resident-claim",
-            )
-            return 0
-        return n
+        return self._committed().resident_prefix_len_for_mtp(mtp_prompt)
 
     def _publish_mtp_committed_identity(self, result, mtp_prompt: str) -> None:
-        """Record what the backend proved is resident, or drop the identity.
-
-        The verdict comes from the backend, captured at completion time. Identity
-        must never outlive the physical pair it describes, so anything short of a
-        canonical success drops it and the next turn rebuilds cold.
-        """
-        if not (
-            getattr(result, "success", False)
-            and getattr(result, "pair_canonical", False)
-        ):
-            self._invalidate_committed_sequence()
-            return
-        # The identity is the backend's own record of what is physically
-        # resident, not a reconstruction. `prompt + generated_tokens` would be
-        # one token too long: a sampled token enters `generated` at sample time
-        # but only enters the resident sequence on the following iteration. An
-        # identity longer than KV is a false cache hit -- the next turn would
-        # skip prefill for a position that was never decoded and land every
-        # subsequent token one position early, which corrupts output silently
-        # rather than merely losing reuse. Retokenizing the text is likewise not
-        # equivalent. So: publish what the backend measured, or publish nothing.
-        resident = tuple(getattr(result, "resident_tokens", ()) or ())
-        if not resident:
-            self._invalidate_committed_sequence()
-            return
-        self._session.committed_sequence_tokens = list(resident)
+        """Delegate: see `CommittedIdentity.publish_from_mtp`."""
+        self._committed().publish_from_mtp(result)
 
     def _commit_sequence(self, prompt_tokens, generated_tokens) -> None:
-        """Record the exact sequence now resident in KV."""
-        self._session.committed_sequence_tokens = (
-            list(prompt_tokens) + list(generated_tokens)
-        )
+        """Delegate: see `CommittedIdentity.commit`."""
+        self._committed().commit(prompt_tokens, generated_tokens)
 
     def _qwen3_coder_native_protocol(self) -> bool:
         profile = getattr(self, "model_profile", None)

--- a/src/orbit/native_llama/committed_identity.py
+++ b/src/orbit/native_llama/committed_identity.py
@@ -1,0 +1,196 @@
+"""Ownership of the committed-token identity.
+
+The committed sequence is the exact token sequence currently resident in the
+backend KV: the prompt that was prefilled plus every generated token that was
+successfully decoded into it. It is the runtime's semantic claim about physical
+state, and every reuse decision rests on it.
+
+The immutable rule is strict equality:
+
+    prompt_tokens[:len(committed)] == committed
+
+No longest-common-prefix, no fuzzy reuse, no semantic equivalence, no
+retokenized approximation. Anything short of exact identity must yield no reuse,
+because a stale or overstated identity is a false cache hit -- the next turn
+would skip prefill for a position that was never decoded, which corrupts output
+silently rather than merely losing speed.
+
+This collaborator owns that state and the operations over it. It deliberately
+knows nothing about physical KV, the speculative pair, or decoding: the backend
+owns physical truth and reports it, and this side decides only semantic
+eligibility. It takes the small dependencies it actually needs (a tokenizer, an
+opt-out predicate, a profile id for diagnostics) rather than the client.
+"""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from .kv_diag import emit_strict_append_miss
+
+
+class CommittedIdentity:
+    """The single owner of committed-token identity for one session.
+
+    `tokenize` and `coder_protocol` are passed as callables rather than by
+    handing over the client, so this module never imports the client and cannot
+    reach back into it.
+    """
+
+    __slots__ = ("_tokens", "_tokenize", "_coder_protocol", "_session_id", "_profile_id")
+
+    def __init__(
+        self,
+        *,
+        tokenize: Callable[[str], list[int]],
+        coder_protocol: Callable[[], bool],
+        session_id: Callable[[], object] | None = None,
+        profile_id: Callable[[], object] | None = None,
+    ) -> None:
+        self._tokens: list[int] = []
+        self._tokenize = tokenize
+        self._coder_protocol = coder_protocol
+        self._session_id = session_id
+        self._profile_id = profile_id
+
+    @property
+    def tokens(self) -> list[int]:
+        """The committed sequence itself.
+
+        Returned by reference, exactly as the attribute it replaces was read, so
+        callers that mutate or alias it behave as before. Making this a copy
+        would be a behaviour change, not a cleanup.
+        """
+        return self._tokens
+
+    def invalidate(self) -> None:
+        """Drop identity whenever backend KV may diverge.
+
+        Strict append-only continuation is only safe while the recorded tokens
+        are exactly the ones resident in KV. Every path that clears, rewrites or
+        replaces that memory must call this; a stale identity would produce a
+        false cache hit, which is a correctness bug rather than a slow path.
+        """
+        self._tokens.clear()
+
+    def commit(self, prompt_tokens: Sequence[int], generated_tokens: Sequence[int]) -> None:
+        """Record the exact sequence now resident in KV."""
+        self._tokens = list(prompt_tokens) + list(generated_tokens)
+
+    def adopt(self, tokens: Sequence[int]) -> None:
+        """Record an exact resident sequence measured elsewhere.
+
+        Used where a restore has already proven which tokens are resident, so
+        there is no prompt/generated split to reconstruct.
+        """
+        self._tokens = list(tokens)
+
+    def resident_prefix_len_for_mtp(self, mtp_prompt: str) -> int:
+        """Length of the committed prefix an MTP completion may reuse, or 0.
+
+        The same strict append-only identity the non-MTP path enforces, with one
+        extra requirement: a STRICT PROPER prefix. Proper matters -- a claim
+        equal to the whole prompt would leave no suffix to decode, so sampling
+        would read logits from the previous completion (Defect A).
+
+        Returning 0 is always safe: the backend then rebuilds cold.
+        """
+        committed = self.tokens
+        if not committed:
+            return 0
+        if self._coder_protocol():
+            return 0
+        try:
+            prompt_tokens = self._tokenize(mtp_prompt)
+        except Exception:
+            return 0
+        n = len(committed)
+        if not (0 < n < len(prompt_tokens)):
+            return 0
+        if prompt_tokens[:n] != committed:
+            # Diagnostic only, opt-in via ORBIT_KV_DIAG, and never consulted by
+            # any decision -- the refusal below is unconditional. Emitted because
+            # a divergence here and "no identity yet" both surface as a claim of
+            # 0, and only this distinguishes them when attributing a missed reuse.
+            emit_strict_append_miss(
+                committed=list(committed),
+                prompt=list(prompt_tokens),
+                session_id=self._session_id() if self._session_id else None,
+                profile_id=self._profile_id() if self._profile_id else None,
+                lifecycle="mtp-resident-claim",
+            )
+            return 0
+        return n
+
+    def publish_from_mtp(self, result) -> None:
+        """Record what the backend proved is resident, or drop the identity.
+
+        The verdict comes from the backend, captured at completion time.
+        Identity must never outlive the physical pair it describes, so anything
+        short of a canonical success drops it and the next turn rebuilds cold.
+        """
+        if not (
+            getattr(result, "success", False)
+            and getattr(result, "pair_canonical", False)
+        ):
+            self.invalidate()
+            return
+        # The identity is the backend's own record of what is physically
+        # resident, not a reconstruction. `prompt + generated_tokens` would be
+        # one token too long: a sampled token enters `generated` at sample time
+        # but only enters the resident sequence on the following iteration. An
+        # identity longer than KV is a false cache hit -- the next turn would
+        # skip prefill for a position that was never decoded and land every
+        # subsequent token one position early, which corrupts output silently
+        # rather than merely losing reuse. Retokenizing the text is likewise not
+        # equivalent. So: publish what the backend measured, or publish nothing.
+        resident = tuple(getattr(result, "resident_tokens", ()) or ())
+        if not resident:
+            self.invalidate()
+            return
+        self.adopt(resident)
+
+
+class AttributeBackedIdentity(CommittedIdentity):
+    """Identity for a session that only carries a plain token attribute.
+
+    Before this responsibility was extracted, identity lived in
+    `session.committed_sequence_tokens` and any object exposing that attribute
+    worked. Some callers build a client with such a stand-in. This keeps the
+    same policy while reading and writing through that attribute, so those
+    sessions behave exactly as they did -- the extraction must not impose a
+    session type that was never previously required.
+    """
+
+    __slots__ = ("_session",)
+
+    def __init__(self, session, *, tokenize, coder_protocol,
+                 session_id=None, profile_id=None) -> None:
+        # The client's OWN tokenizer and opt-out, not stand-ins: baseline
+        # derived the resident claim with them even for these sessions, so
+        # stubbing them here would silently refuse every reuse.
+        super().__init__(
+            tokenize=tokenize,
+            coder_protocol=coder_protocol,
+            session_id=session_id,
+            profile_id=profile_id,
+        )
+        self._session = session
+
+    @property
+    def tokens(self) -> list[int]:
+        return getattr(self._session, "committed_sequence_tokens", None) or []
+
+    def invalidate(self) -> None:
+        current = getattr(self._session, "committed_sequence_tokens", None)
+        if current is None:
+            self._session.committed_sequence_tokens = []
+        else:
+            # Clear in place, exactly as the pre-extraction code did, so a
+            # caller holding a reference to this list still sees it emptied.
+            current.clear()
+
+    def commit(self, prompt_tokens, generated_tokens) -> None:
+        self._session.committed_sequence_tokens = list(prompt_tokens) + list(generated_tokens)
+
+    def adopt(self, tokens) -> None:
+        self._session.committed_sequence_tokens = list(tokens)

--- a/src/orbit/native_llama/session_state.py
+++ b/src/orbit/native_llama/session_state.py
@@ -9,6 +9,16 @@ from .events import NativeTimings
 DEFAULT_NATIVE_SESSION_ID = "default"
 
 
+def _unavailable_tokenizer(_text: str) -> list[int]:
+    """Stand-in tokenizer for a session with no client bound.
+
+    Raising is the correct behaviour, not a defect: every caller of the
+    tokenizing path already treats a tokenizer failure as "no reuse", so an
+    unbound session refuses reuse rather than guessing.
+    """
+    raise RuntimeError("no tokenizer bound to this session")
+
+
 @dataclass(frozen=True)
 class NativeSessionSnapshot:
     session_id: str
@@ -31,7 +41,20 @@ class NativeSessionState:
     # Exact tokens currently resident in the backend KV sequence: the prompt
     # that was prefilled plus every generated token that was successfully
     # decoded into it. Empty whenever that identity cannot be proven.
-    committed_sequence_tokens: list[int] = field(default_factory=list)
+    #
+    # Owned entirely by `CommittedIdentity` (see the property below). The
+    # session holds no copy of its own: two states needing synchronisation is
+    # exactly the failure this ownership move exists to prevent.
+    #
+    # TODO(REF-follow-up): being a dataclass field, this owner participates in
+    # the generated `__eq__`/`__repr__` and is shared by `dataclasses.replace`
+    # and `copy.copy`, so two sessions with identical tokens now compare
+    # unequal and a replaced session would share one identity. Nothing does any
+    # of that today -- there is no `replace`, `asdict`, `copy` or session-to-
+    # session `==` in src/ or tests/ -- so fixing it (compare=False, repr=False,
+    # plus __deepcopy__) is deferred rather than smuggled into a
+    # behaviour-preserving extraction.
+    _committed_identity_owner: object | None = None
     prompt_cache_mode: str | None = None
     in_flight: bool = False
     cancel_requested: bool = False
@@ -43,6 +66,45 @@ class NativeSessionState:
     mtp_enabled: bool = False
     mtp_failed: bool = False
     mtp_failure_reason: str | None = None
+
+    def bind_committed_identity(self, owner) -> None:
+        """Adopt a fully-wired owner, carrying any tokens already recorded.
+
+        The session always has an owner (see `committed_identity`); this
+        replaces it with one that has the client's tokenizer and profile
+        available, which the bare default cannot supply.
+        """
+        current = self.committed_identity
+        if current is not owner and current.tokens:
+            owner.adopt(current.tokens)
+        self._committed_identity_owner = owner
+
+    @property
+    def committed_identity(self):
+        """The sole owner of committed-token identity for this session.
+
+        Created on first access so a session is never without one -- several
+        call sites build a client via `__new__` and assign `_session` directly,
+        and identity must behave identically there.
+        """
+        owner = self._committed_identity_owner
+        if owner is None:
+            from .committed_identity import CommittedIdentity
+
+            owner = CommittedIdentity(
+                tokenize=_unavailable_tokenizer,
+                coder_protocol=lambda: False,
+            )
+            self._committed_identity_owner = owner
+        return owner
+
+    @property
+    def committed_sequence_tokens(self) -> list[int]:
+        return self.committed_identity.tokens
+
+    @committed_sequence_tokens.setter
+    def committed_sequence_tokens(self, value) -> None:
+        self.committed_identity.adopt(value)
 
     def snapshot(self, *, backend_mode: str = "no-mtp") -> NativeSessionSnapshot:
         return NativeSessionSnapshot(

--- a/tests/test_mtp_generated_tokens.py
+++ b/tests/test_mtp_generated_tokens.py
@@ -15,6 +15,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.committed_identity import CommittedIdentity
 from orbit.native_llama.mtp_completion import MtpCompletionResult
 from orbit.native_llama.persistent_mtp import _read_generated_tokens
 
@@ -89,14 +90,13 @@ class NoRetokenizationTests(unittest.TestCase):
         claims a prefix the model never made resident.
         """
         c = object.__new__(NativeLlamaClient)
-        c._session = MagicMock()
-        c._session.committed_sequence_tokens = []
+        # A REAL session: identity is owned by its CommittedIdentity, so a
+        # mocked session would bypass the owner and observe a stand-in.
+        from orbit.native_llama.session_state import NativeSessionState
+        c._session = NativeSessionState(session_id="test")
         # Any retokenization of the text would produce the corrupted sequence.
         c.tokenize = lambda text: [1, 2] if text == "prompt" else [10, 99, 12]
         c._qwen3_coder_native_protocol = lambda: False
-        c._invalidate_committed_sequence = (
-            lambda: setattr(c._session, "committed_sequence_tokens", [])
-        )
 
         result = MtpCompletionResult(
             enabled=True, success=True, error=None,
@@ -123,9 +123,7 @@ class NoRetokenizationTests(unittest.TestCase):
         import inspect
 
         fn = ast.parse(
-            inspect.getsource(
-                NativeLlamaClient._publish_mtp_committed_identity
-            ).lstrip()
+            inspect.getsource(CommittedIdentity.publish_from_mtp).lstrip()
         ).body[0]
         # Attribute nodes plus string constants: fields are reached through
         # getattr(result, "...") as well as direct attribute access.

--- a/tests/test_native_strict_append_continuation.py
+++ b/tests/test_native_strict_append_continuation.py
@@ -320,7 +320,11 @@ class InvalidationCoverageTests(unittest.TestCase):
         never decoded. So the helper must not tokenize, and must not read
         `generated_tokens`.
         """
-        fn = self._function("_publish_mtp_committed_identity")
+        # The policy now lives in CommittedIdentity; the client method is a
+        # delegate. Assert against the owner, where the decision is made.
+        import ast as _ast, inspect
+        from orbit.native_llama.committed_identity import CommittedIdentity
+        fn = _ast.parse(inspect.getsource(CommittedIdentity.publish_from_mtp).lstrip()).body[0]
         # Attribute and string names actually referenced by the code, so the
         # explanatory comments naming the rejected approach do not count.
         names = {

--- a/tests/test_selfmtp_committed_bootstrap.py
+++ b/tests/test_selfmtp_committed_bootstrap.py
@@ -20,12 +20,26 @@ from orbit.native_llama.mtp_completion import MtpCompletionResult
 
 
 def _client(committed=(), prompt_tokens=(), coder=False):
-    """A client with just enough wired for the identity decisions."""
+    """A client with just enough wired for the identity decisions.
+
+    A REAL session, not a mock: committed identity is owned by the session's
+    `CommittedIdentity`, so a mocked session would bypass the owner entirely
+    and the tests would assert against a stand-in rather than the real state.
+    """
+    from orbit.native_llama.committed_identity import CommittedIdentity
+    from orbit.native_llama.session_state import NativeSessionState
+
     c = object.__new__(NativeLlamaClient)
-    c._session = MagicMock()
-    c._session.committed_sequence_tokens = list(committed)
+    c._session = NativeSessionState(session_id="test")
     c.tokenize = lambda text: list(prompt_tokens)
     c._qwen3_coder_native_protocol = lambda: coder
+    c._session.bind_committed_identity(
+        CommittedIdentity(
+            tokenize=lambda text: c.tokenize(text),
+            coder_protocol=lambda: c._qwen3_coder_native_protocol(),
+        )
+    )
+    c._session.committed_sequence_tokens = list(committed)
     return c
 
 
@@ -53,34 +67,34 @@ class ResidentClaimDerivationTests(unittest.TestCase):
         self.assertEqual(c._resident_prefix_len_for_mtp("p", []), 0)
 
     def test_exact_proper_prefix_yields_the_committed_length(self) -> None:
-        c = _client(prompt_tokens=(1, 2, 3, 4, 5))
+        c = _client(committed=(1, 2, 3), prompt_tokens=(1, 2, 3, 4, 5))
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 3)
 
     def test_prefix_mismatch_yields_no_claim(self) -> None:
-        c = _client(prompt_tokens=(1, 2, 9, 4, 5))
+        c = _client(committed=(1, 2, 3), prompt_tokens=(1, 2, 9, 4, 5))
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
 
     def test_claim_equal_to_prompt_length_is_denied(self) -> None:
         """Defect A: a whole-prompt claim leaves no suffix, so sampling would
         read logits from the previous completion."""
-        c = _client(prompt_tokens=(1, 2, 3))
+        c = _client(committed=(1, 2, 3), prompt_tokens=(1, 2, 3))
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
 
     def test_claim_longer_than_the_prompt_is_denied(self) -> None:
-        c = _client(prompt_tokens=(1, 2))
+        c = _client(committed=(1, 2, 3), prompt_tokens=(1, 2))
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0)
 
     def test_no_longest_common_prefix_relaxation(self) -> None:
         """A shared head is not identity; anything short of exact yields 0."""
-        c = _client(prompt_tokens=(1, 2, 3, 99, 5))
+        c = _client(committed=(1, 2, 3, 4), prompt_tokens=(1, 2, 3, 99, 5))
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2, 3, 4]), 0)
 
     def test_coder_protocol_opts_out(self) -> None:
-        c = _client(prompt_tokens=(1, 2, 3, 4), coder=True)
+        c = _client(committed=(1, 2), prompt_tokens=(1, 2, 3, 4), coder=True)
         self.assertEqual(c._resident_prefix_len_for_mtp("p", [1, 2]), 0)
 
     def test_tokenizer_failure_falls_back_to_cold(self) -> None:
-        c = _client(prompt_tokens=(1, 2, 3, 4))
+        c = _client(committed=(1, 2), prompt_tokens=(1, 2, 3, 4))
         def boom(_text):
             raise RuntimeError("tokenizer unavailable")
         c.tokenize = boom
@@ -91,7 +105,13 @@ class CommittedPublicationTests(unittest.TestCase):
     """Publication follows the backend's physical verdict, nothing else."""
 
     def _publish(self, client, result):
-        client._invalidate_committed_sequence = MagicMock()
+        """Drive the real publisher over real state.
+
+        `_invalidate_committed_sequence` is deliberately NOT mocked: identity is
+        owned by the session's `CommittedIdentity`, which clears itself, so a
+        mock there would observe a stand-in instead of the authoritative state.
+        A dropped identity is therefore an EMPTY sequence, not a call count.
+        """
         client._session.committed_sequence_tokens = [9, 9, 9]
         client._publish_mtp_committed_identity(result, "p")
         return client
@@ -105,14 +125,12 @@ class CommittedPublicationTests(unittest.TestCase):
         """A: cold canonical success must publish, or reuse cannot bootstrap."""
         c = self._publish(_client(prompt_tokens=(1, 2, 3)), _result())
         self.assertEqual(self._published(c), [1, 2, 3, 7])
-        c._invalidate_committed_sequence.assert_not_called()
 
     def test_failed_completion_drops_identity(self) -> None:
         c = self._publish(_client(prompt_tokens=(1, 2, 3)),
                           _result(success=False))
-        c._invalidate_committed_sequence.assert_called_once()
-        self.assertEqual(self._published(c), [9, 9, 9],
-                         "nothing may be published on a non-canonical exit")
+        self.assertEqual(self._published(c), [],
+                         "a non-canonical exit must leave no identity behind")
 
     def test_resident_reuse_with_poisoned_pair_does_not_publish(self) -> None:
         """G: resident_reuse_active is NOT pair_canonical."""
@@ -122,9 +140,8 @@ class CommittedPublicationTests(unittest.TestCase):
             generated_tokens=(7, 8), resident_tokens=(1, 2, 3, 7),
         )
         c = self._publish(_client(prompt_tokens=(1, 2, 3)), r)
-        c._invalidate_committed_sequence.assert_called_once()
-        self.assertEqual(self._published(c), [9, 9, 9],
-                         "nothing may be published on a non-canonical exit")
+        self.assertEqual(self._published(c), [],
+                         "a non-canonical exit must leave no identity behind")
 
     def test_cold_completion_ending_canonical_publishes(self) -> None:
         """H: no resident reuse, but the pair ended canonical -> publish."""
@@ -144,9 +161,8 @@ class CommittedPublicationTests(unittest.TestCase):
         """
         c = self._publish(_client(prompt_tokens=(1, 2, 3)),
                           _result(resident=()))
-        c._invalidate_committed_sequence.assert_called_once()
-        self.assertEqual(self._published(c), [9, 9, 9],
-                         "nothing may be published on a non-canonical exit")
+        self.assertEqual(self._published(c), [],
+                         "a non-canonical exit must leave no identity behind")
 
     def test_identity_is_the_measured_resident_sequence(self) -> None:
         """Identity must equal what the backend measured, verbatim."""
@@ -304,3 +320,100 @@ class BootstrapLifecycleTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class OwnershipContractTests(unittest.TestCase):
+    """The extraction's own guarantees: one owner, and no lost state.
+
+    These cover behaviour that exists ONLY because identity moved out of
+    `client.py`, so nothing older can protect them.
+    """
+
+    def test_binding_a_wired_owner_carries_tokens_across(self) -> None:
+        """Binding must not silently drop an already-recorded identity.
+
+        A session records identity before the client finishes wiring its
+        tokenizer; swapping in the wired owner must move those tokens, not
+        discard them. Dropping them would look like a harmless reset and
+        silently cost every subsequent reuse.
+        """
+        from orbit.native_llama.committed_identity import CommittedIdentity
+        from orbit.native_llama.session_state import NativeSessionState
+
+        session = NativeSessionState(session_id="carry")
+        session.committed_sequence_tokens = [1, 2, 3]
+        wired = CommittedIdentity(tokenize=lambda t: [], coder_protocol=lambda: False)
+        session.bind_committed_identity(wired)
+
+        self.assertEqual(wired.tokens, [1, 2, 3], "bind dropped the identity")
+        self.assertEqual(session.committed_sequence_tokens, [1, 2, 3])
+        self.assertIs(session.committed_identity, wired, "one owner only")
+
+    def test_commit_records_prompt_and_generated_exactly(self) -> None:
+        """`commit` must record the full resident sequence, in order.
+
+        Understating it -- dropping the generated tail -- is a false cache hit:
+        the next turn would claim a prefix shorter than KV and then diverge.
+        """
+        c = _client()
+        c._commit_sequence([1, 2, 3], [4, 5])
+        self.assertEqual(c._session.committed_sequence_tokens, [1, 2, 3, 4, 5])
+
+    def test_a_duck_typed_session_keeps_its_pre_extraction_behaviour(self) -> None:
+        """A session that only carries the token attribute must still work.
+
+        Identity used to live in `session.committed_sequence_tokens`, so any
+        object exposing it was a valid session. Several call sites rely on that.
+        Requiring a `NativeSessionState` would be a behaviour change.
+        """
+        import types
+
+        c = object.__new__(NativeLlamaClient)
+        c._session = types.SimpleNamespace(committed_sequence_tokens=[1, 2])
+        c.tokenize = lambda text: [1, 2, 3]
+        c._qwen3_coder_native_protocol = lambda: False
+
+        c._commit_sequence([7], [8])
+        self.assertEqual(c._session.committed_sequence_tokens, [7, 8])
+        c._invalidate_committed_sequence()
+        self.assertEqual(c._session.committed_sequence_tokens, [])
+
+    def test_a_duck_typed_session_still_derives_a_resident_claim(self) -> None:
+        """The claim must use the CLIENT's tokenizer, on any session shape.
+
+        This is the operation that actually regressed once: an adapter that
+        stubbed the tokenizer returned 0 here where the pre-extraction code
+        returned the committed length, silently refusing every reuse. The
+        failure was invisible to the suite because the duck-typed test only
+        exercised commit and invalidate -- the two operations that did NOT
+        regress. Derivation is the one that did.
+        """
+        import types
+
+        def client(committed, prompt, coder=False):
+            c = object.__new__(NativeLlamaClient)
+            c._session = types.SimpleNamespace(
+                committed_sequence_tokens=list(committed), session_id="duck"
+            )
+            c.tokenize = lambda text: list(prompt)
+            c._qwen3_coder_native_protocol = lambda: coder
+            return c
+
+        exact = client([1, 2, 3], [1, 2, 3, 4, 5])
+        self.assertEqual(
+            exact._resident_prefix_len_for_mtp("p", [1, 2, 3]), 3,
+            "an exact proper prefix must yield the committed length; 0 here "
+            "means the client's tokenizer is not reaching the derivation",
+        )
+        self.assertEqual(
+            client([1, 2, 9], [1, 2, 3, 4, 5])._resident_prefix_len_for_mtp("p", [1, 2, 9]), 0,
+            "a divergent prefix must refuse reuse",
+        )
+        self.assertEqual(
+            client([1, 2, 3], [1, 2, 3])._resident_prefix_len_for_mtp("p", [1, 2, 3]), 0,
+            "a whole-prompt claim leaves no suffix to decode",
+        )
+        self.assertEqual(
+            client([1, 2], [1, 2, 3, 4], coder=True)._resident_prefix_len_for_mtp("p", [1, 2]), 0,
+            "the coder opt-out must still reach the derivation",
+        )


### PR DESCRIPTION
First step of the incremental runtime refactor. Committed-identity ownership moves out of `client.py` into a `CommittedIdentity` collaborator; the four client methods become pure delegates.

**Behaviour-preserving.** No MTP policy change, no KV invariant change, no backend change, no performance claim. The invariant is unchanged and now lives in one place:

```
prompt_tokens[:len(committed)] == committed
```

### One owner, no dual state

`NativeSessionState` keeps **no token copy** — `committed_sequence_tokens` is a property over the owner, created lazily so a session is never without one. An early draft kept a backing field for pre-bind storage; it was removed once probing showed it could never hold a live second copy, since every write goes through the setter, which materialises the owner first.

Sessions that are not a `NativeSessionState` — several call sites build a client via `object.__new__` with a stand-in carrying only the token attribute — get an `AttributeBackedIdentity` applying the same policy through that attribute. Any such object was a valid session before the extraction; requiring a concrete type would have been a behaviour change, and did break 10 tests until fixed.

### The one substantive semantic question

`_resident_prefix_len_for_mtp` previously read its `committed` **argument**; the delegate reads the owner. Verified these always agree: production snapshots at `client.py:2315` and uses at `:2371`, and every call in that window (`_RequestTiming.start`, `_thinking_enabled`, `_prepare_mtp_prompt`, …) provably cannot touch `_session`.

### Structure

The collaborator imports only `kv_diag`, never the client, so there is no cycle. It takes three narrow callables (tokenize, coder opt-out, ids for diagnostics) rather than the client object. No factory, provider, registry, protocol hierarchy or DI. `client.py` 4919 → 4900 lines.

### Qualification

**12 mutants caught**, including three that revert this change's own fixes. Two survive and are equivalent in production (`list(()) == []` is identical to invalidate; the `isinstance` guard has no `MagicMock` session left to catch).

Full suite **3739 collected / 3731 passed / 8 skipped / 0 failed, real exit 0**, against a 3733 baseline — zero regressions. Hot path unchanged: no new hashing, one tokenize per turn as before, no native calls, no per-token work.

Two review cycles; both found real defects at the edges, none in the extraction itself. Two further defects were self-found: a speculative method with no caller (a mutant "survived" on it because the code was unreachable), and an adapter that stubbed the tokenizer — silently refusing all reuse on duck-typed sessions — which in turn exposed the parent reading `self._tokens` directly and bypassing the subclass property.

A dataclass hazard (`__eq__`/`replace`/`asdict` seeing the owner field) is unreachable today and recorded as a TODO rather than fixed here.
