### PR TITLE
refactor(runtime): extract rolling route anchor state

### DIFF
--- a/docs/checkpoints/ref5-rolling-route-anchor.md
+++ b/docs/checkpoints/ref5-rolling-route-anchor.md
@@ -1,0 +1,104 @@
+# REF-5: rolling route-anchor state extraction
+
+Fifth step of the incremental, behaviour-preserving runtime refactor.
+
+## Baseline
+
+`fa805af3bc788fdf6a4b55316b4952c0963dd452`
+
+## Seam audit — observed truth, not the estimate
+
+The prior ranking estimated ~4 methods. The family actually holds **9**:
+
+| method | ctx_tgt | lib | verdict |
+|---|---|---|---|
+| `_rolling_anchor_slot` | 0 | 0 | **extracted** |
+| `_rolling_anchor_state_for` | 0 | 0 | **extracted** |
+| `_store_rolling_anchor_state` | 0 | 0 | **extracted** |
+| `_invalidate_rolling_route_anchor` | 0 | 0 | **extracted** |
+| `_rolling_route_identity` | 0 | 0 | stays — needs 5+ client-wide facts |
+| `_ornith_rolling_route_eligible` | 0 | 0 | stays — policy |
+| `_ornith_rolling_analysis_eligible` | 0 | 0 | stays — policy |
+| `_rolling_outranks_route_prefix` | 0 | 0 | stays — policy |
+| `_prepare_memory_with_ornith_rolling_route_anchor` | **1** | **1** | stays — orchestration |
+
+## Extraction gate: GO
+
+The mission required STOP if extraction needed broad `ctx_tgt`/`lib`/KV access.
+It does not. The single native dependency sits entirely in
+`_prepare_memory_with_ornith_rolling_route_anchor`, which calls the native
+restore, `_clear_target_memory`, `_invalidate_committed_sequence` and
+`_prepare_memory_for_prompt`. Moving it inward would have required passing the
+client or the lib into the collaborator — precisely what §2 forbids. It stays
+byte-identical, and `RollingAnchorStore` has **zero** native access (verified by
+AST: imports are `__future__` and the pure state module, nothing else).
+
+## Ownership
+
+Two checkpoint slots — CHAT route and ANALYSIS — with one owner. The client's
+two fields became properties over the store, with an on-demand
+`_rolling_anchor_store()` for `object.__new__` clients. Lineage separation
+follows the identity's own `strategy_id`, so the backend still learns nothing
+about CHAT vs ANALYSIS.
+
+That separation is a **safety** property, not tidiness: restoring an analysis
+checkpoint for a route prompt puts a different conversation's KV behind the
+model, which then answers confidently from someone else's context. Both leak
+directions are pinned by mutation.
+
+## Deleter
+
+A pre-existing test does `del client._rolling_analysis_anchor_state` to simulate
+an absent slot. The property needed a deleter; it empties the slot rather than
+removing the accessor. The contract that matters — a missing checkpoint falls
+cold rather than raising — is identical. `hasattr` and double-`del` differ from
+baseline, and the reviewer confirmed by exhaustive grep that nothing in `src/`
+or `tests/` observes either.
+
+## Qualification
+
+* **10 mutants caught**: store no-op, invalidate no-op, analysis not
+  invalidated, slot always route, slot always analysis, `state_for` reading the
+  wrong slot, client property bypassing the store, deleter not emptying, and —
+  added after review — the already-empty guard dropped on the analysis branch.
+* Three surviving mutants analysed: two provably equivalent (an `or`→`and` that
+  is unreachable after the first invalidation, and a dead `or
+  RollingRouteAnchorState()` carried over from baseline), one redundant
+  (`__init__` store creation, fully covered by the lazy path).
+* Differential equivalence, verified by the reviewer: **16,661 checks over
+  5,024 operation sequences, 0 divergences**.
+* focused 221/221 plus 21 store tests
+* full suite: 3796 collected, **3788 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3775; +21 tests, zero regressions)
+* native calls unchanged: `restore_rolling_route_anchor` called exactly once
+* `client.py` 4912 → 4933; store 103 lines
+
+## Incident: an overwritten module, recovered
+
+While creating the collaborator I wrote it to `rolling_route_anchor.py` without
+checking the name — silently overwriting a **pre-existing tracked 216-line
+module**. An ImportError surfaced it within seconds; it was restored with
+`git checkout HEAD --` and the collaborator placed in `rolling_anchor_store.py`.
+
+Verified byte-identical to baseline (`b45182c3…` both sides, zero diff), and
+independently re-verified by the reviewer, who was told about the incident
+rather than left to find it. Nothing was lost. The lesson is to check whether a
+filename is taken *before* writing it.
+
+## Review
+
+One cycle: **BLOCKER 0 / MAJOR 0 / MINOR 3**. Two fixed, one recorded:
+
+* **MINOR-1** — a text guard in `test_ornith_route_prefix.py` sliced 600 chars
+  from `_rolling_anchor_state_for` to assert the rolling read never touches the
+  prewarm slot. After extraction that window covered only a one-line delegate,
+  so it pinned nothing. Re-pointed at the store, and confirmed it now catches a
+  real injected prewarm-slot leak.
+* **MINOR-3 / H2** — the already-empty guard was pinned on the route slot only;
+  dropping it on the analysis branch survived. Two tests added, mutant caught.
+* **MINOR-2** — the deleter's `hasattr`/double-`del` divergence, unreachable;
+  recorded rather than fixed.
+
+The reviewer also caught a weakness in my own test: the "store makes no native
+calls" check was a raw-text search that failed on the module's own docstring,
+which names `ctx_tgt` to say it does not use it. Rewritten over parsed AST.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -29,6 +29,7 @@ from .bindings import (
 from .chat_bridge import chat_bridge_filename
 from .committed_identity import CommittedIdentity, AttributeBackedIdentity
 from .mtp_session_lifecycle import MtpSessionLifecycle
+from .rolling_anchor_store import RollingAnchorStore
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
@@ -375,13 +376,16 @@ class NativeLlamaClient:
         self._route_prefix_anchor_state = PrefixAnchorState()
         self._route_prefix_prefill_lock = threading.Lock()
         # Exactly one rolling route checkpoint per client, replaced in place.
-        self._rolling_route_anchor_state = RollingRouteAnchorState()
+        # Sole owner of the two rolling-anchor checkpoint slots. The fields
+        # below are properties over it, so the existing readers keep working
+        # with one authoritative copy and nothing to synchronise.
+        self._rolling_anchors = RollingAnchorStore()
         self._rolling_route_identity_cache: RollingRouteIdentity | None = None
         # A second slot, not a second mechanism: same state type, same
         # primitives. Two slots exist because the route chain and an analysis
         # chain are different conversations that interleave, and one slot
         # would make each switch evict the other's still-valid checkpoint.
-        self._rolling_analysis_anchor_state = RollingRouteAnchorState()
+
         self._reset_generation = 0
         self._qwen_route_prefix_anchor_state = PrefixAnchorState()
         self._qwen_route_prefix_spec: QwenRoutePrefixSpec | None = None
@@ -3570,46 +3574,63 @@ class NativeLlamaClient:
             reset_generation=self._reset_generation,
         )
 
