### PR TITLE
fix(analysis): keep deterministic evidence in a refused report

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -2204,12 +2204,16 @@ class AnalysisRuntime:
         report is not evidence: the prose it produces is an answer about the
         record, never part of it.
         """
+        appendix = self.transform_appendix()
         records = self._reportable_records()
         if not records:
             # Deterministic, and free: there is nothing to ground a report in,
             # and asking a model to say so would be a call spent on a fact the
-            # runtime already knows.
-            return AnalysisReport(text=NO_EVIDENCE_REPORT, model_calls=0, evidence_ids=())
+            # runtime already knows. The appendix still stands: what the
+            # artifact determines does not depend on there being findings
+            # about it.
+            text = f"{NO_EVIDENCE_REPORT}\n\n{appendix}" if appendix else NO_EVIDENCE_REPORT
+            return AnalysisReport(text=text, model_calls=0, evidence_ids=())
 
         messages = self._report_messages(question, records)
 
@@ -2218,15 +2222,37 @@ class AnalysisRuntime:
                 on_delta(text)
 
         started = time.monotonic()
-        admitted = self._admit(
-            messages,
-            max_tokens=self.effective_max_tokens,
-            tools=[],
-            # The report runs with tools off and cannot issue a next action, so
-            # withholding that reserve would only narrow the path most likely to
-            # block. Chat makes the same phase-dependent choice.
-            next_action_reserve=0,
-        )
+        # A refused report must not take the deterministic evidence down with
+        # it. Admission fails exactly when the history is most crowded, which
+        # is exactly when a run has the most to say -- and the appendix is not
+        # model output: it is a rendering of records already on disk, and it
+        # costs nothing to produce. Losing it there would mean the values the
+        # runtime computed with certainty are the ones a full context discards
+        # first.
+        try:
+            admitted = self._admit(
+                messages,
+                max_tokens=self.effective_max_tokens,
+                tools=[],
+                # The report runs with tools off and cannot issue a next
+                # action, so withholding that reserve would only narrow the
+                # path most likely to block. Chat makes the same
+                # phase-dependent choice.
+                next_action_reserve=0,
+            )
+        except ContextAdmissionError:
+            if not appendix:
+                raise
+            return AnalysisReport(
+                text=(
+                    "The report could not be composed: the collected evidence "
+                    "no longer fits the context window. The deterministic "
+                    "transformations below are unaffected.\n\n"
+                    f"{appendix}"
+                ),
+                model_calls=0,
+                evidence_ids=tuple(r.evidence_id for r in records),
+            )
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
                 admitted,

--- a/tests/test_analysis_deobfuscate.py
+++ b/tests/test_analysis_deobfuscate.py
@@ -546,6 +546,61 @@ class ReportIntegrationTests(unittest.TestCase):
         for _stage, record in runtime.transform_stages:
             self.assertIn(record.evidence_id, appendix)
 
+    def test_the_appendix_survives_a_refused_report(self) -> None:
+        """Admission fails when the history is most crowded -- which is when a
+        run has the most to say. The appendix is not model output: it renders
+        records already on disk, so losing it there would discard exactly the
+        values the runtime computed with certainty.
+        """
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        uri = "http://synthetic.invalid/beacon?id=REFUSED"
+        runtime = self._runtime(decoder() + f'dec("{encode(uri, 31, ",")}", 31, ",");\n')
+        runtime.evidence_store.add(
+            "execute_analysis", "an action finding",
+            metadata={"tool_call_id": "c1", "user_turn_id": "t1",
+                      "produced_by_phase": "analysis_action"},
+        )
+
+        def _refuse(*_args, **_kwargs):
+            raise ContextAdmissionError("required-context-does-not-fit")
+
+        runtime._admit = _refuse
+        report = runtime.report("summarise")
+
+        self.assertEqual(report.model_calls, 0)
+        self.assertIn("## Deterministic transformations", report.text)
+        self.assertIn(uri, report.text)
+
+    def test_a_refused_report_still_raises_when_there_is_nothing_to_render(self) -> None:
+        """The guard rescues the appendix; it does not hide the failure."""
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        runtime = self._runtime("var x = 1;\n")
+        runtime.evidence_store.add(
+            "execute_analysis", "an action finding",
+            metadata={"tool_call_id": "c1", "user_turn_id": "t1",
+                      "produced_by_phase": "analysis_action"},
+        )
+
+        def _refuse(*_args, **_kwargs):
+            raise ContextAdmissionError("required-context-does-not-fit")
+
+        runtime._admit = _refuse
+        self.assertEqual(runtime.transform_stages, [])
+        with self.assertRaises(ContextAdmissionError):
+            runtime.report("summarise")
+
+    def test_the_appendix_stands_without_any_action_findings(self) -> None:
+        """What the artifact determines does not depend on findings about it."""
+        uri = "http://synthetic.invalid/only-transform"
+        runtime = self._runtime(decoder() + f'dec("{encode(uri, 13, ",")}", 13, ",");\n')
+        report = runtime.report("summarise")
+
+        self.assertEqual(report.model_calls, 0)
+        self.assertIn("## Deterministic transformations", report.text)
+        self.assertIn(uri, report.text)
+
     def test_the_appendix_is_appended_to_the_report_text(self) -> None:
         """Evidence rendering, not model prose -- so it cannot be omitted."""
         from orbit.backend.base import ChatResult


### PR DESCRIPTION
The first live run computed all five deterministic stages, attested them, and put their ids in front of the model — then the report was refused admission and the appendix never rendered, so the exact values never reached the analyst.

Admission fails precisely when the history is most crowded, which is when a run has the most to say. The appendix is not model output: it renders records already on disk. It is now built before the call, survives refusal, and stands when there are no findings at all. A refusal with nothing to render still raises — this rescues the evidence, it does not hide the failure.

Full suite 4060 OK (skipped=8). 3 mutants on the new guard, all caught.
