### PR TITLE
fix(cli): clarify autonomous analysis UX

### DIFF
--- a/src/orbit/terminal/command_registry.py
+++ b/src/orbit/terminal/command_registry.py
@@ -53,28 +53,34 @@ COMMANDS = (
         "Show tool access or local capabilities.",
         "tools",
     ),
+    # Ordered by what each one does, not alphabetically: start, control how it
+    # advances, report on what it found, leave. The four were previously easy
+    # to confuse -- `/autonomous` in particular reads like it begins something,
+    # and it does not.
     CommandSpec(
         "/analysis",
         "Analysis",
         "/analysis <path>",
-        "Analyse one local artifact in an isolated workspace.",
+        "Start analysis of a local artifact and collect evidence.",
         "analysis",
-    ),
-    CommandSpec(
-        "/report",
-        "Analysis",
-        "/report [question]",
-        "Report on the evidence already collected, running no analysis action.",
-        "report",
     ),
     CommandSpec(
         "/autonomous",
         "Analysis",
         "/autonomous [off|on]",
-        "Show or set autonomous analysis for this session.",
+        "Control how ANALYSIS advances. off = one evidence step at a time. "
+        "on = continue automatically until completion or a runtime stop. "
+        "Does not enter analysis mode by itself.",
         "autonomous",
     ),
-    CommandSpec("/chat", "Analysis", "/chat", "Return to normal chat mode.", "chat"),
+    CommandSpec(
+        "/report",
+        "Analysis",
+        "/report [question]",
+        "Answer from evidence already collected. Runs no new analysis action.",
+        "report",
+    ),
+    CommandSpec("/chat", "Analysis", "/chat", "Leave ANALYSIS and return to normal chat.", "chat"),
     CommandSpec("/help", "Help", "/help", "Show command help.", "help"),
 )
 

--- a/src/orbit/terminal/commands.py
+++ b/src/orbit/terminal/commands.py
@@ -81,8 +81,11 @@ def runtime_status(
     backend: LlamaServerBackend,
     *,
     tools_mode: ToolSpec | None = None,
+    autonomous: bool = False,
 ) -> str:
-    status = collect_runtime_status(runtime, config, backend, tools_mode=tools_mode)
+    status = collect_runtime_status(
+        runtime, config, backend, tools_mode=tools_mode, autonomous=autonomous
+    )
     return format_status_panel(status)
 
 

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -51,9 +51,17 @@ from orbit.terminal.status import (
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
-from orbit.terminal.theme import dim, runtime_error_text, sanitize_terminal_text
+from orbit.terminal.theme import dim, on_off, runtime_error_text, sanitize_terminal_text
 from orbit.runtime.thinking_mode import ThinkingMode
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
+
+
+# What an autonomous run is asked to do when the analyst named an artifact and
+# nothing else. It is the analyst's opening line, not a runtime instruction to
+# the model: the same words a person types to begin, so an autonomous session
+# and a guided one start from the same request. Deliberately general -- naming
+# a technique here would be the terminal doing analysis.
+ANALYSIS_OPENING_INSTRUCTION = "Analyse this artifact and report what it does."
 
 
 def _abbreviate_home(path: Path) -> str:
@@ -153,7 +161,15 @@ class Repl:
     def run(self) -> int:
         if self.history:
             self.history.load()
-        status = collect_runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode)
+        status = collect_runtime_status(
+            self.runtime,
+            self.config,
+            self.backend,
+            tools_mode=self.tools_mode,
+            # From the Repl's own state, so the banner cannot claim an
+            # autonomy setting the session does not actually hold.
+            autonomous=bool(self.autonomous_analysis),
+        )
         for line in format_startup_banner(status).splitlines():
             print(dim(line))
         self._announce_workdir()
@@ -174,8 +190,9 @@ class Repl:
             # change the mode, so re-deriving it after the fact would erase
             # the wrong number of rows.
             echo_label = self._prompt_label()
+            echo_auto = bool(self.autonomous_analysis)
             if prompt.startswith("/"):
-                clear_input_echo(prompt, echo_label)
+                clear_input_echo(prompt, echo_label, autonomous=echo_auto)
                 self.prompt_redisplay_pending = True
                 if self._handle_command(prompt):
                     self.prompt_gap_pending = True
@@ -190,9 +207,9 @@ class Repl:
                 if resolution.prompt != prompt:
                     prompt = resolution.prompt
                 else:
-                    replace_input_echo(prompt, echo_label)
+                    replace_input_echo(prompt, echo_label, autonomous=echo_auto)
             else:
-                replace_input_echo(prompt, echo_label)
+                replace_input_echo(prompt, echo_label, autonomous=echo_auto)
             if self.history:
                 self.history.add(prompt)
                 self.history.save()
@@ -219,9 +236,13 @@ class Repl:
     def _prompt_label(self) -> str:
         """The marker for the runtime that owns the next line.
 
-        Read straight off `workflow_mode`, the state the Repl already keeps,
-        so the marker cannot drift from the mode it names. Display only: it
-        is never appended to history and never reaches the backend.
+        Read straight off `workflow_mode`, so the marker cannot drift from the
+        mode it names. The autonomy state shown beside it is passed separately
+        to `input_prompt`, which owns every escape the prompt emits: a label
+        carrying its own colour would land outside readline's ignore markers
+        and corrupt the cursor arithmetic on every edited line.
+
+        Display only: never appended to history, never sent to the backend.
         """
         return "analysis" if self.workflow_mode is WorkflowMode.ANALYSIS else "chat"
 
@@ -232,8 +253,10 @@ class Repl:
         label = self._prompt_label()
         if self.prompt_redisplay_pending:
             self.prompt_redisplay_pending = False
-            return read_prompt_input(redisplay=True, label=label)
-        return read_prompt_input(label=label)
+            return read_prompt_input(
+                redisplay=True, label=label, autonomous=bool(self.autonomous_analysis)
+            )
+        return read_prompt_input(label=label, autonomous=bool(self.autonomous_analysis))
 
     def _ask(self, prompt: str, *, command_action: CommandAction | None = None) -> None:
         # The mode decides which runtime owns this line before anything else
