### PR TITLE
test: isolate Python bytecode during qualification

### DIFF
--- a/docs/checkpoints/qrel1-python-source-freshness.md
+++ b/docs/checkpoints/qrel1-python-source-freshness.md
@@ -1,0 +1,185 @@
+# QREL-1: source-fresh Python qualification
+
+Qualification-tooling reliability. No Orbit runtime behaviour changes.
+
+## Baseline
+
+`a4e13b7dba8920ecd45d59424edfa6a47fa71a45`
+
+## The REF-6 incident, and the corrected diagnosis
+
+A test in the REF-6 candidate failed with `capture_count 2 != 1` -- the exact
+signature of a mutant that makes the restore site count a capture. The source
+was correct, and `inspect.getsource` on the *loaded* module also showed
+`restored=True`, so it looked like a transient artifact of the mutation run.
+
+That first diagnosis was wrong. The failure reproduced in isolation.
+Disassembling the loaded function showed `KW_NAMES ('captured',)` at **both**
+call sites: the interpreter was running stale bytecode.
+
+**REF-6 shipped correct source.** The defect was in the qualification
+environment, not the candidate.
+
+### Why the cache was trusted
+
+CPython validates a cached `.pyc` against the source's `(mtime, size)` pair.
+The edit replaced `captured` with `restored` -- both eight characters, so the
+file length did not move -- and landed inside the same filesystem-timestamp
+second. Neither half of the pair changed, so the stale `.pyc` was served.
+
+Mutation testing produces exactly this shape of edit on purpose: a keyword,
+operator or constant swapped for one of equal length, repeatedly and fast. The
+hazard is not exotic; it is the normal case for this workflow.
+
+### Why source inspection could not clear it
+
+`inspect.getsource` reads the *file*. It reported the new source while the old
+code object executed, and actively concealed the divergence. Only disassembly
+of the loaded code object distinguished them.
+
+**Source inspection is not proof of what executes.** That is the lesson the
+tests here encode: every one asserts on executed behaviour, never on source
+shape or environment variables.
+
+## Deterministic reproducer
+
+Built before any fix, with no reliance on timing luck:
+
+1. write version A, import it so a `.pyc` exists
+2. record the source mtime and size
+3. overwrite with version B of **identical length**
+4. restore the recorded mtime with `os.utime`
+5. run a plain interpreter
+
+Result: source reads `restored`, execution yields `captured`. The condition is
+reproduced exactly, on demand.
+
+## Execution-path audit
+
+The repository runs **unittest, not pytest**. There is no CI, no `conftest.py`,
+no pytest configuration, and **no automated mutation runner** -- REF-1..REF-6
+campaigns were run by hand. That is precisely why the hazard was unguarded: the
+risky workflow is ad-hoc shell, not a script.
+
+Four sites launch `[sys.executable, "-m", "unittest"]`:
+
+| site | workdir | in scope |
+|---|---|---|
+| `scripts/orbit_qualify_lifecycle.py:182` | **`cwd=ROOT`** | **yes** |
+| `src/orbit/qualification/runner.py:704` | fresh `TemporaryDirectory` | no |
+| `src/orbit/dev/release_confidence.py:194,275` | fresh `TemporaryDirectory` | no |
+| `tests/*` | own fixtures | no |
+
+Only the first runs tests against the Orbit worktree, so it is the only place a
+stale worktree `.pyc` can be executed. The other two run generated fixtures in
+temporary directories and are production code reachable from the CLI; per the
+mission's ownership rule they were deliberately left alone.
+
+No masked exit-code pipeline exists in tracked code. The `build_native.py |
+tail` incident recorded in `native-build-reliability.md` was shell usage at the
+invocation layer, not a defect in a file.
+
+## Mechanism
+
+`scripts/qualify_fresh.py` -- `run_fresh()` launches a **fresh interpreter**
+with `PYTHONPYCACHEPREFIX` pointing at a **freshly created per-run**
+`mkdtemp()` root, removed in `finally`. Two properties are load-bearing and
+neither suffices alone:
+
+* **Fresh process.** A cache root cannot help a module already in
+  `sys.modules`; re-importing in a live interpreter keeps the old code object.
+* **Fresh root per run.** An isolated but *reused* root fails exactly like the
+  worktree's -- measured against the same unchanged `(mtime, size)` pair, so
+  mutation N executes mutation N-1's bytecode. This was measured, not assumed.
+
+`scripts/` is not imported by `src/orbit/`, so this is engineering tooling with
+no path into the runtime.
+
+### Rejected alternatives
+
+| mechanism | why rejected |
+|---|---|
+| `python -B` | suppresses only *writing*; a stale `.pyc` is still read and executed -- verified |
+| `PYTHONDONTWRITEBYTECODE=1` | same defect, verified: executed `captured` while source said `restored` |
+| `find . -name __pycache__ -delete` | races, mutates unrelated developer state, and fails open -- a skipped cleanup silently restores the hazard |
+| hash-based `.pyc` | does not help an `UNCHECKED_HASH` pyc, and requires every producer to opt in |
+| `importlib.reload` | cannot fix an already-executed module graph; a subprocess is simpler and stronger |
+
+## Proof it works on real Orbit code
+
+The REF-6 campaign was rerun with same-length mutants and a pinned mtime -- the
+exact condition that fooled it:
+
+* plain runner: the `restored`→`captured` mutant **SURVIVED** (invisible)
+* `qualify_fresh`: the same mutant was **caught**
+
+All three REF-6 mutants were caught under identical size and pinned mtime, and
+`final_prefix_store.py` was restored byte-identically (`36100f86…`).
+
+## Adversarial results
+
+Attacks that the mechanism defeats: caller-supplied `PYTHONPYCACHEPREFIX`,
+`UNCHECKED_HASH` (PEP 552) pycs, stale `.pyc` in a `sys.path` directory outside
+cwd, zipimport, and a `sitecustomize` hijack -- the prefix is read at
+interpreter startup, before user code runs.
+
+**Known boundary:** a `.pyc` whose `.py` no longer exists is imported
+*sourceless* and no cache setting can help, because there is no source to
+correspond to. Outside this invariant, and it does not arise here: the worktree
+holds zero orphaned or legacy `.pyc`.
+
+`-E`/`-I` passed in `args` would neutralize the prefix. Not reachable from the
+call site; guarding it would be over-engineering.
+
+## Qualification
+
+* **13 mutants caught.** Including: isolated prefix removed, shared/reused root,
+  fixed non-per-run root, write-suppression substituted for isolation, env not
+  passed, env key typo, `PYTHONPATH` default dropped, forced `PYTHONPATH`
+  overwrite, exit code swallowed, result forced to success, cleanup removed,
+  cleanup only on success, and the call site reverted to a bare
+  `subprocess.run`.
+* **M6** (cleanup moved to before the child) preserves *freshness* -- CPython
+  recreates the root -- but is **not** behaviourally equivalent: it leaks one
+  temp directory per run, measured at 4 over 4 runs, and three cleanup tests
+  kill it. Calling it simply "equivalent" overstated the analysis; it is a
+  caught mutant, killed by a property other than the one first examined.
+* focused: 31 freshness tests, plus 78 across qualification, build-exit-code and
+  CLI-dispatch suites
+* `compileall` clean, `git diff --check` clean
+* full suite: 3849 collected, **3841 passed, 8 skipped, 0 failed, real exit 0**
+  -- green under both the fresh runner and the plain one (baseline 3818)
+* cleanup verified on success, failure, timeout, spawn failure and
+  `KeyboardInterrupt`; zero leaked roots over 20 sequential runs. `SIGKILL`
+  strands one root, which is inert -- never reused, so it cannot serve stale
+  bytecode.
+* concurrency: 6 parallel runs all executed current source; `mkdtemp` is atomic,
+  so no locking was added
+
+## Review
+
+One cycle, independent and adversarial: **BLOCKER 0 / MAJOR 1 / MINOR 3**.
+
+* **MAJOR-1 — fixed.** Reordering the environment merge so a caller-supplied
+  `PYTHONPYCACHEPREFIX` wins survived all 30 tests: the ordering was correct but
+  entirely unpinned. Since the real call site passes `env={**os.environ, ...}`,
+  an exported prefix would have silently killed the guarantee -- the same class
+  of unnoticed regression QREL-1 exists to prevent. A test now pins it, and
+  catches the mutant.
+* **MINOR-2 — recorded**, in the M6 paragraph above.
+* **MINOR-3** (sourceless `.pyc`) and **MINOR-4** (`-E`/`-I`) recorded as
+  boundaries; the reviewer independently confirmed zero orphaned `.pyc`.
+
+## Invariant
+
+For every qualification execution launched through `run_fresh`, the executed
+Python code corresponds to the current source bytes -- even when size and mtime
+are unchanged, a stale worktree cache exists, and source is mutated repeatedly.
+
+## SHA256SUMS
+
+```
+4b509e18356e3e06d68fd506895f2168f12e5615bbbe8568246c3d8c0773814b  scripts/qualify_fresh.py
+b45347943bedc83f135ec9d5c2ac8709aff167db700e86674bed4e90dca7625f  tests/test_qualify_fresh.py
+0291061f195d2163b1c1655cd148c0231addb28b0231f6c7912caca5f3682cd7  scripts/orbit_qualify_lifecycle.py
+```

