### PR TITLE
fix(analysis): support evidence-aware context compaction

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -58,7 +58,15 @@ from orbit.runtime.analysis_sandbox import (
     execute_analysis,
     scratch_baseline,
 )
-from orbit.runtime.evidence import EvidenceRecord, EvidenceStore, final_card
+from orbit.runtime.evidence import (
+    EvidenceRecord,
+    EvidenceRehydrationError,
+    EvidenceStore,
+    final_card,
+    rehydrated_evidence_block,
+    requested_evidence_ids,
+    tool_evidence_ref,
+)
 from orbit.runtime.completion_shadow import (
     ANALYSIS_COMPLETION_SHADOW_PHASE,
     VERIFIER_MAX_TOKENS,
@@ -127,6 +135,10 @@ ANALYSIS_SYSTEM_PROMPT = (
     "`import orbit_tools` provides read_file(path, offset, limit).\n"
     "Write bounded files under /workspace/work to keep a derived artifact.\n"
     "Perform at most one execute_analysis action per turn, then stop and report what it produced.\n"
+    "Earlier results may appear as an evidence reference (`tool_evidence_ref: true`) "
+    "instead of their full text; that is the exact output, archived, not a summary. "
+    "When you need those exact bytes again, name its id as `evidence:<evidence_id>` "
+    "and they are restored verbatim. Never infer content from a reference alone.\n"
     "Base every claim on the artifact or on output an action actually produced. "
     "State plainly when something is unresolved rather than filling the gap."
 )
@@ -801,19 +813,20 @@ class AnalysisRuntime:
         `plan_exact_context`, called with THIS runtime's history.
 
         Scope of what this buys, stated precisely: for ANALYSIS this is
-        **admit-or-refuse**, not admit-or-compact. `plan_context` can only
-        externalise a tool turn whose evidence id is both available and covered,
-        and analysis tool messages carry no `evidence_id` -- so no turn is ever
-        eligible and the planner returns "unchanged" or "blocked", never
-        "compacted". The empty evidence sets passed below therefore describe
-        reality rather than discarding an option.
+        **admit, compact, or refuse**. A completed tool turn is externalisable
+        once its message carries real evidence identity and its content is
+        already a canonical reference -- both of which `_append_tool_result` now
+        persists -- so the sets built below are genuinely non-empty and the
+        planner can return "compacted" rather than only "unchanged" or
+        "blocked".
 
-        That still fixes the defect: an over-budget step now ends the run
-        explicitly, with the EvidenceStore and history intact and a stop reason
-        the analyst can act on, instead of driving the KV sequence into the
-        context wall and dying inside `llama_decode`. Making analysis history
-        genuinely compactable would mean giving its tool messages evidence
-        identity, which is a larger change than this defect warrants.
+        Refusal remains the floor, not the ceiling: when nothing eligible is
+        left the run still ends explicitly, with the EvidenceStore and history
+        intact and a stop reason the analyst can act on, rather than driving the
+        KV sequence into the context wall and dying inside `llama_decode`.
+        Evidence the current request just rehydrated is withheld from
+        compaction, so answering a question never discards the material that
+        answers it.
 
         Returns the admitted messages. Raises `ContextAdmissionError` when the
         request cannot be made to fit -- deliberately before the backend, so
@@ -833,6 +846,9 @@ class AnalysisRuntime:
         else:
             return messages
 
+        messages, rehydrated = self._with_evidence_rehydration(messages)
+        available, covered = self._compactable_evidence_sets(messages, rehydrated)
+
         plan = plan_exact_context(
             messages,
             backend=self.backend,
@@ -850,8 +866,8 @@ class AnalysisRuntime:
             # permissive direction -- reintroducing exactly the over-admission
             # this method exists to prevent.
             thinking=bool(getattr(self.backend, "thinking", False)),
-            available_evidence_ids=(),
-            covered_evidence_ids=(),
+            available_evidence_ids=available,
+            covered_evidence_ids=covered,
         )
         self.last_context_plan = plan
         if not plan.admitted:
@@ -861,6 +877,85 @@ class AnalysisRuntime:
         if plan.status == "compacted":
             self.context_compactions += 1
         return [dict(message) for message in plan.messages]
+
+    def _with_evidence_rehydration(
+        self, messages: list[Message]
+    ) -> tuple[list[Message], tuple[str, ...]]:
+        """Hand back exact archived output the analyst turn asked for by id.
+
+        This is the half that makes externalisation safe. Once a completed turn
+        is compacted its tool content is a reference, and a reference is not the
+        evidence -- so the model must be able to name an id and get the exact
+        bytes back. Same primitive CHAT uses, same attestation.
+
+        Only the latest USER message is scanned, exactly as CHAT does. Scanning
+        tool messages too would be self-defeating: a canonical reference names
+        its own id in `exact_content_ref`, so every compacted turn would
+        immediately re-inline itself and undo the compaction that just happened.
+        Retrieval is something the model asks for, never something a reference
+        triggers by existing.
+        """
+        latest = None
+        for message in reversed(messages):
+            if message.get("role") == "user":
+                latest = message
+                break
+        evidence_ids = requested_evidence_ids(
+            latest.get("content") if latest is not None else None
+        )
+        if not evidence_ids:
+            return messages, ()
+        try:
+            block = rehydrated_evidence_block(self.evidence_store, evidence_ids)
+        except EvidenceRehydrationError as exc:
+            # Fail closed: an analysis that cannot re-attest the evidence it
+            # asked for must say so, never continue on an approximation.
+            raise ContextAdmissionError(
+                f"context admission failed: evidence-rehydration-unavailable:{exc.args[0]}"
+            ) from exc
+        return [*messages, {"role": "system", "content": block}], evidence_ids
+
+    def _compactable_evidence_sets(
+        self, messages: list[Message], rehydrated: tuple[str, ...]
+    ) -> tuple[set[str], set[str]]:
+        """Which evidence ids in this history may be externalised.
+
+        `available` is every id whose record still re-attests exactly against
+        the reference actually persisted, so a turn is only ever collapsed onto
+        evidence that can be read back. `covered` withholds anything this
+        request just rehydrated: that content is in use right now, and
+        externalising it in the same breath would drop what the model asked for.
+        """
+        available: set[str] = set()
+        for message in messages:
+            if message.get("role") != "tool":
+                continue
+            evidence_id = message.get("evidence_id")
+            reference = message.get("content")
+            if not isinstance(evidence_id, str) or not isinstance(reference, str):
+                continue
+            record = self.evidence_store.records.get(evidence_id)
+            if record is None:
+                continue
+            # The same cross-checks CHAT makes before trusting a pairing
+            # (`_context_evidence_sets`): the record must agree with the message
+            # that claims it. ANALYSIS builds both from one record so a mismatch
+            # cannot arise today -- these are here so it stays that way if the
+            # history is ever reloaded or assembled elsewhere, and so the two
+            # implementations do not silently diverge.
+            if (
+                record.tool_call_id != message.get("tool_call_id")
+                or record.tool_name != message.get("name")
+                or record.user_turn_id != message.get("user_turn_id")
+            ):
+                continue
+            if self.evidence_store.reattest_exact(
+                evidence_id, expected_reference=reference
+            ) is None:
+                continue
+            available.add(evidence_id)
+        covered = available - set(rehydrated)
+        return available, covered
 
     def _context_tokens(self) -> int | None:
         """The backend's own context size, or None when it cannot say.
@@ -1139,7 +1234,7 @@ class AnalysisRuntime:
         )
         # Appended before returning: step N+1 must find this already in place
         # rather than have it reconstructed later.
-        self._append_tool_result(calls[0], observation)
+        self._append_tool_result(calls[0], observation, record=record)
         return AnalysisStepResult(
             model_calls=1,
             action_attempted=True,
@@ -1837,12 +1932,43 @@ class AnalysisRuntime:
             return "tool call contains characters that cannot be encoded"
         return None
 
-    def _append_tool_result(self, call: dict[str, Any], content: str) -> None:
-        self.messages.append(
-            {
-                "role": "tool",
-                "tool_call_id": call.get("id") or "",
-                "name": ANALYSIS_TOOL_NAME,
-                "content": content,
-            }
-        )
+    def _append_tool_result(
+        self,
+        call: dict[str, Any],
+        content: str,
+        *,
+        record: EvidenceRecord | None = None,
+    ) -> None:
+        """Persist one tool result, carrying its evidence identity when it has one.
+
+        A result backed by an attestable record is stored as the canonical
+        evidence reference rather than raw text, and tagged with the record's
+        own `evidence_id` / `user_turn_id`. Those three things together are what
+        make the turn compactable: `plan_context` externalises a completed tool
+        turn only when the identity is present AND the content is already a
+        reference, so identity alone would achieve nothing -- that was measured,
+        not assumed.
+
+        Results with no record -- a refused action, a capacity message -- keep
+        their literal text and carry no identity, because inventing one would
+        claim evidence that does not exist.
+        """
+        message: Message = {
+            "role": "tool",
+            "tool_call_id": call.get("id") or "",
+            "name": ANALYSIS_TOOL_NAME,
+            "content": content,
+        }
+        if record is not None:
+            # The canonical reference is the shared one CHAT already uses, and
+            # ANALYSIS inherits its excerpt rules unchanged -- including that an
+            # observation of roughly 1020-1200 chars is inlined head-only, with
+            # no truncation marker. Accepted rather than forked: the reference
+            # always carries the true `size:` and the exact bytes stay one
+            # `evidence:<id>` request away, and diverging here would give the
+            # two runtimes different evidence rendering.
+            message["content"] = tool_evidence_ref(record)
+            message["evidence_id"] = record.evidence_id
+            if record.user_turn_id:
+                message["user_turn_id"] = record.user_turn_id
+        self.messages.append(message)

--- a/src/orbit/runtime/chat.py
+++ b/src/orbit/runtime/chat.py
@@ -37,12 +37,15 @@ from orbit.runtime.environments import (
     unsupported_tool_mode_result as _unsupported_tool_mode_result,
 )
 from orbit.runtime.evidence import (
+    EvidenceRehydrationError,
     EvidenceStore,
     build_compact_final_evidence_context,
     build_final_evidence_context,
     build_post_tool_route_evidence_context,
     build_route_evidence_context,
     build_web_final_evidence_context,
+    rehydrated_evidence_block,
+    requested_evidence_ids,
     render_cited_evidence,
     build_citation_policy_context,
     DeferredCitationSink,
@@ -1675,28 +1678,18 @@ class ChatRuntime:
         content = latest_user.get("content") if latest_user is not None else None
         if not isinstance(content, str):
             return messages, ()
-        evidence_ids = tuple(dict.fromkeys(re.findall(r"\bevidence:(ev_[0-9a-f]{12}_[0-9a-f]{16})\b", content)))
+        evidence_ids = requested_evidence_ids(content)
         if not evidence_ids:
             return messages, ()
-        parts = ["deterministic_evidence_rehydration: exact archived tool output"]
-        rehydrated: list[str] = []
-        for evidence_id in evidence_ids:
-            raw = self.evidence_store.reattest_exact(evidence_id)
-            record = self.evidence_store.records.get(evidence_id)
-            if raw is None or record is None or _unsafe_rehydrated_evidence(raw):
-                raise ContextAdmissionError(f"context admission failed: evidence-rehydration-unavailable:{evidence_id}")
-            delimiter = f"orbit-evidence-{record.raw_sha256}"
-            parts.extend(
-                [
-                    f"evidence_id: {evidence_id}",
-                    f"sha256: {record.raw_sha256}",
-                    f"exact_content_begin: {delimiter}",
-                    raw,
-                    f"exact_content_end: {delimiter}",
-                ]
+        try:
+            block = rehydrated_evidence_block(
+                self.evidence_store, evidence_ids, unsafe=_unsafe_rehydrated_evidence
             )
-            rehydrated.append(evidence_id)
-        return [*messages, {"role": "system", "content": "\n".join(parts)}], tuple(rehydrated)
+        except EvidenceRehydrationError as exc:
+            raise ContextAdmissionError(
+                f"context admission failed: evidence-rehydration-unavailable:{exc.args[0]}"
+            ) from exc
+        return [*messages, {"role": "system", "content": block}], tuple(evidence_ids)
 
 class _ThoughtOnlyDeltaFilter:
     _THOUGHT_START = "<|channel>thought\n"

--- a/src/orbit/runtime/evidence.py
+++ b/src/orbit/runtime/evidence.py
@@ -7,7 +7,7 @@ import os
 import re
 import shlex
 import stat
-from typing import Callable
+from typing import Callable, Sequence
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse
@@ -332,6 +332,62 @@ def final_card(record: EvidenceRecord) -> str:
     for excerpt in _excerpt_lines(record):
         lines.append(excerpt)
     return "\n".join(lines)
+
+
+EVIDENCE_REFERENCE_PATTERN = r"\bevidence:(ev_[0-9a-f]{12}_[0-9a-f]{16})\b"
+
+
+class EvidenceRehydrationError(RuntimeError):
+    """Referenced evidence could not be re-attested exactly.
+
+    Raised instead of returning partial or substituted content: a caller that
+    asked for exact archived output must never be handed an approximation of
+    it, because the whole point of a reference is that the bytes are the ones
+    that were actually observed.
+    """
+
+
+def requested_evidence_ids(text: object) -> tuple[str, ...]:
+    """The canonical evidence ids named in `text`, in first-seen order."""
+    if not isinstance(text, str):
+        return ()
+    return tuple(dict.fromkeys(re.findall(EVIDENCE_REFERENCE_PATTERN, text)))
+
+
+def rehydrated_evidence_block(
+    store: "EvidenceStore",
+    evidence_ids: Sequence[str],
+    *,
+    unsafe: Callable[[str], bool] | None = None,
+) -> str:
+    """Render exact archived output for `evidence_ids` as one system block.
+
+    The shared half of what CHAT has always done: re-attest each id through
+    `reattest_exact` -- which checks identity, provenance and the raw ref -- and
+    fence the bytes with a per-record delimiter derived from their own digest,
+    so nothing in the content can close the fence early.
+
+    Raises `EvidenceRehydrationError` when any id cannot be re-attested. There
+    is deliberately no partial result: a caller holding a reference needs the
+    exact bytes or an explicit failure, never a silent gap.
+    """
+    parts = ["deterministic_evidence_rehydration: exact archived tool output"]
+    for evidence_id in evidence_ids:
+        raw = store.reattest_exact(evidence_id)
+        record = store.records.get(evidence_id)
+        if raw is None or record is None or (unsafe is not None and unsafe(raw)):
+            raise EvidenceRehydrationError(evidence_id)
+        delimiter = f"orbit-evidence-{record.raw_sha256}"
+        parts.extend(
+            [
+                f"evidence_id: {evidence_id}",
+                f"sha256: {record.raw_sha256}",
+                f"exact_content_begin: {delimiter}",
+                raw,
+                f"exact_content_end: {delimiter}",
+            ]
+        )
+    return "\n".join(parts)
 
 
 def tool_evidence_ref(record: EvidenceRecord) -> str:

--- a/tests/test_analysis_evidence_compaction.py
+++ b/tests/test_analysis_evidence_compaction.py
@@ -1,0 +1,359 @@
+"""ANALYSIS can compact its own history and read the evidence back exactly.
+
+Admission gave ANALYSIS a safe ceiling: an over-budget step stops rather than
+driving the KV sequence into the context wall. It could not do better than stop,
+because `plan_context` externalises a completed tool turn only when the tool
+message carries real evidence identity AND its content is already a canonical
+reference -- and ANALYSIS persisted raw observations with neither.
+
+Adding identity alone achieves nothing; that is measured here, not assumed.
+Replacing observations with references alone would be worse than the ceiling:
+evidence above `COMPAT_INLINE_CHARS` stops being inlined, and without a way to
+read it back the model would lose its own results. So the three parts stand
+together -- identity, canonical reference, exact rehydration -- and these tests
+pin all three, including the failure mode where evidence cannot be re-attested.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.context_manager import (  # noqa: E402
+    ContextAdmissionError,
+    ContextBudget,
+    _eligible_tool_turn,
+    _parse_turns,
+    plan_context,
+)
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+
+SMALL = "S" * 800    # under COMPAT_INLINE_CHARS: stays readable inline
+LARGE = "B" * 3000   # over it: becomes a compact reference
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-evcompact-")
+        self.addCleanup(self._dir.cleanup)
+        tmp = pathlib.Path(self._dir.name)
+        artifact = tmp / "artifact.js"
+        artifact.write_text("var x = 1;", encoding="utf-8")
+        self.source = acquire_analysis_source(artifact, tmp / "owned")
+        self.store = EvidenceStore(root=tmp / "evidence")
+        self.runtime = AnalysisRuntime(
+            backend=object(), source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(self.runtime.close)
+
+    def _turn(self, messages: list[dict], tag: str, body: str):
+        """One completed tool turn, built through the shipped append path."""
+        call = {"id": f"call_{tag}",
+                "function": {"name": "execute_analysis", "arguments": "{}"}}
+        record = self.store.add(
+            "execute_analysis", body,
+            metadata={"tool_call_id": call["id"], "user_turn_id": "turn_1",
+                      "produced_by_phase": "analysis_action"},
+        )
+        messages.append({"role": "user", "content": f"step {tag}"})
+        messages.append({"role": "assistant", "content": "", "tool_calls": [call]})
+        self.runtime.messages = messages
+        self.runtime._append_tool_result(call, body, record=record)
+        messages = self.runtime.messages
+        messages.append({"role": "assistant", "content": f"finding from {tag}"})
+        self.runtime.messages = messages
+        return record
+
+    def _history(self):
+        messages = [{"role": "system", "content": "sys"},
+                    {"role": "user", "content": "artifact"}]
+        small = self._turn(messages, "small", SMALL)
+        large = self._turn(messages, "large", LARGE)
+        return self.runtime.messages, small, large
+
+
+class PersistedReferenceTests(_Base):
+    def test_the_tool_message_carries_real_evidence_identity(self) -> None:
+        messages, _, large = self._history()
+        tool = [m for m in messages if m.get("role") == "tool"][-1]
+        self.assertEqual(tool["evidence_id"], large.evidence_id)
+        self.assertEqual(tool["user_turn_id"], large.user_turn_id)
+        self.assertEqual(tool["tool_call_id"], "call_large")
+        self.assertTrue(tool["content"].startswith("tool_evidence_ref: true"))
+
+    def test_small_evidence_keeps_its_inline_compatibility_content(self) -> None:
+        """Existing EvidenceStore policy decides this, not ANALYSIS."""
+        messages, _, _ = self._history()
+        tool = [m for m in messages if m.get("role") == "tool"][0]
+        self.assertIn("S" * 20, tool["content"])
+
+    def test_large_evidence_becomes_a_compact_reference(self) -> None:
+        messages, _, _ = self._history()
+        tool = [m for m in messages if m.get("role") == "tool"][-1]
+        self.assertNotIn("B" * 20, tool["content"])
+        self.assertLess(len(tool["content"]), len(LARGE))
+
+    def test_a_result_without_evidence_carries_no_identity(self) -> None:
+        """A refused action must not claim evidence that does not exist."""
+        self.runtime.messages = []
+        self.runtime._append_tool_result({"id": "c1"}, "action not executed: nope")
+        message = self.runtime.messages[-1]
+        self.assertNotIn("evidence_id", message)
+        self.assertNotIn("user_turn_id", message)
+        self.assertEqual(message["content"], "action not executed: nope")
+
+
+class CompactabilityTests(_Base):
+    def test_completed_evidence_turns_are_eligible(self) -> None:
+        messages, _, _ = self._history()
+        available, covered = self.runtime._compactable_evidence_sets(messages, ())
+        eligible = [
+            turn for turn in _parse_turns(messages)
+            if _eligible_tool_turn(turn, available=frozenset(available),
+                                   covered=frozenset(covered))
+        ]
+        self.assertEqual(len(eligible), 2)
+
+    def test_an_over_budget_history_is_compacted_and_admitted(self) -> None:
+        messages, _, _ = self._history()
+        available, covered = self.runtime._compactable_evidence_sets(messages, ())
+        budget = ContextBudget(context_tokens=8192, output_reserve=2048,
+                               next_action_reserve=256, safety_margin=256)
+
+        def count(candidate: list[dict]) -> int:
+            inlined = any(
+                ("B" * 20) in str(m.get("content")) or ("S" * 20) in str(m.get("content"))
+                for m in candidate
+            )
+            return 7000 if inlined else 3000
+
+        plan = plan_context(messages, budget=budget,
+                            available_evidence_ids=available,
+                            covered_evidence_ids=covered, count_tokens=count)
+
+        self.assertEqual(plan.status, "compacted")
+        self.assertTrue(plan.admitted)
+        self.assertLessEqual(plan.tokens_after, budget.input_limit)
+        self.assertGreaterEqual(plan.compacted_turns, 1)
+        self.assertTrue(plan.externalized_evidence_ids)
+
+    def test_identity_without_a_reference_is_not_compactable(self) -> None:
+        """Measured, not assumed: identity alone achieves nothing."""
+        messages, _, _ = self._history()
+        raw = [dict(m) for m in messages]
+        for message in raw:
+            if message.get("role") == "tool":
+                message["content"] = "RAW OBSERVATION TEXT"
+        self.assertTrue(all(t.evidence_ids == () for t in _parse_turns(raw)))
+
+
+class RehydrationTests(_Base):
+    def test_exact_large_evidence_is_restored_verbatim(self) -> None:
+        messages, _, large = self._history()
+        asked = [*messages,
+                 {"role": "user", "content": f"need evidence:{large.evidence_id}"}]
+        rehydrated, ids = self.runtime._with_evidence_rehydration(asked)
+        self.assertEqual(ids, (large.evidence_id,))
+        block = rehydrated[-1]["content"]
+        self.assertIn(LARGE, block, "the exact archived bytes must come back")
+        self.assertIn(large.raw_sha256, block, "with their digest, for attestation")
+
+    def test_a_reference_does_not_rehydrate_itself(self) -> None:
+        """Scanning tool messages would undo every compaction immediately.
+
+        A canonical reference names its own id in `exact_content_ref`, so a scan
+        that included tool messages would re-inline each compacted turn on the
+        very next step.
+        """
+        messages, _, _ = self._history()
+        out, ids = self.runtime._with_evidence_rehydration(messages)
+        self.assertEqual(ids, ())
+        self.assertEqual(out, messages)
+
+    def test_rehydrated_evidence_is_withheld_from_compaction(self) -> None:
+        messages, _, large = self._history()
+        available, covered = self.runtime._compactable_evidence_sets(
+            messages, (large.evidence_id,)
+        )
+        self.assertIn(large.evidence_id, available)
+        self.assertNotIn(large.evidence_id, covered)
+
+    def test_missing_evidence_fails_closed(self) -> None:
+        with self.assertRaises(ContextAdmissionError):
+            self.runtime._with_evidence_rehydration(
+                [{"role": "user",
+                  "content": "need evidence:ev_000000000000_0000000000000000"}]
+            )
+
+    def test_a_tampered_reference_is_not_treated_as_available(self) -> None:
+        messages, _, _ = self._history()
+        tampered = [dict(m) for m in messages]
+        for message in tampered:
+            if message.get("role") == "tool":
+                message["content"] = message["content"] + "\ntampered: true"
+        available, _ = self.runtime._compactable_evidence_sets(tampered, ())
+        self.assertEqual(available, set())
+
+    def test_a_pairing_whose_identity_disagrees_with_the_record_is_rejected(
+        self,
+    ) -> None:
+        """A tool message must agree with the record it claims.
+
+        ANALYSIS builds both sides from one record, so today this cannot arise.
+        The check exists so a reloaded or externally assembled history cannot
+        launder one turn's evidence into another turn's slot, and so this stays
+        at parity with CHAT's `_context_evidence_sets`.
+        """
+        for field, value in (
+            ("tool_call_id", "orbit_analysis_call_999"),
+            ("name", "some_other_tool"),
+            ("user_turn_id", "utid_mismatched"),
+        ):
+            with self.subTest(field=field):
+                messages, _, _ = self._history()
+                mismatched = [dict(m) for m in messages]
+                for message in mismatched:
+                    if message.get("role") == "tool":
+                        message[field] = value
+                available, covered = self.runtime._compactable_evidence_sets(
+                    mismatched, ()
+                )
+                self.assertEqual(available, set())
+                self.assertEqual(covered, set())
+
+    def test_the_evidence_store_survives_compaction(self) -> None:
+        messages, small, large = self._history()
+        available, covered = self.runtime._compactable_evidence_sets(messages, ())
+        plan_context(
+            messages,
+            budget=ContextBudget(context_tokens=8192, output_reserve=2048,
+                                 next_action_reserve=256, safety_margin=256),
+            available_evidence_ids=available, covered_evidence_ids=covered,
+            count_tokens=lambda m: 7000,
+        )
+        for record in (small, large):
+            self.assertIsNotNone(
+                self.store.reattest_exact(record.evidence_id),
+                "compaction externalises a reference; it never deletes evidence",
+            )
+
+
+class ShippedPathWiringTests(_Base):
+    """The wiring itself: `step()` must persist a record, `_admit` must offer it."""
+
+    def test_a_real_step_persists_an_evidence_backed_reference(self) -> None:
+        class Backend:
+            thinking = False
+
+            def supports_exact_context_admission(self) -> bool:
+                return True
+
+            def model_info(self):
+                class _Info:
+                    context_length = 8192
+                return _Info()
+
+            def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                return TokenCount(tokens=900, context_tokens=8192,
+                                  rendered_hash="a" * 64, token_hash="b" * 64)
+
+            def chat_stream(self, messages, **kwargs):
+                return ChatResult(
+                    content="", model="m", finish_reason="tool_calls",
+                    tool_calls=[{"function": {"name": "execute_analysis",
+                                              "arguments": '{"code": "print(1)"}'}}],
+                    prompt_tokens=900, completion_tokens=5, cached_tokens=0,
+                    prompt_tokens_per_second=None, generation_tokens_per_second=None,
+                )
+
+        runtime = AnalysisRuntime(
+            backend=Backend(), source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(runtime.close)
+        runtime.step("analyze")
+
+        tool = [m for m in runtime.messages if m.get("role") == "tool"][-1]
+        self.assertIn("evidence_id", tool)
+        self.assertTrue(tool["content"].startswith("tool_evidence_ref: true"))
+        self.assertIsNotNone(
+            self.store.reattest_exact(tool["evidence_id"],
+                                      expected_reference=tool["content"]),
+        )
+
+    def test_admit_rehydrates_evidence_the_analyst_asked_for(self) -> None:
+        """`_admit` must actually call rehydration, not just be able to.
+
+        Without this the request path can drop the call entirely and every unit
+        test still passes -- the model would name an evidence id mid-analysis
+        and silently receive nothing, which is the exact silent-loss failure
+        this capability exists to prevent.
+        """
+        class Backend:
+            thinking = False
+
+            def __init__(self) -> None:
+                self.seen: list[list[dict]] = []
+
+            def supports_exact_context_admission(self) -> bool:
+                return True
+
+            def model_info(self):
+                class _Info:
+                    context_length = 8192
+                return _Info()
+
+            def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+                self.seen.append([dict(m) for m in messages])
+                return TokenCount(tokens=900, context_tokens=8192,
+                                  rendered_hash="a" * 64, token_hash="b" * 64)
+
+        messages, _, large = self._history()
+        backend = Backend()
+        object.__setattr__(self.runtime, "backend", backend)
+
+        admitted = self.runtime._admit(
+            [*messages, {"role": "user", "content": f"need evidence:{large.evidence_id}"}],
+            max_tokens=2048, tools=[],
+        )
+
+        self.assertTrue(
+            any(LARGE in str(m.get("content")) for m in admitted),
+            "the exact evidence the analyst named must reach the request",
+        )
+
+    def test_admit_offers_the_evidence_sets_to_the_planner(self) -> None:
+        import ast
+
+        source = (ROOT / "src/orbit/runtime/analysis_runtime.py").read_text(encoding="utf-8")
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef) or node.name != "_admit":
+                continue
+            body = ast.unparse(node)
+            self.assertIn("available_evidence_ids=available", body)
+            self.assertIn("covered_evidence_ids=covered", body)
+            self.assertIn("_compactable_evidence_sets(", body)
+            return
+        self.fail("_admit not found")
+
+
+class PromptContractTests(unittest.TestCase):
+    def test_the_prompt_teaches_reference_semantics_and_retrieval(self) -> None:
+        from orbit.runtime.analysis_runtime import ANALYSIS_SYSTEM_PROMPT
+
+        self.assertIn("tool_evidence_ref", ANALYSIS_SYSTEM_PROMPT)
+        self.assertIn("evidence:<evidence_id>", ANALYSIS_SYSTEM_PROMPT)
+        self.assertIn("Never infer content from a reference alone",
+                      ANALYSIS_SYSTEM_PROMPT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_runtime.py
+++ b/tests/test_analysis_runtime.py
@@ -279,19 +279,78 @@ class SourceOwnershipTest(AnalysisRuntimeTestBase):
 
 
 class EvidenceBoundTest(AnalysisRuntimeTestBase):
-    def test_large_output_is_bounded_for_the_prompt_but_recorded_in_full(self) -> None:
+    def test_large_output_is_referenced_in_history_but_recorded_in_full(self) -> None:
+        """Large evidence is named in history, kept whole in the store.
+
+        Rewritten for the evidence-reference contract, and deliberately not
+        weakened: it protects strictly more than the truncation assertion it
+        replaces. History must carry a canonical reference with real identity
+        rather than the raw text, the full observation must still be recorded,
+        and the exact bytes must be restorable from the store.
+
+        Scope, stated precisely: restorability is asserted through the store's
+        own `reattest_exact`, so deleting the runtime's rehydration path would
+        not fail *here* -- `test_analysis_evidence_compaction` owns that, and
+        catches it. This test guards the persistence contract; that one guards
+        the retrieval contract.
+        """
         backend = ScriptedBackend(tool_response("print('A' * 60000)"))
         runtime = self.runtime(backend)
         result = runtime.step("emit a lot")
 
-        observation = runtime.messages[-1]["content"]
+        message = runtime.messages[-1]
+        reference = message["content"]
+
+        # History carries the reference, not the observation.
+        self.assertTrue(reference.startswith("tool_evidence_ref: true"))
         self.assertLessEqual(
-            len(observation), MAX_EVIDENCE_CHARS, "model-facing evidence must stay bounded"
+            len(reference), MAX_EVIDENCE_CHARS, "model-facing evidence must stay bounded"
         )
-        self.assertIn("truncated for prompt", observation)
+        self.assertNotIn(
+            "A" * 200, reference, "large raw output must not be embedded in history"
+        )
+
+        # Identity is real, not invented.
+        self.assertEqual(message["evidence_id"], result.evidence.evidence_id)
+        self.assertEqual(message["user_turn_id"], result.evidence.user_turn_id)
+
+        # The full observation is still recorded.
         metadata = result.evidence.metadata
         self.assertTrue(metadata["observation_truncated"])
         self.assertGreater(metadata["observation_full_chars"], MAX_EVIDENCE_CHARS)
+
+        # And the exact bytes come back, attested.
+        restored = runtime.evidence_store.reattest_exact(
+            message["evidence_id"], expected_reference=reference
+        )
+        self.assertIsNotNone(restored, "the persisted reference must re-attest")
+        self.assertIn("truncated for prompt", restored)
+
+    def test_small_output_keeps_its_inline_compatibility_content(self) -> None:
+        """Existing COMPAT_INLINE_CHARS policy is unchanged for small evidence."""
+        backend = ScriptedBackend(tool_response("print('tiny result')"))
+        runtime = self.runtime(backend)
+        runtime.step("emit a little")
+
+        reference = runtime.messages[-1]["content"]
+        self.assertTrue(reference.startswith("tool_evidence_ref: true"))
+        self.assertIn("tiny result", reference)
+
+    def test_tampered_or_missing_evidence_fails_closed(self) -> None:
+        backend = ScriptedBackend(tool_response("print('A' * 60000)"))
+        runtime = self.runtime(backend)
+        runtime.step("emit a lot")
+        message = runtime.messages[-1]
+
+        self.assertIsNone(
+            runtime.evidence_store.reattest_exact(
+                message["evidence_id"], expected_reference=message["content"] + "\nx"
+            ),
+            "a tampered reference must not re-attest",
+        )
+        self.assertIsNone(
+            runtime.evidence_store.reattest_exact("ev_000000000000_0000000000000000")
+        )
 
     def test_evidence_carries_full_provenance(self) -> None:
         backend = ScriptedBackend(tool_response("open('/workspace/work/out.txt','w').write('d')\nprint('ok')"))

--- a/tests/test_eager_analysis_prewarm.py
+++ b/tests/test_eager_analysis_prewarm.py
@@ -47,7 +47,7 @@ from tests.test_native_server_bootstrap import _FakeNativeClient
 # Pinned literals. The prewarm captures this contract verbatim; if either
 # changes the captured prefix is a different token sequence and the identity
 # these tests assert no longer describes what ships.
-ANALYSIS_SYSTEM_PROMPT_SHA256 = "fad4cd857bfb631058a7f5279f81573d800fe56013d82f3e4abab5fb50e2a2c8"
+ANALYSIS_SYSTEM_PROMPT_SHA256 = "88f234df8f26e55b0a7d380e1df4672d87a4a8e719c7342424a5ff4b819c122c"
 ANALYSIS_TOOL_SCHEMA_SHA256 = "57710e9ee2c19683cb74b854d5b6f0714fb4802ad1a51971e43cd7f6d080f2a4"
 
 # Startup prewarm enabled, ANALYSIS eager explicitly requested. Eager capture is

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -338,6 +338,25 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
         "AUTONOMOUS_REPLAN_MESSAGE",
     )
 
+    # One intentional, user-authorized revision to the analysis contract, not
+    # accidental drift. Evidence-aware compaction replaces a large observation
+    # in history with its canonical reference, so the model has to be told what
+    # a reference is and how to read the exact bytes back -- without that
+    # sentence the compaction silently hides evidence, which is worse than the
+    # context ceiling it removes. The clause is pinned verbatim here so the
+    # protection still fires on any OTHER prompt change, including a later edit
+    # to this same clause.
+    AUTHORIZED_PROMPT_ADDITION = (
+        '    "Earlier results may appear as an evidence reference '
+        '(`tool_evidence_ref: true`) "\n'
+        '    "instead of their full text; that is the exact output, archived, '
+        'not a summary. "\n'
+        '    "When you need those exact bytes again, name its id as '
+        '`evidence:<evidence_id>` "\n'
+        '    "and they are restored verbatim. Never infer content from a '
+        'reference alone.\\n"\n'
+    )
+
     def _constant(self, text: str, name: str) -> str | None:
         import re
 
@@ -363,10 +382,28 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
             with self.subTest(constant=name):
                 before = self._constant(baseline, name)
                 self.assertIsNotNone(before, f"{name} not found in baseline")
+                expected = before
+                if name == "ANALYSIS_SYSTEM_PROMPT":
+                    # Baseline plus exactly the authorized clause, in place.
+                    # Anything else -- a reworded clause, a second sentence, an
+                    # unrelated edit elsewhere in the prompt -- still fails.
+                    self.assertNotIn(
+                        self.AUTHORIZED_PROMPT_ADDITION, before,
+                        "the authorized clause must not already be in the baseline",
+                    )
+                    anchor = (
+                        '    "Perform at most one execute_analysis action per turn, '
+                        'then stop and report what it produced.\\n"\n'
+                    )
+                    self.assertIn(anchor, before, "prompt anchor moved")
+                    expected = before.replace(
+                        anchor, anchor + self.AUTHORIZED_PROMPT_ADDITION, 1
+                    )
                 self.assertEqual(
-                    before,
+                    expected,
                     self._constant(current, name),
-                    f"{name} changed; this fix must not alter model-facing text",
+                    f"{name} changed beyond the authorized revision; model-facing "
+                    "text must not drift",
                 )
 
     def test_the_tool_schema_is_unchanged(self) -> None:

--- a/tests/test_ornith_analysis_prefix.py
+++ b/tests/test_ornith_analysis_prefix.py
@@ -40,7 +40,7 @@ from orbit.native_llama.prefix_anchor import PrefixAnchorState
 from orbit.runtime.analysis_runtime import ANALYSIS_SYSTEM_PROMPT, ANALYSIS_TOOL_SCHEMA
 
 # Pinned literal: the prewarm captures this contract verbatim.
-ANALYSIS_SYSTEM_PROMPT_SHA256 = "fad4cd857bfb631058a7f5279f81573d800fe56013d82f3e4abab5fb50e2a2c8"
+ANALYSIS_SYSTEM_PROMPT_SHA256 = "88f234df8f26e55b0a7d380e1df4672d87a4a8e719c7342424a5ff4b819c122c"
 
 
 class AnalysisPrefixConfigTests(unittest.TestCase):
@@ -671,6 +671,13 @@ class AnalysisPromptUnchangedTests(unittest.TestCase):
         # pin moved once, with the input-contract fix that told the model
         # /workspace/input is the artifact file rather than a directory, and
         # only alongside the prefix requalification that change forced.
+        #
+        # It moved a second time, deliberately and with user authorization, for
+        # evidence-aware compaction: a compacted turn shows the model a
+        # reference instead of the observation, so the prompt has to say what a
+        # reference is and how to read the exact bytes back. Without that the
+        # compaction hides evidence, which is worse than the context ceiling it
+        # removes. `test_evidence_authority` pins the exact clause.
         self.assertEqual(
             hashlib.sha256(ANALYSIS_SYSTEM_PROMPT.encode("utf-8")).hexdigest(),
             ANALYSIS_SYSTEM_PROMPT_SHA256,


### PR DESCRIPTION
ANALYSIS could admit or refuse, but never compact. Its tool messages carried the raw observation and no evidence identity, so `plan_context` found no eligible turn: a long run hit the 5632-token budget and ended with `ContextAdmissionError` while the EvidenceStore held every byte it needed.

This gives analysis tool results the identity the shared planner already requires, and adds the retrieval path that makes externalising them safe.

## What changed

- **Identity + reference.** `_append_tool_result` takes the `EvidenceRecord` and persists the canonical `tool_evidence_ref` plus `evidence_id` / `user_turn_id`. Results with no record keep literal text and gain no identity.
- **Eligibility.** `_compactable_evidence_sets` offers the planner only ids that `reattest_exact(id, expected_reference=content)` accepts, and withholds ids the current request just rehydrated, so answering a question never discards the material that answers it. It applies the same record/message cross-checks as CHAT's `_context_evidence_sets`.
- **Rehydration.** `_with_evidence_rehydration` scans the latest **user** message only (as CHAT does) and restores exact archived bytes. A reference names its own id, so scanning tool messages would re-inline every compacted turn; there is a test for that.
- **Shared primitive.** The block builder moved to `evidence.py` and CHAT now calls it. Output is byte-identical -- verified head-to-head against the pre-change implementation.
- **Fail-closed.** Missing, evicted or tampered evidence raises `ContextAdmissionError`. `rehydrated_evidence_block` is all-or-nothing; it never returns a partial block.

## Authorized contract changes

Two deliberate guards were amended narrowly, under explicit user authorization, and neither was removed:

- `test_evidence_authority.py` keeps `ANALYSIS_SYSTEM_PROMPT` in `NAMES` and pins the authorized clause **and its position** (`baseline.replace(anchor, anchor + AUTHORIZED_PROMPT_ADDITION, 1)`). It still fails on an unrelated added sentence, on rewording the clause, and on relocating it.
- The bounded-output test now protects the reference contract instead of the truncation string -- reference in history, no raw bytes inlined, real identity, full observation recorded, exact bytes restorable.
- The prompt SHA pin moved in `test_ornith_analysis_prefix.py` and `test_eager_analysis_prewarm.py`, with the rationale recorded in the first.

## Verification

- Full suite: **3943 tests, OK (skipped=8)**, exit 0.
- **Mutation gate 16/16 caught**, including: identity dropped, raw observation persisted, `record=` not passed at the step site, compaction bypassed, rehydrated evidence not withheld, failed attestation ignored, self-rehydration reintroduced, rehydration removed from `_admit`, partial block instead of raising, and the identity cross-checks removed.
- Capability run: 3000-char evidence becomes a 219-char reference; `plan.status=compacted`, 7000 -> 3000 tokens, admitted; exact bytes rehydrated with matching SHA; store still re-attestable.
- `context_manager.py` has a zero-line diff -- no compaction logic is duplicated, and the strict KV invariant `prompt_tokens[:len(committed)] == committed` is untouched.

Independently reviewed: no BLOCKERs, no MAJORs. All four MINOR findings are addressed in this head, including two docstrings the reviewer proved overclaimed.