@@ -699,7 +722,15 @@ class Repl:
             print(self._handle_think_command(f"/think {arguments}".rstrip()))
             return True
         if handler == "status" and not arguments:
-            print(runtime_status(self.runtime, self.config, self.backend, tools_mode=self.tools_mode))
+            print(
+                runtime_status(
+                    self.runtime,
+                    self.config,
+                    self.backend,
+                    tools_mode=self.tools_mode,
+                    autonomous=bool(self.autonomous_analysis),
+                )
+            )
             print(format_session_token_usage(self.session_token_usage.snapshot()))
             return True
         if handler == "status" and arguments in {"ctx", "context"}:
@@ -718,7 +749,30 @@ class Repl:
             print(self._handle_tools_command(f"/tools {arguments}".rstrip()))
             return True
         if handler == "analysis":
+            opened = self.analysis
             print(self._handle_analysis_command(arguments))
+            # Naming an artifact with autonomy already on is a complete
+            # instruction: the analyst has said what to analyse and how it
+            # should advance, and asking them to type a further line to begin
+            # is asking twice.
+            #
+            # The condition is that THIS command opened a session, not that a
+            # session exists. A refused path leaves the mode and the previous
+            # session deliberately untouched -- "a typo must not silently drop
+            # the analyst out of the session they were in" -- so testing the
+            # mode would let a mistyped name launch a run against the artifact
+            # that was already open. Identity of the session object is what
+            # actually distinguishes the two.
+            #
+            # Toggling autonomy still starts nothing by itself: `/autonomous`
+            # never reaches here. Guided mode is untouched, because the
+            # condition is the setting the analyst chose.
+            if (
+                self.autonomous_analysis
+                and self.analysis is not None
+                and self.analysis is not opened
+            ):
+                self._ask_analysis(ANALYSIS_OPENING_INSTRUCTION)
             return True
         if handler == "report":
             self._handle_report_command(arguments)
@@ -809,7 +863,7 @@ class Repl:
         """
         value = arguments.strip().lower()
         if not value:
-            return f"autonomous analysis: {'on' if self.autonomous_analysis else 'off'}"
+            return f"autonomous analysis: {on_off(self.autonomous_analysis)}"
         if value not in {"on", "off"}:
             # The state is left exactly as it was: a mistyped argument must not
             # decide whether an analysis runs itself.

--- a/src/orbit/terminal/repl_input.py
+++ b/src/orbit/terminal/repl_input.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from shutil import get_terminal_size
 
 from orbit.terminal.prompt_preview import compact_prompt_preview, is_long_text_prompt
-from orbit.terminal.theme import CYAN, RESET, YELLOW, accent, yellow_dim
+from orbit.terminal.theme import CYAN, GREEN, RED, RESET, YELLOW, accent, yellow_dim
 
 
 PASTE_BADGE_PATTERN = re.compile(r"(\[text \d+ chars #[0-9a-f]{8}\])$")
@@ -17,10 +17,12 @@ READLINE_IGNORE_START = "\001"
 READLINE_IGNORE_END = "\002"
 
 
-def read_prompt_input(*, redisplay: bool = False, label: str = "") -> str:
+def read_prompt_input(
+    *, redisplay: bool = False, label: str = "", autonomous: bool = False
+) -> str:
     clear_redisplay_hook = _install_redisplay_hook() if redisplay else None
     try:
-        first_line = input(input_prompt(label))
+        first_line = input(input_prompt(label, autonomous=autonomous))
     finally:
         if clear_redisplay_hook is not None:
             clear_redisplay_hook()
@@ -56,44 +58,74 @@ def _install_redisplay_hook() -> Callable[[], None] | None:
     return clear_hook
 
 
-def input_prompt(label: str = "") -> str:
-    """The marker the analyst types after.
+def prompt_marker(label: str = "", *, autonomous: bool = False) -> str:
+    """The prompt's visible text, with no colour and no readline markers.
 
-    `label` names the runtime that owns the next line. It is display only:
-    the caller passes the mode it already holds, so nothing here decides or
-    stores what mode the session is in, and the string never reaches a model.
+    The single definition of what the analyst sees, so the rendered prompt and
+    the echo-clearing arithmetic cannot disagree about its width. They did:
+    the prompt grew an `[auto:...]` segment while the row count was still
+    computed from the bare mode, which erased one row too few whenever the
+    difference pushed a typed line across the terminal edge.
     """
+    return f"{label} [auto:{'on' if autonomous else 'off'}]> "
+
+
+def input_prompt(label: str = "", *, autonomous: bool = False) -> str:
+    """The marker the analyst types after, with the autonomy state beside it.
+
+    `label` names the runtime that owns the next line and `autonomous` says
+    how it will advance. Both are display only: the caller passes state it
+    already holds, so nothing here decides or stores anything, and the string
+    never reaches a model.
+
+    Autonomy is shown because it is otherwise invisible. `/autonomous on`
+    deliberately changes no mode, so without this the analyst types it, sees
+    the prompt unchanged, and cannot tell whether it took effect.
+
+    Every escape this emits is wrapped in readline's ignore markers, which is
+    why the colouring lives here rather than in the label: readline counts the
+    prompt's width to place the cursor, and an unwrapped escape makes it
+    mis-count on every edited line. A caller that coloured its own label would
+    put those bytes outside the markers.
+    """
+    state = "on" if autonomous else "off"
     if not sys.stdout.isatty():
-        return f"{label}> "
+        return prompt_marker(label, autonomous=autonomous)
     # ANALYSIS is amber, not red: the session is doing normal work under
-    # different rules, and red belongs to failures. The colour is chosen from
-    # the label the caller passed, so it cannot disagree with the text.
+    # different rules, and red belongs to failures. Chosen from the label the
+    # caller passed, so it cannot disagree with the text.
     colour = YELLOW if label == "analysis" else CYAN
