### PR TITLE
test: cover mtp_fallback_reason reason selection

### DIFF
--- a/tests/test_native_mtp_experimental.py
+++ b/tests/test_native_mtp_experimental.py
@@ -53,6 +53,25 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         self.assertEqual(client.mtp_fallback_reason, "draft-mtp-missing")
 
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_a_missing_draft_without_a_reason_uses_the_default(self, _mocked_lib) -> None:
+        """`paths.fallback_reason` is optional, so the default must be reported.
+
+        Its sibling above always supplies a reason, leaving the default half of
+        `fallback_reason or "draft-mtp-unavailable"` unexercised -- a surviving
+        mutant recorded since REF-3. `/props` would otherwise publish `None`
+        while MTP was genuinely unavailable.
+        """
+        client = NativeLlamaClient(
+            self._paths(mtp_available=False, fallback_reason=None),
+            NativeClientConfig(use_mtp_experimental=True),
+        )
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "draft-mtp-unavailable")
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
     def test_try_complete_with_mtp_experimental_skips_when_thinking_is_on(self, _mocked_lib) -> None:
         client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True, thinking=True))
 
@@ -325,6 +344,35 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(client.mtp_fallback_reason, "persistent-mtp-uninitialized")
 
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_an_uninitialized_session_reports_its_own_failure_reason(self, _mocked_lib) -> None:
+        """The session's reason wins; the literal is only a default.
+
+        Its sibling above seeds `mtp_failure_reason` with the very string used
+        as the fallback default, so both halves of `reason or "default"` produce
+        the same answer and neither is pinned -- which is why two opposite
+        mutants (always-default and never-default) both survived here.
+        Seeding a distinct reason separates them.
+        """
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._session.mtp_failure_reason = "session-specific-reason"
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "session-specific-reason")
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_an_uninitialized_session_without_a_reason_uses_the_default(self, _mocked_lib) -> None:
+        """The other half: absent a session reason, the default is reported."""
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._session.mtp_failure_reason = None
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "persistent-mtp-uninitialized")
+
     @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
     @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
     @mock.patch("orbit.native_llama.client.LlamaLibrary")
