### PR TITLE
fix(analysis): bound tool exploration with question ledger

### DIFF
--- a/src/orbit/runtime/analysis_question_ledger.py
+++ b/src/orbit/runtime/analysis_question_ledger.py
@@ -1,0 +1,314 @@
+"""A finite ledger of questions that actually require running something.
+
+Source acquisition stopped being the problem. The live run that motivated this
+supplied the whole artifact, suppressed the one re-read, and still spent seven
+actions -- four of them re-deriving facts the source already showed (twice, in
+near-identical pairs), and three genuinely needing execution. None of the seven
+was caused by an earlier result. The pattern is not bad reasoning; it is that
+every valid new action counts as progress, so an investigation grows until a
+ceiling stops it.
+
+The ledger bounds one thing: which TOOL ACTIONS may run. After coverage the
+model declares the concrete questions it cannot answer from the source it was
+given, and each action must name one of them. When none is open, the run
+reports.
+
+What it deliberately does not bound is what the model may *know*. A finding
+visible in the source needs no question, cannot be suppressed by the ledger,
+and belongs in the report whether or not anyone declared it. An empty ledger
+means "nothing left that needs a tool" -- never "the analysis is complete", and
+never "there is nothing more to say".
+
+The other half of that promise is that an unresolved question stays visibly
+unresolved. A question the model could not answer is reported as open, with
+whatever evidence it did produce. Nothing here marks a question resolved: only
+the model does that, and only about the question its own action just ran.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+# States a question can be in. `OPEN` is the only one an action may target.
+OPEN = "open"
+RESOLVED = "resolved"
+
+# What bounds expansion, on top of the global action ceiling. Depth 1 means a
+# question raised by a result may itself raise nothing: the live evidence shows
+# no causal chains at all, so anything deeper would be building for a case the
+# artifact has never produced.
+MAX_CHILD_DEPTH = 1
+# The most questions a plan may declare, sized so the whole ledger fits the
+# existing model-call budget: coverage and planning cost two calls, each
+# question costs one to run and one to classify, so six questions is fourteen
+# of the fifteen available. A plan that could not be worked through would be
+# one the run cannot honour, which is worse than a shorter one.
+#
+# Children can push past that, and deliberately are not separately capped: the
+# global ceiling is what stops them, and a run that hits it reports with its
+# open questions still shown as open. Nothing is lost when that happens -- the
+# ledger simply stops being what bounded the run.
+MAX_INITIAL_QUESTIONS = 6
+# The most questions a ledger may ever hold, children included. Without it the
+# only bound on growth is the global action ceiling -- one distinct child per
+# action, indefinitely -- which makes termination a property of the ceiling
+# rather than of the ledger, and lets the rendered ledger grow into every later
+# prompt until admission refuses it. Twice the initial cap is exactly "each
+# declared question may raise one child, and no more".
+MAX_TOTAL_QUESTIONS = MAX_INITIAL_QUESTIONS * 2
+
+# Identifiers are model-authored text that ends up in prompts and provenance.
+MAX_ID_CHARS = 16
+MAX_TEXT_CHARS = 300
+# A plan is a short JSON document. Anything vastly larger is not one.
+MAX_PLAN_CHARS = 20_000
+
+_ID = re.compile(r"\A[A-Za-z][A-Za-z0-9_.-]{0,15}\Z")
+
+
+class LedgerError(ValueError):
+    """A plan or classification that cannot be trusted. Always fails closed."""
+
+
+@dataclass(frozen=True)
+class Question:
+    """One thing the model says it cannot answer without running something."""
+
+    id: str
+    question: str
+    why: str
+    depth: int = 0
+    parent: str | None = None
+    caused_by: str | None = None
+
+    def as_line(self) -> str:
+        return f"{self.id} | {self.question} | {self.why}"
+
+
+@dataclass
+class QuestionLedger:
+    """The open/resolved state of one analysis, and the rules that move it.
+
+    Deliberately a plain record with explicit transitions rather than anything
+    that decides on the model's behalf. It refuses; it never resolves.
+    """
+
+    questions: "dict[str, Question]" = field(default_factory=dict)
+    state: "dict[str, str]" = field(default_factory=dict)
+    evidence: "dict[str, str]" = field(default_factory=dict)
+    order: "list[str]" = field(default_factory=list)
+    rejected_free_actions: int = 0
+    rejected_children: int = 0
+    reopen_attempts: int = 0
+
+    @property
+    def open_ids(self) -> "list[str]":
+        return [qid for qid in self.order if self.state.get(qid) == OPEN]
+
+    @property
+    def resolved_ids(self) -> "list[str]":
+        return [qid for qid in self.order if self.state.get(qid) == RESOLVED]
+
+    @property
+    def exhausted(self) -> bool:
+        """No question is open. Never means the analysis is complete."""
+        return not self.open_ids
+
+    def add(self, question: Question) -> None:
+        if question.id in self.questions:
+            raise LedgerError(f"duplicate question id: {question.id}")
+        self.questions[question.id] = question
+        self.state[question.id] = OPEN
+        self.order.append(question.id)
+
+    def is_open(self, qid: str) -> bool:
+        return self.state.get(qid) == OPEN
+
+    def resolve(self, qid: str, evidence_id: str) -> None:
+        """Mark a question answered, on the model's word plus a reference.
+
+        The evidence id is required and recorded so a reader can check the
+        claim. The runtime does not verify that the evidence answers the
+        question -- that judgement is the analysis itself -- but it does insist
+        that something was named.
+        """
+        if not self.is_open(qid):
+            raise LedgerError(f"not an open question: {qid}")
+        if not evidence_id:
+            raise LedgerError(f"no evidence named for {qid}")
+        self.state[qid] = RESOLVED
+        self.evidence[qid] = evidence_id
+
+    def reopen(self, qid: str, caused_by: str) -> None:
+        """A resolved question may return only on new causal evidence.
+
+        Without that rule a run can cycle: resolve, reopen, resolve again,
+        spending the ceiling on a question it has already answered.
+        """
+        if self.state.get(qid) != RESOLVED:
+            raise LedgerError(f"not a resolved question: {qid}")
+        if not caused_by or caused_by == self.evidence.get(qid):
+            self.reopen_attempts += 1
+            raise LedgerError(
+                f"reopening {qid} requires new evidence it was not resolved by"
+            )
+        self.state[qid] = OPEN
+
+    def accept_child(self, child: Question) -> None:
+        """A question raised by a result, admitted only if it is really caused.
+
+        Four conditions, and each rules out a different way a run grows without
+        bound: the parent must exist and have just run, the evidence that
+        caused it must be named, the depth cap must hold, and it must not
+        restate something already asked.
+        """
+        parent = self.questions.get(child.parent or "")
+        if parent is None:
+            self.rejected_children += 1
+            raise LedgerError(f"child {child.id} names no known parent")
+        if not child.caused_by:
+            self.rejected_children += 1
+            raise LedgerError(f"child {child.id} names no causing evidence")
+        if child.depth > MAX_CHILD_DEPTH:
+            self.rejected_children += 1
+            raise LedgerError(
+                f"child {child.id} is deeper than the permitted {MAX_CHILD_DEPTH}"
+            )
+        if child.id in self.questions:
+            self.rejected_children += 1
+            raise LedgerError(f"duplicate question id: {child.id}")
+        if len(self.questions) >= MAX_TOTAL_QUESTIONS:
+            self.rejected_children += 1
+            raise LedgerError(
+                f"ledger already holds {MAX_TOTAL_QUESTIONS} questions"
+            )
+        if _restates(child, self.questions.values()):
+            self.rejected_children += 1
+            raise LedgerError(f"child {child.id} restates an existing question")
+        self.add(child)
+
+    def render(self) -> str:
+        """The ledger as the model sees it, open questions first."""
+        lines = []
+        for qid in self.order:
+            mark = "OPEN" if self.state[qid] == OPEN else "RESOLVED"
+            suffix = ""
+            if self.state[qid] == RESOLVED:
+                suffix = f" (evidence:{self.evidence.get(qid, '?')})"
+            lines.append(f"{qid} [{mark}]{suffix}: {self.questions[qid].question}")
+        return "\n".join(lines)
+
+
+def _normalise(text: str) -> str:
+    """Lowercased alphanumeric words, for exact-duplicate detection only.
+
+    This is not similarity matching and must not become it: it catches a child
+    that is literally the same question reworded in case or spacing. Anything
+    that requires judgement about meaning is the model's to make, and a child
+    that is genuinely new is admitted even if it reads like an existing one.
+    """
+    return " ".join(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def _restates(child: Question, existing) -> bool:
+    target = _normalise(child.question)
+    return any(_normalise(other.question) == target for other in existing)
+
+
+def parse_plan(text: str) -> "list[Question]":
+    """Read a planning response into questions, or raise.
+
+    The wire format is a JSON object with a `questions` array. It is parsed
+    strictly: unknown shapes, missing fields, bad ids and over-long text all
+    raise rather than being coerced, because a plan that has to be guessed at
+    is not a plan the run can be held to.
+
+    An empty list is valid and meaningful -- it says the source answered
+    everything -- so it returns `[]` rather than raising.
+    """
+    if not text or len(text) > MAX_PLAN_CHARS:
+        raise LedgerError("plan is empty or too large")
+    payload = _extract_json_object(text)
+    if not isinstance(payload, dict):
+        raise LedgerError("plan is not a JSON object")
+    raw = payload.get("questions")
+    if raw is None:
+        raise LedgerError("plan has no `questions` field")
+    if not isinstance(raw, list):
+        raise LedgerError("`questions` is not a list")
+    if len(raw) > MAX_INITIAL_QUESTIONS:
+        raise LedgerError(
+            f"plan declares {len(raw)} questions, more than {MAX_INITIAL_QUESTIONS}"
+        )
+    questions: list[Question] = []
+    seen: set[str] = set()
+    for entry in raw:
+        question = _question_from(entry)
+        if question.id in seen:
+            raise LedgerError(f"duplicate question id: {question.id}")
+        seen.add(question.id)
+        questions.append(question)
+    return questions
+
+
+def _question_from(entry: object) -> Question:
+    if not isinstance(entry, dict):
+        raise LedgerError("question entry is not an object")
+    qid = entry.get("id")
+    text = entry.get("question")
+    why = entry.get("why")
+    for value, name in ((qid, "id"), (text, "question"), (why, "why")):
+        if not isinstance(value, str) or not value.strip():
+            raise LedgerError(f"question is missing a usable `{name}`")
+    if not _ID.match(qid):
+        raise LedgerError(f"question id is not a plain identifier: {qid!r}")
+    if len(text) > MAX_TEXT_CHARS or len(why) > MAX_TEXT_CHARS:
+        raise LedgerError(f"question {qid} is longer than {MAX_TEXT_CHARS} characters")
+    return Question(id=qid, question=text.strip(), why=why.strip())
+
+
+def _extract_json_object(text: str) -> object:
+    """The JSON object in a model response, tolerating prose around it.
+
+    Models put a sentence before the JSON, or fence it. Only the object is
+    read; everything else is ignored. This is not tolerant parsing of the plan
+    itself -- the object's contents are still checked strictly -- it is
+    tolerance about where the object sits in the reply.
+    """
+    stripped = text.strip()
+    try:
+        return json.loads(stripped)
+    except ValueError:
+        pass
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start < 0 or end <= start:
+        raise LedgerError("no JSON object found in the plan")
+    try:
+        return json.loads(stripped[start : end + 1])
+    except ValueError as exc:
+        raise LedgerError(f"plan is not valid JSON: {exc}") from exc
+
+
+def parse_resolution(text: str, ledger: QuestionLedger) -> "tuple[str, str, str]":
+    """Read a `question / state / evidence` classification, or raise.
+
+    Returns `(question_id, state, evidence_id)`. The state must be one the
+    ledger recognises and the id must name a question that is currently open --
+    a classification about anything else is not something the run can act on.
+    """
+    payload = _extract_json_object(text)
+    if not isinstance(payload, dict):
+        raise LedgerError("resolution is not a JSON object")
+    qid = payload.get("question")
+    state = payload.get("state")
+    evidence = payload.get("evidence") or ""
+    if not isinstance(qid, str) or not ledger.is_open(qid):
+        raise LedgerError(f"resolution names no open question: {qid!r}")
+    if state not in (RESOLVED, "still_open"):
+        raise LedgerError(f"unknown state: {state!r}")
+    if not isinstance(evidence, str):
+        raise LedgerError("evidence reference is not a string")
+    return qid, state, evidence

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -45,6 +45,17 @@ from orbit.runtime.context_manager import (
     plan_exact_context,
 )
 from orbit.runtime.analysis_deobfuscate import TransformStage, deobfuscate
+from orbit.runtime.analysis_question_ledger import (
+    MAX_CHILD_DEPTH,
+    _extract_json_object,
+    parse_resolution,
+    MAX_INITIAL_QUESTIONS,
+    RESOLVED,
+    LedgerError,
+    Question,
+    QuestionLedger,
+    parse_plan,
+)
 from orbit.runtime.analysis_source_dominance import (
     SOURCE_DOMINATED,
     SourceDominance,
@@ -403,8 +414,32 @@ MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS = 2
 # The closing report is not counted here: it is made outside the loop, is not
 # part of the investigation, and its exclusion is what keeps this number a
 # statement about analysis rather than about bookkeeping.
+#
+# The one-call-per-iteration premise above holds only for a run without a
+# question ledger. On the ledger path an executing iteration costs two -- the
+# step and the call that classifies its question -- and coverage and planning
+# cost one each up front, so the derivation needs a term for that overhead or
+# the action ceiling becomes unreachable and runs end on arithmetic rather than
+# on the action policy. That is the failure this constant's own history records:
+# 13 was raised to 15 precisely because a ceiling no run can hit makes its test
+# vacuous.
+#
+# The added term is a correction to a derived number, not a loosening of a
+# bound. The ledger path is still bounded first by its own finite question
+# count; the unledgered path is unaffected, because it spends none of this
+# overhead and still stops on the same action budget it always did.
+# Coverage, planning, and the classification each ledger action costs. Added
+# so the action policy decides when a run ends rather than arithmetic: measured
+# on the ledger path, 15 stops at 7 actions with "model call bound reached",
+# while 18 reaches the same 8 actions the unledgered path reaches and then
+# stops on the action budget. Raising further buys nothing.
+MAX_LEDGER_OVERHEAD_CALLS = 3
+
 MAX_AUTONOMOUS_MODEL_CALLS = (
-    MAX_AUTONOMOUS_ACTIONS + 1 + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS
+    MAX_AUTONOMOUS_ACTIONS
+    + 1
+    + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS
+    + MAX_LEDGER_OVERHEAD_CALLS
 )
 
 MAX_CONSECUTIVE_NO_PROGRESS = 2
@@ -562,6 +597,108 @@ def _cover_message(
         f"{delimiter}\n"
         f"{coverage.text}\n"
         f"{delimiter} end"
+    )
+
+
+# What the planning call asks for.
+#
+# One tools-free call, after the whole source has been supplied and before any
+# action runs. It asks for the questions the model CANNOT answer from what it
+# was given -- not for a plan of analysis, and not for findings. A finding
+# visible in the source needs no question and belongs in the report directly;
+# putting it here would turn the ledger into a work list and spend actions
+# re-deriving what is already known, which is the behaviour this exists to end.
+#
+# The empty answer is stated as legitimate and first, because it is the honest
+# reply for an artifact the source already explains, and a model that felt
+# obliged to name something would invent work.
+ANALYSIS_PLAN_INSTRUCTION = (
+    "You now have the complete source of this artifact. Before running "
+    "anything, list only the questions you CANNOT answer from that source and "
+    "the evidence already provided -- questions that need a program to be "
+    "executed to settle.\n"
+    "Reply with JSON: {\"questions\": [{\"id\": \"Q1\", \"question\": "
+    "\"...\", \"why\": \"...\"}]}\n"
+    "`why` states what fact is missing that only execution can supply.\n"
+    "If the source answers everything, reply {\"questions\": []} -- that is a "
+    "complete and correct answer, not a failure. Do not list analysis steps, "
+    "and do not list anything you can already conclude by reading the source: "
+    "you will report those directly, and they do not need a question.\n"
+    f"At most {MAX_INITIAL_QUESTIONS} questions."
+)
+
+# Sent when a planning reply could not be parsed. One attempt, then the run
+# falls back to the behaviour it had before this existed.
+ANALYSIS_PLAN_REPAIR = (
+    "That reply could not be read as the required JSON. Reply with exactly "
+    "one JSON object and nothing else: {\"questions\": [{\"id\": \"Q1\", "
+    "\"question\": \"...\", \"why\": \"...\"}]}, or {\"questions\": []} "
+    "if the source answers everything."
+)
+
+
+# `question: Q1` at the head of the reply, which is how an action names the
+# question it belongs to. Read from the assistant's own prose rather than added
+# to the tool schema: the schema is what the sandbox validates, and widening it
+# would change every action's shape for a bookkeeping field.
+_QUESTION_TAG = re.compile(r"question\s*[:=]\s*([A-Za-z][A-Za-z0-9_.-]{0,15})", re.I)
+
+
+def _named_question(assistant_text: str) -> str | None:
+    """The question id this reply claims, or None.
+
+    Only the first few lines are scanned. A model that mentions a question id
+    in passing halfway through its reasoning has not named the question its
+    action belongs to, and treating that as an association would let any
+    mention stand in for a declaration.
+    """
+    head = "\n".join((assistant_text or "").splitlines()[:4])
+    match = _QUESTION_TAG.search(head)
+    return match.group(1) if match else None
+
+
+def _ledger_instruction(ledger: "QuestionLedger") -> str:
+    """What the model is told before each RESOLVE step.
+
+    It names the open questions and requires the next action to belong to one
+    of them. The alternative -- letting an action be untethered -- is what the
+    live run did: seven actions, four of them re-deriving the source, none of
+    them caused by anything earlier.
+
+    It also says plainly what the ledger does not mean. A model told "only
+    these questions" could reasonably infer that nothing else may be reported,
+    which would trade an efficiency problem for a correctness one.
+    """
+    return (
+        "Open questions:\n"
+        f"{ledger.render()}\n"
+        "Run one execution for ONE open question. Begin your reply with "
+        "`question: <id>` naming it, then make the call.\n"
+        "After it runs you will be asked whether that question is resolved.\n"
+        "This list bounds only what you may RUN. Everything you can already "
+        "conclude from the source stays yours to report, whether or not it "
+        "appears here."
+    )
+
+
+# Asked after an action that belonged to a question.
+#
+# The classification is the model's, always. The runtime records it and never
+# infers it: a question the model could not settle stays open and is reported
+# open, which is the honest outcome and the one that keeps an unresolved fact
+# from disappearing.
+def _resolution_instruction(question_id: str) -> str:
+    return (
+        f"Did that resolve {question_id}? Reply with exactly one JSON object: "
+        f'{{"question": "{question_id}", "state": "resolved"|"still_open", '
+        '"evidence": "<evidence id from the result above>"}\n'
+        "Answer `still_open` if it did not settle the question -- that is a "
+        "real answer and the report will say so.\n"
+        "If the result raised a further question that must be settled to "
+        "answer this one, add "
+        '"child": {"id": "...", "question": "...", "why": "...", '
+        '"caused_by": "<evidence id>"} -- only when the evidence you just '
+        "obtained forced it, never for something merely interesting."
     )
 
 
@@ -801,6 +938,9 @@ ANALYSIS_AUTONOMY_ENV = "ORBIT_ANALYSIS_AUTONOMOUS"
 
 # Why a run stopped. Reported verbatim to the analyst.
 STOP_COMPLETE = "model returned prose with no action"
+# Every declared question answered or given up on. Says nothing about the
+# analysis being complete -- only that nothing left open needs a tool.
+STOP_LEDGER_EXHAUSTED = "no open question requires an action"
 STOP_NO_PROGRESS = "no new evidence"
 STOP_ERROR = "repeated action failures"
 STOP_MAX_ACTIONS = "action bound reached"
@@ -1008,6 +1148,15 @@ class AutonomousRunResult:
     # fell back to the ordinary workflow, which is the honest report of a
     # coverage attempt that could not be made complete.
     cover_calls: int = 0
+    # The planning call, and what the ledger ended up holding. Diagnostics for
+    # the analyst: `open_questions` is what the run could not settle, and it is
+    # deliberately not hidden -- a question nobody answered is a result.
+    plan_calls: int = 0
+    initial_questions: int = 0
+    child_questions: int = 0
+    resolved_questions: "tuple[str, ...]" = ()
+    open_questions: "tuple[str, ...]" = ()
+    rejected_free_actions: int = 0
 
     @property
     def source_covered(self) -> bool:
@@ -1265,6 +1414,10 @@ class AnalysisRuntime:
     # the list -- is what makes the pass once-only: an artifact with nothing to
     # decode must not be rescanned on every step.
     _transform_snapshot: str | None = None
+    # The question the action of the step in flight belongs to, set when the
+    # association is checked and read when its result is classified. Per-step
+    # scratch, not session state.
+    _pending_question: str | None = None
 
     @property
     def source_covered(self) -> bool:
@@ -1772,6 +1925,7 @@ class AnalysisRuntime:
         *,
         on_progress: Callable[[Any], None] | None = None,
         on_delta: Callable[[str], None] | None = None,
+        ledger: "QuestionLedger | None" = None,
     ) -> AnalysisStepResult:
         """Run exactly one analyst-driven step and return control.
 
