### PR TITLE
fix(analysis): canonical tool-call identity, then exact context admission

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -697,6 +697,7 @@ class AnalysisRuntime:
     actions_executed: int = 0
     analyst_turns: int = 0
     _synthetic_call_seq: int = 0
+    context_tokens: int | None = None
     context_compactions: int = 0
     last_context_plan: object | None = None
 
@@ -867,6 +868,12 @@ class AnalysisRuntime:
         Read from the backend rather than configured here so ANALYSIS cannot
         drift from the context the model was actually loaded with.
         """
+        if isinstance(self.context_tokens, int) and self.context_tokens > 0:
+            # An operator who narrowed the window with `--context-tokens` means
+            # it here too. CHAT resolves the same way (`cli.py`: configured value
+            # first, backend report as the fallback), and ANALYSIS silently
+            # ignoring it would be a divergence in the permissive direction.
+            return self.context_tokens
         info = getattr(self.backend, "model_info", None)
         if not callable(info):
             return None

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -35,10 +35,14 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from orbit.backend.base import ChatBackend, Message, RecoverableBackendError
-from orbit.runtime.context_manager import ContextAdmissionError
+from orbit.runtime.context_manager import (
+    ContextAdmissionError,
+    DEFAULT_NEXT_ACTION_RESERVE,
+    plan_exact_context,
+)
 from orbit.runtime.analysis_progress import (
     COMPLETE,
     ERROR,
@@ -692,6 +696,9 @@ class AnalysisRuntime:
     model_calls: int = 0
     actions_executed: int = 0
     analyst_turns: int = 0
+    _synthetic_call_seq: int = 0
+    context_compactions: int = 0
+    last_context_plan: object | None = None
 
     def __post_init__(self) -> None:
         if self.workspace is None:
@@ -709,6 +716,137 @@ class AnalysisRuntime:
                     ),
                 }
             )
+
+    def _with_canonical_call_ids(self, calls: Iterable[dict]) -> list[dict]:
+        """Give every accepted tool call a non-empty id, preserving real ones.
+
+        Backends may return tool calls without an `id`. ANALYSIS tolerated that
+        by writing `call.get("id") or ""` into the matching tool result, which
+        is self-consistent but structurally invalid: Orbit's shared context
+        planner requires a non-empty id on every assistant tool call
+        (`context_manager._tool_call_id`), and refuses the whole history
+        without one. That is what blocked exact-context admission for ANALYSIS.
+
+        Normalizing here -- at the single point where a step accepts the
+        backend's calls, before anything is persisted -- means the assistant
+        message and its tool result are built from the same objects and cannot
+        disagree. A backend-supplied id is never replaced; only a missing or
+        empty one is filled.
+
+        Ids are unique per runtime and stable for the call object they were
+        assigned to, because the returned dicts are the ones every downstream
+        step uses.
+        """
+        normalized: list[dict] = []
+        for call in calls:
+            if not isinstance(call, dict):
+                # Not ours to repair: the structural gate rejects it downstream
+                # with its own message rather than being handed a fabricated id.
+                normalized.append(call)
+                continue
+            existing = call.get("id")
+            if isinstance(existing, str) and existing:
+                normalized.append(call)
+                continue
+            self._synthetic_call_seq += 1
+            replacement = dict(call)
+            replacement["id"] = f"orbit_analysis_call_{self._synthetic_call_seq}"
+            normalized.append(replacement)
+        return normalized
+
+    def _admit(self, messages: list[Message], *, max_tokens: int,
+               tools: list[dict] | None, next_action_reserve: int | None = None) -> list[Message]:
+        """Plan one ANALYSIS request through Orbit's shared context admission.
+
+        ANALYSIS had none. Prompts grew 581 -> 2898 -> 5241 -> 6105 -> 6991
+        against a budget of 5632, and the two over-budget calls were submitted
+        anyway; the resident sequence then reached ctx and generation died with
+        `llama_decode == 1` ("could not find a KV slot") at physical frontier
+        8192 of 8192. The cause was logical over-admission, so the fix is the
+        admission CHAT already runs -- not a physical-frontier check, which
+        would only notice one token too late.
+
+        `ChatRuntime`'s wrapper cannot be reused directly: its `prepare` is
+        bound to chat's message list. Only the binding is new here; the policy,
+        the budget arithmetic and the compaction all stay in
+        `plan_exact_context`, called with THIS runtime's history.
+
+        Scope of what this buys, stated precisely: for ANALYSIS this is
+        **admit-or-refuse**, not admit-or-compact. `plan_context` can only
+        externalise a tool turn whose evidence id is both available and covered,
+        and analysis tool messages carry no `evidence_id` -- so no turn is ever
+        eligible and the planner returns "unchanged" or "blocked", never
+        "compacted". The empty evidence sets passed below therefore describe
+        reality rather than discarding an option.
+
+        That still fixes the defect: an over-budget step now ends the run
+        explicitly, with the EvidenceStore and history intact and a stop reason
+        the analyst can act on, instead of driving the KV sequence into the
+        context wall and dying inside `llama_decode`. Making analysis history
+        genuinely compactable would mean giving its tool messages evidence
+        identity, which is a larger change than this defect warrants.
+
+        Returns the admitted messages. Raises `ContextAdmissionError` when the
+        request cannot be made to fit -- deliberately before the backend, so
+        nothing reaches `llama_decode` that is already known not to fit.
+        """
+        capability = getattr(self.backend, "supports_exact_context_admission", None)
+        if callable(capability):
+            status = capability()
+            if status is False:
+                # A non-Orbit endpoint cannot attest exact tokens; admission is
+                # skipped exactly as it is for CHAT rather than guessed at.
+                return messages
+            if status is not True:
+                raise ContextAdmissionError(
+                    "context admission failed: exact-token-capability-unavailable"
+                )
+        else:
+            return messages
+
+        plan = plan_exact_context(
+            messages,
+            backend=self.backend,
+            output_reserve=max_tokens,
+            next_action_reserve=(
+                DEFAULT_NEXT_ACTION_RESERVE
+                if next_action_reserve is None
+                else next_action_reserve
+            ),
+            configured_context_tokens=self._context_tokens(),
+            tools=tools,
+            # The render counted must be the render submitted. `chat_stream`
+            # sends `backend.thinking`, which the REPL sets from `--think`, so
+            # hardcoding False here would under-count a thinking template in the
+            # permissive direction -- reintroducing exactly the over-admission
+            # this method exists to prevent.
+            thinking=bool(getattr(self.backend, "thinking", False)),
+            available_evidence_ids=(),
+            covered_evidence_ids=(),
+        )
+        self.last_context_plan = plan
+        if not plan.admitted:
+            raise ContextAdmissionError(
+                f"context admission failed: {plan.reason or 'required-context-does-not-fit'}"
+            )
+        if plan.status == "compacted":
+            self.context_compactions += 1
+        return [dict(message) for message in plan.messages]
+
+    def _context_tokens(self) -> int | None:
+        """The backend's own context size, or None when it cannot say.
+
+        Read from the backend rather than configured here so ANALYSIS cannot
+        drift from the context the model was actually loaded with.
+        """
+        info = getattr(self.backend, "model_info", None)
+        if not callable(info):
+            return None
+        try:
+            resolved = info()
+        except Exception:
+            return None
+        return getattr(resolved, "context_length", None)
 
     @property
     def effective_max_tokens(self) -> int:
@@ -780,9 +918,14 @@ class AnalysisRuntime:
         # step already makes, so the backend can continue the analysis chain's
         # own KV instead of prefilling it again.
         call_started = time.monotonic()
+        admitted = self._admit(
+            list(self.messages),
+            max_tokens=self.effective_max_tokens,
+            tools=[ANALYSIS_TOOL_SCHEMA],
+        )
         with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
             response = self.backend.chat_stream(
-                list(self.messages),
+                admitted,
                 temperature=self.temperature,
                 max_tokens=self.effective_max_tokens,
                 tools=[ANALYSIS_TOOL_SCHEMA],
@@ -792,7 +935,7 @@ class AnalysisRuntime:
         self.model_calls += 1
         call_seconds = time.monotonic() - call_started
 
-        calls = list(response.tool_calls or [])
+        calls = self._with_canonical_call_ids(response.tool_calls or [])
         content = response.content or ""
         if _unencodable(content):
             # Decoding makes this practically unreachable, but the cost of
@@ -1490,9 +1633,18 @@ class AnalysisRuntime:
                 on_delta(text)
 
         started = time.monotonic()
+        admitted = self._admit(
+            messages,
+            max_tokens=self.effective_max_tokens,
+            tools=[],
+            # The report runs with tools off and cannot issue a next action, so
+            # withholding that reserve would only narrow the path most likely to
+            # block. Chat makes the same phase-dependent choice.
+            next_action_reserve=0,
+        )
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
-                messages,
+                admitted,
                 temperature=self.temperature,
                 max_tokens=self.effective_max_tokens,
                 tools=[],

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -738,6 +738,9 @@ class AnalysisRuntime:
         step uses.
         """
         normalized: list[dict] = []
