### PR TITLE
fix(analysis): state transformation priority in the standing instruction

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -342,6 +342,9 @@ AUTONOMOUS_CONTINUATION_MESSAGE = (
     "Continue from the current evidence. Choose one new useful "
     "evidence-producing step. Do not repeat established actions, inputs or "
     "findings."
+    " If you have already identified a deterministic transformation "
+    "and hold its concrete inputs, run it now rather than inspecting "
+    "the source further."
 )
 
 # Sent on the first unproductive step of a streak. The previous instruction

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -351,7 +351,7 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
     # pin, so relocating a sanctioned clause fails just as an unsanctioned one
     # does. Appending to this tuple is the only way to sanction a change, and
     # it is a reviewed, user-authorized act each time.
-    AUTHORIZED_PROMPT_ADDITIONS = (
+    AUTHORIZED_ADDITIONS = {"ANALYSIS_SYSTEM_PROMPT": (
         # ANALYSIS-COMPACTION-1: evidence references and exact rehydration.
         (
             '    "Perform at most one execute_analysis action per turn, '
@@ -380,7 +380,23 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
             'cannot resolve "\n'
             '    "what only running the transformation can.\\n"\n',
         ),
-    )
+    ),
+    # ANALYSIS-PROGRESS-1, authorized under the mission's clause 22. The live
+    # run proved the runtime side worked -- 12 actions, 12 distinct programs,
+    # nothing to suppress -- while the model still spent its last action on a
+    # further read of source whose decoder inputs it had already extracted.
+    # This is the instruction it reads before every autonomous step, so it is
+    # where a priority between two legitimate next steps has to be stated. It
+    # names no technique, and the generic-language test still enforces that.
+    "AUTONOMOUS_CONTINUATION_MESSAGE": (
+        (
+            '    "findings."\n',
+            '    " If you have already identified a deterministic transformation "\n'
+            '    "and hold its concrete inputs, run it now rather than inspecting "\n'
+            '    "the source further."\n',
+        ),
+    ),
+    }
 
     def _constant(self, text: str, name: str) -> str | None:
         import re
@@ -408,13 +424,13 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
                 before = self._constant(baseline, name)
                 self.assertIsNotNone(before, f"{name} not found in baseline")
                 expected = before
-                if name == "ANALYSIS_SYSTEM_PROMPT":
+                if name in self.AUTHORIZED_ADDITIONS:
                     # Baseline plus exactly the authorized clauses, each at its
                     # own anchor. Anything else -- a reworded clause, a second
                     # sentence, a sanctioned clause moved elsewhere, an
                     # unrelated edit -- still fails.
                     expected = before
-                    for anchor, addition in self.AUTHORIZED_PROMPT_ADDITIONS:
+                    for anchor, addition in self.AUTHORIZED_ADDITIONS[name]:
                         self.assertNotIn(
                             addition, expected,
                             "the authorized clause must not already be present",


### PR DESCRIPTION
Follow-up to #301, from what live run #1 actually showed.

The runtime half works and is **not** what blocks the decode: 12 actions, 12 distinct programs, 12 distinct outputs -- nothing to suppress, no duplicate, no wasted action slot, no KV or context regression. The model extracted every decoder input it needed and then spent its last action listing the function body again instead of running the transformation.

The system prompt already said a transformation outranks another read, but it says it once, at session start, among the other rules. What the model reads immediately before choosing *each* autonomous step is `AUTONOMOUS_CONTINUATION_MESSAGE`, and that asked only for "one new useful evidence-producing step" -- under which a twelfth distinct way to print the same file qualifies.

So the priority is stated where the choice is actually made:

> ...Do not repeat established actions, inputs or findings. **If you have already identified a deterministic transformation and hold its concrete inputs, run it now rather than inspecting the source further.**

## Scope

- **No decoder hardcoding.** The clause names no technique -- no XOR, base64, encoding or format. The pre-existing generic-language test still enforces that, and the model still chooses what to run.
- **No behavioural change.** An AST comparison of base vs head finds 0 function/class bodies changed and exactly 1 module constant changed. No suppression logic, no fingerprint, no bound, no CHAT/native/MTP/KV/admission change; `context_manager.py` untouched.
- **Guard generalised, not weakened.** `AUTHORIZED_ADDITIONS` becomes a map keyed by constant name so a second constant can carry anchor-pinned authorized additions. All five protected constants remain protected.

## Verification

- Full suite: **3967 tests, OK (skipped=8)**, exit 0.
- Independently reviewed: **0 BLOCKER, 0 MAJOR**, 17 mutations all CAUGHT -- including rewording, relocating within the constant, relocating into a different constant, deleting the clause outright, duplicating it, whitespace-only edits, semantic inversion, and an unrelated edit to each of the five protected constants. A dict-key typo fails closed.
