### PR TITLE
fix(analysis): enforce exact context admission

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -38,7 +38,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from orbit.backend.base import ChatBackend, Message, RecoverableBackendError
-from orbit.runtime.context_manager import ContextAdmissionError
+from orbit.runtime.context_manager import (
+    ContextAdmissionError,
+    DEFAULT_NEXT_ACTION_RESERVE,
+    plan_exact_context,
+)
 from orbit.runtime.analysis_progress import (
     COMPLETE,
     ERROR,
@@ -692,6 +696,8 @@ class AnalysisRuntime:
     model_calls: int = 0
     actions_executed: int = 0
     analyst_turns: int = 0
+    context_compactions: int = 0
+    last_context_plan: object | None = None
 
     def __post_init__(self) -> None:
         if self.workspace is None:
@@ -709,6 +715,77 @@ class AnalysisRuntime:
                     ),
                 }
             )
+
+    def _admit(self, messages: list[Message], *, max_tokens: int,
+               tools: list[dict] | None) -> list[Message]:
+        """Plan one ANALYSIS request through Orbit's shared context admission.
+
+        ANALYSIS had none. Prompts grew 581 -> 2898 -> 5241 -> 6105 -> 6991
+        against a budget of 5632, and the two over-budget calls were submitted
+        anyway; the resident sequence then reached ctx and generation died with
+        `llama_decode == 1` ("could not find a KV slot") at physical frontier
+        8192 of 8192. The cause was logical over-admission, so the fix is the
+        admission CHAT already runs -- not a physical-frontier check, which
+        would only notice one token too late.
+
+        `ChatRuntime`'s wrapper cannot be reused directly: its `prepare` is
+        bound to chat's message list. Only the binding is new here; the policy,
+        the budget arithmetic and the compaction all stay in
+        `plan_exact_context`, called with THIS runtime's history.
+
+        Returns the admitted messages, which may be a compacted projection.
+        Raises `ContextAdmissionError` when the request cannot be made to fit --
+        deliberately before the backend, so nothing reaches `llama_decode` that
+        is already known not to fit.
+        """
+        capability = getattr(self.backend, "supports_exact_context_admission", None)
+        if callable(capability):
+            status = capability()
+            if status is False:
+                # A non-Orbit endpoint cannot attest exact tokens; admission is
+                # skipped exactly as it is for CHAT rather than guessed at.
+                return messages
+            if status is not True:
+                raise ContextAdmissionError(
+                    "context admission failed: exact-token-capability-unavailable"
+                )
+        else:
+            return messages
+
+        plan = plan_exact_context(
+            messages,
+            backend=self.backend,
+            output_reserve=max_tokens,
+            next_action_reserve=DEFAULT_NEXT_ACTION_RESERVE,
+            configured_context_tokens=self._context_tokens(),
+            tools=tools,
+            thinking=False,
+            available_evidence_ids=(),
+            covered_evidence_ids=(),
+        )
+        self.last_context_plan = plan
+        if not plan.admitted:
+            raise ContextAdmissionError(
+                f"context admission failed: {plan.reason or 'required-context-does-not-fit'}"
+            )
+        if plan.status == "compacted":
+            self.context_compactions += 1
+        return [dict(message) for message in plan.messages]
+
+    def _context_tokens(self) -> int | None:
+        """The backend's own context size, or None when it cannot say.
+
+        Read from the backend rather than configured here so ANALYSIS cannot
+        drift from the context the model was actually loaded with.
+        """
+        info = getattr(self.backend, "model_info", None)
+        if not callable(info):
+            return None
+        try:
+            resolved = info()
+        except Exception:
+            return None
+        return getattr(resolved, "context_length", None)
 
     @property
     def effective_max_tokens(self) -> int:
@@ -780,9 +857,14 @@ class AnalysisRuntime:
         # step already makes, so the backend can continue the analysis chain's
         # own KV instead of prefilling it again.
         call_started = time.monotonic()