+    state_colour = GREEN if autonomous else RED
     return (
-        f"{READLINE_IGNORE_START}{colour}{READLINE_IGNORE_END}{label}> "
+        f"{READLINE_IGNORE_START}{colour}{READLINE_IGNORE_END}{label} [auto:"
+        f"{READLINE_IGNORE_START}{state_colour}{READLINE_IGNORE_END}{state}"
+        f"{READLINE_IGNORE_START}{colour}{READLINE_IGNORE_END}]> "
         f"{READLINE_IGNORE_START}{RESET}{READLINE_IGNORE_END}"
     )
 
 
-def replace_input_echo(prompt: str, label: str = "") -> None:
+def replace_input_echo(prompt: str, label: str = "", *, autonomous: bool = False) -> None:
     if not should_replace_input_echo(prompt):
         return
     if not sys.stdout.isatty():
         return
+    marker = prompt_marker(label, autonomous=autonomous)
     preview = compact_prompt_preview(prompt, multiline=True)
-    rendered = colorize_user_prompt(f"{label}> {preview}")
+    rendered = colorize_user_prompt(f"{marker}{preview}")
     columns = max(20, get_terminal_size((80, 20)).columns)
-    # The marker occupies columns on the first row, so the label has to be
-    # counted or a wrapped line is erased one row short.
-    visual_rows = visual_row_count(f"{label}> {prompt}", columns=columns)
+    # The marker occupies columns on the first row, so it has to be counted --
+    # in the form actually displayed -- or a wrapped line is erased one row
+    # short.
+    visual_rows = visual_row_count(f"{marker}{prompt}", columns=columns)
     print(f"\x1b[{visual_rows}F\x1b[J{rendered}", flush=True)
 
 
-def clear_input_echo(prompt: str, label: str = "") -> None:
+def clear_input_echo(prompt: str, label: str = "", *, autonomous: bool = False) -> None:
     if not sys.stdout.isatty():
         return
     columns = max(20, get_terminal_size((80, 20)).columns)
-    visual_rows = visual_row_count(f"{label}> {prompt}", columns=columns)
+    marker = prompt_marker(label, autonomous=autonomous)
+    visual_rows = visual_row_count(f"{marker}{prompt}", columns=columns)
     print(f"\x1b[{visual_rows}F\x1b[J", end="", flush=True)
 
 

--- a/src/orbit/terminal/runtime_status.py
+++ b/src/orbit/terminal/runtime_status.py
@@ -12,6 +12,7 @@ from orbit.native_llama.model_registry import load_registry
 from orbit.runtime.session_memory import DEFAULT_CONTEXT_TOKENS, SOFT_MEMORY_RATIO, estimate_message_tokens
 from orbit.runtime.tools import tool_names
 from orbit.terminal.config import AppConfig
+from orbit.terminal.theme import on_off
 from orbit.terminal.tool_mode import ToolSpec
 
 
@@ -83,6 +84,11 @@ class RuntimeStatus:
     host: HostInfo
     acceleration: AccelerationInfo
     banner_model: str | None = None
+    # Shown on the banner so the analyst starts the session knowing
+    # whether an analysis will advance itself. Defaulted, because every
+    # existing caller built a status without it and none are about
+    # analysis.
+    autonomous: str = "off"
 
 
 def collect_host_info() -> HostInfo:
@@ -104,6 +110,7 @@ def collect_runtime_status(
     *,
     tools_mode: ToolSpec | None = None,
     host_info: HostInfo | None = None,
+    autonomous: bool = False,
 ) -> RuntimeStatus:
     info = _safe_call(getattr(backend, "model_info", None))
     props = _safe_call(getattr(backend, "backend_props", None)) or {}
