### PR TITLE
refactor(runtime): complete MTP lifecycle delegation

### DIFF
--- a/docs/checkpoints/ref3-lifecycle-delegation.md
+++ b/docs/checkpoints/ref3-lifecycle-delegation.md
@@ -1,0 +1,94 @@
+# REF-3: complete MTP lifecycle delegation
+
+Third step of the incremental, behaviour-preserving runtime refactor. Finishes
+the REF-2 seam rather than opening a new one.
+
+## Baseline
+
+`3d529498c78c01144eec269c1089d77957f21755`
+
+## What was left
+
+REF-2 made `MtpSessionLifecycle` the sole owner of the MTP runtime handle and
+its four derived session fields, but the completion hot path
+(`_try_complete_with_mtp_experimental`) still hand-wrote those transitions at
+**7 sites** — the request path, and so the one most exposed to the drift the
+extraction exists to prevent.
+
+## Site map
+
+| site | baseline lines | transition | now |
+|---|---|---|---|
+| 1 | 2409-2411 | failure + disable | `record_failure(reason, disable=True)` |
+| 2 | 2415-2417 | attach handle, verdict untouched | `attach(runtime)` |
+| 3 | 2467-2469 | failure + disable (post-cancel) | `record_failure(reason, disable=True)` |
+| 4 | 2471-2476 | publish + clear reason | `publish(runtime, clear_failure_reason=True)` |
+| 5 | 2479-2481 | failure + disable | `record_failure(reason, disable=True)` |
+| 6-7 | 2484-2486 | mark healthy, no handle | `mark_ready()` |
+
+Direct writes to lifecycle-owned fields in the completion path: **32 → 0**. The
+6 init-path writes (client.py ~870-935) are out of REF-3's scope and byte-
+identical to baseline.
+
+## Two methods added, and why
+
+The mission bar is: one coherent transition, ≥2 duplicated sites, behaviourally
+pinnable. Both qualify, and neither is expressible with existing methods:
+
+* **`attach(runtime)`** records the handle and `ctx_dft`/`spec` but deliberately
+  leaves `mtp_enabled`/`mtp_failed` alone. Verified by execution before adding
+  it: from `(enabled=False, failed=True)`, `attach` preserves that, while
+  `publish` flips to `(True, False)`. Using `publish` at site 2 would declare a
+  failed session ready **before the completion has run**.
+* **`mark_ready()`** sets the verdict with no handle changing hands. Expressing
+  it as `publish(self._persistent_mtp_runtime, ...)` errors when nothing is
+  attached — a genuinely different operation.
+
+## Qualification
+
+**9 mutants caught**: `attach`→`publish`, `mark_ready`→no-op, dropped
+`disable=True`, dropped `clear_failure_reason=True`, `attach` not storing the
+handle, `attach` setting enabled, `mark_ready` losing the reason, a restored
+direct `_session.mtp_*` write, and a failed rebuild calling `free` instead of
+recording failure (a double free).
+
+* focused: 386/386 plus 23 lifecycle tests
+* full suite: 3762 collected, **3754 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3752; +10 tests, zero regressions)
+* `client.py` 4913 → **4909**; lifecycle module 135 → 160
+* hot path: delegation only — no hashing, tokenization, native calls, resets,
+  locks, context copies or per-token work
+* `CommittedIdentity` zero diff; five guards unchanged; `use_mtp_experimental`
+  still `False`; no `.cpp`/`.h` in the diff; self-MTP and external-draft still
+  distinct
+
+## The test-quality correction
+
+The first version pinned the call sites with **AST inspection** — asserting
+which method appeared in the source. That is the source-shape pattern three
+earlier review cycles in this repo rejected, and it was wrong here for the same
+reason: it proves shape, not behaviour.
+
+Mid-review I replaced it. The failure block (14 lines, 7 stubbable
+collaborators) and the two success statements are now extracted and **executed
+verbatim** against a real lifecycle, asserting resulting session state. The
+review confirmed the consequence: `mark_ready`→no-op and dropped `disable=True`
+are caught **exclusively** by the executed tests. The suite would still catch
+them with every AST test deleted.
+
+Two AST tests remain as secondary pins, annotated to say so — cheap to keep,
+useful for localising a failure, never the only thing between a mutation and a
+green suite.
+
+## Review
+
+One cycle: **BLOCKER 0 / MAJOR 0 / MINOR 2**.
+
+Equivalence was verified exhaustively rather than by inspection: 6 distinct
+transitions × the full 64-precondition space of the five session fields plus the
+prior handle → **0 divergences**.
+
+Both minors addressed or recorded: the redundant AST tests are annotated, and
+two surviving mutants in `mtp_fallback_reason` plumbing were confirmed
+**pre-existing at baseline** — a client-owned field REF-3 deliberately does not
+own. Recorded as a follow-up, not smuggled into this PR.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -2406,15 +2406,15 @@ class NativeLlamaClient:
             except Exception as exc:
                 self.mtp_fallback_reason = str(exc) or "persistent-mtp-reset-failed"
                 self.last_mtp_completion = MtpCompletionResult(enabled=True, success=False, error=self.mtp_fallback_reason)
