### PR TITLE
fix(runtime): clear stale MTP status on session reset

### DIFF
--- a/docs/checkpoints/runtime-fix1-mtp-reset-state.md
+++ b/docs/checkpoints/runtime-fix1-mtp-reset-state.md
@@ -1,0 +1,120 @@
+# RUNTIME-FIX-1: stale MTP status across session reset
+
+A correctness fix, not a refactor. Structural refactoring is complete.
+
+## Baseline
+
+`a6e420efd9bc7b9bf18e2249c9fda8301c0d2cfb`
+
+## Two independent root causes
+
+`reset_session_state` destroys the conversation: KV memory, cached prompt
+tokens, the committed sequence, every prefix and rolling anchor, and — through
+`publish(runtime, clear_failure_reason=True)` — the session-level
+`mtp_failure_reason`. Two **client-level** fields describing the *last request's*
+MTP outcome were left standing, and both reach `/props`.
+
+They mislead in **opposite directions**, which is why each needed its own case:
+
+| field | `/props` | stale effect |
+|---|---|---|
+| `mtp_fallback_reason` | `app.py:448` | `orbit_smoke_harness.mtp_state_from_props` reads it as a fallback for `mtp_failure_reason`; a leftover reason turns a healthy reset session from `ready` into **`failed`** — under-reporting |
+| `last_mtp_completion` | `app.py:442`, `_mtp_last_completion_payload` at `:1428` | a leftover success reports **`on`** for a session that has completed nothing, and republishes ~20 metric fields (acceptance ratios, token counts, timings) as if they belonged to the new session — over-reporting |
+
+The mission premise held for the first field only. The second was verified to be
+an over-report, not an under-report: its neutral `success` is already `False`,
+so clearing it can never *restore* usability. Both are still defects; the second
+is a data-attribution one.
+
+## Reset contract
+
+Derived from the current code, not from field names: everything describing the
+destroyed conversation is cleared, while configuration and the persistent
+runtime survive. `clear_failure_reason=True` at the end is direct evidence the
+author intended a clean status slate here; the two client-level duplicates were
+simply outside the lifecycle owner's reach.
+
+## The fix
+
+Twelve lines in `reset_session_state`, additions only:
+
+```python
+self.mtp_fallback_reason = None
+self.last_mtp_completion = MtpCompletionResult(
+    enabled=self.config.use_mtp_experimental, success=False, error=None
+)
+```
+
+Neutral values derived from `__init__`, not guessed. `enabled` tracks config
+rather than being hardcoded `False`, because `_mtp_last_completion_payload`
+returns `None` when it is false — hardcoding would hide the payload for a
+client that has MTP configured.
+
+### Placement is load-bearing
+
+After `_invalidate_committed_sequence()`, before every early return.
+
+An earlier placement — right after `reset_cancel()` — was tried and **reverted**.
+It broke `test_real_reset_session_state_invalidates_committed_sequence`, which
+drives the real reset on a duck-typed client with no `self.config` inside
+`try/except Exception: pass`; reading `self.config` above the invalidation makes
+the `AttributeError` fire first, so the invalidation never runs. The new tests
+alone cannot distinguish the two positions — the pre-existing test is what pins
+it. The reviewer independently reproduced this.
+
+Exits audited by AST: one `raise` (the `not ctx_tgt` guard, which precedes any
+mutation — nothing has been reset, so nothing is stale) and two `return`s (the
+absent-runtime and discard paths), both **after** the clears.
+
+## Qualification
+
+* **CASE A / B / C all fail on baseline**, pass with the fix. 6 of 8 original
+  tests fail when the fix is reverted; the 2 that pass are deliberate *guard*
+  tests whose job is to fail on over-reach.
+* **Each clear independently necessary**: removing the fallback clear alone → 6
+  failures; removing the completion clear alone → 5. Neither is masked by the
+  other.
+* **Mutants caught**: both clears removed; both removed together; fallback to a
+  wrong sentinel; completion `enabled=False`; completion `success=True`; clears
+  moved after the early returns; over-reach onto `mtp_failure_reason`,
+  `mtp_failed`, and `_persistent_mtp_runtime`.
+* Every mutation executed through QREL-1 (`scripts/qualify_fresh.py`), with
+  `client.py` restored byte-identically after each.
+* focused: 120 across the reset/lifecycle/persistent-MTP/strict-append suites,
+  plus 180 across every stub-client caller of `reset_session_state`
+* full suite: 3864 collected, **3856 passed, 8 skipped, 0 failed, real exit 0**
+* `compileall` clean, `git diff --check` clean
+* no model inference, no GGUF load
+
+## Unchanged, deliberately
+
+`/props` construction, the harness usability calculation, MTP admission and
+fallback policy, session-level `mtp_enabled` / `mtp_failed` /
+`mtp_failure_reason`, the persistent runtime, CommittedIdentity, and the
+prefix/rolling anchor stores. The self-MTP builder's `return True` contract and
+all write-only telemetry were explicitly out of scope.
+
+## Review
+
+One adversarial cycle: **BLOCKER 0 / MAJOR 0 / MINOR 4**.
+
+* **M-1 — corrected.** I reported "10 mutants caught". Two over-reach mutants
+  (`mtp_failure_reason`, `mtp_enabled`) in fact survive *this* suite: the clears
+  run before `publish`, which repairs them on the happy path. They are caught,
+  but by the pre-existing `test_the_client_never_assigns_lifecycle_state_directly`
+  — my attribution was wrong, not the coverage. A discard-path guard test was
+  added to pin the contract behaviourally.
+* **M-2 — addressed in the comment.** `enabled` carries two meanings: config on
+  reset, "available for this request" at `client.py:2361`. Verified no `/props`
+  drift (the payload is `None` before and after), and the comment now says why.
+* **M-3 — accepted.** A raise before the clears leaves the fields stale. Strictly
+  no worse than baseline, which left them stale on *every* path, and fixing it
+  requires the placement the pre-existing test forbids.
+* **M-4** — untracked `workdir/` artifacts, unrelated to this change.
+
+## SHA256SUMS
+
+```
+cbde5dbd5c0096f8a4ac7a88451c16cb6e54032cd18c48d93c3f1f9e67df1869  src/orbit/native_llama/client.py
+faef07b6a623a12dce66c083259fe26ab22649ab748a9114aa619571ad256fe9  tests/test_mtp_reset_state.py
+```

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -950,6 +950,21 @@ class NativeLlamaClient:
             lib.llama_memory_clear(mem, True)
         self._session.cached_prompt_tokens.clear()
         self._invalidate_committed_sequence()
