### PR TITLE
fix(analysis): add deterministic literal deobfuscation

### DIFF
--- a/src/orbit/runtime/analysis_deobfuscate.py
+++ b/src/orbit/runtime/analysis_deobfuscate.py
@@ -1,0 +1,476 @@
+"""Exact literal deobfuscation. Parsing and arithmetic, never execution.
+
+Some obfuscation is not a question. When a script hands a decoder a string
+literal, an integer literal and a delimiter literal, the result is already
+determined by the bytes on disk: no analysis decides it, and asking a model to
+write the loop that computes it only introduces a way to get it wrong. Three
+real runs did get it wrong -- once by omitting numeric coercion, once by
+passing an evidence id to `open()`, once by not attempting it at all -- while
+a full traceback and a dedicated repair instruction sat in front of the model.
+
+So the runtime computes those, and only those. Everything here is a literal
+match followed by pure arithmetic. Nothing is executed, imported, evaluated or
+fetched; a decoded stage is inert text that may be scanned for another literal
+transformation and is never run.
+
+The line this draws is *ambiguity*, not usefulness. A call whose key, input or
+delimiter is any expression other than a literal is left alone, because
+resolving it would mean interpreting the program rather than reading it -- and
+that is the model's work, on evidence, with the sandbox it already has.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+
+# Bounds. Small, explicit, and about the artifact rather than the machine: a
+# literal chain deep or large enough to exceed these is not the unambiguous
+# case this handles, and stopping is the honest answer.
+MAX_DEPTH = 4
+MAX_INPUT_CHARS = 262_144
+MAX_OUTPUT_CHARS = 262_144
+# Enough for a real layered chain -- the deepest observed artifact yields five
+# -- and small enough that a crafted file full of decoy call sites cannot turn
+# the preamble into the prompt. The bound is on what a model is told about,
+# not on what may be decoded: a file that legitimately exceeds it is unusual
+# enough that stopping is the honest answer.
+MAX_STAGES = 16
+
+# JScript's String.fromCharCode takes a UTF-16 code unit; values are taken
+# modulo 2**16 exactly as the spec's ToUint16 does.
+_UINT16 = 0x1_0000
+
+JSCRIPT_XOR = "jscript_numeric_xor"
+POWERSHELL_XOR = "powershell_numeric_xor"
+
+
+@dataclass(frozen=True)
+class TransformStage:
+    """One decoded stage, with everything needed to reproduce it."""
+
+    kind: str
+    key: int
+    delimiter: str
+    line: int
+    offset: int
+    depth: int
+    encoded: str
+    output: str
+    input_sha256: str
+    output_sha256: str
+
+    @property
+    def summary(self) -> str:
+        return (
+            f"{self.kind} key={self.key} delimiter={self.delimiter!r} "
+            f"line={self.line} depth={self.depth} "
+            f"({len(self.output)} chars, sha256 {self.output_sha256[:16]})"
+        )
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "surrogatepass")).hexdigest()
+
+
+def _to_number(token: str) -> int | None:
+    """JScript's ToNumber, restricted to what a decoder token can be.
+
+    `String.fromCharCode("94" ^ 46)` works because `^` coerces its operands
+    through ToInt32, and a decimal string coerces to its value. The cases that
+    matter and differ from Python's `int()`:
+
+      - surrounding whitespace is ignored (`" 94 "` is 94);
+      - the empty or all-whitespace string is 0, not an error;
+      - anything else -- a letter, a float, a sign in the wrong place -- is
+        NaN, and NaN through ToInt32 is 0.
+
+    Returning None for the NaN case rather than 0 is deliberate: a token that
+    is not a number means the literal is not the token list this claims to
+    recognise, and the whole call site is rejected instead of silently
+    decoding to a run of `chr(key)`.
+    """
+    stripped = token.strip()
+    if not stripped:
+        # An empty token is a real 0 in JScript, produced by a trailing
+        # delimiter. It decodes to chr(key) and is kept.
+        return 0
+    if not stripped.isdigit():
+        return None
+    return int(stripped)
+
+
+def _decode_tokens(encoded: str, key: int, delimiter: str) -> str | None:
+    """split -> ToNumber -> XOR -> fromCharCode -> concat. Pure."""
+    if not delimiter:
+        return None
+    parts = encoded.split(delimiter)
+    if len(parts) < 2:
+        return None
+    out: list[str] = []
+    for token in parts:
+        value = _to_number(token)
+        if value is None:
+            return None
+        out.append(chr((value ^ key) % _UINT16))
+    return "".join(out)
+
+
+# --- JScript ---------------------------------------------------------------
+#
+# Matched structurally, never by name. What identifies the decoder is what its
+# body does: split the first parameter by the third, XOR each token against
+# the second, and pass that to String.fromCharCode. Any names, any whitespace.
+
+_FUNCTION = re.compile(
+    r"function\s+([A-Za-z_$][\w$]*)\s*\(\s*"
+    r"([A-Za-z_$][\w$]*)\s*,\s*([A-Za-z_$][\w$]*)\s*,\s*([A-Za-z_$][\w$]*)\s*\)",
+)
+
+# A string literal in either quote style, with escapes tolerated.
+_STR = r"(?:\"((?:[^\"\\]|\\.)*)\"|'((?:[^'\\]|\\.)*)')"
+# An argument that is a literal, optionally concatenated with identifiers that
+# the file defines as the empty string. The concatenation is what real
+# obfuscators emit; it changes nothing and is resolved before matching.
+_ARG = rf"{_STR}((?:\s*\+\s*[A-Za-z_$][\w$]*)*)"
+
+
+def _is_hex(text: str) -> bool:
+    """A complete hex escape payload.
+
+    Checked rather than attempted: a malformed `\\xZZ` anywhere in the file
+    -- in a string this pass has no interest in -- would otherwise raise out
+    of the whole scan, and the caller's guard would discard every stage the
+    artifact really did determine. One bad byte must not disable the feature
+    on exactly the hostile input it exists for. JScript treats an incomplete
+    escape as the literal character, which is what falling through does.
+    """
+    return len(text) == len(text.strip()) and bool(text) and all(
+        c in "0123456789abcdefABCDEF" for c in text
+    ) and len(text) in (2, 4)
+
+
+def _unescape(text: str) -> str:
+    """Resolve the escapes a JScript string literal may carry."""
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch != "\\" or i + 1 >= len(text):
+            out.append(ch)
+            i += 1
+            continue
+        nxt = text[i + 1]
+        simple = {"n": "\n", "t": "\t", "r": "\r", "0": "\0",
+                  "\\": "\\", '"': '"', "'": "'", "/": "/", "b": "\b", "f": "\f"}
+        if nxt in simple:
+            out.append(simple[nxt])
+            i += 2
+        elif nxt == "x" and _is_hex(text[i + 2:i + 4]):
+            out.append(chr(int(text[i + 2:i + 4], 16)))
+            i += 4
+        elif nxt == "u" and _is_hex(text[i + 2:i + 6]):
+            out.append(chr(int(text[i + 2:i + 6], 16)))
+            i += 6
+        else:
+            out.append(nxt)
+            i += 2
+    return "".join(out)
+
+
+def _assigned_once(name: str, source: str) -> bool:
+    """Whether `source` writes `name` exactly once, however it is spelled.
+
+    A second write -- another declaration, a bare `=`, a compound `+=`, an
+    update through an index or property -- means the value at a given call
+    site depends on control flow, and control flow is interpretation. Such a
+    name is unusable here, whatever it was first assigned.
+    """
+    writes = re.findall(
+        rf"(?<![\w$.]){re.escape(name)}\s*(?:\[[^\]]*\])?\s*(?:\+=|=(?!=))", source
+    )
+    return len(writes) == 1
+
+
+def _empty_string_names(source: str) -> set[str]:
+    """Identifiers that are provably the empty string at every point.
+
+    Obfuscated calls concatenate one of these onto every argument. Folding it
+    away is only sound if the name really is empty *at the call site*, so a
+    name written more than once is refused exactly as `_string_variables`
+    refuses one: reading the declaration of a variable that is later made
+    non-empty would decode a truncated prefix, and a plausible-looking partial
+    result is worse than no result at all.
+    """
+    names: set[str] = set()
+    for match in re.finditer(
+        r"\b(?:var|let|const)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:\"\"|'')\s*[;\n]", source
+    ):
+        name = match.group(1)
+        if _assigned_once(name, source):
+            names.add(name)
+    return names
+
+
+def _string_variables(source: str) -> dict[str, str]:
+    """Identifiers assigned a string literal exactly once, and never rewritten.
+
+    A name is usable only if the whole file agrees on its value. Any second
+    assignment -- another declaration, a bare `x = ...`, a compound `+=`, or
+    an update through an index or property -- means the value at a given call
+    site depends on control flow, and control flow is interpretation. Such a
+    name is dropped rather than guessed at.
+
+    Getting this wrong would be worse than missing the stage: reading the
+    first of two literals would decode confidently to a value the program
+    never uses, and that is indistinguishable from a real result.
+    """
+    values: dict[str, str] = {}
+    rejected: set[str] = set()
+    for match in re.finditer(
+        rf"\b(?:var|let|const)\s+([A-Za-z_$][\w$]*)\s*=\s*{_STR}\s*;", source
+    ):
+        name = match.group(1)
+        if name in values:
+            rejected.add(name)  # declared twice: ambiguous
+            continue
+        raw = match.group(2) if match.group(2) is not None else match.group(3)
+        values[name] = _unescape(raw or "")
+
+    for name in list(values):
+        if not _assigned_once(name, source):
+            rejected.add(name)
+    for name in rejected:
+        values.pop(name, None)
+    return values
+
+
+def _decoder_names(source: str) -> list[str]:
+    """Every function whose body is a split/XOR/fromCharCode decoder."""
+    found: list[str] = []
+    for match in _FUNCTION.finditer(source):
+        name, first, second, third = match.groups()
+        body = source[match.end(): match.end() + 4000]
+        # Structural, in the decoder's own parameter names: the first is split
+        # by the third, and the second is the XOR operand under fromCharCode.
+        splits = re.search(
+            rf"\b{re.escape(first)}\s*\.\s*split\s*\(\s*{re.escape(third)}\s*\)", body
+        )
+        # The XOR must be *inside* the fromCharCode call, not merely somewhere
+        # in the same function. A checksum helper that splits its input, folds
+        # it with `^ seed`, and separately builds a character from the result
+        # satisfies both conditions independently while being no decoder at
+        # all -- and would be "decoded" into noise.
+        xors = any(
+            re.search(rf"\^\s*{re.escape(second)}\b", call.group(1))
+            or re.search(rf"{re.escape(second)}\s*\^", call.group(1))
+            for call in re.finditer(
+                r"String\s*\.\s*fromCharCode\s*\(([^;]*?)\)", body
+            )
+        )
+        if splits and xors:
+            found.append(name)
+    return found
+
+
+def _resolve_argument(
+    literal: str | None,
+    alt: str | None,
+    tail: str,
+    empties: set[str],
+) -> str | None:
+    """A literal argument, with empty-string concatenations folded away."""
+    if literal is None and alt is None:
+        return None
+    for name in re.findall(r"\+\s*([A-Za-z_$][\w$]*)", tail or ""):
+        if name not in empties:
+            # Concatenated with something that is not provably empty: the
+            # value is not determined by the literal alone.
+            return None
+    return _unescape(literal if literal is not None else (alt or ""))
+
+
+def find_jscript_stages(source: str, depth: int = 0) -> list[TransformStage]:
+    """Every call site of a structural decoder whose arguments are literal."""
+    stages: list[TransformStage] = []
+    names = _decoder_names(source)
+    if not names:
+        return stages
+    empties = _empty_string_names(source)
+    variables = _string_variables(source)
+    for name in names:
+        pattern = re.compile(
+            re.escape(name) + r"\s*\(\s*"
+            rf"(?:{_ARG}|([A-Za-z_$][\w$]*))\s*,\s*"      # encoded: literal or var
+            r"(\d+)\s*,\s*"                                # key: integer literal only
+            rf"{_ARG}\s*\)",                               # delimiter: literal
+            re.S,
+        )
+        for match in pattern.finditer(source):
+            enc_lit, enc_alt, enc_tail, enc_var, key_text, dl_lit, dl_alt, dl_tail = (
+                match.groups()
+            )
+            if enc_var is not None:
+                encoded = variables.get(enc_var)
+                if encoded is None:
+                    continue  # not a literal string variable: ambiguous
+            else:
+                encoded = _resolve_argument(enc_lit, enc_alt, enc_tail, empties)
+            delimiter = _resolve_argument(dl_lit, dl_alt, dl_tail, empties)
+            if encoded is None or delimiter is None:
+                continue
+            if len(encoded) > MAX_INPUT_CHARS:
+                continue
+            decoded = _decode_tokens(encoded, int(key_text), delimiter)
+            if decoded is None or len(decoded) > MAX_OUTPUT_CHARS:
+                continue
+            stages.append(
+                TransformStage(
+                    kind=JSCRIPT_XOR,
+                    key=int(key_text),
+                    delimiter=delimiter,
+                    line=source[: match.start()].count("\n") + 1,
+                    offset=match.start(),
+                    depth=depth,
+                    encoded=encoded,
+                    output=decoded,
+                    input_sha256=_sha(encoded),
+                    output_sha256=_sha(decoded),
+                )
+            )
+    return stages
+
+
+# --- PowerShell ------------------------------------------------------------
+#
+# The same shape in another language, and matched the same way: a quoted list
+# of decimal tokens, an integer assigned to a variable, and a `-bxor` against
+# that variable. Nothing is executed; the tokens and the key are read.
+
+_PS_LIST = re.compile(r"\$(\w+)\s*=\s*'((?:\s*\d+\s*,)+\s*\d+\s*)'")
+_PS_INT = re.compile(r"\$(\w+)\s*=\s*(\d+)\s*[;\r\n]")
+_PS_SPLIT = re.compile(r"\$(\w+)\s*-split\s*'([^']*)'")
+_PS_BXOR_VAR = re.compile(r"-bxor\s*\$(\w+)")
+_PS_BXOR_LIT = re.compile(r"-bxor\s*(\d+)")
+
+
+def _reaches_bxor(name: str, source: str) -> bool:
+    """Whether `$name` is connected by name to the `-bxor` in this script.
+
+    Deliberately shallow: it follows assignments of the form `$b = $a ...`
+    from the list variable, and asks whether any name reached that way is
+    split or XORed. That is enough to separate a token list a loop consumes
+    from an unrelated literal, and it stops well short of interpreting
+    PowerShell -- an ambiguous case simply fails the check and is skipped.
+    """
+    reached = {name}
+    for _ in range(4):  # a short chain; deeper aliasing is not the exact case
+        grew = False
+        for target, expression in re.findall(r"\$(\w+)\s*=([^\r\n;]*)", source):
+            if target in reached:
+                continue
+            if any(re.search(rf"\${re.escape(n)}\b", expression) for n in reached):
+                reached.add(target)
+                grew = True
+        if not grew:
+            break
+    for reference in reached:
+        near = rf"\${re.escape(reference)}\b"
+        if re.search(rf"{near}[^\r\n]*-bxor", source):
+            return True
+        if re.search(rf"{near}\s*-split", source):
+            # Split then consumed elementwise by the operator: the loop
+            # variable is not the list name, so the split is the link.
+            return bool(re.search(r"-bxor", source))
+    return False
+
+
+def find_powershell_stages(source: str, depth: int = 0) -> list[TransformStage]:
+    """Literal `-bxor` reconstructions over a quoted numeric token list."""
+    stages: list[TransformStage] = []
+    # Matches rather than groups, so each list keeps the position it was
+    # actually found at. `source.index(tokens)` would report the first place
+    # the same digits appear anywhere -- a comment, another string -- which is
+    # provenance pointing at bytes that did not produce the value.
+    matches = list(_PS_LIST.finditer(source))
+    if not matches:
+        return stages
+    integers = {name: int(value) for name, value in _PS_INT.findall(source)}
+    # The delimiter is whatever `-split` names, defaulting to the comma the
+    # token list is already written with.
+    delimiters = {name: value for name, value in _PS_SPLIT.findall(source)}
+
+    keys: list[int] = [
+        integers[name] for name in _PS_BXOR_VAR.findall(source) if name in integers
+    ]
+    keys.extend(int(value) for value in _PS_BXOR_LIT.findall(source))
+    if len(set(keys)) != 1:
+        # No key, or more than one candidate: which applies to this list is not
+        # determined by the text, so it is left alone.
+        return stages
+    key = keys[0]
+
+    for match in matches:
+        name, tokens = match.group(1), match.group(2)
+        if len(tokens) > MAX_INPUT_CHARS:
+            continue
+        if not _reaches_bxor(name, source):
+            # This list is never fed to the operator. A version string or a
+            # port list is not ciphertext, and XORing it produces noise that
+            # would be recorded with the authority of arithmetic -- worse than
+            # recording nothing, because it invites the analysis to interpret
+            # it. Deciding which key applies is not the same as deciding that
+            # a given list is an input at all.
+            continue
+        delimiter = delimiters.get(name, ",")
+        decoded = _decode_tokens(tokens, key, delimiter)
+        if decoded is None or len(decoded) > MAX_OUTPUT_CHARS:
+            continue
+        offset = match.start(2)
+        stages.append(
+            TransformStage(
+                kind=POWERSHELL_XOR,
+                key=key,
+                delimiter=delimiter,
+                line=source[:offset].count("\n") + 1,
+                offset=offset,
+                depth=depth,
+                encoded=tokens,
+                output=decoded,
+                input_sha256=_sha(tokens),
+                output_sha256=_sha(decoded),
+            )
+        )
+    return stages
+
+
+def deobfuscate(source: str) -> list[TransformStage]:
+    """Every exact literal stage reachable from `source`, breadth-first.
+
+    Bounded on all four axes that could otherwise run away: depth, stage
+    count, per-stage size, and repetition. Cycles are detected by content
+    digest rather than by shape, so a chain that decodes back to something
+    already seen stops whatever route it took to get there.
+    """
+    if len(source) > MAX_INPUT_CHARS:
+        return []
+    stages: list[TransformStage] = []
+    seen: set[str] = {_sha(source)}
+    frontier = [(source, 0)]
+    while frontier and len(stages) < MAX_STAGES:
+        text, depth = frontier.pop(0)
+        if depth >= MAX_DEPTH:
+            continue
+        found = find_jscript_stages(text, depth) + find_powershell_stages(text, depth)
+        for stage in found:
+            if len(stages) >= MAX_STAGES:
+                break
+            if stage.output_sha256 in seen:
+                continue
+            seen.add(stage.output_sha256)
+            stages.append(stage)
+            # Decoded text is inert data that may itself contain a literal
+            # stage. It is scanned, never executed.
+            frontier.append((stage.output, depth + 1))
+    return stages

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -43,6 +44,7 @@ from orbit.runtime.context_manager import (
     DEFAULT_NEXT_ACTION_RESERVE,
     plan_exact_context,
 )
+from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
 from orbit.runtime.analysis_progress import (
     COMPLETE,
     ERROR,
@@ -98,6 +100,49 @@ class _TokenCountUnavailable(RuntimeError):
 # call, not a mode: the backend uses it the way it already uses "route", to know
 # which rolling checkpoint this prompt continues, and learns nothing about CHAT
 # or ANALYSIS from it.
+ANALYSIS_TRANSFORM_PHASE = "analysis_transform"
+
+# How much of a decoded stage the report shows verbatim. Short stages are the
+# point -- an exact string is the whole value of an exact transformation -- so
+# the bound is generous relative to what a decoded moniker or command runs to,
+# and a stage past it is named by type, length and digest instead.
+TRANSFORM_INLINE_CHARS = 400
+TRANSFORM_PREFIX_CHARS = 120
+
+# Absolute URIs in decoded text, so an indicator survives a stage too long to
+# inline. Deliberately syntactic: it extracts what is written, and says
+# nothing about what the address is for -- that is the analysis's conclusion.
+_URI_PATTERN = re.compile(r"\b[a-zA-Z][a-zA-Z0-9+.-]*://[^\s\"'<>()\\]+")
+
+
+def _uris_in(text: str) -> list[str]:
+    """Absolute URIs in `text`, in first-seen order, without duplicates."""
+    return list(dict.fromkeys(_URI_PATTERN.findall(text)))
+
+
+# What the model is told before its first call, when the runtime has already
+# computed something the artifact determines.
+#
+# It states what exists and how to read it, and nothing about what any of it
+# means: naming a stage a decoder, a payload or an indicator would be the
+# runtime interpreting the artifact, which is the model's work. The exact
+# bytes stay behind the evidence mechanism that already exists, so a large
+# stage costs an id here rather than a prompt.
+def _transform_preamble(stages: "list[tuple[TransformStage, EvidenceRecord]]") -> str:
+    lines = [
+        "Deterministic transformations were computed from the artifact before "
+        "this analysis began. Each is an exact literal transformation of bytes "
+        "in the file -- no code was executed -- and each is stored as evidence:",
+    ]
+    for stage, record in stages:
+        lines.append(f"- {record.evidence_id}: {stage.summary}")
+    lines.append(
+        "Name an id as `evidence:<evidence_id>` to read its exact output. "
+        "These are established facts about the artifact; do not recompute them."
+    )
+    return "\n".join(lines)
+
+
 ANALYSIS_STEP_PHASE = "analysis_step"
 
 # The phase a report declares. Distinct from a step because it is a different
@@ -822,6 +867,15 @@ class AnalysisRuntime:
     _observed_fingerprints: dict[str, str] = field(default_factory=dict)
     suppressed_duplicates: int = 0
     last_context_plan: object | None = None
+    # Stages the deterministic pass recovered, paired with the evidence each
+    # became. Computed once per artifact snapshot and read thereafter.
+    transform_stages: list[tuple[TransformStage, EvidenceRecord]] = field(
+        default_factory=list
+    )
+    # The snapshot the pass ran against. Its presence -- not the emptiness of
+    # the list -- is what makes the pass once-only: an artifact with nothing to
+    # decode must not be rescanned on every step.
+    _transform_snapshot: str | None = None
 
     def __post_init__(self) -> None:
         if self.workspace is None:
@@ -839,6 +893,112 @@ class AnalysisRuntime:
                     ),
                 }
             )
+            # Before the first model call, and only here: what the artifact
+            # already determines is not a question to put to a model. A
+            # session that finds nothing appends nothing and is byte-identical
+            # to one built before this existed.
+            self._run_transform_preflight()
+
+    def _run_transform_preflight(self) -> None:
+        """Compute what the artifact determines, once, before any model call.
+
+        Static enrichment, not an action: it runs no sandbox, spends no model
+        call and consumes no action budget, so every bound that makes a run
+        terminate is untouched. It reads the acquired artifact bytes -- the
+        same snapshot the session is pinned to -- and writes one evidence
+        record per stage, each carrying enough provenance to be recomputed
+        from the file by hand.
+
+        Guarded by the snapshot digest rather than by the result, so an
+        artifact with nothing to decode is scanned once and never again.
+
+        Failure here is not failure of the analysis. A malformed artifact, an
+        unreadable file or an evidence store that cannot write must leave the
+        session exactly as it would have been without this pass, which is why
+        the whole thing is wrapped: an enrichment that could abort an analysis
+        would be worse than one that occasionally finds nothing.
+        """
+        if self._transform_snapshot == self.source.sha256:
+            return
+        self._transform_snapshot = self.source.sha256
+        try:
+            text = self.source.snapshot_path.read_text(encoding="utf-8", errors="replace")
+            stages = deobfuscate(text)
+        except (OSError, ValueError):
+            return
+        for index, stage in enumerate(stages, 1):
+            try:
+                record = self.evidence_store.add(
+                    ANALYSIS_TOOL_NAME,
+                    stage.output,
+                    metadata={
+                        # Provenance sufficient to reproduce the value: which
+                        # bytes, which rule, which parameters, and what came
+                        # out. A reader with the artifact can redo it by hand.
+                        "analysis_source_sha256": self.source.sha256,
+                        "original_path": self.source.original_path,
+                        "transform_kind": stage.kind,
+                        "transform_key": stage.key,
+                        "transform_delimiter": stage.delimiter,
+                        "transform_line": stage.line,
+                        "transform_offset": stage.offset,
+                        "transform_depth": stage.depth,
+                        "input_sha256": stage.input_sha256,
+                        "output_sha256": stage.output_sha256,
+                        # Attestation requires all three; the ids are stable
+                        # and name the pass rather than a tool call, because
+                        # no tool call produced this.
+                        "tool_call_id": f"transform_{index}",
+                        "user_turn_id": "turn_0",
+                        "produced_by_phase": ANALYSIS_TRANSFORM_PHASE,
+                    },
+                )
+            except (OSError, ValueError):
+                continue
+            self.transform_stages.append((stage, record))
+        if self.transform_stages:
+            self.messages.append(
+                {"role": "user", "content": _transform_preamble(self.transform_stages)}
+            )
+
+    def transform_appendix(self) -> str:
+        """Exact rendering of the deterministic stages. No model involved.
+
+        A report is model prose about evidence, and prose can omit things. A
+        value the runtime computed exactly should not depend on the model
+        choosing to mention it, so it is rendered here from the records
+        themselves.
+
+        Short outputs are given verbatim, because that is the whole value of
+        an exact result. Long ones are given by type, length, digest and id --
+        enough to recognise and retrieve, without turning a report into a
+        transcript. Any URI a stage produced is listed verbatim regardless of
+        the length of the stage that produced it, since a truncated indicator
+        is useless. Nothing here is labelled: what a decoded string means is
+        the analysis's conclusion, not the renderer's.
+        """
+        if not self.transform_stages:
+            return ""
+        lines = ["## Deterministic transformations", ""]
+        for stage, record in self.transform_stages:
+            lines.append(
+                f"- {stage.kind} | line {stage.line} (offset {stage.offset}) | "
+                f"key {stage.key} | delimiter {stage.delimiter!r} | depth {stage.depth}"
+            )
+            lines.append(f"  evidence: {record.evidence_id}")
+            lines.append(f"  output sha256: {stage.output_sha256}")
+            if len(stage.output) <= TRANSFORM_INLINE_CHARS:
+                lines.append(f"  output: {stage.output}")
+            else:
+                lines.append(
+                    f"  output: {len(stage.output)} chars, begins "
+                    f"{stage.output[:TRANSFORM_PREFIX_CHARS]!r}"
+                )
+            for uri in _uris_in(stage.output):
+                # Verbatim even from a long stage: a truncated indicator is
+                # not an indicator.
+                lines.append(f"  decoded URI: {uri}")
+        return "\n".join(lines)
 
     def _with_canonical_call_ids(self, calls: Iterable[dict]) -> list[dict]:
         """Give every accepted tool call a non-empty id, preserving real ones.