-                self._session.mtp_failed = True
-                self._session.mtp_failure_reason = self.mtp_fallback_reason
-                self._session.mtp_enabled = False
+                self._mtp_lifecycle_owner().record_failure(
+                    self.mtp_fallback_reason, disable=True
+                )
                 return None
         else:
             runtime = self._persistent_mtp_runtime
-        self._persistent_mtp_runtime = runtime
-        self._session.ctx_dft = runtime.ctx_dft
-        self._session.spec = runtime.spec
+        # attach, not publish: readiness is decided by the outcome below, and
+        # the runtime may be the one already in use.
+        self._mtp_lifecycle_owner().attach(runtime)
         streamed_parts: list[str] = []
         generation_cap = max(1, max_tokens)
         self._last_completion_generation_cap = generation_cap
@@ -2464,26 +2464,22 @@ class NativeLlamaClient:
                         ctx_tgt=self._session.ctx_tgt,
                     )
                 except Exception as exc:
-                    self._session.mtp_failed = True
-                    self._session.mtp_failure_reason = str(exc) or "persistent-mtp-reset-failed-after-cancel"
-                    self._session.mtp_enabled = False
+                    self._mtp_lifecycle_owner().record_failure(
+                        str(exc) or "persistent-mtp-reset-failed-after-cancel",
+                        disable=True,
+                    )
                     return None
-                self._persistent_mtp_runtime = runtime
-                self._session.ctx_dft = runtime.ctx_dft
-                self._session.spec = runtime.spec
-                self._session.mtp_failed = False
-                self._session.mtp_failure_reason = None
-                self._session.mtp_enabled = True
+                self._mtp_lifecycle_owner().publish(
+                    runtime, clear_failure_reason=True
+                )
                 return None
             self.mtp_fallback_reason = result.error or "mtp-experimental-failed"
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = self.mtp_fallback_reason
-            self._session.mtp_enabled = False
+            self._mtp_lifecycle_owner().record_failure(
+                self.mtp_fallback_reason, disable=True
+            )
             return None
         self.mtp_fallback_reason = None
-        self._session.mtp_failed = False
-        self._session.mtp_failure_reason = None
-        self._session.mtp_enabled = True
+        self._mtp_lifecycle_owner().mark_ready()
         if result.content and on_token and not streamed_parts:
             on_token(result.content)
         prompt_token_list = self.tokenize(mtp_prompt) if self._vocab else []

--- a/src/orbit/native_llama/mtp_session_lifecycle.py
+++ b/src/orbit/native_llama/mtp_session_lifecycle.py
@@ -88,6 +88,31 @@ class MtpSessionLifecycle:
         if clear_failure_reason:
             self._session.mtp_failure_reason = None
 
