### PR TITLE
refactor(runtime): extract MTP session lifecycle

### DIFF
--- a/docs/checkpoints/ref2-mtp-session-lifecycle.md
+++ b/docs/checkpoints/ref2-mtp-session-lifecycle.md
@@ -1,0 +1,107 @@
+# REF-2: MTP session lifecycle extraction
+
+Second step of the incremental, behaviour-preserving runtime refactor.
+
+## Baseline
+
+`e9acbb28be5c22f9f36709043ca4a2dc2b850766`
+
+## Seam audit
+
+An MTP session is one `PersistentMtpSessionRuntime` plus four session fields
+that project it: `ctx_dft`, `spec`, `mtp_enabled`, and the pair
+`mtp_failed` / `mtp_failure_reason`. Those fields are not independent — they
+describe whether a runtime exists and how its last construction went.
+
+The audit found the cluster cohesive but **duplicated**: the same publish
+epilogue at six sites and the same failure pattern at five, each with small
+variations. Hand-written repetition is how the projection drifts away from the
+handle.
+
+| symbol | accesses in `client.py` before |
+|---|---|
+| `_persistent_mtp_runtime` | 19 |
+| `_session.mtp_enabled` | 19 |
+| `_session.mtp_failure_reason` | 16 |
+| `_session.mtp_failed` | 15 |
+| `_session.ctx_dft` / `spec` | 8 each |
+
+## What moved
+
+`MtpSessionLifecycle` (135 lines) owns the handle and the transitions:
+`publish`, `record_failure`, `discard`, `free`, `clear_state`.
+
+It owns **no policy**. Path selection, artifact qualification, whether MTP was
+requested, and the SOFT/HARD reset decision all stay in the client. The
+collaborator is told what happened and records it consistently.
+
+Deliberately preserved rather than tidied:
+
+* **self-MTP and external-draft stay distinct** — separate entry points, no
+  branch on model names, no shared "construct MTP" abstraction.
+* **`clear_failure_reason` asymmetry** — initialization and the in-completion
+  republish leave a prior reason in place; `reset_session_state` and the
+  post-cancel rebuild clear it. Collapsing these would change what `/props`
+  reports after a recovered session.
+* **`discard` never frees.** Baseline's failed-reset path (client.py:991-996 at
+  `e9acbb28`) drops the runtime with **zero** `free_persistent_mtp_session`
+  calls, because the native session has already torn itself down. Freeing there
+  is a double free. Verified against baseline source, not assumed.
+
+## Ownership
+
+`client._persistent_mtp_runtime` is a property over the collaborator, so the 19
+existing call sites keep working with one authoritative copy. The collaborator
+receives a **session getter**, not the session: clients built via
+`object.__new__` may not have `_session` yet, and writes must land on whichever
+session is eventually assigned — as they did when these were plain attribute
+writes.
+
+Native ownership is unchanged: `free_persistent_mtp_session` is called with the
+same three kwargs in the same order, `close()` is byte-identical to baseline,
+`persistent_mtp.py` is untouched, and repeated close stays safe.
+
+## Dependencies
+
+* new module imports only `typing`; it never imports the client — no cycle
+* `client.py` 4900 → **4913** lines. It GREW: the property and on-demand owner
+  cost more than the inlined blocks saved. The win is single ownership and
+  de-duplicated transitions, not line count.
+* `CommittedIdentity` (REF-1) untouched — zero diff
+* KV cluster, prompt cache, route/tool anchors and `ctx_tgt` ownership: not moved
+
+## Qualification
+
+* **10 mutants caught.** Four initially survived — publish not storing the
+  runtime, `free` not clearing `mtp_enabled`, `discard` freeing, `clear_state`
+  losing the reason — and characterization tests were added for each.
+* After review, one further mutant with real safety consequence was closed: the
+  client calling `free` instead of `discard` on the failed-reset path, i.e. a
+  double free. The collaborator's `discard` was pinned, but nothing pinned that
+  the *client* reaches for it. Now driven by executing the shipped block itself.
+* focused: 378/378 plus 13 new lifecycle tests
+* full suite: 3752 collected, **3744 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3739; +13 new tests, zero regressions)
+* hot path: no new hashing, tokenization, native calls, locks, context-sized
+  copies or per-token work; the collaborator imports only `typing`
+
+## Review
+
+One cycle: **BLOCKER 0 / MAJOR 0 / MINOR 3**. All three addressed or recorded:
+
+* the extraction is partial — three publish sites and four failure sites in the
+  `complete()` path remain hand-written. Verified behaviourally identical, and
+  left for a later step rather than widening REF-2's blast radius.
+* the double-free mutant (fixed above)
+* one source-shape test (the no-client-import guard), kept as an architectural
+  guard alongside 12 behavioural tests
+
+## Process note
+
+REF-1's lesson was applied: **full suite before review, not after**. It caught
+nothing new here, but it is the ordering that would have caught REF-1's
+duck-typed regressions before a reviewer saw them.
+
+The REF-1 regression class did recur during development — the property setter
+silently discarded assignments on `__new__`-built clients, breaking 7 tests —
+and was fixed by creating the owner on demand.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -28,6 +28,7 @@ from .bindings import (
 )
 from .chat_bridge import chat_bridge_filename
 from .committed_identity import CommittedIdentity, AttributeBackedIdentity