@@ -2083,6 +2243,12 @@ class AnalysisRuntime:
             # Truthful rather than silent, and no repair call: a second
             # invocation would cross the boundary this runtime holds.
             text = "the report call produced no usable text"
+        # Appended after the model's prose, not merged into it: this is
+        # evidence rendering, and keeping it separate is what makes it
+        # independent of whether the model chose to mention any of it.
+        appendix = self.transform_appendix()
+        if appendix:
+            text = f"{text}\n\n{appendix}"
         return AnalysisReport(
             text=text,
             model_calls=1,
@@ -2117,6 +2283,18 @@ class AnalysisRuntime:
             record
             for record in self.evidence_store.records.values()
             if record.tool_name == ANALYSIS_TOOL_NAME
+            # Deterministic stages are excluded from the citation budget, not
+            # from the report: `transform_appendix` renders every one of them
+            # exactly and unconditionally, so a place spent here would buy
+            # nothing. It would also be an artifact's to spend -- the stage
+            # count comes from the file, so a crafted sample with many decoy
+            # call sites could otherwise fill the budget before the analysis
+            # produced a single finding of its own.
+            # `getattr`, because this view is required to tolerate a record
+            # that does not carry the field at all -- `superseded_records`
+            # makes the same allowance, and the two must agree about how
+            # defensive to be or a record one accepts breaks the other.
+            and getattr(record, "produced_by_phase", None) != ANALYSIS_TRANSFORM_PHASE
         ]
         return active_records(records)[-MAX_REPORT_EVIDENCE_RECORDS:]
 