+    def attach(self, runtime) -> None:
+        """Point the session at a runtime WITHOUT declaring it ready.
+
+        Distinct from `publish`: this records the handle and its two derived
+        context fields but leaves `mtp_enabled` / `mtp_failed` exactly as they
+        were. The completion path uses it where the runtime may be the one
+        already in use, and where readiness is decided later by the outcome --
+        using `publish` there would flip a failed session to enabled before it
+        had succeeded.
+        """
+        self._runtime = runtime
+        self._session.ctx_dft = runtime.ctx_dft
+        self._session.spec = runtime.spec
+
+    def mark_ready(self) -> None:
+        """Declare the current session healthy after a successful completion.
+
+        The counterpart to `record_failure`: no runtime changes hands, only the
+        verdict. Kept separate from `publish` because there is nothing to
+        publish -- the runtime is already attached.
+        """
+        self._session.mtp_failed = False
+        self._session.mtp_failure_reason = None
+        self._session.mtp_enabled = True
+
     def record_failure(self, reason: str, *, disable: bool = False) -> None:
         """Record that MTP could not be constructed or continued.
 

--- a/tests/test_mtp_session_lifecycle.py
+++ b/tests/test_mtp_session_lifecycle.py
@@ -74,6 +74,71 @@ class PublishTests(unittest.TestCase):
         self.assertIsNone(session.mtp_failure_reason)
 
 
+class AttachAndReadyTests(unittest.TestCase):
+    """`attach` and `mark_ready` split what `publish` does in one step.
+
+    The completion path needs each half separately: it points the session at a
+    runtime BEFORE knowing whether the turn succeeds, and declares readiness
+    only afterwards. Using `publish` in either place would flip the verdict at
+    the wrong moment.
+    """
+
+    def test_attach_leaves_the_verdict_untouched(self) -> None:
+        """The decisive asymmetry: attach must NOT declare the session ready.
+
+        At this point the completion has not run. A failed session flipped to
+        enabled here would report success before anything succeeded.
+        """
+        owner, session, _ = _lifecycle()
+        session.mtp_enabled = False
+        session.mtp_failed = True
+        session.mtp_failure_reason = "previous failure"
+        runtime = _Runtime()
+
+        owner.attach(runtime)
+
+        self.assertIs(owner.runtime, runtime)
+        self.assertEqual(session.ctx_dft, "rt-ctx")
+        self.assertEqual(session.spec, "rt-spec")
+        self.assertFalse(session.mtp_enabled, "attach must not enable")
+        self.assertTrue(session.mtp_failed, "attach must not clear the failure")
+        self.assertEqual(session.mtp_failure_reason, "previous failure")
+
+    def test_mark_ready_declares_health_without_a_runtime(self) -> None:
+        """The counterpart: a verdict with no handle changing hands."""
+        owner, session, _ = _lifecycle()
+        runtime = _Runtime()
+        owner.attach(runtime)
+        session.mtp_failed = True
+        session.mtp_failure_reason = "stale"
+
+        owner.mark_ready()
+
+        self.assertIs(owner.runtime, runtime, "mark_ready must not drop the runtime")
+        self.assertTrue(session.mtp_enabled)
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(session.mtp_failure_reason)
+
+    def test_attach_then_mark_ready_equals_publish(self) -> None:
+        """Together they reach the same state `publish` produces.
+
+        Which is exactly why they must stay separate: the completion path needs
+        the gap between them.
+        """
+        a_owner, a_session, _ = _lifecycle()
+        b_owner, b_session, _ = _lifecycle()
+        runtime = _Runtime()
+
+        a_owner.attach(runtime)
+        a_owner.mark_ready()
+        b_owner.publish(runtime, clear_failure_reason=True)
+
+        for field in ("ctx_dft", "spec", "mtp_enabled", "mtp_failed", "mtp_failure_reason"):
+            self.assertEqual(
+                getattr(a_session, field), getattr(b_session, field), field
+            )
+
+
 class FailureTests(unittest.TestCase):
     def test_record_failure_marks_failed_without_disabling(self) -> None:
         owner, session, _ = _lifecycle()
@@ -289,3 +354,266 @@ class ClientFailedResetTests(unittest.TestCase):
         self.assertFalse(session.mtp_enabled)
         self.assertTrue(session.mtp_failed)
         self.assertIn("reset exploded", session.mtp_failure_reason or "")
+
+
+class HotPathDelegationTests(unittest.TestCase):
+    """The completion path must reach the RIGHT lifecycle operation.
+
+    The collaborator's own tests pin what each method does; these pin which one
+    the client calls. That gap is real: a mutant swapping `attach` for
+    `publish` in the completion path passes every collaborator test while
+    declaring a failed session ready before the turn has run.
+    """
+
+    def _calls(self):
+        """Every lifecycle method invoked by the completion path, in order."""
+        import ast
+        import inspect
+
+        from orbit.native_llama.client import NativeLlamaClient
+
+        tree = ast.parse(
+            inspect.getsource(
+                NativeLlamaClient._try_complete_with_mtp_experimental
+            ).lstrip()
+        ).body[0]
+        found = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                rendered = ast.unparse(node)
+                marker = "_mtp_lifecycle_owner()."
+                if marker in rendered and rendered.count("(") > 1:
+                    found.append(rendered.split(marker, 1)[1])
+        return found
+
+    def test_the_completion_path_owns_no_lifecycle_state(self) -> None:
+        """No direct writes to lifecycle-owned fields may remain."""
+        import inspect
+
+        from orbit.native_llama.client import NativeLlamaClient
+
+        body = inspect.getsource(
+            NativeLlamaClient._try_complete_with_mtp_experimental
+        )
+        for field in ("mtp_enabled", "mtp_failed", "mtp_failure_reason",
+                      "ctx_dft", "spec"):
+            self.assertNotIn(
+                f"_session.{field} =", body,
+                f"the completion path still writes {field} directly; the "
+                f"lifecycle owner must be the only writer",
+            )
+
+    def test_the_runtime_is_attached_not_published(self) -> None:
+        """Before the completion runs, readiness is not yet known.
+
+        `publish` here would enable a session that has failed, and clear its
+        failure, before anything has succeeded.
+
+        Secondary pin. The primary evidence is behavioural: the executed
+        hot-path tests below drive the shipped block and assert resulting
+        state. This one only names the call site, which is cheap to keep and
+        localises a failure, but it must never be the only thing standing
+        between a mutation and a green suite.
+        """
+        calls = self._calls()
+        self.assertTrue(
+            any(c.startswith("attach(") for c in calls),
+            "the completion path must attach the runtime, not publish it",
+        )
+        self.assertFalse(
+            any(c.startswith("publish(runtime)") for c in calls),
+            "an unqualified publish would declare readiness too early",
+        )
+
+    def _run_failure_block(self, *, cancelled: bool, lifecycle, session,
+                           reset_raises=False):
+        """Execute the shipped `if not result.success:` block verbatim.
+
+        Extracted from the completion path and run against a real lifecycle, so
+        the assertions below are about behaviour rather than source shape. The
+        block is 14 lines with 7 stubbable collaborators, which is why it can be
+        driven directly where the whole 196-line method cannot.
+        """
+        import ast
+        import inspect
+        import types
+
+        from orbit.native_llama import client as client_module
+        from orbit.native_llama.client import NativeLlamaClient
+
+        tree = ast.parse(
+            inspect.getsource(
+                NativeLlamaClient._try_complete_with_mtp_experimental
+            ).lstrip()
+        ).body[0]
+        blocks = [
+            n for n in tree.body
+            if isinstance(n, ast.If) and "result.success" in ast.unparse(n.test)
+            and len(ast.unparse(n).splitlines()) > 5
+        ]
+        self.assertEqual(len(blocks), 1, "the failure block moved; update this")
+
+        wrapper = ast.parse(
+            "def _run(self, result, reset_persistent_mtp_session, MtpCompletionResult):\n    pass\n"
+        )
+        wrapper.body[0].body = blocks
+        ast.fix_missing_locations(wrapper)
+
+        class _Client:
+            def __init__(self):
+                self._session = session
+                self.paths = types.SimpleNamespace(llama_root=None)
+                self.cancel_event = types.SimpleNamespace(
+                    is_set=lambda: cancelled
+                )
+                self.last_mtp_completion = None
+                self.mtp_fallback_reason = None
+                self._persistent_mtp_runtime = lifecycle.runtime
+
+            def _mtp_lifecycle_owner(self):
+                return lifecycle
+
+        def reset(**_kwargs):
+            if reset_raises:
+                raise RuntimeError("reset exploded")
+            return _Runtime("rebuilt")
+
+        scope = dict(vars(client_module))
+        exec(  # noqa: S102 - the shipped block, executed verbatim
+            compile(wrapper, "<failure-block>", "exec"), scope, scope
+        )
+        client = _Client()
+        scope["_run"](
+            client,
+            types.SimpleNamespace(success=False, error="it broke"),
+            reset,
+            lambda **kw: types.SimpleNamespace(**kw),
+        )
+        return client
+
+    def test_a_failed_completion_disables_the_session(self) -> None:
+        """A broken runtime must not be offered again on the next turn."""
+        owner, session, _ = _lifecycle()
+        owner.publish(_Runtime())
+
+        self._run_failure_block(cancelled=False, lifecycle=owner, session=session)
+
+        self.assertFalse(
+            session.mtp_enabled,
+            "a failed completion must disable MTP; leaving it enabled offers "
+            "the broken runtime again",
+        )
+        self.assertTrue(session.mtp_failed)
+        self.assertEqual(session.mtp_failure_reason, "it broke")
+
+    def test_a_cancelled_turn_rebuilds_and_clears_the_reason(self) -> None:
+        """A recovered session must not keep reporting the cancelled turn."""
+        owner, session, _ = _lifecycle()
+        owner.publish(_Runtime())
+        session.mtp_failure_reason = "stale"
+
+        self._run_failure_block(cancelled=True, lifecycle=owner, session=session)
+
+        self.assertTrue(session.mtp_enabled, "a rebuilt session is usable again")
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(
+            session.mtp_failure_reason,
+            "a surviving reason would be reported for a recovered session",
+        )
+        self.assertEqual(owner.runtime.name, "rebuilt")
+
+    def test_a_failed_rebuild_after_cancel_disables_without_freeing(self) -> None:
+        """The reset raised, so the native session is gone: drop, never free."""
+        owner, session, freed = _lifecycle()
+        owner.publish(_Runtime())
+
+        self._run_failure_block(
+            cancelled=True, lifecycle=owner, session=session, reset_raises=True
+        )
+
+        self.assertFalse(session.mtp_enabled)
+        self.assertTrue(session.mtp_failed)
+        self.assertIn("reset exploded", session.mtp_failure_reason or "")
+        self.assertEqual(
+            freed, [],
+            "a failed rebuild must not free; the native session already tore "
+            "itself down and freeing again is a double free",
+        )
+
+    def test_a_successful_completion_marks_the_session_ready(self) -> None:
+        """The success path must declare health, not merely skip the failure.
+
+        Executed rather than inspected: the statements that run after the
+        failure block are lifted from the shipped method and driven against a
+        real lifecycle, so a no-op there is visible as a session that never
+        becomes enabled.
+        """
+        import ast
+        import inspect
+        import types
+
+        from orbit.native_llama import client as client_module
+        from orbit.native_llama.client import NativeLlamaClient
+
+        tree = ast.parse(
+            inspect.getsource(
+                NativeLlamaClient._try_complete_with_mtp_experimental
+            ).lstrip()
+        ).body[0]
+        # The two statements immediately following the failure block: clearing
+        # the fallback reason and declaring the session ready.
+        idx = [
+            i for i, n in enumerate(tree.body)
+            if isinstance(n, ast.If) and "result.success" in ast.unparse(n.test)
+            and len(ast.unparse(n).splitlines()) > 5
+        ]
+        self.assertEqual(len(idx), 1, "the failure block moved; update this")
+        success_stmts = tree.body[idx[0] + 1: idx[0] + 3]
+        self.assertTrue(success_stmts, "no statements follow the failure block")
+
+        owner, session, _ = _lifecycle()
+        owner.publish(_Runtime())
+        session.mtp_enabled = False
+        session.mtp_failed = True
+        session.mtp_failure_reason = "earlier turn failed"
+
+        wrapper = ast.parse("def _run(self):\n    pass\n")
+        wrapper.body[0].body = list(success_stmts)
+        ast.fix_missing_locations(wrapper)
+
+        class _Client:
+            mtp_fallback_reason = "stale"
+            _session = session
+
+            def _mtp_lifecycle_owner(self):
+                return owner
+
+        scope = dict(vars(client_module))
+        exec(  # noqa: S102 - the shipped statements, executed verbatim
+            compile(wrapper, "<success-stmts>", "exec"), scope, scope
+        )
+        scope["_run"](_Client())
+
+        self.assertTrue(
+            session.mtp_enabled,
+            "a successful completion must declare the session ready; leaving "
+            "it disabled would refuse MTP on the next turn for no reason",
+        )
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(session.mtp_failure_reason)
+
+    def test_the_post_cancel_rebuild_clears_the_failure_reason(self) -> None:
+        """A rebuilt session must not keep reporting the cancelled turn.
+
+        Secondary pin; `test_a_cancelled_turn_rebuilds_and_clears_the_reason`
+        is the executed one that carries the weight.
+        """
+        calls = self._calls()
+        publishes = [c for c in calls if c.startswith("publish(")]
+        self.assertTrue(publishes)
+        for call in publishes:
+            self.assertIn(
+                "clear_failure_reason=True", call,
+                "the rebuild publishes a healthy session; a surviving reason "
+                "would be reported for a session that recovered",
+            )


### PR DESCRIPTION
**Continuation of the REF-2 seam, not a new one.**

REF-2 made `MtpSessionLifecycle` the sole owner of the MTP runtime handle and its four derived session fields, but the completion hot path still hand-wrote those transitions at **7 sites** — the request path, and so the one most exposed to the drift the extraction exists to prevent.

Direct writes to lifecycle-owned fields in that path: **32 → 0**.

**Behaviour-preserving.** No MTP policy change, no native change, no cache or identity change, no performance claim.

### Two methods added, and why

Each replaced 2 duplicated manual sites, and neither was expressible with the existing methods:

- **`attach(runtime)`** records the handle and `ctx_dft`/`spec` but deliberately leaves `mtp_enabled`/`mtp_failed` alone. Verified before adding it: from `(enabled=False, failed=True)`, `attach` preserves that while `publish` flips to `(True, False)`. Using `publish` there would declare a failed session ready **before the completion had run**.
- **`mark_ready()`** sets the verdict with no handle changing hands. Expressing it as `publish(self._persistent_mtp_runtime, ...)` errors when nothing is attached — a genuinely different operation.

The remaining 5 sites use existing `record_failure(disable=True)` and `publish(clear_failure_reason=True)`.

### On test quality

The first version pinned the call sites by **AST inspection**. That is the source-shape pattern earlier review cycles in this repo rejected, and it was wrong here for the same reason — it proves shape, not behaviour. The failure block (14 lines, 7 stubbable collaborators) and the success statements are now **extracted and executed verbatim** against a real lifecycle, asserting resulting session state.

The consequence is measurable: `mark_ready`→no-op and dropped `disable=True` are caught **exclusively** by the executed tests. The suite would still catch them with every AST test deleted. Two AST tests remain as annotated secondary pins.

### Qualification

Equivalence verified exhaustively rather than by inspection: 6 distinct transitions × the full **64-precondition space** of the five session fields plus the prior handle → **0 divergences**. The 6 init-path direct writes are out of scope and byte-identical to baseline.

**9 mutants caught**, including a failed rebuild calling `free` instead of recording failure — a double free. Full suite **3762 collected / 3754 passed / 8 skipped / 0 failed, real exit 0** against a 3752 baseline. Review: **BLOCKER 0 / MAJOR 0**.

Two surviving mutants in `mtp_fallback_reason` plumbing were confirmed **pre-existing at baseline** — a client-owned field this PR does not own — and are recorded as a follow-up rather than fixed here.

`client.py` 4913 → 4909; lifecycle module 135 → 160. `CommittedIdentity` zero diff; five guards unchanged; `use_mtp_experimental` still `False`.
