### PR TITLE
feat(cli): render final reports as Markdown

### DIFF
--- a/src/orbit/terminal/markdown_report.py
+++ b/src/orbit/terminal/markdown_report.py
@@ -1,0 +1,151 @@
+"""Render a finished report for a terminal, from the whole text at once.
+
+A report is Markdown because that is what it is stored and shared as. On a
+terminal the markers are noise -- `##` and `**` are instructions to a reader
+that a terminal can carry out directly -- so this reads the complete text and
+emits the same content with the structure shown rather than spelled.
+
+Two properties matter more than coverage.
+
+The first is that this changes nothing but appearance. `report.text` is the
+canonical artifact: APIs, saved sessions, files and pipes all read it, and it
+must be byte-identical whatever a terminal happens to do. So nothing here
+writes back, and every path returns the input unchanged when styling is not
+allowed.
+
+The second is that report text is not trusted. It carries decoded artifact
+bytes -- an attacker's choice of characters -- so the text is sanitised before
+any escape of ours is added, and never after: adding structure to sanitised
+text is safe, sanitising text that already contains our escapes would either
+destroy them or, worse, leave a crafted sequence indistinguishable from one.
+
+This is deliberately not a Markdown implementation. It handles the constructs
+a report actually contains, line by line, and leaves anything else exactly as
+written -- a line this does not recognise is still correct, just unstyled.
+"""
+
+from __future__ import annotations
+
+import re
+
+from orbit.terminal.theme import (
+    BOLD,
+    CYAN,
+    DIM,
+    RESET,
+    YELLOW,
+    sanitize_terminal_text,
+    supports_ansi,
+)
+
+# `## Verified indicators` and `## Deterministic transformations` are written
+# by the runtime from evidence, not by the model. They are styled differently
+# from narrative headings so a reader can see which half of the report they
+# are in without either section's text changing.
+_RUNTIME_SECTIONS = ("Verified indicators", "Deterministic transformations")
+
+# The separator after a marker is captured, not merely matched: re-emitting a
+# single hardcoded space would collapse aligned lists (`1.  ` in a numbered
+# list past nine) and, worse, rewrite an indented code block, where the
+# indentation is the content. Rendering must change appearance and nothing
+# else, so every run of whitespace comes back exactly as written.
+_HEADING = re.compile(r"^(#{1,6})([ \t]+)(.*)$")
+_BULLET = re.compile(r"^(\s*)([-*+])([ \t]+)(.*)$")
+_NUMBERED = re.compile(r"^(\s*)(\d+[.)])([ \t]+)(.*)$")
+_FENCE = re.compile(r"^\s*(```|~~~)")
+# `key: value` provenance lines the runtime emits inside its own sections.
+_FIELD = re.compile(r"^(\s+)([a-z_][a-z0-9_ ]*):(\s.*)$")
+
+_BOLD = re.compile(r"\*\*(.+?)\*\*")
+_CODE = re.compile(r"`([^`]+)`")
+# An evidence id as the runtime writes it: `ev_` plus two hex groups. Matched
+# so it can be tinted; the id itself is never rewritten.
+_EVIDENCE_ID = re.compile(r"\bev_[0-9a-f]{12}_[0-9a-f]{16}\b")
+
+
+def render_report(text: str, *, force_style: bool | None = None) -> str:
+    """The report as a terminal should show it.
+
+    Returns the text sanitised but otherwise unchanged whenever styling is not
+    permitted -- NO_COLOR, a dumb terminal, a pipe, a redirect -- so a captured
+    or piped report is raw Markdown with no escape in it at all.
+
+    `force_style` exists for tests, which cannot make a StringIO a terminal.
+    """
+    styled = supports_ansi() if force_style is None else force_style
+    safe = sanitize_terminal_text(text, allow_newlines=True)
+    if not styled or not safe:
+        return safe
+
+    out: list[str] = []
+    in_fence = False
+    for line in safe.split("\n"):
+        if _FENCE.match(line):
+            # The fence markers stay: they are how a reader knows where the
+            # verbatim block begins and ends, and a terminal has no border.
+            in_fence = not in_fence
+            out.append(f"{DIM}{line}{RESET}")
+            continue
+        if in_fence:
+            # Verbatim means verbatim. Inline markers inside a code block are
+            # code, not formatting.
+            out.append(f"{CYAN}{line}{RESET}")
+            continue
+        out.append(_render_line(line))
+    return "\n".join(out)
+
+
+def _render_line(line: str) -> str:
+    heading = _HEADING.match(line)
+    if heading:
+        hashes, gap, title = heading.groups()
+        # Runtime-authored sections are tinted differently from the model's
+        # own headings: same text, different voice.
+        colour = YELLOW if title.strip() in _RUNTIME_SECTIONS else CYAN
+        # The inline spans re-open the heading's own attributes after each
+        # reset, so a bold or code span mid-title does not silently end the
+        # heading's colour for the rest of the line.
+        return f"{colour}{BOLD}{hashes}{gap}{_inline(title, reopen=colour + BOLD)}{RESET}"
+
+    bullet = _BULLET.match(line)
+    if bullet:
+        indent, marker, gap, rest = bullet.groups()
+        return f"{indent}{CYAN}{marker}{RESET}{gap}{_inline(rest)}"
+
+    numbered = _NUMBERED.match(line)
+    if numbered:
+        indent, marker, gap, rest = numbered.groups()
+        return f"{indent}{CYAN}{marker}{RESET}{gap}{_inline(rest)}"
+
+    field = _FIELD.match(line)
+    if field:
+        indent, name, rest = field.groups()
+        return f"{indent}{DIM}{name}:{RESET}{_inline(rest)}"
+
+    return _inline(line)
+
+
+def _inline(text: str, *, reopen: str = "") -> str:
+    """Inline spans, innermost meaning first.
+
+    Code is applied before bold so a marker inside backticks stays literal,
+    and evidence ids are tinted last so an id already inside a code span is
+    not styled twice.
+
+    `reopen` is what the caller had open around this text. A span closes with
+    a full reset, which would otherwise end the caller's attribute too and
+    leave the rest of a heading unstyled; re-opening after each span keeps the
+    line looking like one line.
+    """
+    # The markers are kept, not consumed. Removing them would make the
+    # rendered text differ from the report by more than colour, and the
+    # property worth having is that stripping the escapes gives the canonical
+    # text back exactly -- which is what makes "rendering changed nothing but
+    # appearance" checkable rather than asserted.
+    close = f"{RESET}{reopen}"
+    rendered = _CODE.sub(lambda m: f"{CYAN}`{m.group(1)}`{close}", text)
+    rendered = _BOLD.sub(lambda m: f"{BOLD}**{m.group(1)}**{close}", rendered)
+    # The id is reproduced exactly; only colour is added around it. An
+    # indicator or evidence reference that came back altered would be a
+    # different fact, which is the one thing rendering must never do.
+    return _EVIDENCE_ID.sub(lambda m: f"{DIM}{m.group(0)}{close}", rendered)

