### PR TITLE
fix(analysis): suppress source-dominated observations

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -45,6 +45,11 @@ from orbit.runtime.context_manager import (
     plan_exact_context,
 )
 from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
+from orbit.runtime.analysis_source_dominance import (
+    SOURCE_DOMINATED,
+    SourceDominance,
+    classify_dominated,
+)
 from orbit.runtime.analysis_source_identity import (
     SOURCE_REACQUISITION,
     # Referenced only in quoted annotations, which `from __future__ import
@@ -681,7 +686,7 @@ AUTONOMOUS_REPAIR_MESSAGE = (
 # that re-read one file nine times.
 def _source_reacquisition(
     result: AnalysisResult, source: "AnalysisSource", covered_text: str | None
-) -> "SourceEquivalence | None":
+) -> "SourceEquivalence | SourceDominance | None":
     """Whether this execution only handed back the source already supplied.
 
     Gated on coverage: without it the model was never given the source, so
@@ -720,8 +725,14 @@ def _source_reacquisition(
         # be new state regardless of what it holds, so it defeats the proof.
         return equivalence if not result.artifacts else None
     if result.stdout.strip():
-        # Something was printed that is not the source. Whatever else the
-        # action did, this observation is not a bare reacquisition.
+        # Not the source alone. It may still be the source plus properties
+        # Orbit can recompute from it, which establishes nothing either -- but
+        # only when every component is explained and nothing was written.
+        dominated = classify_dominated(result.stdout, covered_text)
+        if dominated is not None and not result.artifacts:
+            return dominated
+        # Something was printed that is neither, so whatever else the action
+        # did, this observation is not a bare reacquisition.
         return None
     return classify_artifacts(
         list(result.artifacts), source.sha256, source.size_bytes
@@ -738,11 +749,33 @@ def _source_reacquisition(
 #
 # It does not say the analysis is finished, and does not suggest a direction:
 # what to do instead is the model's decision, not the runtime's.
-def _source_reacquisition_observation(equivalence: "SourceEquivalence") -> str:
+def _source_reacquisition_observation(
+    verdict: "SourceEquivalence | SourceDominance",
+) -> str:
+    """What the model is told when its output added nothing.
+
+    Two shapes, and the difference is worth stating: the output was the source
+    itself, or it was the source plus values Orbit recomputed from that same
+    source and found to match. In both cases the program ran and produced
+    exactly what it produced -- the note reports that, and says where those
+    bytes already are, because "you already have this" without a pointer is
+    what produced the re-reading in the first place.
+
+    It does not say the analysis is finished and does not suggest a direction:
+    what to do instead is the model's decision, not the runtime's.
+    """
+    dominated = isinstance(verdict, SourceDominance)
+    lead = (
+        "this output is the complete artifact source together with values "
+        "computed from it, all of which Orbit recomputed from the bytes it "
+        "already supplied and confirmed"
+        if dominated
+        else "this output is the complete artifact source, which Orbit "
+        "already supplied in full earlier in this conversation"
+    )
+    name = SOURCE_DOMINATED if dominated else SOURCE_REACQUISITION
     return (
-        f"{SOURCE_REACQUISITION.upper()}: this output is the complete artifact "
-        f"source, which Orbit already supplied in full earlier in this "
-        f"conversation ({equivalence.detail}). It was executed, and it "
+        f"{name.upper()}: {lead} ({verdict.detail}). It was executed, and it "
         "established nothing the session did not already hold.\n"
         "The source above is the same bytes; re-read it there rather than "
         "running another program to produce it."
@@ -1968,9 +2001,24 @@ class AnalysisRuntime:
                 result,
                 _source_reacquisition_observation(equivalence),
                 extra={
-                    "suppressed_as": SOURCE_REACQUISITION,
-                    "suppression_recognizer": equivalence.recognizer,
+                    "suppressed_as": (
+                        SOURCE_DOMINATED
+                        if isinstance(equivalence, SourceDominance)
+                        else SOURCE_REACQUISITION
+                    ),
+                    "suppression_recognizer": (
+                        equivalence.representation
+                        if isinstance(equivalence, SourceDominance)
+                        else equivalence.recognizer
+                    ),
                     "suppression_detail": equivalence.detail,
+                    # Which recomputed properties were verified, so an audit can
+                    # redo each one against the artifact rather than trust the
+                    # verdict. Empty for exact equivalence, which proves no
+                    # properties.
+                    "verified_properties": list(
+                        getattr(equivalence, "properties", ())
+                    ),
                 },
             )
             # Appended like any other tool result: the model made a call and

--- a/src/orbit/runtime/analysis_source_dominance.py
+++ b/src/orbit/runtime/analysis_source_dominance.py
@@ -304,13 +304,19 @@ def classify_dominated(candidate: str, source: str) -> SourceDominance | None:
     if not rest.strip():
         return None
 
-    # Exactly one leading newline is expected -- the separator between the
-    # source and the first property -- and nothing else may be blank. Dropping
-    # empty lines would be tolerant parsing: a run of them is bytes the program
-    # printed that this grammar does not name.
-    if not rest.startswith("\n"):
+    # A property must begin on its own line, and exactly one newline may
+    # separate it from the source. Two spellings produce that: `print(data)`
+    # appends a newline of its own, and `sys.stdout.write(data)` on a source
+    # that already ends in one does not -- both leave the property at the start
+    # of a line, and requiring the extra newline would silently miss the second,
+    # which is a form the model actually uses. Anything else, a space or a tab
+    # or no separator at all, leaves the boundary to whatever the text allows.
+    if rest.startswith("\n"):
+        body = rest[1:]
+    elif source.endswith("\n"):
+        body = rest
+    else:
         return None
-    body = rest[1:]
     if body.endswith("\n"):
         body = body[:-1]  # the newline the last `print` appended
     lines = body.split("\n")

--- a/src/orbit/runtime/analysis_source_dominance.py
+++ b/src/orbit/runtime/analysis_source_dominance.py
@@ -1,0 +1,297 @@
+"""Prove an observation is the covered source plus only recomputable facts.
+
+Exact equivalence -- `analysis_source_identity` -- catches an output that is
+*only* the source. The live run showed that is rarely what happens: the model
+prints the source and then one deterministic fact about it, `LEN: 1495` or
+`TOTAL_LINES: 46` or a SHA. Each such observation carries nothing the session
+does not already hold, because every one of those values is computable from
+bytes Orbit already supplied, but exact equivalence refuses them all -- the
+output is not the source, it is the source plus a line.
+
+This module decides the narrower question:
+
+    Is this output the covered source, plus properties Orbit can independently
+    recompute from that same source, and nothing else at all?
+
+"Recompute" is the whole boundary. A property qualifies only if Orbit can
+derive it from the artifact's own bytes without interpreting the program:
+how long it is, how many lines, its digest, the hex of an explicitly named
+range. A count of functions, imports or calls does not qualify however
+trivially true it is -- deriving it means parsing the language, which is
+analysis, and analysis is what the model is for.
+
+The proof is total. The observation is parsed into components; every component
+is either the source in a supported representation or a property whose value is
+recomputed and compared exactly; and no byte may remain unexplained. One
+unrecognised line, one value that is off by one, one marker the grammar does not
+name, and the answer is USEFUL. There is no tolerant parsing, no ignored
+suffix, and no normalisation beyond the separators the grammars themselves
+require.
+
+Nothing here executes, imports or evaluates the text it inspects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+from orbit.runtime.analysis_source_identity import (
+    NUMBERED,
+    RAW,
+    REPR,
+    decode_repr_literal,
+    strip_line_numbers,
+)
+
+# Bound on what is worth attempting to prove, in characters. A dominated
+# observation is the source plus a handful of short lines; anything vastly
+# larger cannot be one, and refusing early keeps a hostile megabyte from being
+# scanned line by line.
+MAX_CANDIDATE_RATIO = 8
+MAX_CANDIDATE_CHARS = 4_000_000
+# The most property lines a dominated observation may carry. The live outputs
+# carried one or two; this admits a generous margin while bounding the work.
+MAX_PROPERTIES = 12
+
+SOURCE_DOMINATED = "source_dominated"
+
+# Property kinds, named so provenance can say exactly what was verified.
+BYTE_LENGTH = "byte_length"
+TEXT_LENGTH = "text_length"
+LINE_COUNT = "line_count"
+SHA256 = "sha256"
+HEX_PREFIX = "hex_prefix"
+
+
+@dataclass(frozen=True)
+class SourceDominance:
+    """Why an observation was judged to add nothing to the covered source."""
+
+    representation: str
+    properties: "tuple[str, ...]"
+
+    @property
+    def detail(self) -> str:
+        named = ", ".join(self.properties)
+        return f"{self.representation} of the covered source plus {named}"
+
+
+def _too_large(candidate: str, source: str) -> bool:
+    return (
+        len(candidate) > MAX_CANDIDATE_CHARS
+        or len(candidate) > max(4096, len(source) * MAX_CANDIDATE_RATIO)
+    )
+
+
+# --- properties -----------------------------------------------------------
+#
+# Each entry is a label the model actually printed, mapped to the function that
+# recomputes the value from the covered source. The labels are exhaustive by
+# design: a label not listed here is an unexplained component, and an
+# observation containing one is USEFUL. Adding a label is a deliberate act that
+# has to be justified by an observed output form, not a convenience.
+#
+# `len(str)` and `len(bytes)` are both accepted because a program can print
+# either and both are recomputable. They coincide for ASCII and differ for
+# anything else, so the value is checked against the specific one its label
+# names rather than against whichever happens to match.
+
+
+def _byte_length(source: str) -> str:
+    return str(len(source.encode("utf-8")))
+
+
+def _text_length(source: str) -> str:
+    return str(len(source))
+
+
+def _line_count_split(source: str) -> str:
+    """`len(data.split("\\n"))` -- what the live outputs actually computed.
+
+    Deliberately not `splitlines()`: they differ by one on text ending in a
+    newline, and by more on text containing form feeds or U+2028. The label
+    says which count was taken, and only the matching computation is accepted.
+    """
+    return str(len(source.split("\n")))
+
+
+def _line_count_splitlines(source: str) -> str:
+    """`len(data.splitlines())` -- the other rule the same label can mean.
+
+    Both spellings are accepted for one label, and that is not a loosening:
+    both are values Orbit recomputes from the artifact's own bytes, so a model
+    printing either has told the session nothing it could not derive. What is
+    NOT accepted is anything else -- on text containing U+2028 the two rules
+    differ by two, and the values between them are refused along with every
+    other number.
+    """
+    return str(len(source.splitlines()))
+
+
+def _sha256(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+# Labels observed in the live run, plus the obvious spellings of the same
+# quantities. Every value is compared case-sensitively against the exact string
+# the recomputation produces.
+_PROPERTY_LABELS: "dict[str, tuple[str, tuple]]" = {
+    "LEN": (TEXT_LENGTH, (_text_length, _byte_length)),
+    "LENGTH": (TEXT_LENGTH, (_text_length, _byte_length)),
+    "len_str": (TEXT_LENGTH, (_text_length,)),
+    "len_bytes": (BYTE_LENGTH, (_byte_length,)),
+    "BYTES": (BYTE_LENGTH, (_byte_length,)),
+    "SIZE": (BYTE_LENGTH, (_byte_length, _text_length)),
+    "TOTAL_LINES": (LINE_COUNT, (_line_count_split, _line_count_splitlines)),
+    "LINES": (LINE_COUNT, (_line_count_split, _line_count_splitlines)),
+    "LINE_COUNT": (LINE_COUNT, (_line_count_split, _line_count_splitlines)),
+    "sha256": (SHA256, (_sha256,)),
+    "SHA256": (SHA256, (_sha256,)),
+    "SHA-256": (SHA256, (_sha256,)),
+    "SHA": (SHA256, (_sha256,)),
+}
+
+# `LABEL: value`, with the separator the observed outputs used. `print("X:", v)`
+# emits exactly one space after the colon, and nothing else is accepted: a
+# different separator is a different output that this grammar does not name.
+_PROPERTY_LINE = re.compile(r"\A(?P<label>[A-Za-z][A-Za-z0-9_-]{0,31}): (?P<value>.*)\Z")
+
+# `HEXnnn: <hex>` -- the live form. The number in the label is what makes the
+# range explicit, and it is the ONLY thing that makes this suppressible: the
+# range is read from the label, never guessed. `HEX200` means the first 200
+# characters, which is what `data[:200].encode().hex()` computed.
+_HEX_PREFIX_LINE = re.compile(r"\AHEX(?P<count>\d{1,9}): (?P<value>[0-9a-f]*)\Z")
+
+
+def _verify_property(label: str, value: str, source: str) -> str | None:
+    """The property kind this line proves, or None if it proves nothing.
+
+    None covers three different failures deliberately treated the same: a label
+    outside the allow-list, a value that does not match any recomputation for
+    that label, and a malformed line. All three mean a component is unexplained,
+    and an unexplained component makes the whole observation useful.
+    """
+    entry = _PROPERTY_LABELS.get(label)
+    if entry is None:
+        return None
+    kind, computations = entry
+    for compute in computations:
+        if value == compute(source):
+            return kind
+    return None
+
+
+def _verify_hex_prefix(line: str, source: str) -> str | None:
+    """A `HEXnnn:` line whose hex is exactly that prefix of the source.
+
+    The count in the label names the range, so nothing is guessed. The
+    recomputation uses the same slice-then-encode order the observed code used
+    -- `data[:n].encode("utf-8").hex()` -- because slicing characters and
+    slicing bytes are different ranges on non-ASCII text, and only the one the
+    label describes is accepted.
+
+    A count longer than the source is refused rather than clamped: a program
+    asking for more bytes than exist got a shorter string than its label claims,
+    and quietly treating that as a match would accept a range nobody proved.
+    """
+    match = _HEX_PREFIX_LINE.match(line)
+    if match is None:
+        return None
+    count = int(match.group("count"))
+    if count == 0 or count > len(source):
+        return None
+    if match.group("value") != source[:count].encode("utf-8").hex():
+        return None
+    return HEX_PREFIX
+
+
+def _split_representation(candidate: str, source: str) -> "tuple[str, str] | None":
+    """Peel the leading source representation off, returning (kind, rest).
+
+    Only the representations `analysis_source_identity` already proves are
+    accepted, and each is matched at the START of the candidate so what follows
+    can be parsed as properties. The raw form is tried longest-first: the source
+    may itself end in a newline, and both spellings have to be considered
+    before concluding the output is not the source.
+    """
+    if candidate.startswith(source):
+        return RAW, candidate[len(source) :]
+    representation = repr(source)
+    if candidate.startswith(representation):
+        rest = candidate[len(representation) :]
+        # Guard against a longer literal that merely starts with this one.
+        if not rest or rest.startswith("\n"):
+            return REPR, rest
+    return None
+
+
+def _split_numbered(candidate: str, source: str) -> "tuple[str, str] | None":
+    """Peel a complete numbered listing off the front, if there is one.
+
+    Handled separately because a listing has no fixed length to slice: the
+    boundary is found by trying successively shorter line prefixes, and the
+    first that reconstructs to the source exactly is the listing. Bounded by
+    the number of lines, and every candidate still ends in an exact comparison.
+    """
+    lines = candidate.split("\n")
+    for count in range(len(lines), 1, -1):
+        head = "\n".join(lines[:count])
+        stripped = strip_line_numbers(head)
+        if stripped is None:
+            continue
+        if stripped == source or stripped == source.rstrip("\n"):
+            return NUMBERED, "\n".join(lines[count:])
+    return None
+
+
+def classify_dominated(candidate: str, source: str) -> SourceDominance | None:
+    """Prove `candidate` is `source` plus only recomputable properties.
+
+    Returns None -- meaning USEFUL -- for anything not proven in full. Every
+    component must be explained: the leading representation must be an exact
+    match for the source, each remaining line must be a property whose value
+    Orbit recomputes to exactly what was printed, and nothing may be left over.
+    """
+    if not candidate or not source:
+        return None
+    if _too_large(candidate, source):
+        return None
+
+    split = _split_representation(candidate, source) or _split_numbered(
+        candidate, source
+    )
+    if split is None:
+        return None
+    representation, rest = split
+
+    # Nothing after the source is exact equivalence, which is the other
+    # module's answer -- this one exists for the case where properties follow.
+    if not rest.strip():
+        return None
+
+    lines = [line for line in rest.split("\n") if line]
+    if not lines or len(lines) > MAX_PROPERTIES:
+        return None
+
+    kinds: list[str] = []
+    for line in lines:
+        hex_kind = _verify_hex_prefix(line, source)
+        if hex_kind is not None:
+            kinds.append(hex_kind)
+            continue
+        match = _PROPERTY_LINE.match(line)
+        if match is None:
+            return None  # an unexplained component
+        kind = _verify_property(match.group("label"), match.group("value"), source)
+        if kind is None:
+            return None
+        kinds.append(kind)
+
+    # Ordered, de-duplicated, for a stable provenance string.
+    seen: list[str] = []
+    for kind in kinds:
+        if kind not in seen:
+            seen.append(kind)
+    return SourceDominance(representation, tuple(seen))

--- a/src/orbit/runtime/analysis_source_dominance.py
+++ b/src/orbit/runtime/analysis_source_dominance.py
@@ -41,7 +41,6 @@ from orbit.runtime.analysis_source_identity import (
     NUMBERED,
     RAW,
     REPR,
-    decode_repr_literal,
     strip_line_numbers,
 )
 
@@ -230,20 +229,54 @@ def _split_representation(candidate: str, source: str) -> "tuple[str, str] | Non
 def _split_numbered(candidate: str, source: str) -> "tuple[str, str] | None":
     """Peel a complete numbered listing off the front, if there is one.
 
-    Handled separately because a listing has no fixed length to slice: the
-    boundary is found by trying successively shorter line prefixes, and the
-    first that reconstructs to the source exactly is the listing. Bounded by
-    the number of lines, and every candidate still ends in an exact comparison.
+    The listing is exactly as many lines as the source has, so the boundary is
+    computed rather than searched for: both spellings of the source's line count
+    are tried, each in constant time, and the prefix is stripped once. An
+    earlier version tried successively shorter prefixes and re-stripped each
+    one, which is quadratic -- 4000 numbered lines of ordinary model output
+    cost ten seconds of host CPU after the sandbox had already returned, with
+    no timeout around it.
+
+    Trailing newlines are dropped one at a time rather than with `rstrip`,
+    which would also eat form feeds, carriage returns and spaces: those are
+    ordinary source bytes, and treating them as absent would let a listing that
+    omits real trailing lines pass as complete.
     """
     lines = candidate.split("\n")
-    for count in range(len(lines), 1, -1):
-        head = "\n".join(lines[:count])
+    for expected in _candidate_line_counts(source):
+        if expected < 2 or expected > len(lines):
+            continue
+        head = "\n".join(lines[:expected])
         stripped = strip_line_numbers(head)
         if stripped is None:
             continue
-        if stripped == source or stripped == source.rstrip("\n"):
-            return NUMBERED, "\n".join(lines[count:])
+        if stripped == source or stripped == _drop_one_newline(source):
+            # The remainder keeps its leading newline, exactly as the raw and
+            # repr paths leave it, so the caller sees one shape rather than
+            # two and cannot tolerate a blank line on one path only.
+            return NUMBERED, candidate[len(head) :]
     return None
+
+
+def _drop_one_newline(text: str) -> str:
+    """Exactly one trailing newline, the one a line-wise print drops.
+
+    Deliberately not `rstrip`: `\x0c`, `\r`, `\x0b`, spaces and tabs are
+    ordinary bytes of a source file, and removing them would accept a listing
+    that never showed the lines they belong to.
+    """
+    return text[:-1] if text.endswith("\n") else text
+
+
+def _candidate_line_counts(source: str) -> "tuple[int, ...]":
+    """How many lines a complete listing of this source would have.
+
+    The two counting rules a listing can be built from, de-duplicated. Both are
+    recomputable from the source, so trying both proves nothing extra -- it
+    only avoids guessing which one the program used.
+    """
+    counts = (len(source.split("\n")), len(source.splitlines()))
+    return counts if counts[0] != counts[1] else (counts[0],)
 
 
 def classify_dominated(candidate: str, source: str) -> SourceDominance | None:
@@ -271,8 +304,19 @@ def classify_dominated(candidate: str, source: str) -> SourceDominance | None:
     if not rest.strip():
         return None
 
-    lines = [line for line in rest.split("\n") if line]
-    if not lines or len(lines) > MAX_PROPERTIES:
+    # Exactly one leading newline is expected -- the separator between the
+    # source and the first property -- and nothing else may be blank. Dropping
+    # empty lines would be tolerant parsing: a run of them is bytes the program
+    # printed that this grammar does not name.
+    if not rest.startswith("\n"):
+        return None
+    body = rest[1:]
+    if body.endswith("\n"):
+        body = body[:-1]  # the newline the last `print` appended
+    lines = body.split("\n")
+    if not lines or any(not line for line in lines):
+        return None
+    if len(lines) > MAX_PROPERTIES:
         return None
 
     kinds: list[str] = []

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -247,12 +247,21 @@ class FailClosedRuntimeTests(_Case):
         self._cover(runtime)
         self._assert_useful(runtime, _result(stdout=SOURCE.replace("os", "0s", 1)))
 
-    def test_source_plus_a_computed_line_stays_useful(self) -> None:
-        """The live pattern: the source AND something worked out."""
+    def test_source_plus_a_semantic_line_stays_useful(self) -> None:
+        """The source AND something Orbit cannot recompute from it.
+
+        A count of functions requires parsing the language, which is analysis.
+        It stays useful however trivially true the number is -- the boundary is
+        what Orbit can derive from bytes, not whether the value is correct.
+
+        The narrower case -- the source plus a value Orbit CAN recompute, such
+        as its length -- is dominated rather than useful, and is covered by
+        `test_analysis_source_dominance`.
+        """
         runtime = self._runtime()
         self._cover(runtime)
         self._assert_useful(
-            runtime, _result(stdout=f"{SOURCE}\nLEN: {len(SOURCE)}")
+            runtime, _result(stdout=f"{SOURCE}\nFUNCTIONS: 1")
         )
 
     def test_partial_source_stays_useful(self) -> None:

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -1,0 +1,608 @@
+"""Only the covered source plus recomputable facts may count as adding nothing.
+
+ANALYSIS-SOURCE-DOMINANCE-1. Exact equivalence catches an output that is only
+the source; the live run showed the model almost always prints the source and
+then one deterministic fact about it -- `LEN: 1495`, `TOTAL_LINES: 46`, a SHA,
+a hex prefix -- so equivalence almost never fired and nine actions were spent
+on source-derived observations.
+
+The boundary here is recomputation, not correctness. A property qualifies only
+if Orbit can derive it from the artifact's own bytes without interpreting the
+program: length, line count, digest, the hex of an explicitly named range. A
+count of functions does not qualify however true it is, because deriving it
+means parsing the language.
+
+The proof is total: every component explained, every value recomputed and
+compared exactly, no unexplained bytes. Most of what follows tests what must
+NOT be suppressed, because a false positive discards real evidence while a
+missed one costs only a model call.
+"""
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.runtime.analysis_source_dominance import (  # noqa: E402
+    BYTE_LENGTH,
+    HEX_PREFIX,
+    LINE_COUNT,
+    MAX_PROPERTIES,
+    SHA256,
+    TEXT_LENGTH,
+    classify_dominated,
+)
+from orbit.runtime.analysis_source_identity import NUMBERED, RAW, REPR  # noqa: E402
+
+SOURCE = (
+    "import os\n"
+    "\n"
+    "\n"
+    "def handler(name):\n"
+    "    return os.environ.get(name)\n"
+)
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _numbered(text: str) -> str:
+    return "\n".join(f"{i:3}: {line}" for i, line in enumerate(text.splitlines()))
+
+
+class LengthTests(unittest.TestCase):
+    """A/B. Byte and text length, exact or not at all."""
+
+    def test_source_plus_correct_length_is_dominated(self) -> None:
+        found = classify_dominated(f"{SOURCE}\nLEN: {len(SOURCE)}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.representation, RAW)
+        self.assertIn(TEXT_LENGTH, found.properties)
+
+    def test_length_off_by_one_is_useful(self) -> None:
+        for delta in (-1, 1):
+            with self.subTest(delta=delta):
+                self.assertIsNone(
+                    classify_dominated(
+                        f"{SOURCE}\nLEN: {len(SOURCE) + delta}\n", SOURCE
+                    )
+                )
+
+    def test_byte_length_and_text_length_are_distinguished(self) -> None:
+        """They differ on non-ASCII, and each label accepts only its own."""
+        source = "héllo\n"  # 6 characters, 7 bytes
+        self.assertNotEqual(len(source), len(source.encode("utf-8")))
+        self.assertIsNotNone(
+            classify_dominated(f"{source}\nlen_str: {len(source)}\n", source)
+        )
+        self.assertIsNotNone(
+            classify_dominated(
+                f"{source}\nlen_bytes: {len(source.encode())}\n", source
+            )
+        )
+        # The wrong quantity under a specific label is refused.
+        self.assertIsNone(
+            classify_dominated(f"{source}\nlen_str: {len(source.encode())}\n", source)
+        )
+        self.assertIsNone(
+            classify_dominated(f"{source}\nlen_bytes: {len(source)}\n", source)
+        )
+
+    def test_a_non_numeric_length_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nLEN: many\n", SOURCE))
+
+
+class LineCountTests(unittest.TestCase):
+    """C/D. Line count, under either counting rule the label may mean."""
+
+    def test_source_plus_correct_total_lines_is_dominated(self) -> None:
+        count = len(SOURCE.split("\n"))
+        found = classify_dominated(f"{SOURCE}\nTOTAL_LINES: {count}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertIn(LINE_COUNT, found.properties)
+
+    def test_splitlines_counting_is_also_accepted(self) -> None:
+        count = len(SOURCE.splitlines())
+        self.assertNotEqual(count, len(SOURCE.split("\n")))
+        self.assertIsNotNone(
+            classify_dominated(f"{SOURCE}\nTOTAL_LINES: {count}\n", SOURCE)
+        )
+
+    def test_only_the_two_recomputable_counts_are_accepted(self) -> None:
+        """Two rules for one label, and nothing between them.
+
+        On text containing U+2028 the rules differ by two. Accepting both is
+        not a loosening -- Orbit recomputes each from the same bytes, so
+        neither tells the session anything -- but every other value, including
+        the ones in between, is refused.
+        """
+        text = "a\u2028b\u2028c"
+        by_split = len(text.split("\n"))
+        by_lines = len(text.splitlines())
+        self.assertEqual((by_split, by_lines), (1, 3))
+        for count in (by_split, by_lines):
+            self.assertIsNotNone(
+                classify_dominated(f"{text}\nTOTAL_LINES: {count}\n", text)
+            )
+        for count in (0, 2, 4, 5):
+            with self.subTest(count=count):
+                self.assertIsNone(
+                    classify_dominated(f"{text}\nTOTAL_LINES: {count}\n", text)
+                )
+
+    def test_an_incorrect_line_count_is_useful(self) -> None:
+        for count in (0, 1, 999, len(SOURCE.split("\n")) + 2):
+            with self.subTest(count=count):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\nTOTAL_LINES: {count}\n", SOURCE)
+                )
+
+
+class DigestTests(unittest.TestCase):
+    """E/F. SHA-256 of the complete source."""
+
+    def test_source_plus_exact_digest_is_dominated(self) -> None:
+        found = classify_dominated(f"{SOURCE}\nsha256: {_sha(SOURCE)}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertIn(SHA256, found.properties)
+
+    def test_a_wrong_digest_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nsha256: {'0' * 64}\n", SOURCE))
+
+    def test_a_digest_of_something_else_is_useful(self) -> None:
+        """The digest of a substring is a real finding about that substring."""
+        self.assertIsNone(
+            classify_dominated(f"{SOURCE}\nsha256: {_sha(SOURCE[:20])}\n", SOURCE)
+        )
+
+    def test_md5_is_not_an_allowed_property(self) -> None:
+        """Not on the allow-list, however deterministic it is.
+
+        The list is exhaustive by design: adding a label is a deliberate act
+        justified by an observed output form, not a convenience.
+        """
+        digest = hashlib.md5(SOURCE.encode()).hexdigest()
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nmd5: {digest}\n", SOURCE))
+
+
+class HexRangeTests(unittest.TestCase):
+    """G/H. A hex range, only when the label names it exactly."""
+
+    def test_an_exact_hex_prefix_is_dominated(self) -> None:
+        hexed = SOURCE[:20].encode("utf-8").hex()
+        found = classify_dominated(f"{SOURCE}\nHEX20: {hexed}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertIn(HEX_PREFIX, found.properties)
+
+    def test_the_count_in_the_label_selects_the_range(self) -> None:
+        """A correct hex under the wrong count is refused."""
+        hexed = SOURCE[:20].encode("utf-8").hex()
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nHEX21: {hexed}\n", SOURCE))
+
+    def test_wrong_hex_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nHEX20: {'ab' * 20}\n", SOURCE))
+
+    def test_an_unlabelled_hex_range_is_useful(self) -> None:
+        """Nothing is guessed: without a count there is no proven range."""
+        hexed = SOURCE[:20].encode("utf-8").hex()
+        for label in ("HEX", "HEXDUMP", "hex"):
+            with self.subTest(label=label):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\n{label}: {hexed}\n", SOURCE)
+                )
+
+    def test_a_range_longer_than_the_source_is_useful(self) -> None:
+        """Refused rather than clamped: nobody proved that range."""
+        hexed = SOURCE.encode("utf-8").hex()
+        self.assertIsNone(
+            classify_dominated(f"{SOURCE}\nHEX99999: {hexed}\n", SOURCE)
+        )
+
+    def test_a_zero_length_range_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"{SOURCE}\nHEX0: \n", SOURCE))
+
+    def test_character_slicing_is_what_the_label_means(self) -> None:
+        """`data[:n].encode().hex()` -- not the first n BYTES.
+
+        The two differ on non-ASCII, and only the form the observed code
+        produced is accepted.
+        """
+        source = "héllo world\n"
+        by_chars = source[:5].encode("utf-8").hex()
+        by_bytes = source.encode("utf-8")[:5].hex()
+        self.assertNotEqual(by_chars, by_bytes)
+        self.assertIsNotNone(
+            classify_dominated(f"{source}\nHEX5: {by_chars}\n", source)
+        )
+        self.assertIsNone(classify_dominated(f"{source}\nHEX5: {by_bytes}\n", source))
+
+
+class RepresentationTests(unittest.TestCase):
+    """Every representation equivalence proves, plus properties."""
+
+    def test_repr_plus_length_is_dominated(self) -> None:
+        found = classify_dominated(f"{SOURCE!r}\nLEN: {len(SOURCE)}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.representation, REPR)
+
+    def test_a_numbered_listing_plus_line_count_is_dominated(self) -> None:
+        listing = _numbered(SOURCE)
+        count = len(SOURCE.splitlines())
+        found = classify_dominated(f"{listing}\nTOTAL_LINES: {count}\n", SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.representation, NUMBERED)
+
+    def test_several_exact_properties_together(self) -> None:
+        """I. Length and digest, both exact."""
+        observed = f"{SOURCE}\nLEN: {len(SOURCE)}\nsha256: {_sha(SOURCE)}\n"
+        found = classify_dominated(observed, SOURCE)
+        self.assertIsNotNone(found)
+        self.assertEqual(set(found.properties), {TEXT_LENGTH, SHA256})
+
+    def test_the_source_alone_is_not_dominance(self) -> None:
+        """That is exact equivalence, which the other module answers."""
+        self.assertIsNone(classify_dominated(SOURCE, SOURCE))
+        self.assertIsNone(classify_dominated(SOURCE + "\n", SOURCE))
+
+
+class FailClosedTests(unittest.TestCase):
+    """J-N. Everything that must remain useful evidence."""
+
+    def test_a_semantic_line_defeats_the_proof(self) -> None:
+        """J/K. True or not, a function count is not byte-derived."""
+        for extra in ("FUNCTIONS: 1", "IMPORTS: 1", "CALLS: 2", "VULNS: 0"):
+            with self.subTest(extra=extra):
+                self.assertIsNone(
+                    classify_dominated(
+                        f"{SOURCE}\nLEN: {len(SOURCE)}\n{extra}\n", SOURCE
+                    )
+                )
+
+    def test_partial_source_with_its_own_correct_length_is_useful(self) -> None:
+        """L. The length is right for what was printed, and that is the point.
+
+        Half the file plus the length of that half is a real observation about
+        which half was taken.
+        """
+        half = SOURCE[: len(SOURCE) // 2]
+        self.assertIsNone(classify_dominated(f"{half}\nLEN: {len(half)}\n", SOURCE))
+
+    def test_a_modified_source_with_matching_properties_is_useful(self) -> None:
+        """M. Properties correct for the modification, not for the artifact."""
+        modified = SOURCE.replace("os", "0s", 1)
+        observed = f"{modified}\nLEN: {len(modified)}\nsha256: {_sha(modified)}\n"
+        self.assertIsNone(classify_dominated(observed, SOURCE))
+
+    def test_an_unexplained_marker_is_useful(self) -> None:
+        """The live `===END===` case: a component the grammar does not name."""
+        self.assertIsNone(
+            classify_dominated(
+                f"{SOURCE}\n===END===\nLEN: {len(SOURCE)}\n", SOURCE
+            )
+        )
+
+    def test_a_heading_before_the_source_is_useful(self) -> None:
+        self.assertIsNone(
+            classify_dominated(f"=== source ===\n{SOURCE}\nLEN: {len(SOURCE)}\n", SOURCE)
+        )
+
+    def test_a_property_without_the_source_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"LEN: {len(SOURCE)}\n", SOURCE))
+
+    def test_a_bare_value_with_no_label_is_useful(self) -> None:
+        self.assertIsNone(classify_dominated(f"{SOURCE}\n{len(SOURCE)}\n", SOURCE))
+
+    def test_a_different_separator_is_useful(self) -> None:
+        """`print("X:", v)` emits exactly one space; nothing else is named."""
+        for line in (f"LEN:{len(SOURCE)}", f"LEN =  {len(SOURCE)}",
+                     f"LEN:  {len(SOURCE)}", f"LEN\t{len(SOURCE)}"):
+            with self.subTest(line=line):
+                self.assertIsNone(classify_dominated(f"{SOURCE}\n{line}\n", SOURCE))
+
+    def test_too_many_properties_is_useful(self) -> None:
+        lines = "\n".join(f"LEN: {len(SOURCE)}" for _ in range(MAX_PROPERTIES + 1))
+        self.assertIsNone(classify_dominated(f"{SOURCE}\n{lines}\n", SOURCE))
+
+    def test_an_empty_source_proves_nothing(self) -> None:
+        self.assertIsNone(classify_dominated("anything", ""))
+
+    def test_absurdly_large_output_is_not_scanned(self) -> None:
+        self.assertIsNone(classify_dominated("x" * 10_000_000, SOURCE))
+
+    def test_a_targeted_calculation_stays_useful(self) -> None:
+        """P. Real work that mentions no source at all."""
+        for output in ("FINDING: pickle.loads on cookie",
+                       "AST: Module(body=[Import, FunctionDef])",
+                       "grep 'def': line 4"):
+            with self.subTest(output=output):
+                self.assertIsNone(classify_dominated(output, SOURCE))
+
+
+class SecurityTests(unittest.TestCase):
+    """R. Bounded, deterministic, non-executing."""
+
+    def test_the_module_never_evaluates(self) -> None:
+        import ast
+
+        path = ROOT / "src" / "orbit" / "runtime" / "analysis_source_dominance.py"
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                node.body = body[1:] or [ast.Pass()]
+        code = ast.unparse(tree)
+        for banned in ("eval(", "exec(", "literal_eval", "__import__",
+                       "subprocess", "os.system", "pickle"):
+            self.assertNotIn(banned, code, banned)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                self.assertNotIn(
+                    node.func.id, {"eval", "exec", "compile", "__import__", "open"}
+                )
+
+    def test_hostile_property_lines_are_safe(self) -> None:
+        import time
+
+        hostile = [
+            f"{SOURCE}\n" + "LEN: " + "9" * 100_000,
+            f"{SOURCE}\nHEX" + "9" * 100_000 + ": ab",
+            f"{SOURCE}\n" + "A" * 100_000 + ": 1",
+            f"{SOURCE}\n\x00\x00: 1",
+            f"{SOURCE}\nLEN: __import__('os').system('id')",
+            f"{SOURCE}\n" + "\n".join(":" for _ in range(10_000)),
+            f"{SOURCE}\nHEX5: " + "z" * 10_000,
+        ]
+        started = time.monotonic()
+        for candidate in hostile:
+            with self.subTest(candidate=candidate[:30]):
+                self.assertIsNone(classify_dominated(candidate, SOURCE))
+        self.assertLess(time.monotonic() - started, 10.0)
+
+    def test_a_numbered_listing_search_terminates(self) -> None:
+        import time
+
+        started = time.monotonic()
+        classify_dominated("\n".join(f"{i}: x" for i in range(5000)), SOURCE)
+        self.assertLess(time.monotonic() - started, 10.0)
+
+
+class LiveObservedPatternTests(unittest.TestCase):
+    """The exact forms the last live run produced, judged individually."""
+
+    SAMPLE = ROOT / "workdir" / "samples" / "vulnerable_service.py"
+
+    def setUp(self) -> None:
+        if not self.SAMPLE.exists():
+            self.skipTest("sample missing")
+        self.src = self.SAMPLE.read_text()
+
+    def test_action_1_repr_plus_len(self) -> None:
+        self.assertIsNotNone(
+            classify_dominated(f"{self.src!r}\nLEN: {len(self.src)}\n", self.src)
+        )
+
+    def test_action_2_plain_plus_len(self) -> None:
+        self.assertIsNotNone(
+            classify_dominated(f"{self.src}\nLEN: {len(self.src)}\n", self.src)
+        )
+
+    def test_action_3_marker_between_source_and_len_stays_useful(self) -> None:
+        """`===END===` is a component the grammar does not name."""
+        self.assertIsNone(
+            classify_dominated(
+                f"{self.src}\n===END===\nLEN: {len(self.src)}\n", self.src
+            )
+        )
+
+    def test_action_5_hex_prefix_plus_a_bytes_repr_stays_useful(self) -> None:
+        """`BYTES: b'...'` is a range representation the grammar does not name."""
+        hexed = self.src[:200].encode("utf-8").hex()
+        observed = f"HEX200: {hexed}\nBYTES: {self.src.encode()[:50]!r}\n"
+        self.assertIsNone(classify_dominated(observed, self.src))
+
+    def test_action_6_md5_and_counts_stay_useful(self) -> None:
+        observed = (
+            f"{self.src}\n"
+            f"sha256: {_sha(self.src)}\n"
+            f"md5: {hashlib.md5(self.src.encode()).hexdigest()}\n"
+            "nonascii_count: 0\n"
+        )
+        self.assertIsNone(classify_dominated(observed, self.src))
+
+    def test_action_7_ast_output_stays_useful(self) -> None:
+        self.assertIsNone(
+            classify_dominated("FUNC find_user @ line 14: doc='...'", self.src)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class RuntimeSeamTests(unittest.TestCase):
+    """The gate, end to end: dominance reuses the equivalence seam exactly.
+
+    No parallel progress system -- a dominated observation takes the same path
+    an equivalent one does, so the ledger, the accounting and the provenance
+    are the ones already qualified.
+    """
+
+    def setUp(self) -> None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_reacq", ROOT / "tests" / "test_analysis_reacquisition_runtime.py"
+        )
+        self.helpers = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.helpers)
+
+    def _runtime(self):
+        case = self.helpers._Case()
+        case.setUp() if hasattr(case, "setUp") else None
+        runtime = case._runtime()
+        self.addCleanup(runtime.close)
+        self._case = case
+        return runtime
+
+    def _cover(self, runtime) -> None:
+        coverage = runtime.plan_source_coverage()
+        self.assertTrue(coverage.covered)
+        runtime.cover_source(coverage)
+        self._case.backend.chat_calls.clear()
+
+    def _step(self, runtime, result):
+        from unittest import mock
+
+        from orbit.runtime import analysis_runtime as module
+
+        with mock.patch.object(module, "execute_analysis", lambda **kw: result):
+            return runtime.step("go")
+
+    def test_a_dominated_observation_consumes_no_action(self) -> None:
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        before = runtime.actions_executed
+        step = self._step(
+            runtime,
+            self.helpers._result(stdout=f"{source}\nLEN: {len(source)}"),
+        )
+        self.assertIsNotNone(step.suppressed_duplicate_of)
+        self.assertEqual(runtime.actions_executed, before)
+        self.assertEqual(runtime.suppressed_duplicates, 1)
+        self.assertEqual(runtime.model_calls, 2)  # cover + this step
+
+    def test_the_ledger_sees_no_progress(self) -> None:
+        from orbit.runtime.analysis_progress import NO_PROGRESS, ProgressLedger
+
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(
+            runtime,
+            self.helpers._result(stdout=f"{source}\nLEN: {len(source)}"),
+        )
+        self.assertEqual(
+            ProgressLedger().classify(1, step).classification, NO_PROGRESS
+        )
+
+    def test_provenance_names_the_verified_properties(self) -> None:
+        from orbit.runtime.analysis_source_dominance import SOURCE_DOMINATED
+
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        step = self._step(
+            runtime,
+            self.helpers._result(stdout=f"{source}\nLEN: {len(source)}"),
+        )
+        record = runtime.evidence_store.records[step.suppressed_duplicate_of]
+        self.assertEqual(record.metadata["suppressed_as"], SOURCE_DOMINATED)
+        self.assertEqual(record.metadata["verified_properties"], [TEXT_LENGTH])
+        # The raw output stays retained and re-attestable.
+        raw_id = record.metadata["raw_output_evidence_id"]
+        self.assertIsNotNone(runtime.evidence_store.reattest_exact(raw_id))
+
+    def test_an_artifact_defeats_dominance(self) -> None:
+        """A written file is new state whatever the stdout says."""
+        from orbit.runtime.analysis_sandbox import DerivedArtifact
+
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        written = DerivedArtifact(name="notes.txt", size_bytes=5, sha256="f" * 64)
+        step = self._step(
+            runtime,
+            self.helpers._result(
+                stdout=f"{source}\nLEN: {len(source)}", artifacts=[written]
+            ),
+        )
+        self.assertIsNone(step.suppressed_duplicate_of)
+
+    def test_nothing_is_dominated_without_coverage(self) -> None:
+        """O. Without COVER the model was never given the source."""
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        before = runtime.actions_executed
+        step = self._step(
+            runtime,
+            self.helpers._result(stdout=f"{source}\nLEN: {len(source)}"),
+        )
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertEqual(runtime.actions_executed, before + 1)
+
+    def test_a_failed_or_altered_action_is_never_dominated(self) -> None:
+        """N. Every guard equivalence already applies, applies here too."""
+        source = self.helpers.SOURCE
+        stdout = f"{source}\nLEN: {len(source)}"
+        for label, result in (
+            ("error", self.helpers._result(stdout=stdout, status="error")),
+            ("stderr", self.helpers._result(stdout=stdout, stderr="warn")),
+            ("truncated", self.helpers._truncated_result(stdout)),
+            ("replaced", self.helpers._replaced_result(stdout)),
+        ):
+            with self.subTest(label=label):
+                runtime = self._runtime()
+                self._cover(runtime)
+                step = self._step(runtime, result)
+                self.assertIsNone(step.suppressed_duplicate_of)
+
+    def test_the_repeated_four_way_sequence_never_progresses(self) -> None:
+        """Q. The live shapes in a row, none of them useful."""
+        from orbit.runtime.analysis_progress import NO_PROGRESS, ProgressLedger
+
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        listing = _numbered(source)
+        outputs = [
+            f"{source}\nLEN: {len(source)}",
+            f"{source!r}\nsha256: {_sha(source)}",
+            f"{listing}\nTOTAL_LINES: {len(source.splitlines())}",
+            f"{source}\nHEX20: {source[:20].encode('utf-8').hex()}",
+        ]
+        ledger = ProgressLedger()
+        for index, stdout in enumerate(outputs, 1):
+            self._case.backend.code = f"# variant {index}\nprint(1)"
+            step = self._step(runtime, self.helpers._result(stdout=stdout))
+            self.assertIsNotNone(step.suppressed_duplicate_of, stdout[:40])
+            self.assertEqual(
+                ledger.classify(index, step).classification, NO_PROGRESS
+            )
+        self.assertEqual(runtime.actions_executed, 0)
+        self.assertEqual(runtime.suppressed_duplicates, 4)
+
+    def test_a_legitimate_action_still_runs_after_dominance(self) -> None:
+        """P. Suppression is per-observation, never a mode the run enters."""
+        source = self.helpers.SOURCE
+        runtime = self._runtime()
+        self._cover(runtime)
+        self._case.backend.code = "# one\nprint(1)"
+        self._step(runtime, self.helpers._result(stdout=f"{source}\nLEN: {len(source)}"))
+        self._case.backend.code = "# two\nprint(2)"
+        step = self._step(
+            runtime, self.helpers._result(stdout="FINDING: os.environ read")
+        )
+        self.assertIsNone(step.suppressed_duplicate_of)
+        self.assertEqual(runtime.actions_executed, 1)
+
+    def test_global_ceilings_are_unchanged(self) -> None:
+        from orbit.runtime import analysis_runtime as module
+
+        self.assertEqual(module.MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertEqual(module.SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 15)

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -323,6 +323,91 @@ class FailClosedTests(unittest.TestCase):
                 self.assertIsNone(classify_dominated(output, SOURCE))
 
 
+class TrailingByteFidelityTests(unittest.TestCase):
+    """A listing must show every line, including ones made of whitespace.
+
+    `rstrip()` would treat form feeds, carriage returns, vertical tabs, spaces
+    and tabs as absent -- they are ordinary bytes of a source file, and a
+    listing that never showed the lines they belong to is incomplete. Only the
+    single trailing newline a line-wise print drops may be tolerated.
+    """
+
+    def test_a_listing_omitting_whitespace_only_tail_lines_is_useful(self) -> None:
+        for tail in ("\x0c\r\x0b", " \t \n \t \n", "\x0c\n", "   ", "\t\t"):
+            with self.subTest(tail=tail):
+                source = "a = 1\nb = 2\n" + tail
+                listing = "1: a = 1\n2: b = 2"
+                self.assertIsNone(
+                    classify_dominated(
+                        f"{listing}\nLEN: {len(source)}\n", source
+                    )
+                )
+
+    def test_extra_trailing_newlines_are_not_stripped_away(self) -> None:
+        source = "a\nb\n\n\n"
+        listing = "1: a\n2: b"
+        self.assertIsNone(
+            classify_dominated(f"{listing}\nLEN: {len(source)}\n", source)
+        )
+
+    def test_one_trailing_newline_is_still_tolerated(self) -> None:
+        """The control: the newline `splitlines()` drops is not a missing line."""
+        source = "a\nb\n"
+        listing = "1: a\n2: b"
+        self.assertIsNotNone(
+            classify_dominated(f"{listing}\nLEN: {len(source)}\n", source)
+        )
+
+    def test_blank_lines_between_properties_are_unexplained(self) -> None:
+        """Tolerant parsing in a module that claims none."""
+        for observed in (
+            f"{SOURCE}\n\nLEN: {len(SOURCE)}\n",
+            f"{SOURCE}\nLEN: {len(SOURCE)}\n\n\n",
+            f"{SOURCE}\nLEN: {len(SOURCE)}\n\nsha256: {_sha(SOURCE)}\n",
+        ):
+            with self.subTest(observed=observed[-30:]):
+                self.assertIsNone(classify_dominated(observed, SOURCE))
+
+
+class ComplexityTests(unittest.TestCase):
+    """Bounded host CPU: the sandbox timeout does not cover this code.
+
+    `_split_numbered` once retried every shorter prefix, re-joining and
+    re-stripping each -- quadratic, and reachable from ordinary output: a model
+    printing a numbered listing with one trailing line paid it, in the host
+    process, after the sandbox had already returned and with no timeout around
+    it.
+    """
+
+    def test_numbered_shaped_output_is_classified_in_linear_time(self) -> None:
+        import time
+
+        source = "x = 1\n" * 50
+        timings = []
+        for count in (2000, 8000, 32000):
+            candidate = (
+                "\n".join(f"{i}: line {i} of output" for i in range(count))
+                + "\nTRAILING"
+            )
+            started = time.monotonic()
+            classify_dominated(candidate, source)
+            timings.append(time.monotonic() - started)
+        # Well under a second even at 16x the smallest input; a quadratic
+        # implementation took minutes here.
+        self.assertLess(max(timings), 2.0)
+
+    def test_a_real_listing_is_still_recognised(self) -> None:
+        source = "x = 1\n" * 50
+        listing = "\n".join(
+            f"{i:3}: {line}" for i, line in enumerate(source.splitlines())
+        )
+        self.assertIsNotNone(
+            classify_dominated(
+                f"{listing}\nTOTAL_LINES: {len(source.splitlines())}\n", source
+            )
+        )
+
+
 class SecurityTests(unittest.TestCase):
     """R. Bounded, deterministic, non-executing."""
 

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -291,6 +291,26 @@ class FailClosedTests(unittest.TestCase):
             classify_dominated(f"=== source ===\n{SOURCE}\nLEN: {len(SOURCE)}\n", SOURCE)
         )
 
+    def test_a_property_must_begin_on_its_own_line(self) -> None:
+        """The separator is part of the grammar, not incidental formatting.
+
+        `print(data)` then `print("LEN:", n)` puts a newline between them.
+        Without requiring it, output where the property is merely appended --
+        after a space, or with no separator that the source itself did not
+        supply -- would be accepted, and the boundary between the source and
+        what follows it would be whatever the text happened to allow.
+        """
+        for observed in (
+            f"{SOURCE} LEN: {len(SOURCE)}\n",
+            f"{SOURCE}\tLEN: {len(SOURCE)}\n",
+            f"{SOURCE}  LEN: {len(SOURCE)}\n",
+        ):
+            with self.subTest(observed=observed[-24:]):
+                self.assertIsNone(classify_dominated(observed, SOURCE))
+        self.assertIsNotNone(
+            classify_dominated(f"{SOURCE}\nLEN: {len(SOURCE)}\n", SOURCE)
+        )
+
     def test_a_property_without_the_source_is_useful(self) -> None:
         self.assertIsNone(classify_dominated(f"LEN: {len(SOURCE)}\n", SOURCE))
 
@@ -359,14 +379,26 @@ class TrailingByteFidelityTests(unittest.TestCase):
         )
 
     def test_blank_lines_between_properties_are_unexplained(self) -> None:
-        """Tolerant parsing in a module that claims none."""
+        """Tolerant parsing in a module that claims none.
+
+        A blank line is a byte the program printed. Discarding it would mean
+        the observation contained something the grammar never accounted for,
+        which is the one thing a total proof cannot do -- and it is the seam
+        through which a line could later be smuggled.
+        """
         for observed in (
             f"{SOURCE}\n\nLEN: {len(SOURCE)}\n",
             f"{SOURCE}\nLEN: {len(SOURCE)}\n\n\n",
             f"{SOURCE}\nLEN: {len(SOURCE)}\n\nsha256: {_sha(SOURCE)}\n",
+            f"{SOURCE}\nLEN: {len(SOURCE)}\n\n",
         ):
             with self.subTest(observed=observed[-30:]):
                 self.assertIsNone(classify_dominated(observed, SOURCE))
+        # The control: exactly one separator and one trailing newline is the
+        # shape `print` produces, and it is accepted.
+        self.assertIsNotNone(
+            classify_dominated(f"{SOURCE}\nLEN: {len(SOURCE)}\n", SOURCE)
+        )
 
 
 class ComplexityTests(unittest.TestCase):
@@ -380,21 +412,27 @@ class ComplexityTests(unittest.TestCase):
     """
 
     def test_numbered_shaped_output_is_classified_in_linear_time(self) -> None:
+        """The costly shape: every prefix parses, none of them matches.
+
+        A trailing non-numbered line is cheap -- the strip fails at once on
+        every prefix. What is expensive is output that is numbered
+        consecutively all the way down and simply is not this source: each
+        prefix parses successfully and only the final comparison rejects it,
+        so a search over prefixes does the full parse once per line. The
+        candidate is kept inside `_too_large` so the search is genuinely
+        reached rather than short-circuited.
+        """
         import time
 
-        source = "x = 1\n" * 50
         timings = []
-        for count in (2000, 8000, 32000):
-            candidate = (
-                "\n".join(f"{i}: line {i} of output" for i in range(count))
-                + "\nTRAILING"
-            )
+        for count in (1000, 2000, 4000):
+            source = "\n".join(f"other {i}" for i in range(count)) + "\n"
+            candidate = "\n".join(f"{i}: line {i}" for i in range(count))
             started = time.monotonic()
-            classify_dominated(candidate, source)
+            self.assertIsNone(classify_dominated(candidate, source))
             timings.append(time.monotonic() - started)
-        # Well under a second even at 16x the smallest input; a quadratic
-        # implementation took minutes here.
-        self.assertLess(max(timings), 2.0)
+        # Quadratic here measured 0.8s / 2.2s / 9.9s; linear is milliseconds.
+        self.assertLess(max(timings), 1.0)
 
     def test_a_real_listing_is_still_recognised(self) -> None:
         source = "x = 1\n" * 50

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -545,6 +545,38 @@ class SeparatorTests(unittest.TestCase):
                     )
 
 
+class DeliberateNarrownessTests(unittest.TestCase):
+    """Choices that only ever refuse more, pinned so they are not widened idly.
+
+    Neither of these can cause a false positive -- a value must still equal a
+    recomputation whatever spelling names it, and every counted line is still
+    verified. They are pinned because the safe direction is still a decision:
+    the label table is exhaustive by design, and the cap bounds work rather
+    than trusting the model to be brief.
+    """
+
+    def test_labels_are_case_sensitive(self) -> None:
+        """`len` is not `LEN`. Adding a spelling is a deliberate act."""
+        for label in ("len", "Len", "lEN", "total_lines", "Sha256", "SHA256 "):
+            with self.subTest(label=label):
+                self.assertIsNone(
+                    classify_dominated(
+                        f"{SOURCE}\n{label}: {len(SOURCE)}\n", SOURCE
+                    )
+                )
+
+    def test_the_property_cap_bounds_work(self) -> None:
+        """Every line still verifies; the cap only bounds how many are tried."""
+        correct = "\n".join(f"LEN: {len(SOURCE)}" for _ in range(MAX_PROPERTIES))
+        self.assertIsNotNone(
+            classify_dominated(f"{SOURCE}\n{correct}\n", SOURCE)
+        )
+        one_more = "\n".join(
+            f"LEN: {len(SOURCE)}" for _ in range(MAX_PROPERTIES + 1)
+        )
+        self.assertIsNone(classify_dominated(f"{SOURCE}\n{one_more}\n", SOURCE))
+
+
 class SecurityTests(unittest.TestCase):
     """R. Bounded, deterministic, non-executing."""
 

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -446,6 +446,105 @@ class ComplexityTests(unittest.TestCase):
         )
 
 
+class PrefixValueTests(unittest.TestCase):
+    """A value that is a proper PREFIX of the right one is a different value.
+
+    The comparison must be equality. `startswith` is a plausible slip and a
+    dangerous one: a truncated digest and a shortened count are facts the
+    session does not hold, so accepting them suppresses real information. The
+    existing near-miss tests all use wrong-by-delta or wrong-shaped values,
+    which a prefix comparison still rejects -- only a genuine prefix shows the
+    difference.
+    """
+
+    def test_a_truncated_digest_is_useful(self) -> None:
+        digest = _sha(SOURCE)
+        for width in (1, 8, 16, 32, len(digest) - 1):
+            with self.subTest(width=width):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\nsha256: {digest[:width]}\n", SOURCE)
+                )
+
+    def test_a_truncated_length_is_useful(self) -> None:
+        length = str(len(SOURCE))
+        self.assertGreater(len(length), 1)
+        for width in range(1, len(length)):
+            with self.subTest(width=width):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\nLEN: {length[:width]}\n", SOURCE)
+                )
+
+    def test_a_truncated_line_count_is_useful(self) -> None:
+        source = "\n".join(f"line {i}" for i in range(120)) + "\n"
+        count = str(len(source.split("\n")))
+        self.assertGreater(len(count), 1)
+        for width in range(1, len(count)):
+            with self.subTest(width=width):
+                self.assertIsNone(
+                    classify_dominated(
+                        f"{source}\nTOTAL_LINES: {count[:width]}\n", source
+                    )
+                )
+
+    def test_a_truncated_hex_range_is_useful(self) -> None:
+        hexed = SOURCE[:20].encode("utf-8").hex()
+        for width in (2, 10, len(hexed) - 2):
+            with self.subTest(width=width):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\nHEX20: {hexed[:width]}\n", SOURCE)
+                )
+
+    def test_an_empty_value_is_useful(self) -> None:
+        """The degenerate prefix, which every value starts with."""
+        for label in ("LEN", "TOTAL_LINES", "sha256"):
+            with self.subTest(label=label):
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\n{label}: \n", SOURCE)
+                )
+
+
+class SeparatorTests(unittest.TestCase):
+    """Exactly one newline between the source and the first property.
+
+    Two spellings produce it: `print(data)` appends a newline of its own, and
+    `sys.stdout.write(data)` on a source that already ends in one does not.
+    Both leave the property at the start of a line; requiring the extra newline
+    would miss the second, which is a form the model actually uses.
+    """
+
+    SOURCE_NL = "import os\nprint(1)\n"
+    SOURCE_NO_NL = "import os\nprint(1)"
+
+    def test_print_style_and_write_style_are_both_accepted(self) -> None:
+        source = self.SOURCE_NL
+        self.assertIsNotNone(
+            classify_dominated(f"{source}\nLEN: {len(source)}\n", source)
+        )
+        self.assertIsNotNone(
+            classify_dominated(f"{source}LEN: {len(source)}\n", source)
+        )
+
+    def test_a_source_without_a_newline_needs_the_separator(self) -> None:
+        """Nothing put the property on its own line, so the boundary is unproven."""
+        source = self.SOURCE_NO_NL
+        self.assertIsNone(
+            classify_dominated(f"{source}LEN: {len(source)}\n", source)
+        )
+        self.assertIsNotNone(
+            classify_dominated(f"{source}\nLEN: {len(source)}\n", source)
+        )
+
+    def test_other_separators_stay_useful(self) -> None:
+        for source in (self.SOURCE_NL, self.SOURCE_NO_NL):
+            for gap in (" ", "\t", "  ", " \n"):
+                with self.subTest(source=source[-6:], gap=repr(gap)):
+                    self.assertIsNone(
+                        classify_dominated(
+                            f"{source}{gap}LEN: {len(source)}\n", source
+                        )
+                    )
+
+
 class SecurityTests(unittest.TestCase):
     """R. Bounded, deterministic, non-executing."""
 

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -197,11 +197,39 @@ class HexRangeTests(unittest.TestCase):
                 )
 
     def test_a_range_longer_than_the_source_is_useful(self) -> None:
-        """Refused rather than clamped: nobody proved that range."""
+        """Refused rather than clamped, and tested AT the boundary.
+
+        Python slicing returns a shorter string rather than raising, so
+        `data[:n+1] == data[:n]` and an off-by-one bound goes unnoticed: the
+        label asserts a range the source cannot supply while the value still
+        matches. A distant count like 99999 survives any off-by-one, so the
+        boundary has to be probed one step at a time.
+        """
         hexed = SOURCE.encode("utf-8").hex()
-        self.assertIsNone(
-            classify_dominated(f"{SOURCE}\nHEX99999: {hexed}\n", SOURCE)
+        for over in (1, 2, 3, 100, 99999):
+            with self.subTest(over=over):
+                count = len(SOURCE) + over
+                self.assertIsNone(
+                    classify_dominated(f"{SOURCE}\nHEX{count}: {hexed}\n", SOURCE)
+                )
+        # The control: exactly the whole source is a valid range.
+        self.assertIsNotNone(
+            classify_dominated(f"{SOURCE}\nHEX{len(SOURCE)}: {hexed}\n", SOURCE)
         )
+
+    def test_the_range_bound_is_exact_at_every_step(self) -> None:
+        """The full boundary map, so no single slot is left unguarded."""
+        length = len(SOURCE)
+        for count, expected in (
+            (length - 1, True), (length, True),
+            (length + 1, False), (length + 2, False),
+        ):
+            with self.subTest(count=count):
+                hexed = SOURCE[:count].encode("utf-8").hex()
+                found = classify_dominated(
+                    f"{SOURCE}\nHEX{count}: {hexed}\n", SOURCE
+                )
+                self.assertEqual(found is not None, expected)
 
     def test_a_zero_length_range_is_useful(self) -> None:
         self.assertIsNone(classify_dominated(f"{SOURCE}\nHEX0: \n", SOURCE))


### PR DESCRIPTION
Exact equivalence catches an output that is only the covered source. The live run showed that is rarely what happens: the model prints the source and then one deterministic fact about it -- `LEN: 1495`, `TOTAL_LINES: 46`, a SHA, a hex prefix -- so equivalence almost never fired and nine actions were spent on source-derived observations.

An observation that is the covered source **plus properties Orbit can independently recompute from that same source** now takes the path an exactly equivalent one takes: it runs, it is recorded, it is reported, and it consumes no useful action. Same seam, same ledger, same accounting, same provenance -- no parallel progress system.

## The boundary is recomputation, not correctness

A property qualifies only if Orbit derives it from the artifact's own bytes without interpreting the program: byte length, text length, line count, SHA-256, the hex of a range the label names explicitly. A count of functions, imports or calls does not qualify **however trivially true it is** -- deriving it means parsing the language, which is analysis, and analysis is what the model is for. `md5` is not on the list either: the labels are exhaustive by design.

The proof is total. The leading component must exactly match the source in a representation equivalence already proves; each remaining line must be a property whose value is recomputed and compared exactly; no byte may remain unexplained. The live `===END===` marker between the source and its length is a component the grammar does not name, so that observation stays useful -- as does a range whose hex is right under the wrong count, a length off by one, a digest of a substring, and a partial source with the correct length for the part that was printed.

Quantities that look interchangeable are kept apart: byte and text length coincide on ASCII and differ otherwise; hex ranges distinguish slicing characters from slicing bytes; one label accepts two line-counting rules because Orbit recomputes both, but on text containing U+2028 those differ by two and every value between them is refused.

## What review found

Two BLOCKERs, both of one class -- **a boundary tested only from far away**:

- A `startswith` slip in the property comparison suppressed a truncated digest and a shortened count. Every near-miss test used wrong-by-delta values, which a prefix comparison still rejects; only a genuine prefix exposes it.
- The hex range bound widened by one accepted a label claiming a range the source cannot supply -- Python slicing returns a shorter string rather than raising, so the value still matched. `HEX99999` survives any off-by-one.

Both are now probed one step at a time on both sides. That pattern cost two blockers and is named in the tests.

Also: an O(n²) prefix search in the listing split -- 4000 lines of ordinary model output cost ten seconds of **host** CPU after the sandbox returned, outside its timeout. The boundary is now computed from the source's own line count: 64,000 lines in 3ms. And a regression I introduced, where `sys.stdout.write(data)` output silently stopped being suppressed.

## Scope

Gated on coverage, inheriting every guard: no COVER, a failure, stderr, truncation, character replacement, or any written artifact and the observation stays ordinary evidence. Global ceilings unchanged. CHAT and guided ANALYSIS untouched.

## Qualification

71 focused tests; **25/25 non-equivalent mutants caught**; full suite **4539 OK**; 500k-iteration fuzz with **0 false positives**. Three adversarial review rounds, final round clean apart from the boundary blocker now closed.

No GGUF loaded.