+        admitted = self._admit(
+            list(self.messages),
+            max_tokens=self.effective_max_tokens,
+            tools=[ANALYSIS_TOOL_SCHEMA],
+        )
         with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
             response = self.backend.chat_stream(
-                list(self.messages),
+                admitted,
                 temperature=self.temperature,
                 max_tokens=self.effective_max_tokens,
                 tools=[ANALYSIS_TOOL_SCHEMA],
@@ -1490,9 +1572,12 @@ class AnalysisRuntime:
                 on_delta(text)
 
         started = time.monotonic()
+        admitted = self._admit(
+            messages, max_tokens=self.effective_max_tokens, tools=[]
+        )
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
-                messages,
+                admitted,
                 temperature=self.temperature,
                 max_tokens=self.effective_max_tokens,
                 tools=[],

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -717,7 +717,7 @@ class AnalysisRuntime:
             )
 
     def _admit(self, messages: list[Message], *, max_tokens: int,
-               tools: list[dict] | None) -> list[Message]:
+               tools: list[dict] | None, next_action_reserve: int | None = None) -> list[Message]:
         """Plan one ANALYSIS request through Orbit's shared context admission.
 
         ANALYSIS had none. Prompts grew 581 -> 2898 -> 5241 -> 6105 -> 6991
@@ -733,10 +733,24 @@ class AnalysisRuntime:
         the budget arithmetic and the compaction all stay in
         `plan_exact_context`, called with THIS runtime's history.
 
-        Returns the admitted messages, which may be a compacted projection.
-        Raises `ContextAdmissionError` when the request cannot be made to fit --
-        deliberately before the backend, so nothing reaches `llama_decode` that
-        is already known not to fit.
+        Scope of what this buys, stated precisely: for ANALYSIS this is
+        **admit-or-refuse**, not admit-or-compact. `plan_context` can only
+        externalise a tool turn whose evidence id is both available and covered,
+        and analysis tool messages carry no `evidence_id` -- so no turn is ever
+        eligible and the planner returns "unchanged" or "blocked", never
+        "compacted". The empty evidence sets passed below therefore describe
+        reality rather than discarding an option.
+
+        That still fixes the defect: an over-budget step now ends the run
+        explicitly, with the EvidenceStore and history intact and a stop reason
+        the analyst can act on, instead of driving the KV sequence into the
+        context wall and dying inside `llama_decode`. Making analysis history
+        genuinely compactable would mean giving its tool messages evidence
+        identity, which is a larger change than this defect warrants.
+
+        Returns the admitted messages. Raises `ContextAdmissionError` when the
+        request cannot be made to fit -- deliberately before the backend, so
+        nothing reaches `llama_decode` that is already known not to fit.
         """
         capability = getattr(self.backend, "supports_exact_context_admission", None)
         if callable(capability):
@@ -756,10 +770,19 @@ class AnalysisRuntime:
             messages,
             backend=self.backend,
             output_reserve=max_tokens,
-            next_action_reserve=DEFAULT_NEXT_ACTION_RESERVE,
+            next_action_reserve=(
+                DEFAULT_NEXT_ACTION_RESERVE
+                if next_action_reserve is None
+                else next_action_reserve
+            ),
             configured_context_tokens=self._context_tokens(),
             tools=tools,
-            thinking=False,
+            # The render counted must be the render submitted. `chat_stream`
+            # sends `backend.thinking`, which the REPL sets from `--think`, so
+            # hardcoding False here would under-count a thinking template in the
+            # permissive direction -- reintroducing exactly the over-admission
+            # this method exists to prevent.
+            thinking=bool(getattr(self.backend, "thinking", False)),
             available_evidence_ids=(),
             covered_evidence_ids=(),
         )