+        # The last request's MTP outcome describes a conversation this reset is
+        # destroying. `/props` publishes both, and they mislead in opposite
+        # directions: a stale fallback reason reports a healthy session as
+        # failed, a stale completion reports success -- and its metrics -- for a
+        # session that has run nothing yet. Placed after the memory and
+        # committed-sequence invalidation, which stay first, and before every
+        # early return below, so a failed or absent runtime reset leaves the
+        # status no staler. `enabled` is restored from config rather than
+        # copied: a failed request may record `enabled=False` meaning "MTP was
+        # unavailable for that request", and carrying that forward would hide
+        # the `/props` completion payload for a client that has MTP configured.
+        self.mtp_fallback_reason = None
+        self.last_mtp_completion = MtpCompletionResult(
+            enabled=self.config.use_mtp_experimental, success=False, error=None
+        )
         self._session.prompt_cache_mode = None
         self._session.continuation_ready = False
         self._session.last_metrics = None

--- a/tests/test_mtp_reset_state.py
+++ b/tests/test_mtp_reset_state.py
@@ -1,0 +1,296 @@
+"""A session reset must not leave the previous session's MTP status behind.
+
+`reset_session_state` clears the conversation: the KV memory, the cached prompt
+tokens, the committed sequence, every prefix and rolling anchor, and -- through
+`publish(runtime, clear_failure_reason=True)` -- the session-level
+`mtp_failure_reason`. Two client-level fields describing the *last request's*
+MTP outcome were left standing, and both reach `/props`.
+
+They fail in opposite directions, which is why each needs its own test:
+
+* `mtp_fallback_reason` is read by `orbit_smoke_harness.mtp_state_from_props`
+  as a fallback for `mtp_failure_reason`. A stale one turns a freshly reset,
+  healthy backend from `ready` into **`failed`** -- under-reporting.
+* `last_mtp_completion` carries `success` plus twenty-odd metrics. A stale one
+  reports `on` for a session that has completed nothing yet, and publishes the
+  previous session's acceptance ratios and token counts as if they were this
+  one's -- over-reporting.
+
+These drive the real `reset_session_state` and assert through the same
+`mtp_state_from_props` calculation the harness uses, rather than reading the
+private fields alone.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+for candidate in (ROOT, ROOT / "src"):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from orbit.native_llama.client import NativeClientConfig, NativeLlamaClient
+from orbit.native_llama.mtp_completion import MtpCompletionResult
+from orbit.native_llama.paths import NativeLlamaPaths
+from orbit.native_llama.persistent_mtp import PersistentMtpSessionRuntime
+from scripts.orbit_smoke_harness import mtp_state_from_props
+
+
+def _paths() -> NativeLlamaPaths:
+    return NativeLlamaPaths(
+        llama_root=Path("/llama"),
+        build_bin=Path("/llama/build/bin"),
+        library=Path("/llama/build/bin/libllama.so"),
+        model=Path("/models/target.gguf"),
+        draft_mtp_model=Path("/models/draft.gguf"),
+        mtp_available=True,
+        fallback_reason=None,
+        model_id="gemma4-12b-it-q4km",
+    )
+
+
+def _props(client: NativeLlamaClient) -> dict[str, object]:
+    """The MTP-status fields of `/props`, built exactly as `app.py` builds them."""
+    snapshot = client.session_snapshot()
+    return {
+        "mtp_experimental_enabled": client.config.use_mtp_experimental,
+        "mtp_initialized": snapshot.mtp_initialized,
+        "mtp_failure_reason": snapshot.mtp_failure_reason,
+        "mtp_fallback_reason": client.mtp_fallback_reason,
+        "mtp_last_completion_success": client.last_mtp_completion.success,
+    }
+
+
+class MtpResetStateTests(unittest.TestCase):
+    """Every case drives the real reset, then reads the real status shape."""
+
+    def _healthy_client(self, mocked_lib_cls, mocked_reset) -> NativeLlamaClient:
+        client = NativeLlamaClient(_paths(), NativeClientConfig(use_mtp_experimental=True))
+        fake_lib = mock.Mock()
+        fake_lib.llama_get_memory.return_value = object()
+        mocked_lib_cls.return_value.lib = fake_lib
+        client._session.ctx_tgt = object()
+        client._persistent_mtp_runtime = PersistentMtpSessionRuntime(
+            handle=object(), ctx_dft=object(), spec=object()
+        )
+        mocked_reset.return_value = PersistentMtpSessionRuntime(
+            handle=object(), ctx_dft=object(), spec=object()
+        )
+        # `mtp_initialized` is derived from these three, and the harness needs
+        # it true for the status to be anything but "requested".
+        client._session.ctx_dft = object()
+        client._session.spec = object()
+        client._session.mtp_enabled = True
+        return client
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_case_a_a_stale_fallback_reason_does_not_survive_reset(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """CASE A: fallback stale, completion neutral.
+
+        The harness reads `mtp_fallback_reason` when `mtp_failure_reason` is
+        empty, so a leftover reason reports a healthy backend as `failed`.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.mtp_fallback_reason = "thinking-mode"
+
+        self.assertEqual(mtp_state_from_props(_props(client))["status"], "failed")
+
+        client.reset_session_state()
+
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertEqual(
+            mtp_state_from_props(_props(client))["status"], "ready",
+            "a reset session must not report the previous request's failure",
+        )
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_case_b_a_stale_successful_completion_does_not_survive_reset(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """CASE B: completion stale, fallback neutral.
+
+        The opposite direction: a leftover success reports `on` for a session
+        that has not completed anything since the reset.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None, output_tokens=42, elapsed_ms=12.5
+        )
+
+        self.assertEqual(mtp_state_from_props(_props(client))["status"], "on")
+
+        client.reset_session_state()
+
+        self.assertFalse(
+            client.last_mtp_completion.success,
+            "a reset session has completed nothing; it must not claim a success",
+        )
+        self.assertEqual(mtp_state_from_props(_props(client))["status"], "ready")
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_case_c_both_stale_fields_are_cleared_by_reset(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """CASE C: both stale. Neither clear may depend on the other."""
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.mtp_fallback_reason = "thinking-mode"
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None, output_tokens=42
+        )
+
+        client.reset_session_state()
+
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertFalse(client.last_mtp_completion.success)
+        self.assertEqual(mtp_state_from_props(_props(client))["status"], "ready")
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_the_stale_completion_metrics_do_not_survive_reset(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """`/props` publishes the completion's metrics, not just its success.
+
+        A surviving result would attribute the previous session's acceptance
+        ratios and token counts to the new one.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None,
+            output_tokens=42, acceptance_ratio=0.87, elapsed_ms=99.0,
+        )
+
+        client.reset_session_state()
+
+        self.assertEqual(client.last_mtp_completion.output_tokens, 0)
+        self.assertIsNone(client.last_mtp_completion.acceptance_ratio)
+        self.assertIsNone(client.last_mtp_completion.error)
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_the_cleared_completion_keeps_the_configured_enabled_flag(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """`enabled` describes configuration, not the last request.
+
+        `_mtp_last_completion_payload` returns `None` when it is false, so
+        resetting it to `False` would hide the payload for a client that has
+        MTP enabled.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None
+        )
+
+        client.reset_session_state()
+
+        self.assertTrue(
+            client.last_mtp_completion.enabled,
+            "reset must restore the configured value, not a blanket False",
+        )
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_reset_does_not_disturb_the_session_level_mtp_fields(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """Only the two client-level fields change; the lifecycle keeps its own.
+
+        `publish(clear_failure_reason=True)` already owns the session fields,
+        and this fix must not reach into them.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.mtp_fallback_reason = "thinking-mode"
+
+        client.reset_session_state()
+        snapshot = client.session_snapshot()
+
+        self.assertTrue(snapshot.mtp_enabled)
+        self.assertTrue(snapshot.mtp_initialized)
+        self.assertIsNone(snapshot.mtp_failure_reason)
+        self.assertIsNotNone(
+            client._persistent_mtp_runtime,
+            "the reset republishes the runtime; it must not be discarded",
+        )
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_a_failed_runtime_reset_still_clears_the_stale_status(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """The discard path returns early -- the clears must precede it.
+
+        A reset whose native re-init fails still destroyed the conversation, so
+        the previous request's status is just as stale there.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.mtp_fallback_reason = "thinking-mode"
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None
+        )
+        mocked_reset.side_effect = RuntimeError("reinit failed")
+
+        client.reset_session_state()
+
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertFalse(client.last_mtp_completion.success)
+
+    @mock.patch("orbit.native_llama.client.reset_persistent_mtp_session")
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_the_early_return_paths_leave_session_state_to_its_owner(
+        self, mocked_lib_cls, mocked_reset
+    ) -> None:
+        """Session fields stay the lifecycle's, on the paths `publish` never reaches.
+
+        On the happy path `publish(runtime, clear_failure_reason=True)` runs
+        last and would repair session state damaged earlier, hiding an
+        over-reaching clear. The discard path returns before it, so this is
+        where such damage would actually survive.
+        """
+        client = self._healthy_client(mocked_lib_cls, mocked_reset)
+        client.mtp_fallback_reason = "thinking-mode"
+        mocked_reset.side_effect = RuntimeError("reinit failed")
+
+        client.reset_session_state()
+        snapshot = client.session_snapshot()
+
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertEqual(
+            snapshot.mtp_failure_reason, "reinit failed",
+            "the discard reason belongs to the lifecycle; this fix must not "
+            "overwrite or clear it",
+        )
+        self.assertFalse(snapshot.mtp_enabled)
+
+    @mock.patch("orbit.native_llama.client.LlamaLibrary")
+    def test_reset_without_a_persistent_runtime_still_clears_the_status(
+        self, mocked_lib_cls
+    ) -> None:
+        """The no-runtime path returns early too, and is equally stale."""
+        client = NativeLlamaClient(_paths(), NativeClientConfig(use_mtp_experimental=True))
+        fake_lib = mock.Mock()
+        fake_lib.llama_get_memory.return_value = object()
+        mocked_lib_cls.return_value.lib = fake_lib
+        client._session.ctx_tgt = object()
+        client._persistent_mtp_runtime = None
+        client.mtp_fallback_reason = "thinking-mode"
+        client.last_mtp_completion = MtpCompletionResult(
+            enabled=True, success=True, error=None
+        )
+
+        client.reset_session_state()
+
+        self.assertIsNone(client.mtp_fallback_reason)
+        self.assertFalse(client.last_mtp_completion.success)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Correctness fix. Baseline `a6e420efd9bc7b9bf18e2249c9fda8301c0d2cfb`.

## The defect — two independent causes

`reset_session_state` destroys the conversation: KV memory, cached prompt tokens, the committed sequence, every prefix and rolling anchor, and — via `publish(runtime, clear_failure_reason=True)` — the session-level `mtp_failure_reason`. Two **client-level** fields describing the *last request's* MTP outcome were left standing, and both reach `/props`.

They mislead in **opposite directions**:

| field | `/props` | stale effect |
|---|---|---|
| `mtp_fallback_reason` | `app.py:448` | `orbit_smoke_harness.mtp_state_from_props` reads it as a fallback for `mtp_failure_reason`; a leftover reason turns a healthy reset session from `ready` into **`failed`** — under-reporting |
| `last_mtp_completion` | `app.py:442`, `_mtp_last_completion_payload` | a leftover success reports **`on`** for a session that has completed nothing, and republishes ~20 metric fields (acceptance ratios, token counts, timings) as the new session's — over-reporting |

Worth stating plainly: the second field is an **over**-report, not an under-report. Its neutral `success` is already `False`, so clearing it can never *restore* usability — it is a data-attribution defect. Both are real; only the first matches the "reports unusable" framing.

## The fix

Twelve lines, additions only:

```python
self.mtp_fallback_reason = None
self.last_mtp_completion = MtpCompletionResult(
    enabled=self.config.use_mtp_experimental, success=False, error=None
)
```

Neutral values derived from `__init__`, not guessed. `enabled` tracks config rather than being hardcoded `False`, because `_mtp_last_completion_payload` returns `None` when it is false — hardcoding would hide the payload for a client that has MTP configured.

### Placement is load-bearing

After `_invalidate_committed_sequence()`, before every early return. An earlier placement (right after `reset_cancel()`) was tried and **reverted**: it broke `test_real_reset_session_state_invalidates_committed_sequence`, which drives the real reset on a duck-typed client with no `self.config` inside `try/except Exception: pass` — reading `self.config` above the invalidation makes the `AttributeError` fire first. The new tests alone cannot distinguish the two positions; the pre-existing test pins it.

Exits audited by AST: one `raise` (the `not ctx_tgt` guard, which precedes any mutation — nothing reset, nothing stale) and two `return`s (absent-runtime and discard), both **after** the clears.

## Explicitly unchanged

`/props` construction, the harness usability calculation, MTP admission and fallback policy, session-level `mtp_enabled` / `mtp_failed` / `mtp_failure_reason`, the persistent runtime, CommittedIdentity, and the prefix/rolling anchor stores. No native or KV change. No performance claim. No structural refactor. The self-MTP builder's `return True` contract and write-only telemetry were out of scope.

## Qualification

- CASE A / B / C all fail on baseline, pass with the fix (6 of 8 tests fail when reverted; the 2 that pass are guard tests)
- **each clear independently necessary** — removing either alone is caught
- mutants caught: both clears removed individually and together, wrong sentinels, `enabled=False`, `success=True`, clears moved after the early returns, and over-reach onto `mtp_failure_reason` / `mtp_failed` / `_persistent_mtp_runtime`
- every mutation via QREL-1 (`scripts/qualify_fresh.py`), `client.py` restored byte-identically after each
- focused: 120 across reset/lifecycle/persistent-MTP/strict-append, plus 180 across every stub-client caller
- full suite: 3864 collected, **3856 passed, 8 skipped, 0 failed, real exit 0**
- no model inference, no GGUF load

## Review

One adversarial cycle: **BLOCKER 0 / MAJOR 0 / MINOR 4**.

**M-1 corrected a claim of mine.** I reported "10 mutants caught"; two over-reach mutants in fact survive *this* suite, because the clears run before `publish`, which repairs them on the happy path. They are caught — by the pre-existing `test_the_client_never_assigns_lifecycle_state_directly`. My attribution was wrong, not the coverage. A discard-path guard test was added to pin the contract behaviourally.

M-2 (the `enabled` field carrying two meanings) is addressed in the comment, with `/props` drift verified absent. M-3 (a raise before the clears leaves them stale) is accepted: strictly no worse than baseline, and fixing it needs the placement the pre-existing test forbids.