-    def _rolling_anchor_slot(self, identity: RollingRouteIdentity | None) -> str:
-        """Which checkpoint an identity addresses, decided by its own strategy.
+    @property
+    def _rolling_route_anchor_state(self) -> RollingRouteAnchorState:
+        """The CHAT-route checkpoint, owned by `RollingAnchorStore`.
 
-        The backend still knows nothing about CHAT or ANALYSIS: it reads the
-        strategy the caller already put in the identity it supplied.
+        A property rather than a field so the existing readers keep working
+        while there is exactly one authoritative copy. Clients built via
+        `object.__new__` never run `__init__`, so a missing store reads as an
+        empty checkpoint -- which is what "no anchor" already meant.
         """
-        if identity is not None and identity.strategy_id == ROLLING_ANALYSIS_STRATEGY_ID:
-            return "analysis"
-        return "route"
+        return self._rolling_anchor_store().route_state
+
+    @_rolling_route_anchor_state.setter
+    def _rolling_route_anchor_state(self, state: RollingRouteAnchorState) -> None:
+        self._rolling_anchor_store()._route = state
+
+    @property
+    def _rolling_analysis_anchor_state(self) -> RollingRouteAnchorState:
+        """The ANALYSIS checkpoint; see `_rolling_route_anchor_state`."""
+        return self._rolling_anchor_store().analysis_state
+
+    @_rolling_analysis_anchor_state.setter
+    def _rolling_analysis_anchor_state(self, state: RollingRouteAnchorState) -> None:
+        self._rolling_anchor_store()._analysis = state
+
+    @_rolling_analysis_anchor_state.deleter
+    def _rolling_analysis_anchor_state(self) -> None:
+        # Before the extraction this was a plain attribute, so `del` was legal
+        # and left the slot absent. The contract that matters is what absence
+        # MEANS -- a missing checkpoint falls cold rather than raising -- so
+        # deleting empties the slot instead of removing the accessor.
+        self._rolling_anchor_store()._analysis = RollingRouteAnchorState()
+
+    def _rolling_anchor_store(self) -> RollingAnchorStore:
+        """The checkpoint owner, created on demand for a bare client."""
+        store = self.__dict__.get("_rolling_anchors")
+        if store is None:
+            store = RollingAnchorStore()
+            self._rolling_anchors = store
+        return store
+
+    def _rolling_anchor_slot(self, identity: RollingRouteIdentity | None) -> str:
+        """Delegate: see `RollingAnchorStore.slot_for`."""
+        return RollingAnchorStore.slot_for(identity)
 
     def _rolling_anchor_state_for(self, identity: RollingRouteIdentity | None) -> RollingRouteAnchorState:
-        # An absent slot reads as empty rather than raising: a checkpoint that
-        # is not there must fall cold, never fail the call.
-        if self._rolling_anchor_slot(identity) == "analysis":
-            return getattr(self, "_rolling_analysis_anchor_state", None) or RollingRouteAnchorState()
-        return self._rolling_route_anchor_state
+        """Delegate: see `RollingAnchorStore.state_for`."""
+        return self._rolling_anchor_store().state_for(identity)
 
     def _store_rolling_anchor_state(
         self, identity: RollingRouteIdentity | None, state: RollingRouteAnchorState
     ) -> None:
-        if self._rolling_anchor_slot(identity) == "analysis":
-            self._rolling_analysis_anchor_state = state
-        else:
-            self._rolling_route_anchor_state = state
+        """Delegate: see `RollingAnchorStore.store`."""
+        self._rolling_anchor_store().store(identity, state)
 
     def _invalidate_rolling_route_anchor(self, reason: str) -> None:
-        # Both lineages: a reset destroys the conversation whose tokens these
-        # are, and an analysis checkpoint surviving it would be exactly the
-        # stale-state reuse the identity check exists to prevent.
-        if self._rolling_route_anchor_state.valid or self._rolling_route_anchor_state.identity is not None:
-            self._rolling_route_anchor_state = invalidate_rolling_route_anchor(
-                self._rolling_route_anchor_state, reason
-            )
-        analysis_state = getattr(self, "_rolling_analysis_anchor_state", None)
-        if analysis_state is not None and (
-            analysis_state.valid or analysis_state.identity is not None
-        ):
-            self._rolling_analysis_anchor_state = invalidate_rolling_route_anchor(
-                analysis_state, reason
-            )
+        """Delegate: see `RollingAnchorStore.invalidate`."""
+        self._rolling_anchor_store().invalidate(reason)
 
     def _prepare_memory_with_ornith_rolling_route_anchor(self, prompt_tokens: list[int]) -> int:
         """Restore the rolling route checkpoint, then defer to strict append.