--- a/src/orbit/terminal/repl.py
+++ b/src/orbit/terminal/repl.py
@@ -51,6 +51,7 @@ from orbit.terminal.status import (
 from orbit.terminal.streaming import StreamRenderer
 from orbit.terminal.tool_events import format_tool_activity_label, format_tool_call_event, format_tool_result_event
 from orbit.terminal.tool_mode import USAGE, ToolSpec, allowed_tool_names_for_spec, normalize_tool_spec, tools_are_enabled
+from orbit.terminal.markdown_report import render_report
 from orbit.terminal.theme import dim, on_off, runtime_error_text, sanitize_terminal_text
 from orbit.runtime.thinking_mode import ThinkingMode
 from orbit.runtime.turn_trace import ModelPhaseStart, ModelStepMetrics
@@ -505,12 +506,10 @@ class Repl:
             # text itself is untouched: `run.final_report.text` still holds
             # what the model wrote.
             if run.final_report is not None and not renderer.rendered_visible_text:
-                print(
-                    sanitize_terminal_text(
-                        run.final_report.text, allow_newlines=True
-                    ),
-                    flush=True,
-                )
+                # Nothing streamed, so this is the whole report -- a complete
+                # text, which is the only thing that may be rendered as
+                # Markdown. `render_report` sanitises before it styles.
+                print(render_report(run.final_report.text), flush=True)
             elif run.final_report is not None:
                 # The prose streamed, so `final_report.text` would repeat it --
                 # but the deterministic appendix is attached after the stream
@@ -523,10 +522,11 @@ class Repl:
                 appendix = self.analysis.deterministic_sections()
                 if appendix:
                     print("\n")
-                    print(
-                        sanitize_terminal_text(appendix, allow_newlines=True),
-                        flush=True,
-                    )
+                    # `render_report` sanitises before it styles, so this is
+                    # the same protection the plain print had, with the
+                    # Markdown structure shown instead of spelled. Off a
+                    # terminal it returns the sanitised text unchanged.
+                    print(render_report(appendix), flush=True)
             replans = f" | replans: {run.replans}" if run.replans else ""
             summary = (
                 f"analysis | mode: ANALYSIS | model calls: {run.model_calls} | "
@@ -995,7 +995,7 @@ class Repl:
             # NO_EVIDENCE_REPORT, a refusal notice, or either of those with the
             # deterministic appendix already attached by `report()`. Sanitized
             # because it is a print that never passed the renderer's boundary.
-            print(sanitize_terminal_text(report.text, allow_newlines=True), flush=True)
+            print(render_report(report.text), flush=True)
         else:
             # The model's prose reached the terminal through `on_delta` as it
             # was generated. The appendix did not: `report()` attaches it to
@@ -1012,7 +1012,7 @@ class Repl:
                 # would butt against the prose. `report.text` joins the two
                 # halves with a blank line, and the terminal should match.
                 print("\n")
-                print(sanitize_terminal_text(appendix, allow_newlines=True), flush=True)
+                print(render_report(appendix), flush=True)
         elapsed = time.monotonic() - started
         summary = (
             f"report | mode: ANALYSIS | model calls: {report.model_calls} | "

--- a/src/orbit/terminal/theme.py
+++ b/src/orbit/terminal/theme.py
@@ -9,6 +9,7 @@ DIM = "\033[2m"
 CYAN = "\033[36m"
 RED = "\033[31m"
 GREEN = "\033[32m"
+BOLD = "\033[1m"
 YELLOW = "\033[33m"
 RESET = "\033[0m"
 

--- a/tests/test_final_report_sanitization.py
+++ b/tests/test_final_report_sanitization.py
@@ -75,15 +75,51 @@ class ProductionCallSiteTests(unittest.TestCase):
         source = inspect.getsource(repl.Repl._ask_analysis)
         marker = "if run.final_report is not None and not renderer.rendered_visible_text:"
         self.assertIn(marker, source)
-        branch = source[source.index(marker) : source.index(marker) + 260]
+        # To the end of this branch rather than a fixed character count: the
+        # comment explaining the branch may grow, and a window measured in
+        # characters would then stop short of the print it exists to check.
+        start = source.index(marker)
+        rest = source[start:]
+        end = rest.index("\n            elif ") if "\n            elif " in rest else len(rest)
+        branch = rest[:end]
 
-        # Matched on the two facts that matter -- the report text is passed to
-        # the sanitizer, and nothing in this branch prints it raw -- rather
-        # than on one exact spelling, so wrapping the call over lines or
+        # Matched on the two facts that matter -- the report text goes through
+        # a sanitizing renderer, and nothing in this branch prints it raw --
+        # rather than on one exact spelling, so wrapping the call over lines or
         # binding it to a local does not fail this spuriously.
-        self.assertIn("sanitize_terminal_text(", branch)
+        #
+        # `render_report` is accepted alongside the bare sanitizer because it
+        # sanitizes before it styles; `test_the_markdown_renderer_sanitizes`
+        # below is what holds it to that, so this is not a widened hole.
+        self.assertTrue(
+            "sanitize_terminal_text(" in branch or "render_report(" in branch,
+            "the report text must reach a sanitizing renderer",
+        )
         self.assertIn("run.final_report.text", branch)
         self.assertNotIn("print(run.final_report.text", branch)
+
+    def test_the_markdown_renderer_sanitizes(self) -> None:
+        """What licenses `render_report` at the call sites above.
+
+        Behavioural, not textual: the renderer is handed every control
+        sequence a decoded artifact might carry, in both styled and plain
+        mode, and none may survive.
+        """
+        from orbit.terminal.markdown_report import render_report
+
+        hostile = (
+            "## \x1b[2J\x1b[H heading\n"
+            "- \x1b]0;title\x07 bullet\n"
+            "**\rforged**\n"
+            "`\x1b]52;c;ZXZpbA==\x07`\n"
+            "\x9b2J \x9dpayload\x07\n"
+        )
+        for styled in (True, False):
+            rendered = render_report(hostile, force_style=styled)
+            for control in ("\x1b[2J", "\x1b[H", "\x1b]0;", "\x1b]52;",
+                            "\r", "\x07", "\x9b", "\x9d"):
+                with self.subTest(styled=styled, control=repr(control)):
+                    self.assertNotIn(control, rendered)
 
     def test_all_three_final_output_paths_sanitize(self) -> None:
         """Streamed, non-streaming and empty must agree.
@@ -104,7 +140,13 @@ class ProductionCallSiteTests(unittest.TestCase):
         self.assertNotIn("print(run.final_report.text", repl_source)
         self.assertNotIn("print(report.text", repl_source)
         self.assertIn("run.final_report.text", repl_source)
-        self.assertIn("sanitize_terminal_text(report.text", repl_source)
+        # Either the bare sanitizer or the renderer that wraps it; the test
+        # above proves the renderer really does sanitize.
+        self.assertTrue(
+            "sanitize_terminal_text(report.text" in repl_source
+            or "render_report(report.text" in repl_source,
+            "the report text must reach a sanitizing renderer",
+        )
 
 
 class ControlSequenceTests(unittest.TestCase):

--- a/tests/test_markdown_report.py
+++ b/tests/test_markdown_report.py
@@ -1,0 +1,482 @@
+"""Rendering a finished report changes how it looks and nothing else.
+
+The canonical `report.text` is what APIs, saved sessions, files and pipes
+read, so the two properties that matter most here are that it is never
+touched, and that a terminal-bound reader gets structure without ever getting
+an escape the artifact chose.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import re
+import unittest
+from unittest import mock
+
+from orbit.terminal.markdown_report import render_report
+
+ANSI = re.compile(r"\033\[[0-9;]*[A-Za-z]")
+
+SAMPLE = """## Findings
+
+**Bold claim** and `inline code`.
+
+- first bullet
+- second bullet
+
+1. first step
+2. second step
+
+## Verified indicators
+
+- uri: http://a.invalid/1.php?s=k
+  evidence: ev_26e1592c3e90_6a892b624a2a237c
+"""
+
+
+def visible(text: str) -> str:
+    """The text with every escape removed -- what a reader actually reads."""
+    return ANSI.sub("", text)
+
+
+class CanonicalTextTests(unittest.TestCase):
+    """Rendering is a view. The report itself is never rewritten."""
+
+    def test_the_input_string_is_not_mutated(self) -> None:
+        original = SAMPLE
+        render_report(SAMPLE, force_style=True)
+        self.assertEqual(SAMPLE, original)
+
+    def test_styling_preserves_every_visible_character(self) -> None:
+        """Structure is shown, not edited: strip the escapes and it is the
+        same text, marker for marker."""
+        self.assertEqual(visible(render_report(SAMPLE, force_style=True)), SAMPLE)
+
+    def test_plain_mode_returns_the_text_unchanged(self) -> None:
+        self.assertEqual(render_report(SAMPLE, force_style=False), SAMPLE)
+
+    def test_an_empty_report_stays_empty(self) -> None:
+        self.assertEqual(render_report("", force_style=True), "")
+
+
+class ByteIdentityPropertyTests(unittest.TestCase):
+    """The invariant the whole design rests on, checked over a corpus.
+
+    Rendering may add escapes and may add nothing else. Strip the escapes and
+    the sanitised input must come back exactly -- otherwise the terminal shows
+    an analyst a different byte sequence from the canonical `report.text`,
+    which is the one thing this must never do.
+    """
+
+    CORPUS = (
+        # Markers separated by more than one space, or by a tab. A renderer
+        # that re-emits a hardcoded separator collapses these silently.
+        "1.  Fetches a payload",
+        "10. tenth item",
+        "##   Findings",
+        "-\tTabbed bullet",
+        "*  star bullet",
+        "+   plus bullet",
+        "1)  paren numbered",
+        # Four-space indentation is Markdown's literal code block: the
+        # whitespace IS the content.
+        "    -  literal code, not a bullet",
+        "\t\tdeeply indented",
+        # Inline spans in every awkward arrangement.
+        "**a `b` c** and `d **e** f`",
+        "a ** unmatched",
+        "a ` unmatched",
+        "***triple***",
+        "****",
+        "`` ``",
+        r"escaped \*not bold\*",
+        # Headings and fences at their edges.
+        "#NoSpaceAfterHash",
+        "####### seven hashes",
+        "## Trailing hashes ##",
+        "````\nfour tick fence\n````",
+        "~~~\ntilde fence\n~~~",
+        "    ```\n    indented fence\n    ```",
+        "```\n  key: value inside a fence\n```",
+        # Provenance-shaped lines and ids.
+        "  authority: gibuzuy37v2v.top",
+        "  Mixed_Case: value",
+        "ev_26e1592c3e90_6a892b624a2a237c",
+        "xev_26e1592c3e90_6a892b624a2a237c_extra",
+        "ev_short_id",
+        # Line endings and unusual text.
+        "## A\r\n- b\r\n",
+        "trailing spaces   \n",
+        "\n\n\n",
+        "- 🔥 emoji **bold**",
+        "a\u200bzero width",
+        "",
+        SAMPLE,
+    )
+
+    def test_stripping_the_escapes_returns_the_sanitised_input(self) -> None:
+        from orbit.terminal.theme import sanitize_terminal_text
+
+        for text in self.CORPUS:
+            with self.subTest(text=text[:40]):
+                rendered = render_report(text, force_style=True)
+                self.assertEqual(
+                    visible(rendered),
+                    sanitize_terminal_text(text, allow_newlines=True),
+                )
+
+    def test_plain_mode_matches_the_sanitiser_exactly(self) -> None:
+        from orbit.terminal.theme import sanitize_terminal_text
+
+        for text in self.CORPUS:
+            with self.subTest(text=text[:40]):
+                self.assertEqual(
+                    render_report(text, force_style=False),
+                    sanitize_terminal_text(text, allow_newlines=True),
+                )
+
+    def test_every_style_opened_is_closed(self) -> None:
+        """A style left open bleeds into whatever the terminal prints next."""
+        for text in self.CORPUS:
+            with self.subTest(text=text[:40]):
+                rendered = render_report(text, force_style=True)
+                for line in rendered.split("\n"):
+                    opens = len(re.findall(r"\033\[(?:1|2|33|36)m", line))
+                    closes = line.count("\033[0m")
+                    if not opens:
+                        continue
+                    # Every attribute is closed, and the last escape on the
+                    # line is a reset -- so nothing bleeds into what the
+                    # terminal prints next. Counts rather than a suffix check,
+                    # because a line may legitimately end in unstyled text.
+                    self.assertGreaterEqual(
+                        closes, 1, f"a styled line must reset: {line!r}"
+                    )
+                    last = re.findall(r"\033\[[0-9;]*m", line)[-1]
+                    self.assertEqual(
+                        last, "\033[0m", f"style left open: {line!r}"
+                    )
+
+
+class StructureTests(unittest.TestCase):
+    def _styled(self, text: str) -> str:
+        return render_report(text, force_style=True)
+
+    def test_a_heading_is_styled_and_keeps_its_hashes(self) -> None:
+        rendered = self._styled("## Findings\n")
+        self.assertIn("\033[1m", rendered)
+        self.assertIn("## Findings", visible(rendered))
+
+    def test_runtime_sections_are_styled_apart_from_narrative(self) -> None:
+        """Same text, different voice: one half is written from evidence by
+        the runtime, the other is the model's prose."""
+        runtime = self._styled("## Verified indicators\n")
+        narrative = self._styled("## Findings\n")
+
+        self.assertIn("\033[33m", runtime)      # amber
+        self.assertIn("\033[36m", narrative)    # cyan
+        self.assertNotIn("\033[33m", narrative)
+        self.assertIn("## Verified indicators", visible(runtime))
+
+    def test_the_transformation_appendix_is_styled_the_same_way(self) -> None:
+        rendered = self._styled("## Deterministic transformations\n")
+        self.assertIn("\033[33m", rendered)
+
+    def test_more_than_six_hashes_is_not_a_heading(self) -> None:
+        """Markdown stops at six. Styling a seventh would format prose that
+        merely begins with hashes as a section title."""
+        rendered = self._styled("####### seven hashes\n")
+        self.assertNotIn("\033[1m", rendered)
+        self.assertEqual(visible(rendered), "####### seven hashes\n")
+
+    def test_six_hashes_is_still_a_heading(self) -> None:
+        self.assertIn("\033[1m", self._styled("###### six\n"))
+
+    def test_top_level_prose_with_a_colon_is_not_a_provenance_field(self) -> None:
+        """The dim `key:` styling belongs to the runtime's own indented
+        provenance lines. Applying it to any sentence containing a colon would
+        dim the first words of ordinary narrative."""
+        rendered = self._styled("Note: the artifact deletes itself\n")
+        self.assertNotIn("\033[2m", rendered)
+
+    def test_an_indented_provenance_field_is_styled(self) -> None:
+        rendered = self._styled("  authority: a.invalid\n")
+        self.assertIn("\033[2m", rendered)
+        self.assertEqual(visible(rendered), "  authority: a.invalid\n")
+
+    def test_bold_is_styled_and_keeps_its_markers(self) -> None:
+        rendered = self._styled("a **strong** claim")
+        self.assertIn("\033[1m", rendered)
+        self.assertEqual(visible(rendered), "a **strong** claim")
+
+    def test_inline_code_is_styled(self) -> None:
+        rendered = self._styled("run `Get-Date` now")
+        self.assertIn("\033[36m", rendered)
+        self.assertEqual(visible(rendered), "run `Get-Date` now")
+
+    def test_bullets_keep_their_indentation(self) -> None:
+        rendered = self._styled("- top\n  - nested\n")
+        lines = visible(rendered).split("\n")
+        self.assertEqual(lines[0], "- top")
+        self.assertEqual(lines[1], "  - nested")
+
+    def test_numbered_lists_are_styled(self) -> None:
+        rendered = self._styled("1. first\n2. second\n")
+        self.assertIn("\033[36m", rendered)
+        self.assertEqual(visible(rendered), "1. first\n2. second\n")
+
+    def test_a_report_without_markdown_is_left_readable(self) -> None:
+        plain = "The artifact writes a file and deletes it.\n"
+        self.assertEqual(visible(self._styled(plain)), plain)
+
+
+class SpanBoundaryTests(unittest.TestCase):
+    """Which characters a span covers, not merely that one was styled."""
+
+    def _spans(self, text: str, opener: str) -> list[str]:
+        """The visible text inside each span opened with `opener`."""
+        rendered = render_report(text, force_style=True)
+        return re.findall(
+            re.escape(opener) + r"(.*?)\033\[0m", rendered, re.S
+        )
+
+    def test_bold_is_not_greedy_across_separate_spans(self) -> None:
+        """A greedy match would style `a** x **b` as one run, silently
+        emphasising text the author left plain."""
+        spans = self._spans("**a** x **b**", "\033[1m")
+        self.assertEqual(spans, ["**a**", "**b**"])
+
+    def test_an_empty_code_span_is_not_matched(self) -> None:
+        """```` `` ```` is two literal backticks, not an empty code span."""
+        rendered = render_report("a `` b", force_style=True)
+        self.assertNotIn("\033[36m", rendered)
+        self.assertEqual(visible(rendered), "a `` b")
+
+    def test_an_empty_bold_span_is_not_matched(self) -> None:
+        rendered = render_report("a **** b", force_style=True)
+        self.assertNotIn("\033[1m", rendered)
+        self.assertEqual(visible(rendered), "a **** b")
+
+    def test_only_a_correctly_shaped_evidence_id_is_tinted(self) -> None:
+        """An id is `ev_` plus 12 and 16 hex digits. Anything else is text
+        that merely resembles one, and tinting it would suggest a provenance
+        it does not have."""
+        real = "ev_26e1592c3e90_6a892b624a2a237c"
+        self.assertIn("\033[2m", render_report(real, force_style=True))
+
+        for lookalike in ("ev_short_id", "ev_26e1592c3e90", "ev_zzzzzzzzzzzz_6a892b624a2a237c"):
+            with self.subTest(text=lookalike):
+                rendered = render_report(lookalike, force_style=True)
+                self.assertNotIn("\033[2m", rendered)
+
+    def test_an_embedded_id_is_not_tinted(self) -> None:
+        """Word boundaries: `xev_...` is not an id, and neither is one with
+        extra hex glued to its tail."""
+        for text in (
+            "xev_26e1592c3e90_6a892b624a2a237c",
+            "ev_26e1592c3e90_6a892b624a2a237cff",
+        ):
+            with self.subTest(text=text):
+                self.assertNotIn("\033[2m", render_report(text, force_style=True))
+
+
+class CodeFenceTests(unittest.TestCase):
+    def test_a_fenced_block_is_preserved_verbatim(self) -> None:
+        """Inside a fence, markers are code -- not formatting."""
+        text = "```\nnot **bold** and not `code`\n```\n"
+        rendered = render_report(text, force_style=True)
+
+        self.assertEqual(visible(rendered), text)
+        # Because the markers are preserved, "unchanged text" cannot by itself
+        # prove the block was left alone -- the styling has to be checked. A
+        # renderer that formatted inside the fence would wrap the asterisks in
+        # a bold escape; the whole line carries one code colour instead.
+        body = [ln for ln in rendered.split("\n") if "bold" in ln][0]
+        self.assertNotIn("\033[1m", body)
+        self.assertTrue(body.startswith("\033[36m"))
+        self.assertTrue(body.endswith("\033[0m"))
+
+    def test_formatting_resumes_after_the_fence_closes(self) -> None:
+        text = "```\nraw\n```\n**after**\n"
+        rendered = render_report(text, force_style=True)
+        self.assertIn("\033[1m", rendered)
+        self.assertEqual(visible(rendered), text)
+
+    def test_a_tilde_fence_is_recognised(self) -> None:
+        """Both fence syntaxes are Markdown; treating only one as a fence
+        would format the contents of the other as prose."""
+        text = "~~~\nnot **bold**\n~~~\n"
+        rendered = render_report(text, force_style=True)
+        body = [ln for ln in rendered.split("\n") if "bold" in ln][0]
+        self.assertNotIn("\033[1m", body)
+        self.assertEqual(visible(rendered), text)
+
+    def test_an_indented_fence_is_recognised(self) -> None:
+        text = "  ```\n  not **bold**\n  ```\n"
+        rendered = render_report(text, force_style=True)
+        body = [ln for ln in rendered.split("\n") if "bold" in ln][0]
+        self.assertNotIn("\033[1m", body)
+
+    def test_an_unclosed_fence_does_not_swallow_the_report(self) -> None:
+        text = "```\nstill inside\n"
+        self.assertEqual(visible(render_report(text, force_style=True)), text)
+
+
+class TableTests(unittest.TestCase):
+    """Tables are left as raw Markdown, deliberately."""
+
+    TABLE = "| claim | supported |\n| --- | --- |\n| beacon | NO |\n"
+
+    def test_a_table_is_readable_and_unaltered(self) -> None:
+        rendered = render_report(self.TABLE, force_style=True)
+        self.assertEqual(visible(rendered), self.TABLE)
+
+
+class EvidenceIdTests(unittest.TestCase):
+    EVIDENCE = "ev_26e1592c3e90_6a892b624a2a237c"
+
+    def test_an_evidence_id_is_tinted_but_never_altered(self) -> None:
+        """An id that came back changed would be a different fact."""
+        rendered = render_report(f"see evidence: {self.EVIDENCE} here", force_style=True)
+
+        self.assertIn(self.EVIDENCE, visible(rendered))
+        self.assertEqual(visible(rendered), f"see evidence: {self.EVIDENCE} here")
+        self.assertIn("\033[2m", rendered)
+
+    def test_a_provenance_field_keeps_its_value(self) -> None:
+        line = "  authority: gibuzuy37v2v.top\n"
+        rendered = render_report(line, force_style=True)
+        self.assertEqual(visible(rendered), line)
+        self.assertIn("gibuzuy37v2v.top", visible(rendered))
+
+    def test_an_indicator_section_survives_rendering_whole(self) -> None:
+        section = (
+            "## Verified indicators\n"
+            "\n"
+            "- uri: http://a.invalid/1.php?s=k,2\n"
+            "  authority: a.invalid\n"
+            "  path: /1.php\n"
+            "  query: ?s=k,2\n"
+            f"  evidence: {self.EVIDENCE}\n"
+            "  sha256: " + "a" * 64 + "\n"
+        )
+        self.assertEqual(visible(render_report(section, force_style=True)), section)
+
+
+class TerminalSafetyTests(unittest.TestCase):
+    """Report text carries decoded artifact bytes: an attacker's characters."""
+
+    HOSTILE = (
+        "## \x1b[2J\x1b[H heading\n"
+        "- \x1b]0;title\x07 bullet\n"
+        "**\rforged**\n"
+        "`\x1b]52;c;ZXZpbA==\x07`\n"
+        "\x9b2J\n"
+    )
+
+    def _assert_only_our_escapes(self, rendered: str) -> None:
+        """Every escape present must be one of ours, and nothing else."""
+        for control in ("\x1b[2J", "\x1b[H", "\x1b]0;", "\x1b]52;", "\r", "\x07", "\x9b"):
+            with self.subTest(control=repr(control)):
+                self.assertNotIn(control, rendered)
+
+    def test_styled_output_carries_no_artifact_escape(self) -> None:
+        self._assert_only_our_escapes(render_report(self.HOSTILE, force_style=True))
+
+    def test_plain_output_carries_no_artifact_escape(self) -> None:
+        rendered = render_report(self.HOSTILE, force_style=False)
+        self._assert_only_our_escapes(rendered)
+        self.assertNotIn("\033", rendered)
+
+    def test_sanitisation_happens_before_styling(self) -> None:
+        """Styling sanitised text is safe; sanitising styled text would either
+        destroy our escapes or leave a crafted one indistinguishable."""
+        rendered = render_report("**\x1b[31mred**", force_style=True)
+        self.assertNotIn("\x1b[31m", rendered)
+        self.assertIn("\033[1m", rendered)
+
+    def test_a_fence_cannot_smuggle_escapes(self) -> None:
+        rendered = render_report("```\n\x1b[2Jcleared\n```\n", force_style=True)
+        self.assertNotIn("\x1b[2J", rendered)
+
+
+class NonStreamingReportTests(unittest.TestCase):
+    """A backend that does not stream hands the terminal a whole report.
+
+    That is the one case where the complete text -- prose and appendices --
+    is printed in one call, so it is the case that must be rendered rather
+    than printed raw.
+    """
+
+    def test_a_whole_report_reaches_the_renderer(self) -> None:
+        import inspect
+
+        from orbit.terminal import repl
+
+        source = inspect.getsource(repl.Repl._ask_analysis)
+        self.assertIn("render_report(run.final_report.text)", source)
+        self.assertNotIn(
+            "sanitize_terminal_text(\n                        run.final_report.text",
+            source,
+        )
+
+    def test_every_report_print_site_renders(self) -> None:
+        """No path may print report text unrendered: an unstyled branch is
+        also an unsanitised-by-this-route branch."""
+        import inspect
+
+        from orbit.terminal import repl
+
+        for method in (repl.Repl._ask_analysis, repl.Repl._handle_report_command):
+            source = inspect.getsource(method)
+            with self.subTest(method=method.__name__):
+                self.assertNotIn("print(report.text", source)
+                self.assertNotIn("print(run.final_report.text", source)
+
+
+class OutputModeTests(unittest.TestCase):
+    """Every reason colour may be disallowed produces raw Markdown."""
+
+    def _rendered_under(self, **env) -> str:
+        with mock.patch.dict(os.environ, env, clear=False):
+            for key in ("NO_COLOR",):
+                if key not in env:
+                    os.environ.pop(key, None)
+            return render_report(SAMPLE)
+
+    def test_no_color_yields_raw_markdown(self) -> None:
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=True):
+            rendered = self._rendered_under(NO_COLOR="1")
+        self.assertEqual(rendered, SAMPLE)
+        self.assertNotIn("\033", rendered)
+
+    def test_a_dumb_terminal_yields_raw_markdown(self) -> None:
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=True):
+            rendered = self._rendered_under(TERM="dumb")
+        self.assertEqual(rendered, SAMPLE)
+
+    def test_a_non_tty_yields_raw_markdown(self) -> None:
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=False):
+            rendered = self._rendered_under(TERM="xterm")
+        self.assertEqual(rendered, SAMPLE)
+
+    def test_redirected_output_yields_raw_markdown(self) -> None:
+        """The real path: stdout is a StringIO, not a terminal."""
+        os.environ.pop("NO_COLOR", None)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            print(render_report(SAMPLE))
+        self.assertNotIn("\033", out.getvalue())
+        self.assertIn("## Verified indicators", out.getvalue())
+
+    def test_a_colour_terminal_yields_styled_markdown(self) -> None:
+        with mock.patch("orbit.terminal.theme.is_tty", return_value=True):
+            rendered = self._rendered_under(TERM="xterm")
+        self.assertIn("\033", rendered)
+        self.assertEqual(visible(rendered), SAMPLE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A finished report is now shown with its structure rendered rather than spelled — headings, bold, inline code, lists, fenced blocks, provenance lines and evidence ids. Tables are left as raw Markdown: correct beats complete.

**Only appearance changes.** `report.text` stays canonical for APIs, sessions, files and pipes. The renderer is a view applied at four print sites; off a terminal it returns the text unchanged. Markers are preserved rather than consumed, which makes the invariant checkable: `strip_ansi(render_report(t)) == sanitize_terminal_text(t)`, byte for byte — including whitespace runs that align a numbered list or indent a literal code block.

**Complete text only**, never streamed chunks. **Sanitise-then-style, never the reverse** — report text carries decoded artifact bytes. No new dependency; existing theme primitives plus one `BOLD` constant.

NO_COLOR / TERM=dumb / non-TTY / redirect → raw Markdown, zero ANSI.

Full suite 4213 OK (skipped=8). 21 non-equivalent mutants caught. Review returned BLOCKER 0, 2 MAJOR (whitespace after a marker was silently collapsed, breaking the stated invariant; 16/38 mutants surviving including `RESET=""`) and 2 MINOR (reset bleed in headings; brittle source assertions) — all fixed, each pinned by test, with a property test over a 33-case corpus now carrying the invariant.

The pre-existing sanitisation guard was updated to assert the property rather than one spelling, licensed by a new behavioural test that feeds the renderer hostile bytes in both modes.