@@ -123,6 +130,7 @@ def collect_runtime_status(
         mmproj=_loaded_missing(props.get("multimodal_available")),
         tools=_tools_mode(tools_mode if tools_mode is not None else config.tools),
         think="on" if config.think else "off",
+        autonomous="on" if autonomous else "off",
         max_tokens=str(config.max_tokens),
         temperature=str(config.temperature),
         messages=str(len(runtime.messages)),
@@ -140,13 +148,32 @@ def collect_runtime_status(
     )
 
 
+def _state(value: str) -> str:
+    """Colour an already-rendered on/off token, leaving anything else alone.
+
+    `tools` can also read `restricted`, and a value that is not a plain
+    boolean has no green-or-red answer -- so it is passed through rather than
+    forced into one.
+    """
+    if value == "on":
+        return on_off(True)
+    if value == "off":
+        return on_off(False)
+    return value
+
+
 def format_startup_banner(status: RuntimeStatus) -> str:
     version = status.version if status.version.startswith("v") else f"v{status.version}"
     backend = "native" if status.backend in {"native llama.cpp", "orbit-native"} else status.backend
     return "\n".join(
         [
             f"Orbit {version} · {status.banner_model or status.model} · {backend}",
-            f"workdir {status.workdir} · tools {status.tools} · think {status.think} · ctx {status.context_window}",
+            # Only the state tokens are coloured. The labels around them carry
+            # no state, and colouring a whole line would make one setting look
+            # like a verdict on the run.
+            f"workdir {status.workdir} · tools {_state(status.tools)} · "
+            f"think {_state(status.think)} · autonomous {_state(status.autonomous)} · "
+            f"ctx {status.context_window}",
             "/help for commands · /status for details",
         ]
     )
@@ -164,6 +191,9 @@ def format_status_panel(status: RuntimeStatus) -> str:
         ("MTP", f"{status.mtp}, mmproj {status.mmproj}"),
         ("Tools", status.tools),
         ("Think", status.think),
+        # The banner points at `/status` for details, so the two must agree
+        # about a setting the banner shows.
+        ("Autonomous", status.autonomous),
         ("Max tokens", status.max_tokens),
         ("Workdir", status.workdir),
         ("separator", "Host"),

--- a/src/orbit/terminal/theme.py
+++ b/src/orbit/terminal/theme.py
@@ -8,6 +8,7 @@ from typing import TextIO
 DIM = "\033[2m"
 CYAN = "\033[36m"
 RED = "\033[31m"
+GREEN = "\033[32m"
 YELLOW = "\033[33m"
 RESET = "\033[0m"
 
@@ -40,6 +41,27 @@ def yellow_dim(text: str) -> str:
 
 def danger(text: str) -> str:
     return _styled(text, RED)
+
+
+def on_off(enabled: object, *, on: str = "on", off: str = "off") -> str:
+    """One rendering of a boolean state, coloured where colour is allowed.
+
+    Used wherever a bare on/off state is shown -- the banner's tokens, the
+    `/autonomous` state reply -- so those cannot drift into saying the same
+    thing several ways. Green for on and red for off is the whole convention.
+
+    Two callers deliberately do not use it. The interactive prompt renders its
+    own, because every escape there must sit inside readline's ignore markers
+    or the cursor arithmetic breaks. And a reply that explains a setting in a
+    sentence keeps its plain word, because colouring one word mid-sentence
+    reads as emphasis rather than as state.
+
+    Colour is decided by `_styled`, which is the single place that asks
+    whether ANSI is permitted -- so NO_COLOR, a dumb terminal and a
+    redirected stream all produce bare `on`/`off` here without this function
+    knowing why.
+    """
+    return _styled(on, GREEN) if enabled else _styled(off, RED)
 
 
 def warning_text(value: object) -> str:

--- a/tests/test_autonomous_command.py
+++ b/tests/test_autonomous_command.py
@@ -85,7 +85,9 @@ class HelpTests(unittest.TestCase):
             self.assertIn(usage, analysis_block)
 
     def test_help_describes_the_autonomy_control(self) -> None:
-        self.assertIn("autonomous analysis for this session", help_text().lower())
+        text = help_text().lower()
+        self.assertIn("control how analysis advances", text)
+        self.assertIn("does not enter analysis mode by itself", text)
 
 
 class SessionStateTests(ModeTestBase):

--- a/tests/test_autonomous_ux.py
+++ b/tests/test_autonomous_ux.py
@@ -1,0 +1,550 @@
+"""The prompt tells the truth about mode and autonomy, and colour obeys.
+
+`/autonomous on` deliberately changes no mode, so before this the analyst
+typed it, saw `chat>` unchanged, and had nothing to distinguish a setting that
+took effect from one that did not. The prompt now carries both facts, and one
+formatter renders every on/off Orbit shows.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from orbit.runtime.workflow_mode import WorkflowMode
+from orbit.terminal.config import AppConfig
+from orbit.terminal.repl import Repl
+from orbit.terminal.repl_input import input_prompt
+from orbit.terminal.theme import on_off
+
+
+class _StubBackend:
+    thinking = False
+
+
+class _StubRuntime:
+    def __init__(self) -> None:
+        self.messages: list = []
+        self.context_tokens = 8192
+        self.evidence_store = None
+        self.last_memory_refresh = None
+
+    # Read by `collect_runtime_status`; zero is the truthful value for a
+    # session that has done nothing.
+    memory_refreshes = 0
+    total_memory_tokens_saved = 0
+    mutation_verifications = 0
+    mutation_verification_repairs = 0
+    mutation_verification_failures = 0
+
+    def can_continue_last_response(self) -> bool:
+        return False
+
+
+class UXTestBase(unittest.TestCase):
+    def _prompt(self, repl: Repl) -> str:
+        """The prompt as a non-colour terminal renders it."""
+        with mock.patch("orbit.terminal.repl_input.sys.stdout") as stdout:
+            stdout.isatty.return_value = False
+            return input_prompt(
+                repl._prompt_label(), autonomous=bool(repl.autonomous_analysis)
+            )
+
+    def _repl(self) -> Repl:
+        return Repl(
+            runtime=_StubRuntime(),
+            backend=_StubBackend(),
+            config=AppConfig(workdir=Path(".")),
+        )
+
+    def _command(self, repl: Repl, line: str) -> str:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            repl._handle_command(line)
+        return out.getvalue()
+
+
+class PromptStateTests(UXTestBase):
+    def test_startup_prompt_shows_chat_and_autonomy_off(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = False
+        self.assertEqual(self._prompt(repl), "chat [auto:off]> ")
+
+    def test_toggling_autonomy_on_updates_the_prompt(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = False
+        self._command(repl, "/autonomous on")
+        self.assertEqual(self._prompt(repl), "chat [auto:on]> ")
+
+    def test_toggling_autonomy_on_does_not_enter_analysis(self) -> None:
+        """The whole reason the prompt has to say so: the mode is unchanged."""
+        repl = self._repl()
+        repl.autonomous_analysis = False
+
+        self._command(repl, "/autonomous on")
+
+        self.assertTrue(repl.autonomous_analysis)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertIsNone(repl.analysis)
+
+    def test_toggling_autonomy_off_updates_the_prompt(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = True
+        self._command(repl, "/autonomous off")
+        self.assertEqual(self._prompt(repl), "chat [auto:off]> ")
+
+    def test_analysis_mode_keeps_the_autonomy_marker(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = True
+        repl.workflow_mode = WorkflowMode.ANALYSIS
+        self.assertEqual(self._prompt(repl), "analysis [auto:on]> ")
+
+    def test_autonomy_survives_returning_to_chat(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = True
+        repl.workflow_mode = WorkflowMode.ANALYSIS
+
+        self._command(repl, "/chat")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        self.assertTrue(repl.autonomous_analysis, "the setting is not a mode")
+        self.assertEqual(self._prompt(repl), "chat [auto:on]> ")
+
+    def test_a_mistyped_argument_leaves_the_prompt_unchanged(self) -> None:
+        repl = self._repl()
+        repl.autonomous_analysis = False
+        self._command(repl, "/autonomous maybe")
+        self.assertEqual(self._prompt(repl), "chat [auto:off]> ")
+
+
+class AnalysisStartTests(UXTestBase):
+    """`/analysis <path>` with autonomy on begins; toggling never does."""
+
+    ARTIFACT = "var x = 1;\nconsole.log(x);\n"
+
+    def _artifact(self) -> Path:
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-ux-")
+        self.addCleanup(tmpdir.cleanup)
+        path = Path(tmpdir.name) / "artifact.js"
+        path.write_text(self.ARTIFACT, encoding="utf-8")
+        return path
+
+    def _repl_in(self, workdir: Path) -> Repl:
+        return Repl(
+            runtime=_StubRuntime(),
+            backend=_StubBackend(),
+            config=AppConfig(workdir=workdir),
+        )
+
+    def test_autonomy_on_starts_the_first_step_without_a_second_instruction(self) -> None:
+        artifact = self._artifact()
+        repl = self._repl_in(artifact.parent)
+        repl.autonomous_analysis = True
+
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            self._command(repl, f"/analysis {artifact.name}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        asked.assert_called_once()
+        self.assertTrue(asked.call_args.args[0].strip(), "an opening line is sent")
+
+    def test_autonomy_off_waits_for_the_analyst(self) -> None:
+        """Guided mode is unchanged: entering a session runs nothing."""
+        artifact = self._artifact()
+        repl = self._repl_in(artifact.parent)
+        repl.autonomous_analysis = False
+
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            self._command(repl, f"/analysis {artifact.name}")
+
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+        asked.assert_not_called()
+
+    def test_toggling_autonomy_alone_starts_nothing(self) -> None:
+        repl = self._repl()
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            self._command(repl, "/autonomous on")
+        asked.assert_not_called()
+
+    def test_a_refused_artifact_inside_a_session_starts_nothing(self) -> None:
+        """The dangerous case: a typo while a session is already open.
+
+        A refused path deliberately leaves the mode and the previous session
+        untouched, so a guard on the mode is satisfied by the session that was
+        already there -- and the mistyped command would launch an autonomous
+        run against the wrong artifact while printing an error.
+        """
+        artifact = self._artifact()
+        repl = self._repl_in(artifact.parent)
+        repl.autonomous_analysis = True
+
+        with mock.patch.object(Repl, "_ask_analysis"):
+            self._command(repl, f"/analysis {artifact.name}")
+        opened = repl.analysis
+        self.assertIsNotNone(opened)
+
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            output = self._command(repl, "/analysis no-such-file.js")
+
+        self.assertIn("error", output)
+        asked.assert_not_called()
+        # The session that was open is still the one that is open.
+        self.assertIs(repl.analysis, opened)
+        self.assertIs(repl.workflow_mode, WorkflowMode.ANALYSIS)
+
+    def test_a_second_artifact_starts_its_own_run(self) -> None:
+        """Replacing one session with another is a new instruction."""
+        first = self._artifact()
+        second = first.parent / "second.js"
+        second.write_text(self.ARTIFACT, encoding="utf-8")
+        repl = self._repl_in(first.parent)
+        repl.autonomous_analysis = True
+
+        with mock.patch.object(Repl, "_ask_analysis"):
+            self._command(repl, f"/analysis {first.name}")
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            self._command(repl, f"/analysis {second.name}")
+
+        asked.assert_called_once()
+
+    def test_a_refused_artifact_starts_nothing(self) -> None:
+        """A typo must not launch an autonomous run against nothing."""
+        repl = self._repl()
+        repl.autonomous_analysis = True
+
+        with mock.patch.object(Repl, "_ask_analysis") as asked:
+            output = self._command(repl, "/analysis no-such-file.js")
+
+        self.assertIn("error", output)
+        self.assertIs(repl.workflow_mode, WorkflowMode.CHAT)
+        asked.assert_not_called()
+
+
+class PromptEscapingTests(unittest.TestCase):
+    """Readline counts the prompt's width; every escape must be hidden from it."""
+
+    def _rendered(self, label: str, autonomous: bool, *, tty: bool) -> str:
+        import orbit.terminal.repl_input as repl_input
+
+        original = repl_input.sys.stdout
+        repl_input.sys.stdout = mock.Mock(**{"isatty.return_value": tty})
+        try:
+            return input_prompt(label, autonomous=autonomous)
+        finally:
+            repl_input.sys.stdout = original
+
+    def test_every_escape_sits_inside_the_ignore_markers(self) -> None:
+        """An unwrapped escape makes readline mis-place the cursor on every
+        edited line -- a defect that never shows up in captured output."""
+        import re
+
+        for label, autonomous in (("chat", False), ("chat", True), ("analysis", True)):
+            with self.subTest(label=label, autonomous=autonomous):
+                prompt = self._rendered(label, autonomous, tty=True)
+                # Strip each ... span; no escape may remain outside.
+                visible = re.sub("\001[^\002]*\002", "", prompt)
+                self.assertNotIn("\033", visible)
+                self.assertEqual(
+                    visible,
+                    f"{label} [auto:{'on' if autonomous else 'off'}]> ",
+                )
+
+    def test_analysis_keeps_its_amber_marker(self) -> None:
+        """The mode colour is chosen from the mode, not from a label that now
+        also carries the autonomy state."""
+        prompt = self._rendered("analysis", True, tty=True)
+        self.assertIn("\033[33m", prompt)
+        self.assertNotIn("\033[36m", prompt)
+
+    def test_chat_keeps_its_cyan_marker(self) -> None:
+        prompt = self._rendered("chat", False, tty=True)
+        self.assertIn("\033[36m", prompt)
+        self.assertNotIn("\033[33m", prompt)
+
+    def test_the_state_token_carries_its_own_colour(self) -> None:
+        self.assertIn("\033[32m", self._rendered("chat", True, tty=True))
+        self.assertIn("\033[31m", self._rendered("chat", False, tty=True))
+
+    def test_a_non_tty_prompt_has_no_escapes_or_markers(self) -> None:
+        prompt = self._rendered("analysis", True, tty=False)
+        self.assertEqual(prompt, "analysis [auto:on]> ")
+        for control in ("\033", "\001", "\002"):
+            with self.subTest(control=repr(control)):
+                self.assertNotIn(control, prompt)
+
+
+class BooleanColourTests(unittest.TestCase):
+    """One formatter, and it obeys every reason colour may be disallowed."""
+
+    def _tty(self) -> mock._patch:
+        return mock.patch("orbit.terminal.theme.is_tty", return_value=True)
+
+    def test_on_is_green_and_off_is_red_on_a_colour_terminal(self) -> None:
+        with self._tty(), mock.patch.dict(os.environ, {"TERM": "xterm"}, clear=False):
+            os.environ.pop("NO_COLOR", None)
+            self.assertEqual(on_off(True), "\033[32mon\033[0m")
+            self.assertEqual(on_off(False), "\033[31moff\033[0m")
+
+    def test_no_colour_environment_yields_no_escapes(self) -> None:
+        with self._tty(), mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=False):
+            self.assertEqual(on_off(True), "on")
+            self.assertEqual(on_off(False), "off")
+            self.assertNotIn("\033", on_off(True) + on_off(False))
+
+    def test_a_dumb_terminal_yields_no_escapes(self) -> None:
+        with self._tty(), mock.patch.dict(os.environ, {"TERM": "dumb"}, clear=False):
+            os.environ.pop("NO_COLOR", None)
+            self.assertNotIn("\033", on_off(True) + on_off(False))
+
+    def test_a_non_tty_yields_no_escapes(self) -> None:
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=False):
+            os.environ.pop("NO_COLOR", None)
+            self.assertEqual(on_off(True), "on")
+            self.assertEqual(on_off(False), "off")
+
+    def test_redirected_output_yields_no_escapes(self) -> None:
+        """The real path: stdout is a StringIO, not a terminal."""
+        os.environ.pop("NO_COLOR", None)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            print(on_off(True), on_off(False))
+        self.assertNotIn("\033", out.getvalue())
+        self.assertIn("on off", out.getvalue())
+
+
+class BannerTests(unittest.TestCase):
+    def _status(self, **overrides):
+        import dataclasses
+
+        from orbit.terminal.runtime_status import RuntimeStatus
+
+        values = {field.name: "x" for field in dataclasses.fields(RuntimeStatus)}
+        values.update(
+            version="0.1", workdir="~/w", model="m", backend="native",
+            banner_model="Ornith", context_window="8192",
+            tools="on", think="off", autonomous="off",
+        )
+        values.update(overrides)
+        return RuntimeStatus(**values)
+
+    def test_the_banner_names_autonomy_between_think_and_ctx(self) -> None:
+        from orbit.terminal.runtime_status import format_startup_banner
+
+        banner = format_startup_banner(self._status())
+        self.assertIn(
+            "tools on · think off · autonomous off · ctx 8192", banner
+        )
+
+    def test_the_banner_colours_only_the_state_tokens(self) -> None:
+        from orbit.terminal.runtime_status import format_startup_banner
+
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=True), \
+                mock.patch.dict(os.environ, {"TERM": "xterm"}, clear=False):
+            os.environ.pop("NO_COLOR", None)
+            banner = format_startup_banner(self._status())
+
+        self.assertIn("tools \033[32mon\033[0m", banner)
+        self.assertIn("think \033[31moff\033[0m", banner)
+        self.assertIn("autonomous \033[31moff\033[0m", banner)
+        # The labels and the workdir carry no state and stay plain.
+        self.assertNotIn("\033[32mworkdir", banner)
+        self.assertNotIn("\033[31mctx", banner)
+
+    def test_the_banner_is_plain_without_colour(self) -> None:
+        from orbit.terminal.runtime_status import format_startup_banner
+
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=False):
+            banner = format_startup_banner(self._status())
+        self.assertNotIn("\033", banner)
+
+    def test_a_non_boolean_tools_mode_is_left_alone(self) -> None:
+        """`tools` can read `restricted`, which has no green-or-red answer."""
+        from orbit.terminal.runtime_status import format_startup_banner
+
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=True), \
+                mock.patch.dict(os.environ, {"TERM": "xterm"}, clear=False):
+            os.environ.pop("NO_COLOR", None)
+            banner = format_startup_banner(self._status(tools="restricted"))
+
+        self.assertIn("tools restricted", banner)
+        self.assertNotIn("\033[32mrestricted", banner)
+        self.assertNotIn("\033[31mrestricted", banner)
+
+    def test_the_banner_reports_the_session_setting(self) -> None:
+        from orbit.terminal.runtime_status import format_startup_banner
+
+        banner = format_startup_banner(self._status(autonomous="on"))
+        self.assertIn("autonomous on", banner)
+
+
+class BannerReflectsSessionTests(UXTestBase):
+    """Built through the real collector, so the banner cannot claim a
+    setting the session does not hold."""
+
+    def _banner_for(self, autonomous: bool) -> str:
+        from orbit.terminal.runtime_status import (
+            collect_runtime_status, format_startup_banner,
+        )
+
+        repl = self._repl()
+        repl.autonomous_analysis = autonomous
+        status = collect_runtime_status(
+            repl.runtime, repl.config, repl.backend,
+            tools_mode=repl.tools_mode,
+            autonomous=bool(repl.autonomous_analysis),
+        )
+        return format_startup_banner(status)
+
+    def test_autonomy_on_is_reported_on_the_banner(self) -> None:
+        self.assertIn("autonomous on", self._banner_for(True))
+
+    def test_autonomy_off_is_reported_on_the_banner(self) -> None:
+        banner = self._banner_for(False)
+        self.assertIn("autonomous off", banner)
+        self.assertNotIn("autonomous on", banner)
+
+
+class EchoWidthTests(unittest.TestCase):
+    """The rows erased must match the rows the prompt actually occupied."""
+
+    def test_the_echo_marker_is_the_displayed_prompt(self) -> None:
+        """A marker narrower than the real prompt erases one row too few once
+        the difference pushes a typed line past the terminal edge."""
+        from orbit.terminal.repl_input import input_prompt, prompt_marker
+
+        import orbit.terminal.repl_input as repl_input
+
+        original = repl_input.sys.stdout
+        repl_input.sys.stdout = mock.Mock(**{"isatty.return_value": False})
+        try:
+            for label, autonomous in (("chat", False), ("analysis", True)):
+                with self.subTest(label=label):
+                    self.assertEqual(
+                        prompt_marker(label, autonomous=autonomous),
+                        input_prompt(label, autonomous=autonomous),
+                    )
+        finally:
+            repl_input.sys.stdout = original
+
+    def _rows_erased(self, fn, prompt: str, label: str, autonomous: bool) -> int:
+        """The row count `fn` actually emits, read off its escape sequence."""
+        import re
+
+        import orbit.terminal.repl_input as repl_input
+
+        # A stream that both claims to be a terminal and records what is
+        # written to it: the function checks `isatty` and then prints.
+        class _RecordingTTY(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        out = _RecordingTTY()
+        original = repl_input.sys.stdout
+        repl_input.sys.stdout = out
+        try:
+            with mock.patch(
+                "orbit.terminal.repl_input.get_terminal_size",
+                return_value=os.terminal_size((80, 20)),
+            ), contextlib.redirect_stdout(out):
+                fn(prompt, label, autonomous=autonomous)
+        finally:
+            repl_input.sys.stdout = original
+        match = re.search(r"\x1b\[(\d+)F", out.getvalue())
+        self.assertIsNotNone(match, "the function must emit a cursor-up count")
+        return int(match.group(1))
+
+    def test_clear_input_echo_erases_every_row_it_wrote(self) -> None:
+        """The real function, at the width where a narrower marker under-counts.
+
+        70 typed characters fit on one row after `chat> ` but wrap after
+        `chat [auto:off]> `, so a marker taken from the bare mode leaves a
+        stale row behind on screen.
+        """
+        from orbit.terminal.repl_input import clear_input_echo
+
+        rows = self._rows_erased(clear_input_echo, "x" * 70, "chat", False)
+        self.assertEqual(rows, 2)
+
+    def test_row_count_reflects_the_wider_marker(self) -> None:
+        from orbit.terminal.repl_input import prompt_marker, visual_row_count
+
+        marker = prompt_marker("chat", autonomous=False)
+        typed = "x" * 70
+        self.assertEqual(
+            visual_row_count(f"{marker}{typed}", columns=80),
+            2,
+            "marker plus 70 characters wraps at 80 columns",
+        )
+        # The bare mode would have under-counted this exact case.
+        self.assertEqual(visual_row_count(f"chat> {typed}", columns=80), 1)
+
+
+class StatusPanelTests(UXTestBase):
+    """`/status` is what the banner points at; the two must agree."""
+
+    def _panel(self, autonomous: bool) -> str:
+        from orbit.terminal.commands import runtime_status
+
+        repl = self._repl()
+        repl.autonomous_analysis = autonomous
+        return runtime_status(
+            repl.runtime, repl.config, repl.backend,
+            tools_mode=repl.tools_mode,
+            autonomous=bool(repl.autonomous_analysis),
+        )
+
+    def test_status_reports_autonomy_on(self) -> None:
+        panel = self._panel(True)
+        self.assertIn("Autonomous", panel)
+        self.assertRegex(panel, r"Autonomous\s+on")
+
+    def test_status_reports_autonomy_off(self) -> None:
+        self.assertRegex(self._panel(False), r"Autonomous\s+off")
+
+
+class AnalysisHelpTests(unittest.TestCase):
+    """Four commands, four obviously different contracts."""
+
+    def _analysis_help(self) -> dict[str, str]:
+        from orbit.terminal.command_registry import COMMANDS
+
+        return {
+            command.name: command.description
+            for command in COMMANDS
+            if command.category == "Analysis"
+        }
+
+    def test_analysis_starts_and_collects(self) -> None:
+        text = self._analysis_help()["/analysis"].lower()
+        self.assertIn("start analysis", text)
+        self.assertIn("evidence", text)
+
+    def test_autonomous_controls_progress_and_starts_nothing(self) -> None:
+        text = self._analysis_help()["/autonomous"].lower()
+        self.assertIn("control how analysis advances", text)
+        self.assertIn("one evidence step at a time", text)
+        self.assertIn("does not enter analysis mode by itself", text)
+        self.assertNotIn("start analysis", text)
+
+    def test_report_runs_no_new_action(self) -> None:
+        text = self._analysis_help()["/report"].lower()
+        self.assertIn("evidence already collected", text)
+        self.assertIn("runs no new analysis action", text)
+
+    def test_chat_leaves_analysis(self) -> None:
+        text = self._analysis_help()["/chat"].lower()
+        self.assertIn("leave analysis", text)
+
+    def test_the_four_contracts_are_distinct(self) -> None:
+        descriptions = self._analysis_help()
+        self.assertEqual(len(descriptions), 4)
+        self.assertEqual(len(set(descriptions.values())), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -256,7 +256,7 @@ class ReplTests(unittest.TestCase):
         self.assertIn("Orbit v0.0.1", output)
         self.assertIn("· unknown · unknown", output)
         self.assertIn("workdir ", output)
-        self.assertIn("tools on · think off · ctx 8192", output)
+        self.assertIn("tools on · think off · autonomous off · ctx 8192", output)
         self.assertIn("/help for commands · /status for details", output)
         self.assertNotIn("Machine", output)
         self.assertNotIn("warning: tools on", output)
@@ -668,7 +668,7 @@ class ReplTests(unittest.TestCase):
 
     def test_input_prompt_is_plain_without_tty(self) -> None:
         with mock.patch("sys.stdout.isatty", return_value=False):
-            self.assertEqual(input_prompt(), "> ")
+            self.assertEqual(input_prompt(), " [auto:off]> ")
 
     def test_input_prompt_uses_readline_safe_color_on_tty(self) -> None:
         with mock.patch("sys.stdout.isatty", return_value=True):
@@ -717,7 +717,7 @@ class ReplTests(unittest.TestCase):
         ):
             self.assertEqual(read_prompt_input(redisplay=True), "hello")
 
-        input_mock.assert_called_once_with("> ")
+        input_mock.assert_called_once_with(" [auto:off]> ")
         readline.set_pre_input_hook.assert_not_called()
         readline.redisplay.assert_not_called()
 
@@ -882,7 +882,7 @@ class ReplTests(unittest.TestCase):
                 responses = iter(("", "next"))
                 stdout = io.StringIO()
 
-                def fake_read(*, label: str = "") -> str:
+                def fake_read(*, label: str = "", autonomous: bool = False) -> str:
                     print("> ")
                     return next(responses)
 
@@ -921,7 +921,7 @@ class ReplTests(unittest.TestCase):
 
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "", autonomous: bool = False) -> str:
                 nonlocal reads
                 reads += 1
                 redisplays.append(redisplay)