--- a/src/orbit/native_llama/rolling_anchor_store.py
+++ b/src/orbit/native_llama/rolling_anchor_store.py
@@ -1,0 +1,103 @@
+"""Ownership of the rolling route-anchor checkpoint slots.
+
+A rolling anchor is a KV checkpoint the runtime may restore instead of
+prefilling a prompt from cold. There are two independent lineages -- CHAT route
+and ANALYSIS -- and keeping them apart is the point: a route prompt must never
+meet an analysis checkpoint. The slot follows the identity's own `strategy_id`,
+so the separation is data-driven rather than a branch on model or call-site
+names, and the backend never learns the distinction.
+
+This owns the two slots and the operations over them: which slot an identity
+addresses, what is stored there, storing a new state, and invalidating both.
+
+Deliberately NOT here:
+
+* **Eligibility.** Whether a call takes the rolling strategy at all is policy
+  and stays in the client.
+* **Identity construction.** Building a `RollingRouteIdentity` needs the model
+  path, profile, config, metadata identity and reset generation -- client-wide
+  facts. This module consumes an identity; it never assembles one.
+* **Physical KV.** No `ctx_tgt`, no `lib`, no native calls. Capturing and
+  restoring a checkpoint are backend primitives the client executes; this side
+  only records the resulting state.
+* **Committed identity.** That belongs to `CommittedIdentity`. The restore path
+  publishes through its existing contract; nothing here touches it.
+
+Reuse *authorization* also stays outside: `rolling_route_reuse_start` and the
+strict exact-prefix rule in `_prepare_memory_for_prompt` remain the single
+authority on whether reuse is allowed.
+"""
+from __future__ import annotations
+
+from .rolling_route_anchor import (
+    ROLLING_ANALYSIS_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+    invalidate_rolling_route_anchor,
+)
+
+
+class RollingAnchorStore:
+    """The single owner of the two rolling-anchor checkpoint slots."""
+
+    __slots__ = ("_route", "_analysis")
+
+    def __init__(self) -> None:
+        self._route = RollingRouteAnchorState()
+        self._analysis = RollingRouteAnchorState()
+
+    @staticmethod
+    def slot_for(identity: RollingRouteIdentity | None) -> str:
+        """Which checkpoint an identity addresses, decided by its own strategy.
+
+        The backend still knows nothing about CHAT or ANALYSIS: it reads the
+        strategy the caller already put in the identity it supplied.
+        """
+        if identity is not None and identity.strategy_id == ROLLING_ANALYSIS_STRATEGY_ID:
+            return "analysis"
+        return "route"
+
+    @property
+    def route_state(self) -> RollingRouteAnchorState:
+        return self._route
+
+    @property
+    def analysis_state(self) -> RollingRouteAnchorState:
+        return self._analysis
+
+    def state_for(self, identity: RollingRouteIdentity | None) -> RollingRouteAnchorState:
+        """What is stored in the slot this identity addresses.
+
+        An absent slot reads as empty rather than raising: a checkpoint that is
+        not there must fall cold, never fail the call.
+        """
+        if self.slot_for(identity) == "analysis":
+            return self._analysis or RollingRouteAnchorState()
+        return self._route
+
+    def store(
+        self, identity: RollingRouteIdentity | None, state: RollingRouteAnchorState
+    ) -> None:
+        """Record a checkpoint in the slot this identity addresses."""
+        if self.slot_for(identity) == "analysis":
+            self._analysis = state
+        else:
+            self._route = state
+
+    def invalidate(self, reason: str) -> None:
+        """Invalidate BOTH lineages.
+
+        A reset destroys the conversation whose tokens these are, and an
+        analysis checkpoint surviving it would be exactly the stale-state reuse
+        the identity check exists to prevent.
+
+        An already-empty slot is left untouched rather than rewritten with a
+        fresh invalidated state: that mirrors the shipped behaviour, and it
+        keeps the recorded `invalidation_reason` of the first invalidation
+        instead of overwriting it with whatever reason came last.
+        """
+        if self._route.valid or self._route.identity is not None:
+            self._route = invalidate_rolling_route_anchor(self._route, reason)
+        analysis = self._analysis
+        if analysis is not None and (analysis.valid or analysis.identity is not None):
+            self._analysis = invalidate_rolling_route_anchor(analysis, reason)

