### PR TITLE
fix(analysis): retry one failed deterministic execution

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -364,6 +364,32 @@ AUTONOMOUS_REPLAN_MESSAGE = (
     "repeat an exhausted action, input or established finding."
 )
 
+# Sent once after an execution that ran and raised.
+#
+# A program that failed on its own defect is not the same situation as one
+# that produced nothing useful: the model already holds the two things a fix
+# needs -- the exact source it submitted, still in its own preceding message,
+# and the interpreter's verbatim diagnosis, already inlined in the tool
+# result. What it was missing is an invitation to use them. Without one the
+# observed behaviour is to abandon the attempt and resume reading source,
+# which spends the budget re-establishing what was already known.
+#
+# It names no technique, no error class and no correction. Deciding whether a
+# failure is locally correctable, and what the correction is, is the model's
+# work; the runtime only declines to change the subject for one call.
+#
+# The final clause is what keeps this honest. A traceback sometimes proves the
+# opposite of a typo -- that an assumption about the artifact was wrong, and
+# more evidence really is required -- and a runtime that insisted on a retry
+# there would be arguing with a model that had correctly changed its mind.
+AUTONOMOUS_REPAIR_MESSAGE = (
+    "The previous analysis execution failed. Review the submitted action and "
+    "its traceback above. If it is locally correctable, submit one corrected "
+    "execution now. Do not return to source observation unless the error "
+    "proves more evidence is required."
+)
+
+
 # What the runtime returns instead of re-running an experiment the session has
 # already run against this exact state.
 #
@@ -589,6 +615,10 @@ class AutonomousRunResult:
     # re-running. Each cost a model call and no action slot, which is the
     # distinction this counter exists to make visible.
     suppressed_duplicates: int = 0
+    # Failed executions this run invited a correction for. At most one per
+    # failure and never two consecutively, so this also bounds how many of
+    # `model_calls` were spent on repair rather than new direction.
+    repairs: int = 0
     final_report: "AnalysisReport | None" = None
     # Diagnostics only. Nothing in the loop reads this back, and its verifier
     # calls are deliberately absent from `model_calls`: a shadow observation
@@ -692,6 +722,37 @@ def _rejected_action_text(assistant_text: str, rejection: str) -> str:
     note = f"[action refused: {rejection}]"
     text = assistant_text.strip()
     return f"{text}\n\n{note}" if text else note
+
+
+def _is_locally_repairable(step: "AnalysisStepResult") -> bool:
+    """Whether one step failed in a way its own author could plausibly fix.
+
+    Narrow on purpose. The offer is worth making exactly when the model has
+    both halves of a fix in hand: a program it wrote, and the interpreter's
+    verbatim reason for rejecting it. That is the sandbox's `error` status --
+    the process ran and exited non-zero -- and nothing else.
+
+    Everything the sandbox can report instead is excluded because resubmitting
+    could not help. `ok` did not fail. `timeout` and `bounded` are resource
+    ceilings, not defects: the same program is the wrong answer there, and
+    inviting a retry would spend a call re-hitting the same wall. A step that
+    never executed -- a malformed call, a refused action, a capacity stop --
+    has no traceback to reason from, and one the runtime suppressed as a
+    duplicate did not fail at all. Backend failures, cancellations and
+    admission stops never reach here: the loop breaks on those before any step
+    is classified.
+    """
+    if not step.action_executed or step.suppressed_duplicate_of is not None:
+        return False
+    result = step.result
+    # `error` alone: the process ran and exited non-zero, and `stderr` is what
+    # a correction would be reasoned from. A failure that said nothing gives
+    # the model no more than "try again", which is what this exists to avoid.
+    return (
+        result is not None
+        and result.status == "error"
+        and bool(result.stderr.strip())
+    )
 
 
 def _raw_action_output(result: AnalysisResult) -> str:
@@ -1389,11 +1450,18 @@ class AnalysisRuntime:
         what a step may do changes. The model still chooses what to examine;
         the runtime only decides whether it is worth asking again.
 
