### PR TITLE
docs(runtime): correct the self-MTP initialization contract

### DIFF
--- a/docs/checkpoints/runtime-audit2-selfmtp-init-contract.md
+++ b/docs/checkpoints/runtime-audit2-selfmtp-init-contract.md
@@ -1,0 +1,110 @@
+# RUNTIME-AUDIT-2 — self-MTP initialization boolean contract
+
+Baseline: `4f012ec44c75d37cc772da2239a17b11752d8846`
+Model inference: NONE. No GGUF loaded, no benchmark run.
+
+## Question
+
+`_initialize_self_mtp_session` documented its return as *"True when it was
+actually built"*, yet three fail-closed paths also returned `True`. Two
+readings were possible:
+
+* **A** — `True` = self-MTP was successfully constructed.
+* **B** — `True` = self-MTP handling is terminal; the caller must not fall
+  through to external-draft.
+
+## Verdict: CONTRACT B. Classification: DOCSTRING_DEFECT.
+
+No behavioural bug. No production behaviour changed.
+
+## Return-site matrix
+
+Derived by executing the shipped method against deterministic stubs.
+
+| # | Branch | Returns | Runtime built | `mtp_enabled` | `mtp_failed` | reason |
+|---|--------|---------|---------------|---------------|--------------|--------|
+| 1 | capability resolution raised | `True` | **no** | False | True | `self-mtp-capability-error: …` |
+| 2 | not eligible | `False` | no | False | False | `None` (untouched) |
+| 3 | target context missing | `True` | **no** | False | True | `target-context-missing` |
+| 4 | constructor raised (incl. missing self-MTP ABI) | `True` | **no** | False | True | exception text |
+| 5 | constructed | `True` | yes | True | False | `None` |
+
+Four of the five `True` sites build nothing. `True` cannot mean "built".
+
+## Caller
+
+Exactly one production caller, `client.py:918`:
+
+```python
+if self._initialize_self_mtp_session():
+    return
+```
+
+It is a pure control-flow guard. The value is never stored, never returned,
+never compared to a success notion; `_initialize_persistent_mtp_session`
+itself returns `None`. Success is read from lifecycle state
+(`mtp_enabled` / `mtp_failed`), never from this boolean. No CONTRACT_SPLIT.
+
+The decisive behavioural row: a self-MTP **failure** with external-draft fully
+eligible (`profile.mtp_supported=True`, `paths.mtp_available=True`, a draft
+GGUF declared) does **not** attempt external-draft. Only reading B explains it.
+
+## Mutation evidence (all via QREL-1 source-fresh execution)
+
+| Mutant | Pre-existing suite | New module |
+|--------|--------------------|------------|
+| capability-error `True`→`False` | caught (3) | caught |
+| target-context-missing `True`→`False` | caught (2) | caught |
+| constructor-failure `True`→`False` | caught (1) | caught |
+| ineligible `False`→`True` | caught (4) | caught |
+| **success `True`→`False`** | **SURVIVED the whole suite (3864, OK)** | **caught (3)** |
+
+The asymmetry is the whole finding. The suite pinned "terminal ⇒ True"
+thoroughly and "built ⇒ True" not at all — because the latter was never the
+contract. That surviving mutant is the coverage gap this module closes.
+
+## Historical intent
+
+Both the code and the docstring arrived together in `dfd6e50` (#268). The
+fail-closed `return True` sites were present from the first commit, carrying an
+explicit comment:
+
+> A capability resolution failure is not an MTP verdict. Fail closed and say
+> why rather than silently trying another path.
+
+So the behaviour was deliberate from birth and the docstring was **stale on
+arrival**, not drifted into. The same commit added
+`FailureDoesNotFallThroughTests`, whose docstring names the return value as the
+mechanism outright:
+
+> A qualified artifact that fails must not silently try external-draft.
+> Asserted without a draft model configured too, so **the guard is the return
+> value** rather than the absence of a draft path.
+
+That is the strongest intent evidence available: the author states, in the
+introducing commit, that the boolean *is* the fall-through guard.
+
+One nuance: at birth the fail-closed sites wrote `mtp_failed` /
+`mtp_failure_reason` directly; the `record_failure(...)` indirection arrived
+with the later lifecycle extraction. The return-value semantics are unchanged
+by that refactor.
+
+Why fail-closed is the right behaviour: external-draft is a different
+architecture requiring a separate draft GGUF. A qualified single-GGUF artifact
+that fails to build self-MTP has a malfunction worth reporting, not a reason to
+silently start a different topology on a model chosen for this one.
+
+## Change
+
+* `src/orbit/native_llama/client.py` — docstring only. **Zero executable lines
+  changed.**
+* `tests/test_selfmtp_initialization_contract.py` — new, 10 tests.
+
+## Files
+
+```
+SHA256 (post-change)
+```
+dbadfeffe08e32562936702b346491f597d38fd7b567cc89ba5fbeab8a016860  src/orbit/native_llama/client.py
+52c7d38d7942a88fbe96fdc528ac911c102fa474a88bf505159828bf7a2919a6  tests/test_selfmtp_initialization_contract.py
+```

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -852,11 +852,25 @@ class NativeLlamaClient:
         )
 
     def _initialize_self_mtp_session(self) -> bool:
-        """Construct the self-MTP session. True when it was actually built.
+        """Attempt the self-MTP session. True when the attempt is TERMINAL.
 
-        Returns False without touching session state when this artifact is not
-        qualified, so the caller can fall through to the external-draft path
-        exactly as it did before this existed.
+        The return value is a fall-through guard, not a success signal, and the
+        two readings genuinely differ: four of the five `True` sites below
+        build no runtime at all. Success is read from the lifecycle state
+        (`mtp_enabled` / `mtp_failed`), never from this boolean.
+
+        True
+            Self-MTP handled this initialization attempt and the caller must
+            NOT try external-draft -- whether it was built (`publish`) or it
+            failed closed (`record_failure`). A qualified artifact that fails
+            is a malfunction to report, not a reason to silently start the
+            other architecture on a model chosen for this one.
+
+        False
+            Self-MTP did not handle the request. Returned only when the
+            artifact is not qualified, and only WITHOUT touching session state,
+            so the caller may evaluate external-draft exactly as it did before
+            this path existed.
         """
         try:
             eligible = self._self_mtp_eligible()

--- a/tests/test_selfmtp_initialization_contract.py
+++ b/tests/test_selfmtp_initialization_contract.py
@@ -1,0 +1,273 @@
+"""The contract of `_initialize_self_mtp_session`'s return value.
+
+RUNTIME-AUDIT-2. The boolean is a fall-through guard -- "self-MTP handled this
+attempt; do not try external-draft" -- and NOT a success signal. Four of its
+five `True` sites build no runtime.
+
+The distinction was untested rather than untrue. Flipping the SUCCESS return
+`True -> False` survived the whole suite, while flipping any of the four
+terminal-failure returns was caught. That asymmetry is the gap these tests
+close: every `True` site is pinned here with the runtime it did or did not
+build, so a future reader cannot reintroduce the "True means built" reading by
+returning False from the one site where it happens to be true.
+
+No production behaviour is asserted to change; these tests pass unmodified
+against the audited source.
+"""
+from __future__ import annotations
+
+import types
+import unittest
+from unittest import mock
+
+from orbit.native_llama import client as client_mod
+from orbit.native_llama.client import NativeLlamaClient
+from orbit.native_llama.model_profiles import ORNITH15_PROFILE_ID
+from orbit.native_llama.mtp_session_lifecycle import MtpSessionLifecycle
+from orbit.native_llama.session_state import NativeSessionState
+
+
+class _Eligibility:
+    """Patch BOTH stages of `_self_mtp_eligible`, as a context manager.
+
+    Eligibility is decided in two stages: the verified identity is consulted
+    for whether any artifact of this profile declares `self_mtp` at all, and
+    only then is the ~46 s digest of the artifact worth paying. Both are
+    patched so these tests are isolated from the real
+    `VERIFIED_NATIVE_MODEL_IDENTITIES` registry -- otherwise the outcome of
+    every case below would depend on live registry contents rather than on the
+    branch each test is pinning.
+    """
+
+    def __init__(self, *, supported=None, error=None):
+        identity = types.SimpleNamespace(
+            artifact_capabilities={"self_mtp": ("sha",)}
+        )
+        digest = (
+            mock.patch.object(
+                client_mod, "verified_artifact_supports", side_effect=error
+            )
+            if error is not None
+            else mock.patch.object(
+                client_mod, "verified_artifact_supports", return_value=supported
+            )
+        )
+        self._patches = [
+            mock.patch.object(
+                client_mod, "verified_native_model_identity", return_value=identity
+            ),
+            digest,
+        ]
+
+    def __enter__(self):
+        for patch in self._patches:
+            patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        for patch in reversed(self._patches):
+            patch.stop()
+        return False
+
+
+class _Runtime:
+    """A constructed self-MTP runtime, deterministic and native-free."""
+
+    self_mtp = True
+
+    def __init__(self) -> None:
+        self.ctx_dft = "ctx-dft"
+        self.spec = "spec"
+
+
+def _client(*, ctx_tgt="ctx-tgt", mtp_supported=True, draft="/models/draft.gguf"):
+    """A client whose EXTERNAL-DRAFT path is fully eligible.
+
+    Deliberate: if external-draft were unavailable anyway, "it was not
+    attempted" would prove nothing about the return value. Here the only thing
+    that can stop it is the boolean.
+    """
+    c = object.__new__(NativeLlamaClient)
+    session = NativeSessionState(session_id="contract")
+    session.ctx_tgt = ctx_tgt
+    c._session = session
+    c._mtp_lifecycle = MtpSessionLifecycle(lambda: session, free_runtime=lambda r: None)
+    c.paths = types.SimpleNamespace(
+        llama_root=None, model="artifact.gguf", mtp_available=True,
+        draft_mtp_model=draft, fallback_reason=None,
+    )
+    c.config = types.SimpleNamespace(
+        use_mtp_experimental=True, context_tokens=8, batch_size=1,
+        ubatch_size=1, threads=1, threads_batch=1,
+    )
+    c.model_profile = types.SimpleNamespace(
+        profile_id=ORNITH15_PROFILE_ID, verified=True, mtp_supported=mtp_supported
+    )
+    c._model = "model-handle"
+    c._free_persistent_mtp_session = lambda: None
+    return c
+
+
+class TerminalOutcomesReturnTrueTests(unittest.TestCase):
+    """Every failure that OWNS the attempt returns True and builds nothing."""
+
+    def test_a_capability_error_is_terminal_and_built_nothing(self) -> None:
+        c = _client()
+        with _Eligibility(error=OSError("io")):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertTrue(handled, "a capability error must be terminal")
+        self.assertIsNone(
+            c._mtp_lifecycle.runtime,
+            "True here cannot mean 'built': nothing was constructed",
+        )
+        self.assertFalse(c._session.mtp_enabled)
+        self.assertTrue(c._session.mtp_failed)
+
+    def test_a_missing_target_context_is_terminal_and_built_nothing(self) -> None:
+        c = _client(ctx_tgt=None)
+        with _Eligibility(supported=True):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertTrue(handled)
+        self.assertIsNone(c._mtp_lifecycle.runtime)
+        self.assertEqual(c._session.mtp_failure_reason, "target-context-missing")
+
+    def test_a_constructor_failure_is_terminal_and_built_nothing(self) -> None:
+        c = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", side_effect=RuntimeError("boom")
+        ):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertTrue(handled)
+        self.assertIsNone(c._mtp_lifecycle.runtime)
+        self.assertTrue(c._session.mtp_failed)
+
+    def test_a_missing_self_mtp_abi_is_terminal_and_built_nothing(self) -> None:
+        """A shim without the self-MTP symbols surfaces as a constructor error.
+
+        Same terminal shape as any other construction failure, pinned
+        separately because it is the case a rebuilt or older shim produces.
+        """
+        c = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session",
+            side_effect=AttributeError("orbit_mtp_session_create"),
+        ):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertTrue(handled)
+        self.assertIsNone(c._mtp_lifecycle.runtime)
+        self.assertIn("orbit_mtp_session_create", c._session.mtp_failure_reason)
+
+
+class SuccessAlsoReturnsTrueTests(unittest.TestCase):
+    """The one True that DID build. Untested before this module existed."""
+
+    def test_a_constructed_session_is_terminal(self) -> None:
+        c = _client()
+        runtime = _Runtime()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", return_value=runtime
+        ):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertTrue(handled, "a built session must also be terminal")
+        self.assertIs(c._mtp_lifecycle.runtime, runtime)
+        self.assertTrue(c._session.mtp_enabled)
+        self.assertFalse(c._session.mtp_failed)
+
+    def test_success_and_terminal_failure_are_indistinguishable_by_return(self) -> None:
+        """The audit's core finding, asserted rather than described.
+
+        Both return True; only the lifecycle state separates them. A caller
+        reading this boolean as "built" would be wrong exactly half the time.
+        """
+        built = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", return_value=_Runtime()
+        ):
+            built_returned = built._initialize_self_mtp_session()
+
+        failed = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", side_effect=RuntimeError("boom")
+        ):
+            failed_returned = failed._initialize_self_mtp_session()
+
+        self.assertEqual(built_returned, failed_returned)
+        self.assertNotEqual(
+            built._session.mtp_enabled, failed._session.mtp_enabled,
+            "the states must differ even though the return values do not",
+        )
+
+
+class NotHandledReturnsFalseTests(unittest.TestCase):
+    """The only False: not qualified, and no state touched."""
+
+    def test_an_ineligible_artifact_is_not_handled(self) -> None:
+        c = _client()
+        with _Eligibility(supported=False):
+            handled = c._initialize_self_mtp_session()
+
+        self.assertFalse(handled)
+        self.assertIsNone(c._mtp_lifecycle.runtime)
+        self.assertFalse(c._session.mtp_failed)
+        self.assertIsNone(
+            c._session.mtp_failure_reason,
+            "an unhandled attempt must leave the verdict to the next path",
+        )
+
+
+class CallerHonoursTheGuardTests(unittest.TestCase):
+    """What the single production caller actually does with each value.
+
+    External-draft is eligible in every case here, so its absence or presence
+    is caused by the boolean alone.
+    """
+
+    def test_a_terminal_failure_suppresses_external_draft(self) -> None:
+        c = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", side_effect=RuntimeError("boom")
+        ), mock.patch.object(
+            client_mod, "create_persistent_mtp_session"
+        ) as external:
+            c._initialize_persistent_mtp_session()
+
+        external.assert_not_called()
+        self.assertTrue(
+            c._session.mtp_failed,
+            "the failure is reported rather than papered over by a fallback",
+        )
+
+    def test_a_built_session_suppresses_external_draft(self) -> None:
+        c = _client()
+        with _Eligibility(supported=True), mock.patch.object(
+            client_mod, "create_self_mtp_session", return_value=_Runtime()
+        ), mock.patch.object(
+            client_mod, "create_persistent_mtp_session"
+        ) as external:
+            c._initialize_persistent_mtp_session()
+
+        external.assert_not_called()
+        self.assertTrue(c._session.mtp_enabled)
+
+    def test_an_unhandled_attempt_lets_external_draft_run(self) -> None:
+        c = _client()
+        with _Eligibility(supported=False), mock.patch.object(
+            client_mod, "create_persistent_mtp_session", return_value=_Runtime()
+        ) as external:
+            c._initialize_persistent_mtp_session()
+
+        external.assert_called_once()
+        self.assertTrue(
+            c._session.mtp_enabled,
+            "the fall-through path is genuinely reachable, which is what makes "
+            "suppressing it in the terminal cases a decision rather than a no-op",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_initialize_self_mtp_session` documented its return as *"True when it was actually built"*, but four of its five `True` sites build nothing. The boolean is a fall-through guard — "self-MTP handled this attempt; do not try external-draft" — and never a success signal.

## Evidence

| # | Branch | Returns | Runtime built |
|---|--------|---------|---------------|
| 1 | capability resolution raised | `True` | **no** |
| 2 | not eligible | `False` | no |
| 3 | target context missing | `True` | **no** |
| 4 | constructor raised | `True` | **no** |
| 5 | constructed | `True` | yes |

The decisive behavioural case: with external-draft made fully eligible (`profile.mtp_supported=True`, `paths.mtp_available=True`, a declared draft GGUF), a self-MTP *failure* still suppresses it. Only the terminal reading explains that. The single production caller (`client.py:918`) uses the value purely as `if ...: return` and reads success from lifecycle state (`mtp_enabled` / `mtp_failed`).

## Why this is a documentation defect, not a bug

Fail-closed was deliberate from the introducing commit `dfd6e50` (#268), which shipped the `return True` failure paths carrying the comment *"A capability resolution failure is not an MTP verdict. Fail closed and say why rather than silently trying another path"*, alongside a test class whose docstring states *"the guard is the return value rather than the absence of a draft path"*. The docstring was wrong the day it was written, not drifted into.

**Zero executable lines change.** Verified by compiling both revisions and comparing all 200 nested code objects: every `co_code` is identical, and the only differing constant in the module is the docstring itself.

## The coverage gap this closes

| Mutant | Pre-existing suite | New module |
|--------|--------------------|------------|
| capability-error `True`→`False` | caught (3) | caught |
| target-context-missing `True`→`False` | caught (2) | caught |
| constructor-failure `True`→`False` | caught (1) | caught |
| ineligible `False`→`True` | caught (4) | caught |
| **success `True`→`False`** | **SURVIVED all 3864** | **caught (3)** |

The suite pinned "terminal ⇒ True" thoroughly and "built ⇒ True" not at all — because the latter was never the contract. The 10 new tests pin every return site with the runtime it did or did not build.

## Validation

- Full suite source-fresh: **3874 tests, OK (skipped=8), exit 0**
- All mutation probes via the QREL-1 fresh-interpreter mechanism; source restored byte-identically after each
- Independent adversarial review: **BLOCKER 0 / MAJOR 0 / MINOR 3** (all three were inaccuracies in my own comments and checkpoint — a wrong rationale in a test helper docstring, an off-by-14 line reference, and a test-count wording — all fixed)
- No model loaded, no inference, no benchmarks
