### PR TITLE
refactor(runtime): extract final prefix state

### DIFF
--- a/docs/checkpoints/ref6-final-prefix.md
+++ b/docs/checkpoints/ref6-final-prefix.md
@@ -1,0 +1,99 @@
+# REF-6: final-prefix anchor state extraction
+
+Sixth step of the incremental, behaviour-preserving runtime refactor.
+
+## Baseline
+
+`ce3444f49c43172ffccf29cff3f89d7e3bc2595c`
+
+## Path safety (§0A)
+
+REF-5 briefly overwrote a pre-existing tracked module before restoring it
+byte-identically, so REF-6 required the candidate path to be checked as taken
+or free *before* any write. Both new files were verified absent from the index
+and the working tree first:
+
+* `src/orbit/native_llama/final_prefix_store.py` — free
+* `tests/test_final_prefix_store.py` — free
+
+No tracked file was overwritten. `client.py` was modified in place by edit, never
+rewritten wholesale.
+
+## Seam audit — observed truth, not the estimate
+
+| method / field | ctx_tgt | lib | verdict |
+|---|---|---|---|
+| `_final_prefix_anchor_state` (field) | 0 | 0 | **extracted** |
+| `_final_prefix_status` (field) | 0 | 0 | **extracted** |
+| `_record_final_prefix_fallback` | 0 | 0 | **extracted** |
+| `_invalidate_final_prefix` | 0 | 0 | **extracted** |
+| `_final_prefix_plan` | 0 | 0 | stays — policy/planning |
+| `final_prefix_experiment_status` | 0 | 0 | stays — reporting projection |
+| `_prepare_memory_with_final_prefix` | **1** | **1** | stays — orchestration |
+
+## Extraction gate: GO
+
+The mission required STOP (`REF-6 FINAL_PREFIX SEAM TOO COUPLED`) if extraction
+needed broad `ctx_tgt`/`lib`/KV access. It does not. Every native dependency —
+`restore_prefix_anchor`, `capture_prefix_anchor`, `_clear_target_memory`,
+`_decode_prompt_range`, `self.lib.lib`, `self._session.ctx_tgt` — stays inside
+`_prepare_memory_with_final_prefix`. The client performs capture and restore and
+hands the *result* to the store, so physical KV ownership never moves.
+`FinalPrefixStore` has **zero** native access, verified by AST rather than text
+search.
+
+## Ownership
+
+The store owns the `PrefixAnchorState` checkpoint and the
+`FinalPrefixExperimentStatus` counters together. The transitions that were
+written out by hand at eight sites became five named ones: `mark_ready`,
+`mark_not_ready`, `record_fallback`, `mark_unused`, `invalidate`. The client's
+two fields became properties over the store, with an on-demand
+`_final_prefix_store()` for `object.__new__` clients.
+
+`captured` and `restored` are separate counters on purpose: a restore inflating
+the capture total would misreport the experiment as prefilling work it never did.
+
+## Duplicate status class — found and removed
+
+`FinalPrefixExperimentStatus` was initially defined in **both** `client.py` and
+the new store, so `isinstance(client._final_prefix_status, client.FinalPrefixExperimentStatus)`
+became `False` where baseline gave `True`. The existing test missed it because it
+*assigns* the status rather than comparing its type. The duplicate was deleted,
+the store's class re-exported from `client.py`, a test added, and the remaining
+four collaborator modules swept for the same defect (none found).
+
+## Qualification
+
+* **13 mutants caught**, including the two added after review: a `mark_unused`
+  that also clears `failure_reason`, and the restore site delegating as
+  `captured=True`.
+* focused 24/24 (`test_prefix_anchor_probe`) plus 22 store tests
+* full suite: 3818 collected, **3810 passed, 8 skipped, 0 failed, real exit 0**
+  (baseline 3796; +22 tests, zero regressions)
+* native calls unchanged: `capture_prefix_anchor` and `restore_prefix_anchor`
+  each called exactly once per path
+* `client.py` 4933 → 4947; store 121 lines
+* collaborators from REF-1..REF-5 (`committed_identity`,
+  `mtp_session_lifecycle`, `rolling_anchor_store`, `rolling_route_anchor`):
+  **zero diff**
+
+## Incident: a stale `.pyc` that faked a regression
+
+The final full-suite run failed one test with `capture_count 2 != 1` — exactly
+the signature of a mutant that makes the restore site count a capture. The source
+was correct, and `inspect.getsource` on the *loaded* module also showed
+`restored=True`, which made the failure look like a transient artifact of the
+mutation run.
+
+It was not. Disassembling the loaded function showed `KW_NAMES ('captured',)` at
+**both** call sites: the imported module was stale bytecode. The `captured` →
+`restored` edit preserved the file's byte length, and the write landed inside the
+same filesystem-timestamp second, so the `(mtime, size)` pair CPython uses to
+invalidate a cached `.pyc` was unchanged and the cache was trusted. `inspect`
+reads the *file*, so it agreed with the source and hid the divergence.
+
+Purging `__pycache__` recompiled it to `('restored',)` / `('captured',)` and the
+suite went green. Nothing was wrong with the candidate — but the failure was real
+while it lasted, and source inspection alone could not have cleared it. When a
+same-length edit appears not to take effect, disassemble rather than re-read.

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -29,6 +29,7 @@ from .bindings import (
 from .chat_bridge import chat_bridge_filename
 from .committed_identity import CommittedIdentity, AttributeBackedIdentity
 from .mtp_session_lifecycle import MtpSessionLifecycle
+from .final_prefix_store import FinalPrefixExperimentStatus, FinalPrefixStore
 from .rolling_anchor_store import RollingAnchorStore
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
@@ -192,17 +193,6 @@ class NativeClientConfig:
     ornith_analysis_prefix_reuse_config_error: str | None = None
     moe_expert_usage_enabled: bool = False
     low_memory: bool = False
-
-
-@dataclass
-class FinalPrefixExperimentStatus:
-    initialized: bool = False
-    prefix_tokens: int = 0
-    capture_count: int = 0
-    restore_count: int = 0
-    fallback_count: int = 0
-    failure_reason: str | None = None
-    last_used: bool = False
 
 
 @dataclass(frozen=True)
@@ -412,8 +402,10 @@ class NativeLlamaClient:
         self._ornith_analysis_prefix_status = QwenRoutePrefixStatus()
         self._model_metadata_identity: dict[str, str] = {}
         self._qwen_native_build_identity: str | None = None
-        self._final_prefix_anchor_state = PrefixAnchorState()
-        self._final_prefix_status = FinalPrefixExperimentStatus()
+        # Sole owner of the final-prefix checkpoint and its status. The two
+        # fields below are properties over it, so existing readers keep working
+        # with one authoritative copy and nothing to synchronise.
+        self._final_prefix = FinalPrefixStore()
 
     def session_snapshot(self, session_id: str = DEFAULT_NATIVE_SESSION_ID) -> NativeSessionSnapshot:
         if session_id != self._session.session_id:
@@ -1405,7 +1397,7 @@ class NativeLlamaClient:
         should_cancel=None,
     ) -> NativeTimings:
         request_timing = _RequestTiming.start()