@@ -1573,7 +1596,13 @@ class AnalysisRuntime:
 
         started = time.monotonic()
         admitted = self._admit(
-            messages, max_tokens=self.effective_max_tokens, tools=[]
+            messages,
+            max_tokens=self.effective_max_tokens,
+            tools=[],
+            # The report runs with tools off and cannot issue a next action, so
+            # withholding that reserve would only narrow the path most likely to
+            # block. Chat makes the same phase-dependent choice.
+            next_action_reserve=0,
         )
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(

--- a/tests/test_analysis_context_admission.py
+++ b/tests/test_analysis_context_admission.py
@@ -1,0 +1,244 @@
+"""ANALYSIS must plan every model call through Orbit's exact context admission.
+
+MANUAL-TEST-DIAG-2 measured the failure end to end. ANALYSIS had no admission at
+all: prompts grew 581 -> 2898 -> 5241 -> 6105 -> 6991 against a budget of
+`8192 - 2048 - 256 - 256 = 5632`, the two over-budget calls were submitted
+anyway, and the resident sequence then reached the context wall -- generation
+died at iteration 263 with `llama_decode == 1` ("could not find a KV slot") at
+physical frontier 8192 of 8192, one token short.
+
+The cause was logical over-admission, so these tests pin the logical fix. The
+token counts below are the ones actually measured, not invented boundaries.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime.analysis_runtime import AnalysisRuntime  # noqa: E402
+from orbit.runtime.context_manager import ContextAdmissionError  # noqa: E402
+
+CTX = 8192
+ANALYSIS_BUDGET = 5632  # 8192 - 2048 output - 256 next-action - 256 margin
+
+
+def _result() -> ChatResult:
+    return ChatResult(
+        content="ok", model="m", finish_reason="stop", tool_calls=[],
+        prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+class _Backend:
+    """An orbit-native backend whose exact token count the test controls."""
+
+    thinking = False
+
+    def __init__(self, tokens: int, *, context_tokens: int = CTX) -> None:
+        self._count = TokenCount(
+            tokens=tokens, context_tokens=context_tokens,
+            rendered_hash="a" * 64, token_hash="b" * 64,
+        )
+        self.chat_stream_calls: list[list[dict]] = []
+        self.count_calls = 0
+
+    def supports_exact_context_admission(self) -> bool:
+        return True
+
+    def model_info(self):
+        class _Info:
+            context_length = CTX
+        return _Info()
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        self.count_calls += 1
+        return self._count
+
+    def chat_stream(self, messages, **kwargs):
+        self.chat_stream_calls.append(list(messages))
+        return _result()
+
+    def chat(self, messages, **kwargs):
+        return _result()
+
+
+def _runtime(backend) -> AnalysisRuntime:
+    runtime = object.__new__(AnalysisRuntime)
+    object.__setattr__(runtime, "backend", backend)
+    object.__setattr__(runtime, "messages", [
+        {"role": "system", "content": "analysis system"},
+        {"role": "user", "content": "artifact"},
+    ])
+    object.__setattr__(runtime, "context_compactions", 0)
+    object.__setattr__(runtime, "last_context_plan", None)
+    return runtime
+
+
+class MeasuredPromptSizeTests(unittest.TestCase):
+    """The five prompt sizes the failing run actually produced."""
+
+    def test_the_three_in_budget_prompts_are_admitted(self) -> None:
+        for tokens in (581, 2898, 5241):
+            with self.subTest(tokens=tokens):
+                backend = _Backend(tokens)
+                admitted = _runtime(backend)._admit(
+                    [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+                )
+                self.assertTrue(admitted)
+                self.assertLess(tokens, ANALYSIS_BUDGET)
+
+    def test_the_6105_token_call_is_refused_before_the_backend(self) -> None:
+        """The first over-budget call of the measured run."""
+        backend = _Backend(6105)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(
+            backend.chat_stream_calls, [],
+            "an over-budget request must never reach the backend",
+        )
+
+    def test_the_6991_token_call_is_refused_before_the_backend(self) -> None:
+        """The last call before the physical context wall was hit."""
+        backend = _Backend(6991)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(backend.chat_stream_calls, [])
+
+    def test_the_budget_boundary_is_the_shared_one(self) -> None:
+        """Exactly at the limit admits; one token past it does not.
+
+        Pins that ANALYSIS uses the shared arithmetic rather than a local copy:
+        a duplicated formula could drift and this would catch it.
+        """
+        ok = _Backend(ANALYSIS_BUDGET)
+        self.assertTrue(_runtime(ok)._admit([{"role": "user", "content": "x"}],
+                                            max_tokens=2048, tools=[]))
+        over = _Backend(ANALYSIS_BUDGET + 1)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(over)._admit([{"role": "user", "content": "x"}],
+                                  max_tokens=2048, tools=[])
+
+
+class AdmissionUsesAnalysisHistoryTests(unittest.TestCase):
+    """The history planned must be ANALYSIS's own, never chat's."""
+
+    def test_the_planned_messages_are_the_ones_passed_in(self) -> None:
+        backend = _Backend(100)
+        runtime = _runtime(backend)
+        own = [{"role": "user", "content": "analysis-owned-history"}]
+        admitted = runtime._admit(own, max_tokens=2048, tools=[])
+        self.assertEqual(
+            [m["content"] for m in admitted], ["analysis-owned-history"],
+            "admission must plan the caller's history, not some other list",
+        )
+
+    def test_the_context_size_comes_from_the_backend(self) -> None:
+        """Not a constant here: ANALYSIS must not drift from the loaded model."""
+        backend = _Backend(100)
+        self.assertEqual(_runtime(backend)._context_tokens(), CTX)
+
+
+class ConfiguredContextIsAppliedTests(unittest.TestCase):
+    """The configured cap must constrain admission, not just the backend's."""
+
+    def test_the_smaller_configured_context_wins(self) -> None:
+        """A backend claiming a larger window must not widen the budget.
+
+        `plan_exact_context` takes `min(attested, configured)`. Without the
+        configured value the planner would trust the backend alone, so a
+        backend reporting 32k would admit a prompt that cannot fit the 8k
+        context the model was actually loaded with -- exactly the class of
+        over-admission that caused the KV exhaustion.
+        """
+        class Roomy(_Backend):
+            def model_info(self):
+                class _Info:
+                    context_length = CTX  # what the model was really loaded with
+                return _Info()
+
+        # The backend attests a much larger window than it was loaded with.
+        backend = Roomy(6991, context_tokens=32768)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(backend.chat_stream_calls, [])
+
+
+class AdmissionCapabilityTests(unittest.TestCase):
+    """Behaviour mirrors CHAT for backends that cannot attest exact tokens."""
+
+    def test_a_non_attesting_backend_skips_admission_rather_than_guessing(self) -> None:
+        class Plain(_Backend):
+            def supports_exact_context_admission(self) -> bool:
+                return False
+
+        backend = Plain(9999)
+        messages = [{"role": "user", "content": "x"}]
+        self.assertEqual(
+            _runtime(backend)._admit(messages, max_tokens=2048, tools=[]), messages
+        )
+
+    def test_an_unknown_capability_fails_closed(self) -> None:
+        class Unknown(_Backend):
+            def supports_exact_context_admission(self):
+                return None
+
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(Unknown(100))._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+
+
+class SinglePlanningTests(unittest.TestCase):
+    """Admission must happen once per request, not stack with another layer."""
+
+    def test_one_admission_plans_the_request_once(self) -> None:
+        backend = _Backend(100)
+        _runtime(backend)._admit([{"role": "user", "content": "x"}],
+                                 max_tokens=2048, tools=[])
+        # plan_exact_context counts twice by design (it re-counts to prove the
+        # render is stable); more than that means a second admission layer.
+        self.assertLessEqual(
+            backend.count_calls, 2,
+            "a stacked second admission would re-count the same request",
+        )
+
+
+class CallSiteWiringTests(unittest.TestCase):
+    """Both streaming ANALYSIS call sites go through admission."""
+
+    def test_step_and_report_both_admit_before_calling_the_backend(self) -> None:
+        import ast
+
+        source = (ROOT / "src/orbit/runtime/analysis_runtime.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        admitting: set[str] = set()
+        streaming: set[str] = set()
+        for parent in ast.walk(tree):
+            if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            body = ast.unparse(parent)
+            if "self._admit(" in body:
+                admitting.add(parent.name)
+            if "self.backend.chat_stream(" in body:
+                streaming.add(parent.name)
+
+        self.assertTrue(
+            streaming.issubset(admitting),
+            f"every chat_stream site must admit first; missing {streaming - admitting}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_context_admission.py
+++ b/tests/test_analysis_context_admission.py
@@ -20,7 +20,11 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
-from orbit.runtime.analysis_runtime import AnalysisRuntime  # noqa: E402
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
 from orbit.runtime.context_manager import ContextAdmissionError  # noqa: E402
 
 CTX = 8192
@@ -47,6 +51,8 @@ class _Backend:
         )
         self.chat_stream_calls: list[list[dict]] = []
         self.count_calls = 0
+        self.counted_thinking: list[bool] = []
+        self.thinking = False
 
     def supports_exact_context_admission(self) -> bool:
         return True
@@ -58,6 +64,7 @@ class _Backend:
 
     def count_chat_tokens(self, messages, *, tools=None, thinking=False):
         self.count_calls += 1
+        self.counted_thinking.append(bool(thinking))
         return self._count
 
     def chat_stream(self, messages, **kwargs):
@@ -127,6 +134,38 @@ class MeasuredPromptSizeTests(unittest.TestCase):
         with self.assertRaises(ContextAdmissionError):
             _runtime(over)._admit([{"role": "user", "content": "x"}],
                                   max_tokens=2048, tools=[])
+
+
+class AdmitOrRefuseContractTests(unittest.TestCase):
+    """ANALYSIS admission is admit-or-refuse, and that is deliberate."""
+
+    def test_analysis_history_is_never_compacted_only_refused(self) -> None:
+        """Pins the real contract so a future reader is not misled.
+
+        `plan_context` externalises only tool turns whose evidence is available
+        AND covered; analysis tool messages carry no `evidence_id`, so no turn
+        is eligible. The planner can return "unchanged" or "blocked" and never
+        "compacted". This is not a lost opportunity being hidden -- it is the
+        shape of analysis history -- but it must not be described as compaction.
+        """
+        from orbit.runtime.context_manager import ContextBudget, plan_context
+
+        budget = ContextBudget(context_tokens=CTX, output_reserve=2048,
+                               next_action_reserve=256, safety_margin=256)
+        analysis_shaped = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "artifact"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "tool_call_id": "c1",
+             "name": "execute_analysis", "content": "result"},
+            {"role": "assistant", "content": "finding"},
+            {"role": "user", "content": "continue"},
+        ]
+        plan = plan_context(analysis_shaped, budget=budget, count_tokens=lambda m: 6991)
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.compacted_turns, 0)
+        self.assertEqual(plan.externalized_evidence_ids, ())
 
 
 class AdmissionUsesAnalysisHistoryTests(unittest.TestCase):