--- a/tests/test_analysis_deobfuscate.py
+++ b/tests/test_analysis_deobfuscate.py
@@ -1,0 +1,589 @@
+"""Exact literal deobfuscation: what it decodes, and what it refuses to.
+
+The refusals matter as much as the decodes. Anything whose key, input or
+delimiter is not a literal is left to the model and its sandbox, because
+resolving it would mean interpreting the program rather than reading it.
+
+Every fixture here is synthetic and benign; the outputs are unrelated to any
+real artifact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import unittest
+
+from orbit.runtime.analysis_deobfuscate import (
+    JSCRIPT_XOR,
+    MAX_DEPTH,
+    POWERSHELL_XOR,
+    deobfuscate,
+    find_jscript_stages,
+    find_powershell_stages,
+)
+
+
+def encode(text: str, key: int, delimiter: str) -> str:
+    return delimiter.join(str(ord(c) ^ key) for c in text)
+
+
+def decoder(name: str = "dec", a: str = "s", b: str = "k", c: str = "d") -> str:
+    return (
+        f"function {name}({a}, {b}, {c}) {{\n"
+        f"    var out = '';\n"
+        f"    var parts = {a}.split({c});\n"
+        f"    for (var i = 0; i < parts.length; i++) {{\n"
+        f"        out += String.fromCharCode(parts[i] ^ {b});\n"
+        f"    }}\n"
+        f"    return out;\n"
+        f"}}\n"
+    )
+
+
+class JScriptMatcherTests(unittest.TestCase):
+    def test_a_renamed_decoder_function_is_still_recognised(self) -> None:
+        """Matched by what the body does, never by the name."""
+        for name in ("dec", "GxQ9_zzT", "$a", "_0x4f2b"):
+            with self.subTest(name=name):
+                src = decoder(name) + f'{name}("{encode("HELLO", 9, "-")}", 9, "-");\n'
+                stages = find_jscript_stages(src)
+                self.assertEqual([s.output for s in stages], ["HELLO"])
+
+    def test_renamed_parameters_are_still_recognised(self) -> None:
+        src = decoder("d", a="zz1", b="zz2", c="zz3")
+        src += f'd("{encode("PARAMS", 3, "|")}", 3, "|");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["PARAMS"])
+
+    def test_a_different_key_decodes_correctly(self) -> None:
+        for key in (1, 7, 60, 123, 255):
+            with self.subTest(key=key):
+                src = decoder() + f'dec("{encode("KEYED", key, ",")}", {key}, ",");\n'
+                self.assertEqual([s.output for s in find_jscript_stages(src)], ["KEYED"])
+
+    def test_a_different_delimiter_decodes_correctly(self) -> None:
+        for delimiter in (",", "|", "<", ">", "[", ":", "~"):
+            with self.subTest(delimiter=delimiter):
+                src = decoder() + (
+                    f'dec("{encode("DELIM", 5, delimiter)}", 5, "{delimiter}");\n'
+                )
+                self.assertEqual([s.output for s in find_jscript_stages(src)], ["DELIM"])
+
+    def test_whitespace_and_multiline_formatting_are_tolerated(self) -> None:
+        body = encode("SPACED", 11, ",")
+        src = decoder() + f'dec(\n    "{body}",\n    11,\n    ","\n);\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["SPACED"])
+
+    def test_every_qualifying_call_site_is_decoded(self) -> None:
+        src = decoder()
+        src += f'dec("{encode("ONE", 4, ",")}", 4, ",");\n'
+        src += f'dec("{encode("TWO", 8, "|")}", 8, "|");\n'
+        src += f'dec("{encode("THREE", 12, ">")}", 12, ">");\n'
+        self.assertEqual(
+            sorted(s.output for s in find_jscript_stages(src)), ["ONE", "THREE", "TWO"]
+        )
+
+    def test_source_location_is_recorded(self) -> None:
+        src = decoder() + "\n\n" + f'dec("{encode("LOC", 2, ",")}", 2, ",");\n'
+        stage = find_jscript_stages(src)[0]
+        self.assertEqual(stage.line, src[: stage.offset].count("\n") + 1)
+        self.assertEqual(src[stage.offset:stage.offset + 3], "dec")
+
+
+class JScriptRejectionTests(unittest.TestCase):
+    def test_a_malformed_numeric_token_rejects_the_call_site(self) -> None:
+        """Not a token list; decoding it would invent a value."""
+        src = decoder() + 'dec("72,NOPE,74", 0, ",");\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+    def test_a_dynamic_key_is_rejected(self) -> None:
+        src = decoder() + f'dec("{encode("X", 5, ",")}", someKey, ",");\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+    def test_a_dynamic_delimiter_is_rejected(self) -> None:
+        """Including one whose name is defined elsewhere as a string.
+
+        A bare identifier must not be resolved here: the delimiter is only
+        accepted as a literal at the call site, so a matcher that fell back to
+        reading the variable would be interpreting the program.
+        """
+        src = decoder() + f'dec("{encode("XY", 5, ",")}", 5, sep);\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+        defined = 'var sep = ",";\n' + decoder()
+        defined += f'dec("{encode("XY", 5, ",")}", 5, sep);\n'
+        self.assertEqual(find_jscript_stages(defined), [])
+
+    def test_a_dynamic_encoded_input_is_rejected(self) -> None:
+        src = decoder() + 'dec(buildPayload(), 5, ",");\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+    def test_a_non_empty_concatenation_is_rejected(self) -> None:
+        """Only provably-empty identifiers may be folded away."""
+        src = "var pad = 'x';\n" + decoder()
+        src += f'dec("{encode("X", 5, ",")}" + pad, 5, ",");\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+    def test_a_rewritten_variable_is_refused_rather_than_guessed(self) -> None:
+        """A wrong decode is worse than a missing one.
+
+        If a name holds one literal at its declaration and another by the time
+        the decoder is called, reading the declaration would produce a
+        confident value the program never uses -- indistinguishable, in the
+        evidence, from a real result. Every form of second assignment is
+        therefore disqualifying.
+        """
+        first = encode("FIRST", 5, ",")
+        second = encode("SECOND", 5, ",")
+        cases = {
+            "reassigned": f'var p = "{first}";\np = "{second}";\ndec(p, 5, ",");\n',
+            "declared twice": f'var p = "{first}";\nvar p = "{second}";\ndec(p, 5, ",");\n',
+            "appended": f'var p = "{first}";\np += "99";\ndec(p, 5, ",");\n',
+            "indexed write": f'var p = "{first}";\np[0] = "9";\ndec(p, 5, ",");\n',
+        }
+        for label, tail in cases.items():
+            with self.subTest(case=label):
+                self.assertEqual(find_jscript_stages(decoder() + tail), [])
+
+    def test_a_variable_assigned_exactly_once_is_usable(self) -> None:
+        """The refusal above must not swallow the ordinary case."""
+        payload = encode("SINGLE", 5, ",")
+        src = decoder() + f'var p = "{payload}";\ndec(p, 5, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["SINGLE"])
+
+    def test_a_similarly_named_variable_does_not_disqualify(self) -> None:
+        """Matching must be on the name, not on a substring of one."""
+        payload = encode("EXACT", 5, ",")
+        src = decoder() + f'var p = "{payload}";\nvar padding = "x";\npadding = "y";\ndec(p, 5, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["EXACT"])
+
+    def test_decoy_numeric_strings_are_not_decoded(self) -> None:
+        """A number list that no decoder consumes stays untouched."""
+        src = 'var version = "1,2,3,4";\nvar ports = "80,443,8080";\n'
+        self.assertEqual(find_jscript_stages(src), [])
+        self.assertEqual(deobfuscate(src), [])
+
+    def test_no_matching_decoder_yields_nothing(self) -> None:
+        src = 'function notADecoder(a, b, c) { return a + b + c; }\nnotADecoder("1,2", 3, ",");\n'
+        self.assertEqual(find_jscript_stages(src), [])
+
+
+class CoercionSemanticsTests(unittest.TestCase):
+    def test_whitespace_around_a_token_is_ignored(self) -> None:
+        """JScript ToNumber trims; Python int() happens to agree, but the
+        empty-token and non-numeric cases below do not, so all three are
+        pinned together."""
+        src = decoder() + 'dec(" 72 , 73 ", 0, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["HI"])
+
+    def test_an_empty_token_is_zero_not_an_error(self) -> None:
+        """A trailing delimiter yields chr(key), exactly as JScript does."""
+        src = decoder() + 'dec("72,73,", 0, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["HI\x00"])
+
+    def test_values_are_taken_modulo_2_16(self) -> None:
+        """String.fromCharCode takes a UTF-16 code unit."""
+        src = decoder() + 'dec("65536,65601", 0, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["\x00A"])
+
+
+class PowerShellMatcherTests(unittest.TestCase):
+    def _script(self, text: str, key: int) -> str:
+        tokens = ",".join(str(ord(c) ^ key) for c in text)
+        return (
+            f"$data='{tokens}';$k={key};$out='';\n"
+            f"$parts=$data -split ',';\n"
+            f"foreach($t in $parts){{$out=$out+[char]($t -bxor $k);}}\n"
+        )
+
+    def test_a_literal_bxor_reconstruction_is_decoded(self) -> None:
+        stages = find_powershell_stages(self._script("PS-STAGE", 34))
+        self.assertEqual([s.output for s in stages], ["PS-STAGE"])
+        self.assertEqual(stages[0].kind, POWERSHELL_XOR)
+
+    def test_a_literal_key_operand_is_accepted(self) -> None:
+        script = (
+            "$data='115,114,113';\n"
+            "$parts=$data -split ',';\n"
+            "foreach($t in $parts){$o=$o+[char]($t -bxor 55);}\n"
+        )
+        self.assertEqual([s.output for s in find_powershell_stages(script)], ["DEF"])
+
+    def test_the_offset_names_the_assignment_not_an_earlier_lookalike(self) -> None:
+        """Provenance must point at the bytes that produced the value.
+
+        The same digits can appear earlier in a comment or another string;
+        searching for the token text would report that position instead, and
+        a reader following it would find nothing that explains the result.
+        """
+        tokens = ",".join(str(ord(c) ^ 34) for c in "AB")
+        script = (
+            f"# decoy {tokens}\n"
+            f"$a='{tokens}';$k=34;\n"
+            "$parts=$a -split ',';\n"
+            "foreach($t in $parts){$o=$o+[char]($t -bxor $k);}\n"
+        )
+        stage = find_powershell_stages(script)[0]
+        self.assertEqual(stage.line, 2)
+        self.assertEqual(script[stage.offset:stage.offset + len(tokens)], tokens)
+        self.assertEqual(script[stage.offset - 1], "'")
+
+    def test_ambiguous_keys_are_rejected(self) -> None:
+        """Two candidate keys: which applies is not determined by the text."""
+        script = (
+            "$data='1,2,3';$a=7;$b=9;\n"
+            "$parts=$data -split ',';\n"
+            "foreach($t in $parts){$x=($t -bxor $a);$y=($t -bxor $b);}\n"
+        )
+        self.assertEqual(find_powershell_stages(script), [])
+
+    def test_no_key_yields_nothing(self) -> None:
+        self.assertEqual(find_powershell_stages("$data='1,2,3';\n"), [])
+
+
+class RecursionAndBoundTests(unittest.TestCase):
+    def test_a_nested_stage_is_reached(self) -> None:
+        """A JScript stage decoding to a PowerShell stage, and both recorded."""
+        inner = "$data='" + ",".join(str(ord(c) ^ 34) for c in "NESTED-OK") + "';$k=34;\n"
+        inner += "$parts=$data -split ',';\n"
+        inner += "foreach($t in $parts){$o=$o+[char]($t -bxor $k);}\n"
+        src = decoder() + f'dec("{encode(inner, 46, "<")}", 46, "<");\n'
+        stages = deobfuscate(src)
+        kinds = [s.kind for s in stages]
+        self.assertIn(JSCRIPT_XOR, kinds)
+        self.assertIn(POWERSHELL_XOR, kinds)
+        self.assertIn("NESTED-OK", [s.output for s in stages])
+        self.assertEqual(max(s.depth for s in stages), 1)
+
+    def test_recursion_stops_at_the_depth_bound(self) -> None:
+        """A chain deeper than the bound is followed exactly to the bound."""
+        chain = "TERMINAL-VALUE"
+        # Each layer decodes to a whole decoder plus its own call site, so the
+        # nesting is real rather than a string that merely looks nested.
+        for key in (11, 13, 17, 19, 23, 29):
+            chain = decoder() + f'dec("{encode(chain, key, ",")}", {key}, ",");\n'
+
+        stages = deobfuscate(chain)
+        depths = sorted({s.depth for s in stages})
+
+        self.assertEqual(depths, list(range(MAX_DEPTH)))
+        self.assertEqual(len(stages), MAX_DEPTH)
+        # The chain is longer than the bound, so the innermost value is out of
+        # reach -- which is the bound doing its job, not a decode failure.
+        self.assertNotIn("TERMINAL-VALUE", [s.output for s in stages])
+
+    def test_a_repeated_output_is_not_recorded_twice(self) -> None:
+        """Cycle detection is by content digest, not by shape."""
+        payload = encode("SAME", 6, ",")
+        src = decoder() + f'dec("{payload}", 6, ",");\n' + f'dec("{payload}", 6, ",");\n'
+        self.assertEqual([s.output for s in deobfuscate(src)], ["SAME"])
+
+
+class GenericityTests(unittest.TestCase):
+    """No knowledge of any particular artifact may live in production."""
+
+    ORACLE = (
+        "smartmaket", "AA1789FF", "Fattura981033956",
+        "GaYHJ7mHg1DKQlXezhTy8NwK0YN9ZGDm0ueVP3hviz",
+    )
+
+    def test_production_contains_no_sample_or_oracle_constant(self) -> None:
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / "src" / "orbit"
+        for path in root.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for term in self.ORACLE:
+                with self.subTest(path=path.name, term=term):
+                    self.assertNotIn(term, text)
+
+    def test_no_arbitrary_execution_primitive_is_used(self) -> None:
+        from pathlib import Path
+
+        import orbit.runtime.analysis_deobfuscate as module
+
+        text = Path(module.__file__).read_text(encoding="utf-8")
+        for token in ("eval(", "exec(", "__import__", "subprocess", "socket",
+                      "urllib", "os.system", "popen"):
+            with self.subTest(token=token):
+                self.assertNotIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class RuntimeIntegrationTests(unittest.TestCase):
+    """The pass as ANALYSIS runs it: once, before the model, as evidence."""
+
+    def _runtime(self, source_text: str):
+        import tempfile
+        from pathlib import Path
+
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime, acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-deobf-")
+        self.addCleanup(tmpdir.cleanup)
+        tmp = Path(tmpdir.name)
+        artifact = tmp / "artifact.js"
+        artifact.write_text(source_text, encoding="utf-8")
+        source = acquire_analysis_source(artifact, tmp / "owned")
+        store = EvidenceStore(root=tmp / "evidence")
+        runtime = AnalysisRuntime(backend=None, source=source, evidence_store=store)
+        self.addCleanup(runtime.close)
+        return runtime, store
+
+    def _fixture(self) -> str:
+        return decoder() + f'dec("{encode("SYNTHETIC-STAGE", 17, ",")}", 17, ",");\n'
+
+    def test_each_stage_becomes_evidence_with_full_provenance(self) -> None:
+        runtime, store = self._runtime(self._fixture())
+        self.assertEqual(len(runtime.transform_stages), 1)
+        stage, record = runtime.transform_stages[0]
+
+        meta = record.metadata
+        self.assertEqual(meta["analysis_source_sha256"], runtime.source.sha256)
+        self.assertEqual(meta["transform_kind"], JSCRIPT_XOR)
+        self.assertEqual(meta["transform_key"], 17)
+        self.assertEqual(meta["transform_delimiter"], ",")
+        self.assertEqual(meta["transform_depth"], 0)
+        self.assertEqual(meta["input_sha256"], stage.input_sha256)
+        self.assertEqual(meta["output_sha256"], stage.output_sha256)
+        self.assertIn("transform_line", meta)
+        self.assertIn("transform_offset", meta)
+        # The digest recorded is the digest of what was stored.
+        self.assertEqual(
+            stage.output_sha256,
+            hashlib.sha256(stage.output.encode("utf-8")).hexdigest(),
+        )
+
+    def test_transform_evidence_re_attests(self) -> None:
+        runtime, store = self._runtime(self._fixture())
+        _stage, record = runtime.transform_stages[0]
+        self.assertEqual(store.reattest_exact(record.evidence_id), "SYNTHETIC-STAGE")
+
+    def test_the_model_receives_references_not_a_transcript(self) -> None:
+        runtime, _store = self._runtime(self._fixture())
+        preamble = runtime.messages[-1]["content"]
+        _stage, record = runtime.transform_stages[0]
+        self.assertIn(record.evidence_id, preamble)
+        self.assertIn("evidence:<evidence_id>", preamble)
+
+    def test_the_pass_runs_once_per_snapshot(self) -> None:
+        """Not rescanned on every step: guarded by the snapshot digest."""
+        runtime, _store = self._runtime(self._fixture())
+        before = list(runtime.transform_stages)
+        for _ in range(3):
+            runtime._run_transform_preflight()
+        self.assertEqual(runtime.transform_stages, before)
+
+    def test_an_artifact_with_nothing_to_decode_is_unchanged(self) -> None:
+        """Byte-identical to a session built before this existed."""
+        runtime, _store = self._runtime("var x = 1;\nconsole.log(x);\n")
+        self.assertEqual(runtime.transform_stages, [])
+        self.assertEqual(runtime.transform_appendix(), "")
+        self.assertEqual([m["role"] for m in runtime.messages], ["system", "user"])
+
+    def test_the_appendix_renders_exact_output_and_provenance(self) -> None:
+        runtime, _store = self._runtime(self._fixture())
+        appendix = runtime.transform_appendix()
+        _stage, record = runtime.transform_stages[0]
+
+        self.assertIn("## Deterministic transformations", appendix)
+        self.assertIn("SYNTHETIC-STAGE", appendix)
+        self.assertIn(record.evidence_id, appendix)
+        self.assertIn(_stage.output_sha256, appendix)
+        self.assertIn("key 17", appendix)
+
+    def test_a_decoded_uri_appears_verbatim_even_from_a_long_stage(self) -> None:
+        """A truncated indicator is not an indicator."""
+        uri = "http://synthetic.invalid/path?token=ABC123"
+        payload = ("filler " * 120) + uri
+        source = decoder() + f'dec("{encode(payload, 23, ",")}", 23, ",");\n'
+        runtime, _store = self._runtime(source)
+
+        appendix = runtime.transform_appendix()
+        stage, _record = runtime.transform_stages[0]
+        self.assertGreater(len(stage.output), 400)
+        self.assertNotIn(payload, appendix)          # not inlined whole
+        self.assertIn(f"decoded URI: {uri}", appendix)  # but the URI survives
+
+    def test_the_appendix_labels_nothing(self) -> None:
+        """What a decoded string means is the analysis's conclusion."""
+        uri = "http://synthetic.invalid/x"
+        source = decoder() + f'dec("{encode(uri, 29, ",")}", 29, ",");\n'
+        runtime, _store = self._runtime(source)
+        appendix = runtime.transform_appendix().lower()
+        for word in ("c2", "command and control", "malicious", "payload", "attacker"):
+            with self.subTest(word=word):
+                self.assertNotIn(word, appendix)
+
+
+class WrongDecodeRefusalTests(unittest.TestCase):
+    """The failure that matters most: a confident value the program never uses."""
+
+    def test_a_rewritten_empty_string_concat_is_refused(self) -> None:
+        """Folding away a concatenation is sound only if the name stays empty.
+
+        Reading the declaration of a variable that is later made non-empty
+        decodes a truncated prefix -- and a plausible-looking partial result
+        is worse than no result, because nothing marks it as partial.
+        """
+        payload = encode("SAFE", 5, ",")
+        src = (
+            'var e = "";\n'
+            'e = ",112,103,99,110";\n'
+            + decoder()
+            + f'dec("{payload}" + e, 5, ",");\n'
+        )
+        self.assertEqual(find_jscript_stages(src), [])
+
+    def test_a_stable_empty_string_concat_is_still_folded(self) -> None:
+        payload = encode("KEEP", 5, ",")
+        src = 'var pad = "";\n' + decoder() + f'dec("{payload}" + pad, 5, ",");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["KEEP"])
+
+    def test_a_non_decoder_that_merely_splits_and_xors_is_not_matched(self) -> None:
+        """`fromCharCode` and the XOR must be the same expression.
+
+        A checksum helper splits its input, folds it with `^ seed`, and
+        separately builds a character from the result. Both conditions hold
+        independently while the function decodes nothing at all.
+        """
+        helper = (
+            "function mix(data, seed, sep){var acc=0;var p=data.split(sep);"
+            "for(var i=0;i<p.length;i++){acc=acc^seed;}"
+            "return String.fromCharCode(65+acc);}\n"
+        )
+        self.assertEqual(find_jscript_stages(helper + 'mix("10,20,30", 7, ",");\n'), [])
+
+
+class MalformedInputTests(unittest.TestCase):
+    def test_a_malformed_escape_does_not_discard_every_stage(self) -> None:
+        """One bad byte must not disable the pass on hostile input.
+
+        The escape appears in a string this pass has no interest in; raising
+        out of the scan would lose every stage the artifact really determines.
+        """
+        good = decoder() + f'dec("{encode("OK", 5, ",")}", 5, ",");\n'
+        for junk in (r'var j = "\uWXYZ";', r'var j = "\xZZ";', 'var j = "trailing\\";'):
+            with self.subTest(junk=junk):
+                stages = deobfuscate(junk + "\n" + good)
+                self.assertEqual([s.output for s in stages], ["OK"])
+
+    def test_a_valid_escape_is_still_resolved(self) -> None:
+        src = decoder() + f'dec("{encode("AB", 0, ",")}", 0, "\\x2c");\n'
+        self.assertEqual([s.output for s in find_jscript_stages(src)], ["AB"])
+
+
+class PowerShellLinkageTests(unittest.TestCase):
+    def test_a_list_the_operator_never_consumes_is_not_decoded(self) -> None:
+        """Deciding which key applies is not deciding that a list is input.
+
+        A version string or a port list XORed against a key found elsewhere
+        produces noise, and noise recorded with the authority of arithmetic is
+        worse than silence: it invites the analysis to interpret it.
+        """
+        tokens = ",".join(str(ord(c) ^ 34) for c in "REAL")
+        script = (
+            f"$payload='{tokens}';$k=34;$o='';\n"
+            "$ports='1,2,3,4,5';\n"
+            "$parts=$payload -split ',';\n"
+            "foreach($t in $parts){$o=$o+[char]($t -bxor $k);}\n"
+        )
+        self.assertEqual([s.output for s in find_powershell_stages(script)], ["REAL"])
+
+    def test_a_dead_code_key_decodes_nothing(self) -> None:
+        script = "$versions='10,20,30';\n$x = 5 -bxor 7;\n"
+        self.assertEqual(find_powershell_stages(script), [])
+
+
+class ReportIntegrationTests(unittest.TestCase):
+    """The appendix must reach the report, and cost no citation slots."""
+
+    def _runtime(self, source_text: str):
+        import tempfile
+        from pathlib import Path
+
+        from orbit.runtime.analysis_runtime import (
+            AnalysisRuntime, acquire_analysis_source,
+        )
+        from orbit.runtime.evidence import EvidenceStore
+
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-deobf-rep-")
+        self.addCleanup(tmpdir.cleanup)
+        tmp = Path(tmpdir.name)
+        artifact = tmp / "artifact.js"
+        artifact.write_text(source_text, encoding="utf-8")
+        runtime = AnalysisRuntime(
+            backend=None,
+            source=acquire_analysis_source(artifact, tmp / "owned"),
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def test_transform_records_do_not_consume_the_citation_budget(self) -> None:
+        """The stage count comes from the artifact, so it must not be the
+        artifact's to spend: a crafted file with many decoy call sites would
+        otherwise fill the report's places before the analysis found anything
+        of its own. The appendix renders every stage regardless.
+        """
+        from orbit.runtime.analysis_runtime import MAX_REPORT_EVIDENCE_RECORDS
+
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n'
+            for i in range(MAX_REPORT_EVIDENCE_RECORDS + 4)
+        )
+        runtime = self._runtime(source)
+
+        self.assertGreater(len(runtime.transform_stages), 0)
+        self.assertEqual(runtime._reportable_records(), [])
+        # Still fully rendered, so nothing is lost by excluding them.
+        appendix = runtime.transform_appendix()
+        for _stage, record in runtime.transform_stages:
+            self.assertIn(record.evidence_id, appendix)
+
+    def test_the_appendix_is_appended_to_the_report_text(self) -> None:
+        """Evidence rendering, not model prose -- so it cannot be omitted."""
+        from orbit.backend.base import ChatResult
+
+        class _Backend:
+            def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                            on_delta=None, on_progress=None):
+                if on_delta:
+                    on_delta("model prose about the artifact")
+                return ChatResult(
+                    content="model prose about the artifact", model="m",
+                    finish_reason="stop", tool_calls=[], prompt_tokens=10,
+                    completion_tokens=5, cached_tokens=0,
+                    prompt_tokens_per_second=None,
+                    generation_tokens_per_second=None,
+                )
+
+        uri = "http://synthetic.invalid/beacon?id=XYZ"
+        runtime = self._runtime(decoder() + f'dec("{encode(uri, 29, ",")}", 29, ",");\n')
+        runtime.backend = _Backend()
+        # A finding of its own, so the report has something to cite.
+        runtime.evidence_store.add(
+            "execute_analysis", "an action finding",
+            metadata={"tool_call_id": "c1", "user_turn_id": "t1",
+                      "produced_by_phase": "analysis_action"},
+        )
+
+        report = runtime.report("summarise")
+        self.assertIn("model prose about the artifact", report.text)
+        self.assertIn("## Deterministic transformations", report.text)
+        self.assertIn(uri, report.text)
+
+
+class StageBudgetTests(unittest.TestCase):
+    def test_a_crafted_artifact_cannot_grow_the_preamble_without_bound(self) -> None:
+        from orbit.runtime.analysis_deobfuscate import MAX_STAGES
+
+        src = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n' for i in range(MAX_STAGES * 4)
+        )
+        self.assertEqual(len(deobfuscate(src)), MAX_STAGES)