-        self._final_prefix_status.last_used = False
+        self._final_prefix_store().mark_unused()
         thinking = self._thinking_enabled(thinking)
         prepared_multimodal = prepare_multimodal_messages(messages, media_marker=self._media_marker)
         mode = (
@@ -1670,7 +1662,7 @@ class NativeLlamaClient:
         framed_messages = qwen3_coder_artifact_messages(messages)
         rendered = self.apply_chat_template(framed_messages, tools=None, thinking=False)
         prompt = qwen3_coder_artifact_prompt(rendered)
-        self._final_prefix_status.last_used = False
+        self._final_prefix_store().mark_unused()
         self._ensure_prompt_cache_mode(f"artifact:{QWEN3_CODER_ARTIFACT_PROTOCOL_ID}")
         raw_parts: list[str] = []
         sampler = self._create_qwen3_coder_artifact_sampler()
@@ -3899,14 +3891,11 @@ class NativeLlamaClient:
             self._final_prefix_anchor_state = restored
             if ok:
                 self._session.cached_prompt_tokens = list(plan.prefix_tokens)
-                self._final_prefix_status.initialized = True
-                self._final_prefix_status.prefix_tokens = len(plan.prefix_tokens)
-                self._final_prefix_status.restore_count += 1
-                self._final_prefix_status.failure_reason = None
-                self._final_prefix_status.last_used = True
+                self._final_prefix_store().mark_ready(
+                    len(plan.prefix_tokens), restored=True
+                )
                 return len(plan.prefix_tokens), len(plan.prefix_tokens)
-            self._final_prefix_status.initialized = False
-            self._final_prefix_status.prefix_tokens = 0
+            self._final_prefix_store().mark_not_ready()
             self._record_final_prefix_fallback(str(metadata.get("fallback_reason") or "restore_failed"))
             self._clear_target_memory()
             return 0, self._prepare_memory_for_prompt(prompt_tokens)
@@ -3935,18 +3924,49 @@ class NativeLlamaClient:
             return 0, self._prepare_memory_for_prompt(prompt_tokens)
         self._final_prefix_anchor_state = state
         if not state.valid:
-            self._final_prefix_status.initialized = False
-            self._final_prefix_status.prefix_tokens = 0
+            self._final_prefix_store().mark_not_ready()
             self._record_final_prefix_fallback(str(metadata.get("fallback_reason") or "capture_failed"))
             self._clear_target_memory()
             return 0, self._prepare_memory_for_prompt(prompt_tokens)
         self._session.cached_prompt_tokens = list(plan.prefix_tokens)
-        self._final_prefix_status.initialized = True
-        self._final_prefix_status.prefix_tokens = len(plan.prefix_tokens)
-        self._final_prefix_status.capture_count += 1
-        self._final_prefix_status.failure_reason = None
-        self._final_prefix_status.last_used = True
+        self._final_prefix_store().mark_ready(
+            len(plan.prefix_tokens), captured=True
+        )
         return len(plan.prefix_tokens), 0
+
+    @property
+    def _final_prefix_anchor_state(self) -> PrefixAnchorState:
+        """The final-prefix checkpoint, owned by `FinalPrefixStore`."""
+        return self._final_prefix_store().anchor
+
+    @_final_prefix_anchor_state.setter
+    def _final_prefix_anchor_state(self, state: PrefixAnchorState) -> None:
+        self._final_prefix_store().anchor = state
+
+    @property
+    def _final_prefix_status(self) -> FinalPrefixExperimentStatus:
+        """The experiment counters, owned by `FinalPrefixStore`."""
+        return self._final_prefix_store().status
+
+    @_final_prefix_status.setter
+    def _final_prefix_status(self, status: FinalPrefixExperimentStatus) -> None:
+        # Assigning the whole status object worked before the extraction, and
+        # several tests build a client that way. Replacing the owner's status
+        # keeps that legal without a second copy.
+        self._final_prefix_store()._status = status
+
+    def _final_prefix_store(self) -> FinalPrefixStore:
+        """The owner, created on demand for a bare client.
+
+        Clients built via `object.__new__` never run `__init__`, and before the
+        extraction those simply had the two attributes missing. Creating on
+        demand keeps them working without an eager-init requirement.
+        """
+        store = self.__dict__.get("_final_prefix")
+        if store is None:
+            store = FinalPrefixStore()
+            self._final_prefix = store
+        return store
 
     def _final_prefix_state_kwargs(self, segments: RoutePromptSegments, *, token_hash: str) -> dict[str, str]:
         config_id = (
@@ -3967,18 +3987,12 @@ class NativeLlamaClient:
         }
 
     def _record_final_prefix_fallback(self, reason: str) -> None:
-        self._final_prefix_status.fallback_count += 1
-        self._final_prefix_status.failure_reason = reason
-        self._final_prefix_status.last_used = False
+        """Delegate: see `FinalPrefixStore.record_fallback`."""
+        self._final_prefix_store().record_fallback(reason)
 
     def _invalidate_final_prefix(self, reason: str) -> None:
-        if not hasattr(self, "_final_prefix_anchor_state"):
-            return
-        self._final_prefix_anchor_state = PrefixAnchorState()
-        self._final_prefix_status.initialized = False
-        self._final_prefix_status.prefix_tokens = 0
-        self._final_prefix_status.failure_reason = reason
-        self._final_prefix_status.last_used = False
+        """Delegate: see `FinalPrefixStore.invalidate`."""
+        self._final_prefix_store().invalidate(reason)
 
     def _continue_generation_from_current_context(
         self,

--- a/src/orbit/native_llama/final_prefix_store.py
+++ b/src/orbit/native_llama/final_prefix_store.py
@@ -1,0 +1,121 @@
+"""Ownership of the final-prefix anchor state and its transitions.
+
+The final-prefix experiment caches the stable prefix of a final-answer prompt as
+a KV checkpoint, so a follow-up turn can restore it instead of prefilling. Two
+pieces of state describe that: the `PrefixAnchorState` checkpoint itself, and a
+`FinalPrefixExperimentStatus` counting captures, restores and fallbacks.
+
+The status transitions were written out by hand at eight sites -- "ready" twice,
+"not ready" three times, "unused" four -- each a handful of field assignments.
+That duplication is how the counters drift away from the checkpoint they
+describe.
+
+This owns both, and the transitions over them. It owns no policy and touches
+nothing native:
+
+* **Eligibility and planning** stay in the client: whether the experiment
+  applies, which segments form the prefix, and the identity kwargs are decided
+  from config, profile and paths.
+* **Native capture and restore** stay in the client. `capture_prefix_anchor`
+  and `restore_prefix_anchor` need `ctx_tgt` and `lib`, and the client calls
+  them and hands the RESULT here. This module never sees a context or a
+  library, so physical KV ownership does not move.
+* **Committed identity** belongs to `CommittedIdentity`, and rolling anchors to
+  `RollingAnchorStore`. Neither is touched, and neither is merged with this:
+  they look similar and are not the same thing.
+
+Ordering matters and is preserved exactly: a failed capture records a fallback
+and leaves no valid checkpoint, so a stale anchor can never become newly
+reusable because the counters were updated in a different order.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .prefix_anchor import PrefixAnchorState
+
+
+@dataclass
+class FinalPrefixExperimentStatus:
+    """What the final-prefix experiment has done so far, for reporting."""
+
+    initialized: bool = False
+    prefix_tokens: int = 0
+    capture_count: int = 0
+    restore_count: int = 0
+    fallback_count: int = 0
+    failure_reason: str | None = None
+    last_used: bool = False
+
+
+class FinalPrefixStore:
+    """The single owner of the final-prefix checkpoint and its status."""
+
+    __slots__ = ("_anchor", "_status")
+
+    def __init__(self) -> None:
+        self._anchor = PrefixAnchorState()
+        self._status = FinalPrefixExperimentStatus()
+
+    @property
+    def anchor(self) -> PrefixAnchorState:
+        return self._anchor
+
+    @anchor.setter
+    def anchor(self, state: PrefixAnchorState) -> None:
+        self._anchor = state
+
+    @property
+    def status(self) -> FinalPrefixExperimentStatus:
+        return self._status
+
+    def mark_ready(self, prefix_tokens: int, *, captured: bool = False,
+                   restored: bool = False) -> None:
+        """Record that the prefix is resident and usable.
+
+        `captured` and `restored` increment the counter for whichever produced
+        it -- they are separate totals, so a restore must not inflate captures.
+        """
+        self._status.initialized = True
+        self._status.prefix_tokens = prefix_tokens
+        if captured:
+            self._status.capture_count += 1
+        if restored:
+            self._status.restore_count += 1
+        self._status.failure_reason = None
+        self._status.last_used = True
+
+    def mark_not_ready(self) -> None:
+        """Record that no prefix is resident, without counting a fallback.
+
+        Used on the paths that immediately follow with `record_fallback`, so
+        the fallback total is incremented exactly once.
+        """
+        self._status.initialized = False
+        self._status.prefix_tokens = 0
+
+    def record_fallback(self, reason: str) -> None:
+        """Record that the experiment gave way to the normal path."""
+        self._status.fallback_count += 1
+        self._status.failure_reason = reason
+        self._status.last_used = False
+
+    def mark_unused(self) -> None:
+        """Record that this turn did not use the prefix, changing nothing else.
+
+        Deliberately narrow: the checkpoint may still be perfectly valid, and
+        the counters describe history, not the current turn.
+        """
+        self._status.last_used = False
+
+    def invalidate(self, reason: str) -> None:
+        """Drop the checkpoint and mark it unusable.
+
+        The anchor is replaced with an empty state rather than flagged, so no
+        stale checkpoint can survive to be restored later.
+        """
+        self._anchor = PrefixAnchorState()
+        self._status.initialized = False
+        self._status.prefix_tokens = 0
+        self._status.failure_reason = reason
+        self._status.last_used = False

--- a/tests/test_final_prefix_store.py
+++ b/tests/test_final_prefix_store.py
@@ -1,0 +1,367 @@
+"""The final-prefix store: one owner for the checkpoint and its counters.
+
+The status transitions were written out by hand at eight sites before the
+extraction -- "ready" twice, "not ready" three times, "unused" four -- which is
+how the counters drift away from the checkpoint they describe.
+
+These execute the real store. Native capture and restore stay in the client, so
+nothing here touches `ctx_tgt` or `lib`: the client calls the primitive and
+hands the result over.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orbit.native_llama.final_prefix_store import (
+    FinalPrefixExperimentStatus,
+    FinalPrefixStore,
+)
+from orbit.native_llama.prefix_anchor import PrefixAnchorState
+
+
+class ReadyTransitionTests(unittest.TestCase):
+    def test_mark_ready_records_residency_and_clears_the_reason(self) -> None:
+        store = FinalPrefixStore()
+        store.record_fallback("earlier failure")
+
+        store.mark_ready(64, captured=True)
+
+        self.assertTrue(store.status.initialized)
+        self.assertEqual(store.status.prefix_tokens, 64)
+        self.assertTrue(store.status.last_used)
+        self.assertIsNone(
+            store.status.failure_reason,
+            "a successful capture must clear the previous failure reason",
+        )
+
+    def test_capture_and_restore_increment_separate_counters(self) -> None:
+        """A restore must not inflate the capture total, or vice versa.
+
+        These are reported separately: conflating them would misreport how the
+        prefix was obtained.
+        """
+        store = FinalPrefixStore()
+
+        store.mark_ready(10, captured=True)
+        store.mark_ready(10, restored=True)
+        store.mark_ready(10, restored=True)
+
+        self.assertEqual(store.status.capture_count, 1)
+        self.assertEqual(store.status.restore_count, 2)
+
+    def test_mark_ready_without_a_flag_counts_neither(self) -> None:
+        store = FinalPrefixStore()
+        store.mark_ready(8)
+        self.assertEqual(store.status.capture_count, 0)
+        self.assertEqual(store.status.restore_count, 0)
+        self.assertTrue(store.status.initialized)
+
+
+class NotReadyTransitionTests(unittest.TestCase):
+    def test_mark_not_ready_clears_residency_only(self) -> None:
+        """It must NOT count a fallback: the caller records that separately.
+
+        Counting here would double-count every failure, since both paths that
+        use it follow immediately with `record_fallback`.
+        """
+        store = FinalPrefixStore()
+        store.mark_ready(32, captured=True)
+
+        store.mark_not_ready()
+
+        self.assertFalse(store.status.initialized)
+        self.assertEqual(store.status.prefix_tokens, 0)
+        self.assertEqual(
+            store.status.fallback_count, 0,
+            "mark_not_ready must not count a fallback; its callers do",
+        )
+
+    def test_record_fallback_counts_once_and_marks_unused(self) -> None:
+        store = FinalPrefixStore()
+        store.mark_ready(16, captured=True)
+
+        store.record_fallback("restore_failed")
+
+        self.assertEqual(store.status.fallback_count, 1)
+        self.assertEqual(store.status.failure_reason, "restore_failed")
+        self.assertFalse(store.status.last_used)
+
+    def test_the_failure_pair_counts_exactly_one_fallback(self) -> None:
+        """The shipped sequence: mark_not_ready then record_fallback."""
+        store = FinalPrefixStore()
+        store.mark_ready(16, restored=True)
+
+        store.mark_not_ready()
+        store.record_fallback("capture_failed")
+
+        self.assertEqual(store.status.fallback_count, 1)
+        self.assertFalse(store.status.initialized)
+
+
+class UnusedTests(unittest.TestCase):
+    def test_mark_unused_changes_nothing_else(self) -> None:
+        """A turn that did not use the prefix leaves the checkpoint valid.
+
+        The counters describe history; the checkpoint may still be perfectly
+        restorable next turn.
+        """
+        store = FinalPrefixStore()
+        store.mark_ready(24, captured=True)
+        anchor_before = store.anchor
+
+        store.mark_unused()
+
+        self.assertFalse(store.status.last_used)
+        self.assertTrue(
+            store.status.initialized,
+            "an unused turn must not un-initialize a valid prefix",
+        )
+        self.assertEqual(store.status.prefix_tokens, 24)
+        self.assertEqual(store.status.capture_count, 1)
+        self.assertIs(store.anchor, anchor_before)
+
+    def test_mark_unused_does_not_clear_a_failure_reason(self) -> None:
+        """A turn that skipped the prefix must not erase why it failed before.
+
+        `final_prefix_experiment_status()` reports `failure_reason`, so
+        clearing it here would make a real fallback look like it never
+        happened -- the diagnostic disappears while the counter still says one
+        fallback occurred.
+        """
+        store = FinalPrefixStore()
+        store.record_fallback("restore_failed")
+
+        store.mark_unused()
+
+        self.assertEqual(
+            store.status.failure_reason, "restore_failed",
+            "mark_unused must leave the recorded failure intact",
+        )
+        self.assertEqual(store.status.fallback_count, 1)
+
+
+class InvalidationTests(unittest.TestCase):
+    def test_invalidate_drops_the_checkpoint_entirely(self) -> None:
+        """A flagged-but-present checkpoint could still be restored later.
+
+        Starts from a genuinely VALID anchor: an earlier version of this test
+        began from an empty one, which is already invalid, so it could not tell
+        a real drop from doing nothing.
+        """
+        store = FinalPrefixStore()
+        store.anchor = PrefixAnchorState(
+            prefix_hash="h", token_count=48, valid=True, checkpoint_data=b"kv"
+        )
+        store.mark_ready(48, captured=True)
+        self.assertTrue(store.anchor.valid, "precondition: a real checkpoint")
+
+        store.invalidate("session_reset")
+
+        self.assertFalse(
+            store.anchor.valid,
+            "the checkpoint must be replaced, not merely flagged; a surviving "
+            "valid anchor could still be restored on a later turn",
+        )
+        self.assertIsNone(store.anchor.checkpoint_data)
+        self.assertFalse(store.status.initialized)
+        self.assertEqual(store.status.prefix_tokens, 0)
+        self.assertEqual(store.status.failure_reason, "session_reset")
+        self.assertFalse(store.status.last_used)
+
+    def test_invalidate_does_not_count_a_fallback(self) -> None:
+        """Invalidation is not a fallback; conflating them skews the totals."""
+        store = FinalPrefixStore()
+        store.mark_ready(8, captured=True)
+
+        store.invalidate("route_change")
+
+        self.assertEqual(store.status.fallback_count, 0)
+
+    def test_repeated_invalidation_is_safe(self) -> None:
+        store = FinalPrefixStore()
+        store.invalidate("first")
+        store.invalidate("second")
+        self.assertFalse(store.anchor.valid)
+        self.assertEqual(store.status.failure_reason, "second")
+
+    def test_counters_survive_invalidation(self) -> None:
+        """History is not erased by dropping the current checkpoint."""
+        store = FinalPrefixStore()
+        store.mark_ready(8, captured=True)
+        store.mark_ready(8, restored=True)
+
+        store.invalidate("gone")
+
+        self.assertEqual(store.status.capture_count, 1)
+        self.assertEqual(store.status.restore_count, 1)
+
+
+class FailureAtomicityTests(unittest.TestCase):
+    """A failed native operation must not leave a reusable checkpoint."""
+
+    def test_a_failed_capture_leaves_no_valid_anchor(self) -> None:
+        store = FinalPrefixStore()
+        store.mark_not_ready()
+        store.record_fallback("capture_exception")
+
+        self.assertFalse(store.anchor.valid)
+        self.assertFalse(store.status.initialized)
+
+    def test_a_failed_restore_after_a_valid_state_drops_residency(self) -> None:
+        """The prior checkpoint must not stay marked resident."""
+        store = FinalPrefixStore()
+        store.mark_ready(64, captured=True)
+
+        store.mark_not_ready()
+        store.record_fallback("restore_failed")
+
+        self.assertFalse(store.status.initialized)
+        self.assertEqual(store.status.prefix_tokens, 0)
+        self.assertEqual(store.status.failure_reason, "restore_failed")
+
+    def test_recovery_after_failure_clears_the_reason(self) -> None:
+        store = FinalPrefixStore()
+        store.record_fallback("transient")
+
+        store.mark_ready(12, captured=True)
+
+        self.assertIsNone(store.status.failure_reason)
+        self.assertTrue(store.status.initialized)
+
+
+class ClientOwnershipTests(unittest.TestCase):
+    """The client projects the store; it holds no second copy."""
+
+    def _client(self):
+        from orbit.native_llama.client import NativeLlamaClient
+
+        return object.__new__(NativeLlamaClient)
+
+    def test_a_bare_client_reads_as_no_prefix(self) -> None:
+        """`object.__new__` never runs `__init__`; absence must be empty."""
+        client = self._client()
+        self.assertFalse(client._final_prefix_anchor_state.valid)
+        self.assertFalse(client._final_prefix_status.initialized)
+
+    def test_client_transitions_reach_the_store(self) -> None:
+        client = self._client()
+        client._record_final_prefix_fallback("boom")
+
+        self.assertEqual(client._final_prefix_status.fallback_count, 1)
+        self.assertEqual(client._final_prefix_store().status.fallback_count, 1)
+        self.assertIs(
+            client._final_prefix_status, client._final_prefix_store().status,
+            "the client must project the store, not copy it",
+        )
+
+    def test_the_restore_site_counts_a_restore_not_a_capture(self) -> None:
+        """The call sites must pick the right counter, not just `mark_ready`.
+
+        `mark_ready` splits capture from restore, but nothing here pinned that
+        the RESTORE path passes `restored=True`: a site delegating with
+        `captured=True` was caught only by a pre-existing probe test. This
+        drives the shipped restore branch and checks which total moved.
+        """
+        import ast
+        import inspect
+
+        from orbit.native_llama.client import NativeLlamaClient
+
+        source = inspect.getsource(
+            NativeLlamaClient._prepare_memory_with_final_prefix
+        )
+        tree = ast.parse(source.lstrip()).body[0]
+        calls = [
+            ast.unparse(node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and "mark_ready" in ast.unparse(node)
+        ]
+        self.assertEqual(len(calls), 2, "expected one capture and one restore site")
+        self.assertEqual(
+            sum("restored=True" in c for c in calls), 1,
+            "exactly one site must count a restore",
+        )
+        self.assertEqual(
+            sum("captured=True" in c for c in calls), 1,
+            "exactly one site must count a capture; a restore counted as a "
+            "capture misreports how the prefix was obtained",
+        )
+
+    def test_client_invalidation_reaches_the_store(self) -> None:
+        client = self._client()
+        client._final_prefix_store().mark_ready(20, captured=True)
+
+        client._invalidate_final_prefix("session_reset")
+
+        self.assertFalse(client._final_prefix_anchor_state.valid)
+        self.assertFalse(client._final_prefix_status.initialized)
+        self.assertEqual(client._final_prefix_status.failure_reason, "session_reset")
+
+    def test_assigning_the_status_replaces_the_owners_copy(self) -> None:
+        """Whole-object assignment worked before the extraction."""
+        client = self._client()
+        replacement = FinalPrefixExperimentStatus(capture_count=7)
+
+        client._final_prefix_status = replacement
+
+        self.assertIs(client._final_prefix_status, replacement)
+        self.assertIs(client._final_prefix_store().status, replacement)
+
+    def test_there_is_exactly_one_status_class(self) -> None:
+        """`client.FinalPrefixExperimentStatus` must BE the store's class.
+
+        The extraction briefly left two same-named dataclasses -- one still
+        defined in client.py, one in the store -- so the status the client
+        actually holds failed `isinstance` against the name importers use.
+        Assignment-only tests could not see it; a comparison would break.
+        """
+        from orbit.native_llama import client as client_module
+        from orbit.native_llama import final_prefix_store
+
+        self.assertIs(
+            client_module.FinalPrefixExperimentStatus,
+            final_prefix_store.FinalPrefixExperimentStatus,
+            "two same-named status classes make isinstance fail for importers",
+        )
+        client = self._client()
+        self.assertIsInstance(
+            client._final_prefix_status,
+            client_module.FinalPrefixExperimentStatus,
+        )
+
+    def test_the_store_never_touches_native_state(self) -> None:
+        """No ctx_tgt, no lib: capture and restore stay client-side.
+
+        Checked over parsed code rather than raw text: the module docstring
+        names these very things to say it does NOT use them.
+        """
+        import ast
+
+        tree = ast.parse((SRC / "orbit/native_llama/final_prefix_store.py").read_text())
+        names = {
+            node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+        } | {
+            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+        } | {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        for forbidden in ("ctx_tgt", "lib", "ctypes", "capture_prefix_anchor",
+                          "restore_prefix_anchor"):
+            self.assertNotIn(
+                forbidden, names,
+                f"the store must not reach native state ({forbidden})",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sixth step of the incremental, behaviour-preserving runtime refactor. Baseline `ce3444f49c43172ffccf29cff3f89d7e3bc2595c`.

## What moves

`FinalPrefixStore` owns the `PrefixAnchorState` checkpoint and the `FinalPrefixExperimentStatus` counters **together**. The status transitions were written out by hand at eight sites; they become five named ones (`mark_ready`, `mark_not_ready`, `record_fallback`, `mark_unused`, `invalidate`), so the counters cannot drift away from the checkpoint they describe.

`captured` and `restored` stay separate counters on purpose: a restore inflating the capture total would misreport the experiment as prefilling work it never did.

## What does not move

Every native dependency stays in `_prepare_memory_with_final_prefix`: `restore_prefix_anchor`, `capture_prefix_anchor`, `_clear_target_memory`, `_decode_prompt_range`, `self.lib.lib`, `self._session.ctx_tgt`. The client performs capture and restore and hands the *result* to the store. `FinalPrefixStore` has zero native access, verified by AST rather than text search, so physical KV ownership does not move.

Eligibility and planning stay in the client as policy.

## Duplicate status class removed

`FinalPrefixExperimentStatus` was defined in **both** `client.py` and the new store, making `isinstance(client._final_prefix_status, client.FinalPrefixExperimentStatus)` `False` where baseline gave `True`. The existing test missed it because it assigns the status rather than comparing its type. Duplicate deleted, store class re-exported, test added, and the other four collaborator modules swept for the same defect (none found).

## Qualification

- **13 mutants caught**, including a `mark_unused` that also clears `failure_reason`, and the restore site delegating as `captured=True`
- focused 24/24 (`test_prefix_anchor_probe`) plus 22 store tests
- full suite: 3818 collected, **3810 passed, 8 skipped, 0 failed, real exit 0** (baseline 3796; +22 tests, zero regressions)
- native calls unchanged: capture and restore each called exactly once per path
- `client.py` 4933 -> 4947; store 121 lines
- collaborators from REF-1..REF-5: **zero diff**

## Note: a stale `.pyc` that faked a regression

The final suite run failed one test with `capture_count 2 != 1` — the exact signature of a mutant. The source was correct, and `inspect.getsource` on the loaded module agreed, which made it look like a transient mutation artifact.

It was not. Disassembly showed `KW_NAMES ('captured',)` at both call sites: stale bytecode. The `captured` -> `restored` edit preserved the file's byte length and landed within the same filesystem-timestamp second, so the `(mtime, size)` pair CPython uses to invalidate a cached `.pyc` was unchanged. `inspect` reads the file, so it hid the divergence. Purging `__pycache__` recompiled correctly and the suite went green — the candidate was never wrong, but source inspection alone could not have cleared it.
