### PR TITLE
fix(repl): render deterministic analysis appendix after streaming

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -2272,7 +2272,8 @@ class AnalysisRuntime:
         # Appended after the model's prose, not merged into it: this is
         # evidence rendering, and keeping it separate is what makes it
         # independent of whether the model chose to mention any of it.
-        appendix = self.transform_appendix()
+        # Computed once at the top of the call and reused here, so the object
+        # a caller receives and the text a terminal prints cannot diverge.
         if appendix:
             text = f"{text}\n\n{appendix}"
         return AnalysisReport(

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -488,6 +488,22 @@ class Repl:
                     ),
                     flush=True,
                 )
+            elif run.final_report is not None:
+                # The prose streamed, so `final_report.text` would repeat it --
+                # but the deterministic appendix is attached after the stream
+                # finishes and so has never been shown. Same omission the
+                # `/report` path had, on the path that produces the most
+                # evidence: without this, a run that decodes an address
+                # computes it, attests it, and never tells anyone. Sanitized
+                # for the same reason as the branch above: this print does not
+                # pass the renderer, and the content is decoded artifact bytes.
+                appendix = self.analysis.transform_appendix()
+                if appendix:
+                    print("\n")
+                    print(
+                        sanitize_terminal_text(appendix, allow_newlines=True),
+                        flush=True,
+                    )
             replans = f" | replans: {run.replans}" if run.replans else ""
             summary = (
                 f"analysis | mode: ANALYSIS | model calls: {run.model_calls} | "
@@ -921,11 +937,28 @@ class Repl:
             return
         renderer.finish()
         if report.model_calls == 0:
-            # Today this branch can only carry NO_EVIDENCE_REPORT, a constant.
-            # It is sanitized anyway because it is a print that never passed
-            # the renderer's boundary: if the branch ever comes to carry model
-            # prose, it is already safe rather than newly vulnerable.
+            # Nothing was streamed, so this branch carries the whole report --
+            # NO_EVIDENCE_REPORT, a refusal notice, or either of those with the
+            # deterministic appendix already attached by `report()`. Sanitized
+            # because it is a print that never passed the renderer's boundary.
             print(sanitize_terminal_text(report.text, allow_newlines=True), flush=True)
+        else:
+            # The model's prose reached the terminal through `on_delta` as it
+            # was generated. The appendix did not: `report()` attaches it to
+            # `report.text` after the stream has finished, so printing only
+            # what was streamed drops it silently -- and it is the half of the
+            # report that does not depend on the model having mentioned
+            # anything. Printing `report.text` here instead would repeat the
+            # prose the analyst has already watched arrive, so only the part
+            # that was never shown is printed.
+            appendix = self.analysis.transform_appendix()
+            if appendix:
+                # Two breaks, not one: streamed deltas leave the cursor
+                # mid-line, so a single newline only closes it and the heading
+                # would butt against the prose. `report.text` joins the two
+                # halves with a blank line, and the terminal should match.
+                print("\n")
+                print(sanitize_terminal_text(appendix, allow_newlines=True), flush=True)
         elapsed = time.monotonic() - started
         summary = (
             f"report | mode: ANALYSIS | model calls: {report.model_calls} | "

--- a/tests/test_analysis_report_visibility.py
+++ b/tests/test_analysis_report_visibility.py
@@ -1,0 +1,576 @@
+"""The deterministic appendix must reach the analyst on both report paths.
+
+`report()` streams the model's prose through `on_delta` and attaches the
+appendix to `report.text` afterwards. A terminal that prints `report.text`
+only when no model call happened therefore shows the appendix on the empty
+path and silently drops it on the ordinary one -- losing exactly the half of
+the report that does not depend on the model having mentioned anything.
+
+These cover both paths, and the two failure modes a naive fix invites: the
+prose printed twice, or the appendix printed twice.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.backend.base import ChatResult
+from orbit.runtime.analysis_runtime import (
+    AnalysisRuntime,
+    acquire_analysis_source,
+)
+from orbit.runtime.evidence import EvidenceStore
+from orbit.terminal.config import AppConfig
+from orbit.terminal.repl import Repl
+from orbit.runtime.workflow_mode import WorkflowMode
+
+PROSE = "The artifact drops a hidden second stage."
+HEADING = "## Deterministic transformations"
+
+DECODER = (
+    "function dec(s, k, d) {\n"
+    "    var out = '';\n"
+    "    var parts = s.split(d);\n"
+    "    for (var i = 0; i < parts.length; i++) {\n"
+    "        out += String.fromCharCode(parts[i] ^ k);\n"
+    "    }\n"
+    "    return out;\n"
+    "}\n"
+)
+
+
+def encode(text: str, key: int, delimiter: str) -> str:
+    return delimiter.join(str(ord(c) ^ key) for c in text)
+
+
+class _ReportBackend:
+    """Streams prose the way the real backend does, then returns it."""
+
+    def __init__(self, prose: str = PROSE) -> None:
+        self.prose = prose
+        self.calls = 0
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                    on_delta=None, on_progress=None):
+        self.calls += 1
+        if on_delta:
+            on_delta(self.prose)
+        return ChatResult(
+            content=self.prose, model="m", finish_reason="stop", tool_calls=[],
+            prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+
+
+class _StubBackend:
+    """The Repl configures `thinking` on its backend at construction."""
+
+    thinking = False
+
+
+class _StubRuntime:
+    """The chat runtime the Repl requires but this path never uses."""
+
+    def __init__(self) -> None:
+        self.messages: list = []
+        self.context_tokens = 8192
+        self.evidence_store = None
+        self.last_memory_refresh = None
+
+    def can_continue_last_response(self) -> bool:
+        return False
+
+
+class ReportVisibilityTestBase(unittest.TestCase):
+    def _analysis(self, source_text: str, backend=None) -> AnalysisRuntime:
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-report-vis-")
+        self.addCleanup(tmpdir.cleanup)
+        tmp = Path(tmpdir.name)
+        artifact = tmp / "artifact.js"
+        artifact.write_text(source_text, encoding="utf-8")
+        runtime = AnalysisRuntime(
+            backend=backend,
+            source=acquire_analysis_source(artifact, tmp / "owned"),
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def _repl(self, analysis: AnalysisRuntime) -> Repl:
+        stub = _StubRuntime()
+        repl = Repl(runtime=stub, backend=_StubBackend(), config=AppConfig(workdir=Path(".")))
+        repl.analysis = analysis
+        repl.workflow_mode = WorkflowMode.ANALYSIS
+        return repl
+
+    def _render(self, analysis: AnalysisRuntime) -> str:
+        """What the analyst actually sees for `/report`."""
+        repl = self._repl(analysis)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._handle_report_command("summarise")
+        return out.getvalue()
+
+    def _finding(self, analysis: AnalysisRuntime) -> None:
+        """One ordinary action finding, so a model report has something to cite."""
+        analysis.evidence_store.add(
+            "execute_analysis", "an action finding",
+            metadata={"tool_call_id": "c1", "user_turn_id": "t1",
+                      "produced_by_phase": "analysis_action"},
+        )
+
+
+class StreamedPathTests(ReportVisibilityTestBase):
+    """model_calls > 0: prose streamed, appendix printed after."""
+
+    def _source(self, secret: str = "STAGE-TWO") -> str:
+        return DECODER + f'dec("{encode(secret, 19, ",")}", 19, ",");\n'
+
+    def test_prose_and_appendix_each_appear_exactly_once(self) -> None:
+        analysis = self._analysis(self._source(), backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertEqual(output.count(PROSE), 1, "model prose must not repeat")
+        self.assertEqual(output.count(HEADING), 1, "appendix must not repeat")
+        self.assertIn("STAGE-TWO", output)
+
+    def test_the_appendix_follows_the_model_prose(self) -> None:
+        analysis = self._analysis(self._source(), backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertLess(
+            output.index(PROSE), output.index(HEADING),
+            "deterministic evidence is rendered after the reasoning about it",
+        )
+
+    def test_the_whole_report_text_is_not_printed_again(self) -> None:
+        """Printing `report.text` here would repeat prose already streamed."""
+        analysis = self._analysis(self._source(), backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+        self.assertEqual(output.count(PROSE), 1)
+
+    def test_prose_resembling_the_appendix_is_not_truncated_or_split(self) -> None:
+        """No slicing of the report text: the two halves are never separated
+        by searching for a heading that the model may itself have written."""
+        mimic = f"I will now describe them.\n{HEADING}\nnothing real here."
+        analysis = self._analysis(self._source(), backend=_ReportBackend(mimic))
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertIn("I will now describe them.", output)
+        self.assertIn("nothing real here.", output)
+        # The model's imitation plus the real one.
+        self.assertEqual(output.count(HEADING), 2)
+        self.assertIn("STAGE-TWO", output)
+
+    def test_multiple_stages_all_render(self) -> None:
+        source = DECODER + "".join(
+            f'dec("{encode(f"STAGE-{i}", 7, ",")}", 7, ",");\n' for i in range(4)
+        )
+        analysis = self._analysis(source, backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertEqual(len(analysis.transform_stages), 4)
+        for index in range(4):
+            with self.subTest(stage=index):
+                self.assertIn(f"STAGE-{index}", output)
+        for _stage, record in analysis.transform_stages:
+            self.assertIn(record.evidence_id, output)
+
+    def test_a_decoded_uri_is_rendered_verbatim(self) -> None:
+        uri = "http://synthetic.invalid/beacon?id=VISIBLE"
+        analysis = self._analysis(
+            DECODER + f'dec("{encode(uri, 29, ",")}", 29, ",");\n',
+            backend=_ReportBackend(),
+        )
+        self._finding(analysis)
+
+        self.assertIn(uri, self._render(analysis))
+
+
+class ZeroModelCallPathTests(ReportVisibilityTestBase):
+    """model_calls == 0: the whole report is printed, and only once."""
+
+    def test_the_appendix_appears_once_with_no_findings(self) -> None:
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("ONLY-TRANSFORM", 11, ",")}", 11, ",");\n'
+        )
+        output = self._render(analysis)
+
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertIn("ONLY-TRANSFORM", output)
+
+    def test_the_no_evidence_notice_reaches_the_terminal(self) -> None:
+        """The zero-call branch carries the whole report, not just the
+        appendix: a session with nothing to say must still say it."""
+        from orbit.runtime.analysis_runtime import NO_EVIDENCE_REPORT
+
+        analysis = self._analysis("var x = 1;\n")
+        output = self._render(analysis)
+
+        self.assertIn(NO_EVIDENCE_REPORT, output)
+
+    def test_the_no_evidence_notice_accompanies_the_appendix(self) -> None:
+        """Both halves, when an artifact decodes but produced no findings."""
+        from orbit.runtime.analysis_runtime import NO_EVIDENCE_REPORT
+
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("NOTICE-AND-STAGE", 5, ",")}", 5, ",");\n'
+        )
+        output = self._render(analysis)
+
+        self.assertIn(NO_EVIDENCE_REPORT, output)
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertIn("NOTICE-AND-STAGE", output)
+
+    def test_a_refusal_notice_reaches_the_terminal(self) -> None:
+        """A refused report must say so, not silently print evidence."""
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("REFUSAL-TEXT", 9, ",")}", 9, ",");\n',
+            backend=_ReportBackend(),
+        )
+        self._finding(analysis)
+
+        def _refuse(*_args, **_kwargs):
+            raise ContextAdmissionError("required-context-does-not-fit")
+
+        analysis._admit = _refuse
+        output = self._render(analysis)
+
+        self.assertIn("could not be composed", output)
+        self.assertIn("REFUSAL-TEXT", output)
+
+    def test_a_refused_report_still_shows_the_appendix_once(self) -> None:
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("REFUSED-BUT-SHOWN", 23, ",")}", 23, ",");\n',
+            backend=_ReportBackend(),
+        )
+        self._finding(analysis)
+
+        def _refuse(*_args, **_kwargs):
+            raise ContextAdmissionError("required-context-does-not-fit")
+
+        analysis._admit = _refuse
+        output = self._render(analysis)
+
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertIn("REFUSED-BUT-SHOWN", output)
+
+
+class NoTransformTests(ReportVisibilityTestBase):
+    """An artifact with nothing to decode emits no appendix at all."""
+
+    def test_no_phantom_appendix_on_the_streamed_path(self) -> None:
+        analysis = self._analysis("var x = 1;\n", backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertEqual(analysis.transform_stages, [])
+        self.assertIn(PROSE, output)
+        self.assertNotIn(HEADING, output)
+        self.assertNotIn("Deterministic", output)
+        # Nor blank separators for an appendix that does not exist: the guard
+        # decides whether anything is emitted at all, not merely what. Without
+        # it the branch still prints its separator, leaving trailing blank
+        # lines after the prose that no content ever follows.
+        self.assertEqual(output.rstrip("\n").count("\n\n\n"), 0)
+        self.assertFalse(
+            output.endswith("\n\n\n"),
+            "an absent appendix must emit no separator of its own",
+        )
+
+    def test_no_phantom_appendix_on_the_zero_call_path(self) -> None:
+        analysis = self._analysis("var x = 1;\n")
+        output = self._render(analysis)
+        self.assertNotIn(HEADING, output)
+
+
+REPORT_PROSE = "Closing report prose, distinct from any step."
+
+
+class _TwoPhaseBackend:
+    """Step prose first, then a distinct closing-report prose.
+
+    The autonomous path makes several model calls; reusing one string for all
+    of them would make "printed once" unfalsifiable.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def chat_stream(self, messages, *, temperature, max_tokens, tools=None,
+                    on_delta=None, on_progress=None):
+        self.calls += 1
+        text = REPORT_PROSE if tools == [] else PROSE
+        if on_delta:
+            on_delta(text)
+        return ChatResult(
+            content=text, model="m", finish_reason="stop", tool_calls=[],
+            prompt_tokens=10, completion_tokens=5, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+
+
+class AutonomousRunTests(ReportVisibilityTestBase):
+    """The closing report of an autonomous run has the same two paths.
+
+    This is where a run produces the most evidence, so an appendix dropped
+    here is the whole defect again on the path that matters most: the address
+    is computed, attested, and never told to anyone.
+    """
+
+    def _autonomous_repl(self, analysis: AnalysisRuntime) -> Repl:
+        repl = self._repl(analysis)
+        repl.autonomous_analysis = True
+        return repl
+
+    def _run(self, analysis: AnalysisRuntime) -> str:
+        repl = self._autonomous_repl(analysis)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._ask_analysis("analyse this artifact")
+        return out.getvalue()
+
+    def _source(self, secret: str) -> str:
+        return DECODER + f'dec("{encode(secret, 21, ",")}", 21, ",");\n'
+
+    def _run_with_finding(self, analysis: AnalysisRuntime) -> str:
+        """A finding, so the closing report really makes a model call.
+
+        Without one `report()` short-circuits to NO_EVIDENCE_REPORT with
+        `model_calls == 0` -- the other branch entirely, which would leave the
+        streamed path untested while appearing to pass.
+        """
+        self._finding(analysis)
+        return self._run(analysis)
+
+    def test_the_appendix_reaches_the_terminal_when_the_report_streams(self) -> None:
+        uri = "http://synthetic.invalid/c2-AUTONOMOUS"
+        analysis = self._analysis(self._source(uri), backend=_ReportBackend())
+
+        output = self._run_with_finding(analysis)
+
+        self.assertIn(PROSE, output, "the closing report must have streamed")
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertIn(uri, output)
+
+    def test_the_closing_prose_is_not_repeated_when_the_report_streams(self) -> None:
+        """Printing `final_report.text` here would show it a second time."""
+        analysis = self._analysis(self._source("AUTO-STAGE"), backend=_TwoPhaseBackend())
+        output = self._run_with_finding(analysis)
+
+        self.assertEqual(output.count(REPORT_PROSE), 1)
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertIn("AUTO-STAGE", output)
+
+    def test_decoded_control_sequences_are_neutralised_on_this_path_too(self) -> None:
+        hostile = "\x1b[2Jforged\r\x07"
+        analysis = self._analysis(
+            DECODER + f'dec("{encode(hostile, 21, ",")}", 21, ",");\n',
+            backend=_ReportBackend(),
+        )
+        output = self._run_with_finding(analysis)
+
+        self.assertIn(HEADING, output)
+        for char in ("\x1b", "\r", "\x07"):
+            with self.subTest(control=repr(char)):
+                self.assertNotIn(char, output)
+
+    def test_no_phantom_appendix_when_nothing_decodes(self) -> None:
+        analysis = self._analysis("var x = 1;\n", backend=_ReportBackend())
+        output = self._run_with_finding(analysis)
+        self.assertIn(PROSE, output)
+        self.assertNotIn(HEADING, output)
+
+
+class TerminalSafetyTests(ReportVisibilityTestBase):
+    """Decoded bytes are attacker-controlled and reach the terminal here.
+
+    The appendix renders content the artifact chose. Printing it unsanitised
+    would let a decoded payload clear the screen, forge Orbit's own output,
+    set the window title, or write the clipboard through OSC 52 -- so the
+    sanitiser on this path is a security control, and these pin it.
+    """
+
+    HOSTILE = (
+        "\x1b[2J\x1b[H"          # clear screen, home cursor
+        "\x1b[31mforged\x1b[0m"  # colour, imitating runtime output
+        "\r overwrite"           # carriage return
+        "\x1b]0;title\x07"       # OSC window title + BEL
+        "\x1b]52;c;ZXZpbA==\x07"  # OSC 52 clipboard write
+        "\x9b2J"                 # 8-bit C1 CSI
+    )
+
+    def _hostile_source(self) -> str:
+        return DECODER + f'dec("{encode(self.HOSTILE, 3, ",")}", 3, ",");\n'
+
+    def _assert_inert(self, output: str) -> None:
+        for name, char in (
+            ("ESC", "\x1b"), ("CR", "\r"), ("BEL", "\x07"),
+            ("C1-CSI", "\x9b"), ("NUL", "\x00"),
+        ):
+            with self.subTest(control=name):
+                self.assertNotIn(char, output)
+
+    def test_the_streamed_path_neutralises_decoded_control_sequences(self) -> None:
+        analysis = self._analysis(self._hostile_source(), backend=_ReportBackend())
+        self._finding(analysis)
+
+        raw = analysis.transform_appendix()
+        self.assertIn("\x1b", raw, "the fixture must really carry escapes")
+
+        output = self._render(analysis)
+        self.assertIn(HEADING, output)
+        self._assert_inert(output)
+
+    def test_the_zero_call_path_neutralises_decoded_control_sequences(self) -> None:
+        analysis = self._analysis(self._hostile_source())
+        output = self._render(analysis)
+
+        self.assertIn(HEADING, output)
+        self._assert_inert(output)
+
+    def test_the_appendix_keeps_its_line_structure(self) -> None:
+        """`allow_newlines=True`: without it the whole appendix collapses into
+        one unreadable line and every entry runs together."""
+        source = DECODER + "".join(
+            f'dec("{encode(f"LINE-{i}", 7, ",")}", 7, ",");\n' for i in range(3)
+        )
+        analysis = self._analysis(source, backend=_ReportBackend())
+        self._finding(analysis)
+
+        output = self._render(analysis)
+        appendix_lines = [
+            line for line in output.splitlines() if line.startswith("  output: ")
+        ]
+        self.assertEqual(len(appendix_lines), 3)
+
+
+class ReportObjectTests(ReportVisibilityTestBase):
+    """The report object an API consumer receives is unchanged."""
+
+    def test_report_text_still_carries_prose_and_appendix(self) -> None:
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("API-STAGE", 17, ",")}", 17, ",");\n',
+            backend=_ReportBackend(),
+        )
+        self._finding(analysis)
+
+        report = analysis.report("summarise")
+
+        self.assertEqual(report.model_calls, 1)
+        self.assertIn(PROSE, report.text)
+        self.assertIn(HEADING, report.text)
+        self.assertIn("API-STAGE", report.text)
+
+    def test_rendering_does_not_mutate_the_store_or_the_stages(self) -> None:
+        analysis = self._analysis(
+            DECODER + f'dec("{encode("STABLE", 13, ",")}", 13, ",");\n',
+            backend=_ReportBackend(),
+        )
+        self._finding(analysis)
+        before_stages = list(analysis.transform_stages)
+        before_ids = set(analysis.evidence_store.records)
+
+        self._render(analysis)
+
+        self.assertEqual(analysis.transform_stages, before_stages)
+        self.assertEqual(set(analysis.evidence_store.records), before_ids)
+        for _stage, record in analysis.transform_stages:
+            self.assertIsNotNone(
+                analysis.evidence_store.reattest_exact(record.evidence_id)
+            )
+
+
+class RealSampleRenderingTests(ReportVisibilityTestBase):
+    """The pinned artifact, rendered with no model inference.
+
+    The expected URL is used here as a post-generation oracle: the
+    deterministic pass recovered it independently, and this asserts only that
+    what was recovered actually reaches the analyst.
+    """
+
+    SAMPLE = Path(__file__).resolve().parents[1] / "workdir" / "samples" / "Fattura981033956.js"
+    SAMPLE_SHA = "b7cfd5fdeb16d7b5ecea1063419bdad6ad280ed9b73c636707874c3f4001dc0c"
+    EXPECTED_URI = (
+        "http://smartmaket.com/1.php?s=AA1789FF-522F-4D9A-94E9-C9BE2BA3A1D3"
+    )
+
+    def _real_analysis(self) -> AnalysisRuntime:
+        import hashlib
+
+        if not self.SAMPLE.exists():
+            self.skipTest("pinned sample not present")
+        data = self.SAMPLE.read_bytes()
+        if hashlib.sha256(data).hexdigest() != self.SAMPLE_SHA:
+            self.skipTest("sample is not the pinned artifact")
+
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-real-render-")
+        self.addCleanup(tmpdir.cleanup)
+        tmp = Path(tmpdir.name)
+        artifact = tmp / "sample.js"
+        shutil.copy(self.SAMPLE, artifact)
+        runtime = AnalysisRuntime(
+            backend=_ReportBackend(),
+            source=acquire_analysis_source(artifact, tmp / "owned"),
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def test_every_stage_reaches_the_terminal(self) -> None:
+        analysis = self._real_analysis()
+        self._finding(analysis)
+
+        output = self._render(analysis)
+
+        self.assertEqual(len(analysis.transform_stages), 5)
+        self.assertEqual(output.count(HEADING), 1)
+        # S1-S3: exact short outputs.
+        self.assertIn(r"winmgmts:\\.\root\cimv2", output)
+        self.assertIn("Win32_ProcessStartup", output)
+        self.assertIn(r"winmgmts:\\.\root\cimv2:Win32_Process", output)
+        # S4: too long to inline, so identity, length and digest.
+        self.assertIn("1008 chars", output)
+        self.assertIn(
+            "ec8ccda0cbdce79a76748c0e32c1fb788276c762abc5fd8c6f77609a0c8f58f1", output
+        )
+        # S5: the recovered address, verbatim.
+        self.assertIn(self.EXPECTED_URI, output)
+
+    def test_the_appendix_is_rendered_exactly_once(self) -> None:
+        """Once as a block. The address appears twice inside it -- as the
+        stage's own short output and again on the `decoded URI` line, which
+        exists so an indicator survives a stage too long to inline -- and that
+        redundancy is the rendering rule rather than a repeated appendix.
+        """
+        analysis = self._real_analysis()
+        self._finding(analysis)
+        output = self._render(analysis)
+
+        self.assertEqual(output.count(HEADING), 1)
+        self.assertEqual(output.count(f"decoded URI: {self.EXPECTED_URI}"), 1)
+        self.assertEqual(output.count(PROSE), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The deterministic pass recovers a decoded address from the artifact bytes, attests it, attaches it to the report — and the analyst never saw it. `report()` streams the model's prose via `on_delta` and appends the appendix to `report.text` afterwards, so a terminal printing `report.text` only when `model_calls == 0` showed it on the empty path and dropped it silently on the ordinary one.

**Both** report paths had the omission: `/report`, and the closing report of an autonomous run (which printed the full text only when the backend had *not* streamed — real backends always do). The second is where a run produces the most evidence.

Each now prints only the appendix; printing `report.text` would repeat prose already streamed. Both prints are sanitized — the content is decoded artifact bytes, so a payload must not be able to clear the screen, forge Orbit output, or write the clipboard via OSC 52. The report object is unchanged.

Full suite 4084 OK (skipped=8). 15 non-equivalent mutants caught. Independent review returned BLOCKER 0 and 2 MAJOR (the autonomous path still dropping the appendix; sanitization untested) plus 1 MINOR (separator parity) — all three fixed, each pinned by test.