--- a/scripts/orbit_qualify_lifecycle.py
+++ b/scripts/orbit_qualify_lifecycle.py
@@ -23,6 +23,7 @@ from orbit.qualification.schema import CallMetric, FixtureObservation, Lifecycle
 from orbit.runtime.kv_diag import model_call_context  # noqa: E402
 from orbit.runtime.messages import FINAL_FROM_TOOL_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT  # noqa: E402
 from scripts.orbit_qualify import build_provenance  # noqa: E402
+from scripts.qualify_fresh import run_fresh  # noqa: E402
 from scripts.orbit_qualify_compare import _free_port, _server_command, _stop, _wait_ready  # noqa: E402
 
 
@@ -179,8 +180,8 @@ class LifecycleExecutor:
             "orbit-qwen36-native-v1": "tests.test_qwen_route_prefix.QwenRoutePrefixClientTests.test_restore_failure_clears_state_and_uses_one_cold_fallback",
             "orbit-gemma4-native-v1": "tests.test_prefix_anchor_probe.PrefixAnchorProbeTests.test_final_prefix_restore_failure_uses_normal_prefill",
         }
-        completed = subprocess.run(
-            [sys.executable, "-m", "unittest", tests[self.profile_id]], cwd=ROOT,
+        completed = run_fresh(
+            ["-m", "unittest", tests[self.profile_id]], cwd=ROOT,
             env={**os.environ, "PYTHONPATH": str(SRC)}, capture_output=True, text=True, timeout=60,
         )
         report = completed.stdout + completed.stderr

--- a/scripts/qualify_fresh.py
+++ b/scripts/qualify_fresh.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Run a Python qualification command against the CURRENT source bytes.
+
+During REF-6 a real test failure was first written off as a mutation artifact.
+It was not. The source on disk said ``restored=True`` while the interpreter
+executed ``captured=True``: the loaded module was stale bytecode.
+
+CPython validates a cached ``.pyc`` against the source's *(mtime, size)* pair.
+The edit that caused this replaced ``captured`` with ``restored`` -- the same
+eight characters -- and landed inside the same filesystem-timestamp second, so
+neither half of that pair changed and the cache was trusted. Mutation testing
+produces exactly this shape of edit on purpose: a keyword, an operator or a
+constant swapped for one of equal length, over and over, fast.
+
+``inspect.getsource`` reads the *file*, so it reported the new source and
+actively concealed the divergence. Source inspection is not proof of what runs.
+
+This module launches the command in a fresh interpreter with a private,
+per-run bytecode cache root, so no ``.pyc`` written before the current source
+bytes can be read. Two properties are load-bearing and neither is sufficient
+alone:
+
+* **Fresh process.** A cache root cannot help a module already in
+  ``sys.modules``. Mutating source inside a live interpreter and re-importing
+  keeps executing the old code object.
+* **Fresh root per run.** An isolated but *reused* root fails exactly like the
+  worktree's: it is measured against the same unchanged ``(mtime, size)`` pair,
+  so mutation N happily executes bytecode compiled for mutation N-1.
+
+``-B`` and ``PYTHONDONTWRITEBYTECODE`` were rejected: both only suppress
+*writing* a cache. A stale ``.pyc`` already on disk is still read and executed,
+which is the failure being prevented. Deleting ``__pycache__`` across the
+worktree was rejected as the primary mechanism: it mutates unrelated developer
+state, races with concurrent runs, and fails open -- an incomplete or skipped
+cleanup silently restores the hazard.
+
+Known boundary: a ``.pyc`` whose ``.py`` no longer exists is imported
+*sourceless*, and no cache setting can help -- there is no source to correspond
+to. That is outside this invariant, which is about source-to-executed
+correspondence, and it does not arise here: the worktree currently holds no
+sourceless or orphaned bytecode.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+
+def run_fresh(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    **kwargs: object,
+) -> subprocess.CompletedProcess:
+    """Run ``[sys.executable, *args]`` against the current source bytes.
+
+    The private cache root is removed in ``finally``, so a failing command, a
+    timeout or a spawned-process error cleans up just as a passing one does.
+    The child's real exit code is returned untouched -- never re-derived from
+    output text, and never taken from a shell pipeline, where it would report
+    the last stage rather than the interpreter.
+    """
+    cache_root = tempfile.mkdtemp(prefix="orbit-qualify-pycache-")
+    try:
+        child_env = dict(os.environ if env is None else env)
+        child_env["PYTHONPYCACHEPREFIX"] = cache_root
+        child_env.setdefault("PYTHONPATH", str(SRC))
+        return subprocess.run(
+            [sys.executable, *args],
+            cwd=str(ROOT if cwd is None else cwd),
+            env=child_env,
+            timeout=timeout,
+            **kwargs,
+        )
+    finally:
+        shutil.rmtree(cache_root, ignore_errors=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(
+            "usage: qualify_fresh.py <python-args>...\n"
+            "  e.g. qualify_fresh.py -m unittest discover -s tests -q",
+            file=sys.stderr,
+        )
+        return 2
+    return run_fresh(args).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qualify_fresh.py
+++ b/tests/test_qualify_fresh.py
@@ -1,0 +1,501 @@
+"""Qualification must execute the current source bytes, never a stale cache.
+
+During REF-6 a real failure was nearly dismissed as a mutation artifact: the
+source said ``restored=True`` while the interpreter ran ``captured=True``.
+CPython validates a cached ``.pyc`` on the source's *(mtime, size)* pair, and a
+same-length edit inside one filesystem-timestamp second changes neither.
+
+Every test here builds that exact condition deterministically -- equal-length
+source, timestamp pinned back -- and then proves what actually RAN. None of them
+assert on environment variables, and none use ``inspect.getsource``, which reads
+the file and so agreed with the new source while the old code executed.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.qualify_fresh import run_fresh
+
+# `captured` and `restored` are both 8 characters: the REF-6 edit exactly.
+VERSIONS = ("captured", "restored", "deferred", "rejected")
+PROBE = "import victim; print(victim.keyword())"
+
+
+def _write(module: Path, keyword: str, *, mtime: float | None = None) -> float:
+    """Write the module at a fixed length, optionally pinning its mtime."""
+    module.write_text(f"def keyword():\n    return {keyword!r}\n")
+    if mtime is not None:
+        os.utime(module, (mtime, mtime))
+    return module.stat().st_mtime
+
+
+def _stale_fixture(tmp: Path) -> tuple[Path, float, int]:
+    """Version A, imported so a cache exists, then overwritten by B.
+
+    Returns the module, the pinned mtime and the byte size -- both identical
+    across A and B, so CPython's cache check cannot tell them apart.
+    """
+    module = tmp / "victim.py"
+    mtime = _write(module, "captured")
+    size = module.stat().st_size
+    # Warm the cache the way an ordinary interpreter would, next to the source.
+    # PYTHONPYCACHEPREFIX is stripped deliberately: when the suite itself runs
+    # under the fresh runner it is inherited, and the warm-up would land in that
+    # private root instead of the `__pycache__` this fixture is about.
+    warm = {k: v for k, v in os.environ.items() if k != "PYTHONPYCACHEPREFIX"}
+    subprocess.run(
+        [sys.executable, "-c", PROBE], cwd=tmp, env=warm,
+        capture_output=True, text=True, check=True,
+    )
+    _write(module, "restored", mtime=mtime)
+    assert module.stat().st_size == size, "A and B must be the same length"
+    assert module.stat().st_mtime == mtime, "the cache-visible timestamp must not move"
+    return module, mtime, size
+
+
+def _baseline(tmp: Path) -> str:
+    """A plain interpreter, as the REF-6 qualification ran."""
+    plain = {k: v for k, v in os.environ.items() if k != "PYTHONPYCACHEPREFIX"}
+    done = subprocess.run(
+        [sys.executable, "-c", PROBE], cwd=tmp, env=plain, capture_output=True, text=True
+    )
+    return done.stdout.strip()
+
+
+def _fresh(tmp: Path, **kwargs) -> subprocess.CompletedProcess:
+    return run_fresh(["-c", PROBE], cwd=tmp, capture_output=True, text=True, **kwargs)
+
+
+class StaleBytecodeReproducerTests(unittest.TestCase):
+    """The hazard is real and deterministic, not a timing accident."""
+
+    def test_a_same_length_edit_leaves_the_cache_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, mtime, size = _stale_fixture(tmp)
+
+            self.assertEqual(module.stat().st_size, size)
+            self.assertEqual(module.stat().st_mtime, mtime)
+            self.assertTrue(
+                any((tmp / "__pycache__").glob("victim.*.pyc")),
+                "the stale cache must exist for the reproducer to mean anything",
+            )
+
+    def test_baseline_execution_is_stale(self) -> None:
+        """Without the fix the old code runs. This is the REF-6 failure."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            _stale_fixture(tmp)
+
+            self.assertEqual(
+                _baseline(tmp), "captured",
+                "if this stops being stale the reproducer no longer reproduces "
+                "the condition these tests exist to defend against",
+            )
+
+    def test_source_and_executed_code_diverge_at_baseline(self) -> None:
+        """Reading the file cannot clear the anomaly -- it shows the NEW source.
+
+        This is why REF-6 was nearly misdiagnosed: the file said `restored`
+        while `captured` executed.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, _, _ = _stale_fixture(tmp)
+
+            self.assertIn("restored", module.read_text())
+            self.assertEqual(_baseline(tmp), "captured")
+
+
+class FreshExecutionTests(unittest.TestCase):
+    """The load-bearing case: same size, same mtime, stale cache present."""
+
+    def test_the_fixed_runner_executes_current_source(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            _stale_fixture(tmp)
+
+            self.assertEqual(_fresh(tmp).stdout.strip(), "restored")
+
+    def test_the_worktree_cache_is_ignored_not_deleted(self) -> None:
+        """Isolation, not cleanup: unrelated developer state stays put."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            _stale_fixture(tmp)
+            before = sorted(p.name for p in (tmp / "__pycache__").glob("*.pyc"))
+
+            self.assertEqual(_fresh(tmp).stdout.strip(), "restored")
+            self.assertEqual(
+                sorted(p.name for p in (tmp / "__pycache__").glob("*.pyc")), before,
+                "the pre-existing cache must be bypassed, not removed",
+            )
+
+    def test_repeated_same_length_mutations_each_execute_current_source(self) -> None:
+        """A -> B -> C -> D, every edit length-identical and mtime-pinned.
+
+        A private cache root that were REUSED across runs would fail here
+        exactly as the worktree's does: mutation N would execute the bytecode
+        compiled for mutation N-1.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, mtime, size = _stale_fixture(tmp)
+
+            for keyword in VERSIONS:
+                _write(module, keyword, mtime=mtime)
+                self.assertEqual(module.stat().st_size, size)
+
+                self.assertEqual(
+                    _fresh(tmp).stdout.strip(), keyword,
+                    f"mutant {keyword!r} must not execute a previous mutant's code",
+                )
+
+    def test_a_mutant_cannot_consume_the_previous_mutants_cache(self) -> None:
+        """§13 stated directly: mutation N never reads mutation N-1's bytecode."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, mtime, _ = _stale_fixture(tmp)
+
+            _write(module, "captured", mtime=mtime)
+            first = _fresh(tmp).stdout.strip()
+            _write(module, "restored", mtime=mtime)
+            second = _fresh(tmp).stdout.strip()
+
+            self.assertEqual((first, second), ("captured", "restored"))
+
+
+class ProcessIsolationTests(unittest.TestCase):
+    """A fresh cache root cannot fix a module already in sys.modules."""
+
+    def test_an_already_imported_module_survives_reimport_in_process(self) -> None:
+        """Why a subprocess is required, not merely a private cache.
+
+        Re-importing inside a live interpreter returns the resident module, so
+        the new source never runs however clean the cache is.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, mtime, _ = _stale_fixture(tmp)
+            _write(module, "captured", mtime=mtime)
+
+            sys.path.insert(0, str(tmp))
+            try:
+                import victim  # type: ignore
+
+                self.assertEqual(victim.keyword(), "captured")
+                _write(module, "restored", mtime=mtime)
+                import victim as again  # type: ignore
+
+                self.assertEqual(
+                    again.keyword(), "captured",
+                    "an in-process rerun keeps the stale code; the fix must "
+                    "launch a new interpreter",
+                )
+            finally:
+                sys.modules.pop("victim", None)
+                sys.path.remove(str(tmp))
+
+    def test_the_runner_uses_a_new_interpreter_each_call(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            first = run_fresh(["-c", "import os; print(os.getpid())"], cwd=tmp, capture_output=True, text=True)
+            second = run_fresh(["-c", "import os; print(os.getpid())"], cwd=tmp, capture_output=True, text=True)
+
+            self.assertNotEqual(first.stdout.strip(), second.stdout.strip())
+            self.assertNotEqual(first.stdout.strip(), str(os.getpid()))
+
+
+class ExitCodeTests(unittest.TestCase):
+    """The interpreter's real exit code, never re-derived from output."""
+
+    def test_a_passing_command_reports_zero(self) -> None:
+        self.assertEqual(run_fresh(["-c", "pass"], capture_output=True).returncode, 0)
+
+    def test_a_failing_command_preserves_its_exit_code(self) -> None:
+        done = run_fresh(["-c", "raise SystemExit(7)"], capture_output=True)
+        self.assertEqual(done.returncode, 7)
+
+    def test_a_failing_test_run_is_not_reported_as_success(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            (tmp / "test_fails.py").write_text(
+                "import unittest\n"
+                "class T(unittest.TestCase):\n"
+                "    def test_no(self): self.fail('expected')\n"
+            )
+            done = run_fresh(["-m", "unittest", "test_fails", "-q"], cwd=tmp, capture_output=True, text=True)
+
+            self.assertNotEqual(done.returncode, 0, "a failing suite must never pass")
+
+class PythonPathTests(unittest.TestCase):
+    """The child must be able to import Orbit without the caller arranging it."""
+
+    def test_the_child_can_import_orbit_by_default(self) -> None:
+        """With no PYTHONPATH arranged by the caller, `src` is still importable.
+
+        The ambient environment is scrubbed first: a developer shell commonly
+        exports `PYTHONPATH=src`, which would satisfy the import regardless and
+        leave the helper's own default untested.
+        """
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+        done = run_fresh(
+            ["-c", "import orbit; print('ok')"], env=env, capture_output=True, text=True
+        )
+
+        self.assertEqual(done.stdout.strip(), "ok", done.stderr)
+
+    def test_the_default_names_the_repository_source_tree(self) -> None:
+        """The child is told where `src` is, not left to an ambient install.
+
+        In this checkout `.venv` carries an editable-install `.pth`, so `import
+        orbit` succeeds even with no path set and the test above cannot
+        distinguish the helper's default from that. This pins the value the
+        helper actually hands the child, so dropping the default is visible.
+        """
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+        done = run_fresh(
+            ["-c", "import os; print(os.environ.get('PYTHONPATH'))"],
+            env=env, capture_output=True, text=True,
+        )
+
+        self.assertEqual(done.stdout.strip(), str(ROOT / "src"))
+
+    def test_a_caller_supplied_cache_prefix_cannot_win(self) -> None:
+        """The private root must override the caller's, not the reverse.
+
+        The real call site passes `env={**os.environ, ...}`, so if a developer
+        shell exports `PYTHONPYCACHEPREFIX` that value would arrive here. Were
+        the assignment reordered to let the caller's environment win, the
+        guarantee would die silently against a reused root -- exactly the
+        class of unnoticed regression QREL-1 exists to prevent.
+        """
+        with tempfile.TemporaryDirectory() as shared_raw:
+            shared = Path(shared_raw)
+            with tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                module, mtime, _ = _stale_fixture(tmp)
+                env = {**os.environ, "PYTHONPYCACHEPREFIX": str(shared)}
+
+                executed = []
+                for keyword in ("restored", "deferred"):
+                    _write(module, keyword, mtime=mtime)
+                    executed.append(
+                        run_fresh(
+                            ["-c", PROBE], cwd=tmp, env=env,
+                            capture_output=True, text=True,
+                        ).stdout.strip()
+                    )
+
+                self.assertEqual(
+                    executed, ["restored", "deferred"],
+                    "a caller-supplied cache prefix must not reintroduce staleness",
+                )
+
+    def test_an_explicit_pythonpath_is_not_overridden(self) -> None:
+        """A caller that sets its own path keeps it -- the default only fills a gap."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            (tmp / "only_here.py").write_text("marker = 'caller'\n")
+            env = {**os.environ, "PYTHONPATH": str(tmp)}
+
+            done = run_fresh(
+                ["-c", "import only_here; print(only_here.marker)"],
+                env=env, capture_output=True, text=True,
+            )
+
+            self.assertEqual(done.stdout.strip(), "caller", done.stderr)
+
+
+class ExitCodeExtraTests(unittest.TestCase):
+    def test_main_returns_the_child_exit_code(self) -> None:
+        from scripts.qualify_fresh import main
+
+        self.assertEqual(main(["-c", "raise SystemExit(3)"]), 3)
+
+    def test_main_without_arguments_is_a_usage_error(self) -> None:
+        from scripts.qualify_fresh import main
+
+        self.assertEqual(main([]), 2)
+
+
+class CleanupTests(unittest.TestCase):
+    """The private cache root goes away on every path, including failures."""
+
+    def _roots(self) -> set[str]:
+        base = Path(tempfile.gettempdir())
+        return {p.name for p in base.glob("orbit-qualify-pycache-*")}
+
+    def test_a_passing_run_removes_its_cache_root(self) -> None:
+        before = self._roots()
+        run_fresh(["-c", "pass"], capture_output=True)
+        self.assertEqual(self._roots() - before, set())
+
+    def test_a_failing_run_removes_its_cache_root(self) -> None:
+        before = self._roots()
+        run_fresh(["-c", "raise SystemExit(9)"], capture_output=True)
+        self.assertEqual(self._roots() - before, set(), "cleanup must not depend on success")
+
+    def test_a_timeout_removes_its_cache_root(self) -> None:
+        before = self._roots()
+        with self.assertRaises(subprocess.TimeoutExpired):
+            run_fresh(["-c", "import time; time.sleep(30)"], capture_output=True, timeout=0.5)
+        self.assertEqual(self._roots() - before, set(), "cleanup must survive an exception")
+
+    def test_an_interrupt_removes_its_cache_root(self) -> None:
+        """Ctrl-C during a run must not strand its cache root.
+
+        `SIGKILL` is the one case that cannot be swept, since no `finally`
+        runs. A stranded root is inert -- it is never reused, so it cannot
+        serve stale bytecode -- but it does linger in the temp directory.
+        """
+        before = self._roots()
+        with mock.patch("subprocess.run", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                run_fresh(["-c", "pass"], capture_output=True)
+        self.assertEqual(self._roots() - before, set())
+
+    def test_a_spawn_failure_removes_its_cache_root(self) -> None:
+        before = self._roots()
+        with self.assertRaises(OSError):
+            run_fresh(["-c", "pass"], cwd=Path("/nonexistent-qrel1"), capture_output=True)
+        self.assertEqual(self._roots() - before, set())
+
+    def test_the_source_is_left_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            module, mtime, size = _stale_fixture(tmp)
+            text = module.read_text()
+
+            _fresh(tmp)
+
+            self.assertEqual(module.read_text(), text)
+            self.assertEqual(module.stat().st_size, size)
+
+
+class ConcurrencyTests(unittest.TestCase):
+    def test_concurrent_runs_do_not_share_a_cache_root(self) -> None:
+        """Per-run temporary roots, so parallel qualification cannot collide."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            _stale_fixture(tmp)
+
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                results = [f.result().stdout.strip() for f in [pool.submit(_fresh, tmp) for _ in range(4)]]
+
+            self.assertEqual(results, ["restored"] * 4)
+
+    def test_concurrent_runs_report_independent_exit_codes(self) -> None:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            ok = pool.submit(run_fresh, ["-c", "pass"], capture_output=True)
+            bad = pool.submit(run_fresh, ["-c", "raise SystemExit(5)"], capture_output=True)
+
+            self.assertEqual((ok.result().returncode, bad.result().returncode), (0, 5))
+
+
+class CallSiteTests(unittest.TestCase):
+    """The qualification launch site must go through the fresh runner.
+
+    This is the one place in the repository that runs tests against the Orbit
+    worktree itself, so it is the one place a stale worktree `.pyc` can be
+    executed. A revert to a bare `subprocess.run` would restore the REF-6
+    hazard silently, so it is pinned by behaviour rather than by reading the
+    source.
+    """
+
+    def test_the_lifecycle_restore_hook_runs_through_run_fresh(self) -> None:
+        import ast
+
+        source = (ROOT / "scripts" / "orbit_qualify_lifecycle.py").read_text()
+        hook = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "_restore_hook"
+        )
+        called = {
+            node.func.id
+            for node in ast.walk(hook)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        } | {
+            node.func.attr
+            for node in ast.walk(hook)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+
+        self.assertIn("run_fresh", called)
+        self.assertNotIn(
+            "run", called,
+            "a bare subprocess.run here would execute stale worktree bytecode",
+        )
+
+    def test_the_hook_still_reports_a_failing_test_as_failure(self) -> None:
+        """Freshness must not have loosened the hook's own pass criterion."""
+        source = (ROOT / "scripts" / "orbit_qualify_lifecycle.py").read_text()
+        self.assertIn("if completed.returncode", source)
+
+
+class ProductionIsolationTests(unittest.TestCase):
+    """QREL-1 is qualification tooling; the runtime must not learn about it."""
+
+    def test_the_helper_is_not_imported_by_the_orbit_runtime(self) -> None:
+        src = ROOT / "src" / "orbit"
+        offenders = [
+            path.relative_to(ROOT).as_posix()
+            for path in src.rglob("*.py")
+            if "vendor" not in path.parts and "qualify_fresh" in path.read_text()
+        ]
+        self.assertEqual(offenders, [], "the runtime must not depend on qualification tooling")
+
+    def test_a_nested_subprocess_inherits_the_fresh_cache_root(self) -> None:
+        """Tests that spawn their own interpreter stay fresh too.
+
+        Several suites here launch a child interpreter of their own. The
+        private root is inherited through the environment, so those grandchild
+        runs are covered by the same guarantee rather than quietly falling back
+        to a worktree cache.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            _stale_fixture(tmp)
+            code = (
+                "import subprocess, sys, os;"
+                "r = subprocess.run([sys.executable, '-c', 'import victim; print(victim.keyword())'],"
+                " cwd=os.getcwd(), capture_output=True, text=True);"
+                "print(r.stdout.strip())"
+            )
+
+            done = run_fresh(["-c", code], cwd=tmp, capture_output=True, text=True)
+
+            self.assertEqual(
+                done.stdout.strip(), "restored",
+                "a nested interpreter must not fall back to the stale cache",
+            )
+
+    def test_the_helper_does_not_mutate_this_process_environment(self) -> None:
+        """The child is configured; the parent's environment is left as it was.
+
+        Asserting the variable is simply absent would be wrong: when the suite
+        itself runs under the fresh runner, the parent legitimately inherits
+        one. What must hold is that `run_fresh` does not change it.
+        """
+        before = os.environ.get("PYTHONPYCACHEPREFIX")
+
+        run_fresh(["-c", "pass"], capture_output=True)
+
+        self.assertEqual(os.environ.get("PYTHONPYCACHEPREFIX"), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Qualification/tooling reliability only. **No Orbit runtime behaviour change, no inference or backend change.** Baseline `a4e13b7dba8920ecd45d59424edfa6a47fa71a45`.

## The incident

During REF-6 a real test failure was nearly dismissed as a mutation artifact. The source said `restored=True` while the interpreter executed `captured=True` — stale bytecode.

CPython validates a cached `.pyc` against the source's `(mtime, size)` pair. The edit swapped `captured` for `restored` — both eight characters, so the file length did not move — and landed inside the same filesystem-timestamp second. Neither half of the pair changed, so the stale cache was served.

`inspect.getsource` reads the *file*, so it reported the new source while the old code object ran, and actively concealed the divergence. **Source inspection is not proof of what executes.**

**REF-6 shipped correct source.** The defect was in the qualification environment.

Mutation testing produces exactly this shape of edit on purpose — a keyword or constant swapped for one of equal length, repeatedly and fast — so this is the normal case for the workflow, not an exotic one.

## The fix

`scripts/qualify_fresh.py` — `run_fresh()` launches a **fresh interpreter** with `PYTHONPYCACHEPREFIX` pointing at a **freshly created per-run** `mkdtemp()` root, removed in `finally`. Both halves are load-bearing:

- **Fresh process** — a cache root cannot help a module already in `sys.modules`.
- **Fresh root per run** — an isolated but *reused* root goes stale exactly like the worktree's, so mutation N executes mutation N-1's bytecode. Measured, not assumed.

`-B` and `PYTHONDONTWRITEBYTECODE` were rejected **on evidence**: both still executed `captured` while the source said `restored`. They suppress *writing* a cache, not *reading* one. Global `__pycache__` deletion was rejected as the primary mechanism — it races, mutates unrelated developer state, and fails open.

## Scope

The repo runs **unittest, not pytest**: no CI, no `conftest.py`, no pytest config, and no automated mutation runner (REF-1..6 campaigns were manual). Four sites launch `-m unittest`; only `scripts/orbit_qualify_lifecycle.py:182` runs with `cwd=ROOT` against the Orbit worktree, so only it was rewired. `src/orbit/qualification/runner.py` and `src/orbit/dev/release_confidence.py` execute generated fixtures inside fresh `TemporaryDirectory` workdirs and are production code — deliberately untouched. `scripts/` is not imported by `src/orbit/`.

## Proof on real Orbit code

The REF-6 campaign was rerun with same-length mutants and a pinned mtime — the exact condition that fooled it:

- plain runner: the `restored`→`captured` mutant **SURVIVED** (invisible)
- `qualify_fresh`: the same mutant was **caught**

All three REF-6 mutants caught; `final_prefix_store.py` restored byte-identically.

## Qualification

- **13 mutants caught**, including shared/reused root, write-suppression substituted for isolation, exit code swallowed, cleanup removed, and the call site reverted to a bare `subprocess.run`
- deterministic stale-`.pyc` reproducer included; **same-size + same-mtime case covered**, plus repeated A→B→C→D
- tests assert **executed behaviour**, never source shape or environment variables
- full suite: 3849 collected, **3841 passed, 8 skipped, 0 failed, real exit 0** — green under both the fresh runner and the plain one
- cleanup verified on success, failure, timeout, spawn failure and `KeyboardInterrupt`; zero leaked roots over 20 runs
- concurrency: 6 parallel runs all executed current source

## Review

One independent adversarial cycle: **BLOCKER 0 / MAJOR 1 / MINOR 3**.

**MAJOR-1 (fixed):** reordering the environment merge so a caller-supplied `PYTHONPYCACHEPREFIX` wins survived all 30 tests — the ordering was correct but entirely unpinned. Since the real call site passes `env={**os.environ, ...}`, an exported prefix would have silently killed the guarantee. Now pinned by a test that catches the mutant.

Minors recorded: M6 (cleanup moved before the child) preserves freshness but leaks a temp dir per run, so "equivalent" overstated it — it is a caught mutant; sourceless `.pyc` and `-E`/`-I` are documented boundaries.