--- a/tests/test_ornith_route_prefix.py
+++ b/tests/test_ornith_route_prefix.py
@@ -658,8 +658,21 @@ class OrnithAnalysisIsolationTests(unittest.TestCase):
         self.assertIn("_rolling_analysis_anchor_state", text)
         self.assertIn("_ornith_route_prefix_anchor_state", text)
         # The prewarm slot must never be read by the analysis rolling path.
-        analysis_fn = text[text.index("def _rolling_anchor_state_for") :][:600]
-        self.assertNotIn("_ornith_route_prefix_anchor_state", analysis_fn)
+        # Slot selection now lives in RollingAnchorStore, so the guard follows
+        # it there: a window over the client's one-line delegate would cover
+        # only the delegate and pin nothing.
+        store = (
+            Path(__file__).resolve().parents[1]
+            / "src/orbit/native_llama/rolling_anchor_store.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn(
+            "_ornith_route_prefix_anchor_state", store,
+            "the rolling store must never reach the prewarm slot",
+        )
+        self.assertNotIn(
+            "ornith_route_prefix", store,
+            "the rolling lineages are independent of the prewarm anchor",
+        )
 
     def test_route_prefix_registry_never_returns_the_analysis_slot(self) -> None:
         source = Path(__file__).resolve().parents[1] / "src/orbit/native_llama/client.py"