-        The loop stops the moment a step stops adding state. It never repairs,
-        never retries, never re-runs a rejected action, and never makes a
-        second kind of model call: there is no finalisation pass and no
-        classifier, because both would be the runtime forming an opinion about
-        an analysis it is not qualified to judge.
+        The loop stops the moment a step stops adding state. It never re-runs
+        a rejected action and never makes a second kind of model call: there
+        is no finalisation pass and no classifier, because both would be the
+        runtime forming an opinion about an analysis it is not qualified to
+        judge.
+
+        One exception, and it is an ordinary step rather than a new kind of
+        call: an execution that ran and raised earns a single repair message
+        instead of the generic continuation, because the model already holds
+        its own source and the interpreter's reason and is one edit from
+        useful work. The runtime supplies no correction and never re-runs the
+        failed code itself; a repair that fails again gets no second offer.
 
         Cancellation propagates: `KeyboardInterrupt` from the backend ends the
         run and returns what has already been established, with the workspace
@@ -1418,6 +1486,14 @@ class AnalysisRuntime:
         consecutive_errors = 0
         replans = 0
         replan_pending = False
+        # One repair opportunity per failed execution, and never two in a row.
+        # `repair_pending` is what the next iteration will send; `repairing`
+        # remembers that the step about to run IS the repair, so a correction
+        # that fails again falls back to the ordinary loop instead of being
+        # offered a second chance at the same defect.
+        repair_pending = False
+        repairing = False
+        repairs = 0
         message = analyst_message
         stop_reason = STOP_MAX_MODEL_CALLS
         cancelled = False
@@ -1514,6 +1590,13 @@ class AnalysisRuntime:
                 stop_reason = STOP_COMPLETE
                 break
 
+            # Decided before the stop checks, so the flag reflects this step
+            # rather than surviving from the previous one, and cleared on
+            # every path -- a step that is not an eligible failure must not
+            # inherit an offer armed earlier.
+            was_repairing, repairing = repairing, False
+            repair_pending = _is_locally_repairable(step) and not was_repairing
+
             if record.classification == ERROR:
                 consecutive_errors += 1
                 consecutive_no_progress = 0
@@ -1543,7 +1626,6 @@ class AnalysisRuntime:
                 # that recovers and stalls again is told again, because that is
                 # a different stall.
                 replan_pending = True
-                replans += 1
             else:
                 consecutive_no_progress = 0
                 consecutive_errors = 0
@@ -1575,9 +1657,37 @@ class AnalysisRuntime:
                 stop_reason = STOP_SOFT_MAX_ACTIONS
                 break
 
-            if replan_pending:
+            if repair_pending:
+                # Ahead of the replan: a step that raised is a more specific
+                # situation than one that merely added nothing, and the replan
+                # would send the model looking for a *different* strategy --
+                # the opposite of what a fixable program needs. Costs one
+                # model call from the existing ceiling and no extra action
+                # budget; the correction itself is an ordinary action.
+                message = AUTONOMOUS_REPAIR_MESSAGE
+                repair_pending = False
+                repairing = True
+                repairs += 1
+                # Reachable, and load-bearing. A failing program writes its
+                # traceback as evidence, so the FIRST such failure is
+                # NEW_CONTENT -- but a later failure with byte-identical
+                # stderr produces the same evidence hash, adds no state, and
+                # is classified NO_PROGRESS while the sandbox still reports a
+                # diagnosed error. Both flags arm on that step. The repair is
+                # the more specific instruction, so it wins and the replan is
+                # dropped rather than queued: sending both would put two
+                # directives about one step in front of the model, one asking
+                # it to fix this program and the other to abandon it.
+                replan_pending = False
+            elif replan_pending:
                 message = AUTONOMOUS_REPLAN_MESSAGE
                 replan_pending = False
+                # Counted here rather than where the stall is detected: a
+                # replan can be armed and then dropped when the same step also
+                # earns a repair, and a counter that recorded the intention
+                # would report a replan the model was never sent. The analyst
+                # reads this figure, so it counts messages.
+                replans += 1
             else:
                 message = AUTONOMOUS_CONTINUATION_MESSAGE
 
@@ -1659,6 +1769,7 @@ class AnalysisRuntime:
             cancelled=cancelled,
             replans=replans,
             suppressed_duplicates=suppressed,