@@ -957,7 +957,7 @@ class ReplTests(unittest.TestCase):
             )
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "", autonomous: bool = False) -> str:
                 redisplays.append(redisplay)
                 try:
                     return next(prompts)
@@ -992,7 +992,7 @@ class ReplTests(unittest.TestCase):
             prompts = iter(("/read note.txt summarize",))
             redisplays: list[bool] = []
 
-            def fake_read(*, redisplay: bool = False, label: str = "") -> str:
+            def fake_read(*, redisplay: bool = False, label: str = "", autonomous: bool = False) -> str:
                 redisplays.append(redisplay)
                 try:
                     return next(prompts)

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -34,7 +34,7 @@ class RuntimeStatusFormattingTests(unittest.TestCase):
         self.assertEqual(
             banner,
             "Orbit v0.0.1 · Gemma 4 12B · native\n"
-            "workdir /tmp/orbit · tools on · think off · ctx 8192\n"
+            "workdir /tmp/orbit · tools on · think off · autonomous off · ctx 8192\n"
             "/help for commands · /status for details",
         )
         self.assertNotIn("Machine", banner)

--- a/tests/test_workflow_mode.py
+++ b/tests/test_workflow_mode.py
@@ -1570,11 +1570,14 @@ class PromptMarkerTest(ModeTestBase):
 
         with mock.patch("orbit.terminal.repl_input.sys.stdout") as stdout:
             stdout.isatty.return_value = False