@@ -1844,6 +1998,31 @@ class AnalysisRuntime:
             )
 
         rejection = self._structural_rejection(calls) if calls else None
+        if rejection is None and calls and ledger is not None:
+            # An action must belong to a declared open question. Refused here,
+            # with the other structural refusals, because an untethered action
+            # is exactly the unbounded exploration the ledger exists to stop --
+            # and because refusing before the sandbox means nothing runs.
+            #
+            # This is a refusal, not a suppression: the model is told which
+            # questions are open and asked again. Nothing is hidden and no
+            # finding is lost, because the ledger governs what may RUN and
+            # never what may be concluded or reported.
+            named = _named_question(content)
+            if named is None:
+                ledger.rejected_free_actions += 1
+                rejection = (
+                    "no question named; begin the reply with `question: <id>` "
+                    f"for one of: {', '.join(ledger.open_ids) or 'none open'}"
+                )
+            elif not ledger.is_open(named):
+                ledger.rejected_free_actions += 1
+                rejection = (
+                    f"{named} is not an open question; open: "
+                    f"{', '.join(ledger.open_ids) or 'none'}"
+                )
+            else:
+                self._pending_question = named
         if rejection is not None and _stopped_at_generation_limit(response):
             # Same refusal path, a truer reason. The call is unparseable
             # because generation ended mid-JSON, not because the model
@@ -2317,6 +2496,179 @@ class AnalysisRuntime:
         self.messages.append({"role": "assistant", "content": content})
         return 1
 
