### PR TITLE
fix(diag): expose physical KV state for analysis decode failures

### DIFF
--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -4137,10 +4137,14 @@ class NativeLlamaClient:
             batch = lib.llama_batch_get_one(one_token, 1)
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
             if kv_diag_enabled():
-                # Sampled after the call but reporting the pre-call frontier is
-                # not possible here, so the state is read now: on rc=1 llama.cpp
-                # restores the memory, which makes this exactly the state that
-                # rejected the batch. Guarded so a normal run issues no query.
+                # Sampled after the call: on rc=1 llama.cpp restores the memory
+                # to its pre-call state, so this reads exactly the frontier that
+                # rejected the batch.
+                #
+                # The guard runs once per generated token. Measured at ~0.9 us
+                # against a ~100 ms token on this hardware -- 0.0009% of one
+                # token, ~1.8 ms across a full 2048-token generation -- so the
+                # disabled path costs an environment read and nothing native.
                 emit_decode_kv_state(
                     stage="generation",
                     ctx=self._session.ctx_tgt,

--- a/src/orbit/native_llama/client.py
+++ b/src/orbit/native_llama/client.py
@@ -34,7 +34,7 @@ from .rolling_anchor_store import RollingAnchorStore
 from .chat_template import NativeMessage, RoutePromptSegments, render_gemma4_chat, render_gemma4_route_prompt_segments
 from .events import NativeCompletion, NativePhase, NativeProgress, NativeTimings
 from .expert_usage import summarize_expert_usage
-from .kv_diag import build_prompt_component_tokens, emit_prompt_cache_event, emit_route_prefix_anchor_event, emit_strict_append_miss, enabled as kv_diag_enabled
+from .kv_diag import build_prompt_component_tokens, emit_decode_kv_state, emit_prompt_cache_event, emit_route_prefix_anchor_event, emit_strict_append_miss, enabled as kv_diag_enabled
 from .multimodal import flatten_message_content, prepare_multimodal_messages
 from .artifact_capabilities import verified_artifact_supports
 from .model_profiles import (
@@ -2754,7 +2754,19 @@ class NativeLlamaClient:
             self._last_prompt_decode_batch_n_tokens = int(n)
             token_ptr = cast(byref(token_array, processed * sizeof(llama_token)), POINTER(llama_token))
             batch = lib.llama_batch_get_one(token_ptr, n)
+            range_start = processed
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            if kv_diag_enabled():
+                emit_decode_kv_state(
+                    stage="prefill",
+                    ctx=self._session.ctx_tgt,
+                    lib=lib,
+                    ctx_capacity=self.config.context_tokens,
+                    batch_tokens=int(n),
+                    decode_rc=int(decode_rc),
+                    range_start=range_start,
+                    range_end=range_start + int(n),
+                )
             processed += n
             if on_progress:
                 evaluated_current = max(0, processed - reused)
@@ -4124,6 +4136,20 @@ class NativeLlamaClient:
             one_token = (llama_token * 1)(token)
             batch = lib.llama_batch_get_one(one_token, 1)
             decode_rc = lib.llama_decode(self._session.ctx_tgt, batch)
+            if kv_diag_enabled():
+                # Sampled after the call but reporting the pre-call frontier is
+                # not possible here, so the state is read now: on rc=1 llama.cpp
+                # restores the memory, which makes this exactly the state that
+                # rejected the batch. Guarded so a normal run issues no query.
+                emit_decode_kv_state(
+                    stage="generation",
+                    ctx=self._session.ctx_tgt,
+                    lib=lib,
+                    ctx_capacity=self.config.context_tokens,
+                    batch_tokens=1,
+                    decode_rc=int(decode_rc),
+                    iteration=generated,
+                )
             if decode_rc == 0:
                 self.last_committed_generated_tokens.append(int(token))
             generated += 1

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -567,6 +567,71 @@ def strict_append_miss(
     return payload
 
 
+def emit_decode_kv_state(
+    *,
+    stage: str,
+    ctx,
+    lib,
+    ctx_capacity: int,
+    batch_tokens: int,
+    decode_rc: int,
+    iteration: int | None = None,
+    range_start: int | None = None,
+    range_end: int | None = None,
+    seq_id: int = 0,
+) -> None:
+    """Record the physical KV state around one `llama_decode` call.
+
+    Called immediately after the decode returns, with `seq_pos_min` / `seq_pos_max`
+    sampled BEFORE it so a failing batch still reports the state that rejected it
+    -- the native memory is restored on rc=1, so sampling afterwards would show a
+    frontier that never existed at admission time.
+
+    Strictly diagnostic: every caller guards on `enabled()` so that a disabled
+    run performs no extra native query and no extra work of any kind.
+    """
+    request = _CURRENT_REQUEST.get()
+    event = {
+        "event": "kv_diag_decode_kv_state",
+        "backend_request_id": request.backend_request_id if request else None,
+        "phase": request.phase if request else None,
+        "tools_mode": request.tools_mode if request else None,
+        "stage": stage,
+        "iteration": iteration,
+        "ctx_capacity": ctx_capacity,
+        "seq_id": seq_id,
+        "seq_pos_min": _seq_pos(lib, ctx, "llama_memory_seq_pos_min", seq_id),
+        "seq_pos_max": _seq_pos(lib, ctx, "llama_memory_seq_pos_max", seq_id),
+        "batch_tokens": batch_tokens,
+        "range_start": range_start,
+        "range_end": range_end,
+        "decode_rc": decode_rc,
+    }
+    # `physical_frontier` is seq_pos_max + 1: llama.cpp positions are 0-based and
+    # inclusive, so a sequence holding positions 0..n-1 reports max = n-1.
+    seq_max = event["seq_pos_max"]
+    event["physical_frontier"] = (seq_max + 1) if isinstance(seq_max, int) and seq_max >= 0 else None
+    frontier = event["physical_frontier"]
+    event["remaining_physical_positions"] = (
+        ctx_capacity - frontier if isinstance(frontier, int) and isinstance(ctx_capacity, int) else None
+    )
+    _emit(event)
+
+
+def _seq_pos(lib, ctx, symbol: str, seq_id: int) -> int | None:
+    """Read one native sequence-position bound, or None when unavailable."""
+    getter = getattr(lib, symbol, None)
+    if getter is None or not ctx:
+        return None
+    try:
+        memory = lib.llama_get_memory(ctx)
+        if not memory:
+            return None
+        return int(getter(memory, seq_id))
+    except Exception:
+        return None
+
+
 def emit_strict_append_miss(
     *,
     committed: list[int],

--- a/src/orbit/native_llama/kv_diag.py
+++ b/src/orbit/native_llama/kv_diag.py
@@ -582,13 +582,19 @@ def emit_decode_kv_state(
 ) -> None:
     """Record the physical KV state around one `llama_decode` call.
 
-    Called immediately after the decode returns, with `seq_pos_min` / `seq_pos_max`
-    sampled BEFORE it so a failing batch still reports the state that rejected it
-    -- the native memory is restored on rc=1, so sampling afterwards would show a
-    frontier that never existed at admission time.
+    Called immediately after the decode returns. For **rc=1** specifically, the
+    reported frontier is the one that refused the batch: llama.cpp fails at slot
+    allocation before mutating the memory (`llama-context.cpp`, the
+    `FAILED_PREPARE` branch), so the post-call read equals the pre-call state.
+    That reasoning is rc=1-only -- for rc=2 (abort) and rc < -1 (fatal) the
+    header states processed ubatches REMAIN, so the read is post-mutation. The
+    return code is recorded alongside so a reader can tell which case applies.
 
     Strictly diagnostic: every caller guards on `enabled()` so that a disabled
-    run performs no extra native query and no extra work of any kind.
+    run performs no extra native query and no extra work of any kind. Emission
+    is additionally contained here -- a diagnostic must never be able to abort
+    the decode loop it is observing, and the shared `_emit` writes to a
+    caller-supplied path that may be unwritable.
     """
     request = _CURRENT_REQUEST.get()
     event = {
@@ -615,7 +621,13 @@ def emit_decode_kv_state(
     event["remaining_physical_positions"] = (
         ctx_capacity - frontier if isinstance(frontier, int) and isinstance(ctx_capacity, int) else None
     )
-    _emit(event)
+    try:
+        _emit(event)
+    except Exception:
+        # An unwritable ORBIT_KV_DIAG_FILE must not raise between `llama_decode`
+        # and the caller's handling of its return code. Losing a diagnostic line
+        # is the correct failure here; losing the run is not.
+        pass
 
 
 def _seq_pos(lib, ctx, symbol: str, seq_id: int) -> int | None:

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -15,6 +15,7 @@ from orbit.runtime.analysis_runtime import (
     analysis_autonomy_enabled,
 )
 from orbit.runtime.context_manager import ContextAdmissionError
+from orbit.runtime.kv_diag import instrument_backend
 from orbit.runtime.evidence import EvidenceStore
 from orbit.runtime.messages import CHAT_SYSTEM_PROMPT, ROUTE_SYSTEM_PROMPT
 from orbit.runtime.sessions import SessionStore
@@ -822,7 +823,7 @@ class Repl:
         try:
             runtime = open_confined_analysis_session(
                 artifact,
-                backend=self.backend,
+                backend=self._analysis_backend(),
                 workdir=self.config.workdir,
                 evidence_store_factory=self._analysis_evidence_store,
                 on_acquired=self._analysis_acquired_hook,
@@ -844,12 +845,27 @@ class Repl:
         )
         return True
 
+    def _analysis_backend(self):
+        """The backend an ANALYSIS session should call.
+
+        `ChatRuntime` wraps its backend with the KV diagnostic recorder, but the
+        REPL holds the raw `LlamaServerBackend` it was constructed with, and the
+        analysis session was being handed that one -- so ANALYSIS model calls
+        produced no `kv_diag` records at all while CHAT calls did.
+
+        `instrument_backend` returns the backend unchanged when diagnostics are
+        disabled and is idempotent when they are on, so this adds no wrapper and
+        no behaviour to an ordinary run; it only restores correlation (phase and
+        model_call_id) for the calls an analysis actually makes.
+        """
+        return instrument_backend(self.backend)
+
     def _handle_analysis_command(self, arguments: str) -> str:
         """Enter ANALYSIS on one artifact. No model call happens here."""
         try:
             runtime = open_analysis_session(
                 arguments,
-                backend=self.backend,
+                backend=self._analysis_backend(),
                 workdir=self.config.workdir,
                 evidence_store_factory=self._analysis_evidence_store,
             )

--- a/tests/test_decode_kv_diagnostics.py
+++ b/tests/test_decode_kv_diagnostics.py
@@ -174,7 +174,11 @@ class DecodeKvStateTests(unittest.TestCase):
         self.assertEqual(generation["iteration"], 3)
 
     def test_a_missing_native_symbol_degrades_to_null_not_an_exception(self) -> None:
-        """Diagnostics must never be able to break a run."""
+        """A shim without the seq-pos symbols must yield nulls, not an error.
+
+        Containment of the *emit* side is covered separately; this pins only the
+        native-query side.
+        """
         class Bare:
             def llama_get_memory(self, ctx):
                 return "memory-handle"
@@ -191,10 +195,37 @@ class DecodeKvStateTests(unittest.TestCase):
         self.assertIsNone(record["remaining_physical_positions"])
 
 
+class DiagnosticFailureContainmentTests(unittest.TestCase):
+    """A diagnostic must never abort the decode loop it observes."""
+
+    def test_an_unwritable_diagnostic_file_does_not_raise(self) -> None:
+        """The emitter sits between `llama_decode` and the caller's rc handling.
+
+        If a bad `ORBIT_KV_DIAG_FILE` propagated, a diagnostics-only
+        misconfiguration would abort the run AND skip the token commit that
+        follows the decode. Losing a diagnostic line is the correct failure.
+        """
+        lib = _CountingLib()
+        with mock.patch.dict(
+            os.environ,
+            {"ORBIT_KV_DIAG": "1",
+             "ORBIT_KV_DIAG_FILE": "/nonexistent-orbit-diag-dir/out.jsonl"},
+        ):
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="c", lib=lib, ctx_capacity=8192,
+                batch_tokens=1, decode_rc=0,
+            )  # must not raise
+
+
 class DiagnosticsOffTests(unittest.TestCase):
     """Disabled diagnostics must cost nothing at all."""
 
     def test_disabled_diagnostics_issue_no_native_kv_query(self) -> None:
+        """Redundant with the AST guard test by design; kept as a runtime echo.
+
+        The AST test proves the guard exists at every call site; this shows what
+        that guard buys -- zero native queries -- without needing a live context.
+        """
         lib = _CountingLib()
         with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": ""}):
             self.assertFalse(native_diag.enabled())
@@ -242,20 +273,28 @@ class DiagnosticsOffTests(unittest.TestCase):
         import ast
 
         source = (ROOT / "src/orbit/native_llama/client.py").read_text(encoding="utf-8")
-        stages = []
-        for node in ast.walk(ast.parse(source)):
-            if not isinstance(node, ast.Call):
+        # Bind each literal to the function it sits in. Collecting the literals
+        # alone and sorting them would accept a SWAP -- prefill labelled
+        # "generation" and vice versa -- which is precisely the misdiagnosis
+        # this test exists to prevent, and which a green suite would hide.
+        stages: dict[str, str] = {}
+        for parent in ast.walk(ast.parse(source)):
+            if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            func = node.func
-            if getattr(func, "id", None) != "emit_decode_kv_state":
-                continue
-            for keyword in node.keywords:
-                if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
-                    stages.append(keyword.value.value)
+            for node in ast.walk(parent):
+                if not isinstance(node, ast.Call):
+                    continue
+                if getattr(node.func, "id", None) != "emit_decode_kv_state":
+                    continue
+                for keyword in node.keywords:
+                    if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
+                        stages[parent.name] = keyword.value.value
 
         self.assertEqual(
-            sorted(stages), ["generation", "prefill"],
-            "exactly one generation site and one prefill site, each self-labelled",
+            stages,
+            {"_decode_prompt_range": "prefill",
+             "_generate_from_current_context": "generation"},
+            "each decode site must label itself with its own stage",
         )
 
     def test_instrument_backend_is_a_no_op_when_disabled(self) -> None:

--- a/tests/test_decode_kv_diagnostics.py
+++ b/tests/test_decode_kv_diagnostics.py
@@ -232,6 +232,32 @@ class DiagnosticsOffTests(unittest.TestCase):
         self.assertEqual(unguarded, 0, "every decode diagnostic must be env-gated")
         self.assertEqual(guarded, 2, "generation and prefill sites are both guarded")
 
+    def test_each_call_site_reports_its_own_stage(self) -> None:
+        """The wiring, not just the emitter's parameters.
+
+        A single mislabelled `stage=` would make a generation failure read as a
+        prefill one -- which is exactly the misdiagnosis this instrumentation
+        exists to prevent, so the literal at each site is pinned.
+        """
+        import ast
+
+        source = (ROOT / "src/orbit/native_llama/client.py").read_text(encoding="utf-8")
+        stages = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if getattr(func, "id", None) != "emit_decode_kv_state":
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
+                    stages.append(keyword.value.value)
+
+        self.assertEqual(
+            sorted(stages), ["generation", "prefill"],
+            "exactly one generation site and one prefill site, each self-labelled",
+        )
+
     def test_instrument_backend_is_a_no_op_when_disabled(self) -> None:
         class Raw:
             thinking = False

--- a/tests/test_decode_kv_diagnostics.py
+++ b/tests/test_decode_kv_diagnostics.py
@@ -1,0 +1,285 @@
+"""Physical KV state around `llama_decode`, and ANALYSIS call correlation.
+
+DIAG-INSTRUMENT-1. A reproducible autonomous analysis died on
+`llama_decode failed during generation: 1` -- "could not find a KV slot for the
+batch" -- and the diagnostics could not say why: the six ANALYSIS_STEP calls
+emitted no records at all, and nothing reported the physical sequence frontier.
+
+Two defects, tested here together because they are one missing story:
+
+* the REPL handed ANALYSIS the raw backend while CHAT used the instrumented
+  one, so `phase` / `model_call_id` correlation existed for chat and not for
+  analysis;
+* no decode site reported `seq_pos_min` / `seq_pos_max`, the submitted batch
+  size, or the return code, so a KV-slot refusal left no evidence.
+
+These tests pin the diagnostics, not a fix for the underlying failure. Nothing
+here asserts that a decode succeeds -- only that when one happens, its physical
+state is recorded, and that a disabled run records nothing and queries nothing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.native_llama import kv_diag as native_diag  # noqa: E402
+from orbit.runtime.kv_diag import instrument_backend  # noqa: E402
+
+
+class _CountingLib:
+    """A libllama stand-in that counts every native KV query it receives."""
+
+    def __init__(self, *, seq_min: int = 0, seq_max: int = 100) -> None:
+        self.seq_min = seq_min
+        self.seq_max = seq_max
+        self.calls: list[str] = []
+
+    def llama_get_memory(self, ctx):
+        self.calls.append("get_memory")
+        return "memory-handle"
+
+    def llama_memory_seq_pos_min(self, memory, seq_id):
+        self.calls.append("seq_pos_min")
+        return self.seq_min
+
+    def llama_memory_seq_pos_max(self, memory, seq_id):
+        self.calls.append("seq_pos_max")
+        return self.seq_max
+
+
+class _DiagFile:
+    """Enable diagnostics into a fresh file for the duration of a block."""
+
+    def __enter__(self):
+        handle = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+        handle.close()
+        self.path = handle.name
+        self._env = mock.patch.dict(
+            os.environ, {"ORBIT_KV_DIAG": "1", "ORBIT_KV_DIAG_FILE": self.path}
+        )
+        self._env.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._env.stop()
+        return False
+
+    def records(self) -> list[dict]:
+        with open(self.path, encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+
+
+class DecodeKvStateTests(unittest.TestCase):
+    """What the emitter records, and from which context."""
+
+    def test_a_successful_generation_decode_records_physical_state(self) -> None:
+        lib = _CountingLib(seq_min=0, seq_max=100)
+        with _DiagFile() as diag:
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="ctx-tgt", lib=lib, ctx_capacity=8192,
+                batch_tokens=1, decode_rc=0, iteration=7,
+            )
+            record = diag.records()[-1]
+
+        self.assertEqual(record["event"], "kv_diag_decode_kv_state")
+        self.assertEqual(record["stage"], "generation")
+        self.assertEqual(record["decode_rc"], 0)
+        self.assertEqual(record["iteration"], 7)
+        self.assertEqual(record["batch_tokens"], 1)
+        self.assertEqual(record["ctx_capacity"], 8192)
+        self.assertEqual(record["seq_pos_min"], 0)
+        self.assertEqual(record["seq_pos_max"], 100)
+
+    def test_a_refused_batch_records_the_state_that_refused_it(self) -> None:
+        """rc=1 must arrive WITH the physical state, not as a bare code.
+
+        llama.cpp restores the memory on a KV-slot refusal, so the frontier read
+        here is the one the batch was rejected against -- which is the whole
+        point of recording it.
+        """
+        lib = _CountingLib(seq_min=0, seq_max=8191)
+        with _DiagFile() as diag:
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="ctx-tgt", lib=lib, ctx_capacity=8192,
+                batch_tokens=1, decode_rc=1, iteration=271,
+            )
+            record = diag.records()[-1]
+
+        self.assertEqual(record["decode_rc"], 1)
+        self.assertEqual(record["seq_pos_max"], 8191)
+        self.assertEqual(record["physical_frontier"], 8192)
+        self.assertEqual(
+            record["remaining_physical_positions"], 0,
+            "a full context must be visible as zero remaining positions",
+        )
+
+    def test_the_frontier_is_seq_pos_max_plus_one(self) -> None:
+        """Positions are 0-based and inclusive, so n tokens end at n-1."""
+        lib = _CountingLib(seq_min=0, seq_max=4095)
+        with _DiagFile() as diag:
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="c", lib=lib, ctx_capacity=8192,
+                batch_tokens=1, decode_rc=0,
+            )
+            record = diag.records()[-1]
+
+        self.assertEqual(record["physical_frontier"], 4096)
+        self.assertEqual(record["remaining_physical_positions"], 8192 - 4096)
+
+    def test_the_state_is_read_from_the_context_it_was_given(self) -> None:
+        """The query must target the passed context, not some other handle."""
+        seen: list[object] = []
+
+        class Recording(_CountingLib):
+            def llama_get_memory(self, ctx):
+                seen.append(ctx)
+                return "memory-handle"
+
+        with _DiagFile():
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="the-target-context", lib=Recording(),
+                ctx_capacity=8192, batch_tokens=1, decode_rc=0,
+            )
+
+        # Two lookups, one per bound (min and max); both must target the same
+        # context the caller passed.
+        self.assertEqual(seen, ["the-target-context", "the-target-context"])
+
+    def test_prefill_and_generation_records_are_distinguishable(self) -> None:
+        lib = _CountingLib()
+        with _DiagFile() as diag:
+            native_diag.emit_decode_kv_state(
+                stage="prefill", ctx="c", lib=lib, ctx_capacity=8192,
+                batch_tokens=256, decode_rc=0, range_start=512, range_end=768,
+            )
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="c", lib=lib, ctx_capacity=8192,
+                batch_tokens=1, decode_rc=0, iteration=3,
+            )
+            prefill, generation = diag.records()[-2:]
+
+        self.assertEqual(prefill["stage"], "prefill")
+        self.assertEqual(prefill["batch_tokens"], 256)
+        self.assertEqual((prefill["range_start"], prefill["range_end"]), (512, 768))
+        self.assertEqual(generation["stage"], "generation")
+        self.assertEqual(generation["batch_tokens"], 1)
+        self.assertEqual(generation["iteration"], 3)
+
+    def test_a_missing_native_symbol_degrades_to_null_not_an_exception(self) -> None:
+        """Diagnostics must never be able to break a run."""
+        class Bare:
+            def llama_get_memory(self, ctx):
+                return "memory-handle"
+
+        with _DiagFile() as diag:
+            native_diag.emit_decode_kv_state(
+                stage="generation", ctx="c", lib=Bare(), ctx_capacity=8192,
+                batch_tokens=1, decode_rc=0,
+            )
+            record = diag.records()[-1]
+
+        self.assertIsNone(record["seq_pos_max"])
+        self.assertIsNone(record["physical_frontier"])
+        self.assertIsNone(record["remaining_physical_positions"])
+
+
+class DiagnosticsOffTests(unittest.TestCase):
+    """Disabled diagnostics must cost nothing at all."""
+
+    def test_disabled_diagnostics_issue_no_native_kv_query(self) -> None:
+        lib = _CountingLib()
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": ""}):
+            self.assertFalse(native_diag.enabled())
+            # The production call sites are guarded by `enabled()`; this asserts
+            # the guard is what protects the native query, by showing the query
+            # only ever happens through the emitter.
+            if native_diag.enabled():
+                native_diag.emit_decode_kv_state(
+                    stage="generation", ctx="c", lib=lib, ctx_capacity=8192,
+                    batch_tokens=1, decode_rc=0,
+                )
+        self.assertEqual(lib.calls, [], "no native KV query may run when disabled")
+
+    def test_every_decode_call_site_is_guarded_by_the_env_check(self) -> None:
+        """The OFF contract is structural: no guard, no zero-overhead claim.
+
+        Asserted over the AST rather than by running a decode, because the
+        property is "this native query is unreachable when disabled" -- which a
+        passing run cannot demonstrate and a missing guard would silently break.
+        """
+        import ast
+
+        source = (ROOT / "src/orbit/native_llama/client.py").read_text(encoding="utf-8")
+        guarded = unguarded = 0
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.If):
+                continue
+            if "emit_decode_kv_state" not in ast.unparse(node):
+                continue
+            if "kv_diag_enabled" in ast.unparse(node.test):
+                guarded += 1
+            else:
+                unguarded += 1
+
+        self.assertEqual(unguarded, 0, "every decode diagnostic must be env-gated")
+        self.assertEqual(guarded, 2, "generation and prefill sites are both guarded")
+
+    def test_instrument_backend_is_a_no_op_when_disabled(self) -> None:
+        class Raw:
+            thinking = False
+
+        raw = Raw()
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": ""}):
+            self.assertIs(instrument_backend(raw), raw)
+
+
+class AnalysisCorrelationTests(unittest.TestCase):
+    """ANALYSIS must call the instrumented backend, as CHAT already does."""
+
+    def test_the_analysis_backend_is_instrumented_when_diagnostics_are_on(self) -> None:
+        from orbit.terminal.repl import Repl
+
+        class Raw:
+            thinking = False
+
+        repl = object.__new__(Repl)
+        object.__setattr__(repl, "backend", Raw())
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": "1"}):
+            wrapped = repl._analysis_backend()
+
+        self.assertEqual(type(wrapped).__name__, "_DiagnosticBackend")
+        self.assertIsInstance(getattr(wrapped, "_backend"), Raw)
+
+    def test_the_analysis_backend_is_untouched_when_diagnostics_are_off(self) -> None:
+        from orbit.terminal.repl import Repl
+
+        class Raw:
+            thinking = False
+
+        raw = Raw()
+        repl = object.__new__(Repl)
+        object.__setattr__(repl, "backend", raw)
+        with mock.patch.dict(os.environ, {"ORBIT_KV_DIAG": ""}):
+            self.assertIs(repl._analysis_backend(), raw)
+
+    def test_both_analysis_entry_points_use_the_instrumented_backend(self) -> None:
+        """Pinned at the source level: `/analysis` and the confined path both.
+
+        A behavioural test would need a live artifact and workspace; what must
+        not regress is that neither call site goes back to `self.backend`.
+        """
+        source = (ROOT / "src/orbit/terminal/repl.py").read_text(encoding="utf-8")
+        self.assertEqual(source.count("backend=self._analysis_backend(),"), 2)
+        self.assertNotIn("                backend=self.backend,\n", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An autonomous analysis reproducibly dies on model call 7 with `llama_decode failed during generation: 1` — llama.cpp b9551's *"could not find a KV slot for the batch"* — and the diagnostics could not say why. **This mission measures the failure; it does not fix it.**

## Two gaps, one missing story

**ANALYSIS calls emitted no `kv_diag` records at all.** `ChatRuntime` wraps its backend with the diagnostic recorder (`chat.py:190`), but `cli.py` passes the *same raw* `LlamaServerBackend` to both `ChatRuntime` and `Repl` — and the analysis session was handed that one. So `phase`/`model_call_id` correlation existed for CHAT and not for ANALYSIS. Both analysis entry points now go through `instrument_backend`, which returns the backend unchanged when disabled and is idempotent when enabled.

**No decode site reported physical state.** `emit_decode_kv_state` now records `seq_pos_min`/`seq_pos_max`, the derived `physical_frontier` (`seq_pos_max + 1`; positions are 0-based inclusive), `remaining_physical_positions`, the submitted batch token count, the prefill decode range, the generation iteration, and the return code. Generation is the mandatory site; prefill is instrumented too so the two are comparable.

## Why the failure-path read is trustworthy

On **rc=1** llama.cpp fails at slot *allocation* before mutating memory, so the post-call read equals the pre-call state — it is genuinely the frontier that refused the batch. That reasoning is rc=1-specific and the docstring now says so; for rc=2 and rc < −1 processed ubatches remain.

## OFF contract

Both call sites are guarded by `kv_diag_enabled()`, asserted over the AST because "this native query is unreachable when disabled" is a property a passing run cannot demonstrate. Measured cost of the guard: **~0.9 µs per generated token**, 0.0009 % of a ~100 ms token, ~1.8 ms across a full 2048-token generation.

## Review

BLOCKER 0 / MAJOR 2 / MINOR 3, all addressed. The review found a **surviving mutant** in my own test: swapping the two `stage=` literals passed, because I sorted the multiset instead of binding each literal to its site — the precise misdiagnosis this change exists to prevent. Fixed and re-qualified. It also proved my "diagnostics can never break a run" claim false for an unwritable `ORBIT_KV_DIAG_FILE`; that exposure is now contained at this emitter.

14 tests, 10 mutants caught, full suite **3888 pass**. Scope: 4 files, no behaviour, policy, admission, ctx, compaction, batch, MTP or UX change.
