### PR TITLE
refactor(runtime): complete MTP lifecycle ownership

### DIFF
--- a/docs/checkpoints/ref4-mtp-initialization-ownership.md
+++ b/docs/checkpoints/ref4-mtp-initialization-ownership.md
@@ -1,0 +1,99 @@
+# REF-4: complete MTP lifecycle ownership
+
+Fourth step of the incremental, behaviour-preserving runtime refactor. Closes
+the REF-2/REF-3 seam.
+
+## Baseline
+
+`b7308a71d2ad1ddc70181477ef4b4f66fb028ea3`
+
+## Audit: observed truth, not the estimate
+
+The mission estimated ~6 remaining direct writes. The current source held
+**12 writes across 7 sites**, all in the initialization path.
+
+| site | branch | transition |
+|---|---|---|
+| capability probe raised | self-MTP | `record_failure(reason)` |
+| target context missing | self-MTP | `record_failure("target-context-missing")` |
+| constructor raised | self-MTP | `record_failure(str(exc))` |
+| profile does not support MTP | external-draft | `record_unavailable(...)` |
+| no draft model / not available | external-draft | `record_unavailable(...)` |
+| target context missing | external-draft | `record_failure("target-context-missing")` |
+| constructor raised | external-draft | `record_failure(str(exc))` |
+
+**Direct lifecycle writes in all of `client.py`: 12 → 0.** With REF-3 having
+cleared the completion path, `MtpSessionLifecycle` is now genuinely the only
+writer.
+
+## One method added: `record_unavailable`
+
+Two sites set **only** `mtp_failure_reason`, deliberately leaving `mtp_failed`
+False. Verified by execution that `record_failure` flips it True — so using it
+would turn *"MTP does not apply here"* into *"MTP broke"*.
+
+Honest scope of that claim: `mtp_failed` has **no production reader** today and
+is absent from `NativeSessionSnapshot`. The distinction is preserved because the
+pre-extraction code drew it, not because a consumer depends on it — a latent
+invariant, not a live one. The docstring says so. Collapsing it during a
+behaviour-preserving extraction would still be an unforced change, and the field
+is public on the session dataclass.
+
+Meets the bar: 2 duplicated sites, not expressible by existing methods without
+semantic distortion, behaviourally distinguished by tests.
+
+## Policy stayed in the client
+
+`record_unavailable` is a single-field write with no branching. Every decision
+remains in `client.py`: eligibility, whether MTP was requested, profile support,
+ABI/artifact availability, context presence, and the self-MTP → external-draft
+ordering. The collaborator still takes no client reference.
+
+## Preserved asymmetries
+
+* an **ineligible** artifact returns False and records *nothing* — that is what
+  lets external-draft be attempted
+* a **capability error** records a failure and returns True, blocking fallback
+* the two **unavailability** sites record only a reason
+* a self-MTP failure is still not equivalent to an external-draft failure
+
+## Qualification
+
+* **9 mutants caught**: unavailable→failure (×2), `record_unavailable` setting
+  `mtp_failed`, capability-error→unavailable, ordering skipped, restored direct
+  write in init, restored direct write in the completion path, handle assigned
+  outside its property setter, ineligible path recording a reason.
+* **U6 proven equivalent** rather than waved through: adding `disable=True` at
+  an init site is unobservable, because `_initialize_self_mtp_session` has one
+  caller, reached only after `clear_state()` sets `mtp_enabled = False`. The
+  reviewer independently confirmed the reachability and noted it is
+  reachability-dependent, so a hypothetical direct caller would diverge.
+* equivalence verified across **2304 exhaustive precondition combinations** by
+  the reviewer, comparing return value, all six session fields, the runtime
+  handle and the full call-order trace: **0 divergences**
+* focused 363/363 plus 36 lifecycle tests
+* full suite: 3775 collected, **3767 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3762; +13 tests, zero regressions)
+* init call counts across 12 branch combinations: no new hashing, model loads,
+  context creation, native constructors or ABI checks
+* `client.py` 4909 → 4912; lifecycle module 160 → 171
+
+## Out of scope, deliberately
+
+`mtp_fallback_reason` was not touched. Its two pre-existing surviving mutants
+were confirmed neither fixed nor worsened — one (`H3`, dropping the
+`"draft-mtp-unavailable"` default) sits one line from code this PR edited and
+was still left alone.
+
+## Review
+
+One cycle: **BLOCKER 0 / MAJOR 0 / MINOR 2**, both fixed.
+
+MINOR-1 corrected a claim in my own docstring: I had written that the
+unsupported/broken distinction is "visible in `/props`", and it is not. The
+justification now rests on baseline preservation, which is the true reason.
+
+The reviewer also strengthened my argument for the AST-based direct-write guard:
+I had defended it as necessary because a restored direct write is "invisible
+behaviourally", and that is false — the behavioural tests catch it, along with
+three evasion variants. The AST test is defence-in-depth, not the sole guard.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -867,14 +867,14 @@ class NativeLlamaClient:
         except Exception as exc:
             # A capability resolution failure is not an MTP verdict. Fail
             # closed and say why rather than silently trying another path.
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = f"self-mtp-capability-error: {exc}"
+            self._mtp_lifecycle_owner().record_failure(
+                f"self-mtp-capability-error: {exc}"
+            )
             return True
         if not eligible:
             return False
         if not self._session.ctx_tgt:
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = "target-context-missing"
+            self._mtp_lifecycle_owner().record_failure("target-context-missing")
             return True
         try:
             runtime = create_self_mtp_session(
@@ -891,8 +891,7 @@ class NativeLlamaClient:
         except Exception as exc:
             # The borrowed model and target context are untouched by a failed
             # construction; the client still owns and frees them.
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = str(exc)
+            self._mtp_lifecycle_owner().record_failure(str(exc))
             return True
         self._mtp_lifecycle_owner().publish(runtime)
         return True
@@ -910,14 +909,19 @@ class NativeLlamaClient:
             return
         profile = getattr(self, "model_profile", None)
         if profile is not None and not profile.mtp_supported:
-            self._session.mtp_failure_reason = "model_profile_mtp_unsupported"
+            # Unavailable, not failed: this profile does not offer the
+            # external-draft architecture, which is not a malfunction.
+            self._mtp_lifecycle_owner().record_unavailable(
+                "model_profile_mtp_unsupported"
+            )
             return
         if not self.paths.mtp_available or self.paths.draft_mtp_model is None:
-            self._session.mtp_failure_reason = self.paths.fallback_reason or "draft-mtp-unavailable"
+            self._mtp_lifecycle_owner().record_unavailable(
+                self.paths.fallback_reason or "draft-mtp-unavailable"
+            )
             return
         if not self._session.ctx_tgt:
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = "target-context-missing"
+            self._mtp_lifecycle_owner().record_failure("target-context-missing")
             return
         try:
             runtime = create_persistent_mtp_session(
@@ -931,8 +935,7 @@ class NativeLlamaClient:
                 threads_batch=self.config.threads_batch,
             )
         except Exception as exc:
-            self._session.mtp_failed = True
-            self._session.mtp_failure_reason = str(exc)
+            self._mtp_lifecycle_owner().record_failure(str(exc))
             return
         self._mtp_lifecycle_owner().publish(runtime)
 

--- a/src/orbit/native_llama/mtp_session_lifecycle.py
+++ b/src/orbit/native_llama/mtp_session_lifecycle.py
@@ -126,6 +126,23 @@ class MtpSessionLifecycle:
         if disable:
             self._session.mtp_enabled = False
 
+    def record_unavailable(self, reason: str) -> None:
+        """Record that MTP does not apply, without marking it broken.
+
+        Distinct from `record_failure`: nothing went wrong. The artifact or
+        profile simply does not offer this architecture, so `mtp_failed` stays
+        False and only the reason is recorded.
+
+        The distinction is preserved because the pre-extraction code drew it,
+        not because anything currently depends on it: `mtp_failed` has no
+        production reader today and is absent from `NativeSessionSnapshot`.
+        That makes it a latent invariant rather than a live one -- but
+        "unsupported" and "broken" are genuinely different states, the field is
+        public on the session dataclass, and collapsing them during a
+        behaviour-preserving extraction would be an unforced change.
+        """
+        self._session.mtp_failure_reason = reason
+
     def discard(self, reason: str) -> None:
         """Drop a session whose runtime is no longer usable.
 

--- a/tests/test_mtp_session_lifecycle.py
+++ b/tests/test_mtp_session_lifecycle.py
@@ -617,3 +617,292 @@ class HotPathDelegationTests(unittest.TestCase):
                 "the rebuild publishes a healthy session; a surviving reason "
                 "would be reported for a session that recovered",
             )
+
+
+class UnavailableVsFailedTests(unittest.TestCase):
+    """"MTP does not apply here" is not "MTP broke".
+
+    The initialization path distinguishes them, and `/props` and every
+    diagnostic downstream depend on the difference. Collapsing them would
+    report a healthy unsupported configuration as a failure.
+    """
+
+    def test_record_unavailable_does_not_mark_the_session_failed(self) -> None:
+        owner, session, _ = _lifecycle()
+
+        owner.record_unavailable("model_profile_mtp_unsupported")
+
+        self.assertFalse(
+            session.mtp_failed,
+            "an unsupported profile is not a malfunction; marking it failed "
+            "reports a healthy configuration as broken",
+        )
+        self.assertEqual(
+            session.mtp_failure_reason, "model_profile_mtp_unsupported"
+        )
+
+    def test_record_unavailable_leaves_enabled_untouched(self) -> None:
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                owner, session, _ = _lifecycle()
+                session.mtp_enabled = enabled
+
+                owner.record_unavailable("draft-mtp-unavailable")
+
+                self.assertEqual(session.mtp_enabled, enabled)
+
+    def test_failure_and_unavailable_differ_exactly_in_mtp_failed(self) -> None:
+        """The one field that separates them, pinned so it cannot drift."""
+        a_owner, a_session, _ = _lifecycle()
+        b_owner, b_session, _ = _lifecycle()
+
+        a_owner.record_failure("same reason")
+        b_owner.record_unavailable("same reason")
+
+        self.assertEqual(a_session.mtp_failure_reason, b_session.mtp_failure_reason)
+        self.assertTrue(a_session.mtp_failed)
+        self.assertFalse(b_session.mtp_failed)
+
+
+class InitializationDelegationTests(unittest.TestCase):
+    """The initialization path must reach the right lifecycle transition.
+
+    Executed against a recording owner rather than inspected: which method is
+    called is the whole point, and a source-shape assertion would pass on a
+    call that never runs.
+    """
+
+    class _Recorder(MtpSessionLifecycle):
+        """A lifecycle that records the transitions it is asked to perform."""
+
+        def __init__(self, session):
+            super().__init__(lambda: session, free_runtime=lambda r: None)
+            self.calls: list[tuple] = []
+
+        def record_failure(self, reason, *, disable=False):
+            self.calls.append(("record_failure", reason, disable))
+            super().record_failure(reason, disable=disable)
+
+        def record_unavailable(self, reason):
+            self.calls.append(("record_unavailable", reason))
+            super().record_unavailable(reason)
+
+        def publish(self, runtime, *, clear_failure_reason=False):
+            self.calls.append(("publish", clear_failure_reason))
+            super().publish(runtime, clear_failure_reason=clear_failure_reason)
+
+    def _client(self, session, recorder):
+        import types
+
+        from orbit.native_llama.client import NativeLlamaClient
+
+        client = object.__new__(NativeLlamaClient)
+        client._session = session
+        client._mtp_lifecycle = recorder
+        client.paths = types.SimpleNamespace(
+            llama_root=None, mtp_available=False, draft_mtp_model=None,
+            fallback_reason=None,
+        )
+        client.config = types.SimpleNamespace(use_mtp_experimental=True)
+        client.model_profile = None
+        client._free_persistent_mtp_session = lambda: None
+        return client
+
+    def test_a_capability_error_is_recorded_as_a_failure(self) -> None:
+        """A capability probe that raises is a malfunction, not unavailability."""
+        session = NativeSessionState(session_id="cap")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client._self_mtp_eligible = lambda: (_ for _ in ()).throw(
+            RuntimeError("probe exploded")
+        )
+
+        self.assertTrue(client._initialize_self_mtp_session())
+
+        self.assertEqual(len(recorder.calls), 1)
+        kind, reason, disable = recorder.calls[0]
+        self.assertEqual(kind, "record_failure")
+        self.assertIn("self-mtp-capability-error", reason)
+        self.assertFalse(
+            disable, "initialization failure must not disable; nothing was on"
+        )
+        self.assertTrue(session.mtp_failed)
+
+    def test_an_ineligible_artifact_touches_no_state(self) -> None:
+        """Falling through to external-draft must leave the session alone.
+
+        The self-MTP path returns False WITHOUT recording anything, which is
+        what lets the caller try the other architecture.
+        """
+        session = NativeSessionState(session_id="inelig")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client._self_mtp_eligible = lambda: False
+
+        self.assertFalse(client._initialize_self_mtp_session())
+
+        self.assertEqual(recorder.calls, [], "no transition may be recorded")
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(session.mtp_failure_reason)
+
+    def test_a_missing_target_context_is_a_failure(self) -> None:
+        session = NativeSessionState(session_id="noctx")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client._self_mtp_eligible = lambda: True
+
+        self.assertTrue(client._initialize_self_mtp_session())
+
+        self.assertEqual(recorder.calls[0][0], "record_failure")
+        self.assertEqual(recorder.calls[0][1], "target-context-missing")
+
+    def test_an_unsupported_profile_is_unavailable_not_failed(self) -> None:
+        """The decisive asymmetry, driven through the shipped method."""
+        import types
+
+        session = NativeSessionState(session_id="profile")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client.model_profile = types.SimpleNamespace(mtp_supported=False)
+        client._initialize_self_mtp_session = lambda: False
+
+        client._initialize_persistent_mtp_session()
+
+        kinds = [c[0] for c in recorder.calls]
+        self.assertIn(
+            "record_unavailable", kinds,
+            "an unsupported profile must be recorded as unavailable, not failed",
+        )
+        self.assertNotIn("record_failure", kinds)
+        self.assertFalse(session.mtp_failed)
+
+    def test_a_missing_draft_model_is_unavailable_not_failed(self) -> None:
+        session = NativeSessionState(session_id="nodraft")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client._initialize_self_mtp_session = lambda: False
+
+        client._initialize_persistent_mtp_session()
+
+        kinds = [c[0] for c in recorder.calls]
+        self.assertIn("record_unavailable", kinds)
+        self.assertNotIn("record_failure", kinds)
+        self.assertFalse(session.mtp_failed)
+
+    def test_mtp_off_records_nothing_at_all(self) -> None:
+        import types
+
+        session = NativeSessionState(session_id="off")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client.config = types.SimpleNamespace(use_mtp_experimental=False)
+
+        client._initialize_persistent_mtp_session()
+
+        self.assertEqual(
+            recorder.calls, [],
+            "MTP off must record no failure and no unavailability",
+        )
+        self.assertFalse(session.mtp_failed)
+        self.assertIsNone(session.mtp_failure_reason)
+
+    def test_self_mtp_is_attempted_before_external_draft(self) -> None:
+        """Ordering is policy and stays in the client; pin it behaviourally."""
+        order: list[str] = []
+        session = NativeSessionState(session_id="order")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+
+        def self_mtp():
+            order.append("self-mtp")
+            return False
+
+        client._initialize_self_mtp_session = self_mtp
+        client._initialize_persistent_mtp_session()
+
+        self.assertEqual(
+            order, ["self-mtp"],
+            "self-MTP must be attempted first; reversing the order would admit "
+            "the external-draft architecture for a qualified single-GGUF build",
+        )
+
+    def test_a_successful_self_mtp_short_circuits_external_draft(self) -> None:
+        session = NativeSessionState(session_id="short")
+        recorder = self._Recorder(session)
+        client = self._client(session, recorder)
+        client._initialize_self_mtp_session = lambda: True
+        client.model_profile = None
+
+        client._initialize_persistent_mtp_session()
+
+        self.assertEqual(
+            [c for c in recorder.calls if c[0] in ("record_unavailable", "record_failure")],
+            [],
+            "a handled self-MTP outcome must not fall through to external-draft",
+        )
+
+
+class NoDirectLifecycleWritesTests(unittest.TestCase):
+    """`client.py` must not write lifecycle-owned state anywhere.
+
+    REF-2 established the owner, REF-3 cleared the completion path and REF-4
+    the initialization path. A restored direct write is invisible to the
+    behavioural tests -- it produces the same state by the wrong route -- so it
+    is pinned structurally here, deliberately, as the one place where source
+    shape IS the contract.
+    """
+
+    OWNED = ("mtp_enabled", "mtp_failed", "mtp_failure_reason", "ctx_dft", "spec")
+
+    def test_the_client_never_assigns_lifecycle_state_directly(self) -> None:
+        import ast
+
+        source = (SRC / "orbit/native_llama/client.py").read_text()
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, (ast.Assign, ast.AugAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr in self.OWNED
+                    and isinstance(target.value, ast.Attribute)
+                    and target.value.attr == "_session"
+                ):
+                    offenders.append((target.attr, node.lineno))
+        self.assertEqual(
+            offenders, [],
+            f"client.py writes lifecycle-owned state directly at {offenders}; "
+            f"every transition must go through MtpSessionLifecycle, or the "
+            f"owner stops being authoritative",
+        )
+
+    def test_the_runtime_handle_is_never_assigned_outside_the_property(self) -> None:
+        """`_persistent_mtp_runtime = ...` is allowed only in its own setter."""
+        import ast
+
+        source = (SRC / "orbit/native_llama/client.py").read_text()
+        tree = ast.parse(source)
+        setters = {
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_persistent_mtp_runtime"
+        }
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "_persistent_mtp_runtime"
+                    and not any(abs(node.lineno - s) < 20 for s in setters)
+                ):
+                    offenders.append(node.lineno)
+        self.assertEqual(
+            offenders, [],
+            f"the runtime handle is assigned outside its property setter at "
+            f"{offenders}; that bypasses the owner",
+        )


### PR DESCRIPTION
**Closes the REF-2/REF-3 seam.** The initialization path still hand-wrote lifecycle state; those transitions now go through `MtpSessionLifecycle`, which becomes the only writer of the MTP runtime handle and its four derived session fields.

**Direct lifecycle writes in all of `client.py`: 12 → 0.**

The audit found **12 writes across 7 sites**, not the ~6 estimated — observed truth was used. Five map to the existing `record_failure(reason)`.

**Behaviour-preserving.** No MTP policy change, no native change, no cache or identity change, no performance claim.

### One method added

`record_unavailable(reason)`, because two sites set **only** `mtp_failure_reason` and deliberately leave `mtp_failed` False. Verified by execution that `record_failure` flips it True, turning *"MTP does not apply here"* into *"MTP broke"*.

The scope of that claim is stated honestly in the docstring: `mtp_failed` has **no production reader** today and is absent from `NativeSessionSnapshot`, so the distinction is preserved because the pre-extraction code drew it — a latent invariant, not a live one. Collapsing it during a behaviour-preserving extraction would still be an unforced change, and the field is public on the session dataclass.

### Policy stayed in the client

Eligibility, whether MTP was requested, profile support, ABI availability, context presence and the **self-MTP → external-draft ordering** are all unchanged. `record_unavailable` is a single-field write with no branching; the collaborator still takes no client reference.

Asymmetries preserved: an **ineligible** artifact records *nothing* (which is what lets external-draft be tried), a **capability error** records a failure and blocks fallback, and the two **unavailability** sites record only a reason.

### Qualification

**9 mutants caught.** U6 (adding `disable=True` at an init site) is proven **equivalent** rather than waved through: `_initialize_self_mtp_session` has one caller, reached only after `clear_state()` sets `mtp_enabled = False`.

Equivalence independently verified across **2304 exhaustive precondition combinations** — return value, all six session fields, runtime handle and full call-order trace — with **zero divergences**. Init call counts across 12 branch combinations show no new hashing, model loads, context creation or ABI checks.

Full suite **3775 collected / 3767 passed / 8 skipped / 0 failed, real exit 0** against a 3762 baseline. Review: **BLOCKER 0 / MAJOR 0**.

`mtp_fallback_reason` deliberately untouched — including a known surviving mutant sitting one line from edited code.

### Review corrections

One finding corrected a claim in my own docstring: I had written that the unsupported/broken distinction is "visible in `/props`", and it is not. The reviewer also *strengthened* my defence of the AST-based direct-write guard — I argued a restored direct write is "invisible behaviourally", which is false: the behavioural tests catch it, along with three evasion variants. It is defence-in-depth, not the sole guard.
