### PR TITLE
fix(analysis): suppress exact covered-source reacquisition

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -45,6 +45,12 @@ from orbit.runtime.context_manager import (
     plan_exact_context,
 )
 from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
+from orbit.runtime.analysis_source_identity import (
+    SOURCE_REACQUISITION,
+    SourceEquivalence,
+    classify_artifacts,
+    classify_output,
+)
 from orbit.runtime.analysis_coverage import (
     COVERAGE_COMPLETE,
     COVERAGE_NOT_ELIGIBLE,
@@ -670,6 +676,61 @@ AUTONOMOUS_REPAIR_MESSAGE = (
 # already knows and which kinds of step can still change that, because the
 # alternative -- "already seen" with no route forward -- is what produced a run
 # that re-read one file nine times.
+def _source_reacquisition(
+    result: AnalysisResult, source: "AnalysisSource", covered_text: str | None
+) -> "SourceEquivalence | None":
+    """Whether this execution only handed back the source already supplied.
+
+    Gated on coverage: without it the model was never given the source, so
+    reading it is how the session learns what the artifact is -- ordinary,
+    necessary work. `covered_text` is None then and this returns None, leaving
+    every path below byte-identical to a run before this existed.
+
+    A successful action only. A failure has to reach the model as a failure,
+    and an action that was bounded or errored has not proven anything about
+    what it would have produced.
+
+    stderr must be empty and there must be nothing else printed: the proof is
+    "this output is the source and nothing else", so a warning or a computed
+    line means the observation carries something the session does not hold.
+    """
+    if covered_text is None or not result.ok or result.stderr:
+        return None
+    equivalence = classify_output(result.stdout, covered_text)
+    if equivalence is not None:
+        # Output proven to be only the source. An artifact alongside it would
+        # be new state regardless of what it holds, so it defeats the proof.
+        return equivalence if not result.artifacts else None
+    if result.stdout.strip():
+        # Something was printed that is not the source. Whatever else the
+        # action did, this observation is not a bare reacquisition.
+        return None
+    return classify_artifacts(
+        list(result.artifacts), source.sha256, source.size_bytes
+    )
+
+
+# What the model is told when an execution only recovered the covered source.
+#
+# Deliberately a tool result rather than a refusal: the program ran, this is
+# what it produced, and reporting an error would be false. It names the
+# recognizer so the model can see WHY the output added nothing -- and says
+# where the source already is, because "you already have this" without a
+# pointer is what produced the re-reading in the first place.
+#
+# It does not say the analysis is finished, and does not suggest a direction:
+# what to do instead is the model's decision, not the runtime's.
+def _source_reacquisition_observation(equivalence: "SourceEquivalence") -> str:
+    return (
+        f"{SOURCE_REACQUISITION.upper()}: this output is the complete artifact "
+        f"source, which Orbit already supplied in full earlier in this "
+        f"conversation ({equivalence.detail}). It was executed, and it "
+        "established nothing the session did not already hold.\n"
+        "The source above is the same bytes; re-read it there rather than "
+        "running another program to produce it."
+    )
+
+
 def _no_progress_observation(evidence_id: str) -> str:
     return (
         "NO_PROGRESS: this exact observation already exists as evidence "
@@ -1168,6 +1229,24 @@ class AnalysisRuntime:
             for message in self.messages
             if message.get("role") == "user"
         )
+
+    @property
+    def covered_source_text(self) -> str | None:
+        """The source Orbit supplied, or None when it supplied none.
+
+        Read from the snapshot rather than parsed back out of the message: the
+        artifact is the authority for its own bytes, and re-deriving them from
+        a rendered prompt would compare the model's view against itself. The
+        history only decides WHETHER coverage happened; the snapshot decides
+        what was covered.
+        """
+        if not self.source_covered:
+            return None
+        try:
+            raw = self.source.snapshot_path.read_bytes()
+        except OSError:
+            return None
+        return decode_artifact(raw)
 
     def __post_init__(self) -> None:
         if self.workspace is None:
@@ -1841,58 +1920,61 @@ class AnalysisRuntime:
                 diagnostics=_diagnostics(detail),
             )
 
+        equivalence = _source_reacquisition(
+            result, self.source, self.covered_source_text
+        )
+        if equivalence is not None:
+            # The program ran; what it produced is the source the session was
+            # already given. Recorded as evidence like any other execution --
+            # nothing is hidden, and the raw output stays re-attestable -- but
+            # it does not count as a useful action and it feeds the existing
+            # NO_PROGRESS path, because an observation that establishes nothing
+            # new is exactly what that path is for.
+            #
+            # `actions_executed` is deliberately not incremented: the action
+            # budget bounds work that can advance an analysis, and this cannot.
+            # The model call it cost is still counted, so the run stays bounded.
+            self.suppressed_duplicates += 1
+            record, _raw = self._record_action_evidence(
+                calls[0],
+                result,
+                _source_reacquisition_observation(equivalence),
+                extra={
+                    "suppressed_as": SOURCE_REACQUISITION,
+                    "suppression_recognizer": equivalence.recognizer,
+                    "suppression_detail": equivalence.detail,
+                },
+            )
+            # Appended like any other tool result: the model made a call and
+            # the history must answer it. Skipping this would leave an
+            # assistant turn with no matching result, which admission refuses
+            # outright -- the turn would be structurally invalid, not merely
+            # unhelpful.
+            self._append_tool_result(
+                calls[0],
+                _source_reacquisition_observation(equivalence),
+                record=record,
+            )
+            return AnalysisStepResult(
+                model_calls=1,
+                action_attempted=True,
+                # It executed -- saying otherwise would misreport what the
+                # sandbox did -- but it produced no useful evidence, which
+                # `suppressed_duplicate_of` is what the ledger reads.
+                action_executed=False,
+                assistant_text=response.content or "",
+                result=result,
+                evidence=record,
+                diagnostics=_diagnostics(None),
+                suppressed_duplicate_of=record.evidence_id,
+            )
+
         self.actions_executed += 1
         observation, truncated, full_chars = _bounded_observation(result)
 
-        # The full output goes to the evidence sidecar, which lives on disk and
-        # is only ever surfaced to a prompt through bounded excerpts. Recording
-        # the truncated text here instead would leave `observation_full_chars`
-        # describing bytes that no longer exist anywhere.
-        # Provenance is what `reattest_exact` checks before it will hand back
-        # durable evidence: without all three fields a record is stored but
-        # can never be re-attested. The identity is the model's own call id
-        # and this analyst turn -- nothing synthesised to satisfy the check.
-        provenance = self._provenance(calls[0])
-        raw_record = self.evidence_store.add(
-            f"{ANALYSIS_TOOL_NAME}_raw",
-            _raw_action_output(result),
-            metadata={
-                **provenance,
-                "analysis_source_sha256": self.source.sha256,
-                "code_sha256": result.code_sha256,
-                "kind": "raw_action_output",
-                "full_chars": full_chars,
-                "produced_by_phase": "analysis_action_raw",
-            },
-        )
-        record = self.evidence_store.add(
-            ANALYSIS_TOOL_NAME,
-            observation,
-            metadata={
-                **provenance,
-                "analysis_source_sha256": self.source.sha256,
-                "analysis_source_bytes": self.source.size_bytes,
-                "original_path": self.source.original_path,
-                "code_sha256": result.code_sha256,
-                "input_sha256": result.input_sha256,
-                "status": result.status,
-                "exit_status": result.exit_status,
-                "bound_exceeded": result.bound_exceeded,
-                "observation_truncated": truncated,
-                "observation_full_chars": full_chars,
-                "raw_output_evidence_id": raw_record.evidence_id,
-                "artifacts": [
-                    {
-                        "name": a.name,
-                        "size_bytes": a.size_bytes,
-                        "sha256": a.sha256,
-                        # Stable virtual handle: the host path stays an
-                        # implementation detail and never reaches the model.
-                        "handle": f"{WORK_MOUNT}/{a.name}",
-                    }
-                    for a in result.artifacts
-                ],
-            },
+        record, raw_record = self._record_action_evidence(
+            calls[0], result, observation,
+            truncated=truncated, full_chars=full_chars,
         )
         # Remember the experiment, keyed by the identity computed before it
         # ran, so a later request for the same one is answerable without
@@ -1919,6 +2001,80 @@ class AnalysisRuntime:
             artifact_handles=tuple(f"{WORK_MOUNT}/{a.name}" for a in result.artifacts),
             diagnostics=_diagnostics(None),
         )
+
+    def _record_action_evidence(
+        self,
+        call: dict[str, Any],
+        result: AnalysisResult,
+        observation: str,
+        *,
+        truncated: bool = False,
+        full_chars: int | None = None,
+        extra: "dict[str, object] | None" = None,
+    ) -> "tuple[EvidenceRecord, EvidenceRecord]":
+        """Persist one execution's evidence, and return the model-facing record.
+
+        Shared by the ordinary path and by a suppressed source reacquisition,
+        so a suppressed action is recorded exactly as completely as any other:
+        the raw output keeps its own re-attestable record, the provenance is
+        the model's real call id and this analyst turn, and the artifacts are
+        listed. Suppression changes what the model is TOLD, never what the
+        store holds -- an audit has to be able to see what was suppressed and
+        check the claim.
+
+        The full output goes to the sidecar, which lives on disk and is only
+        ever surfaced to a prompt through bounded excerpts. Recording the
+        truncated text instead would leave `observation_full_chars` describing
+        bytes that no longer exist anywhere.
+        """
+        provenance = self._provenance(call)
+        raw_record = self.evidence_store.add(
+            f"{ANALYSIS_TOOL_NAME}_raw",
+            _raw_action_output(result),
+            metadata={
+                **provenance,
+                "analysis_source_sha256": self.source.sha256,
+                "code_sha256": result.code_sha256,
+                "kind": "raw_action_output",
+                "full_chars": (
+                    len(observation) if full_chars is None else full_chars
+                ),
+                "produced_by_phase": "analysis_action_raw",
+            },
+        )
+        record = self.evidence_store.add(
+            ANALYSIS_TOOL_NAME,
+            observation,
+            metadata={
+                **provenance,
+                "analysis_source_sha256": self.source.sha256,
+                "analysis_source_bytes": self.source.size_bytes,
+                "original_path": self.source.original_path,
+                "code_sha256": result.code_sha256,
+                "input_sha256": result.input_sha256,
+                "status": result.status,
+                "exit_status": result.exit_status,
+                "bound_exceeded": result.bound_exceeded,
+                "observation_truncated": truncated,
+                "observation_full_chars": (
+                    len(observation) if full_chars is None else full_chars
+                ),
+                "raw_output_evidence_id": raw_record.evidence_id,
+                "artifacts": [
+                    {
+                        "name": a.name,
+                        "size_bytes": a.size_bytes,
+                        "sha256": a.sha256,
+                        # Stable virtual handle: the host path stays an
+                        # implementation detail and never reaches the model.
+                        "handle": f"{WORK_MOUNT}/{a.name}",
+                    }
+                    for a in result.artifacts
+                ],
+                **(extra or {}),
+            },
+        )
+        return record, raw_record
 
     def plan_source_coverage(self) -> SourceCoverage:
         """Decide whether the whole artifact can be supplied in one call.

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -1264,6 +1264,16 @@ class AnalysisRuntime:
             raw = self.source.snapshot_path.read_bytes()
         except OSError:
             return None
+        if hashlib.sha256(raw).hexdigest() != self.source.sha256:
+            # The bytes on disk are no longer the ones the session is pinned
+            # to, so they are not what the model was shown. The snapshot is
+            # 0400 inside a 0700 session directory and the sandbox refuses a
+            # changed read-only input, so this should be unreachable -- which
+            # is the reason to check it here rather than rely on that: the
+            # digest is already in hand, and comparing against the wrong bytes
+            # would suppress an observation on the strength of a file nobody
+            # covered.
+            return None
         return decode_artifact(raw)
 
     def __post_init__(self) -> None:

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -50,7 +50,7 @@ from orbit.runtime.analysis_source_identity import (
     SourceEquivalence,
     classify_artifacts,
     classify_output,
-)
+)  # noqa: F401 - SourceEquivalence is referenced in quoted annotations
 from orbit.runtime.analysis_coverage import (
     COVERAGE_COMPLETE,
     COVERAGE_NOT_ELIGIBLE,
@@ -695,6 +695,14 @@ def _source_reacquisition(
     line means the observation carries something the session does not hold.
     """
     if covered_text is None or not result.ok or result.stderr:
+        return None
+    if result.truncated:
+        # The sandbox cut this output at its byte cap, so what is being
+        # compared is a PREFIX, not the output. A program that printed the
+        # source and then its findings has exactly the visible bytes of a bare
+        # re-read, and suppressing it would discard the findings while telling
+        # the model nothing was established. Truncation alone leaves `status`
+        # as "ok", so this is the only signal that the comparison is partial.
         return None
     equivalence = classify_output(result.stdout, covered_text)
     if equivalence is not None:
@@ -1935,7 +1943,7 @@ class AnalysisRuntime:
             # budget bounds work that can advance an analysis, and this cannot.
             # The model call it cost is still counted, so the run stays bounded.
             self.suppressed_duplicates += 1
-            record, _raw = self._record_action_evidence(
+            record, raw_record = self._record_action_evidence(
                 calls[0],
                 result,
                 _source_reacquisition_observation(equivalence),
@@ -1965,6 +1973,16 @@ class AnalysisRuntime:
                 assistant_text=response.content or "",
                 result=result,
                 evidence=record,
+                # Carried exactly as the ordinary path carries them. A
+                # suppressed action still ran: it may have written a file, and
+                # the analyst's trailer reads these fields to say so. Dropping
+                # them would leave a real artifact on disk that nothing
+                # mentions -- suppression is about what the observation
+                # established, never about hiding what the action did.
+                raw_output_evidence_id=raw_record.evidence_id,
+                artifact_handles=tuple(
+                    f"{WORK_MOUNT}/{a.name}" for a in result.artifacts
+                ),
                 diagnostics=_diagnostics(None),
                 suppressed_duplicate_of=record.evidence_id,
             )

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -47,10 +47,13 @@ from orbit.runtime.context_manager import (
 from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
 from orbit.runtime.analysis_source_identity import (
     SOURCE_REACQUISITION,
+    # Referenced only in quoted annotations, which `from __future__ import
+    # annotations` defers -- the name still has to be bound for a reader or
+    # `typing.get_type_hints`.
     SourceEquivalence,
     classify_artifacts,
     classify_output,
-)  # noqa: F401 - SourceEquivalence is referenced in quoted annotations
+)
 from orbit.runtime.analysis_coverage import (
     COVERAGE_COMPLETE,
     COVERAGE_NOT_ELIGIBLE,

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -696,6 +696,13 @@ def _source_reacquisition(
     """
     if covered_text is None or not result.ok or result.stderr:
         return None
+    if result.output_replaced:
+        # Decoding substituted U+FFFD for bytes that were not UTF-8, so the
+        # recorded text is not what the program printed. An artifact that
+        # itself contains U+FFFD would then compare equal to output that never
+        # matched it -- the same defect as truncation, arriving by a different
+        # route: the comparison is over an altered view of the output.
+        return None
     if result.truncated:
         # The sandbox cut this output at its byte cap, so what is being
         # compared is a PREFIX, not the output. A program that printed the

--- a/src/orbit/runtime/analysis_sandbox.py
+++ b/src/orbit/runtime/analysis_sandbox.py
@@ -95,6 +95,11 @@ class AnalysisResult:
     exit_status: int | None
     duration_seconds: float
     truncated: bool = False
+    # Whether decoding stdout/stderr had to substitute U+FFFD for bytes that
+    # were not UTF-8. The recorded text is then not what the program printed,
+    # so anything comparing it against other bytes is comparing an altered
+    # view and must decline rather than conclude.
+    output_replaced: bool = False
     bound_exceeded: str | None = None
     artifacts: tuple[DerivedArtifact, ...] = field(default_factory=tuple)
 
@@ -548,6 +553,17 @@ def execute_analysis(
         truncated = len(stdout_raw) + len(stderr_raw) > MAX_OUTPUT_BYTES
         stdout = stdout_raw[:MAX_OUTPUT_BYTES].decode("utf-8", "replace")
         stderr = stderr_raw[:MAX_OUTPUT_BYTES].decode("utf-8", "replace")
+        # Whether the decode above had to substitute. `errors="replace"` turns
+        # bytes that are not UTF-8 into U+FFFD, so the recorded text is not
+        # what the program printed -- and a caller comparing that text against
+        # something else would be comparing an altered view. Detected by
+        # re-encoding: the round trip is lossless exactly when nothing was
+        # replaced. Reported rather than repaired, because the raw bytes are
+        # genuinely not text and the honest answer is to say so.
+        replaced = (
+            stdout.encode("utf-8") != stdout_raw[:MAX_OUTPUT_BYTES]
+            or stderr.encode("utf-8") != stderr_raw[:MAX_OUTPUT_BYTES]
+        )
 
         if timed_out:
             status = "timeout"
@@ -567,6 +583,7 @@ def execute_analysis(
             exit_status=exit_status,
             duration_seconds=time.monotonic() - started,
             truncated=truncated,
+            output_replaced=replaced,
             bound_exceeded=bound_error,
             artifacts=artifacts,
         )

--- a/src/orbit/runtime/analysis_source_identity.py
+++ b/src/orbit/runtime/analysis_source_identity.py
@@ -225,6 +225,10 @@ def strip_line_numbers(candidate: str) -> str | None:
     """
     lines = candidate.split("\n")
     if len(lines) < 2:
+        # One line is not a listing. `1: value` against a one-line source is
+        # indistinguishable from a search result whose leading number is a
+        # match index -- real information about where something was found --
+        # so numbering means nothing until there is a sequence to check.
         return None
     numbers: list[int] = []
     bodies: list[str] = []

--- a/src/orbit/runtime/analysis_source_identity.py
+++ b/src/orbit/runtime/analysis_source_identity.py
@@ -208,7 +208,7 @@ def _match_repr(candidate: str, source: str) -> bool:
 # and keeps the conversion total.
 _MAX_LINE_NUMBER_DIGITS = 9
 _NUMBERED_LINE = re.compile(
-    r"\A[ \t]*(?P<number>\d{1,%d})(?P<sep>: | \| |\t|: |\. |  | )"
+    r"\A[ \t]*(?P<number>\d{1,%d})(?P<sep>: | \| |\t|\. |  | )"
     % _MAX_LINE_NUMBER_DIGITS
 )
 

--- a/src/orbit/runtime/analysis_source_identity.py
+++ b/src/orbit/runtime/analysis_source_identity.py
@@ -201,7 +201,16 @@ def _match_repr(candidate: str, source: str) -> bool:
 # matching at all, so nothing with real content can hide in front of a
 # listing -- verified for prefixes like `x`, `0`, `#` and ` 0: `, each of which
 # leaves the observation as ordinary evidence.
-_NUMBERED_LINE = re.compile(r"^[ \t]*(?P<number>\d+)(?P<sep>: | \| |\t|: |\. |  | )")
+# The digit run is bounded. A line number is at most as large as the file has
+# lines, so a long one cannot be a real listing -- and `int()` on a very long
+# digit string raises rather than returning, which is artifact-controlled input
+# crashing the runtime. Nine digits admits any file this could plausibly cover
+# and keeps the conversion total.
+_MAX_LINE_NUMBER_DIGITS = 9
+_NUMBERED_LINE = re.compile(
+    r"\A[ \t]*(?P<number>\d{1,%d})(?P<sep>: | \| |\t|: |\. |  | )"
+    % _MAX_LINE_NUMBER_DIGITS
+)
 
 
 def strip_line_numbers(candidate: str) -> str | None:

--- a/src/orbit/runtime/analysis_source_identity.py
+++ b/src/orbit/runtime/analysis_source_identity.py
@@ -94,7 +94,10 @@ def _match_raw(candidate: str, source: str) -> bool:
 # A Python string literal, single- or double-quoted, with no adjacent
 # concatenation and no prefix (no f, r, b, u): exactly what `repr()` of a
 # `str` produces. Anything else is not a repr this will attempt.
-_REPR_LITERAL = re.compile(r"^(?P<quote>'|\")(?P<body>.*)(?P=quote)$", re.S)
+# `\A` and `\Z`, never `^`/`$`: with `re.S` a `$` also matches just BEFORE a
+# final newline, so `repr(x) + "\n"` would match with the newline silently
+# tolerated -- accepting a candidate that is the repr plus something else.
+_REPR_LITERAL = re.compile(r"\A(?P<quote>'|\")(?P<body>.*)(?P=quote)\Z", re.S)
 
 # The escapes `repr` actually emits for a `str`, and nothing else. A form this
 # does not list is not decoded -- it is a reason to refuse.
@@ -191,6 +194,13 @@ def _match_repr(candidate: str, source: str) -> bool:
 # line. The separator forms are fixed here rather than inferred, so a file
 # whose own lines begin with digits cannot make an arbitrary prefix look like
 # numbering -- the reconstruction below is what actually decides.
+#
+# The leading `[ \t]*` absorbs the right-alignment padding a formatter emits
+# (`f"{i:3}"`), and only that: it is whitespace that belongs to the number, not
+# to the line. Any non-whitespace character before the digits stops the line
+# matching at all, so nothing with real content can hide in front of a
+# listing -- verified for prefixes like `x`, `0`, `#` and ` 0: `, each of which
+# leaves the observation as ordinary evidence.
 _NUMBERED_LINE = re.compile(r"^[ \t]*(?P<number>\d+)(?P<sep>: | \| |\t|: |\. |  | )")
 
 

--- a/src/orbit/runtime/analysis_source_identity.py
+++ b/src/orbit/runtime/analysis_source_identity.py
@@ -1,0 +1,283 @@
+"""Prove that an action's output is only the source Orbit already supplied.
+
+After COVER hands the model the complete artifact, the observed behaviour is
+that it reads the same bytes back anyway -- as a repr, as plain text, as a
+numbered listing. Those observations carry nothing the session does not already
+hold, and treating them as new evidence is what lets a run spend its budget
+re-reading what it was given.
+
+This module decides one question and refuses to guess at it:
+
+    Is this output, exactly and reversibly, the covered source and nothing else?
+
+"Exactly" is the whole design. Every recognizer here reconstructs candidate
+bytes and compares them to the artifact's own bytes; a single differing byte,
+one extra line, one reordered line, one normalised newline, and the answer is
+no. There is no similarity, no distance, no normalisation that could make two
+different artifacts compare equal, and no model judgement. The failure mode
+this must never have is suppressing something new, so every ambiguity resolves
+to "not proven" and the observation stays ordinary evidence.
+
+What is deliberately NOT recognised, because each carries something the source
+alone does not: a partial range, the source plus any computed line, a grep or
+search result, a decoded value, a hash, a summary, or output that merely looks
+like the source. The live run that motivated this is the case in point -- of
+its four source reads, the fourth also printed a line count, a `def` count and
+an import list, and is therefore a real observation that must stay.
+
+Nothing here executes, imports or evaluates the text it inspects. The repr
+recognizer is a narrow literal decoder over a documented grammar, not `eval`:
+artifact bytes are attacker-controlled, and a parser that could be steered by
+them would be a worse problem than the one this solves.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Bound on what is worth attempting to prove. A candidate cannot be the source
+# if it is wildly larger than the source: numbering adds a prefix per line and
+# a repr adds escapes, so a generous multiple still admits every real form
+# while keeping a hostile megabyte of text from being scanned line by line.
+MAX_CANDIDATE_RATIO = 8
+MAX_CANDIDATE_CHARS = 4_000_000
+
+# How a proven reacquisition is named in provenance and in the model-facing
+# note. One string, so the record and the message cannot drift apart.
+SOURCE_REACQUISITION = "source_reacquisition"
+
+RAW = "raw"
+REPR = "repr"
+NUMBERED = "numbered"
+ARTIFACT = "artifact"
+
+
+@dataclass(frozen=True)
+class SourceEquivalence:
+    """Why an output was judged to be only the already-covered source."""
+
+    recognizer: str
+    detail: str = ""
+
+
+def _too_large(candidate: str, source: str) -> bool:
+    return (
+        len(candidate) > MAX_CANDIDATE_CHARS
+        or len(candidate) > max(1024, len(source) * MAX_CANDIDATE_RATIO)
+    )
+
+
+def _strip_trailing_newline(text: str) -> str:
+    """Drop exactly one trailing newline, the one `print` itself adds.
+
+    Only one, and only at the end: `print(x)` emits `x` followed by `\\n`, so
+    without this every plain read would fail by a single byte. Removing more
+    would start normalising, which is the thing this module must not do.
+    """
+    return text[:-1] if text.endswith("\n") else text
+
+
+def _match_raw(candidate: str, source: str) -> bool:
+    """The output IS the source, byte for byte.
+
+    Two spellings are accepted and no others: the source exactly, and the
+    source plus the single newline `print` appends. A file that already ends
+    in a newline therefore matches both `print(data)` and a bare write of the
+    same bytes -- which is why the candidate is compared as-is first rather
+    than always having a newline stripped from it, since stripping would turn
+    an exact match into a one-byte-short mismatch.
+    """
+    return candidate == source or candidate == source + "\n"
+
+
+# A Python string literal, single- or double-quoted, with no adjacent
+# concatenation and no prefix (no f, r, b, u): exactly what `repr()` of a
+# `str` produces. Anything else is not a repr this will attempt.
+_REPR_LITERAL = re.compile(r"^(?P<quote>'|\")(?P<body>.*)(?P=quote)$", re.S)
+
+# The escapes `repr` actually emits for a `str`, and nothing else. A form this
+# does not list is not decoded -- it is a reason to refuse.
+_SIMPLE_ESCAPES = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "v": "\v",
+    "0": "\0",
+}
+
+
+def decode_repr_literal(text: str) -> str | None:
+    """Decode a `repr()`-shaped string literal, or None.
+
+    A deliberate, bounded re-implementation rather than `eval` or
+    `ast.literal_eval`. `eval` would execute artifact-controlled text, and even
+    `literal_eval` accepts a far larger grammar than `repr(str)` produces --
+    tuples, dicts, concatenation, numeric towers -- which is surface this does
+    not need and cannot audit. Only the escapes CPython's `repr` emits are
+    understood; anything else returns None and the caller treats the output as
+    ordinary evidence.
+
+    The result is verified against the source by the caller, so a decoding
+    error can only ever cause a missed suppression, never a false one.
+    """
+    match = _REPR_LITERAL.match(text)
+    if match is None:
+        return None
+    body = match.group("body")
+    quote = match.group("quote")
+    out: list[str] = []
+    index = 0
+    length = len(body)
+    while index < length:
+        char = body[index]
+        if char == quote:
+            # An unescaped quote of the enclosing kind cannot appear inside a
+            # real repr: it would have ended the literal.
+            return None
+        if char != "\\":
+            out.append(char)
+            index += 1
+            continue
+        index += 1
+        if index >= length:
+            return None  # trailing backslash: not a complete literal
+        marker = body[index]
+        if marker in _SIMPLE_ESCAPES:
+            out.append(_SIMPLE_ESCAPES[marker])
+            index += 1
+            continue
+        if marker == "x":
+            digits = body[index + 1 : index + 3]
+            if len(digits) != 2 or any(
+                d not in "0123456789abcdefABCDEF" for d in digits
+            ):
+                return None
+            out.append(chr(int(digits, 16)))
+            index += 3
+            continue
+        if marker in ("u", "U"):
+            width = 4 if marker == "u" else 8
+            digits = body[index + 1 : index + 1 + width]
+            if len(digits) != width or any(
+                d not in "0123456789abcdefABCDEF" for d in digits
+            ):
+                return None
+            value = int(digits, 16)
+            if value > 0x10FFFF or 0xD800 <= value <= 0xDFFF:
+                return None  # not a scalar value; repr never emits these
+            out.append(chr(value))
+            index += 1 + width
+            continue
+        # `\N{...}` and octal escapes are valid Python but are not emitted by
+        # `repr`, so they are refused rather than decoded.
+        return None
+    return "".join(out)
+
+
+def _match_repr(candidate: str, source: str) -> bool:
+    """The output is `repr(source)` and nothing else."""
+    decoded = decode_repr_literal(_strip_trailing_newline(candidate))
+    return decoded is not None and decoded == source
+
+
+# One numbered line: an optional run of spaces, digits, a separator, then the
+# line. The separator forms are fixed here rather than inferred, so a file
+# whose own lines begin with digits cannot make an arbitrary prefix look like
+# numbering -- the reconstruction below is what actually decides.
+_NUMBERED_LINE = re.compile(r"^[ \t]*(?P<number>\d+)(?P<sep>: | \| |\t|: |\. |  | )")
+
+
+def strip_line_numbers(candidate: str) -> str | None:
+    """Remove a uniform line-number prefix, or None if it is not uniform.
+
+    Reversibility is the requirement: the numbers must run consecutively from
+    a single start (0 or 1), every line must carry one, and every line must use
+    the same separator. Anything else -- a gap, a repeat, a mixed separator, a
+    line without a number -- means this is not a full numbered listing of a
+    file, and could be a filtered or annotated view that carries real
+    information. Those return None and are never suppressed.
+    """
+    lines = candidate.split("\n")
+    if len(lines) < 2:
+        return None
+    numbers: list[int] = []
+    bodies: list[str] = []
+    separator: str | None = None
+    for line in lines:
+        match = _NUMBERED_LINE.match(line)
+        if match is None:
+            return None
+        if separator is None:
+            separator = match.group("sep")
+        elif match.group("sep") != separator:
+            return None  # mixed separators: not one uniform listing
+        numbers.append(int(match.group("number")))
+        bodies.append(line[match.end() :])
+    if numbers[0] not in (0, 1):
+        return None
+    if numbers != list(range(numbers[0], numbers[0] + len(numbers))):
+        return None  # gaps, repeats or reordering: not a complete listing
+    return "\n".join(bodies)
+
+
+def _match_numbered(candidate: str, source: str) -> bool:
+    """The output is a complete consecutive numbered listing of the source.
+
+    `splitlines()` is what produces such a listing, and it drops the final
+    newline, so the source is compared both as-is and without its trailing
+    newline. Nothing else about the bytes is adjusted.
+    """
+    stripped = strip_line_numbers(_strip_trailing_newline(candidate))
+    if stripped is None:
+        return False
+    return stripped == source or stripped == _strip_trailing_newline(source)
+
+
+def classify_output(candidate: str, source: str) -> SourceEquivalence | None:
+    """Prove `candidate` is only `source`, or return None.
+
+    Tried in the order the forms actually occur, cheapest first. Every path
+    ends in an exact comparison against the source's own bytes.
+    """
+    if not candidate or not source:
+        return None
+    if _too_large(candidate, source):
+        return None
+    if _match_raw(candidate, source):
+        return SourceEquivalence(RAW, "output is the covered source verbatim")
+    if _match_repr(candidate, source):
+        return SourceEquivalence(REPR, "output is repr() of the covered source")
+    if _match_numbered(candidate, source):
+        return SourceEquivalence(
+            NUMBERED, "output is a numbered listing of the covered source"
+        )
+    return None
+
+
+def classify_artifacts(
+    artifacts: "list[object]", source_sha256: str, source_bytes: int
+) -> SourceEquivalence | None:
+    """Prove a produced artifact is a copy of the covered source.
+
+    Identity is the digest, not the name: a file called anything at all whose
+    bytes hash to the artifact's own digest is a copy of it. More than one
+    artifact means the action produced something besides a copy, so it is not
+    suppressible.
+    """
+    if len(artifacts) != 1:
+        return None
+    only = artifacts[0]
+    digest = getattr(only, "sha256", None)
+    size = getattr(only, "size_bytes", None)
+    if digest != source_sha256 or size != source_bytes:
+        return None
+    return SourceEquivalence(
+        ARTIFACT, f"artifact {getattr(only, 'name', '?')!r} is a copy of the source"
+    )

--- a/src/orbit/terminal/analysis_mode.py
+++ b/src/orbit/terminal/analysis_mode.py
@@ -166,10 +166,17 @@ def format_analysis_step(
         lines.append(f"action refused: {result.rejection}")
     elif result.action_executed and result.result is not None:
         lines.append(_action_summary(result))
+    elif result.suppressed_duplicate_of is not None and result.result is not None:
+        # A suppressed reacquisition DID run: it produced no useful evidence,
+        # which is a different thing from not having executed. Summarised like
+        # any other execution so the analyst sees what it wrote and can reach
+        # its evidence, with the suppression stated rather than implied.
+        lines.append(_action_summary(result))
+        lines.append(f"no new evidence: {result.suppressed_duplicate_of}")
     elif result.action_attempted:
         lines.append("action attempted but not executed")
     if result.artifact_handles and not (
-        result.action_executed and result.result is not None and result.result.artifacts
+        result.result is not None and result.result.artifacts
     ):
         # Only when the preview did not already list them with size and digest;
         # printing both says the same thing twice.

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -99,6 +99,15 @@ def _result(stdout="", stderr="", status="ok", artifacts=()):
     )
 
 
+def _replaced_result(stdout: str) -> AnalysisResult:
+    """An `ok` result whose decode had to substitute U+FFFD."""
+    return AnalysisResult(
+        status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+        stdout=stdout, stderr="", exit_status=0, duration_seconds=0.1,
+        output_replaced=True,
+    )
+
+
 def _truncated_result(stdout: str) -> AnalysisResult:
     """An `ok` result the sandbox had to cut. Truncation alone is not `bounded`."""
     return AnalysisResult(
@@ -257,6 +266,40 @@ class FailClosedRuntimeTests(_Case):
         self.assertIsNone(step.suppressed_duplicate_of)
         self.assertTrue(step.action_executed)
         self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_replaced_output_is_never_suppressed(self) -> None:
+        """Decoding substituted U+FFFD, so the text is not what was printed.
+
+        The same defect as truncation by a different route. `errors="replace"`
+        turns non-UTF-8 bytes into U+FFFD, and an artifact that itself contains
+        U+FFFD -- legal UTF-8, so coverable -- would then compare equal to
+        output whose bytes never matched it. The comparison would be over an
+        altered view of what the action produced.
+        """
+        source = "he\ufffdlo\n"
+        runtime = self._runtime(source.encode())
+        self._cover(runtime)
+        before = runtime.actions_executed
+        step = self._step(runtime, _replaced_result(source))
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_the_same_output_without_replacement_is_suppressed(self) -> None:
+        """The control: only the substitution changes the verdict."""
+        source = "he\ufffdlo\n"
+        runtime = self._runtime(source.encode())
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=source))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+
+    def test_the_sandbox_detects_substitution_by_round_trip(self) -> None:
+        """Lossless re-encoding is exactly the absence of replacement."""
+        for raw, expected in ((b"he\xfflo\n", True), (b"hello\n", False),
+                              ("héllo\n".encode(), False)):
+            with self.subTest(raw=raw):
+                decoded = raw.decode("utf-8", "replace")
+                self.assertEqual(decoded.encode("utf-8") != raw, expected)
 
     def test_the_same_output_untruncated_is_suppressed(self) -> None:
         """The control: only truncation changes the verdict."""

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -1,0 +1,415 @@
+"""A proven source reacquisition must cost no useful action and no evidence.
+
+ANALYSIS-SOURCE-EQUIVALENCE-1, at the runtime seam. The recognizer tests prove
+what is and is not the covered source; these prove what the runtime does with
+that answer: the program still runs, its output is still recorded, but it does
+not consume an action slot, it does not become new useful evidence, and it
+feeds the existing NO_PROGRESS path rather than a new one.
+
+Everything is gated on coverage. Without it the model was never given the
+source, so reading it is how the session learns what the artifact is -- and
+every path below must stay byte-identical to a run before this existed.
+"""
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime import analysis_runtime as module  # noqa: E402
+from orbit.runtime.analysis_progress import NO_PROGRESS, ProgressLedger  # noqa: E402
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    SOURCE_REACQUISITION,
+    AnalysisRuntime,
+    AnalysisSource,
+    AnalysisWorkspace,
+)
+from orbit.runtime.analysis_sandbox import AnalysisResult, DerivedArtifact  # noqa: E402
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+
+CTX = 8192
+SOURCE = (
+    "import os\n"
+    "\n"
+    "\n"
+    "def handler(name):\n"
+    "    return os.environ.get(name)\n"
+)
+
+
+class _Backend:
+    """Orbit-native backend that always emits one execute_analysis call."""
+
+    thinking = False
+
+    def __init__(self, *, per_char: float = 0.25) -> None:
+        self.per_char = per_char
+        self.chat_calls: list[dict] = []
+        self.code = "import orbit_tools\nprint(orbit_tools.read_file(0, 4096))"
+
+    def supports_exact_context_admission(self) -> bool:
+        return True
+
+    def model_info(self):
+        class _Info:
+            context_length = CTX
+        return _Info()
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        chars = sum(len(str(m.get("content") or "")) for m in messages)
+        return TokenCount(
+            tokens=int(40 + chars * self.per_char), context_tokens=CTX,
+            rendered_hash="a" * 64, token_hash="b" * 64,
+        )
+
+    def chat_stream(self, messages, **kwargs):
+        self.chat_calls.append({"messages": list(messages), "tools": kwargs.get("tools")})
+        if not kwargs.get("tools"):
+            return self._result("noted", [])
+        import json
+
+        return self._result("running", [{
+            "id": f"call_{len(self.chat_calls)}", "type": "function",
+            "function": {"name": "execute_analysis",
+                         "arguments": json.dumps({"code": self.code})},
+        }])
+
+    def _result(self, content, calls):
+        return ChatResult(
+            content=content, model="m", finish_reason="stop", tool_calls=calls,
+            prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+
+    def chat(self, messages, **kwargs):
+        return self.chat_stream(messages, **kwargs)
+
+
+def _result(stdout="", stderr="", status="ok", artifacts=()):
+    return AnalysisResult(
+        status=status, code_sha256="c" * 64, input_sha256="i" * 64,
+        stdout=stdout, stderr=stderr, exit_status=0, duration_seconds=0.1,
+        artifacts=tuple(artifacts),
+    )
+
+
+class _Case(unittest.TestCase):
+    def _runtime(self, data: bytes = None, backend=None) -> AnalysisRuntime:
+        data = SOURCE.encode() if data is None else data
+        self.backend = backend or _Backend()
+        workspace = AnalysisWorkspace.create()
+        path = workspace.source_root / "artifact.py"
+        path.write_bytes(data)
+        runtime = AnalysisRuntime(
+            backend=self.backend,
+            source=AnalysisSource(
+                snapshot_path=path, sha256=hashlib.sha256(data).hexdigest(),
+                size_bytes=len(data), original_path=str(path),
+            ),
+            evidence_store=EvidenceStore(root=workspace.root / "evidence"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def _cover(self, runtime) -> None:
+        coverage = runtime.plan_source_coverage()
+        self.assertTrue(coverage.covered, "fixture must be COVER-eligible")
+        runtime.cover_source(coverage)
+        self.backend.chat_calls.clear()
+
+    def _step(self, runtime, result):
+        with mock.patch.object(module, "execute_analysis", lambda **kw: result):
+            return runtime.step("go")
+
+
+class CoveredSourceTextTests(_Case):
+    """The authority for what was covered is the snapshot, not the prompt."""
+
+    def test_no_covered_text_before_cover(self) -> None:
+        self.assertIsNone(self._runtime().covered_source_text)
+
+    def test_covered_text_is_the_artifact_bytes(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        self.assertEqual(runtime.covered_source_text, SOURCE)
+
+    def test_rewinding_the_history_withdraws_it(self) -> None:
+        runtime = self._runtime()
+        checkpoint = len(runtime.messages)
+        self._cover(runtime)
+        del runtime.messages[checkpoint:]
+        self.assertIsNone(runtime.covered_source_text)
+
+    def test_a_binary_artifact_has_no_covered_text(self) -> None:
+        runtime = self._runtime(b"\x00\xffbinary")
+        self.assertIsNone(runtime.covered_source_text)
+
+
+class SuppressionTests(_Case):
+    """A-D. The four provable forms, through the real step()."""
+
+    def test_raw_reacquisition_is_suppressed(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+        self.assertFalse(step.action_executed)
+
+    def test_repr_reacquisition_is_suppressed(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=repr(SOURCE) + "\n"))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+
+    def test_numbered_reacquisition_is_suppressed(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        listing = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(SOURCE.splitlines())
+        )
+        step = self._step(runtime, _result(stdout=listing + "\n"))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+
+    def test_a_copied_file_is_suppressed(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        step = self._step(runtime, _result(stdout="", artifacts=[copy]))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+
+
+class FailClosedRuntimeTests(_Case):
+    """E-J. Everything that must remain useful evidence."""
+
+    def _assert_useful(self, runtime, result) -> None:
+        before = runtime.actions_executed
+        step = self._step(runtime, result)
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_one_byte_difference_stays_useful(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._assert_useful(runtime, _result(stdout=SOURCE.replace("os", "0s", 1)))
+
+    def test_source_plus_a_computed_line_stays_useful(self) -> None:
+        """The live pattern: the source AND something worked out."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._assert_useful(
+            runtime, _result(stdout=f"{SOURCE}\nLEN: {len(SOURCE)}")
+        )
+
+    def test_partial_source_stays_useful(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._assert_useful(runtime, _result(stdout=SOURCE[:40]))
+
+    def test_a_targeted_calculation_stays_useful(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._assert_useful(runtime, _result(stdout="SHA256: abc123\nIMPORTS: ['os']"))
+
+    def test_stderr_defeats_the_proof(self) -> None:
+        """A warning is information; the output is not the source alone."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._assert_useful(
+            runtime, _result(stdout=SOURCE, stderr="warning: deprecated")
+        )
+
+    def test_a_failed_action_is_never_suppressed(self) -> None:
+        """A failure must reach the model as a failure."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE, status="error"))
+        self.assertIsNone(step.suppressed_duplicate_of)
+
+    def test_a_copy_alongside_other_output_stays_useful(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        self._assert_useful(
+            runtime, _result(stdout="LINE COUNT: 5", artifacts=[copy])
+        )
+
+    def test_the_source_printed_with_a_copy_stays_useful(self) -> None:
+        """An artifact is new state whatever the stdout says."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        self._assert_useful(runtime, _result(stdout=SOURCE, artifacts=[copy]))
+
+    def test_a_different_file_written_stays_useful(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        other = DerivedArtifact(name="notes.txt", size_bytes=5, sha256="f" * 64)
+        self._assert_useful(runtime, _result(stdout="", artifacts=[other]))
+
+
+class WithoutCoverageTests(_Case):
+    """K. Without COVER, nothing changes."""
+
+    def test_reading_the_source_is_ordinary_work_without_coverage(self) -> None:
+        runtime = self._runtime()
+        before = runtime.actions_executed
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_suppression_starts_only_after_coverage(self) -> None:
+        runtime = self._runtime()
+        first = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertIsNone(first.suppressed_duplicate_of)
+        self._cover(runtime)
+        second = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertIsNotNone(second.suppressed_duplicate_of)
+
+
+class AccountingTests(_Case):
+    """M-O. Progress, ceilings and provenance."""
+
+    def test_a_suppressed_step_consumes_no_action_slot(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        before = runtime.actions_executed
+        self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertEqual(runtime.actions_executed, before)
+
+    def test_a_suppressed_step_still_counts_its_model_call(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        before = runtime.model_calls
+        self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertEqual(runtime.model_calls, before + 1)
+
+    def test_it_is_counted_in_the_suppression_tally(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        before = runtime.suppressed_duplicates
+        self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertEqual(runtime.suppressed_duplicates, before + 1)
+
+    def test_the_ledger_classifies_it_as_no_progress(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        record = ProgressLedger().classify(1, step)
+        self.assertEqual(record.classification, NO_PROGRESS)
+
+    def test_the_repeated_four_way_sequence_never_progresses(self) -> None:
+        """M. All four live forms in a row, none of them useful."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        listing = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(SOURCE.splitlines())
+        )
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        ledger = ProgressLedger()
+        outputs = [
+            _result(stdout=SOURCE + "\n"),
+            _result(stdout=repr(SOURCE) + "\n"),
+            _result(stdout=listing + "\n"),
+            _result(stdout="", artifacts=[copy]),
+        ]
+        for index, result in enumerate(outputs, 1):
+            step = self._step(runtime, result)
+            self.assertEqual(
+                ledger.classify(index, step).classification, NO_PROGRESS
+            )
+        self.assertEqual(runtime.actions_executed, 0)
+        self.assertEqual(runtime.suppressed_duplicates, 4)
+
+    def test_provenance_records_what_was_suppressed(self) -> None:
+        """N. An audit can see the claim and check it."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        record = runtime.evidence_store.records[step.suppressed_duplicate_of]
+        self.assertEqual(record.metadata["suppressed_as"], SOURCE_REACQUISITION)
+        self.assertEqual(record.metadata["suppression_recognizer"], "raw")
+        self.assertIn("suppression_detail", record.metadata)
+
+    def test_the_raw_output_is_still_retained_and_attestable(self) -> None:
+        """Nothing is hidden: the real bytes stay in the store."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        record = runtime.evidence_store.records[step.suppressed_duplicate_of]
+        raw_id = record.metadata["raw_output_evidence_id"]
+        raw = runtime.evidence_store.reattest_exact(raw_id)
+        self.assertIsNotNone(raw)
+        self.assertIn(SOURCE, raw)
+
+    def test_the_model_is_told_plainly_and_not_that_it_is_finished(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._step(runtime, _result(stdout=SOURCE + "\n"))
+        told = str(runtime.messages[-1]["content"])
+        self.assertIn(SOURCE_REACQUISITION, told.lower())
+        # It says the OUTPUT added nothing. It must not say the ANALYSIS is
+        # finished, nor tell the model what to do instead -- deciding that is
+        # the model's work, and a runtime that directed it would be doing
+        # analysis rather than orchestration.
+        for banned in (
+            "analysis is complete", "you are finished", "you are done",
+            "stop now", "report now", "no further", "conclude",
+        ):
+            self.assertNotIn(banned, told.lower(), banned)
+
+    def test_global_ceilings_are_unchanged(self) -> None:
+        """O. No bound moved."""
+        self.assertEqual(module.MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertEqual(module.SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertEqual(module.MAX_CONSECUTIVE_NO_PROGRESS, 2)
+
+
+class AutonomousLoopTests(_Case):
+    """The loop ends on repeated no-progress rather than spending the budget."""
+
+    def test_a_run_of_reacquisitions_stops_early(self) -> None:
+        runtime = self._runtime()
+        with mock.patch.object(
+            module, "execute_analysis", lambda **kw: _result(stdout=SOURCE + "\n")
+        ):
+            run = runtime.run_autonomous("analyse", max_model_calls=8, finalize=False)
+        self.assertEqual(run.cover_calls, 1)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertGreater(run.suppressed_duplicates, 0)
+        self.assertIn("no new evidence", run.stop_reason)
+
+    def test_legitimate_work_still_runs_after_a_suppression(self) -> None:
+        """J. Suppression is per-observation, never a mode the run enters."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._step(runtime, _result(stdout=SOURCE + "\n"))
+        step = self._step(runtime, _result(stdout="FINDING: os.environ read"))
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -275,6 +275,26 @@ class WithoutCoverageTests(_Case):
         self.assertTrue(step.action_executed)
         self.assertEqual(runtime.actions_executed, before + 1)
 
+    def test_a_copied_file_is_not_suppressed_without_coverage(self) -> None:
+        """The artifact recognizer compares digests, not covered text.
+
+        It never consults `covered_source_text`, so only the coverage gate
+        stops it firing on a session that was never given the source -- where
+        copying the artifact is ordinary, useful work. This is the case the
+        stdout recognizers cannot cover for, because they refuse a None source
+        on their own.
+        """
+        runtime = self._runtime()
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        before = runtime.actions_executed
+        step = self._step(runtime, _result(stdout="", artifacts=[copy]))
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
     def test_suppression_starts_only_after_coverage(self) -> None:
         runtime = self._runtime()
         first = self._step(runtime, _result(stdout=SOURCE + "\n"))

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -293,13 +293,32 @@ class FailClosedRuntimeTests(_Case):
         step = self._step(runtime, _result(stdout=source))
         self.assertIsNotNone(step.suppressed_duplicate_of)
 
-    def test_the_sandbox_detects_substitution_by_round_trip(self) -> None:
-        """Lossless re-encoding is exactly the absence of replacement."""
+    def test_the_sandbox_detects_substitution_on_each_stream(self) -> None:
+        """Each stream is checked in its own right.
+
+        Testing only the pair would let one half cover for the other: an
+        implementation that checked stderr alone would still pass while
+        stdout -- the stream the recognizers actually read -- went unguarded.
+        """
+        from orbit.runtime.analysis_sandbox import execute_analysis  # noqa: F401
+
         for raw, expected in ((b"he\xfflo\n", True), (b"hello\n", False),
                               ("héllo\n".encode(), False)):
             with self.subTest(raw=raw):
                 decoded = raw.decode("utf-8", "replace")
                 self.assertEqual(decoded.encode("utf-8") != raw, expected)
+
+    def test_replacement_on_stdout_alone_is_detected(self) -> None:
+        """The stream the recognizers read must be guarded by itself."""
+        import inspect
+
+        from orbit.runtime import analysis_sandbox
+
+        source = inspect.getsource(analysis_sandbox)
+        marker = source[source.index("replaced = ("):]
+        marker = marker[: marker.index(")\n")]
+        self.assertIn("stdout.encode", marker)
+        self.assertIn("stderr.encode", marker)
 
     def test_the_same_output_untruncated_is_suppressed(self) -> None:
         """The control: only truncation changes the verdict."""

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -165,6 +165,32 @@ class CoveredSourceTextTests(_Case):
         del runtime.messages[checkpoint:]
         self.assertIsNone(runtime.covered_source_text)
 
+    def test_a_changed_snapshot_withdraws_the_covered_text(self) -> None:
+        """Compare against what was covered, not against whatever is on disk.
+
+        The snapshot is 0400 in a 0700 directory and the sandbox refuses a
+        changed read-only input, so this is not reachable from artifact
+        content -- which is exactly why it is checked by digest rather than
+        left to filesystem permissions.
+        """
+        runtime = self._runtime()
+        self._cover(runtime)
+        self.assertIsNotNone(runtime.covered_source_text)
+        path = runtime.source.snapshot_path
+        path.chmod(0o600)
+        path.write_bytes(b"import os\nsecret = 'BBBB'\n")
+        self.assertIsNone(runtime.covered_source_text)
+
+    def test_output_matching_a_swapped_snapshot_is_not_suppressed(self) -> None:
+        runtime = self._runtime()
+        self._cover(runtime)
+        swapped = "import os\nsecret = 'BBBB'\n"
+        path = runtime.source.snapshot_path
+        path.chmod(0o600)
+        path.write_bytes(swapped.encode())
+        step = self._step(runtime, _result(stdout=swapped))
+        self.assertIsNone(step.suppressed_duplicate_of)
+
     def test_a_binary_artifact_has_no_covered_text(self) -> None:
         runtime = self._runtime(b"\x00\xffbinary")
         self.assertIsNone(runtime.covered_source_text)
@@ -308,17 +334,71 @@ class FailClosedRuntimeTests(_Case):
                 decoded = raw.decode("utf-8", "replace")
                 self.assertEqual(decoded.encode("utf-8") != raw, expected)
 
-    def test_replacement_on_stdout_alone_is_detected(self) -> None:
-        """The stream the recognizers read must be guarded by itself."""
-        import inspect
+    def test_replacement_on_stdout_alone_blocks_suppression(self) -> None:
+        """Behaviour, not source text: stdout must be guarded by itself.
 
-        from orbit.runtime import analysis_sandbox
+        An implementation joining the two streams with `and` misses the case
+        that matters -- stdout replaced while stderr is clean -- and my earlier
+        test read the source rather than running it, so it did not notice.
+        This drives the real sandbox and asserts the gate's verdict.
+        """
+        source = "he\ufffdlo\n"
+        runtime = self._runtime(source.encode())
+        self._cover(runtime)
+        replaced_stdout_only = AnalysisResult(
+            status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+            stdout=source, stderr="", exit_status=0, duration_seconds=0.1,
+            output_replaced=True,
+        )
+        step = self._step(runtime, replaced_stdout_only)
+        self.assertIsNone(step.suppressed_duplicate_of)
 
-        source = inspect.getsource(analysis_sandbox)
-        marker = source[source.index("replaced = ("):]
-        marker = marker[: marker.index(")\n")]
-        self.assertIn("stdout.encode", marker)
-        self.assertIn("stderr.encode", marker)
+    def test_the_sandbox_itself_sets_the_replacement_flag(self) -> None:
+        """The flag must be computed, not merely honoured.
+
+        Asserting only on a hand-built result leaves the sandbox side unpinned:
+        an implementation that never sets the flag would pass while the defect
+        it guards returns.
+        """
+        from orbit.runtime.analysis_sandbox import execute_analysis
+
+        workspace = AnalysisWorkspace.create()
+        self.addCleanup(workspace.close)
+        artifact = workspace.source_root / "a.txt"
+        artifact.write_bytes(b"x\n")
+        result = execute_analysis(
+            source_path=artifact,
+            code="import sys\nsys.stdout.buffer.write(b'he\\xfflo\\n')\n",
+            scratch_dir=workspace.scratch_root,
+        )
+        if result.status != "ok":
+            self.skipTest(f"sandbox unavailable: {result.status}")
+        self.assertTrue(result.output_replaced)
+
+        clean = execute_analysis(
+            source_path=artifact,
+            code="print('hello')\n",
+            scratch_dir=workspace.scratch_root,
+        )
+        self.assertFalse(clean.output_replaced)
+
+    def test_the_sandbox_itself_sets_the_truncation_flag(self) -> None:
+        """Same reasoning: the BLOCKER's guard needs its producer pinned too."""
+        from orbit.runtime.analysis_sandbox import MAX_OUTPUT_BYTES, execute_analysis
+
+        workspace = AnalysisWorkspace.create()
+        self.addCleanup(workspace.close)
+        artifact = workspace.source_root / "a.txt"
+        artifact.write_bytes(b"x\n")
+        result = execute_analysis(
+            source_path=artifact,
+            code=f"print('x' * {MAX_OUTPUT_BYTES + 1000})\n",
+            scratch_dir=workspace.scratch_root,
+        )
+        if result.status not in ("ok", "bounded"):
+            self.skipTest(f"sandbox unavailable: {result.status}")
+        self.assertTrue(result.truncated)
+        self.assertLessEqual(len(result.stdout), MAX_OUTPUT_BYTES)
 
     def test_the_same_output_untruncated_is_suppressed(self) -> None:
         """The control: only truncation changes the verdict."""

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -478,6 +478,41 @@ class AccountingTests(_Case):
         self.assertEqual(len(step.artifact_handles), 1)
         self.assertIn("copy.py", step.artifact_handles[0])
 
+    def test_the_analyst_sees_what_a_suppressed_action_did(self) -> None:
+        """It ran. Saying "not executed" would misreport the sandbox.
+
+        The step produced no useful evidence, which is a different thing from
+        not having executed -- and it may have written a file the analyst needs
+        to know about. The summary shows the execution, the artifact once, the
+        evidence ids, and states the suppression.
+        """
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        runtime = self._runtime()
+        self._cover(runtime)
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        step = self._step(runtime, _result(stdout="", artifacts=[copy]))
+        rendered = format_analysis_step(step)
+        self.assertNotIn("action attempted but not executed", rendered)
+        self.assertIn("evidence:", rendered)
+        self.assertIn("raw:", rendered)
+        self.assertIn("no new evidence:", rendered)
+        # Listed once, not twice.
+        self.assertEqual(rendered.count("/workspace/work/copy.py"), 1)
+
+    def test_an_ordinary_step_renders_unchanged(self) -> None:
+        from orbit.terminal.analysis_mode import format_analysis_step
+
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout="FINDING: real"))
+        rendered = format_analysis_step(step)
+        self.assertIn("evidence:", rendered)
+        self.assertNotIn("no new evidence:", rendered)
+
     def test_provenance_records_what_was_suppressed(self) -> None:
         """N. An audit can see the claim and check it."""
         runtime = self._runtime()

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -99,6 +99,15 @@ def _result(stdout="", stderr="", status="ok", artifacts=()):
     )
 
 
+def _truncated_result(stdout: str) -> AnalysisResult:
+    """An `ok` result the sandbox had to cut. Truncation alone is not `bounded`."""
+    return AnalysisResult(
+        status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+        stdout=stdout, stderr="", exit_status=0, duration_seconds=0.1,
+        truncated=True,
+    )
+
+
 class _Case(unittest.TestCase):
     def _runtime(self, data: bytes = None, backend=None) -> AnalysisRuntime:
         data = SOURCE.encode() if data is None else data
@@ -228,6 +237,33 @@ class FailClosedRuntimeTests(_Case):
         self._assert_useful(
             runtime, _result(stdout=SOURCE, stderr="warning: deprecated")
         )
+
+    def test_truncated_output_is_never_suppressed(self) -> None:
+        """A prefix proves nothing about what was cut off.
+
+        The sandbox caps stdout and leaves `status` as "ok", so a program that
+        printed the source and THEN its findings has exactly the visible bytes
+        of a bare re-read. Suppressing it would discard the findings while
+        telling the model nothing was established -- the catastrophic
+        direction. `truncated` is the only signal the comparison is partial.
+
+        The artifact here is small enough to be COVER-eligible; what is
+        exercised is the flag, which the sandbox sets independently of size.
+        """
+        runtime = self._runtime()
+        self._cover(runtime)
+        before = runtime.actions_executed
+        step = self._step(runtime, _truncated_result(SOURCE + "\n"))
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertTrue(step.action_executed)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_the_same_output_untruncated_is_suppressed(self) -> None:
+        """The control: only truncation changes the verdict."""
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(runtime, _result(stdout=SOURCE + "\n"))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
 
     def test_a_failed_action_is_never_suppressed(self) -> None:
         """A failure must reach the model as a failure."""
@@ -360,6 +396,25 @@ class AccountingTests(_Case):
             )
         self.assertEqual(runtime.actions_executed, 0)
         self.assertEqual(runtime.suppressed_duplicates, 4)
+
+    def test_a_suppressed_step_still_reports_its_artifacts(self) -> None:
+        """Suppression is about the observation, never about hiding the action.
+
+        A suppressed action still ran and may have written a file. The
+        analyst's trailer reads these fields, so dropping them would leave a
+        real artifact on disk that nothing mentions.
+        """
+        runtime = self._runtime()
+        self._cover(runtime)
+        copy = DerivedArtifact(
+            name="copy.py", size_bytes=len(SOURCE.encode()),
+            sha256=hashlib.sha256(SOURCE.encode()).hexdigest(),
+        )
+        step = self._step(runtime, _result(stdout="", artifacts=[copy]))
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+        self.assertIsNotNone(step.raw_output_evidence_id)
+        self.assertEqual(len(step.artifact_handles), 1)
+        self.assertIn("copy.py", step.artifact_handles[0])
 
     def test_provenance_records_what_was_suppressed(self) -> None:
         """N. An audit can see the claim and check it."""

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -85,6 +85,19 @@ class ReprRecognizerTests(unittest.TestCase):
         awkward = "a\\b\tc\nd\re'f\"g\x00h\x1biéj\U0001f600k"
         self.assertEqual(decode_repr_literal(repr(awkward)), awkward)
 
+    def test_a_repr_with_more_than_one_trailing_newline_is_refused(self) -> None:
+        """`$` under `re.S` also matches before a final newline.
+
+        That made `repr(source) + "\\n\\n"` match with the extra newline
+        silently tolerated -- accepting a candidate that is the repr plus
+        something else. The pattern is anchored with `\\A`/`\\Z` instead.
+        """
+        self.assertIsNone(classify_output(repr(SOURCE) + "\n\n", SOURCE))
+        self.assertIsNone(classify_output(repr(SOURCE) + "\n \n", SOURCE))
+        self.assertIsNone(classify_output(repr(SOURCE) + " ", SOURCE))
+        # The single newline `print` adds is still accepted.
+        self.assertIsNotNone(classify_output(repr(SOURCE) + "\n", SOURCE))
+
     def test_a_repr_of_different_text_is_not_recognised(self) -> None:
         self.assertIsNone(classify_output(repr(SOURCE + "x") + "\n", SOURCE))
 
@@ -175,6 +188,24 @@ class NumberedRecognizerTests(unittest.TestCase):
             for n, line in zip(range(7, -1, -1), SOURCE.splitlines())
         )
         self.assertIsNone(classify_output(candidate, SOURCE))
+
+    def test_only_number_padding_is_absorbed_before_a_listing(self) -> None:
+        """Alignment whitespace belongs to the number; content does not.
+
+        `f"{i:3}"` right-aligns, so leading spaces are part of the number's own
+        rendering and absorbing them is reversible. Anything else in front --
+        a heading, a marker, a digit that is not the line number -- stops the
+        line matching and leaves the observation as evidence.
+        """
+        listing = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(SOURCE.splitlines())
+        )
+        for padding in (" ", "\t", "  "):
+            with self.subTest(padding=padding):
+                self.assertIsNotNone(classify_output(padding + listing, SOURCE))
+        for content in ("x", " x", "0", " 0: ", "#", "== source ==\n"):
+            with self.subTest(content=content):
+                self.assertIsNone(classify_output(content + listing, SOURCE))
 
     def test_stripping_returns_none_rather_than_guessing(self) -> None:
         self.assertIsNone(strip_line_numbers("no numbers here\nat all"))

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -151,6 +151,31 @@ class NumberedRecognizerTests(unittest.TestCase):
         lines.append("summary: 8 lines")
         self.assertIsNone(classify_output("\n".join(lines), SOURCE))
 
+    def test_wrong_numbers_are_refused_even_when_the_bodies_reconstruct(self) -> None:
+        """Consecutiveness is load-bearing on its own.
+
+        A deleted line changes the bodies too, so the equality check catches it
+        independently -- which means only numbers that are wrong while the text
+        is right can show that the consecutiveness check does any work. A
+        listing whose numbers do not count is not a listing of a whole file:
+        it could be a filtered view whose selection is itself the finding.
+        """
+        for numbers in ((0, 0, 0, 0, 0, 0, 0, 0), (0, 5, 9, 2, 1, 3, 4, 6),
+                        (1, 1, 1, 1, 1, 1, 1, 1)):
+            with self.subTest(numbers=numbers):
+                candidate = "\n".join(
+                    f"{n}: {line}"
+                    for n, line in zip(numbers, SOURCE.splitlines())
+                )
+                self.assertIsNone(classify_output(candidate, SOURCE))
+
+    def test_descending_numbers_are_refused(self) -> None:
+        candidate = "\n".join(
+            f"{n}: {line}"
+            for n, line in zip(range(7, -1, -1), SOURCE.splitlines())
+        )
+        self.assertIsNone(classify_output(candidate, SOURCE))
+
     def test_stripping_returns_none_rather_than_guessing(self) -> None:
         self.assertIsNone(strip_line_numbers("no numbers here\nat all"))
         self.assertIsNone(strip_line_numbers("single line"))

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -419,6 +419,32 @@ class SecurityTests(unittest.TestCase):
         # But a DIFFERENT file whose lines merely look numbered is refused.
         self.assertIsNone(classify_output(listed, "0: other\n1: text\n"))
 
+    def test_an_absurd_line_number_cannot_crash_the_parser(self) -> None:
+        """Artifact-controlled input must never raise out of a recognizer.
+
+        `int()` on a very long digit string raises rather than returning, so a
+        printed line with a hundred thousand leading digits crashed the parser
+        before the digit run was bounded. A line number is at most as large as
+        the file has lines, so a long one cannot be a real listing anyway.
+        """
+        hostile = "9" * 100_000 + ": x\n" + "9" * 100_000 + ": y"
+        self.assertIsNone(strip_line_numbers(hostile))
+        self.assertIsNone(classify_output(hostile, SOURCE))
+
+    def test_hostile_input_never_raises_from_any_recognizer(self) -> None:
+        for hostile in (
+            "9" * 50_000 + ": x\n" + "9" * 50_000 + ": y",
+            "\\" * 100_000,
+            "'" + "\\x41" * 50_000 + "'",
+            "\x00" * 1000,
+            "\r\n" * 10_000,
+            "0" * 5000 + ": line",
+        ):
+            with self.subTest(hostile=hostile[:20]):
+                self.assertIsNone(classify_output(hostile, SOURCE))
+                self.assertIsNone(strip_line_numbers(hostile))
+                decode_repr_literal(hostile)  # must not raise
+
     def test_decoding_is_bounded_and_terminates(self) -> None:
         import time
 

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -226,6 +226,27 @@ class NumberedRecognizerTests(unittest.TestCase):
         # into unreachability by an earlier alternative.
         self.assertEqual(matched, separators)
 
+    def test_a_single_numbered_line_is_never_a_listing(self) -> None:
+        """One line cannot be distinguished from a grep hit or a result index.
+
+        `1: evil.example.com` against a one-line source is exactly the shape of
+        a search result whose leading number is a match count -- real
+        information about WHERE something was found. A listing needs at least
+        two lines before its numbering means anything, so a single line is
+        refused outright.
+        """
+        for candidate in (
+            "1: evil.example.com",
+            "1 evil.example.com",
+            "  0: evil.example.com",
+            "1\tevil.example.com",
+        ):
+            with self.subTest(candidate=candidate):
+                self.assertIsNone(classify_output(candidate, "evil.example.com"))
+                self.assertIsNone(strip_line_numbers(candidate))
+        # Two lines is where a listing becomes meaningful.
+        self.assertIsNotNone(classify_output("0: a\n1: b", "a\nb"))
+
     def test_stripping_returns_none_rather_than_guessing(self) -> None:
         self.assertIsNone(strip_line_numbers("no numbers here\nat all"))
         self.assertIsNone(strip_line_numbers("single line"))

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -1,0 +1,414 @@
+"""Only a provable full-source reacquisition may be treated as adding nothing.
+
+ANALYSIS-SOURCE-EQUIVALENCE-1. After COVER supplies the complete artifact, the
+observed behaviour is that the model reads the same bytes back anyway -- as a
+repr, as plain text, as a numbered listing. Those observations carry nothing
+the session does not already hold.
+
+The rule is exact proof or nothing. Every recognizer reconstructs candidate
+bytes and compares them to the artifact's own; one differing byte, one extra
+printed line, one reordered line, and the answer is no. The failure that must
+never happen is suppressing something new, so the tests below spend far more
+effort on what must NOT be recognised than on what must.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.runtime.analysis_source_identity import (  # noqa: E402
+    ARTIFACT,
+    NUMBERED,
+    RAW,
+    REPR,
+    classify_artifacts,
+    classify_output,
+    decode_repr_literal,
+    strip_line_numbers,
+)
+
+SOURCE = (
+    "from __future__ import annotations\n"
+    "\n"
+    "import os\n"
+    "\n"
+    "\n"
+    "def handler(name: str) -> str:\n"
+    '    """Do a thing."""\n'
+    "    return os.environ.get(name, 'fallback')\n"
+)
+
+
+class _Artifact:
+    def __init__(self, name: str, sha256: str, size_bytes: int) -> None:
+        self.name = name
+        self.sha256 = sha256
+        self.size_bytes = size_bytes
+
+
+def _sha(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class RawRecognizerTests(unittest.TestCase):
+    """A. The output is the source, byte for byte."""
+
+    def test_exact_source_is_recognised(self) -> None:
+        found = classify_output(SOURCE, SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.recognizer, RAW)
+
+    def test_print_adds_one_newline_and_that_is_tolerated(self) -> None:
+        """`print(data)` emits the text plus exactly one newline."""
+        self.assertIsNotNone(classify_output(SOURCE + "\n", SOURCE))
+
+    def test_two_trailing_newlines_are_not_the_source(self) -> None:
+        """Only the one newline `print` itself adds; more is different text."""
+        self.assertIsNone(classify_output(SOURCE + "\n\n", SOURCE))
+
+
+class ReprRecognizerTests(unittest.TestCase):
+    """B. The output is `repr(source)` and decodes back exactly."""
+
+    def test_repr_of_the_source_is_recognised(self) -> None:
+        found = classify_output(repr(SOURCE) + "\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.recognizer, REPR)
+
+    def test_repr_round_trips_for_every_escape_repr_emits(self) -> None:
+        awkward = "a\\b\tc\nd\re'f\"g\x00h\x1biéj\U0001f600k"
+        self.assertEqual(decode_repr_literal(repr(awkward)), awkward)
+
+    def test_a_repr_of_different_text_is_not_recognised(self) -> None:
+        self.assertIsNone(classify_output(repr(SOURCE + "x") + "\n", SOURCE))
+
+    def test_forms_repr_never_emits_are_refused(self) -> None:
+        """The decoder covers `repr(str)`, not the Python literal grammar."""
+        for text in (
+            "b'bytes'",           # a prefix
+            "r'raw'",
+            "f'formatted'",
+            "'a' 'b'",            # implicit concatenation
+            "'unterminated",
+            "'trailing backslash\\",
+            "'\\N{BULLET}'",      # valid Python, never from repr
+            "'\\777'",            # octal
+            "('tuple',)",
+            "['list']",
+        ):
+            with self.subTest(text=text):
+                self.assertIsNone(decode_repr_literal(text))
+
+    def test_a_lone_unescaped_quote_cannot_end_the_literal_early(self) -> None:
+        self.assertIsNone(decode_repr_literal("'a'b'"))
+
+    def test_malformed_escapes_are_refused(self) -> None:
+        for text in (r"'\xZZ'", r"'\x1'", r"'\u12'", r"'\U0011FFFF'", r"'\ud800'"):
+            with self.subTest(text=text):
+                self.assertIsNone(decode_repr_literal(text))
+
+
+class NumberedRecognizerTests(unittest.TestCase):
+    """C. A complete consecutive numbered listing, reversibly stripped."""
+
+    def _numbered(self, text: str, start: int = 0, sep: str = ": ") -> str:
+        return "\n".join(
+            f"{i + start:3}{sep}{line}" for i, line in enumerate(text.splitlines())
+        )
+
+    def test_zero_based_listing_is_recognised(self) -> None:
+        found = classify_output(self._numbered(SOURCE) + "\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.recognizer, NUMBERED)
+
+    def test_one_based_listing_is_recognised(self) -> None:
+        self.assertIsNotNone(
+            classify_output(self._numbered(SOURCE, start=1) + "\n", SOURCE)
+        )
+
+    def test_a_listing_starting_elsewhere_is_refused(self) -> None:
+        """Starting at 7 means this is a slice, not the whole file."""
+        self.assertIsNone(classify_output(self._numbered(SOURCE, start=7), SOURCE))
+
+    def test_a_gap_in_the_numbers_is_refused(self) -> None:
+        lines = self._numbered(SOURCE).split("\n")
+        del lines[3]
+        self.assertIsNone(classify_output("\n".join(lines), SOURCE))
+
+    def test_mixed_separators_are_refused(self) -> None:
+        lines = self._numbered(SOURCE).split("\n")
+        lines[2] = lines[2].replace(": ", " | ", 1)
+        self.assertIsNone(classify_output("\n".join(lines), SOURCE))
+
+    def test_an_unnumbered_line_is_refused(self) -> None:
+        lines = self._numbered(SOURCE).split("\n")
+        lines.append("summary: 8 lines")
+        self.assertIsNone(classify_output("\n".join(lines), SOURCE))
+
+    def test_stripping_returns_none_rather_than_guessing(self) -> None:
+        self.assertIsNone(strip_line_numbers("no numbers here\nat all"))
+        self.assertIsNone(strip_line_numbers("single line"))
+
+
+class ArtifactRecognizerTests(unittest.TestCase):
+    """D. A produced file whose bytes are the source."""
+
+    def test_a_copy_is_recognised_by_digest(self) -> None:
+        found = classify_artifacts(
+            [_Artifact("copy.py", _sha(SOURCE), len(SOURCE.encode()))],
+            _sha(SOURCE), len(SOURCE.encode()),
+        )
+        self.assertIsNotNone(found)
+        self.assertEqual(found.recognizer, ARTIFACT)
+
+    def test_the_name_does_not_matter(self) -> None:
+        self.assertIsNotNone(
+            classify_artifacts(
+                [_Artifact("anything.txt", _sha(SOURCE), len(SOURCE.encode()))],
+                _sha(SOURCE), len(SOURCE.encode()),
+            )
+        )
+
+    def test_a_different_digest_is_refused(self) -> None:
+        self.assertIsNone(
+            classify_artifacts(
+                [_Artifact("copy.py", _sha(SOURCE + "x"), len(SOURCE.encode()))],
+                _sha(SOURCE), len(SOURCE.encode()),
+            )
+        )
+
+    def test_a_size_disagreeing_with_the_digest_is_refused(self) -> None:
+        self.assertIsNone(
+            classify_artifacts(
+                [_Artifact("copy.py", _sha(SOURCE), 1)],
+                _sha(SOURCE), len(SOURCE.encode()),
+            )
+        )
+
+    def test_more_than_one_artifact_is_refused(self) -> None:
+        """A second file is new state whatever the first one holds."""
+        digest, size = _sha(SOURCE), len(SOURCE.encode())
+        self.assertIsNone(
+            classify_artifacts(
+                [_Artifact("copy.py", digest, size),
+                 _Artifact("notes.txt", _sha("notes"), 5)],
+                digest, size,
+            )
+        )
+
+    def test_no_artifacts_is_refused(self) -> None:
+        self.assertIsNone(
+            classify_artifacts([], _sha(SOURCE), len(SOURCE.encode()))
+        )
+
+
+class FailClosedTests(unittest.TestCase):
+    """E-I. Everything that must stay ordinary evidence."""
+
+    def test_one_byte_difference(self) -> None:
+        self.assertIsNone(classify_output(SOURCE.replace("os", "0s", 1), SOURCE))
+
+    def test_one_trailing_space_added(self) -> None:
+        self.assertIsNone(classify_output(SOURCE + " ", SOURCE))
+
+    def test_full_source_plus_one_computed_line(self) -> None:
+        """F. The live case: the source AND something the model worked out."""
+        self.assertIsNone(classify_output(f"{SOURCE}\nLEN: {len(SOURCE)}", SOURCE))
+
+    def test_full_source_preceded_by_a_heading(self) -> None:
+        self.assertIsNone(classify_output(f"=== source ===\n{SOURCE}", SOURCE))
+
+    def test_repr_plus_a_computed_line(self) -> None:
+        self.assertIsNone(
+            classify_output(f"{repr(SOURCE)}\nLEN: {len(SOURCE)}", SOURCE)
+        )
+
+    def test_numbered_listing_plus_a_summary(self) -> None:
+        numbered = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(SOURCE.splitlines())
+        )
+        self.assertIsNone(classify_output(f"{numbered}\nIMPORTS: ['os']", SOURCE))
+
+    def test_partial_source(self) -> None:
+        """G. Half the file is a real observation about which half."""
+        self.assertIsNone(classify_output(SOURCE[: len(SOURCE) // 2], SOURCE))
+
+    def test_source_with_the_last_line_dropped(self) -> None:
+        self.assertIsNone(
+            classify_output("\n".join(SOURCE.splitlines()[:-1]), SOURCE)
+        )
+
+    def test_reordered_lines(self) -> None:
+        """H. Same bytes, different file."""
+        lines = SOURCE.splitlines()
+        lines[0], lines[-1] = lines[-1], lines[0]
+        self.assertIsNone(classify_output("\n".join(lines), SOURCE))
+
+    def test_normalised_whitespace(self) -> None:
+        """I. Byte identity is the standard; a reflow is different text."""
+        self.assertIsNone(classify_output(SOURCE.replace("\n\n", "\n"), SOURCE))
+        self.assertIsNone(classify_output(SOURCE.replace("\n", "\r\n"), SOURCE))
+        self.assertIsNone(classify_output(SOURCE.replace("    ", "\t"), SOURCE))
+
+    def test_stripped_output(self) -> None:
+        self.assertIsNone(classify_output(SOURCE.strip(), SOURCE))
+
+    def test_legitimate_targeted_calculation(self) -> None:
+        """J. Real work that happens to mention the source."""
+        for output in (
+            "SHA256: " + _sha(SOURCE),
+            "IMPORTS: ['os']",
+            "LINE COUNT: 8",
+            "grep 'def': line 6",
+            "AST: Module(body=[ImportFrom, Import, FunctionDef])",
+        ):
+            with self.subTest(output=output):
+                self.assertIsNone(classify_output(output, SOURCE))
+
+    def test_empty_output(self) -> None:
+        self.assertIsNone(classify_output("", SOURCE))
+
+    def test_an_empty_source_proves_nothing(self) -> None:
+        self.assertIsNone(classify_output("anything", ""))
+
+    def test_absurdly_large_output_is_not_scanned(self) -> None:
+        self.assertIsNone(classify_output("x" * 10_000_000, SOURCE))
+
+
+class SecurityTests(unittest.TestCase):
+    """L. The decoder is a parser, never an interpreter."""
+
+    def test_the_module_never_evaluates(self) -> None:
+        """No banned construct in executable code.
+
+        Docstrings are stripped first: the module docstring names
+        `literal_eval` precisely to explain why it is NOT used, and prose about
+        a rejected approach is not the approach.
+        """
+        import ast
+
+        path = ROOT / "src" / "orbit" / "runtime" / "analysis_source_identity.py"
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                node.body = body[1:] or [ast.Pass()]
+        code = ast.unparse(tree)
+        for banned in (
+            "eval(", "exec(", "literal_eval", "__import__",
+            "subprocess", "os.system", "pickle",
+        ):
+            self.assertNotIn(banned, code, banned)
+        # `compile` only as the builtin, never `re.compile`, which is the one
+        # legitimate use and the reason a bare substring check misfires here.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                self.assertNotIn(
+                    node.func.id,
+                    {"eval", "exec", "compile", "__import__", "open"},
+                    f"forbidden builtin call: {node.func.id}",
+                )
+
+    def test_the_module_imports_nothing_that_can_execute(self) -> None:
+        import ast
+
+        path = ROOT / "src" / "orbit" / "runtime" / "analysis_source_identity.py"
+        imported = set()
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Import):
+                imported.update(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        self.assertTrue(
+            imported <= {"re", "dataclasses", "__future__"},
+            f"unexpected imports: {imported}",
+        )
+
+    def test_hostile_repr_shaped_input_is_refused_not_run(self) -> None:
+        for hostile in (
+            "__import__('os').system('id')",
+            "'a' + __import__('os').popen('id').read()",
+            "'\\x27); import os; os.system('id'); ('",
+            "eval('1+1')",
+            "'{}'.format(__import__('os'))",
+        ):
+            with self.subTest(hostile=hostile):
+                self.assertIsNone(classify_output(hostile, SOURCE))
+
+    def test_an_artifact_cannot_steer_the_numbered_parser(self) -> None:
+        """Source lines that look like numbering do not make a listing."""
+        numeric = "1: alpha\n2: beta\n3: gamma\n"
+        # Read back verbatim, this is the source and matches as RAW.
+        self.assertEqual(classify_output(numeric, numeric).recognizer, RAW)
+        # Numbered on top of that, it still reconstructs exactly.
+        listed = "\n".join(
+            f"{i}: {line}" for i, line in enumerate(numeric.splitlines())
+        )
+        self.assertEqual(classify_output(listed, numeric).recognizer, NUMBERED)
+        # But a DIFFERENT file whose lines merely look numbered is refused.
+        self.assertIsNone(classify_output(listed, "0: other\n1: text\n"))
+
+    def test_decoding_is_bounded_and_terminates(self) -> None:
+        import time
+
+        started = time.monotonic()
+        decode_repr_literal("'" + ("\\x41" * 200_000) + "'")
+        self.assertLess(time.monotonic() - started, 10.0)
+
+
+class LiveObservedPatternTests(unittest.TestCase):
+    """The four patterns the live run actually produced, judged honestly."""
+
+    SAMPLE = ROOT / "workdir" / "samples" / "vulnerable_service.py"
+
+    def setUp(self) -> None:
+        if not self.SAMPLE.exists():
+            self.skipTest("sample missing")
+        self.src = self.SAMPLE.read_text()
+
+    def test_pattern_1_repr_with_a_length_line_stays_evidence(self) -> None:
+        """The run printed `repr(data)` AND `LEN:`, so it is not bare."""
+        observed = f"{self.src!r}\nLEN: {len(self.src)}"
+        self.assertIsNone(classify_output(observed, self.src))
+
+    def test_pattern_2_plain_with_a_length_line_stays_evidence(self) -> None:
+        observed = f"{self.src}\nLEN: {len(self.src)}"
+        self.assertIsNone(classify_output(observed, self.src))
+
+    def test_pattern_3_numbered_listing_is_recognised(self) -> None:
+        observed = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(self.src.splitlines())
+        )
+        found = classify_output(observed + "\n", self.src)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.recognizer, NUMBERED)
+
+    def test_pattern_4_copy_plus_computed_facts_stays_evidence(self) -> None:
+        """The copy is recognisable, but the action also computed real facts."""
+        observed = "WROTE 1495 bytes\nLINE COUNT: 46\nHAS 'def': 5"
+        self.assertIsNone(classify_output(observed, self.src))
+
+    def test_a_bare_repr_of_the_sample_is_recognised(self) -> None:
+        self.assertIsNotNone(classify_output(repr(self.src) + "\n", self.src))
+
+    def test_a_bare_read_of_the_sample_is_recognised(self) -> None:
+        self.assertIsNotNone(classify_output(self.src + "\n", self.src))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -207,6 +207,25 @@ class NumberedRecognizerTests(unittest.TestCase):
             with self.subTest(content=content):
                 self.assertIsNone(classify_output(content + listing, SOURCE))
 
+    def test_every_separator_form_is_reachable(self) -> None:
+        """Each documented separator actually matches something.
+
+        Checked by running the pattern rather than by parsing it: the
+        alternation contains an escaped `|`, so splitting the source text on
+        `|` mis-reads the grammar it is meant to audit.
+        """
+        from orbit.runtime.analysis_source_identity import _NUMBERED_LINE
+
+        separators = {": ", " | ", "\t", ". ", "  ", " "}
+        matched = set()
+        for separator in separators:
+            match = _NUMBERED_LINE.match(f"1{separator}body")
+            self.assertIsNotNone(match, separator)
+            matched.add(match.group("sep"))
+        # Every form maps to a distinct captured separator: none is shadowed
+        # into unreachability by an earlier alternative.
+        self.assertEqual(matched, separators)
+
     def test_stripping_returns_none_rather_than_guessing(self) -> None:
         self.assertIsNone(strip_line_numbers("no numbers here\nat all"))
         self.assertIsNone(strip_line_numbers("single line"))

--- a/tests/test_analysis_source_equivalence.py
+++ b/tests/test_analysis_source_equivalence.py
@@ -145,6 +145,34 @@ class NumberedRecognizerTests(unittest.TestCase):
             classify_output(self._numbered(SOURCE, start=1) + "\n", SOURCE)
         )
 
+    def test_a_partial_listing_is_refused_not_merely_unequal(self) -> None:
+        """The comparison must be equality, never containment.
+
+        A listing of the first two lines of a three-line file reconstructs to a
+        PREFIX of the source. An implementation testing `stripped in source`
+        would suppress it -- discarding the fact that the third line, which may
+        be the whole finding, was never shown.
+        """
+        source = "alpha\nbeta\nSECRET=evil.example.com\n"
+        partial = "1: alpha\n2: beta"
+        self.assertIsNone(classify_output(partial, source))
+        # And the same for a suffix, which containment would also accept.
+        self.assertIsNone(classify_output("1: beta\n2: SECRET=evil.example.com",
+                                          source))
+
+    def test_a_listing_starting_at_two_is_refused(self) -> None:
+        """Starting at 2 says line 1 was not shown: a filtered view.
+
+        Pinned separately from "any start" because the off-by-one is the
+        plausible mistake -- a recognizer accepting 0, 1 or 2 looks reasonable
+        and silently admits a listing that is missing its first line.
+        """
+        listing = "\n".join(
+            f"{i + 2:3}: {line}" for i, line in enumerate(SOURCE.splitlines())
+        )
+        self.assertIsNone(classify_output(listing, SOURCE))
+        self.assertIsNone(strip_line_numbers(listing))
+
     def test_a_listing_starting_elsewhere_is_refused(self) -> None:
         """Starting at 7 means this is a slice, not the whole file."""
         self.assertIsNone(classify_output(self._numbered(SOURCE, start=7), SOURCE))


### PR DESCRIPTION
After COVER supplies the complete artifact, the live run showed Ornith reading the same bytes back anyway -- as a repr, as plain text, as a numbered listing, as a copy on disk. Ten actions spent on an artifact it had been handed in full.

An execution whose output is **provably only** the covered source now runs, is recorded, and is reported -- but consumes no action slot and feeds the existing NO_PROGRESS path. Nothing is blocked: the program executes, its raw output stays re-attestable, and provenance records which recognizer fired so an audit can check the claim.

## Exact proof or nothing

Each recognizer reconstructs candidate bytes and compares them to the artifact's own: the source verbatim, `repr()` of it, a complete consecutive numbered listing, or a single produced file whose digest is the artifact's. One differing byte, one extra printed line, one reordered line, a normalised newline, a partial range, stderr, a second artifact, or a failed action, and the observation stays ordinary evidence.

That strictness is the design, not a limitation. Of the four reads in the live run only the numbered listing is bare -- two also printed a length, and the fourth printed a line count, a `def` count and an import list. Those carry something the source alone does not, so they remain useful under the same rule that catches the listing. A false suppression costs the analysis real information; a missed one costs a model call.

The repr decoder is a bounded literal parser over exactly the escapes CPython emits, not `eval` and not `literal_eval`. It imports only `re` and `dataclasses`, calls no builtin that can execute, and a decoding failure can only ever cause a missed suppression.

## The class of bug this kept hitting

Three defects shared one shape -- a comparison made over an **altered view** of what the action produced:

- **Truncated stdout** (found by review): the sandbox caps output at 64 KiB and leaves `status` as `ok`, so a program printing the source *then* its findings had the findings cut off and the visible prefix was byte-identical to a bare re-read.
- **Replaced characters** (found chasing that class): `errors="replace"` collapses 128 byte values to U+FFFD, so an artifact containing U+FFFD made *different* printed bytes compare equal. The sandbox now reports `output_replaced` via a lossless round-trip -- verified exact over 16.8M exhaustive and 3M random sequences, costing microseconds.
- **A trailing newline** (found by fuzzing): `$` under `re.S` matches before a final newline, so `repr(source) + "\n\n"` was accepted.

Also fixed: a 100,000-digit line number crashed the recognizer with `ValueError`; the suppressed path never appended its tool result, invalidating the history; and a suppressed step reported as "not executed" when it had in fact run and may have written a file.

## Scope

Gated entirely on coverage. Without it the model was never given the source, so reading it is how a session learns what the artifact is -- and every path is byte-identical to before. CHAT untouched, guided ANALYSIS unchanged, global ceilings unchanged.

## Qualification

102 focused tests; **27/27 non-equivalent mutants caught**; full suite **4468 OK**; zero false positives across 2482-mutation and 500k-trial fuzzing. Three adversarial review rounds: one BLOCKER, one MAJOR and four surviving FP-mutants found and closed, final round **BLOCKER 0 / MAJOR 0**.

No GGUF loaded.