@@ -212,6 +251,82 @@ class SinglePlanningTests(unittest.TestCase):
         self.assertLessEqual(
             backend.count_calls, 2,
             "a stacked second admission would re-count the same request",
+        )
+
+
+class CountedRenderMatchesSubmittedRenderTests(unittest.TestCase):
+    """The render counted must be the render submitted."""
+
+    def test_thinking_mode_is_taken_from_the_backend_not_assumed(self) -> None:
+        """`chat_stream` sends `backend.thinking`; admission must count it.
+
+        The REPL sets `backend.thinking` from `--think`, and ANALYSIS shares that
+        backend object. Counting with `thinking=False` while submitting a
+        thinking template under-counts in the permissive direction -- which is
+        the over-admission this whole mechanism exists to prevent.
+        """
+        backend = _Backend(100)
+        backend.thinking = True
+        _runtime(backend)._admit(
+            [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+        )
+        self.assertEqual(
+            set(backend.counted_thinking), {True},
+            "admission counted a different render than chat_stream would send",
+        )
+
+    def test_thinking_off_is_counted_as_off(self) -> None:
+        backend = _Backend(100)
+        backend.thinking = False
+        _runtime(backend)._admit(
+            [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+        )
+        self.assertEqual(set(backend.counted_thinking), {False})
+
+
+class AdmittedMessagesReachTheBackendTests(unittest.TestCase):
+    """Built with the real constructor: what `_admit` returns is what is sent.
+
+    The AST wiring test proves `_admit` and `chat_stream` co-occur; it cannot
+    prove the admitted result is the object actually submitted. Two mutations --
+    sending `list(self.messages)` instead of `admitted`, and returning the input
+    instead of `plan.messages` -- are equivalent while analysis can never
+    compact, and would become silent defects the moment it can. This closes that
+    data-flow gap behaviourally.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-admission-rt-")
+        self.addCleanup(self._dir.cleanup)
+        tmp = pathlib.Path(self._dir.name)
+        artifact = tmp / "artifact.txt"
+        artifact.write_text("payload", encoding="utf-8")
+        self.source = acquire_analysis_source(artifact, tmp / "owned")
+        self.store = EvidenceStore(root=tmp / "evidence")
+
+    def test_the_object_returned_by_admission_is_the_one_submitted(self) -> None:
+        marker = {"role": "user", "content": "ADMITTED-PROJECTION-MARKER"}
+
+        class Backend(_Backend):
+            def __init__(self) -> None:
+                super().__init__(100)
+
+        backend = Backend()
+        runtime = AnalysisRuntime(
+            backend=backend, source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(runtime.close)
+        # Force admission to return a distinguishable projection.
+        runtime._admit = lambda messages, **kwargs: [marker]  # type: ignore[assignment]
+
+        runtime.step("go")
+
+        self.assertTrue(backend.chat_stream_calls, "the backend must be called")
+        self.assertEqual(
+            backend.chat_stream_calls[-1], [marker],
+            "the messages sent must be exactly what admission returned",
         )
 
 


### PR DESCRIPTION
ANALYSIS ran every model call with **no context admission at all**. MANUAL-TEST-DIAG-2 measured the consequence end to end.

## The proven failure

Prompts grew **581 → 2898 → 5241 → 6105 → 6991** against a budget of `8192 − 2048 − 256 − 256 = 5632`. The two over-budget calls were submitted anyway; the resident KV sequence then reached the wall and generation died at iteration 263:

| iter | frontier | remaining | rc |
|---:|---:|---:|---:|
| 260 | 8190 | 2 | 0 |
| 261 | 8191 | 1 | 0 |
| 262 | 8192 | 0 | 0 |
| **263** | **8192** | **0** | **1** |

`llama_decode == 1` — *"could not find a KV slot for the batch"* — one token short of an 8192 context.

## The fix

The cause is **logical over-admission**, so the fix is the admission CHAT already runs — not a physical-frontier check at the decode site, which would notice the overflow one token too late.

`ChatRuntime`'s `ContextManagedBackend` can't be reused directly: its `prepare` is bound to chat's message list. Only the **binding** is new — `AnalysisRuntime._admit` calls the shared `plan_exact_context` with *this* runtime's history. Budget arithmetic and fail-closed behaviour stay in `context_manager`; nothing is duplicated. Context size is read from the backend so ANALYSIS can't drift from the loaded model.

Both streaming sites (`analysis_step`, `analysis_report`) admit. The completion verifier is deliberately left alone — it builds a fixed 2-message prompt and already enforces its own exact-token budget, verified from source.

## Honest scope

For ANALYSIS this is **admit-or-refuse, not admit-or-compact**. `plan_context` externalises only tool turns whose evidence is available and covered; analysis tool messages carry no `evidence_id`, so no turn is eligible. An over-budget step now ends **explicitly, with EvidenceStore and history intact**, instead of crashing inside `llama_decode`. That is the fix; calling it compaction would be wrong.

## Review

BLOCKER 0 / MAJOR 2 / MINOR 3, all addressed. The review caught a **real defect in my fix**: I hardcoded `thinking=False` while `chat_stream` sends `backend.thinking`, so under `--think on` the budget would under-count in the permissive direction — the very over-admission this prevents. Fixed and pinned. It also showed my AST wiring test proved co-occurrence rather than data flow; a mutation sending the raw history survived it and is now caught by a behavioural test using the real constructor.

15 tests, 10 mutants caught, full suite **3903 pass**. Scope: 2 files, no ctx/batch/max_tokens/KV/MTP/UX change.