--- a/tests/test_analysis_deobfuscate_oracle.py
+++ b/tests/test_analysis_deobfuscate_oracle.py
@@ -1,0 +1,111 @@
+"""The deterministic pass against the real artifact, with no model involved.
+
+Qualification only. The sample path and the expected digests live here, in the
+test, because that is where knowledge of a particular artifact belongs -- the
+production module must be able to decode this file without ever having heard
+of it, and `GenericityTests` enforces that separately.
+
+Digests rather than plaintext for the recovered stages: this file states what
+the transformation must produce without reproducing a live indicator in the
+repository. The one exception is the scheme-and-shape assertion on the final
+stage, which checks a URI was recovered without writing the address out.
+
+Skipped when the sample is absent, so a checkout without it still qualifies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import unittest
+from pathlib import Path
+
+from orbit.runtime.analysis_deobfuscate import (
+    JSCRIPT_XOR,
+    POWERSHELL_XOR,
+    deobfuscate,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLE = ROOT / "workdir" / "samples" / "Fattura981033956.js"
+ORIGIN = ROOT / "workdir" / "samples" / "Fattura981033956_origin.js"
+
+SAMPLE_SHA = "b7cfd5fdeb16d7b5ecea1063419bdad6ad280ed9b73c636707874c3f4001dc0c"
+ORIGIN_SHA = "924fb89c69486151861e6eb82788718804aeee26f0989bb7c17356b15da622f4"
+
+# Output digests of the five stages the artifact determines: three WMI
+# monikers/classes, the command stage, and the address the command builds.
+EXPECTED = {
+    "S1": "6a892b624a2a237ca8b6fdd64d2dc02a30aa1afc08db9b9a21f269d9fb67eac2",
+    "S2": "cafa14b8acab599aeb5425fabb3bdb519935cd39947e653dd89619db19b1b3fe",
+    "S3": "8716f5d4559ed0f5dbfdb7bfb1717abcc9cfa1171caeea548aaf9c38fccd04db",
+    "S4": "ec8ccda0cbdce79a76748c0e32c1fb788276c762abc5fd8c6f77609a0c8f58f1",
+    "S5": "6a4277aa4ae872f43b368c35fcee79ea2ee40824822ae215cf52483f8faa48a3",
+}
+S4_CHARS = 1008
+
+
+def _load(path: Path, expected_sha: str) -> str:
+    if not path.exists():
+        raise unittest.SkipTest(f"{path.name} not present")
+    data = path.read_bytes()
+    if hashlib.sha256(data).hexdigest() != expected_sha:
+        raise unittest.SkipTest(f"{path.name} is not the pinned artifact")
+    return data.decode("utf-8", "replace")
+
+
+class RealSampleOracleTests(unittest.TestCase):
+    def test_every_stage_is_recovered_from_the_pinned_sample(self) -> None:
+        stages = deobfuscate(_load(SAMPLE, SAMPLE_SHA))
+        digests = {s.output_sha256 for s in stages}
+        for name, expected in EXPECTED.items():
+            with self.subTest(stage=name):
+                self.assertIn(expected, digests)
+
+    def test_the_stage_shape_is_what_the_artifact_determines(self) -> None:
+        stages = deobfuscate(_load(SAMPLE, SAMPLE_SHA))
+        by_digest = {s.output_sha256: s for s in stages}
+
+        for name in ("S1", "S2", "S3", "S4"):
+            self.assertEqual(by_digest[EXPECTED[name]].kind, JSCRIPT_XOR)
+            self.assertEqual(by_digest[EXPECTED[name]].depth, 0)
+
+        nested = by_digest[EXPECTED["S5"]]
+        self.assertEqual(nested.kind, POWERSHELL_XOR)
+        self.assertEqual(nested.depth, 1, "the address is reached through the command")
+
+        command = by_digest[EXPECTED["S4"]]
+        self.assertEqual(len(command.output), S4_CHARS)
+
+    def test_input_digests_are_recorded_for_every_stage(self) -> None:
+        for stage in deobfuscate(_load(SAMPLE, SAMPLE_SHA)):
+            with self.subTest(line=stage.line):
+                self.assertEqual(
+                    stage.input_sha256,
+                    hashlib.sha256(stage.encoded.encode("utf-8")).hexdigest(),
+                )
+                self.assertEqual(
+                    stage.output_sha256,
+                    hashlib.sha256(stage.output.encode("utf-8")).hexdigest(),
+                )
+
+    def test_an_absolute_uri_is_recovered_by_the_final_stage(self) -> None:
+        """Asserted by shape, so the address itself is not written here."""
+        from orbit.runtime.analysis_runtime import _uris_in
+
+        stages = deobfuscate(_load(SAMPLE, SAMPLE_SHA))
+        final = next(s for s in stages if s.output_sha256 == EXPECTED["S5"])
+        uris = _uris_in(final.output)
+        self.assertEqual(len(uris), 1)
+        self.assertTrue(uris[0].startswith("http://"))
+        self.assertEqual(uris[0], final.output)
+
+    def test_the_original_and_cleaned_artifacts_decode_identically(self) -> None:
+        """Comments and formatting differ; the executable chain does not."""
+        cleaned = {s.output_sha256 for s in deobfuscate(_load(SAMPLE, SAMPLE_SHA))}
+        original = {s.output_sha256 for s in deobfuscate(_load(ORIGIN, ORIGIN_SHA))}
+        self.assertEqual(cleaned, original)
+        self.assertEqual(cleaned, set(EXPECTED.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When a script hands a decoder a string literal, an integer literal and a delimiter literal, the result is already determined by the bytes on disk. Three real runs showed the model getting that computation wrong — missing numeric coercion, passing an evidence id to `open()`, or not attempting it — with a full traceback and a dedicated repair instruction already in front of it. So the runtime computes those, and only those.

**Contract**

- **No malware/sample-specific constants in production.** Decoders are matched structurally by what their body does, never by name. A test rglobs `src/orbit` and fails on any sample or indicator constant.
- **Literal static transformations only.** Any call whose key, input or delimiter is not a literal is refused, as is a variable assigned more than once, and a PowerShell token list no `-bxor` consumes.
- **No arbitrary code execution.** No `eval`/`exec`/`__import__`/`subprocess`; decoded text is inert data that may be scanned, never run.
- **No network.** Only `hashlib`, `re`, `dataclasses`.
- **Outputs are EvidenceStore-attested,** one record per stage with provenance sufficient to redo it by hand; all re-attest.
- **Existing protections unchanged:** prompt guard, bounded repair, duplicate suppression, context admission, compaction/rehydration, KV prefix, CHAT. Runs once per artifact digest; spends **0 model calls and 0 action budget**.

**Qualification.** Full suite 4057 OK (skipped=8). 24 non-equivalent mutants caught, 2 proven equivalent. Offline oracle recovers all five stages from the pinned sample and from `_origin.js`, hashes matching.

Independent adversarial review returned BLOCKER 0 and 4 MAJOR — a wrong-decode via unguarded empty-string reassignment, PowerShell lists decoded without dataflow linkage, one malformed escape discarding every stage, and transform records consuming the report citation budget. All four reproduced and fixed with regression tests; two further defects (wrong-value decode on reassignment, wrong provenance offset) were found and fixed during implementation.