+        # Ids already spoken for by this batch as well as by prior history: a
+        # backend id preserved one entry earlier must not be re-issued here.
+        claimed: set[str] = set()
         for call in calls:
             if not isinstance(call, dict):
                 # Not ours to repair: the structural gate rejects it downstream
@@ -746,13 +749,38 @@ class AnalysisRuntime:
                 continue
             existing = call.get("id")
             if isinstance(existing, str) and existing:
+                claimed.add(existing)
                 normalized.append(call)
                 continue
-            self._synthetic_call_seq += 1
             replacement = dict(call)
-            replacement["id"] = f"orbit_analysis_call_{self._synthetic_call_seq}"
+            replacement["id"] = self._next_synthetic_call_id(claimed)
+            claimed.add(replacement["id"])
             normalized.append(replacement)
         return normalized
+
+    def _next_synthetic_call_id(self, claimed: set[str]) -> str:
+        """A fresh id that no call in this conversation already claims.
+
+        The counter alone is not enough. A backend is free to return an id that
+        happens to match the generated form, and preserving it -- which is
+        correct -- would otherwise leave the next synthetic id colliding with
+        it. A duplicate silently breaks the assistant/result pairing the shared
+        planner depends on, so the sequence skips anything already in use,
+        whether it came from earlier history or from earlier in this batch.
+        """
+        taken = set(claimed)
+        taken |= {
+            call.get("id")
+            for message in self.messages
+            if message.get("role") == "assistant"
+            for call in (message.get("tool_calls") or [])
+            if isinstance(call, dict)
+        }
+        while True:
+            self._synthetic_call_seq += 1
+            candidate = f"orbit_analysis_call_{self._synthetic_call_seq}"
+            if candidate not in taken:
+                return candidate
 
     def _admit(self, messages: list[Message], *, max_tokens: int,
                tools: list[dict] | None, next_action_reserve: int | None = None) -> list[Message]:

--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -43,6 +43,7 @@ def open_analysis_session(
     backend: ChatBackend,
     workdir: Path,
     evidence_store_factory: Callable[[Path], EvidenceStore],
+    context_tokens: int | None = None,
 ) -> AnalysisRuntime:
     """Snapshot the artifact and return a runtime bound to it.
 
@@ -67,6 +68,7 @@ def open_analysis_session(
         source=source,
         evidence_store=evidence_store,
         workspace=workspace,
+        context_tokens=context_tokens,
     )
 
 
@@ -76,6 +78,7 @@ def open_confined_analysis_session(
     backend: ChatBackend,
     workdir: Path,
     evidence_store_factory: Callable[[Path], EvidenceStore],
+    context_tokens: int | None = None,
     on_acquired: Callable[[], None] | None = None,
 ) -> AnalysisRuntime:
     """Open a session on a path the model chose, acquiring it safely.
@@ -113,6 +116,7 @@ def open_confined_analysis_session(
         source=source,
         evidence_store=evidence_store,
         workspace=workspace,
+        context_tokens=context_tokens,
     )
 
 

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -824,6 +824,7 @@ class Repl:
             runtime = open_confined_analysis_session(
                 artifact,
                 backend=self._analysis_backend(),
+                context_tokens=self.runtime.context_tokens,
                 workdir=self.config.workdir,
                 evidence_store_factory=self._analysis_evidence_store,
                 on_acquired=self._analysis_acquired_hook,
@@ -866,6 +867,7 @@ class Repl:
             runtime = open_analysis_session(
                 arguments,
                 backend=self._analysis_backend(),
+                context_tokens=self.runtime.context_tokens,
                 workdir=self.config.workdir,
                 evidence_store_factory=self._analysis_evidence_store,
             )

--- a/tests/test_analysis_context_admission.py
+++ b/tests/test_analysis_context_admission.py
@@ -1,0 +1,359 @@
+"""ANALYSIS must plan every model call through Orbit's exact context admission.
+
+MANUAL-TEST-DIAG-2 measured the failure end to end. ANALYSIS had no admission at
+all: prompts grew 581 -> 2898 -> 5241 -> 6105 -> 6991 against a budget of
+`8192 - 2048 - 256 - 256 = 5632`, the two over-budget calls were submitted
+anyway, and the resident sequence then reached the context wall -- generation
+died at iteration 263 with `llama_decode == 1` ("could not find a KV slot") at
+physical frontier 8192 of 8192, one token short.
+
+The cause was logical over-admission, so these tests pin the logical fix. The
+token counts below are the ones actually measured, not invented boundaries.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+from orbit.runtime.context_manager import ContextAdmissionError  # noqa: E402
+
+CTX = 8192
+ANALYSIS_BUDGET = 5632  # 8192 - 2048 output - 256 next-action - 256 margin
+
+
+def _result() -> ChatResult:
+    return ChatResult(
+        content="ok", model="m", finish_reason="stop", tool_calls=[],
+        prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+class _Backend:
+    """An orbit-native backend whose exact token count the test controls."""
+
+    thinking = False
+
+    def __init__(self, tokens: int, *, context_tokens: int = CTX) -> None:
+        self._count = TokenCount(
+            tokens=tokens, context_tokens=context_tokens,
+            rendered_hash="a" * 64, token_hash="b" * 64,
+        )
+        self.chat_stream_calls: list[list[dict]] = []
+        self.count_calls = 0
+        self.counted_thinking: list[bool] = []
+        self.thinking = False
+
+    def supports_exact_context_admission(self) -> bool:
+        return True
+
+    def model_info(self):
+        class _Info:
+            context_length = CTX
+        return _Info()
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        self.count_calls += 1
+        self.counted_thinking.append(bool(thinking))
+        return self._count
+
+    def chat_stream(self, messages, **kwargs):
+        self.chat_stream_calls.append(list(messages))
+        return _result()
+
+    def chat(self, messages, **kwargs):
+        return _result()
+
+
+def _runtime(backend) -> AnalysisRuntime:
+    runtime = object.__new__(AnalysisRuntime)
+    object.__setattr__(runtime, "backend", backend)
+    object.__setattr__(runtime, "messages", [
+        {"role": "system", "content": "analysis system"},
+        {"role": "user", "content": "artifact"},
+    ])
+    object.__setattr__(runtime, "context_compactions", 0)
+    object.__setattr__(runtime, "last_context_plan", None)
+    return runtime
+
+
+class MeasuredPromptSizeTests(unittest.TestCase):
+    """The five prompt sizes the failing run actually produced."""
+
+    def test_the_three_in_budget_prompts_are_admitted(self) -> None:
+        for tokens in (581, 2898, 5241):
+            with self.subTest(tokens=tokens):
+                backend = _Backend(tokens)
+                admitted = _runtime(backend)._admit(
+                    [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+                )
+                self.assertTrue(admitted)
+                self.assertLess(tokens, ANALYSIS_BUDGET)
+
+    def test_the_6105_token_call_is_refused_before_the_backend(self) -> None:
+        """The first over-budget call of the measured run."""
+        backend = _Backend(6105)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(
+            backend.chat_stream_calls, [],
+            "an over-budget request must never reach the backend",
+        )
+
+    def test_the_6991_token_call_is_refused_before_the_backend(self) -> None:
+        """The last call before the physical context wall was hit."""
+        backend = _Backend(6991)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(backend.chat_stream_calls, [])
+
+    def test_the_budget_boundary_is_the_shared_one(self) -> None:
+        """Exactly at the limit admits; one token past it does not.
+
+        Pins that ANALYSIS uses the shared arithmetic rather than a local copy:
+        a duplicated formula could drift and this would catch it.
+        """
+        ok = _Backend(ANALYSIS_BUDGET)
+        self.assertTrue(_runtime(ok)._admit([{"role": "user", "content": "x"}],
+                                            max_tokens=2048, tools=[]))
+        over = _Backend(ANALYSIS_BUDGET + 1)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(over)._admit([{"role": "user", "content": "x"}],
+                                  max_tokens=2048, tools=[])
+
+
+class AdmitOrRefuseContractTests(unittest.TestCase):
+    """ANALYSIS admission is admit-or-refuse, and that is deliberate."""
+
+    def test_analysis_history_is_never_compacted_only_refused(self) -> None:
+        """Pins the real contract so a future reader is not misled.
+
+        `plan_context` externalises only tool turns whose evidence is available
+        AND covered; analysis tool messages carry no `evidence_id`, so no turn
+        is eligible. The planner can return "unchanged" or "blocked" and never
+        "compacted". This is not a lost opportunity being hidden -- it is the
+        shape of analysis history -- but it must not be described as compaction.
+        """
+        from orbit.runtime.context_manager import ContextBudget, plan_context
+
+        budget = ContextBudget(context_tokens=CTX, output_reserve=2048,
+                               next_action_reserve=256, safety_margin=256)
+        analysis_shaped = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "artifact"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "tool_call_id": "c1",
+             "name": "execute_analysis", "content": "result"},
+            {"role": "assistant", "content": "finding"},
+            {"role": "user", "content": "continue"},
+        ]
+        plan = plan_context(analysis_shaped, budget=budget, count_tokens=lambda m: 6991)
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(plan.compacted_turns, 0)
+        self.assertEqual(plan.externalized_evidence_ids, ())
+
+
+class AdmissionUsesAnalysisHistoryTests(unittest.TestCase):
+    """The history planned must be ANALYSIS's own, never chat's."""
+
+    def test_the_planned_messages_are_the_ones_passed_in(self) -> None:
+        backend = _Backend(100)
+        runtime = _runtime(backend)
+        own = [{"role": "user", "content": "analysis-owned-history"}]
+        admitted = runtime._admit(own, max_tokens=2048, tools=[])
+        self.assertEqual(
+            [m["content"] for m in admitted], ["analysis-owned-history"],
+            "admission must plan the caller's history, not some other list",
+        )
+
+    def test_the_context_size_comes_from_the_backend(self) -> None:
+        """Not a constant here: ANALYSIS must not drift from the loaded model."""
+        backend = _Backend(100)
+        self.assertEqual(_runtime(backend)._context_tokens(), CTX)
+
+
+class ConfiguredContextIsAppliedTests(unittest.TestCase):
+    """The configured cap must constrain admission, not just the backend's."""
+
+    def test_the_smaller_configured_context_wins(self) -> None:
+        """A backend claiming a larger window must not widen the budget.
+
+        `plan_exact_context` takes `min(attested, configured)`. Without the
+        configured value the planner would trust the backend alone, so a
+        backend reporting 32k would admit a prompt that cannot fit the 8k
+        context the model was actually loaded with -- exactly the class of
+        over-admission that caused the KV exhaustion.
+        """
+        class Roomy(_Backend):
+            def model_info(self):
+                class _Info:
+                    context_length = CTX  # what the model was really loaded with
+                return _Info()
+
+        # The backend attests a much larger window than it was loaded with.
+        backend = Roomy(6991, context_tokens=32768)
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(backend)._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+        self.assertEqual(backend.chat_stream_calls, [])
+
+
+class AdmissionCapabilityTests(unittest.TestCase):
+    """Behaviour mirrors CHAT for backends that cannot attest exact tokens."""
+
+    def test_a_non_attesting_backend_skips_admission_rather_than_guessing(self) -> None:
+        class Plain(_Backend):
+            def supports_exact_context_admission(self) -> bool:
+                return False
+
+        backend = Plain(9999)
+        messages = [{"role": "user", "content": "x"}]
+        self.assertEqual(
+            _runtime(backend)._admit(messages, max_tokens=2048, tools=[]), messages
+        )
+
+    def test_an_unknown_capability_fails_closed(self) -> None:
+        class Unknown(_Backend):
+            def supports_exact_context_admission(self):
+                return None
+
+        with self.assertRaises(ContextAdmissionError):
+            _runtime(Unknown(100))._admit(
+                [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+            )
+
+
+class SinglePlanningTests(unittest.TestCase):
+    """Admission must happen once per request, not stack with another layer."""
+
+    def test_one_admission_plans_the_request_once(self) -> None:
+        backend = _Backend(100)
+        _runtime(backend)._admit([{"role": "user", "content": "x"}],
+                                 max_tokens=2048, tools=[])
+        # plan_exact_context counts twice by design (it re-counts to prove the
+        # render is stable); more than that means a second admission layer.
+        self.assertLessEqual(
+            backend.count_calls, 2,
+            "a stacked second admission would re-count the same request",
+        )
+
+
+class CountedRenderMatchesSubmittedRenderTests(unittest.TestCase):
+    """The render counted must be the render submitted."""
+
+    def test_thinking_mode_is_taken_from_the_backend_not_assumed(self) -> None:
+        """`chat_stream` sends `backend.thinking`; admission must count it.
+
+        The REPL sets `backend.thinking` from `--think`, and ANALYSIS shares that
+        backend object. Counting with `thinking=False` while submitting a
+        thinking template under-counts in the permissive direction -- which is
+        the over-admission this whole mechanism exists to prevent.
+        """
+        backend = _Backend(100)
+        backend.thinking = True
+        _runtime(backend)._admit(
+            [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+        )
+        self.assertEqual(
+            set(backend.counted_thinking), {True},
+            "admission counted a different render than chat_stream would send",
+        )
+
+    def test_thinking_off_is_counted_as_off(self) -> None:
+        backend = _Backend(100)
+        backend.thinking = False
+        _runtime(backend)._admit(
+            [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
+        )
+        self.assertEqual(set(backend.counted_thinking), {False})
+
+
+class AdmittedMessagesReachTheBackendTests(unittest.TestCase):
+    """Built with the real constructor: what `_admit` returns is what is sent.
+
+    The AST wiring test proves `_admit` and `chat_stream` co-occur; it cannot
+    prove the admitted result is the object actually submitted. Two mutations --
+    sending `list(self.messages)` instead of `admitted`, and returning the input
+    instead of `plan.messages` -- are equivalent while analysis can never
+    compact, and would become silent defects the moment it can. This closes that
+    data-flow gap behaviourally.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-admission-rt-")
+        self.addCleanup(self._dir.cleanup)
+        tmp = pathlib.Path(self._dir.name)
+        artifact = tmp / "artifact.txt"
+        artifact.write_text("payload", encoding="utf-8")
+        self.source = acquire_analysis_source(artifact, tmp / "owned")
+        self.store = EvidenceStore(root=tmp / "evidence")
+
+    def test_the_object_returned_by_admission_is_the_one_submitted(self) -> None:
+        marker = {"role": "user", "content": "ADMITTED-PROJECTION-MARKER"}
+
+        class Backend(_Backend):
+            def __init__(self) -> None:
+                super().__init__(100)
+
+        backend = Backend()
+        runtime = AnalysisRuntime(
+            backend=backend, source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(runtime.close)
+        # Force admission to return a distinguishable projection.
+        runtime._admit = lambda messages, **kwargs: [marker]  # type: ignore[assignment]
+
+        runtime.step("go")
+
+        self.assertTrue(backend.chat_stream_calls, "the backend must be called")
+        self.assertEqual(
+            backend.chat_stream_calls[-1], [marker],
+            "the messages sent must be exactly what admission returned",
+        )
+
+
+class CallSiteWiringTests(unittest.TestCase):
+    """Both streaming ANALYSIS call sites go through admission."""
+
+    def test_step_and_report_both_admit_before_calling_the_backend(self) -> None:
+        import ast
+
+        source = (ROOT / "src/orbit/runtime/analysis_runtime.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        admitting: set[str] = set()
+        streaming: set[str] = set()
+        for parent in ast.walk(tree):
+            if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            body = ast.unparse(parent)
+            if "self._admit(" in body:
+                admitting.add(parent.name)
+            if "self.backend.chat_stream(" in body:
+                streaming.add(parent.name)
+
+        self.assertTrue(
+            streaming.issubset(admitting),
+            f"every chat_stream site must admit first; missing {streaming - admitting}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_context_admission.py
+++ b/tests/test_analysis_context_admission.py
@@ -84,6 +84,7 @@ def _runtime(backend) -> AnalysisRuntime:
     ])
     object.__setattr__(runtime, "context_compactions", 0)
     object.__setattr__(runtime, "last_context_plan", None)
+    object.__setattr__(runtime, "context_tokens", None)
     return runtime
 
 
@@ -205,13 +206,45 @@ class ConfiguredContextIsAppliedTests(unittest.TestCase):
                     context_length = CTX  # what the model was really loaded with
                 return _Info()
 
-        # The backend attests a much larger window than it was loaded with.
+        # The backend attests a larger window than `model_info` reports; the
+        # configured value must clamp it back down.
         backend = Roomy(6991, context_tokens=32768)
         with self.assertRaises(ContextAdmissionError):
             _runtime(backend)._admit(
                 [{"role": "user", "content": "x"}], max_tokens=2048, tools=[]
             )
         self.assertEqual(backend.chat_stream_calls, [])
+
+
+class OperatorContextOverrideTests(unittest.TestCase):
+    """`--context-tokens` must narrow ANALYSIS as it narrows CHAT."""
+
+    def test_a_configured_context_narrower_than_the_backend_wins(self) -> None:
+        """CHAT resolves configured-first (`cli.py`); ANALYSIS must match.
+
+        An operator who narrows the window gets that narrowing in CHAT. If
+        ANALYSIS kept using the backend's larger report it would admit prompts
+        the operator meant to exclude -- a silent divergence in the permissive
+        direction, in exactly the dimension this admission governs.
+        """
+        backend = _Backend(3000)  # attests ctx 8192 -> budget 5632, would admit
+        runtime = _runtime(backend)
+        object.__setattr__(runtime, "context_tokens", 4096)  # operator narrows
+
+        # 4096 - 2048 - 256 - 256 = 1536, so 3000 no longer fits.
+        with self.assertRaises(ContextAdmissionError):
+            runtime._admit([{"role": "user", "content": "x"}],
+                           max_tokens=2048, tools=[])
+        self.assertEqual(backend.chat_stream_calls, [])
+
+    def test_without_a_configured_value_the_backend_report_is_used(self) -> None:
+        backend = _Backend(3000)
+        runtime = _runtime(backend)
+        object.__setattr__(runtime, "context_tokens", None)
+        self.assertTrue(
+            runtime._admit([{"role": "user", "content": "x"}],
+                           max_tokens=2048, tools=[])
+        )
 
 
 class AdmissionCapabilityTests(unittest.TestCase):

--- a/tests/test_analysis_tool_call_identity.py
+++ b/tests/test_analysis_tool_call_identity.py
@@ -20,8 +20,17 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from orbit.runtime.analysis_runtime import AnalysisRuntime  # noqa: E402
-from orbit.runtime.context_manager import ContextBudget, plan_context  # noqa: E402
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+from orbit.runtime.context_manager import (  # noqa: E402
+    ContextBudget,
+    conversation_structure_error,
+    plan_context,
+)
 
 
 def _runtime() -> AnalysisRuntime:
@@ -179,6 +188,96 @@ class PlannerAcceptsAnalysisHistoryTests(unittest.TestCase):
         plan = self._plan(self._history(_call()))
         self.assertFalse(plan.admitted)
         self.assertEqual(plan.reason, "invalid-message-structure:missing-tool-call-id")
+
+
+class RealStepProducesParsableHistoryTests(unittest.TestCase):
+    """The outcome, not the shape: run real steps and check what they left.
+
+    The AST test pins that `step()` mentions the normalizer; it cannot see
+    whether the normalized calls are the ones persisted. Two mutations slip past
+    it -- persisting a separate raw list, and writing a different id into the
+    tool result -- and each silently restores the exact regression this change
+    exists to remove. Asserting on `conversation_structure_error` of the real
+    resulting history catches both, because that is the same grammar admission
+    itself applies.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-idflow-")
+        self.addCleanup(self._dir.cleanup)
+        tmp = pathlib.Path(self._dir.name)
+        artifact = tmp / "artifact.txt"
+        artifact.write_text("payload", encoding="utf-8")
+        self.source = acquire_analysis_source(artifact, tmp / "owned")
+        self.store = EvidenceStore(root=tmp / "evidence")
+
+    def _runtime(self):
+        class Backend:
+            """Returns tool calls with NO id -- the shape that regressed main."""
+
+            thinking = False
+
+            def supports_exact_context_admission(self) -> bool:
+                return True
+
+            def model_info(self):
+                class _Info:
+                    context_length = 8192
+                return _Info()
+
+            def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                return TokenCount(tokens=900, context_tokens=8192,
+                                  rendered_hash="a" * 64, token_hash="b" * 64)
+
+            def chat_stream(self, messages, **kwargs):
+                return ChatResult(
+                    content="", model="m", finish_reason="tool_calls",
+                    tool_calls=[{"function": {"name": "execute_analysis",
+                                              "arguments": '{"code": "pass"}'}}],
+                    prompt_tokens=900, completion_tokens=5, cached_tokens=0,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+
+        runtime = AnalysisRuntime(
+            backend=Backend(), source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def test_two_real_steps_leave_a_history_admission_can_parse(self) -> None:
+        """Step 2 is where the reverted change died. It must run."""
+        runtime = self._runtime()
+        runtime.step("analyze this")
+        runtime.step("continue")
+
+        self.assertIsNone(
+            conversation_structure_error(runtime.messages),
+            "the persisted history must satisfy the same grammar admission uses",
+        )
+
+    def test_the_persisted_ids_pair_up_and_are_unique(self) -> None:
+        runtime = self._runtime()
+        runtime.step("analyze this")
+        runtime.step("continue")
+
+        assistant_ids = [
+            call.get("id")
+            for message in runtime.messages
+            if message.get("role") == "assistant"
+            for call in (message.get("tool_calls") or [])
+        ]
+        result_ids = [
+            message.get("tool_call_id")
+            for message in runtime.messages
+            if message.get("role") == "tool"
+        ]
+
+        self.assertTrue(assistant_ids, "the run must have produced tool calls")
+        self.assertEqual(assistant_ids, result_ids, "assistant and result must agree")
+        self.assertTrue(all(assistant_ids), "no persisted id may be empty")
+        self.assertEqual(len(set(assistant_ids)), len(assistant_ids), "ids must be unique")
 
 
 class StepUsesNormalizedCallsTests(unittest.TestCase):

--- a/tests/test_analysis_tool_call_identity.py
+++ b/tests/test_analysis_tool_call_identity.py
@@ -1,0 +1,172 @@
+"""Every ANALYSIS tool call carries a non-empty, unique, matching id.
+
+Backends may return tool calls without an `id`. ANALYSIS tolerated that by
+writing `call.get("id") or ""` into the matching tool result -- self-consistent,
+but structurally invalid: Orbit's shared context planner requires a non-empty id
+on every assistant tool call (`context_manager._tool_call_id`) and refuses the
+whole history without one, with `invalid-message-structure:missing-tool-call-id`.
+
+That is what made exact-context admission impossible for ANALYSIS, and what made
+a first attempt at admission stop a real run at step 2. These tests pin the
+prerequisite: a canonical id at the single point where a step accepts backend
+calls, before anything is persisted.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.runtime.analysis_runtime import AnalysisRuntime  # noqa: E402
+from orbit.runtime.context_manager import ContextBudget, plan_context  # noqa: E402
+
+
+def _runtime() -> AnalysisRuntime:
+    runtime = object.__new__(AnalysisRuntime)
+    object.__setattr__(runtime, "_synthetic_call_seq", 0)
+    return runtime
+
+
+def _call(**extra) -> dict:
+    call = {"function": {"name": "execute_analysis", "arguments": "{}"}}
+    call.update(extra)
+    return call
+
+
+class IdPreservationTests(unittest.TestCase):
+    """A real backend id is authoritative and must survive untouched."""
+
+    def test_a_backend_supplied_id_is_preserved_exactly(self) -> None:
+        out = _runtime()._with_canonical_call_ids([_call(id="call_abc123")])
+        self.assertEqual(out[0]["id"], "call_abc123")
+
+    def test_preserving_an_id_does_not_consume_the_counter(self) -> None:
+        """A run of real ids must not leave gaps that look like lost calls."""
+        runtime = _runtime()
+        runtime._with_canonical_call_ids([_call(id="a"), _call(id="b")])
+        generated = runtime._with_canonical_call_ids([_call()])
+        self.assertEqual(generated[0]["id"], "orbit_analysis_call_1")
+
+    def test_the_rest_of_the_call_is_carried_through_unchanged(self) -> None:
+        out = _runtime()._with_canonical_call_ids(
+            [_call(id="keep", function={"name": "execute_analysis", "arguments": '{"code":"x"}'})]
+        )
+        self.assertEqual(out[0]["function"]["arguments"], '{"code":"x"}')
+
+
+class GeneratedIdTests(unittest.TestCase):
+    """A missing or empty id is filled, never left invalid."""
+
+    def test_a_missing_id_is_generated(self) -> None:
+        out = _runtime()._with_canonical_call_ids([_call()])
+        self.assertTrue(out[0]["id"], "a generated id must be non-empty")
+
+    def test_an_empty_id_is_treated_as_missing(self) -> None:
+        """`""` is the exact shape the old code produced, and is invalid."""
+        out = _runtime()._with_canonical_call_ids([_call(id="")])
+        self.assertTrue(out[0]["id"])
+
+    def test_a_non_string_id_is_replaced(self) -> None:
+        out = _runtime()._with_canonical_call_ids([_call(id=7)])
+        self.assertIsInstance(out[0]["id"], str)
+        self.assertTrue(out[0]["id"])
+
+    def test_two_id_less_calls_get_different_ids(self) -> None:
+        out = _runtime()._with_canonical_call_ids([_call(), _call()])
+        self.assertNotEqual(out[0]["id"], out[1]["id"])
+
+    def test_ids_stay_unique_across_steps_of_one_runtime(self) -> None:
+        runtime = _runtime()
+        first = runtime._with_canonical_call_ids([_call()])
+        second = runtime._with_canonical_call_ids([_call()])
+        self.assertNotEqual(first[0]["id"], second[0]["id"])
+
+    def test_the_generated_id_is_stable_on_the_returned_object(self) -> None:
+        """Downstream steps reuse the returned dict, so its id cannot drift."""
+        call = _runtime()._with_canonical_call_ids([_call()])[0]
+        self.assertEqual(call["id"], call["id"])
+        self.assertTrue(call["id"])
+
+    def test_a_non_dict_call_is_passed_through_untouched(self) -> None:
+        """Not ours to repair: the structural gate rejects it with its own message."""
+        out = _runtime()._with_canonical_call_ids(["not-a-call"])
+        self.assertEqual(out, ["not-a-call"])
+
+
+class AssistantAndResultAgreeTests(unittest.TestCase):
+    """The id on the assistant call and on its tool result must match."""
+
+    def test_the_tool_result_uses_the_same_id_as_the_assistant_call(self) -> None:
+        """Reproduces the real message shapes the step builds from `calls`."""
+        call = _runtime()._with_canonical_call_ids([_call()])[0]
+        assistant = {"role": "assistant", "content": "", "tool_calls": [call]}
+        # `_append_tool_result` writes `call.get("id") or ""` -- with a canonical
+        # id present that is now the same non-empty value.
+        result = {"role": "tool", "tool_call_id": call.get("id") or "",
+                  "name": "execute_analysis", "content": "observation"}
+
+        self.assertEqual(assistant["tool_calls"][0]["id"], result["tool_call_id"])
+        self.assertTrue(result["tool_call_id"])
+
+
+class PlannerAcceptsAnalysisHistoryTests(unittest.TestCase):
+    """The point of the change: real ANALYSIS history now parses."""
+
+    def _history(self, call: dict) -> list[dict]:
+        return [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "artifact"},
+            {"role": "assistant", "content": "", "tool_calls": [call]},
+            {"role": "tool", "tool_call_id": call.get("id") or "",
+             "name": "execute_analysis", "content": "result"},
+            {"role": "assistant", "content": "finding"},
+        ]
+
+    def _plan(self, messages: list[dict]):
+        budget = ContextBudget(context_tokens=8192, output_reserve=2048,
+                               next_action_reserve=256, safety_margin=256)
+        return plan_context(messages, budget=budget, count_tokens=lambda m: 1000)
+
+    def test_normalized_history_is_accepted_by_the_shared_planner(self) -> None:
+        call = _runtime()._with_canonical_call_ids([_call()])[0]
+        plan = self._plan(self._history(call))
+        self.assertTrue(plan.admitted)
+        self.assertEqual(plan.status, "unchanged")
+
+    def test_unnormalized_history_is_still_rejected(self) -> None:
+        """The regression this prerequisite exists to remove, pinned.
+
+        Without normalization the planner refuses the entire history, which is
+        what stopped a real analysis at step 2.
+        """
+        plan = self._plan(self._history(_call()))
+        self.assertFalse(plan.admitted)
+        self.assertEqual(plan.reason, "invalid-message-structure:missing-tool-call-id")
+
+
+class StepUsesNormalizedCallsTests(unittest.TestCase):
+    """The wiring: a step must normalize before persisting anything."""
+
+    def test_the_step_normalizes_the_backend_calls_it_accepts(self) -> None:
+        import ast
+
+        source = (ROOT / "src/orbit/runtime/analysis_runtime.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name != "step":
+                continue
+            body = ast.unparse(node)
+            self.assertIn("_with_canonical_call_ids(", body)
+            self.assertNotIn("list(response.tool_calls or [])", body,
+                             "raw backend calls must not be persisted unnormalized")
+            return
+        self.fail("step() not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_tool_call_identity.py
+++ b/tests/test_analysis_tool_call_identity.py
@@ -27,6 +27,7 @@ from orbit.runtime.context_manager import ContextBudget, plan_context  # noqa: E
 def _runtime() -> AnalysisRuntime:
     runtime = object.__new__(AnalysisRuntime)
     object.__setattr__(runtime, "_synthetic_call_seq", 0)
+    object.__setattr__(runtime, "messages", [])
     return runtime
 
 
@@ -94,6 +95,39 @@ class GeneratedIdTests(unittest.TestCase):
         """Not ours to repair: the structural gate rejects it with its own message."""
         out = _runtime()._with_canonical_call_ids(["not-a-call"])
         self.assertEqual(out, ["not-a-call"])
+
+
+class NoCollisionWithBackendIdsTests(unittest.TestCase):
+    """A generated id must never duplicate one already in use."""
+
+    def _runtime_with_history(self, history):
+        runtime = object.__new__(AnalysisRuntime)
+        object.__setattr__(runtime, "_synthetic_call_seq", 0)
+        object.__setattr__(runtime, "messages", history)
+        return runtime
+
+    def test_a_persisted_backend_id_in_the_generated_form_is_skipped(self) -> None:
+        """A backend may return an id shaped exactly like a generated one.
+
+        Preserving it is correct, but the next synthetic id must then skip it:
+        a duplicate silently breaks the assistant/result pairing the shared
+        planner depends on.
+        """
+        runtime = self._runtime_with_history([
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "orbit_analysis_call_1"}]},
+        ])
+        out = runtime._with_canonical_call_ids([_call()])
+        self.assertNotEqual(out[0]["id"], "orbit_analysis_call_1")
+
+    def test_an_id_preserved_earlier_in_the_same_batch_is_skipped(self) -> None:
+        runtime = self._runtime_with_history([])
+        out = runtime._with_canonical_call_ids(
+            [_call(id="orbit_analysis_call_1"), _call()]
+        )
+        ids = [c["id"] for c in out]
+        self.assertEqual(ids[0], "orbit_analysis_call_1", "the real id is kept")
+        self.assertEqual(len(set(ids)), len(ids), "and the generated one differs")
 
 
 class AssistantAndResultAgreeTests(unittest.TestCase):


### PR DESCRIPTION
PR #297 added exact-context admission to ANALYSIS and had to be reverted (#298): it refused **real** histories at step 2 with `invalid-message-structure:missing-tool-call-id`. The admission was right; the prerequisite was missing. This lands both, in order.

## 1. Tool-call identity (the prerequisite)

Backends may return tool calls with **no `id`**. ANALYSIS tolerated that by writing `call.get("id") or ""` into the matching tool result — self-consistent, but structurally invalid: the shared planner requires a non-empty id on every assistant tool call (`context_manager._tool_call_id`) and refuses the whole history without one.

`_with_canonical_call_ids` normalizes at the **single point** where a step accepts backend calls, before anything is persisted, so the assistant message and its tool result are built from the same objects and cannot disagree. A backend id is never replaced; only a missing, empty or non-string one is filled. Generated ids skip anything already claimed — by earlier history or earlier in the same batch — since a backend may return an id shaped exactly like a generated one.

## 2. Context admission (the fix)

Returns unchanged in policy: `_admit` calls the shared `plan_exact_context` with ANALYSIS's own history. No duplicated budget arithmetic, no duplicated compaction. Both `chat_stream` sites admit; the verifier is excluded because it already enforces its own exact-token budget.

Measured regression protected at ctx 8192 (budget 5632): **5241 admitted; 6105 and 6991 refused before the backend** — the two calls that produced the proven exhaustion (`seq_pos_max 8191`, `frontier 8192`, `remaining 0`, `batch 1`, `llama_decode 1`).

## Honest scope

For ANALYSIS this is **admit-or-refuse**, not admit-or-compact: analysis tool messages carry no `evidence_id`, so no turn is externalisable. An over-budget step now ends **explicitly, evidence and history intact**, instead of crashing inside `llama_decode`.

## Review — three real findings, all mine

BLOCKER 0 / MAJOR 3 / MINOR 3, all addressed:

- **Two mutants survived** that each silently restored the reverted regression with a green suite — persisting a separate raw list (evading my AST substring check) and writing a mismatched result id. My tests pinned the *shape* of `step()`, not its *outcome*. Now fixed by running two real steps and asserting `conversation_structure_error(messages) is None`.
- **ANALYSIS ignored `--context-tokens`.** CHAT resolves configured-first; ANALYSIS read only the backend report, so an operator narrowing the window was silently overruled. Now plumbed through and pinned.
- A test whose docstring described a scenario its fixture never exercised is corrected.

35 tests across the two modules, 12 mutants caught, full suite **3923 pass**. Verified end-to-end without a model: steps 1 and 2 both run, ids pair up.