+    def plan_questions(
+        self,
+        *,
+        on_progress: Callable[[Any], None] | None = None,
+        on_delta: Callable[[str], None] | None = None,
+    ) -> "tuple[QuestionLedger | None, int]":
+        """One tools-free call asking what still needs a tool. Returns (ledger, calls).
+
+        `None` means the run should proceed exactly as it did before this
+        existed: the reply could not be read even after one repair, or the
+        backend refused. That is the fail-closed direction, and it is the right
+        one -- a ledger nobody could parse is not a bound, and forcing a report
+        from an unreadable plan would end an analysis on a formatting error.
+
+        An empty ledger is not `None`. It is the model saying the source
+        answered everything, which is a legitimate reply and leads straight to
+        the report.
+        """
+        calls = 0
+        message = ANALYSIS_PLAN_INSTRUCTION
+        for attempt in range(2):
+            self.messages.append({"role": "user", "content": message})
+
+            def _capture(text: str) -> None:
+                if on_delta is not None and text:
+                    on_delta(text)
+
+            admitted = self._admit(
+                list(self.messages), max_tokens=self.effective_max_tokens, tools=[]
+            )
+            with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="off"):
+                response = self.backend.chat_stream(
+                    admitted,
+                    temperature=self.temperature,
+                    max_tokens=self.effective_max_tokens,
+                    tools=[],
+                    on_delta=_capture,
+                    on_progress=on_progress,
+                )
+            self.model_calls += 1
+            calls += 1
+            content = response.content or ""
+            if _unencodable(content):
+                content = content.encode("utf-8", "replace").decode("utf-8")
+            self.messages.append({"role": "assistant", "content": content})
+            try:
+                questions = parse_plan(content)
+            except LedgerError:
+                if attempt == 0:
+                    # One bounded repair. A second failure is a real one: the
+                    # model cannot produce the format, and retrying would spend
+                    # the ceiling learning that again.
+                    message = ANALYSIS_PLAN_REPAIR
+                    continue
+                return None, calls
+            ledger = QuestionLedger()
+            for question in questions:
+                try:
+                    ledger.add(question)
+                except LedgerError:
+                    return None, calls
+            return ledger, calls
+        return None, calls
+
+    def _classify_question(
+        self,
+        ledger: "QuestionLedger",
+        question_id: str,
+        step: "AnalysisStepResult",
+        *,
+        on_progress: Callable[[Any], None] | None = None,
+        on_delta: Callable[[str], None] | None = None,
+    ) -> int:
+        """Ask whether the action just run settled its question. Returns calls.
+
+        Tools off: this is bookkeeping about what happened, not another chance
+        to act. A reply that cannot be read leaves the question open, which is
+        the fail-closed direction -- an unreadable classification must never
+        close a question, and the run simply asks about it again or moves on
+        when the ceiling is reached.
+        """
+        self.messages.append(
+            {"role": "user", "content": _resolution_instruction(question_id)}
+        )
+
+        def _capture(text: str) -> None:
+            if on_delta is not None and text:
+                on_delta(text)
+
+        try:
+            admitted = self._admit(
+                list(self.messages), max_tokens=self.effective_max_tokens, tools=[]
+            )
+            with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="off"):
+                response = self.backend.chat_stream(
+                    admitted,
+                    temperature=self.temperature,
+                    max_tokens=self.effective_max_tokens,
+                    tools=[],
+                    on_delta=_capture,
+                    on_progress=on_progress,
+                )
+        except (ContextAdmissionError, TimeoutError, RecoverableBackendError):
+            # The question stays open and the turn is closed cleanly.
+            self._close_incomplete_turn()
+            return 0
+        self.model_calls += 1
+        content = response.content or ""
+        if _unencodable(content):
+            content = content.encode("utf-8", "replace").decode("utf-8")
+        self.messages.append({"role": "assistant", "content": content})
+
+        evidence_id = getattr(step.evidence, "evidence_id", "") or ""
+        try:
+            named, state, cited = parse_resolution(content, ledger)
+        except LedgerError:
+            return 1  # unreadable: the question stays open
+        if named != question_id:
+            return 1  # about a different question: not something to act on
+        if state == RESOLVED:
+            try:
+                ledger.resolve(question_id, cited or evidence_id)
+            except LedgerError:
+                return 1
+        self._accept_child_question(ledger, content, question_id, evidence_id)
+        return 1
+
+    def _accept_child_question(
+        self,
+        ledger: "QuestionLedger",
+        content: str,
+        parent_id: str,
+        evidence_id: str,
+    ) -> None:
+        """Admit a question the result forced, if it really was forced.
+
+        Every rejection here is silent by design: a child that does not qualify
+        simply is not added, and the run continues with the questions it had.
+        Telling the model why would invite it to rephrase until something
+        stuck, which is the unbounded growth this is meant to prevent.
+        """
+        try:
+            payload = _extract_json_object(content)
+        except LedgerError:
+            return
+        if not isinstance(payload, dict):
+            return
+        raw = payload.get("child")
+        if not isinstance(raw, dict):
+            return
+        parent = ledger.questions.get(parent_id)
+        if parent is None:
+            return
+        qid = raw.get("id")
+        text = raw.get("question")
+        why = raw.get("why")
+        caused_by = raw.get("caused_by") or evidence_id
+        if not all(isinstance(v, str) and v.strip() for v in (qid, text, why)):
+            return
+        try:
+            ledger.accept_child(
+                Question(
+                    id=qid.strip(),
+                    question=text.strip(),
+                    why=why.strip(),
+                    depth=parent.depth + 1,
+                    parent=parent_id,
+                    caused_by=caused_by,
+                )
+            )
+        except LedgerError:
+            return
+
     def run_autonomous(
         self,
         analyst_message: str,
@@ -2331,6 +2683,7 @@ class AnalysisRuntime:
         on_step: Callable[[AnalysisStepResult, ProgressRecord], None] | None = None,
         finalize: bool = True,
         cover: bool = True,
+        plan: bool = True,
     ) -> AutonomousRunResult:
         """Run analyst-directed steps until progress stops or a bound is hit.
 
@@ -2368,7 +2721,7 @@ class AnalysisRuntime:
         `model_calls` counts them all, so the figure reported is the figure
         spent.
         """
-        ledger = ProgressLedger()
+        progress_ledger = ProgressLedger()
         steps: list[AnalysisStepResult] = []
         records: list[ProgressRecord] = []
         model_calls = 0
@@ -2418,6 +2771,8 @@ class AnalysisRuntime:
         # These calls count against `max_model_calls` like every other call, so
         # a covered run is bounded exactly as an uncovered one is.
         covered_calls = 0
+        plan_calls = 0
+        ledger: "QuestionLedger | None" = None
         if cover and not self.source_covered:
             try:
                 coverage = self.plan_source_coverage()
@@ -2433,6 +2788,16 @@ class AnalysisRuntime:
                     # must not now tell the model to go and read it. The
                     # analyst's own line still governs what the run is for.
                     message = analyst_message
+                    # One tools-free call to declare what still needs a tool.
+                    # A ledger of None means it could not be read even after a
+                    # repair, and the run continues exactly as it did before
+                    # this existed -- an unreadable plan is not a bound.
+                    if plan and model_calls < max_model_calls:
+                        ledger, planning_calls = self.plan_questions(
+                            on_progress=on_progress, on_delta=on_delta
+                        )
+                        model_calls += planning_calls
+                        plan_calls = planning_calls
             except KeyboardInterrupt:
                 cancelled = True
                 stop_reason = STOP_CANCELLED
@@ -2468,8 +2833,20 @@ class AnalysisRuntime:
             if model_calls >= max_model_calls:
                 stop_reason = STOP_MAX_MODEL_CALLS
                 break
+            if ledger is not None and ledger.exhausted:
+                # Nothing declared is still open, so no action is left to run.
+                # This is not a claim that the analysis is complete: the whole
+                # source and every piece of evidence remain in the history, and
+                # the report below draws on them regardless of what was asked.
+                stop_reason = STOP_LEDGER_EXHAUSTED
+                break
             try:
-                step = self.step(message, on_progress=on_progress, on_delta=on_delta)
+                step = self.step(
+                    _ledger_instruction(ledger) if ledger is not None else message,
+                    on_progress=on_progress,
+                    on_delta=on_delta,
+                    ledger=ledger,
+                )
             except KeyboardInterrupt:
                 # What ran already stands. `step()` has committed its own
                 # history and evidence, or rewound nothing; the analyst keeps
@@ -2537,7 +2914,24 @@ class AnalysisRuntime:
                 # above, so the run remains bounded.
                 suppressed += 1
 
-            record = ledger.classify(len(records) + 1, step)
+            if (
+                ledger is not None
+                and step.action_executed
+                and self._pending_question is not None
+                and model_calls < max_model_calls
+            ):
+                # The classification is one ordinary model call, tools off:
+                # the model says whether its own action settled its own
+                # question. The runtime records the answer and never supplies
+                # it -- a question nobody could resolve stays open, and the
+                # report says so.
+                model_calls += self._classify_question(
+                    ledger, self._pending_question, step,
+                    on_progress=on_progress, on_delta=on_delta,
+                )
+            self._pending_question = None
+
+            record = progress_ledger.classify(len(records) + 1, step)
             records.append(record)
             if on_step is not None:
                 on_step(step, record)
@@ -2678,10 +3072,19 @@ class AnalysisRuntime:
         # Cancellation is the exception. The analyst asked for the run to stop,
         # and spending another model call -- minutes of generation -- to
         # summarise it is the opposite of stopping.
-        if not cancelled and finalize and steps:
+        # `steps` is no longer the only thing worth reporting on. A covered
+        # run whose plan was empty took no step at all -- the model said the
+        # source answered everything, which the planning instruction calls a
+        # correct reply -- and skipping the report there would turn the whole
+        # analysis into nothing, discarding a source the model was given in
+        # full. So a run that covered the source reports even with no steps.
+        if not cancelled and finalize and (steps or covered_calls):
             try:
                 final_report = self.report(
-                    question=self._final_question(stop_reason),
+                    question=self._final_question(
+                        stop_reason,
+                        tuple(ledger.open_ids) if ledger is not None else (),
+                    ),
                     on_progress=on_progress,
                     on_delta=on_delta,
                 )
@@ -2744,6 +3147,20 @@ class AnalysisRuntime:
             final_report=final_report,
             completion_shadow=shadow,
             cover_calls=covered_calls,
+            plan_calls=plan_calls,
+            initial_questions=(
+                sum(1 for q in ledger.questions.values() if q.depth == 0)
+                if ledger is not None else 0
+            ),
+            child_questions=(
+                sum(1 for q in ledger.questions.values() if q.depth > 0)
+                if ledger is not None else 0
+            ),
+            resolved_questions=tuple(ledger.resolved_ids) if ledger else (),
+            open_questions=tuple(ledger.open_ids) if ledger else (),
+            rejected_free_actions=(
+                ledger.rejected_free_actions if ledger is not None else 0
+            ),
         )
 
     def _write_shadow_final(
@@ -2870,19 +3287,40 @@ class AnalysisRuntime:
             )
 
     @staticmethod
-    def _final_question(stop_reason: str) -> str:
+    def _final_question(
+        stop_reason: str, open_questions: "tuple[str, ...]" = ()
+    ) -> str:
         """What the closing report is asked, given how the run ended.
 
         A run that ended naturally is simply asked to report. One that was cut
         short says so, because a reader who is not told that a bound intervened
         would read an incomplete analysis as a finished one.
+
+        Questions still open are named. A question the model could not settle
+        is a result, and leaving it out of the closing prompt would let the
+        report read as though everything had been answered -- which is the one
+        thing the ledger must never cause.
         """
-        if stop_reason == STOP_COMPLETE:
+        unresolved = ""
+        if open_questions:
+            unresolved = (
+                " These questions were raised and not resolved: "
+                f"{', '.join(open_questions)}. Say what remains unknown about "
+                "each rather than omitting them."
+            )
+        if stop_reason == STOP_COMPLETE and not unresolved:
             return ""
+        if stop_reason in (STOP_COMPLETE, STOP_LEDGER_EXHAUSTED):
+            # Not "cut short": the model finished, or nothing left needed a
+            # tool. Saying a bound intervened would be false.
+            return (
+                "Report what the evidence and the artifact source establish."
+                f"{unresolved}"
+            )
         return (
             "This analysis stopped before the model chose to finish "
             f"({stop_reason}). Report what the evidence establishes and what "
-            "remains unresolved."
+            f"remains unresolved.{unresolved}"
         )
 
     def _close_incomplete_turn(self) -> None:
@@ -3018,6 +3456,14 @@ class AnalysisRuntime:
         """
         appendix = self.deterministic_sections()
         records = self._reportable_records()
+        if not records and self.source_covered:
+            # No action ran, but the model was given the whole source. Reporting
+            # "no evidence" here would be false: the source IS the evidence, and
+            # a run whose plan was empty is exactly the case where nothing else
+            # exists. The covered history is the grounding instead.
+            return self._report_from_coverage(
+                question, on_progress=on_progress, on_delta=on_delta
+            )
         if not records:
             # Deterministic, and free: there is nothing to ground a report in,
             # and asking a model to say so would be a call spent on a fact the
@@ -3103,6 +3549,84 @@ class AnalysisRuntime:
                 duration_seconds=round(seconds, 3),
             ),
         )
+
+    def _report_from_coverage(
+        self,
+        question: str,
+        *,
+        on_progress: Callable[[Any], None] | None = None,
+        on_delta: Callable[[str], None] | None = None,
+    ) -> "AnalysisReport":
+        """Report on a covered source when no action produced evidence.
+
+        The case this exists for: coverage supplied the whole artifact and the
+        model declared no question needing a tool, so nothing ran and the
+        EvidenceStore is empty. Saying "no evidence has been collected" there
+        would be false -- the source was supplied in full, and it is the
+        evidence. Reporting from the conversation that already holds it is what
+        keeps an empty plan from erasing what the model was given.
+
+        Tools off, like every other report. The history is used as-is rather
+        than rebuilt from cards, because the covered source lives there and
+        nowhere else.
+        """
+        appendix = self.deterministic_sections()
+        asked = question.strip() or "Report on what the artifact establishes."
+        messages: list[Message] = [
+            *self.messages,
+            {
+                "role": "user",
+                "content": (
+                    f"{asked}\n"
+                    "No execution was performed. Base the report on the "
+                    "artifact source supplied above and say plainly what it "
+                    "does and what, if anything, could not be determined "
+                    "without running it."
+                ),
+            },
+        ]
+
+        def _capture(text: str) -> None:
+            if on_delta is not None and text:
+                on_delta(text)
+
+        try:
+            admitted = self._admit(
+                messages,
+                max_tokens=self.effective_max_tokens,
+                tools=[],
+                next_action_reserve=0,
+            )
+        except ContextAdmissionError:
+            # Never "no evidence has been collected": the source WAS supplied
+            # in full, and saying otherwise is the same false claim this
+            # method exists to prevent. What failed is composing the report,
+            # which is a different fact and the one worth reporting.
+            text = (
+                "The report could not be composed: the covered source no "
+                "longer fits the context window. The artifact was supplied in "
+                "full and nothing was executed, so no finding was lost -- but "
+                "none could be stated here either."
+            )
+            if appendix:
+                text = (
+                    f"{text} The deterministic transformations below are "
+                    f"unaffected.\n\n{appendix}"
+                )
+            return AnalysisReport(text=text, model_calls=0, evidence_ids=())
+        with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
+            response = self.backend.chat_stream(
+                admitted,
+                temperature=self.temperature,
+                max_tokens=self.effective_max_tokens,
+                tools=[],
+                on_delta=_capture,
+                on_progress=on_progress,
+            )
+        text = (response.content or "").strip() or "the report call produced no usable text"
+        if appendix:
+            text = f"{text}\n\n{appendix}"
+        return AnalysisReport(text=text, model_calls=1, evidence_ids=())
 
     def _reportable_records(self) -> list[EvidenceRecord]:
         """The action evidence a report may cite, oldest first and bounded.

--- a/tests/test_analysis_autonomous.py
+++ b/tests/test_analysis_autonomous.py
@@ -384,7 +384,13 @@ class BoundsAreEnforcedTests(AutonomousTestBase):
     def test_bounds_are_small_and_explicit(self) -> None:
         self.assertEqual(SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
         self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
-        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        # 18, not 15: a question-ledger action costs two calls rather than one
+        # -- the step and the call classifying its question -- plus coverage
+        # and planning up front. Without a term for that overhead the action
+        # ceiling is unreachable and runs end on arithmetic instead of on the
+        # action policy, which is the defect that raised this from 13 to 15 in
+        # the first place. The action bounds themselves are unchanged.
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 18)
         self.assertEqual(MAX_CONSECUTIVE_NO_PROGRESS, 2)
         self.assertEqual(MAX_CONSECUTIVE_ERRORS, 2)
         # The call bound must leave room for calls that execute nothing.
@@ -1314,7 +1320,11 @@ class BoundedReplanTests(AutonomousTestBase):
         # its own replan. This is the property; the exact count depends on
         # where the action budget cuts the trajectory off.
         self.assertGreater(run.replans, 1, "each fresh stall earns its own replan")
-        self.assertEqual(run.replans, stalls)
+        # Every stall that completed earned a replan. The run can end on the
+        # call ceiling mid-stall, in which case the final classification is
+        # recorded but its replan was never sent -- so the counts differ by at
+        # most the one stall in flight.
+        self.assertIn(run.replans, (stalls, stalls - 1))
         # Each stall here is a suppressed duplicate: a model call, no action
         # slot. Both bounds still hold and are asserted at their tightest --
         # a suppressed stall follows a step that did consume an action, so
@@ -1690,12 +1700,25 @@ class SoftActionBudgetTests(AutonomousTestBase):
         self.assertEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
         self.assertNotEqual(run.stop_reason, STOP_MAX_MODEL_CALLS)
 
-    def test_the_nonproductive_allowance_is_explicit(self) -> None:
-        """The only chosen term in the budget is named, not folded into a number."""
+    def test_the_chosen_terms_in_the_budget_are_explicit(self) -> None:
+        """Every chosen term is named, not folded into a number.
+
+        Two of them now. The non-productive allowance is what a run may spend
+        on calls that execute nothing; the ledger overhead is what the
+        question-ledger path costs beyond one call per action -- coverage,
+        planning, and a classification per action. Both are stated so the
+        ceiling stays derived rather than picked.
+        """
+        from orbit.runtime.analysis_runtime import MAX_LEDGER_OVERHEAD_CALLS
+
         self.assertEqual(MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS, 2)
+        self.assertEqual(MAX_LEDGER_OVERHEAD_CALLS, 3)
         self.assertEqual(
             MAX_AUTONOMOUS_MODEL_CALLS,
-            MAX_AUTONOMOUS_ACTIONS + 1 + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS,
+            MAX_AUTONOMOUS_ACTIONS
+            + 1
+            + MAX_AUTONOMOUS_NONPRODUCTIVE_CALLS
+            + MAX_LEDGER_OVERHEAD_CALLS,
         )
 
     def test_the_budget_relation_is_derived_not_guessed(self) -> None:

--- a/tests/test_analysis_cover_runtime.py
+++ b/tests/test_analysis_cover_runtime.py
@@ -625,13 +625,30 @@ class AutonomousIntegrationTests(_Case):
         self.assertEqual(self.backend.chat_calls, [])
 
     def test_tools_return_after_coverage(self) -> None:
-        """5/J. Nothing is permanently disabled."""
+        """5/J. Nothing is permanently disabled.
+
+        Planning follows coverage and is also tools-free -- it asks what still
+        needs a tool, so offering one there would invite the action it is
+        deciding about. What must hold is that tools return for the steps
+        after it, which is what this checks. With planning off, the call right
+        after coverage carries them.
+        """
         runtime = self._runtime(b"body\n")
         result = runtime.run_autonomous("Analyse it.", max_model_calls=4,
-                                        finalize=False)
+                                        plan=False, finalize=False)
         after = [c["tools"] for c in self.backend.chat_calls[result.cover_calls:]]
         self.assertTrue(after)
         self.assertTrue(all(after), "tools must be offered after COVER")
+
+    def test_planning_is_tools_free_and_steps_after_it_are_not(self) -> None:
+        """The full shape: cover and plan tools-free, then tools return."""
+        runtime = self._runtime(b"body\n")
+        result = runtime.run_autonomous("Analyse it.", max_model_calls=6,
+                                        finalize=False)
+        modes = [bool(c["tools"]) for c in self.backend.chat_calls]
+        overhead = result.cover_calls + result.plan_calls
+        self.assertEqual(modes[:overhead], [False] * overhead)
+        self.assertTrue(any(modes[overhead:]), "tools must return after planning")
 
     def test_a_later_analyst_step_still_offers_tools(self) -> None:
         """J. An explicit follow-up keeps normal tools."""
@@ -946,10 +963,30 @@ class CeilingTests(_Case):
         self.assertEqual(len(result.steps), 1)
 
     def test_two_calls_allow_coverage_and_a_step(self) -> None:
+        """With planning off, two calls buy coverage and one step.
+
+        Planning costs a call of its own, so with it on the same budget buys
+        coverage and a plan and leaves nothing to investigate with -- which is
+        why the ledger is sized against the full budget rather than this one.
+        """
         runtime = self._runtime(b"body\n")
-        result = runtime.run_autonomous("Go.", max_model_calls=2, finalize=False)
+        result = runtime.run_autonomous("Go.", max_model_calls=2, plan=False,
+                                        finalize=False)
         self.assertEqual(result.cover_calls, 1)
         self.assertEqual(len(result.steps), 1)
+
+    def test_planning_costs_calls_of_its_own(self) -> None:
+        """Planning spends from the same budget as everything else.
+
+        This backend answers with prose, so the plan is unreadable and the one
+        bounded repair fires -- two calls, after which the run falls back to
+        the unbounded path with nothing left to spend.
+        """
+        runtime = self._runtime(b"body\n")
+        result = runtime.run_autonomous("Go.", max_model_calls=3, finalize=False)
+        self.assertEqual(result.cover_calls, 1)
+        self.assertEqual(result.plan_calls, 2)
+        self.assertEqual(result.initial_questions, 0)
 
 
 class PinnedArtifactTests(_Case):

--- a/tests/test_analysis_evidence_first.py
+++ b/tests/test_analysis_evidence_first.py
@@ -451,7 +451,7 @@ class BudgetTests(EvidenceFirstTestBase):
 
     def test_the_ceilings_are_unchanged(self) -> None:
         self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
-        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 18)
 
     def test_no_synthetic_action_is_recorded(self) -> None:
         backend = RecordingBackend(prose_response("done"))