--- a/tests/test_rolling_anchor_store.py
+++ b/tests/test_rolling_anchor_store.py
@@ -1,0 +1,328 @@
+"""The rolling-anchor store: one owner for two independent checkpoint slots.
+
+CHAT route and ANALYSIS keep separate checkpoints, and the separation is the
+safety property: restoring an analysis checkpoint for a route prompt would put
+someone else's KV behind the model. The slot follows the identity's own
+`strategy_id`, so neither lineage can address the other's slot.
+
+These execute the real store over real `RollingRouteAnchorState` values.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.rolling_anchor_store import RollingAnchorStore
+from orbit.native_llama.rolling_route_anchor import (
+    ROLLING_ANALYSIS_STRATEGY_ID,
+    ROLLING_ROUTE_STRATEGY_ID,
+    RollingRouteAnchorState,
+    RollingRouteIdentity,
+)
+
+
+def _identity(strategy: str = ROLLING_ROUTE_STRATEGY_ID) -> RollingRouteIdentity:
+    return RollingRouteIdentity(
+        strategy_id=strategy,
+        session_id="s",
+        profile_id="p",
+        model_id="m",
+        template_id="t",
+        tool_schema_hash="h",
+        capability_summary_hash="c",
+        runtime_policy_hash="r",
+        native_version="v",
+        tools_mode="on",
+        reset_generation=0,
+    )
+
+
+def _state(tokens, identity=None) -> RollingRouteAnchorState:
+    return RollingRouteAnchorState(
+        identity=identity or _identity(),
+        tokens=list(tokens),
+        checkpoint_data=b"kv",
+    )
+
+
+class SlotSelectionTests(unittest.TestCase):
+    """Which slot an identity addresses is read from the identity itself."""
+
+    def test_route_identity_addresses_the_route_slot(self) -> None:
+        self.assertEqual(RollingAnchorStore.slot_for(_identity()), "route")
+
+    def test_analysis_identity_addresses_the_analysis_slot(self) -> None:
+        self.assertEqual(
+            RollingAnchorStore.slot_for(_identity(ROLLING_ANALYSIS_STRATEGY_ID)),
+            "analysis",
+        )
+
+    def test_absent_identity_defaults_to_route(self) -> None:
+        """No identity must not raise and must not reach the analysis slot."""
+        self.assertEqual(RollingAnchorStore.slot_for(None), "route")
+
+
+class StoreAndReadTests(unittest.TestCase):
+    def test_an_empty_store_reads_as_no_checkpoint(self) -> None:
+        store = RollingAnchorStore()
+        self.assertFalse(store.state_for(_identity()).valid)
+        self.assertFalse(
+            store.state_for(_identity(ROLLING_ANALYSIS_STRATEGY_ID)).valid
+        )
+
+    def test_a_stored_checkpoint_reads_back(self) -> None:
+        store = RollingAnchorStore()
+        identity = _identity()
+        state = _state([1, 2, 3], identity)
+
+        store.store(identity, state)
+
+        self.assertIs(store.state_for(identity), state)
+        self.assertEqual(store.state_for(identity).tokens, [1, 2, 3])
+
+    def test_storing_replaces_the_previous_checkpoint(self) -> None:
+        store = RollingAnchorStore()
+        identity = _identity()
+        store.store(identity, _state([1, 2], identity))
+        store.store(identity, _state([1, 2, 3], identity))
+
+        self.assertEqual(
+            store.state_for(identity).tokens, [1, 2, 3],
+            "a stale checkpoint must not survive its replacement",
+        )
+
+
+class LineageIsolationTests(unittest.TestCase):
+    """Neither lineage may ever read the other's checkpoint.
+
+    This is the safety property, not a tidiness one: restoring an analysis
+    checkpoint for a route prompt puts a different conversation's KV behind the
+    model, which answers confidently from someone else's context.
+    """
+
+    def test_a_route_checkpoint_is_invisible_to_analysis(self) -> None:
+        store = RollingAnchorStore()
+        route_id = _identity()
+        store.store(route_id, _state([1, 2, 3], route_id))
+
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        self.assertFalse(
+            store.state_for(analysis_id).valid,
+            "an analysis prompt must never see the route checkpoint",
+        )
+
+    def test_an_analysis_checkpoint_is_invisible_to_route(self) -> None:
+        store = RollingAnchorStore()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        store.store(analysis_id, _state([9, 9], analysis_id))
+
+        self.assertFalse(
+            store.state_for(_identity()).valid,
+            "a route prompt must never see the analysis checkpoint",
+        )
+
+    def test_the_two_slots_hold_different_checkpoints_at_once(self) -> None:
+        store = RollingAnchorStore()
+        route_id = _identity()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        store.store(route_id, _state([1, 2], route_id))
+        store.store(analysis_id, _state([7, 8, 9], analysis_id))
+
+        self.assertEqual(store.state_for(route_id).tokens, [1, 2])
+        self.assertEqual(store.state_for(analysis_id).tokens, [7, 8, 9])
+
+
+class InvalidationTests(unittest.TestCase):
+    def test_invalidation_clears_both_lineages(self) -> None:
+        """A reset destroys the conversation both checkpoints belong to."""
+        store = RollingAnchorStore()
+        route_id = _identity()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        store.store(route_id, _state([1, 2], route_id))
+        store.store(analysis_id, _state([7, 8], analysis_id))
+
+        store.invalidate("session_reset")
+
+        self.assertFalse(store.state_for(route_id).valid)
+        self.assertFalse(
+            store.state_for(analysis_id).valid,
+            "an analysis checkpoint surviving a reset is exactly the stale "
+            "reuse the identity check exists to prevent",
+        )
+
+    def test_invalidation_records_the_reason(self) -> None:
+        store = RollingAnchorStore()
+        identity = _identity()
+        store.store(identity, _state([1, 2], identity))
+
+        store.invalidate("route_change")
+
+        self.assertEqual(
+            store.state_for(identity).invalidation_reason, "route_change"
+        )
+
+    def test_an_invalidated_checkpoint_cannot_be_read_back(self) -> None:
+        store = RollingAnchorStore()
+        identity = _identity()
+        store.store(identity, _state([1, 2, 3], identity))
+        store.invalidate("gone")
+
+        self.assertEqual(
+            store.state_for(identity).tokens, [],
+            "invalidation must drop the tokens, not merely flag them",
+        )
+
+    def test_repeated_invalidation_keeps_the_first_reason(self) -> None:
+        """An already-empty slot is left alone rather than rewritten.
+
+        This mirrors the shipped guard: rewriting would overwrite the reason
+        that explains why the checkpoint went away with whatever reason came
+        last, losing the diagnostic.
+        """
+        store = RollingAnchorStore()
+        identity = _identity()
+        store.store(identity, _state([1, 2], identity))
+
+        store.invalidate("first_reason")
+        store.invalidate("second_reason")
+
+        self.assertEqual(
+            store.state_for(identity).invalidation_reason, "first_reason"
+        )
+
+    def test_repeated_invalidation_keeps_the_first_reason_on_analysis(self) -> None:
+        """The same guard, on the ANALYSIS slot.
+
+        Its sibling above exercises only the route slot, so dropping the guard
+        on this branch went undetected: an already-empty analysis slot would be
+        rewritten and its original `invalidation_reason` replaced by whatever
+        reason came last, losing the diagnostic that explains why the
+        checkpoint went away.
+        """
+        store = RollingAnchorStore()
+        identity = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        store.store(identity, _state([1, 2], identity))
+
+        store.invalidate("first_reason")
+        store.invalidate("second_reason")
+
+        self.assertEqual(
+            store.state_for(identity).invalidation_reason, "first_reason"
+        )
+
+    def test_invalidating_an_already_empty_analysis_slot_records_nothing(self) -> None:
+        """An untouched slot must stay untouched, reason included."""
+        store = RollingAnchorStore()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        route_id = _identity()
+        store.store(route_id, _state([1], route_id))
+
+        store.invalidate("route_only")
+
+        self.assertIsNone(
+            store.state_for(analysis_id).invalidation_reason,
+            "an empty analysis slot must not acquire a reason it never earned",
+        )
+
+    def test_invalidating_an_empty_store_is_safe(self) -> None:
+        store = RollingAnchorStore()
+        store.invalidate("nothing_to_drop")
+        self.assertFalse(store.state_for(_identity()).valid)
+
+
+class ClientOwnershipTests(unittest.TestCase):
+    """The client must project the store, never hold a second copy."""
+
+    def _client(self):
+        from orbit.native_llama.client import NativeLlamaClient
+
+        return object.__new__(NativeLlamaClient)
+
+    def test_the_client_properties_read_the_store(self) -> None:
+        client = self._client()
+        identity = _identity()
+        state = _state([4, 5], identity)
+
+        client._store_rolling_anchor_state(identity, state)
+
+        self.assertIs(client._rolling_route_anchor_state, state)
+        self.assertIs(client._rolling_anchor_state_for(identity), state)
+
+    def test_a_bare_client_reads_as_no_checkpoint(self) -> None:
+        """`object.__new__` never runs `__init__`; absence must be empty."""
+        client = self._client()
+        self.assertFalse(client._rolling_route_anchor_state.valid)
+        self.assertFalse(client._rolling_analysis_anchor_state.valid)
+
+    def test_client_invalidation_reaches_both_slots(self) -> None:
+        client = self._client()
+        route_id = _identity()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        client._store_rolling_anchor_state(route_id, _state([1], route_id))
+        client._store_rolling_anchor_state(analysis_id, _state([2], analysis_id))
+
+        client._invalidate_rolling_route_anchor("session_reset")
+
+        self.assertFalse(client._rolling_route_anchor_state.valid)
+        self.assertFalse(client._rolling_analysis_anchor_state.valid)
+
+    def test_deleting_the_analysis_slot_empties_it(self) -> None:
+        """`del` used to be legal on a plain attribute; absence means empty.
+
+        The contract is what absence MEANS -- a missing checkpoint falls cold
+        rather than raising -- so deleting empties the slot.
+        """
+        client = self._client()
+        analysis_id = _identity(ROLLING_ANALYSIS_STRATEGY_ID)
+        client._store_rolling_anchor_state(analysis_id, _state([1, 2], analysis_id))
+
+        del client._rolling_analysis_anchor_state
+
+        self.assertFalse(client._rolling_analysis_anchor_state.valid)
+        self.assertFalse(client._rolling_anchor_state_for(analysis_id).valid)
+
+    def test_the_store_never_touches_native_state(self) -> None:
+        """No ctx_tgt, no lib: physical KV ownership stays in the client.
+
+        Checked over parsed code, not raw text: the module docstring names
+        these very things to say it does NOT use them, and a substring search
+        would flag its own explanation.
+        """
+        import ast
+
+        source = (SRC / "orbit/native_llama/rolling_anchor_store.py").read_text()
+        tree = ast.parse(source)
+        names = {
+            node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+        } | {
+            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+        } | {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        } | {
+            node.module or ""
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+        }
+        for forbidden in ("ctx_tgt", "lib", "ctypes"):
+            self.assertNotIn(
+                forbidden, names,
+                f"the store must not reach native state ({forbidden}); "
+                f"capture and restore stay backend primitives",
+            )
+        self.assertFalse(
+            [n for n in names if n.startswith("llama_")],
+            "the store must make no native calls",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fifth incremental extraction. The rolling route-anchor family kept two independent KV checkpoint slots — **CHAT route** and **ANALYSIS** — in `client.py`. `RollingAnchorStore` now owns those slots and the four operations over them: slot selection, lookup, store and invalidation.

**Behaviour-preserving.** Runtime-only extraction, no broad KV ownership move, no committed-identity change, no MTP policy change, no backend semantic change, no performance claim.

### The extraction gate

The audit found **9 methods** in the family, not the ~4 estimated. Only 4 moved.

The gate holds: the single `ctx_tgt`/`lib` dependency sits entirely in `_prepare_memory_with_ornith_rolling_route_anchor`, which orchestrates the native restore, `_clear_target_memory`, `_invalidate_committed_sequence` and `_prepare_memory_for_prompt`. Moving it inward would have meant passing the client or the lib into the collaborator — precisely the coupling the mission forbids — so it stays **byte-identical**. The store has zero native access; its only imports are `__future__` and the pure state module.

Identity construction (5+ client-wide facts) and the three eligibility predicates also stay. **The store owns the slot, not the strategy.**

### Lineage isolation is a safety property

Separation follows the identity's own `strategy_id`, so the backend still learns nothing about CHAT vs ANALYSIS. Restoring an analysis checkpoint for a route prompt would put a different conversation's KV behind the model, which then answers confidently from someone else's context. **Both leak directions are pinned by mutation.**

### Deleter

A pre-existing test uses `del` to simulate an absent slot. The property gained a deleter that empties the slot; the contract that matters — a missing checkpoint falls cold rather than raising — is identical.

### Qualification

**10 mutants caught**, including one surfaced in review: the already-empty guard was pinned on the route slot only, so dropping it on the *analysis* branch survived. Two tests added; mutant now caught. A second review finding re-pointed a text guard that the extraction had silently defanged — it sliced 600 chars from a method that is now a one-line delegate, so it pinned nothing; it now catches a real injected prewarm-slot leak.

Equivalence independently verified across **16,661 checks over 5,024 operation sequences, zero divergences**. Native calls unchanged (`restore_rolling_route_anchor` called exactly once).

Full suite **3796 collected / 3788 passed / 8 skipped / 0 failed, real exit 0** against a 3775 baseline. Review: **BLOCKER 0 / MAJOR 0**.

`client.py` 4912 → 4933; store 103 lines. `rolling_route_anchor.py`, `committed_identity.py` and `mtp_session_lifecycle.py` all zero diff.