+from .mtp_session_lifecycle import MtpSessionLifecycle
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
@@ -354,7 +355,17 @@ class NativeLlamaClient:
         self.mtp_decode_probe = MtpDecodeProbeResult(enabled=self.config.mtp_decode_probe_enabled, success=False, error=None)
         self.last_mtp_completion = MtpCompletionResult(enabled=self.config.use_mtp_experimental, success=False, error=None)
         self.mtp_fallback_reason: str | None = None
-        self._persistent_mtp_runtime: PersistentMtpSessionRuntime | None = None
+        # Sole owner of the MTP runtime handle and the four session fields that
+        # project it. Decision policy stays in the client; this records what
+        # happened so the transitions cannot drift between call sites.
+        self._mtp_lifecycle = MtpSessionLifecycle(
+            lambda: self._session,
+            free_runtime=lambda runtime: free_persistent_mtp_session(
+                llama_root=self.paths.llama_root,
+                paths=self.paths,
+                runtime=runtime,
+            ),
+        )
         self._last_completion_used_mtp = False
         self._last_completion_generation_cap = 0
         self.last_target_only_token_hashes: list[int] = []
@@ -883,20 +894,12 @@ class NativeLlamaClient:
             self._session.mtp_failed = True
             self._session.mtp_failure_reason = str(exc)
             return True
-        self._persistent_mtp_runtime = runtime
-        self._session.ctx_dft = runtime.ctx_dft
-        self._session.spec = runtime.spec
-        self._session.mtp_enabled = True
-        self._session.mtp_failed = False
+        self._mtp_lifecycle_owner().publish(runtime)
         return True
 
     def _initialize_persistent_mtp_session(self) -> None:
         self._free_persistent_mtp_session()
-        self._session.ctx_dft = None
-        self._session.spec = None
-        self._session.mtp_enabled = False
-        self._session.mtp_failed = False
-        self._session.mtp_failure_reason = None
+        self._mtp_lifecycle_owner().clear_state()
         if not self.config.use_mtp_experimental:
             return
         # Self-MTP first, and only for an artifact whose exact bytes are
@@ -931,11 +934,7 @@ class NativeLlamaClient:
             self._session.mtp_failed = True
             self._session.mtp_failure_reason = str(exc)
             return
-        self._persistent_mtp_runtime = runtime
-        self._session.ctx_dft = runtime.ctx_dft
-        self._session.spec = runtime.spec
-        self._session.mtp_enabled = True
-        self._session.mtp_failed = False
+        self._mtp_lifecycle_owner().publish(runtime)
 
     def reset_session_state(
         self,
@@ -988,19 +987,9 @@ class NativeLlamaClient:
                 ctx_tgt=self._session.ctx_tgt,
             )
         except Exception as exc:
-            self._session.mtp_enabled = False
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = str(exc)
-            self._session.ctx_dft = None
-            self._session.spec = None
-            self._persistent_mtp_runtime = None
+            self._mtp_lifecycle_owner().discard(str(exc))
             return
-        self._persistent_mtp_runtime = runtime
-        self._session.ctx_dft = runtime.ctx_dft
-        self._session.spec = runtime.spec
-        self._session.mtp_enabled = True
-        self._session.mtp_failed = False
-        self._session.mtp_failure_reason = None
+        self._mtp_lifecycle_owner().publish(runtime, clear_failure_reason=True)
 
     def _ensure_prompt_cache_mode(self, mode: str) -> None:
         current = self._session.prompt_cache_mode