+            repairs=repairs,
             final_report=final_report,
             completion_shadow=shadow,
         )

--- a/tests/test_analysis_repair.py
+++ b/tests/test_analysis_repair.py
@@ -1,0 +1,427 @@
+"""One repair opportunity after an execution that ran and raised.
+
+A program that failed on its own defect is not the same situation as one that
+produced nothing useful: the model already holds the source it submitted and
+the interpreter's verbatim reason. Observed behaviour without an invitation to
+use them is to abandon the attempt and resume reading source, which spends the
+budget re-establishing what was already known.
+
+These cover the offer and, more importantly, its bounds: exactly one per
+failure, never two in a row, never for a failure resubmitting cannot fix, and
+never at the cost of the ceilings that make a run terminate.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.backend.base import ChatResult
+from orbit.runtime.analysis_runtime import (
+    ANALYSIS_TOOL_NAME,
+    AUTONOMOUS_CONTINUATION_MESSAGE,
+    AUTONOMOUS_REPAIR_MESSAGE,
+    AUTONOMOUS_REPLAN_MESSAGE,
+    MAX_AUTONOMOUS_ACTIONS,
+    MAX_AUTONOMOUS_MODEL_CALLS,
+    AnalysisRuntime,
+    _is_locally_repairable,
+    acquire_analysis_source,
+)
+from orbit.runtime.analysis_sandbox import AnalysisResult
+from orbit.runtime.evidence import EvidenceStore
+
+SECRET = "STAGE-TWO-COMMAND"
+ENCODED = "-".join(str(ord(c) ^ 7) for c in SECRET)
+SOURCE = f"var x = 1;\npayload={ENCODED}\n"
+
+# The real shape of the observed failure: JScript coerces a string operand,
+# Python does not. The corrected form differs only by the int() call.
+BROKEN = (
+    "import orbit_tools\n"
+    "src = orbit_tools.read_file('/workspace/input')\n"
+    "blob = src.split('payload=')[1].strip()\n"
+    "print(''.join(chr(t ^ 7) for t in blob.split('-')))\n"
+)
+FIXED = BROKEN.replace("chr(t ^ 7)", "chr(int(t) ^ 7)")
+READ = "import orbit_tools; print(orbit_tools.read_file('/workspace/input')[:60])"
+
+
+def _tool_call(code: str, *, call_id: str = "call_1") -> ChatResult:
+    return ChatResult(
+        content="", model="m", finish_reason="stop",
+        tool_calls=[{
+            "id": call_id, "type": "function",
+            "function": {"name": ANALYSIS_TOOL_NAME, "arguments": json.dumps({"code": code})},
+        }],
+        prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+def _prose(text: str) -> ChatResult:
+    return ChatResult(
+        content=text, model="m", finish_reason="stop", tool_calls=[],
+        prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+        prompt_tokens_per_second=None, generation_tokens_per_second=None,
+    )
+
+
+class RecordingBackend:
+    """Serves scripted responses and records the analyst line that drove each."""
+
+    def __init__(self, *responses: ChatResult) -> None:
+        self._responses = list(responses)
+        self.calls = 0
+        self.instructions: list[str] = []
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                    on_delta, on_progress=None):
+        if self.calls >= len(self._responses):
+            raise AssertionError(
+                f"model invoked {self.calls + 1} times; only {len(self._responses)} scripted"
+            )
+        users = [m for m in messages if m.get("role") == "user"]
+        self.instructions.append(users[-1]["content"] if users else "")
+        response = self._responses[self.calls]
+        self.calls += 1
+        if response.content:
+            on_delta(response.content)
+        return response
+
+
+class RepairTestBase(unittest.TestCase):
+    SOURCE_TEXT = SOURCE
+
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory(prefix="orbit-repair-")
+        self.addCleanup(self._dir.cleanup)
+        self.tmp = Path(self._dir.name)
+        artifact = self.tmp / "artifact.js"
+        artifact.write_text(self.SOURCE_TEXT, encoding="utf-8")
+        self.source = acquire_analysis_source(artifact, self.tmp / "owned")
+        self.store = EvidenceStore(root=self.tmp / "evidence")
+
+    def runtime(self, backend) -> AnalysisRuntime:
+        built = AnalysisRuntime(
+            backend=backend, source=self.source, evidence_store=self.store
+        )
+        self.addCleanup(built.close)
+        return built
+
+
+def _result(status: str, *, stderr: str = "", stdout: str = "") -> AnalysisResult:
+    return AnalysisResult(
+        status=status, code_sha256="c", input_sha256="i",
+        stdout=stdout, stderr=stderr,
+        exit_status=0 if status == "ok" else 1, duration_seconds=0.1,
+    )
+
+
+class _Step:
+    """The fields `_is_locally_repairable` reads, and nothing else."""
+
+    def __init__(self, *, executed=True, result=None, suppressed=None):
+        self.action_executed = executed
+        self.result = result
+        self.suppressed_duplicate_of = suppressed
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_an_execution_that_ran_and_raised_is_repairable(self) -> None:
+        step = _Step(result=_result("error", stderr="Traceback...\nTypeError: x"))
+        self.assertTrue(_is_locally_repairable(step))
+
+    def test_success_is_not_repairable(self) -> None:
+        self.assertFalse(_is_locally_repairable(_Step(result=_result("ok", stdout="hi"))))
+
+    def test_resource_ceilings_are_not_repairable(self) -> None:
+        """The same program is the wrong answer; a retry re-hits the wall."""
+        for status in ("timeout", "bounded"):
+            with self.subTest(status=status):
+                step = _Step(result=_result(status, stderr="killed"))
+                self.assertFalse(_is_locally_repairable(step))
+
+    def test_a_step_that_never_executed_is_not_repairable(self) -> None:
+        """No traceback to reason from.
+
+        Checked with a result attached as well as without: a refused step is
+        ineligible because nothing ran, not merely because `result` happened
+        to be None. The refusal path can carry a prior result object, and
+        keying on its absence would offer a repair for a program the sandbox
+        never executed.
+        """
+        self.assertFalse(_is_locally_repairable(_Step(executed=False, result=None)))
+        self.assertFalse(
+            _is_locally_repairable(
+                _Step(executed=False, result=_result("error", stderr="Traceback\nboom"))
+            )
+        )
+
+    def test_a_suppressed_duplicate_is_not_repairable(self) -> None:
+        step = _Step(result=_result("error", stderr="boom"), suppressed="ev_1")
+        self.assertFalse(_is_locally_repairable(step))
+
+    def test_a_silent_failure_is_not_repairable(self) -> None:
+        """"Try again" with no diagnosis is exactly what this avoids."""
+        self.assertFalse(_is_locally_repairable(_Step(result=_result("error", stderr="   "))))
+
+
+class GenericContractTests(unittest.TestCase):
+    """The offer must not learn anything about what it is analysing."""
+
+    FORBIDDEN = (
+        "xor", "base64", "hex", "decode", "decoder", "decrypt", "malware",
+        "javascript", "jscript", "powershell", "int(", "typeerror",
+        "nameerror", "valueerror", "attributeerror", "syntaxerror",
+    )
+
+    def test_the_repair_message_names_no_technique_or_error_class(self) -> None:
+        lowered = AUTONOMOUS_REPAIR_MESSAGE.lower()
+        for term in self.FORBIDDEN:
+            with self.subTest(term=term):
+                self.assertNotIn(term, lowered)
+
+    def test_eligibility_does_not_inspect_the_error_text(self) -> None:
+        """Any diagnosed failure qualifies, whatever the exception class.
+
+        Keying on a particular exception would make the runtime an expert on
+        the artifact rather than on its own execution, and would silently stop
+        offering repairs the day a program failed some other way.
+        """
+        for stderr in (
+            "Traceback (most recent call last):\nTypeError: bad operand",
+            "Traceback (most recent call last):\nValueError: bad literal",
+            "Traceback (most recent call last):\nKeyError: 'k'",
+            "Traceback (most recent call last):\nZeroDivisionError: division by zero",
+            "SyntaxError: invalid syntax",
+            "some non-python diagnostic on stderr",
+        ):
+            with self.subTest(stderr=stderr.splitlines()[-1]):
+                self.assertTrue(
+                    _is_locally_repairable(_Step(result=_result("error", stderr=stderr)))
+                )
+
+
+class RepairFlowTests(RepairTestBase):
+    def test_failure_then_repair_then_success(self) -> None:
+        backend = RecordingBackend(
+            _tool_call(BROKEN), _tool_call(FIXED, call_id="call_2"), _prose("decoded")
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 1, "exactly one repair opportunity")
+        self.assertEqual(backend.instructions[1], AUTONOMOUS_REPAIR_MESSAGE)
+        # No observational detour between the failure and the correction.
+        self.assertNotIn(AUTONOMOUS_CONTINUATION_MESSAGE, backend.instructions[1])
+        self.assertNotIn(AUTONOMOUS_REPLAN_MESSAGE, backend.instructions[1])
+
+        corrected = run.steps[1]
+        self.assertTrue(corrected.action_executed)
+        self.assertIsNone(corrected.suppressed_duplicate_of)
+        self.assertIn(SECRET, self.store.reattest_exact(corrected.evidence.evidence_id))
+
+    def test_the_repair_call_sees_the_failed_code_and_its_traceback(self) -> None:
+        """Both halves of a fix must still be in front of the model."""
+        backend = RecordingBackend(
+            _tool_call(BROKEN), _tool_call(FIXED, call_id="call_2"), _prose("ok")
+        )
+        runtime = self.runtime(backend)
+        runtime.run_autonomous("analyse", finalize=False)
+
+        history = "\n".join(
+            str(m.get("content", "")) for m in runtime.messages
+        ) + json.dumps([
+            m.get("tool_calls") for m in runtime.messages if m.get("tool_calls")
+        ])
+        self.assertIn("chr(t ^ 7)", history, "the submitted code is preserved")
+        self.assertIn("TypeError", history, "the traceback is preserved")
+
+    def test_the_correction_adds_state_and_the_offer_does_not_depend_on_ERROR(self) -> None:
+        """A raised program still writes its traceback, so the ledger calls it
+        NEW_CONTENT. The offer keys off the sandbox status, not the
+        classification, which is why it fires here at all -- and the
+        correction adds state of its own rather than restating the failure.
+        """
+        backend = RecordingBackend(
+            _tool_call(BROKEN), _tool_call(FIXED, call_id="call_2"), _prose("done")
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 1)
+        self.assertTrue(run.progress[1].is_new_content)
+        self.assertNotEqual(
+            run.steps[0].evidence.raw_sha256, run.steps[1].evidence.raw_sha256
+        )
+
+    def test_a_successful_execution_is_never_offered_a_repair(self) -> None:
+        backend = RecordingBackend(
+            _tool_call(FIXED), _tool_call(READ, call_id="call_2"), _prose("done")
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 0)
+        self.assertNotIn(AUTONOMOUS_REPAIR_MESSAGE, backend.instructions)
+
+
+class RepairBoundTests(RepairTestBase):
+    def test_a_repair_that_fails_again_gets_no_third_attempt(self) -> None:
+        """One offer per failure, and never two consecutively."""
+        broken_two = BROKEN.replace("[:60]", "[:61]") + "# variant\n"
+        backend = RecordingBackend(
+            _tool_call(BROKEN),
+            _tool_call(broken_two, call_id="call_2"),
+            _prose("giving up"),
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 1, "the second failure earns no new offer")
+        self.assertEqual(backend.instructions.count(AUTONOMOUS_REPAIR_MESSAGE), 1)
+
+    def test_a_failed_repair_hands_back_to_the_ordinary_loop(self) -> None:
+        """One instruction per step, and the repair is spent exactly once.
+
+        A second failing program whose stderr matches the first adds no new
+        state, so the ledger calls it NO_PROGRESS while the sandbox still
+        reports a diagnosed error -- a stall and a diagnosed failure at once.
+        Because that step IS the repair, it earns no second offer, and the
+        ordinary replan takes over: the model is asked for a different
+        strategy rather than a third attempt at the same program.
+        """
+        fail = (
+            "import sys\n"
+            "sys.stderr.write('Traceback\\nBoomError: x\\n')\n"
+            "sys.exit(1)\n"
+        )
+        backend = RecordingBackend(
+            _tool_call(fail),
+            _tool_call(fail + "# variant\n", call_id="call_2"),
+            _prose("stopping"),
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 1, "the repair is offered exactly once")
+        self.assertEqual(backend.instructions[1], AUTONOMOUS_REPAIR_MESSAGE)
+        # Handed back: the failed repair gets the ordinary replan, not a
+        # second repair, and never both directives for one step.
+        self.assertEqual(backend.instructions[2], AUTONOMOUS_REPLAN_MESSAGE)
+        self.assertEqual(backend.instructions.count(AUTONOMOUS_REPAIR_MESSAGE), 1)
+
+    def test_a_dropped_replan_is_not_counted_as_one_sent(self) -> None:
+        """`replans` counts messages, not intentions.
+
+        A failing program writes its traceback as evidence, so the first such
+        failure is NEW_CONTENT -- but a later failure with byte-identical
+        stderr yields the same evidence hash, adds no state, and is classified
+        NO_PROGRESS while the sandbox still reports a diagnosed error. Both
+        the replan and the repair arm on that step; the repair wins and the
+        replan is dropped. The analyst reads this figure, so a counter that
+        recorded the intention would report a replan nobody was sent.
+        """
+        fail = (
+            "import sys\n"
+            "sys.stderr.write('Traceback\\nBoomError: x\\n')\n"
+            "sys.exit(1)\n"
+        )
+        backend = RecordingBackend(
+            _tool_call(fail),                                # NEW_CONTENT, repairable
+            _tool_call("print('p1')\n", call_id="call_2"),   # the repair: progress
+            _tool_call(fail + "#3\n", call_id="call_3"),     # same stderr: NO_PROGRESS *and* repairable
+            _tool_call("print('p2')\n", call_id="call_4"),
+            _prose("done"),
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        # The overlap really occurs: a repairable step classified NO_PROGRESS,
+        # with no repair in flight, so both the replan and the repair arm.
+        self.assertEqual(run.progress[2].classification, "NO_PROGRESS")
+        # The repair wins and the replan is dropped -- not queued behind it.
+        self.assertEqual(backend.instructions[3], AUTONOMOUS_REPAIR_MESSAGE)
+        self.assertNotIn(AUTONOMOUS_REPLAN_MESSAGE, backend.instructions)
+        self.assertEqual(
+            run.replans,
+            backend.instructions.count(AUTONOMOUS_REPLAN_MESSAGE),
+            "replans must count messages actually sent, not intentions",
+        )
+        self.assertEqual(run.replans, 0)
+
+    def test_an_offer_is_never_carried_across_an_intervening_step(self) -> None:
+        """Freshly decided each iteration, never accumulated.
+
+        An offer armed by step N and consumed at step N+2 would invite a fix
+        to a program the model has since moved on from.
+        """
+        fail = (
+            "import sys\n"
+            "sys.stderr.write('Traceback\\nBoomError: y\\n')\n"
+            "sys.exit(1)\n"
+        )
+        backend = RecordingBackend(
+            _tool_call(fail),
+            _tool_call("print('unrelated observation')\n", call_id="call_2"),
+            _tool_call("print('another observation')\n", call_id="call_3"),
+            _prose("done"),
+        )
+        runtime = self.runtime(backend)
+        runtime.run_autonomous("analyse", finalize=False)
+
+        # Offered once, immediately after the failure, and never again.
+        self.assertEqual(backend.instructions[1], AUTONOMOUS_REPAIR_MESSAGE)
+        self.assertNotIn(AUTONOMOUS_REPAIR_MESSAGE, backend.instructions[2:])
+
+    def test_repair_does_not_raise_the_ceilings(self) -> None:
+        """It spends an existing model call and no extra action budget."""
+        backend = RecordingBackend(
+            _tool_call(BROKEN), _tool_call(FIXED, call_id="call_2"), _prose("done")
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        # The ceilings themselves, not just conformance to them: a repair
+        # mechanism that quietly bought headroom would still satisfy
+        # `<= ceiling`, so the values are pinned here.
+        self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertLessEqual(run.model_calls, MAX_AUTONOMOUS_MODEL_CALLS)
+        self.assertLessEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
+        # The correction is an ordinary action, not a free one.
+        self.assertEqual(run.actions_executed, 2)
+        self.assertEqual(run.model_calls, 3)
+
+    def test_the_runtime_never_re_runs_the_failed_code_itself(self) -> None:
+        """Every execution is one the model submitted."""
+        backend = RecordingBackend(
+            _tool_call(BROKEN), _tool_call(FIXED, call_id="call_2"), _prose("done")
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(backend.calls, 3)
+        self.assertEqual(len(run.steps), 3)
+
+    def test_a_later_failure_after_progress_earns_its_own_repair(self) -> None:
+        """The bound is per failure, not per run."""
+        backend = RecordingBackend(
+            _tool_call(BROKEN),
+            _tool_call(FIXED, call_id="call_2"),
+            _tool_call(BROKEN.replace("[1].strip()", "[1].strip()  # second"), call_id="call_3"),
+            _tool_call(READ, call_id="call_4"),
+            _prose("done"),
+        )
+        runtime = self.runtime(backend)
+        run = runtime.run_autonomous("analyse", finalize=False)
+
+        self.assertEqual(run.repairs, 2)
+        self.assertEqual(backend.instructions.count(AUTONOMOUS_REPAIR_MESSAGE), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -398,6 +398,37 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
     ),
     }
 
+    # Model-facing constants introduced AFTER the baseline revision, which the
+    # diff above cannot protect: there is nothing to compare them against. They
+    # are pinned by digest instead, so the protection is the same in substance
+    # -- the text cannot drift without a reviewed, user-authorized edit here.
+    #
+    # ANALYSIS-REPAIR-1: sent once after an execution that ran and raised. The
+    # live run proved the model attempts the transformation, receives its own
+    # source and a full traceback, and then abandons the attempt to resume
+    # reading source. This is the one instruction that declines to change the
+    # subject for a single call. It names no error class and no correction.
+    POST_BASELINE_DIGESTS = {
+        "AUTONOMOUS_REPAIR_MESSAGE": (
+            "5358c64e548cf4ad2c22fc8ca2ffa252ee490ae21e33de616dc8be00a46b5c81"
+        ),
+    }
+
+    def test_post_baseline_constants_are_pinned(self) -> None:
+        """A constant younger than the baseline still cannot drift silently."""
+        import hashlib
+
+        from orbit.runtime import analysis_runtime
+
+        for name, digest in self.POST_BASELINE_DIGESTS.items():
+            with self.subTest(constant=name):
+                value = getattr(analysis_runtime, name)
+                self.assertEqual(
+                    hashlib.sha256(value.encode()).hexdigest(),
+                    digest,
+                    f"{name} changed; model-facing text must not drift",
+                )
+
     def _constant(self, text: str, name: str) -> str | None:
         import re
 


### PR DESCRIPTION
A real run found the decoder, extracted its inputs, submitted the transformation, and it raised. The model received its own source and the interpreter's full traceback inline — then abandoned the attempt and spent the rest of its budget re-reading source it had already collected.

Both halves of a fix were already in front of it. What was missing was an invitation to use them: the generic continuation asks for a new useful step, under which "read the file a different way" qualifies and "fix the program that just failed" is not obviously preferred.

So one message, sent once, after an execution that ran and raised. It names no technique, no error class and no correction. Eligibility is the sandbox's own `error` status with a non-empty stderr; `ok`, `timeout`, `bounded`, refused and suppressed steps are all excluded. A repair that fails again gets no second offer.

No ceiling moves — worst-case alternating fail/progress still stops on the action bound (12 actions, 12 calls, 6 repairs).

Full suite 4004 OK (skipped=8). 16/16 non-equivalent mutants caught, 1 proven equivalent. Independent adversarial review returned BLOCKER 0 and one MAJOR — a false "unreachable" claim in a comment plus an inflated `replans` counter — both reproduced and fixed, with the real overlap case now pinned by test.