-            self.assertEqual(input_prompt("chat"), "chat> ")
-            self.assertEqual(input_prompt("analysis"), "analysis> ")
+            self.assertEqual(input_prompt("chat"), "chat [auto:off]> ")
+            self.assertEqual(input_prompt("analysis"), "analysis [auto:off]> ")
         with mock.patch("orbit.terminal.repl_input.sys.stdout") as stdout:
             stdout.isatty.return_value = True
-            self.assertIn("analysis> ", input_prompt("analysis"))
+            # The visible text is the marker; the escapes around it are
+            # readline's, and sit inside its ignore markers.
+            self.assertIn("analysis [auto:", input_prompt("analysis"))
+            self.assertIn("]> ", input_prompt("analysis"))
 
 
 class ActionCauseRenderingTest(unittest.TestCase):
@@ -2308,7 +2311,11 @@ class AmberAnalysisPromptTest(ModeTestBase):
 
         with mock.patch.object(repl_input.sys, "stdout") as stdout:
             stdout.isatty.return_value = True
-            self.assertNotIn(RED, repl_input.input_prompt("analysis"))
+            # Red is now a legitimate colour on the autonomy token, so this
+            # asserts about the mode marker: amber, never red.
+            rendered = repl_input.input_prompt("analysis", autonomous=True)
+            self.assertNotIn(RED, rendered)
+            self.assertIn("\033[33m", rendered)
 
     def test_no_ansi_in_non_tty(self) -> None:
         from orbit.terminal import repl_input
