### PR TITLE
docs(benchmarks): correct RSS unit conversions

### DIFF
--- a/docs/checkpoints/perf-baseline1-post-refactor.md
+++ b/docs/checkpoints/perf-baseline1-post-refactor.md
@@ -57,8 +57,12 @@ auto-MTP off**, verified from `/props` before and after every phase:
 | Metric | Value |
 |---|---|
 | Process start → `/props` ready | **41.21 s** |
-| RSS after load (idle) | 37,355,268 kB = **34.79 GiB** |
-| Peak RSS (`VmHWM`, whole lifetime) | 37,433,472 kB = **34.86 GiB** |
+| RSS after load (idle) | 37,355,268 kB = **35.62 GiB** |
+| Peak RSS (`VmHWM`, whole lifetime) | 37,433,472 kB = **35.70 GiB** |
+
+`/proc/<pid>/status` labels these fields `kB` but the values are KiB, so the
+conversion is `value / 1024 / 1024`. The raw values above are the evidence; the
+GiB figures are derived from them.
 
 ## Warm-up (excluded from medians)
 
@@ -115,6 +119,8 @@ prefix is reused. Strict prefix reuse is intact after the refactor line.
 | 6 | 228 | 210 | 18 | 92.1 % | 2.733 s | 37,280,396 |
 | 7 | 270 | 252 | 18 | 93.3 % | 2.785 s | 37,280,396 |
 | 8 | 315 | 294 | 21 | 93.3 % | 2.903 s | 37,280,396 |
+
+RSS held at 37,280,396 kB = **35.55 GiB** on every turn.
 
 * **RSS: byte-identical across all 8 turns.** No growth.
 * **Evaluated tokens flat at 17–21** while the prompt grows 17 → 315.


### PR DESCRIPTION
The PERF-BASELINE-1 memory table divided the raw `/proc/<pid>/status` values by ~1,073,823 instead of 1,048,576, understating each figure by ~2.4 %.

The error was confined to two summary lines. The comparison table already used the correct **35.70 GiB** for the same raw value, so the document contradicted itself — which is what surfaced the bug.

| Value (raw) | Was | Corrected |
|---|---:|---:|
| 37,355,268 kB (idle) | 34.79 GiB | **35.62 GiB** |
| 37,433,472 kB (peak `VmHWM`) | 34.86 GiB | **35.70 GiB** |
| 37,280,396 kB (session) | — | **35.55 GiB** (now stated) |

`/proc/<pid>/status` labels these fields `kB` but the values are KiB, so the conversion is `value / 1024 / 1024`. A note to that effect is added.

**Raw values unchanged** — they remain the evidence; only derived units move. No measurement was rerun; no source, test or configuration changed.

**The performance verdict is unaffected**: peak RSS 35.70 GiB vs 35.78 GiB historical = −0.23 %, still effectively neutral.
