### PR TITLE
fix(analysis): report deterministic traversal truncation

### DIFF
--- a/src/orbit/runtime/analysis_deobfuscate.py
+++ b/src/orbit/runtime/analysis_deobfuscate.py
@@ -291,7 +291,9 @@ def _resolve_argument(
     return _unescape(literal if literal is not None else (alt or ""))
 
 
-def find_jscript_stages(source: str, depth: int = 0) -> list[TransformStage]:
+def find_jscript_stages(
+    source: str, depth: int = 0, truncation: "_Truncation | None" = None
+) -> list[TransformStage]:
     """Every call site of a structural decoder whose arguments are literal."""
     stages: list[TransformStage] = []
     names = _decoder_names(source)
@@ -321,9 +323,16 @@ def find_jscript_stages(source: str, depth: int = 0) -> list[TransformStage]:
             if encoded is None or delimiter is None:
                 continue
             if len(encoded) > MAX_INPUT_CHARS:
+                # A call site this pass could have decoded and did not.
+                if truncation is not None:
+                    truncation.dropped_input = True
                 continue
             decoded = _decode_tokens(encoded, int(key_text), delimiter)
-            if decoded is None or len(decoded) > MAX_OUTPUT_CHARS:
+            if decoded is None:
+                continue
+            if len(decoded) > MAX_OUTPUT_CHARS:
+                if truncation is not None:
+                    truncation.dropped_output = True
                 continue
             stages.append(
                 TransformStage(
@@ -386,7 +395,9 @@ def _reaches_bxor(name: str, source: str) -> bool:
     return False
 
 
-def find_powershell_stages(source: str, depth: int = 0) -> list[TransformStage]:
+def find_powershell_stages(
+    source: str, depth: int = 0, truncation: "_Truncation | None" = None
+) -> list[TransformStage]:
     """Literal `-bxor` reconstructions over a quoted numeric token list."""
     stages: list[TransformStage] = []
     # Matches rather than groups, so each list keeps the position it was
@@ -414,6 +425,8 @@ def find_powershell_stages(source: str, depth: int = 0) -> list[TransformStage]:
     for match in matches:
         name, tokens = match.group(1), match.group(2)
         if len(tokens) > MAX_INPUT_CHARS:
+            if truncation is not None:
+                truncation.dropped_input = True
             continue
         if not _reaches_bxor(name, source):
             # This list is never fed to the operator. A version string or a
@@ -425,7 +438,11 @@ def find_powershell_stages(source: str, depth: int = 0) -> list[TransformStage]:
             continue
         delimiter = delimiters.get(name, ",")
         decoded = _decode_tokens(tokens, key, delimiter)
-        if decoded is None or len(decoded) > MAX_OUTPUT_CHARS:
+        if decoded is None:
+            continue
+        if len(decoded) > MAX_OUTPUT_CHARS:
+            if truncation is not None:
+                truncation.dropped_output = True
             continue
         offset = match.start(2)
         stages.append(
@@ -445,26 +462,107 @@ def find_powershell_stages(source: str, depth: int = 0) -> list[TransformStage]:
     return stages
 
 
-def deobfuscate(source: str) -> list[TransformStage]:
-    """Every exact literal stage reachable from `source`, breadth-first.
+# Why a traversal stopped.
+#
+# The distinction that matters is between a walk that ended because there was
+# nothing left, and one that ended because a ceiling stopped it -- the second
+# leaves the artifact holding a transformation nobody ran, and a caller
+# reasoning about completeness must be able to tell them apart.
+#
+# Refusing an ambiguous call site is neither. A dynamic key, a dynamic
+# delimiter, a reassigned variable, a malformed token, an ambiguous operand:
+# this pass handles literals and declines everything else, and declining is
+# the contract rather than a limit. Those stay COMPLETE, because nothing ran
+# out. So does a cycle: its output is already recovered, so nothing is
+# missing. Only a call site this pass could have decoded, and did not because
+# of a size ceiling, is a truncation.
+COMPLETE = "complete"
+STAGE_LIMIT = "stage_limit"
+DEPTH_LIMIT = "depth_limit"
+INPUT_LIMIT = "input_limit"
+OUTPUT_LIMIT = "output_limit"
 
-    Bounded on all four axes that could otherwise run away: depth, stage
-    count, per-stage size, and repetition. Cycles are detected by content
-    digest rather than by shape, so a chain that decodes back to something
-    already seen stops whatever route it took to get there.
+
+class _Truncation:
+    """Whether a finder dropped a call site for exceeding a per-stage bound.
+
+    The finders return a list, which has no room to say "and one more was
+    skipped". A skipped call site is a real gap -- the artifact holds a
+    transformation nobody ran -- and a traversal that reported a fixed point
+    while one existed would be calling a truncation a completed result.
+
+    Deliberately a small mutable passed down rather than a changed return
+    type: both finders are called directly elsewhere, and widening their
+    contract to carry a flag would complicate every caller for the benefit of
+    the one that needs it.
+    """
+
+    def __init__(self) -> None:
+        self.dropped_input = False
+        self.dropped_output = False
+
+    @property
+    def dropped(self) -> bool:
+        return self.dropped_input or self.dropped_output
+
+    @property
+    def status(self) -> str:
+        """Which ceiling to name. Input first: it is the earlier refusal."""
+        return INPUT_LIMIT if self.dropped_input else OUTPUT_LIMIT
+
+
+@dataclass(frozen=True)
+class TransformResult:
+    """Stages, and whether the traversal that found them finished."""
+
+    stages: "list[TransformStage]"
+    status: str
+
+    @property
+    def complete(self) -> bool:
+        return self.status == COMPLETE
+
+
+def deobfuscate_with_status(source: str) -> TransformResult:
+    """`deobfuscate`, plus why it stopped.
+
+    Separate from `deobfuscate` rather than replacing it: every existing
+    caller wants the stages and nothing else, and the status only matters to
+    a decision about whether the recovered chain is the whole chain.
+
+    A bound reached is not a failure -- the stages found are still exact --
+    but it means something was not looked at, and a caller reasoning about
+    completeness has to be able to tell the difference.
     """
     if len(source) > MAX_INPUT_CHARS:
-        return []
+        return TransformResult([], INPUT_LIMIT)
     stages: list[TransformStage] = []
     seen: set[str] = {_sha(source)}
     frontier = [(source, 0)]
+    status = COMPLETE
+    # Text a ceiling stopped the walk from scanning. Whether that is a
+    # truncation or an irrelevance is decided after the loop, by asking what
+    # it would have produced -- a bound reached over inert text cost nothing,
+    # and reporting it as incomplete would be the mirror of the bug this
+    # function exists to prevent.
+    unexamined: list[str] = []
+    truncation = _Truncation()
     while frontier and len(stages) < MAX_STAGES:
         text, depth = frontier.pop(0)
         if depth >= MAX_DEPTH:
+            # Not followed, and not yet known to matter: whether the ceiling
+            # cost anything depends on what this text would have yielded, and
+            # that is settled once, below.
+            unexamined.append(text)
             continue
-        found = find_jscript_stages(text, depth) + find_powershell_stages(text, depth)
+        found = find_jscript_stages(
+            text, depth, truncation
+        ) + find_powershell_stages(text, depth, truncation)
         for stage in found:
             if len(stages) >= MAX_STAGES:
+                # A stage this walk found and could not record: unlike an
+                # unscanned output, this one is known to exist.
+                status = STAGE_LIMIT
                 break
             if stage.output_sha256 in seen:
                 continue
@@ -473,4 +571,44 @@ def deobfuscate(source: str) -> list[TransformStage]:
             # Decoded text is inert data that may itself contain a literal
             # stage. It is scanned, never executed.
             frontier.append((stage.output, depth + 1))
-    return stages
+    if status == COMPLETE:
+        # Anything the ceilings left unscanned: outputs still on the frontier
+        # when the stage ceiling stopped the walk, plus text refused for
+        # depth. Scanning them here does not extend the result -- no stage is
+        # added -- it only answers whether stopping cost anything. A ceiling
+        # reached over text that yields nothing is not a truncation, and a
+        # traversal that ended with nothing left to find is complete however
+        # close to a bound it came.
+        for text in [entry for entry, _depth in frontier] + unexamined:
+            probe = _Truncation()
+            if find_jscript_stages(text, 0, probe) or find_powershell_stages(
+                text, 0, probe
+            ):
+                status = STAGE_LIMIT if frontier else DEPTH_LIMIT
+                break
+            if probe.dropped:
+                status = probe.status
+                break
+    if truncation.dropped and status == COMPLETE:
+        # A call site was recognised and not decoded because its input or its
+        # output exceeded a per-stage bound. The frontier may have drained and
+        # no traversal bound may have tripped, but the artifact still holds a
+        # transformation nobody ran -- and a result with a hole in it is not a
+        # fixed point, whatever the loop looked like from the outside.
+        status = truncation.status
+    return TransformResult(stages, status)
+
+
+def deobfuscate(source: str) -> list[TransformStage]:
+    """Every exact literal stage reachable from `source`, breadth-first.
+
+    Bounded on all four axes that could otherwise run away: depth, stage
+    count, per-stage size, and repetition. Cycles are detected by content
+    digest rather than by shape, so a chain that decodes back to something
+    already seen stops whatever route it took to get there.
+
+    Kept as the plain form because every caller of it wants the stages and
+    nothing else. It delegates rather than repeating the traversal: two copies
+    of a bounded breadth-first walk would be two places for a bound to drift.
+    """
+    return deobfuscate_with_status(source).stages

--- a/tests/test_analysis_deobfuscate.py
+++ b/tests/test_analysis_deobfuscate.py
@@ -14,10 +14,18 @@ import hashlib
 import unittest
 
 from orbit.runtime.analysis_deobfuscate import (
+    COMPLETE,
+    DEPTH_LIMIT,
+    INPUT_LIMIT,
     JSCRIPT_XOR,
     MAX_DEPTH,
+    MAX_INPUT_CHARS,
+    MAX_STAGES,
+    OUTPUT_LIMIT,
     POWERSHELL_XOR,
+    STAGE_LIMIT,
     deobfuscate,
+    deobfuscate_with_status,
     find_jscript_stages,
     find_powershell_stages,
 )
@@ -276,6 +284,300 @@ class RecursionAndBoundTests(unittest.TestCase):
         payload = encode("SAME", 6, ",")
         src = decoder() + f'dec("{payload}", 6, ",");\n' + f'dec("{payload}", 6, ",");\n'
         self.assertEqual([s.output for s in deobfuscate(src)], ["SAME"])
+
+
+class TruncationStatusTests(unittest.TestCase):
+    """A bound reached must never be reported as a finished traversal.
+
+    The stages found are still exact either way -- what changes is whether
+    they are all of them. A caller reasoning about completeness has to be able
+    to tell "nothing further exists" from "something further was not looked
+    at", and a truncation that reports itself as a fixed point makes those
+    indistinguishable.
+    """
+
+    def test_a_clean_artifact_is_complete(self) -> None:
+        source = decoder() + f'dec("{encode("OK", 5, ",")}", 5, ",");\n'
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(result.status, COMPLETE)
+        self.assertTrue(result.complete)
+        self.assertEqual([s.output for s in result.stages], ["OK"])
+
+    def test_an_artifact_with_nothing_to_decode_is_complete(self) -> None:
+        """Nothing found is a finished answer, not a truncated one."""
+        result = deobfuscate_with_status("var x = 1;\n")
+
+        self.assertEqual(result.status, COMPLETE)
+        self.assertEqual(result.stages, [])
+
+    def test_the_stage_bound_is_reported(self) -> None:
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n' for i in range(MAX_STAGES * 3)
+        )
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(result.status, STAGE_LIMIT)
+        self.assertFalse(result.complete)
+        self.assertEqual(len(result.stages), MAX_STAGES)
+
+    def test_the_depth_bound_is_reported(self) -> None:
+        chain = "TERMINAL"
+        for key in (11, 13, 17, 19, 23, 29):
+            chain = decoder() + f'dec("{encode(chain, key, ",")}", {key}, ",");\n'
+        result = deobfuscate_with_status(chain)
+
+        self.assertEqual(result.status, DEPTH_LIMIT)
+        self.assertFalse(result.complete)
+
+    def test_the_whole_input_bound_is_reported(self) -> None:
+        result = deobfuscate_with_status("x" * (MAX_INPUT_CHARS + 1))
+
+        self.assertEqual(result.status, INPUT_LIMIT)
+        self.assertEqual(result.stages, [])
+
+    def test_a_call_site_dropped_for_its_output_size_is_reported(self) -> None:
+        """The case that motivated this.
+
+        A recognised call site whose decoded output exceeds the per-stage cap
+        is skipped. The frontier still drains and no traversal bound trips, so
+        the loop looks finished from the outside -- but the artifact holds a
+        transformation nobody ran, and saying `complete` would call that a
+        fixed point.
+        """
+        import orbit.runtime.analysis_deobfuscate as module
+
+        source = decoder()
+        source += f'dec("{encode("SMALL", 7, ",")}", 7, ",");\n'
+        source += f'dec("{encode("Y" * 300, 7, ",")}", 7, ",");\n'
+
+        original = module.MAX_OUTPUT_CHARS
+        try:
+            module.MAX_OUTPUT_CHARS = 100
+            result = deobfuscate_with_status(source)
+        finally:
+            module.MAX_OUTPUT_CHARS = original
+
+        self.assertEqual(result.status, OUTPUT_LIMIT)
+        self.assertFalse(result.complete)
+        # The stage that did fit is still exact and still returned.
+        self.assertEqual([s.output for s in result.stages], ["SMALL"])
+
+    def test_the_same_artifact_is_complete_when_nothing_is_dropped(self) -> None:
+        """The bound, not the shape of the artifact, is what changes it."""
+        source = decoder()
+        source += f'dec("{encode("SMALL", 7, ",")}", 7, ",");\n'
+        source += f'dec("{encode("Y" * 300, 7, ",")}", 7, ",");\n'
+
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(result.status, COMPLETE)
+        self.assertEqual(len(result.stages), 2)
+
+    def test_a_powershell_call_site_dropped_for_size_is_reported(self) -> None:
+        """Both finders report, not just the one that was easiest to reach."""
+        import orbit.runtime.analysis_deobfuscate as module
+
+        tokens = ",".join(str(ord(c) ^ 34) for c in "Y" * 300)
+        script = (
+            f"$d='{tokens}';$k=34;$o='';\n"
+            "$p=$d -split ',';\n"
+            "foreach($t in $p){$o=$o+[char]($t -bxor $k);}\n"
+        )
+
+        original = module.MAX_OUTPUT_CHARS
+        try:
+            module.MAX_OUTPUT_CHARS = 100
+            result = deobfuscate_with_status(script)
+        finally:
+            module.MAX_OUTPUT_CHARS = original
+
+        self.assertEqual(result.status, OUTPUT_LIMIT)
+
+    def test_no_bound_ever_reports_complete(self) -> None:
+        """The invariant itself, across every way a traversal can stop."""
+        for status in (STAGE_LIMIT, DEPTH_LIMIT, INPUT_LIMIT, OUTPUT_LIMIT):
+            with self.subTest(status=status):
+                self.assertNotEqual(status, COMPLETE)
+
+
+class BoundBoundaryTests(unittest.TestCase):
+    """A ceiling reached is not the same as a ceiling that cost something.
+
+    The mirror of the bug this change fixes: reporting incompleteness for a
+    traversal that actually finished is as wrong as reporting completeness for
+    one that did not, and it is the easier mistake to make, because the loop
+    knows it stopped without knowing whether stopping mattered.
+    """
+
+    def test_exactly_the_stage_ceiling_with_inert_outputs_is_complete(self) -> None:
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n' for i in range(MAX_STAGES)
+        )
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(len(result.stages), MAX_STAGES)
+        for stage in result.stages:
+            self.assertEqual(deobfuscate_with_status(stage.output).stages, [])
+        self.assertEqual(result.status, COMPLETE)
+
+    def test_more_than_the_stage_ceiling_is_reported(self) -> None:
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n'
+            for i in range(MAX_STAGES * 3)
+        )
+        self.assertEqual(deobfuscate_with_status(source).status, STAGE_LIMIT)
+
+    def test_a_recorded_stage_with_an_unscanned_output_is_reported(self) -> None:
+        """The stage ceiling can stop the walk after recording a stage but
+        before scanning what it decoded to. That output is a real hole even
+        though the ceiling was reached rather than exceeded."""
+        nested = decoder() + f'dec("{encode("DEEP", 3, ",")}", 3, ",");\n'
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n'
+            for i in range(MAX_STAGES - 1)
+        )
+        source += f'dec("{encode(nested, 23, "<")}", 23, "<");\n'
+
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(len(result.stages), MAX_STAGES)
+        self.assertEqual(result.status, STAGE_LIMIT)
+
+    def test_a_chain_ending_exactly_at_the_depth_ceiling_is_complete(self) -> None:
+        """The last text was refused for depth and would have yielded
+        nothing, so the ceiling cost nothing."""
+        chain = "TERMINAL"
+        for key in (11, 13, 17, 19)[:MAX_DEPTH]:
+            chain = decoder() + f'dec("{encode(chain, key, ",")}", {key}, ",");\n'
+
+        self.assertEqual(deobfuscate_with_status(chain).status, COMPLETE)
+
+    def test_a_chain_deeper_than_the_ceiling_is_reported(self) -> None:
+        chain = "TERMINAL"
+        for key in (11, 13, 17, 19, 23, 29):
+            chain = decoder() + f'dec("{encode(chain, key, ",")}", {key}, ",");\n'
+
+        self.assertEqual(deobfuscate_with_status(chain).status, DEPTH_LIMIT)
+
+    def test_an_input_ceiling_drop_is_named_as_such(self) -> None:
+        """Not folded into the output ceiling: they are different refusals."""
+        import orbit.runtime.analysis_deobfuscate as module
+
+        payload = encode("A" * 40, 7, ",")
+        source = decoder() + f'dec("{payload}", 7, ",");\n'
+        original = module.MAX_INPUT_CHARS
+        try:
+            # Below the encoded literal, so this call site is refused for its
+            # input rather than for what it would produce.
+            module.MAX_INPUT_CHARS = len(payload) - 1
+            recorder = module._Truncation()
+            module.find_jscript_stages(source, 0, recorder)
+        finally:
+            module.MAX_INPUT_CHARS = original
+
+        self.assertTrue(recorder.dropped_input)
+        self.assertFalse(recorder.dropped_output)
+        self.assertEqual(recorder.status, INPUT_LIMIT)
+
+    def test_a_traversal_bound_outranks_a_size_drop(self) -> None:
+        """Both can happen; the traversal bound is the larger statement."""
+        import orbit.runtime.analysis_deobfuscate as module
+
+        source = decoder() + "".join(
+            f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n'
+            for i in range(MAX_STAGES * 3)
+        )
+        source += f'dec("{encode("Y" * 300, 7, ",")}", 7, ",");\n'
+
+        original = module.MAX_OUTPUT_CHARS
+        try:
+            module.MAX_OUTPUT_CHARS = 100
+            result = deobfuscate_with_status(source)
+        finally:
+            module.MAX_OUTPUT_CHARS = original
+
+        self.assertEqual(result.status, STAGE_LIMIT)
+
+
+class AmbiguityIsNotTruncationTests(unittest.TestCase):
+    """Refusing a non-literal call site is the contract, not a limit.
+
+    This pass handles literals and declines everything else. Reporting a bound
+    for a declined call site would say a resource ran out when none did, and
+    would make every artifact containing one dynamic expression look truncated
+    -- which is most of them.
+    """
+
+    def _status(self, tail: str) -> str:
+        source = decoder() + f'dec("{encode("OK", 5, ",")}", 5, ",");\n' + tail
+        return deobfuscate_with_status(source).status
+
+    def test_ambiguous_call_sites_stay_complete(self) -> None:
+        for label, tail in (
+            ("malformed token", 'dec("72,NOPE,74", 0, ",");\n'),
+            ("dynamic key", 'dec("1,2,3", someKey, ",");\n'),
+            ("dynamic delimiter", 'dec("1,2,3", 5, sep);\n'),
+            ("dynamic input", "dec(buildPayload(), 5, \",\");\n"),
+            ("single token", 'dec("72", 0, ",");\n'),
+        ):
+            with self.subTest(case=label):
+                self.assertEqual(self._status(tail), COMPLETE)
+
+    def test_a_repeated_output_stays_complete(self) -> None:
+        """A cycle recovers nothing new because it has nothing new: the
+        output is already held."""
+        repeated = f'dec("{encode("OK", 5, ",")}", 5, ",");\n'
+        source = decoder() + repeated + repeated
+
+        result = deobfuscate_with_status(source)
+
+        self.assertEqual(result.status, COMPLETE)
+        self.assertEqual(len(result.stages), 1)
+
+    def test_only_a_size_ceiling_reports_truncation(self) -> None:
+        """The same artifact, complete or truncated depending only on the
+        bound -- which is what makes this a statement about limits rather
+        than about the artifact."""
+        import orbit.runtime.analysis_deobfuscate as module
+
+        source = decoder()
+        source += f'dec("{encode("SMALL", 7, ",")}", 7, ",");\n'
+        source += f'dec("{encode("Y" * 300, 7, ",")}", 7, ",");\n'
+
+        self.assertEqual(deobfuscate_with_status(source).status, COMPLETE)
+
+        original = module.MAX_OUTPUT_CHARS
+        try:
+            module.MAX_OUTPUT_CHARS = 100
+            self.assertEqual(deobfuscate_with_status(source).status, OUTPUT_LIMIT)
+        finally:
+            module.MAX_OUTPUT_CHARS = original
+
+
+class DeobfuscateCompatibilityTests(unittest.TestCase):
+    """`deobfuscate()` keeps its contract: stages, and nothing else."""
+
+    def _cases(self) -> tuple[str, ...]:
+        return (
+            "var x = 1;\n",
+            decoder() + f'dec("{encode("OK", 5, ",")}", 5, ",");\n',
+            decoder() + "".join(
+                f'dec("{encode(f"D{i}", 7, ",")}", 7, ",");\n'
+                for i in range(MAX_STAGES * 3)
+            ),
+        )
+
+    def test_it_returns_the_same_stages_as_the_status_form(self) -> None:
+        for source in self._cases():
+            with self.subTest(source=source[:40]):
+                self.assertEqual(
+                    [s.output_sha256 for s in deobfuscate(source)],
+                    [s.output_sha256 for s in deobfuscate_with_status(source).stages],
+                )
+
+    def test_it_still_returns_a_plain_list(self) -> None:
+        self.assertIsInstance(deobfuscate("var x = 1;\n"), list)
 
 
 class GenericityTests(unittest.TestCase):


### PR DESCRIPTION
A recognised call site whose decoded output exceeded the per-stage ceiling was skipped with a bare `continue` — the frontier still drained, no traversal bound tripped, and the walk reported success. A caller could not distinguish "nothing further exists" from "something further was not looked at".

`deobfuscate_with_status` now returns stages plus why the walk stopped: `complete`, `stage_limit`, `depth_limit`, `input_limit`, `output_limit`. `deobfuscate()` keeps its signature and list and delegates — one traversal, no second copy to drift.

**Reaching a ceiling is not the same as a ceiling costing something.** The outcome is decided after the loop, by scanning whatever the ceilings left unexamined — not to extend the result but to answer whether stopping mattered. Exactly `MAX_STAGES` stages with inert outputs is complete; a chain ending exactly at `MAX_DEPTH` is complete. Only genuine holes are reported.

**Ambiguity is not truncation.** Dynamic keys, reassigned variables, malformed tokens, ambiguous operands and cycles all stay `complete`: declining a non-literal is this pass's contract, not a limit.

Scope: this is the correctness fix uncovered while investigating an autonomous-analysis fast path. That design was disproven — transform-graph completeness does not establish whole-artifact coverage — and none of it is in this PR.

Full suite 4263 OK (skipped=8). 7 non-equivalent mutants caught. Independent review returned BLOCKER 0 and 2 MAJOR (false `stage_limit`/`depth_limit` on traversals that actually finished — the mirror of the bug being fixed) plus 3 MINOR; all reproduced and fixed, each pinned by test.