@@ -403,6 +451,96 @@ class NativeMtpExperimentalTests(unittest.TestCase):
         self.assertFalse(client.cancel_event.is_set())
         self.assertTrue(client.last_mtp_completion.success)
         self.assertIsNone(client.mtp_fallback_reason)
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_a_failed_completion_without_an_error_uses_the_default(
+        self, _mocked_lib, mocked_reset, mocked_run
+    ) -> None:
+        """A failure that carries no error string still names a reason.
+
+        `MtpCompletionResult.error` is optional, so `result.error or
+        "mtp-experimental-failed"` can reach its default. Without this the
+        published reason would be `None` even though the completion failed --
+        the surviving half of a mutant recorded since REF-3.
+        """
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        self._enable_mock_persistent_mtp(client, mocked_reset)
+        client.tokenize = lambda prompt: [1, 2, 3]
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True, success=False, error=None
+        )
+
+        result = client._try_complete_with_mtp_experimental("hello", max_tokens=8)
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "mtp-experimental-failed")
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_a_successful_mtp_completion_clears_a_stale_fallback_reason(
+        self, _mocked_lib, mocked_reset, mocked_run
+    ) -> None:
+        """A reason left by an earlier request must not outlive a success.
+
+        `mtp_fallback_reason` is served over `/props`, and `orbit_smoke_harness`
+        reads it as a fallback for `mtp_failure_reason` to decide whether MTP is
+        usable. A stale reason therefore reports a healthy backend as unusable.
+
+        The sibling test above asserts the same field is `None` after a success,
+        but builds a fresh client where it is *already* `None`, so it passes
+        whether or not the clear happens. This one seeds a stale value first,
+        which is what makes the assertion mean something.
+        """
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        self._enable_mock_persistent_mtp(client, mocked_reset)
+        client.tokenize = lambda prompt: [1, 2, 3]
+        client.mtp_fallback_reason = "thinking-mode"
+        mocked_run.return_value = MtpCompletionResult(
+            enabled=True,
+            success=True,
+            error=None,
+            content="ok",
+            output_tokens=1,
+            elapsed_ms=12.5,
+        )
+
+        client.complete_prompt("hello", max_tokens=8)
+
+        self.assertIsNone(
+            client.mtp_fallback_reason,
+            "a success must clear the previous request's fallback reason",
+        )
+
+    @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_a_cancelled_mtp_attempt_records_the_cancelled_reason(
+        self, _mocked_lib, mocked_reset, mocked_run
+    ) -> None:
+        """Cancellation reports `cancelled`, not the reason it replaced.
+
+        `settled_backend_props` polls past exactly `{"cancelled", "timeout"}`,
+        so this specific string is what lets a caller distinguish a transient
+        cancellation from a real failure.
+        """
+        client = NativeLlamaClient(self._paths(), NativeClientConfig(use_mtp_experimental=True))
+        client._vocab = object()
+        self._enable_mock_persistent_mtp(client, mocked_reset)
+        client.tokenize = lambda prompt: [1, 2, 3]
+        client.mtp_fallback_reason = "thinking-mode"
+        client.cancel()
+
+        result = client._try_complete_with_mtp_experimental(
+            "hello", max_tokens=8, thinking=False
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(client.mtp_fallback_reason, "cancelled")
 
     @mock.patch("orbit.native_llama.client.time.monotonic_ns", side_effect=[1_000_000_000, 1_200_000_000])
     @mock.patch("orbit.native_llama.client.run_persistent_mtp_completion")


### PR DESCRIPTION
RUNTIME-AUDIT-1 outcome. **Test-only — no production source changed; `src/` is byte-identical to baseline `8c61be98`.**

## What the audit found

`mtp_fallback_reason` is **LIVE_BUT_UNCOVERED**, not dead state:

- **11 writers, 7 readers.** One reader is external: `native_server/app.py:448` publishes it over HTTP `GET /props`. The other six forward it into `MtpCompletionResult.error` or `record_failure` in the same statement that wrote it.
- **Zero readers influence control flow** — no `Load` site appears in a conditional.
- Two script consumers (`orbit_smoke_harness.py`, `bench_mtp_throughput.py`) read it as a fallback for `mtp_failure_reason` to compute whether MTP is usable.

So it is externally observable state whose exact reason strings matter to consumers, and it was under-tested rather than unused.

## The two historical survivors, closed

The mutants recorded as surviving since REF-3/REF-4 share one cause: a `reason or "default"` disjunction exercised with a seeded value **equal to the default**. Both halves then produce the same answer, so neither is pinned — which is why two *opposite* mutants (always-default and never-default) both survived. Seeding a distinct reason separates them.

Also closed: a vacuous assertion. The existing success-path test asserts `mtp_fallback_reason is None` on a freshly constructed client where it is already `None`, so it passed whether or not the clear-on-success actually ran.

## Coverage added (6 tests)

Both directions now caught at all three disjunction sites (`draft-mtp-unavailable`, `persistent-mtp-uninitialized`, `mtp-experimental-failed`), plus the clear-on-success and cancelled paths.

Mutants verified caught: H3, H3i, H3b, H4, H4i, M1, M5, M6, M7, M8, M9, M10, M11. Every mutation ran through the QREL-1 source-fresh mechanism (`scripts/qualify_fresh.py`), with `client.py` restored byte-identically after each.

## Deliberately not done

No production change. A stale `mtp_fallback_reason` can outlive a successful `reset_session_state` (which clears every sibling field, including `mtp_failure_reason` via `publish(clear_failure_reason=True)`), and a consumer polling `/props` before the next successful MTP completion would compute `usable=False`. That is a real observable asymmetry, but fixing it changes `/props` output — a behaviour/API decision requiring its own evidence and mission, not a test PR. Recorded, not smuggled in.

No observability added or removed. No MTP policy change. No model inference.

## Qualification

- focused: 243 tests across 8 MTP/smoke/lifecycle modules, OK
- full suite: 3855 collected, **3847 passed, 8 skipped, 0 failed, real exit 0**, via source-fresh execution
- `compileall` clean, `git diff --check` clean