@@ -2316,7 +2323,7 @@ class AmberAnalysisPromptTest(ModeTestBase):
         with mock.patch.object(repl_input.sys, "stdout") as stdout:
             stdout.isatty.return_value = False
             for label in ("chat", "analysis"):
-                self.assertEqual(repl_input.input_prompt(label), f"{label}> ")
+                self.assertEqual(repl_input.input_prompt(label), f"{label} [auto:off]> ")
 
 
 class WorkdirReminderTest(ModeTestBase):


### PR DESCRIPTION
`/autonomous on` changes a setting and enters no mode, so the prompt stayed `chat>` and the analyst could not tell whether it took effect. The prompt now carries mode and autonomy — `chat [auto:off]>`, `analysis [auto:on]>` — and the banner reads `tools on · think off · autonomous off · ctx 8192` with only the state tokens coloured.

One `on_off` formatter, green/red, plain under NO_COLOR, `TERM=dumb`, non-TTY and redirects. The prompt renders its own escapes so they sit inside readline's ignore markers, and the echo-clearing arithmetic now counts the marker as displayed.

`/analysis <path>` with autonomy already on begins the run; toggling autonomy alone still starts nothing, and guided mode still waits.

Analysis help rewritten so the four contracts are distinct: start / control how it advances / report from evidence / leave.

No model inference, no malware run, no runtime or backend change — the diff touches only `src/orbit/terminal/`. Full suite 4124 OK (skipped=8). 21 non-equivalent mutants caught.

Independent review returned 1 BLOCKER (a mistyped `/analysis` inside an open session launched an autonomous run against the *previous* artifact), 2 MAJOR (echo-width under-count; `/status` always reporting `off`) and 1 MINOR — all four reproduced and fixed, each pinned by test. Two further defects found during implementation (ANALYSIS losing its amber marker; escapes outside readline's markers) were fixed the same way.