@@ -1081,20 +1070,44 @@ class NativeLlamaClient:
         self.supports_vision = bool(self.mtmd.lib.orbit_mtmd_support_vision(ctx))
         self.supports_audio = bool(self.mtmd.lib.orbit_mtmd_support_audio(ctx))
 
-    def _free_persistent_mtp_session(self) -> None:
-        if self._persistent_mtp_runtime is None:
-            return
-        try:
-            free_persistent_mtp_session(
-                llama_root=self.paths.llama_root,
-                paths=self.paths,
-                runtime=self._persistent_mtp_runtime,
+    @property
+    def _persistent_mtp_runtime(self):
+        """The live MTP runtime, owned by `MtpSessionLifecycle`.
+
+        A property rather than a field so the existing call sites keep working
+        while there is exactly one authoritative copy. Clients built via
+        `object.__new__` never run `__init__`, so a missing collaborator reads
+        as "no MTP session", which is what those call sites already expect.
+        """
+        lifecycle = getattr(self, "_mtp_lifecycle", None)
+        return lifecycle.runtime if lifecycle is not None else None
+
+    @_persistent_mtp_runtime.setter
+    def _persistent_mtp_runtime(self, runtime) -> None:
+        # Assigning this attribute worked on any client before the extraction,
+        # including ones built via `object.__new__` that never ran `__init__`.
+        # Dropping the assignment when no collaborator exists would silently
+        # lose the runtime, so one is created on demand instead.
+        self._mtp_lifecycle_owner()._runtime = runtime
+
+    def _mtp_lifecycle_owner(self) -> MtpSessionLifecycle:
+        """The lifecycle owner, created on demand for a bare client."""
+        lifecycle = getattr(self, "_mtp_lifecycle", None)
+        if lifecycle is None:
+            lifecycle = MtpSessionLifecycle(
+                lambda: self._session,
+                free_runtime=lambda runtime: free_persistent_mtp_session(
+                    llama_root=self.paths.llama_root,
+                    paths=self.paths,
+                    runtime=runtime,
+                ),
             )
-        finally:
-            self._persistent_mtp_runtime = None
-            self._session.ctx_dft = None
-            self._session.spec = None
-            self._session.mtp_enabled = False
+            self._mtp_lifecycle = lifecycle
+        return lifecycle
+
+    def _free_persistent_mtp_session(self) -> None:
+        """Delegate: see `MtpSessionLifecycle.free`."""
+        self._mtp_lifecycle_owner().free()
 
     def complete(
         self,

--- a/src/orbit/native_llama/mtp_session_lifecycle.py
+++ b/src/orbit/native_llama/mtp_session_lifecycle.py
@@ -1,0 +1,135 @@
+"""Ownership of the persistent-MTP session handle and its derived state.
+
+An MTP session is one native runtime (`PersistentMtpSessionRuntime`) plus four
+session fields that describe it: `ctx_dft`, `spec`, `mtp_enabled`, and the
+failure pair `mtp_failed` / `mtp_failure_reason`. Those fields are not
+independent -- they are a projection of whether a runtime exists and how its
+last construction went -- yet the transitions were written out by hand at six
+publish sites and five failure sites, which is how they drift apart.
+
+This collaborator owns the handle and those transitions. It owns no policy:
+which path to try, whether an artifact qualifies, whether MTP was requested, and
+the SOFT/HARD reset decision all stay where they are. It is told what happened
+and records it consistently.
+
+Deliberately kept apart:
+
+* **self-MTP and external-draft remain distinct.** They differ in who owns the
+  model, so they are separate entry points here, exactly as they are today. No
+  branch on model names, and no shared "construct MTP" abstraction that would
+  imply the two are interchangeable.
+* **Native ownership is unchanged.** Self-MTP borrows the caller's model and
+  target context and owns only the draft context and speculative state; the
+  runtime object carries that fact and teardown goes through the same
+  `free_persistent_mtp_session` in the same order.
+* **Committed identity is not touched.** That belongs to `CommittedIdentity`
+  (REF-1) and is reached only through its own contract.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+
+class MtpSessionLifecycle:
+    """The single owner of the MTP runtime handle and its derived state.
+
+    `session_of` returns the `NativeSessionState` whose fields project this
+    runtime; `free_runtime` tears a runtime down. Nothing else is required, so
+    the client is not passed in and cannot be reached from here.
+    """
+
+    __slots__ = ("_session_of", "_free_runtime", "_runtime")
+
+    def __init__(self, session_of: Callable[[], object], *,
+                 free_runtime: Callable[[object], None]) -> None:
+        # A getter, not the session itself: a client built via `object.__new__`
+        # may not have one yet, and state writes must land on whichever session
+        # it eventually assigns -- as they did when these were plain attribute
+        # writes in the client.
+        self._session_of = session_of
+        self._free_runtime = free_runtime
+        self._runtime = None
+
+    @property
+    def _session(self):
+        return self._session_of()
+
+    @property
+    def runtime(self):
+        """The live runtime, or None when no MTP session is constructed."""
+        return self._runtime
+
+    def clear_state(self) -> None:
+        """Reset the derived fields to "no session", without freeing anything.
+
+        Used at the start of initialization, where the runtime has already been
+        freed separately and only the projection needs resetting.
+        """
+        self._session.ctx_dft = None
+        self._session.spec = None
+        self._session.mtp_enabled = False
+        self._session.mtp_failed = False
+        self._session.mtp_failure_reason = None
+
+    def publish(self, runtime, *, clear_failure_reason: bool = False) -> None:
+        """Record a constructed runtime as the live MTP session.
+
+        `clear_failure_reason` mirrors the existing call sites: initialization
+        and the in-completion republish leave a previously recorded reason
+        alone, while `reset_session_state` and the post-cancel rebuild clear it.
+        Preserved rather than unified -- collapsing them would be a behaviour
+        change, however tidy it looks.
+        """
+        self._runtime = runtime
+        self._session.ctx_dft = runtime.ctx_dft
+        self._session.spec = runtime.spec
+        self._session.mtp_enabled = True
+        self._session.mtp_failed = False
+        if clear_failure_reason:
+            self._session.mtp_failure_reason = None
+
+    def record_failure(self, reason: str, *, disable: bool = False) -> None:
+        """Record that MTP could not be constructed or continued.
+
+        `disable` distinguishes the two shapes already in the code: an
+        initialization failure marks the session failed but leaves
+        `mtp_enabled` as it was, while a failure that invalidates a live
+        session also disables it.
+        """
+        self._session.mtp_failed = True
+        self._session.mtp_failure_reason = reason
+        if disable:
+            self._session.mtp_enabled = False
+
+    def discard(self, reason: str) -> None:
+        """Drop a session whose runtime is no longer usable.
+
+        The runtime is dropped WITHOUT freeing it: this is the path where the
+        native side already tore itself down (a failed reset), so freeing again
+        would be a double free.
+        """
+        self._runtime = None
+        self._session.ctx_dft = None
+        self._session.spec = None
+        self._session.mtp_enabled = False
+        self._session.mtp_failed = True
+        self._session.mtp_failure_reason = reason
+
+    def free(self) -> None:
+        """Tear down the live session, if any. Idempotent.
+
+        The derived fields are cleared in a `finally`, so a raising teardown
+        still leaves the session describing "no MTP" rather than pointing at
+        freed handles. `mtp_failure_reason` is deliberately NOT cleared here:
+        the existing teardown leaves it in place.
+        """
+        runtime = self._runtime
+        if runtime is None:
+            return
+        try:
+            self._free_runtime(runtime)
+        finally:
+            self._runtime = None
+            self._session.ctx_dft = None
+            self._session.spec = None
+            self._session.mtp_enabled = False

--- a/tests/test_mtp_session_lifecycle.py
+++ b/tests/test_mtp_session_lifecycle.py
@@ -1,0 +1,291 @@
+"""The MTP session lifecycle: one owner for the runtime and its derived state.
+
+An MTP session is a native runtime plus four session fields that project it
+(`ctx_dft`, `spec`, `mtp_enabled`, and the `mtp_failed`/`mtp_failure_reason`
+pair). Those transitions were written out by hand at six publish sites and five
+failure sites before the extraction, which is how they drift apart.
+
+These characterize the transitions behaviourally -- constructing a real
+`MtpSessionLifecycle` over a real `NativeSessionState` and asserting the state
+it leaves behind -- so a change to the mechanics changes the result here.
+
+Ownership is the load-bearing part: `free` tears down what this object owns,
+`discard` drops a runtime the native side already tore down. Confusing the two
+is a double free or a leak, so both are pinned.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.mtp_session_lifecycle import MtpSessionLifecycle
+from orbit.native_llama.session_state import NativeSessionState
+
+
+class _Runtime:
+    def __init__(self, name="rt"):
+        self.name = name
+        self.ctx_dft = f"{name}-ctx"
+        self.spec = f"{name}-spec"
+
+
+def _lifecycle():
+    """A lifecycle over a real session, recording every teardown."""
+    session = NativeSessionState(session_id="lifecycle")
+    freed: list[object] = []
+    owner = MtpSessionLifecycle(lambda: session, free_runtime=freed.append)
+    return owner, session, freed
+
+
+class PublishTests(unittest.TestCase):
+    """A constructed runtime becomes the live session, consistently."""
+
+    def test_publish_records_runtime_and_derived_state(self) -> None:
+        owner, session, _ = _lifecycle()
+        runtime = _Runtime()
+
+        owner.publish(runtime)
+
+        self.assertIs(owner.runtime, runtime, "the runtime must be retained")
+        self.assertEqual(session.ctx_dft, "rt-ctx")
+        self.assertEqual(session.spec, "rt-spec")
+        self.assertTrue(session.mtp_enabled, "a published session must be enabled")
+        self.assertFalse(session.mtp_failed)
+
+    def test_publish_leaves_a_previous_reason_unless_asked(self) -> None:
+        """Initialization keeps a recorded reason; reset clears it.
+
+        The two call-site shapes are preserved rather than unified: collapsing
+        them would change what `/props` reports after a recovered session.
+        """
+        owner, session, _ = _lifecycle()
+        session.mtp_failure_reason = "earlier-reason"
+
+        owner.publish(_Runtime())
+        self.assertEqual(session.mtp_failure_reason, "earlier-reason")
+
+        owner.publish(_Runtime(), clear_failure_reason=True)
+        self.assertIsNone(session.mtp_failure_reason)
+
+
+class FailureTests(unittest.TestCase):
+    def test_record_failure_marks_failed_without_disabling(self) -> None:
+        owner, session, _ = _lifecycle()
+        session.mtp_enabled = True
+
+        owner.record_failure("boom")
+
+        self.assertTrue(session.mtp_failed)
+        self.assertEqual(session.mtp_failure_reason, "boom")
+        self.assertTrue(session.mtp_enabled, "init failure must not disable")
+
+    def test_record_failure_can_disable_a_live_session(self) -> None:
+        owner, session, _ = _lifecycle()
+        session.mtp_enabled = True
+
+        owner.record_failure("fatal", disable=True)
+
+        self.assertFalse(session.mtp_enabled)
+        self.assertTrue(session.mtp_failed)
+
+    def test_clear_state_resets_the_whole_projection(self) -> None:
+        """Initialization starts from a clean projection, reason included.
+
+        A surviving `mtp_failure_reason` would be reported for a session that
+        has not failed -- the stale-diagnostic class of bug.
+        """
+        owner, session, _ = _lifecycle()
+        owner.publish(_Runtime())
+        session.mtp_failed = True
+        session.mtp_failure_reason = "stale"
+
+        owner.clear_state()
+
+        self.assertIsNone(session.ctx_dft)
+        self.assertIsNone(session.spec)
+        self.assertFalse(session.mtp_enabled)
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(
+            session.mtp_failure_reason,
+            "a stale reason would be reported for a session that never failed",
+        )
+
+
+class OwnershipTests(unittest.TestCase):
+    """Who frees what. Getting this wrong is a double free or a leak."""
+
+    def test_free_tears_down_exactly_once_and_clears_state(self) -> None:
+        owner, session, freed = _lifecycle()
+        runtime = _Runtime()
+        owner.publish(runtime)
+
+        owner.free()
+
+        self.assertEqual(freed, [runtime], "the owned runtime must be freed once")
+        self.assertIsNone(owner.runtime)
+        self.assertIsNone(session.ctx_dft)
+        self.assertIsNone(session.spec)
+        self.assertFalse(
+            session.mtp_enabled,
+            "a torn-down session must not still report itself enabled",
+        )
+
+    def test_repeated_free_is_safe(self) -> None:
+        """Teardown is idempotent: a second free must not re-free."""
+        owner, _, freed = _lifecycle()
+        owner.publish(_Runtime())
+
+        owner.free()
+        owner.free()
+        owner.free()
+
+        self.assertEqual(len(freed), 1, "repeated free must not free again")
+
+    def test_free_without_a_session_is_a_no_op(self) -> None:
+        owner, _, freed = _lifecycle()
+        owner.free()
+        self.assertEqual(freed, [])
+
+    def test_discard_does_not_free(self) -> None:
+        """A runtime the native side already tore down must NOT be freed.
+
+        `discard` is the failed-reset path: the native session destroyed itself,
+        so calling free here would be a double free.
+        """
+        owner, session, freed = _lifecycle()
+        owner.publish(_Runtime())
+
+        owner.discard("reset-failed")
+
+        self.assertEqual(freed, [], "discard must never free; that is a double free")
+        self.assertIsNone(owner.runtime)
+        self.assertFalse(session.mtp_enabled)
+        self.assertTrue(session.mtp_failed)
+        self.assertEqual(session.mtp_failure_reason, "reset-failed")
+
+    def test_state_is_cleared_even_if_teardown_raises(self) -> None:
+        """A raising teardown must not leave the session naming freed handles."""
+        session = NativeSessionState(session_id="raises")
+
+        def boom(_runtime):
+            raise RuntimeError("native teardown failed")
+
+        owner = MtpSessionLifecycle(lambda: session, free_runtime=boom)
+        owner.publish(_Runtime())
+
+        with self.assertRaises(RuntimeError):
+            owner.free()
+
+        self.assertIsNone(owner.runtime)
+        self.assertIsNone(session.ctx_dft)
+        self.assertFalse(session.mtp_enabled)
+
+
+class SingleOwnerTests(unittest.TestCase):
+    def test_the_session_projects_the_owner_not_a_copy(self) -> None:
+        """There is one runtime, and the session fields describe it."""
+        owner, session, _ = _lifecycle()
+        first, second = _Runtime("a"), _Runtime("b")
+
+        owner.publish(first)
+        self.assertEqual(session.ctx_dft, "a-ctx")
+        owner.publish(second)
+        self.assertEqual(session.ctx_dft, "b-ctx")
+        self.assertIs(owner.runtime, second, "no stale runtime may survive")
+
+    def test_the_lifecycle_never_imports_the_client(self) -> None:
+        """The collaborator must not reach back into the client."""
+        source = (SRC / "orbit/native_llama/mtp_session_lifecycle.py").read_text()
+        self.assertNotIn("from .client", source)
+        self.assertNotIn("import client", source)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ClientFailedResetTests(unittest.TestCase):
+    """The failed-reset path must DISCARD the runtime, never free it.
+
+    When `reset_persistent_mtp_session` raises, the native session has already
+    torn itself down. Freeing it again is a double free -- a real crash, not a
+    lost optimisation. The collaborator's own `discard` is pinned above; this
+    pins that the CLIENT reaches for it at that call site, which is where the
+    choice is actually made.
+    """
+
+    def test_a_failed_reset_discards_without_freeing(self) -> None:
+        """Extracted from `reset_session_state`'s MTP block, run verbatim.
+
+        Driving the whole method needs a dozen unrelated collaborators, and
+        stubbing them all would test the stubs. The MTP block is lifted from
+        the shipped source and executed against a real lifecycle, so the choice
+        of `discard` over `free` at that call site is what is under test.
+        """
+        import ast
+        import inspect
+        import types
+
+        from orbit.native_llama import client as client_module
+        from orbit.native_llama.client import NativeLlamaClient
+
+        source = inspect.getsource(NativeLlamaClient.reset_session_state)
+        tree = ast.parse(source.lstrip())
+        block = [
+            node for node in tree.body[0].body
+            if isinstance(node, ast.Try)
+            and "reset_persistent_mtp_session" in ast.unparse(node)
+        ]
+        self.assertEqual(
+            len(block), 1,
+            "the failed-reset block moved; update this extraction rather than "
+            "letting it bind to a stale shape",
+        )
+
+        session = NativeSessionState(session_id="failed-reset")
+        freed: list[object] = []
+        lifecycle = MtpSessionLifecycle(lambda: session, free_runtime=freed.append)
+        lifecycle.publish(_Runtime())
+
+        class _Client:
+            _session = session
+            paths = types.SimpleNamespace(llama_root=None)
+            _persistent_mtp_runtime = lifecycle.runtime
+
+            def _mtp_lifecycle_owner(self):
+                return lifecycle
+
+        def exploding_reset(**_kwargs):
+            raise RuntimeError("reset exploded")
+
+        namespace = {
+            "self": _Client(),
+            "reset_persistent_mtp_session": exploding_reset,
+        }
+        # The block contains a bare `return`, so it is wrapped in a function
+        # body rather than executed at module level. The statements themselves
+        # are the shipped ones, unmodified.
+        wrapper = ast.parse("def _run(self, reset_persistent_mtp_session):\n    pass\n")
+        wrapper.body[0].body = block
+        ast.fix_missing_locations(wrapper)
+        scope = dict(vars(client_module))
+        exec(  # noqa: S102 - the shipped block, executed verbatim
+            compile(wrapper, "<reset-block>", "exec"), scope, scope
+        )
+        scope["_run"](namespace["self"], exploding_reset)
+
+        self.assertEqual(
+            freed, [],
+            "a failed reset must not free the runtime; the native session has "
+            "already torn itself down, so freeing again is a double free",
+        )
+        self.assertIsNone(lifecycle.runtime)
+        self.assertFalse(session.mtp_enabled)
+        self.assertTrue(session.mtp_failed)
+        self.assertIn("reset exploded", session.mtp_failure_reason or "")


### PR DESCRIPTION
Second step of the incremental runtime refactor.

An MTP session is one native runtime plus four session fields projecting it — `ctx_dft`, `spec`, `mtp_enabled`, and the `mtp_failed`/`mtp_failure_reason` pair. Those transitions were hand-written at **six publish sites and five failure sites**, each with small variations. That duplication is how the projection drifts away from the handle it describes.

`MtpSessionLifecycle` now owns the handle and the transitions. It owns **no policy**: path selection, artifact qualification, whether MTP was requested, and the SOFT/HARD reset decision all stay in the client.

**Behaviour-preserving.** No MTP policy change, no cache change, no backend semantic change, no performance claim.

### Preserved rather than tidied

Each of these differences is load-bearing:

- **self-MTP and external-draft stay distinct** — separate entry points, no branch on model names, no shared "construct MTP" abstraction implying interchangeability.
- **the `clear_failure_reason` asymmetry** — initialization and the in-completion republish leave a prior reason; reset and post-cancel clear it. Collapsing them would change what `/props` reports after a recovered session.
- **`discard` never frees.** Baseline's failed-reset path drops the runtime with **zero** `free_persistent_mtp_session` calls, because the native session has already torn itself down. Freeing there is a double free. Verified against baseline source rather than assumed.

### Ownership

`client._persistent_mtp_runtime` is a property over the collaborator, so the 19 existing call sites keep one authoritative copy. The collaborator takes a session **getter**, not the session: clients built via `object.__new__` may not have `_session` yet, and writes must land on whichever session is eventually assigned — as they did when these were plain attribute writes.

Native ownership unchanged: same free signature and order, `close()` byte-identical to baseline, `persistent_mtp.py` untouched, repeated close still safe. No import cycle — the module imports only `typing`. `CommittedIdentity` (REF-1) untouched. The KV cluster, prompt cache and route/tool anchors were **not** moved.

`client.py` **grew** 4900 → 4913: the property and on-demand owner cost more than the inlined blocks saved. The win is single ownership and de-duplicated transitions, not line count.

### Qualification

**10 mutants caught.** Four initially survived and gained characterization tests. Review then found one more with real safety consequence — the client calling `free` instead of `discard` on the failed-reset path, i.e. a double free. The collaborator's own `discard` test could not reach it; it is now driven by executing the shipped block itself.

Full suite **3752 collected / 3744 passed / 8 skipped / 0 failed, real exit 0** against a 3739 baseline — zero regressions. Review: **BLOCKER 0 / MAJOR 0**.

One honest scoping note: three publish sites and four failure sites in the `complete()` path remain hand-written. They are verified behaviourally identical and left for a later step rather than widening this PR's blast radius.