--- a/tests/test_analysis_ledger_runtime.py
+++ b/tests/test_analysis_ledger_runtime.py
@@ -1,0 +1,832 @@
+"""The ledger bounds actions. It must never bound knowledge.
+
+ANALYSIS-QUESTION-LEDGER-1 at the runtime seam. The efficiency case is easy to
+test and easy to get right; the correctness case is the one that matters. A
+mechanism that hid an unresolved fact because nobody declared it as a question
+would be worse than the inefficiency it replaces, so
+`LedgerDoesNotEraseKnowledgeTests` is the heart of this file: an omitted
+behaviour must still reach the report, and a fact that genuinely needs
+execution must be reportable as unresolved rather than silently dropped.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
+from orbit.runtime import analysis_runtime as module  # noqa: E402
+from orbit.runtime.analysis_question_ledger import (  # noqa: E402
+    Question,
+    QuestionLedger,
+)
+from orbit.runtime.analysis_runtime import (  # noqa: E402
+    STOP_LEDGER_EXHAUSTED,
+    AnalysisRuntime,
+    AnalysisSource,
+    AnalysisWorkspace,
+    _named_question,
+)
+from orbit.runtime.analysis_sandbox import AnalysisResult  # noqa: E402
+from orbit.runtime.evidence import EvidenceStore  # noqa: E402
+
+CTX = 8192
+SOURCE = (
+    "import os\n"
+    "import pickle\n"
+    "\n"
+    "\n"
+    "def load(raw):\n"
+    "    return pickle.loads(raw)\n"
+    "\n"
+    "\n"
+    "def token(email):\n"
+    "    return abs(hash(email)) % 1000000\n"
+)
+
+
+class _Script:
+    """A scripted model: a queue of replies, each optionally with a call."""
+
+    def __init__(self, replies) -> None:
+        self.replies = list(replies)
+        self.calls: list[dict] = []
+        self.default = ("done", None)
+
+    def next(self):
+        return self.replies.pop(0) if self.replies else self.default
+
+
+class _Backend:
+    thinking = False
+
+    def __init__(self, script: _Script, *, per_char: float = 0.25) -> None:
+        self.script = script
+        self.per_char = per_char
+        self.chat_calls: list[dict] = []
+
+    def supports_exact_context_admission(self) -> bool:
+        return True
+
+    def model_info(self):
+        class _Info:
+            context_length = CTX
+        return _Info()
+
+    def count_chat_tokens(self, messages, *, tools=None, thinking=False):
+        chars = sum(len(str(m.get("content") or "")) for m in messages)
+        return TokenCount(tokens=int(40 + chars * self.per_char), context_tokens=CTX,
+                          rendered_hash="a" * 64, token_hash="b" * 64)
+
+    def chat_stream(self, messages, **kwargs):
+        tools = kwargs.get("tools")
+        self.chat_calls.append({"tools": tools, "messages": list(messages)})
+        if not tools:
+            # COVER, PLAN and classification calls all arrive tools-free.
+            text, _ = self.script.next()
+            return self._result(text, [])
+        text, code = self.script.next()
+        calls = []
+        if code is not None:
+            calls = [{
+                "id": f"c{len(self.chat_calls)}", "type": "function",
+                "function": {"name": "execute_analysis",
+                             "arguments": json.dumps({"code": code})},
+            }]
+        return self._result(text, calls)
+
+    def _result(self, content, calls):
+        return ChatResult(
+            content=content, model="m", finish_reason="stop", tool_calls=calls,
+            prompt_tokens=1, completion_tokens=1, cached_tokens=0,
+            prompt_tokens_per_second=None, generation_tokens_per_second=None,
+        )
+
+    def chat(self, messages, **kwargs):
+        return self.chat_stream(messages, **kwargs)
+
+
+def _sandbox(stdout="FINDING: something real"):
+    return AnalysisResult(
+        status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+        stdout=stdout, stderr="", exit_status=0, duration_seconds=0.1,
+    )
+
+
+class _Case(unittest.TestCase):
+    def _runtime(self, script, data: bytes = None) -> AnalysisRuntime:
+        data = SOURCE.encode() if data is None else data
+        self.backend = _Backend(script)
+        workspace = AnalysisWorkspace.create()
+        path = workspace.source_root / "artifact.py"
+        path.write_bytes(data)
+        runtime = AnalysisRuntime(
+            backend=self.backend,
+            source=AnalysisSource(
+                snapshot_path=path, sha256=hashlib.sha256(data).hexdigest(),
+                size_bytes=len(data), original_path=str(path),
+            ),
+            evidence_store=EvidenceStore(root=workspace.root / "evidence"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    def _run(self, runtime, sandbox=None, **kwargs):
+        result = sandbox or _sandbox()
+        with mock.patch.object(module, "execute_analysis", lambda **kw: result):
+            return runtime.run_autonomous(
+                "Analyse it.", finalize=False, **kwargs
+            )
+
+
+def _plan(*questions) -> str:
+    return json.dumps({"questions": [
+        {"id": qid, "question": text, "why": "needs execution"}
+        for qid, text in questions
+    ]})
+
+
+def _resolved(qid, evidence="ev", child=None) -> str:
+    payload = {"question": qid, "state": "resolved", "evidence": evidence}
+    if child:
+        payload["child"] = child
+    return json.dumps(payload)
+
+
+class EmptyPlanTests(_Case):
+    """A. COVER answered everything: no actions at all."""
+
+    def test_an_empty_plan_runs_no_actions(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),          # COVER reply
+            ('{"questions":[]}', None),  # PLAN
+        ]))
+        run = self._run(runtime)
+        self.assertEqual(run.cover_calls, 1)
+        self.assertEqual(run.plan_calls, 1)
+        self.assertEqual(run.initial_questions, 0)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+
+    def test_no_tools_are_offered_during_cover_or_plan(self) -> None:
+        """K/L. Both are bookkeeping calls, not chances to act."""
+        runtime = self._runtime(_Script([
+            ("noted", None), ('{"questions":[]}', None),
+        ]))
+        self._run(runtime)
+        self.assertEqual([bool(c["tools"]) for c in self.backend.chat_calls],
+                         [False, False])
+
+
+class TargetedResolutionTests(_Case):
+    """B. Two questions, two targeted actions, both resolved, then report."""
+
+    def test_two_questions_produce_exactly_two_actions(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is pickle reachable?"), ("Q2", "is the token stable?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+            ("question: Q2\nrunning", "print(2)"),
+            (_resolved("Q2", "ev_2"), None),
+        ]))
+        run = self._run(runtime)
+        self.assertEqual(run.initial_questions, 2)
+        self.assertEqual(run.actions_executed, 2)
+        self.assertEqual(set(run.resolved_questions), {"Q1", "Q2"})
+        self.assertEqual(run.open_questions, ())
+        self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+
+    def test_a_still_open_question_stays_open(self) -> None:
+        """The action ran and did not settle it. That is a real outcome."""
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is pickle reachable?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (json.dumps({"question": "Q1", "state": "still_open",
+                         "evidence": "ev_1"}), None),
+            ("question: Q1\nagain", "print(2)"),
+            (_resolved("Q1", "ev_2"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=8)
+        self.assertIn("Q1", run.resolved_questions)
+
+
+class ChildQuestionRuntimeTests(_Case):
+    """C. A child forced by the evidence is accepted and worked."""
+
+    def test_a_caused_child_is_accepted_and_resolved(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is pickle reachable?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1", child={
+                "id": "Q1.1", "question": "which opcode does it accept?",
+                "why": "the result showed an opcode", "caused_by": "ev_1"}), None),
+            ("question: Q1.1\nrunning", "print(2)"),
+            (_resolved("Q1.1", "ev_2"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=10)
+        self.assertEqual(run.initial_questions, 1)
+        self.assertEqual(run.child_questions, 1)
+        self.assertEqual(run.actions_executed, 2)
+        self.assertEqual(set(run.resolved_questions), {"Q1", "Q1.1"})
+
+    def test_a_child_without_causing_evidence_is_not_accepted(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is pickle reachable?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (json.dumps({"question": "Q1", "state": "resolved", "evidence": "ev_1",
+                         "child": {"id": "Q1.1", "question": "unrelated",
+                                   "why": "curious"}}), None),
+        ]))
+        run = self._run(runtime, max_model_calls=10)
+        # `caused_by` defaults to the evidence of the action, so this one IS
+        # caused; what must not be accepted is a child at depth 2 or a restatement.
+        self.assertLessEqual(run.child_questions, 1)
+
+    def test_a_grandchild_is_refused(self) -> None:
+        ledger = QuestionLedger()
+        ledger.add(Question("Q1", "root", "w"))
+        ledger.resolve("Q1", "ev_1")
+        ledger.accept_child(Question("Q1.1", "child", "w", 1, "Q1", "ev_1"))
+        ledger.resolve("Q1.1", "ev_2")
+        runtime = self._runtime(_Script([]))
+        runtime._accept_child_question(
+            ledger,
+            json.dumps({"child": {"id": "Q1.1.1", "question": "grandchild",
+                                  "why": "w", "caused_by": "ev_2"}}),
+            "Q1.1", "ev_2",
+        )
+        self.assertNotIn("Q1.1.1", ledger.questions)
+
+
+class FreeExplorationTests(_Case):
+    """D. An action that belongs to no open question does not run."""
+
+    def test_an_unnamed_action_is_refused(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is pickle reachable?")), None),
+            ("let me look at something else", "print('exploring')"),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=10)
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(run.rejected_free_actions, 1)
+
+    def test_an_action_naming_a_closed_question_is_refused(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "a"), ("Q2", "b")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+            ("question: Q1\nagain", "print(2)"),     # already resolved
+            ("question: Q2\nrunning", "print(3)"),
+            (_resolved("Q2", "ev_2"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=12)
+        self.assertEqual(run.rejected_free_actions, 1)
+        self.assertEqual(run.actions_executed, 2)
+
+    def test_the_question_tag_is_read_only_from_the_head(self) -> None:
+        """A mention buried in reasoning is not a declaration."""
+        self.assertEqual(_named_question("question: Q1\nrunning"), "Q1")
+        self.assertEqual(_named_question("Question = Q2"), "Q2")
+        self.assertIsNone(_named_question("no tag here"))
+        buried = "\n".join(["thinking"] * 8 + ["question: Q1"])
+        self.assertIsNone(_named_question(buried))
+
+
+class MalformedPlanTests(_Case):
+    """F. One repair, then fall back to the behaviour that existed before."""
+
+    def test_a_repaired_plan_is_used(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            ("I think we should look at pickle.", None),   # malformed
+            (_plan(("Q1", "is pickle reachable?")), None),  # repaired
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=10)
+        self.assertEqual(run.plan_calls, 2)
+        self.assertEqual(run.initial_questions, 1)
+
+    def test_two_malformed_plans_fall_back_to_the_old_path(self) -> None:
+        """No ledger: actions are unrestricted, exactly as before."""
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            ("prose", None),
+            ("still prose", None),
+            ("exploring freely", "print(1)"),
+        ]))
+        run = self._run(runtime, max_model_calls=6)
+        self.assertEqual(run.plan_calls, 2)
+        self.assertEqual(run.initial_questions, 0)
+        self.assertEqual(run.actions_executed, 1)   # ran without naming a question
+        self.assertEqual(run.rejected_free_actions, 0)
+        self.assertNotEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+
+
+class UnchangedPathTests(_Case):
+    """G/H/I/K. Everything outside the covered autonomous path is untouched."""
+
+    def test_without_coverage_there_is_no_plan(self) -> None:
+        runtime = self._runtime(_Script([
+            ("exploring", "print(1)"),
+        ]), data=b"\x00\xffbinary")
+        run = self._run(runtime, max_model_calls=4)
+        self.assertEqual(run.cover_calls, 0)
+        self.assertEqual(run.plan_calls, 0)
+        self.assertEqual(run.actions_executed, 1)
+
+    def test_planning_can_be_disabled(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            ("exploring", "print(1)"),
+        ]))
+        run = self._run(runtime, plan=False, max_model_calls=4)
+        self.assertEqual(run.cover_calls, 1)
+        self.assertEqual(run.plan_calls, 0)
+        self.assertEqual(run.actions_executed, 1)
+
+    def test_a_guided_step_is_unrestricted(self) -> None:
+        """H/I. `step()` without a ledger offers tools and needs no question."""
+        runtime = self._runtime(_Script([("exploring", "print(1)")]))
+        with mock.patch.object(module, "execute_analysis", lambda **kw: _sandbox()):
+            step = runtime.step("look at it")
+        self.assertTrue(step.action_executed)
+        self.assertTrue(self.backend.chat_calls[0]["tools"])
+
+    def test_a_full_initial_ledger_fits_the_model_call_budget(self) -> None:
+        """§2. Every declared question can actually be worked through.
+
+        Coverage and planning cost two calls; each question costs one to run
+        and one to classify. A plan the run could not finish would be a plan it
+        cannot honour.
+        """
+        from orbit.runtime.analysis_question_ledger import MAX_INITIAL_QUESTIONS
+
+        needed = 2 + 2 * MAX_INITIAL_QUESTIONS
+        self.assertLessEqual(needed, module.MAX_AUTONOMOUS_MODEL_CALLS)
+
+    def test_a_ledger_that_outgrows_the_budget_still_reports_openly(self) -> None:
+        """§4. Children may exceed it; the ceiling stops the run, losing nothing."""
+        script = [("noted", None), (_plan(("Q1", "a"), ("Q2", "b")), None)]
+        for qid in ("Q1", "Q2"):
+            script += [(f"question: {qid}\nrunning", "print(1)"),
+                       (json.dumps({"question": qid, "state": "still_open",
+                                    "evidence": "ev"}), None)]
+        runtime = self._runtime(_Script(script))
+        run = self._run(runtime, max_model_calls=4)
+        # Stopped by the ceiling, with both questions still visibly open.
+        self.assertEqual(run.stop_reason, module.STOP_MAX_MODEL_CALLS)
+        self.assertEqual(set(run.open_questions), {"Q1", "Q2"})
+        self.assertEqual(run.resolved_questions, ())
+
+    def test_the_ledger_path_costs_two_calls_per_action(self) -> None:
+        """The budget derivation changes shape on this path, and says so.
+
+        Off the ledger an iteration is one call. On it an executing iteration
+        is two -- the step and its classification -- plus coverage and planning
+        up front. The constant is unchanged deliberately: six declared
+        questions fit, and twelve actions was never a target but the point at
+        which an unbounded run is stopped.
+        """
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "a"), ("Q2", "b")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+            ("question: Q2\nrunning", "print(2)"),
+            (_resolved("Q2", "ev_2"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=12)
+        self.assertEqual(run.actions_executed, 2)
+        # cover + plan + 2*(step + classify)
+        self.assertEqual(run.model_calls, 6)
+
+    def test_action_ceilings_are_unchanged(self) -> None:
+        self.assertEqual(module.MAX_AUTONOMOUS_ACTIONS, 12)
+        self.assertEqual(module.SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
+        self.assertEqual(module.MAX_CONSECUTIVE_NO_PROGRESS, 2)
+
+    def test_a_ledger_run_ends_on_policy_not_arithmetic(self) -> None:
+        """A ceiling no run can hit makes its own test vacuous.
+
+        Behaviour, not arithmetic: a ledger run working a full plan must stop
+        because the questions ran out, never because the call budget did.
+        Asserting only that the constant is large enough would pass on an
+        implementation whose overhead term is zero.
+        """
+        script = [("noted", None),
+                  (_plan(*[(f"Q{i}", f"q{i}") for i in range(6)]), None)]
+        for i in range(6):
+            script += [(f"question: Q{i}\nrunning", f"print({i})"),
+                       (_resolved(f"Q{i}", f"ev_{i}"), None)]
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        runtime = self._runtime(_Script(script))
+        counter = {"n": 0}
+
+        def distinct(**kwargs):
+            counter["n"] += 1
+            return AnalysisResult(
+                status="ok", code_sha256=f"{counter['n']:064d}",
+                input_sha256="i" * 64, stdout=f"FINDING {counter['n']}",
+                stderr="", exit_status=0, duration_seconds=0.1,
+            )
+
+        with mock.patch.object(module, "execute_analysis", distinct):
+            run = runtime.run_autonomous("Analyse it.", finalize=False)
+        self.assertEqual(run.actions_executed, 6)
+        self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+        self.assertNotEqual(run.stop_reason, module.STOP_MAX_MODEL_CALLS)
+
+    def test_a_plan_with_children_still_ends_on_policy(self) -> None:
+        """Where the overhead term actually bites.
+
+        Six declared questions cost fourteen calls and fit either ceiling, so
+        the plain case cannot show the term does anything. Children are what
+        push past it: seven worked questions need sixteen calls, and without
+        the term the run dies on "model call bound reached" with questions
+        still open rather than finishing them.
+        """
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        script = [("noted", None),
+                  (_plan(*[(f"Q{i}", f"q{i}") for i in range(6)]), None)]
+        for i in range(6):
+            child = None
+            if i == 0:
+                child = {"id": "Q0.1", "question": "forced follow-up",
+                         "why": "the result forced it", "caused_by": "ev_0"}
+            script += [(f"question: Q{i}\nrunning", f"print({i})"),
+                       (_resolved(f"Q{i}", f"ev_{i}", child=child), None)]
+        script += [("question: Q0.1\nrunning", "print(99)"),
+                   (_resolved("Q0.1", "ev_child"), None)]
+        runtime = self._runtime(_Script(script))
+        counter = {"n": 0}
+
+        def distinct(**kwargs):
+            counter["n"] += 1
+            return AnalysisResult(
+                status="ok", code_sha256=f"{counter['n']:064d}",
+                input_sha256="i" * 64, stdout=f"FINDING {counter['n']}",
+                stderr="", exit_status=0, duration_seconds=0.1,
+            )
+
+        with mock.patch.object(module, "execute_analysis", distinct):
+            run = runtime.run_autonomous("Analyse it.", finalize=False)
+        self.assertEqual(run.child_questions, 1)
+        self.assertEqual(run.actions_executed, 7)
+        self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+        self.assertEqual(run.open_questions, ())
+
+    def test_the_unledgered_path_spends_none_of_the_new_overhead(self) -> None:
+        """Raising the ceiling must not loosen the path that does not use it."""
+        self.assertGreater(
+            module.MAX_AUTONOMOUS_MODEL_CALLS, module.MAX_AUTONOMOUS_ACTIONS
+        )
+        runtime = self._runtime(_Script([
+            ("noted", None), ("prose", None), ("prose", None),
+        ]))
+        run = self._run(runtime, plan=False)
+        # No plan, no classification: one call per iteration, as before.
+        self.assertEqual(run.plan_calls, 0)
+
+
+class _Insatiable(_Backend):
+    """A model that always has another idea -- the behaviour actually observed.
+
+    It answers by call TYPE rather than from a fixed script, so it keeps
+    proposing actions for as long as it is asked. Without a ledger it runs to
+    the action ceiling; with one it stops at the questions it declared.
+    """
+
+    def __init__(self, questions) -> None:
+        super().__init__(_Script([]))
+        self.questions = list(questions)
+        self.pending: str | None = None
+        self.n = 0
+
+    def chat_stream(self, messages, **kwargs):
+        import re
+
+        tools = kwargs.get("tools")
+        self.chat_calls.append({"tools": tools, "messages": list(messages)})
+        last = str(messages[-1].get("content", ""))
+        self.n += 1
+        if not tools:
+            if "Did that resolve" in last:
+                question, self.pending = self.pending, None
+                return self._result(_resolved(question, "ev"), [])
+            if "list only the questions" in last or "could not be read" in last:
+                return self._result(
+                    _plan(*[(q, f"question {q}") for q in self.questions]), []
+                )
+            return self._result("noted", [])
+        call = [{
+            "id": f"c{self.n}", "type": "function",
+            "function": {"name": "execute_analysis",
+                         "arguments": json.dumps({"code": f"print({self.n})"})},
+        }]
+        open_ids = re.findall(r"^(\S+) \[OPEN\]", last, re.M)
+        if open_ids:
+            self.pending = open_ids[0]
+            return self._result(f"question: {open_ids[0]}\nrunning", call)
+        return self._result("exploring something else", call)
+
+
+class TerminationAgainstAnInsatiableModelTests(_Case):
+    """§10. The ledger terminates because it is finite, not because the model stops.
+
+    This is the decision the whole design rests on. Driven by a model that
+    never runs out of ideas, the current path spends the entire action budget;
+    the ledger stops at exactly the questions that were declared, and the
+    complete source is still in the history when it does.
+    """
+
+    def _run_insatiable(self, questions, plan):
+        from orbit.runtime.analysis_sandbox import AnalysisResult
+
+        runtime = self._runtime(_Script([]))
+        runtime.backend = _Insatiable(questions)
+        self.backend = runtime.backend
+        counter = {"n": 0}
+
+        def distinct(**kwargs):
+            counter["n"] += 1
+            return AnalysisResult(
+                status="ok", code_sha256=f"{counter['n']:064d}",
+                input_sha256="i" * 64, stdout=f"DISTINCT FINDING {counter['n']}",
+                stderr="", exit_status=0, duration_seconds=0.1,
+            )
+
+        with mock.patch.object(module, "execute_analysis", distinct):
+            run = runtime.run_autonomous("go", plan=plan, finalize=False)
+        history = "\n".join(str(m.get("content")) for m in runtime.messages)
+        return run, SOURCE in history
+
+    def test_without_a_ledger_the_run_reaches_the_action_ceiling(self) -> None:
+        run, _ = self._run_insatiable([], plan=False)
+        self.assertEqual(run.actions_executed, module.MAX_AUTONOMOUS_ACTIONS)
+        self.assertEqual(run.stop_reason, module.STOP_MAX_ACTIONS)
+
+    def test_with_a_ledger_the_run_stops_at_its_declared_questions(self) -> None:
+        for declared in ([], ["Q1"], ["Q1", "Q2", "Q3"]):
+            with self.subTest(declared=len(declared)):
+                run, source_kept = self._run_insatiable(declared, plan=True)
+                self.assertEqual(run.actions_executed, len(declared))
+                self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+                self.assertEqual(set(run.resolved_questions), set(declared))
+                # And the source is still there for the report to draw on.
+                self.assertTrue(source_kept)
+
+    def test_the_ledger_costs_far_fewer_actions_than_the_ceiling(self) -> None:
+        bounded, _ = self._run_insatiable(["Q1", "Q2", "Q3"], plan=True)
+        unbounded, _ = self._run_insatiable([], plan=False)
+        self.assertLess(bounded.actions_executed, unbounded.actions_executed)
+
+
+class LedgerDoesNotEraseKnowledgeTests(_Case):
+    """§8. The ledger controls tool use, never what the model knows.
+
+    These are the tests that decide whether this design is acceptable at all.
+    An omitted behaviour must still be reportable, and a fact that genuinely
+    needs execution must be reportable as unresolved rather than vanish.
+    """
+
+    def test_the_whole_source_stays_in_the_history_after_an_empty_plan(self) -> None:
+        """J. Nothing was asked, so nothing ran -- and nothing was lost."""
+        runtime = self._runtime(_Script([
+            ("noted", None), ('{"questions":[]}', None),
+        ]))
+        self._run(runtime)
+        history = "\n".join(str(m.get("content")) for m in runtime.messages)
+        self.assertIn(SOURCE, history)
+        # Both behaviours are visible even though neither was ever a question.
+        self.assertIn("pickle.loads", history)
+        self.assertIn("hash(email)", history)
+
+    def test_a_deliberately_incomplete_plan_still_leaves_the_source(self) -> None:
+        """The plan omits the pickle behaviour entirely; the source keeps it."""
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is the token stable?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q1", "ev_1"), None),
+        ]))
+        run = self._run(runtime, max_model_calls=10)
+        self.assertEqual(run.initial_questions, 1)
+        history = "\n".join(str(m.get("content")) for m in runtime.messages)
+        self.assertIn("pickle.loads", history)
+
+    def test_the_report_is_built_from_evidence_not_from_the_ledger(self) -> None:
+        """The report path never consults the ledger, so it cannot filter.
+
+        `report()` takes a `question` parameter, but that is the analyst's own
+        query -- unrelated to the ledger. What matters is that no ledger state
+        reaches it: the report is a view over the EvidenceStore and the
+        history, both of which hold everything COVER supplied.
+        """
+        import inspect
+
+        source = inspect.getsource(AnalysisRuntime.report)
+        for banned in ("ledger", "open_questions", "resolved_questions",
+                       "QuestionLedger", "_pending_question"):
+            self.assertNotIn(banned, source, banned)
+        # And the messages it builds come from the store, not from questions.
+        builder = inspect.getsource(AnalysisRuntime._report_messages)
+        for banned in ("ledger", "open_questions", "QuestionLedger"):
+            self.assertNotIn(banned, builder, banned)
+
+    def test_an_unresolved_question_is_reported_open_not_dropped(self) -> None:
+        """The fact needs execution and was not settled. It must stay visible."""
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "is the token stable across processes?")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (json.dumps({"question": "Q1", "state": "still_open",
+                         "evidence": "ev_1"}), None),
+            ("question: Q1\nagain", "print(2)"),
+            (json.dumps({"question": "Q1", "state": "still_open",
+                         "evidence": "ev_2"}), None),
+        ]))
+        run = self._run(runtime, max_model_calls=8)
+        self.assertIn("Q1", run.open_questions)
+        self.assertEqual(run.resolved_questions, ())
+
+    def test_an_unreadable_classification_never_resolves(self) -> None:
+        """The failure path, not just the explicit `still_open` answer.
+
+        A garbled or truncated classification reply must leave its question
+        open. Resolving it there would report a question the model could not
+        answer as answered -- the erasure this design exists to avoid -- and
+        the explicit `still_open` path being covered does not cover this one.
+        """
+        for garbled in ("I think so?", "", "{truncated", '{"question":"Q1"}'):
+            with self.subTest(garbled=garbled[:12]):
+                runtime = self._runtime(_Script([
+                    ("noted", None),
+                    (_plan(("Q1", "needs execution")), None),
+                    ("question: Q1\nrunning", "print(1)"),
+                    (garbled, None),
+                ]))
+                run = self._run(runtime, max_model_calls=5)
+                self.assertEqual(run.open_questions, ("Q1",))
+                self.assertEqual(run.resolved_questions, ())
+
+    def test_a_classification_about_another_question_never_resolves(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "a"), ("Q2", "b")), None),
+            ("question: Q1\nrunning", "print(1)"),
+            (_resolved("Q2", "ev_1"), None),   # answered about the wrong one
+        ]))
+        run = self._run(runtime, max_model_calls=5)
+        self.assertEqual(run.resolved_questions, ())
+        self.assertEqual(set(run.open_questions), {"Q1", "Q2"})
+
+    def test_a_backend_failure_during_classification_never_resolves(self) -> None:
+        """The comment says the question stays open; this makes it so."""
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            (_plan(("Q1", "needs execution")), None),
+            ("question: Q1\nrunning", "print(1)"),
+        ]))
+        real = runtime._admit
+        state = {"cover_and_plan": 0}
+
+        def refuse_on_classification(messages, **kwargs):
+            last = str(messages[-1].get("content", ""))
+            if "Did that resolve" in last:
+                raise ContextAdmissionError("context admission failed: test")
+            return real(messages, **kwargs)
+
+        runtime._admit = refuse_on_classification
+        run = self._run(runtime, max_model_calls=5)
+        self.assertEqual(run.resolved_questions, ())
+        self.assertIn("Q1", run.open_questions)
+
+    def test_exhaustion_is_not_a_completeness_claim(self) -> None:
+        """§6. The stop reason says what it means and no more."""
+        self.assertIn("action", STOP_LEDGER_EXHAUSTED)
+        for banned in ("complete", "finished", "done", "nothing left"):
+            self.assertNotIn(banned, STOP_LEDGER_EXHAUSTED.lower(), banned)
+
+    def test_open_questions_reach_the_closing_report(self) -> None:
+        """A question nobody answered must be named in the report prompt.
+
+        `AutonomousRunResult` carrying it is not enough: if the finalising
+        model is never told, the report reads as though everything was
+        answered, which is the erasure this design must not cause.
+        """
+        asked = AnalysisRuntime._final_question(
+            STOP_LEDGER_EXHAUSTED, ("Q1", "Q3")
+        )
+        self.assertIn("Q1", asked)
+        self.assertIn("Q3", asked)
+        self.assertIn("not resolved", asked)
+
+    def test_an_exhausted_run_is_not_described_as_cut_short(self) -> None:
+        """It ended because nothing needed a tool, not because a bound hit."""
+        asked = AnalysisRuntime._final_question(STOP_LEDGER_EXHAUSTED, ())
+        self.assertNotIn("stopped before", asked)
+        self.assertIn("artifact source", asked)
+
+    def test_a_run_cut_short_by_a_bound_still_says_so(self) -> None:
+        """The other half: a bound that intervened must not read as finished.
+
+        Both halves are needed. A test that only checks the exhausted wording
+        passes on an implementation that gives every ending that wording --
+        including the ones where a ceiling stopped the analysis mid-way, which
+        a reader would then take for a completed one.
+        """
+        for stop in (module.STOP_MAX_ACTIONS, module.STOP_MAX_MODEL_CALLS,
+                     module.STOP_NO_PROGRESS, module.STOP_ERROR):
+            with self.subTest(stop=stop):
+                asked = AnalysisRuntime._final_question(stop, ())
+                self.assertIn("stopped before the model chose to finish", asked)
+                self.assertIn(stop, asked)
+
+    def test_a_covered_run_reports_even_with_no_steps(self) -> None:
+        """The empty plan is a correct reply and must not erase the analysis.
+
+        Skipping the report here would turn a run that was handed the whole
+        source into "no evidence has been collected", discarding everything
+        COVER supplied.
+        """
+        runtime = self._runtime(_Script([
+            ("noted", None),
+            ('{"questions":[]}', None),
+            ("The module calls pickle.loads on untrusted bytes.", None),
+        ]))
+        with mock.patch.object(module, "execute_analysis", lambda **kw: _sandbox()):
+            run = runtime.run_autonomous("Analyse it.", finalize=True)
+        self.assertEqual(len(run.steps), 0)
+        self.assertIsNotNone(run.final_report)
+        self.assertIn("pickle.loads", run.final_report.text)
+
+    def test_a_refused_coverage_report_never_claims_no_evidence(self) -> None:
+        """The last leak of the invariant, on the admission-refusal path.
+
+        The source WAS supplied in full, so "no analysis evidence has been
+        collected" is the same false claim the coverage report exists to
+        prevent. What failed is composing the report, which is a different
+        fact -- and the accurate wording must not be gated on a deterministic
+        appendix that most artifacts do not have.
+        """
+        from orbit.runtime.context_manager import ContextAdmissionError
+
+        runtime = self._runtime(_Script([("noted", None), ('{"questions":[]}', None)]))
+        runtime.cover_source(runtime.plan_source_coverage())
+        self.assertFalse(runtime.deterministic_sections())
+        real = runtime._admit
+
+        def refuse_the_report(messages, **kwargs):
+            if any("No execution was performed" in str(m.get("content", ""))
+                   for m in messages):
+                raise ContextAdmissionError("context admission failed: test")
+            return real(messages, **kwargs)
+
+        runtime._admit = refuse_the_report
+        report = runtime.report()
+        self.assertNotIn("No analysis evidence", report.text)
+        self.assertIn("supplied in full", report.text)
+
+    def test_the_coverage_report_is_grounded_in_the_supplied_source(self) -> None:
+        runtime = self._runtime(_Script([
+            ("noted", None), ('{"questions":[]}', None), ("report", None),
+        ]))
+        with mock.patch.object(module, "execute_analysis", lambda **kw: _sandbox()):
+            runtime.run_autonomous("Analyse it.", finalize=True)
+        sent = "\n".join(
+            str(m.get("content"))
+            for call in self.backend.chat_calls[-1:]
+            for m in call["messages"]
+        )
+        self.assertIn(SOURCE, sent)
+
+    def test_the_ledger_message_says_it_bounds_only_running(self) -> None:
+        ledger = QuestionLedger()
+        ledger.add(Question("Q1", "a question", "w"))
+        told = module._ledger_instruction(ledger)
+        self.assertIn("bounds only what you may RUN", told)
+        self.assertIn("stays yours to report", told)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_question_ledger.py
+++ b/tests/test_analysis_question_ledger.py
@@ -1,0 +1,393 @@
+"""Tool exploration is bounded by declared questions; knowledge is not.
+
+ANALYSIS-QUESTION-LEDGER-1. Source acquisition stopped being the problem: the
+live run supplied the whole artifact, suppressed the one re-read, and still
+spent seven actions -- four re-deriving facts the source already showed (two of
+them near-identical repeats), three genuinely needing execution, and none
+caused by an earlier result. Every valid new action counted as progress, so the
+run grew until a ceiling stopped it.
+
+The ledger bounds which ACTIONS may run. It must never bound what the model may
+conclude or report: a finding visible in the source needs no question, and a
+question nobody could answer stays visibly open. The tests that matter most
+here are the ones in `LedgerDoesNotEraseKnowledgeTests` -- a mechanism that
+hid an unresolved fact because nobody declared it would be worse than the
+inefficiency it replaces.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from orbit.runtime.analysis_question_ledger import (  # noqa: E402
+    MAX_CHILD_DEPTH,
+    MAX_INITIAL_QUESTIONS,
+    OPEN,
+    RESOLVED,
+    LedgerError,
+    Question,
+    QuestionLedger,
+    parse_plan,
+    parse_resolution,
+)
+
+
+def _ledger(*ids: str) -> QuestionLedger:
+    ledger = QuestionLedger()
+    for qid in ids:
+        ledger.add(Question(qid, f"question for {qid}", "needs execution"))
+    return ledger
+
+
+class PlanParsingTests(unittest.TestCase):
+    """The plan is read strictly, or not at all."""
+
+    def test_a_well_formed_plan_is_read(self) -> None:
+        questions = parse_plan(
+            '{"questions":[{"id":"Q1","question":"Is the token predictable?",'
+            '"why":"hash() salting cannot be read off the source"}]}'
+        )
+        self.assertEqual([q.id for q in questions], ["Q1"])
+        self.assertEqual(questions[0].depth, 0)
+
+    def test_an_empty_plan_is_valid_and_meaningful(self) -> None:
+        """A. The source answered everything -- a correct reply, not a failure."""
+        self.assertEqual(parse_plan('{"questions":[]}'), [])
+
+    def test_json_inside_prose_or_a_fence_is_read(self) -> None:
+        body = '{"questions":[{"id":"Q1","question":"q","why":"w"}]}'
+        for wrapper in (
+            f"Here is my plan:\n{body}",
+            f"```json\n{body}\n```",
+            f"{body}\n\nLet me know if that works.",
+        ):
+            with self.subTest(wrapper=wrapper[:16]):
+                self.assertEqual(len(parse_plan(wrapper)), 1)
+
+    def test_malformed_plans_are_refused(self) -> None:
+        for text, label in (
+            ("", "empty"),
+            ("no json at all", "prose only"),
+            ("{", "truncated"),
+            ('{"questions": "Q1"}', "not a list"),
+            ('{"nope": []}', "missing field"),
+            ('{"questions":[{"id":"Q1"}]}', "missing question"),
+            ('{"questions":[{"id":"Q1","question":"q"}]}', "missing why"),
+            ('{"questions":[{"id":"","question":"q","why":"w"}]}', "empty id"),
+            ('{"questions":[{"id":"a b","question":"q","why":"w"}]}', "spaced id"),
+            ('{"questions":[{"id":"Q1","question":"q","why":"w"},'
+             '{"id":"Q1","question":"r","why":"w"}]}', "duplicate id"),
+            ('{"questions":["Q1"]}', "not objects"),
+        ):
+            with self.subTest(label=label):
+                with self.assertRaises(LedgerError, msg=label):
+                    parse_plan(text)
+
+    def test_an_over_long_plan_is_refused(self) -> None:
+        entries = ",".join(
+            f'{{"id":"Q{i}","question":"q","why":"w"}}'
+            for i in range(MAX_INITIAL_QUESTIONS + 1)
+        )
+        with self.assertRaises(LedgerError):
+            parse_plan('{"questions":[' + entries + ']}')
+
+    def test_over_long_text_is_refused(self) -> None:
+        with self.assertRaises(LedgerError):
+            parse_plan(
+                '{"questions":[{"id":"Q1","question":"' + "x" * 5000
+                + '","why":"w"}]}'
+            )
+
+    def test_an_absurdly_large_plan_is_refused_without_parsing(self) -> None:
+        with self.assertRaises(LedgerError):
+            parse_plan("{" + "x" * 100_000)
+
+
+class LedgerTransitionTests(unittest.TestCase):
+    """E. Resolution is one-way without new causal evidence."""
+
+    def test_questions_start_open(self) -> None:
+        ledger = _ledger("Q1", "Q2")
+        self.assertEqual(ledger.open_ids, ["Q1", "Q2"])
+        self.assertFalse(ledger.exhausted)
+
+    def test_resolving_closes_exactly_one(self) -> None:
+        ledger = _ledger("Q1", "Q2")
+        ledger.resolve("Q1", "ev_1")
+        self.assertEqual(ledger.open_ids, ["Q2"])
+        self.assertEqual(ledger.resolved_ids, ["Q1"])
+
+    def test_an_exhausted_ledger_has_nothing_open(self) -> None:
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_1")
+        self.assertTrue(ledger.exhausted)
+
+    def test_resolution_requires_named_evidence(self) -> None:
+        ledger = _ledger("Q1")
+        with self.assertRaises(LedgerError):
+            ledger.resolve("Q1", "")
+
+    def test_a_resolved_question_cannot_be_resolved_again(self) -> None:
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_1")
+        with self.assertRaises(LedgerError):
+            ledger.resolve("Q1", "ev_2")
+
+    def test_reopening_without_new_evidence_is_refused(self) -> None:
+        """A run that could reopen freely would cycle on one question."""
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_1")
+        for evidence in ("", "ev_1"):
+            with self.subTest(evidence=evidence):
+                with self.assertRaises(LedgerError):
+                    ledger.reopen("Q1", evidence)
+        self.assertEqual(ledger.state["Q1"], RESOLVED)
+        self.assertEqual(ledger.reopen_attempts, 2)
+
+    def test_reopening_on_genuinely_new_evidence_is_allowed(self) -> None:
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_1")
+        ledger.reopen("Q1", "ev_2")
+        self.assertEqual(ledger.state["Q1"], OPEN)
+
+    def test_an_unknown_question_cannot_be_resolved(self) -> None:
+        with self.assertRaises(LedgerError):
+            _ledger("Q1").resolve("Q9", "ev_1")
+
+
+class ChildQuestionTests(unittest.TestCase):
+    """C. A child is admitted only when the evidence really forced it."""
+
+    def _parent(self) -> QuestionLedger:
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_a")
+        return ledger
+
+    def test_a_caused_child_is_accepted(self) -> None:
+        ledger = self._parent()
+        ledger.accept_child(
+            Question("Q1.1", "Does the salt persist across runs?", "follow-up",
+                     depth=1, parent="Q1", caused_by="ev_a")
+        )
+        self.assertEqual(ledger.open_ids, ["Q1.1"])
+
+    def test_a_child_without_a_known_parent_is_refused(self) -> None:
+        ledger = self._parent()
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q9.1", "x", "y", depth=1, parent="Qz", caused_by="ev_a")
+            )
+
+    def test_a_child_naming_no_evidence_is_refused(self) -> None:
+        ledger = self._parent()
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q1.2", "x", "y", depth=1, parent="Q1", caused_by=None)
+            )
+
+    def test_a_child_beyond_the_depth_cap_is_refused(self) -> None:
+        ledger = self._parent()
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q1.3", "x", "y", depth=MAX_CHILD_DEPTH + 1,
+                         parent="Q1", caused_by="ev_a")
+            )
+
+    def test_a_child_restating_an_existing_question_is_refused(self) -> None:
+        """D. Rewording is not a new question."""
+        ledger = self._parent()
+        original = ledger.questions["Q1"].question
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q1.4", original.upper() + "   ", "y",
+                         depth=1, parent="Q1", caused_by="ev_a")
+            )
+
+    def test_a_duplicate_child_id_is_refused(self) -> None:
+        ledger = self._parent()
+        ledger.accept_child(
+            Question("Q1.1", "first", "y", depth=1, parent="Q1", caused_by="ev_a")
+        )
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q1.1", "second", "y", depth=1, parent="Q1",
+                         caused_by="ev_a")
+            )
+
+    def test_every_refusal_is_counted(self) -> None:
+        ledger = self._parent()
+        for child in (
+            Question("A", "x", "y", 1, "Qz", "ev_a"),
+            Question("B", "x", "y", 1, "Q1", None),
+            Question("C", "x", "y", 9, "Q1", "ev_a"),
+        ):
+            with self.assertRaises(LedgerError):
+                ledger.accept_child(child)
+        self.assertEqual(ledger.rejected_children, 3)
+
+
+class TerminationTests(unittest.TestCase):
+    """§10. The ledger terminates structurally, not by the model relenting."""
+
+    def test_a_ledger_with_no_children_ends_after_its_questions(self) -> None:
+        ledger = _ledger("Q1", "Q2", "Q3")
+        for index, qid in enumerate(list(ledger.open_ids)):
+            ledger.resolve(qid, f"ev_{index}")
+        self.assertTrue(ledger.exhausted)
+
+    def test_children_cannot_chain_beyond_the_depth_cap(self) -> None:
+        """The adversarial case: every answer tries to raise another question."""
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev_0")
+        ledger.accept_child(
+            Question("Q1.1", "child", "y", 1, "Q1", "ev_0")
+        )
+        ledger.resolve("Q1.1", "ev_1")
+        # A grandchild is refused however it is dressed up.
+        with self.assertRaises(LedgerError):
+            ledger.accept_child(
+                Question("Q1.1.1", "grandchild", "y", 2, "Q1.1", "ev_1")
+            )
+        self.assertTrue(ledger.exhausted)
+
+    def test_the_total_size_is_capped_independently_of_the_ceilings(self) -> None:
+        """§10. Termination must be the ledger's property, not the ceiling's.
+
+        Without this cap the only bound on growth is the global action limit --
+        one distinct child per action, indefinitely -- and the rendered ledger
+        grows into every later prompt until admission refuses it. That is a run
+        bounded by a ceiling, not by a finite plan.
+        """
+        from orbit.runtime.analysis_question_ledger import MAX_TOTAL_QUESTIONS
+
+        ledger = _ledger("Q1")
+        ledger.resolve("Q1", "ev")
+        accepted = 0
+        for index in range(1000):
+            try:
+                ledger.accept_child(
+                    Question(f"C{index}", f"distinct child {index}", "w",
+                             1, "Q1", "ev")
+                )
+                accepted += 1
+            except LedgerError:
+                break
+        self.assertLessEqual(len(ledger.questions), MAX_TOTAL_QUESTIONS)
+        self.assertLess(accepted, 1000)
+
+    def test_the_worst_case_size_is_bounded(self) -> None:
+        """N initial questions, each raising one child, and no more."""
+        ledger = _ledger(*[f"Q{i}" for i in range(MAX_INITIAL_QUESTIONS)])
+        for index, qid in enumerate(list(ledger.open_ids)):
+            ledger.resolve(qid, f"ev_{index}")
+            ledger.accept_child(
+                Question(f"{qid}.1", f"child of {qid}", "y", 1, qid, f"ev_{index}")
+            )
+        self.assertEqual(len(ledger.questions), MAX_INITIAL_QUESTIONS * 2)
+        for index, qid in enumerate(list(ledger.open_ids)):
+            ledger.resolve(qid, f"evc_{index}")
+        self.assertTrue(ledger.exhausted)
+
+
+class ResolutionParsingTests(unittest.TestCase):
+    """The classification is read strictly and never inferred."""
+
+    def test_a_resolved_classification_is_read(self) -> None:
+        ledger = _ledger("Q1")
+        self.assertEqual(
+            parse_resolution(
+                '{"question":"Q1","state":"resolved","evidence":"ev_1"}', ledger
+            ),
+            ("Q1", RESOLVED, "ev_1"),
+        )
+
+    def test_still_open_is_a_real_answer(self) -> None:
+        ledger = _ledger("Q1")
+        qid, state, _ = parse_resolution(
+            '{"question":"Q1","state":"still_open","evidence":"ev_1"}', ledger
+        )
+        self.assertEqual((qid, state), ("Q1", "still_open"))
+
+    def test_a_classification_about_a_closed_question_is_refused(self) -> None:
+        ledger = _ledger("Q1", "Q2")
+        ledger.resolve("Q1", "ev_1")
+        with self.assertRaises(LedgerError):
+            parse_resolution(
+                '{"question":"Q1","state":"resolved","evidence":"ev_2"}', ledger
+            )
+
+    def test_malformed_classifications_are_refused(self) -> None:
+        ledger = _ledger("Q1")
+        for text, label in (
+            ("nonsense", "prose"),
+            ('{"question":"Q9","state":"resolved"}', "unknown question"),
+            ('{"question":"Q1","state":"done"}', "unknown state"),
+            ('{"question":"Q1","state":"resolved","evidence":5}', "bad evidence"),
+            ('["Q1"]', "not an object"),
+        ):
+            with self.subTest(label=label):
+                with self.assertRaises(LedgerError):
+                    parse_resolution(text, ledger)
+
+
+class SafetyTests(unittest.TestCase):
+    """§6. No execution, no language-specific policy, no hardcoded findings."""
+
+    SOURCE = ROOT / "src" / "orbit" / "runtime" / "analysis_question_ledger.py"
+
+    def test_the_module_never_evaluates(self) -> None:
+        import ast
+
+        tree = ast.parse(self.SOURCE.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            body = node.body
+            if (
+                body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                node.body = body[1:] or [ast.Pass()]
+        code = ast.unparse(tree)
+        for banned in ("eval(", "exec(", "literal_eval", "__import__",
+                       "subprocess", "os.system", "pickle"):
+            self.assertNotIn(banned, code, banned)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                self.assertNotIn(
+                    node.func.id, {"eval", "exec", "compile", "__import__", "open"}
+                )
+
+    def test_no_language_or_vulnerability_specific_policy(self) -> None:
+        text = self.SOURCE.read_text().lower()
+        for banned in ("javascript", "powershell", "python-specific", "sql",
+                       "injection", "traversal", "pickle", "xss", "cve",
+                       "vulnerab"):
+            self.assertNotIn(banned, text, banned)
+
+    def test_hostile_input_is_bounded_and_never_raises_unexpectedly(self) -> None:
+        import time
+
+        started = time.monotonic()
+        for hostile in (
+            "{" * 50_000,
+            '{"questions":[' + ",".join('{"id":"Q","question":"q","why":"w"}'
+                                        for _ in range(10_000)) + "]}",
+            '{"questions":[{"id":"' + "9" * 100_000 + '","question":"q","why":"w"}]}',
+            "\x00" * 10_000,
+        ):
+            with self.subTest(hostile=hostile[:12]):
+                with self.assertRaises(LedgerError):
+                    parse_plan(hostile)
+        self.assertLess(time.monotonic() - started, 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis_reacquisition_runtime.py
+++ b/tests/test_analysis_reacquisition_runtime.py
@@ -643,7 +643,7 @@ class AccountingTests(_Case):
         """O. No bound moved."""
         self.assertEqual(module.MAX_AUTONOMOUS_ACTIONS, 12)
         self.assertEqual(module.SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
-        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 18)
         self.assertEqual(module.MAX_CONSECUTIVE_NO_PROGRESS, 2)
 
 

--- a/tests/test_analysis_repair.py
+++ b/tests/test_analysis_repair.py
@@ -389,7 +389,7 @@ class RepairBoundTests(RepairTestBase):
         # mechanism that quietly bought headroom would still satisfy
         # `<= ceiling`, so the values are pinned here.
         self.assertEqual(MAX_AUTONOMOUS_ACTIONS, 12)
-        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertEqual(MAX_AUTONOMOUS_MODEL_CALLS, 18)
         self.assertLessEqual(run.model_calls, MAX_AUTONOMOUS_MODEL_CALLS)
         self.assertLessEqual(run.actions_executed, MAX_AUTONOMOUS_ACTIONS)
         # The correction is an ordinary action, not a free one.

--- a/tests/test_analysis_source_dominance.py
+++ b/tests/test_analysis_source_dominance.py
@@ -887,4 +887,4 @@ class RuntimeSeamTests(unittest.TestCase):
 
         self.assertEqual(module.MAX_AUTONOMOUS_ACTIONS, 12)
         self.assertEqual(module.SOFT_MAX_AUTONOMOUS_ACTIONS, 8)
-        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 15)
+        self.assertEqual(module.MAX_AUTONOMOUS_MODEL_CALLS, 18)


### PR DESCRIPTION
Source acquisition stopped being the problem. The live run that motivated this supplied the whole artifact, suppressed the one re-read, and still spent seven actions: four re-deriving facts the source already showed -- two in near-identical pairs -- and three genuinely needing execution. **None of the seven was caused by an earlier result.** The pattern is not bad reasoning; it is that every valid new action counts as progress, so an investigation grows until a ceiling stops it.

After coverage the model now declares, in one tools-free call, the concrete questions it cannot answer from the source it was given. Each action must name one; after it runs the model says whether that question is resolved; when none is open the run reports. All three of the live run's real questions were declarable at that point, so this is a bound the observed behaviour actually fits.

## Termination is structural

Against a scripted model that never runs out of ideas, the current path spends the whole twelve-action budget. The ledger stops at exactly the questions declared -- three, one, or zero -- with the complete source still in the history. At most six initial questions and twelve in total; children only when the evidence just obtained forced them, and only to depth one, because the live evidence shows no causal chains at all.

## What it must never do

The ledger bounds what may RUN, never what may be known. Review found that violated in the one case the design calls correct: an empty plan took no step, the finalizer only ran when a step had, and `report()` then said *"no analysis evidence has been collected"* -- because it reads the EvidenceStore and coverage writes no record. **A run handed the entire source reported nothing.**

A covered run now reports whether or not a step ran, grounded in the covered history when no action produced evidence. Open questions reach the finalising model with a request to say what remains unknown; they were carried on the result but never put in front of the report, so an unsettled question read as answered. An exhausted ledger is no longer described as cut short -- it ended because nothing open needed a tool.

## Fail closed everywhere

An unreadable plan gets one repair and then returns the run to exactly its previous behaviour. An unreadable classification, one about a different question, and a backend failure during classification all leave the question open -- three mutants review found surviving, all on the failure paths of a classification whose success path was covered.

The model-call ceiling gained a named term for what the ledger costs. Without it a run ends on arithmetic rather than on the action policy, which is the defect this constant's own history records. Action bounds unchanged; the unledgered path spends none of it.

## Qualification

107 focused tests; **23/23 mutants caught**; full suite **4614 OK**. Two adversarial review rounds: three BLOCKERs and two MAJORs found and fixed, final round ready-to-merge.

Guided ANALYSIS, CHAT and uncovered runs untouched. No GGUF loaded.
