### PR TITLE
fix(analysis): repair one unparsable control response, and stop asking for it

### DIFF
--- a/src/orbit/backend/base.py
+++ b/src/orbit/backend/base.py
@@ -28,6 +28,25 @@ class RecoverableBackendError(RuntimeError):
     """
 
 
+class ToolCallParseError(RecoverableBackendError):
+    """The backend could not parse the model's output into a message.
+
+    Narrower than its parent on purpose. The model answered, and the answer
+    was in a shape the tool-call grammar refuses -- so no assistant message
+    exists to inspect or reject structurally, and the request failed for a
+    reason the model itself could correct if asked again.
+
+    A caller may therefore treat this as a repairable turn. Nothing else may
+    be: a decode failure, a transport error, a cancelled request, a model that
+    would not load and a context refusal all arrive as the parent type and all
+    mean the model was never given a fair chance to answer. Re-prompting those
+    spends a call to fail the same way.
+
+    Defined beside `RecoverableBackendError` rather than in a concrete backend
+    so a runtime can name it without importing a backend implementation.
+    """
+
+
 class StreamConsumerAbort(Exception):
     """A stream consumer stopped its own call on purpose; the backend is fine.
 

--- a/src/orbit/backend/llama_server.py
+++ b/src/orbit/backend/llama_server.py
@@ -36,13 +36,38 @@ from orbit.native_llama.qwen3_coder_route_prefix import resolve_qwen3_coder_rout
 from orbit.native_llama.prefix_anchor import prefix_anchor_enabled
 from orbit.runtime.history_serialization import serialize_profile_messages
 from orbit.runtime.analysis_runtime import ANALYSIS_STEP_PHASE
-from orbit.backend.base import RecoverableBackendError
+from orbit.backend.base import RecoverableBackendError, ToolCallParseError
 from orbit.runtime.kv_diag import current_phase, current_tools_mode, enabled as kv_diag_enabled
 from orbit.runtime.tool_healing import tool_call_healing_status
 
 
 class LlamaServerError(RecoverableBackendError):
     pass
+
+
+# What the server says when its tool-call grammar rejects the model's output.
+# Matched here, once, at the boundary that owns output parsing -- not in the
+# runtimes that decide what to do about it. The text comes from `chat.cpp`'s
+# parser and is stable; a wording change turns a repairable failure back into
+# a fatal one, which is the safe direction to fail.
+_TOOL_CALL_PARSE_MARKERS = ("failed to parse input at pos",)
+
+
+class LlamaServerToolCallParseError(LlamaServerError, ToolCallParseError):
+    """A `LlamaServerError` that is also the narrow output-parse failure.
+
+    Inherits both so existing handlers catching `LlamaServerError` keep
+    working unchanged, while a caller that wants only the repairable case can
+    name `ToolCallParseError`.
+    """
+
+
+def _stream_error(message: str) -> LlamaServerError:
+    """Type one server error event. Output-parse failures get the narrow type."""
+    lowered = message.lower()
+    if any(marker in lowered for marker in _TOOL_CALL_PARSE_MARKERS):
+        return LlamaServerToolCallParseError(message)
+    return LlamaServerError(message)
 
 
 class LlamaServerBackend:
@@ -777,7 +802,7 @@ def _parse_native_stream(
             stream_done = True
         elif current_event == "error":
             message = _str_or_none(data.get("message")) or "native stream error"
-            raise LlamaServerError(message)
+            raise _stream_error(message)
         model = _str_or_none(data.get("model")) or model
         current_event = None
 

--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -38,7 +38,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
-from orbit.backend.base import ChatBackend, Message, RecoverableBackendError
+from orbit.backend.base import (
+    ChatBackend,
+    Message,
+    RecoverableBackendError,
+    ToolCallParseError,
+)
 from orbit.runtime.context_manager import (
     ContextAdmissionError,
     DEFAULT_NEXT_ACTION_RESERVE,
@@ -240,6 +245,32 @@ ANALYSIS_SYSTEM_PROMPT = (
     "what only running the transformation can.\n"
     "Base every claim on the artifact or on output an action actually produced. "
     "State plainly when something is unresolved rather than filling the gap."
+)
+
+# The system prompt a control phase runs under.
+#
+# The ordinary prompt tells the model to inspect the artifact by running
+# `execute_analysis`, which is correct for a RESOLVE step and a direct
+# contradiction during PLAN or a question completion: those phases offer one
+# control tool and no analysis tool at all. A live run showed the cost --
+# offered only `submit_analysis_plan`, the model followed the prose it could
+# still see and emitted an `execute_analysis` call, which the server's
+# tool-call grammar then refused to parse at all.
+#
+# So a control phase states its own contract. This replaces the system turn in
+# the transient control context only; the permanent history keeps the ordinary
+# prompt, because that is what the RESOLVE steps run under.
+CONTROL_SYSTEM_PROMPT = (
+    "You are performing static analysis of one artifact in an isolated "
+    "offline workspace. There is no network.\n"
+    "This is a control turn, not an analysis turn. Exactly one control tool "
+    "is offered to you, and it is the only action available: call it. No "
+    "program runs during this turn, and no analysis tool is available to "
+    "call -- naming one produces nothing.\n"
+    "Earlier results may appear as an evidence reference "
+    "(`tool_evidence_ref: true`) rather than their full text; that is the "
+    "exact output, archived. Cite such a result by its evidence id.\n"
+    "Base every claim on the artifact text you were given."
 )
 
 PLAN_TOOL_NAME = "submit_analysis_plan"
@@ -653,7 +684,6 @@ def _evidence_first_instruction(
     )
 
 
-
 # What COVER says. It is deliberately about the transaction, not the artifact:
 # it names no language, no file type, no technique and no finding, because the
 # whole point is that coverage is the same operation whatever the bytes are.
@@ -959,6 +989,8 @@ STOP_COMPLETE = "model returned prose with no action"
 # Every declared question answered or given up on. Says nothing about the
 # analysis being complete -- only that nothing left open needs a tool.
 STOP_LEDGER_EXHAUSTED = "no open question requires an action"
+
+
 # The model could not use the structured control protocol. A bounded, honest
 # outcome -- preferable to spending the ceiling recovering, and deliberately
 # not a reason to fall back to the free-form loop.
@@ -1174,6 +1206,13 @@ class AutonomousRunResult:
     # the analyst: `open_questions` is what the run could not settle, and it is
     # deliberately not hidden -- a question nobody answered is a result.
     plan_calls: int = 0
+    # Control calls actually dispatched, and how many were a second attempt
+    # after an unparsable response. `plan_calls` keeps its meaning -- calls
+    # that returned into planning -- which is why these are separate: a phase
+    # whose first call raised reported `plan_calls == 0`, and that read as a
+    # planning step that never ran rather than one that failed.
+    control_attempts: int = 0
+    control_repairs: int = 0
     initial_questions: int = 0
     child_questions: int = 0
     resolved_questions: "tuple[str, ...]" = ()
@@ -1404,6 +1443,58 @@ def _bounded_observation(result: AnalysisResult) -> tuple[str, bool, int]:
     return text[:keep] + notice, True, full
 
 
+# How much of a parse failure the repair turn is allowed to quote. The message
+# embeds the model's own unparsable output, which is untrusted text of
+# unbounded length -- it is a description of what went wrong, not an
+# instruction, and it must not be able to dominate the repair prompt.
+MAX_CONTROL_ERROR_CHARS = 240
+
+
+def _sanitise_control_error(exc: BaseException) -> str:
+    """A bounded single-line description of a control failure.
+
+    Collapses whitespace so the quoted text cannot forge prompt structure, and
+    truncates so a large unparsable response cannot crowd out the instruction
+    that follows it.
+    """
+    text = " ".join(str(exc).split())
+    if len(text) > MAX_CONTROL_ERROR_CHARS:
+        text = text[:MAX_CONTROL_ERROR_CHARS] + "..."
+    return text or "the response could not be read"
+
+
+def _control_context(messages: "list[Message]") -> "list[Message]":
+    """The transient messages a control turn runs under.
+
+    The ordinary system prompt instructs the model to run `execute_analysis`.
+    A control phase offers no analysis tool, so that instruction is a
+    contradiction the model can only resolve by emitting a call that does not
+    exist -- which is what a live run did, and what the server's tool-call
+    grammar then refused to parse.
+
+    Only the leading system turn is substituted. Everything after it is the
+    artifact history the phase genuinely needs, and nothing here is written
+    back: the caller discards this list.
+    """
+    control = {"role": "system", "content": CONTROL_SYSTEM_PROMPT}
+    replaced = False
+    out: "list[Message]" = []
+    for message in messages:
+        # Every system turn, not just the first. Production appends exactly
+        # one, so this is the same list either way -- but a second one would
+        # be another place the analysis instruction could reappear, and
+        # leaving that to the caller's ordering is not worth the risk.
+        if message.get("role") == "system":
+            if not replaced:
+                out.append(control)
+                replaced = True
+            continue
+        out.append(message)
+    if not replaced:
+        out.insert(0, control)
+    return out
+
+
 @dataclass
 class AnalysisRuntime:
     """Analyst-driven analysis. One model call and one action per step."""
@@ -1426,6 +1517,11 @@ class AnalysisRuntime:
     # exactly the scope in which "already established" is answerable.
     _observed_fingerprints: dict[str, str] = field(default_factory=dict)
     suppressed_duplicates: int = 0
+    # Control calls dispatched, counted before the backend can raise, and the
+    # subset that were a second attempt after an unparsable response. A phase
+    # that fails on its first call still attempted one.
+    control_attempts: int = 0
+    control_repairs: int = 0
     last_context_plan: object | None = None
     # Stages the deterministic pass recovered, paired with the evidence each
     # became. Computed once per artifact snapshot and read thereafter.
@@ -2511,21 +2607,29 @@ class AnalysisRuntime:
         Exactly one tool is offered, so a reply that calls anything else is a
         protocol failure rather than an action to run.
         """
-        admitted = self._admit(
-            list(messages),
-            max_tokens=self.effective_max_tokens,
-            tools=[schema],
-            next_action_reserve=0,
-        )
-        with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
-            response = self.backend.chat_stream(
-                admitted,
-                temperature=self.temperature,
-                max_tokens=self.effective_max_tokens,
-                tools=[schema],
-                on_progress=on_progress,
+        allowed = schema["function"]["name"]
+        try:
+            response = self._control_dispatch(messages, schema, on_progress=on_progress)
+        except ToolCallParseError as exc:
+            # The model answered and the server could not parse the answer
+            # into a message, so there is nothing to reject structurally and
+            # nothing to repair from except the fact of the failure. Exactly
+            # one more attempt, restating the contract this phase actually
+            # offers. A second failure is the model's answer.
+            self.control_repairs += 1
+            repaired = [
+                *messages,
+                {"role": "user", "content": (
+                    "The previous control response could not be parsed: "
+                    f"{_sanitise_control_error(exc)}\n"
+                    f"This phase accepts only the {allowed} control call. "
+                    f"Submit that control call now. Do not execute an "
+                    "analysis action."
+                )},
+            ]
+            response = self._control_dispatch(
+                repaired, schema, on_progress=on_progress
             )
-        self.model_calls += 1
         text = response.content or ""
         if _unencodable(text):
             text = text.encode("utf-8", "replace").decode("utf-8")
@@ -2539,6 +2643,45 @@ class AnalysisRuntime:
                 return None, text
             return arguments, text
         return None, text
+
+    def _control_dispatch(
+        self,
+        messages: "list[Message]",
+        schema: "dict[str, Any]",
+        *,
+        on_progress: Callable[[Any], None] | None = None,
+    ):
+        """One control call to the backend. Counted at dispatch.
+
+        The counter is incremented before the call, not after it returns: a
+        call that raises still reached the model and still cost a turn, and a
+        counter that only counts successes reports a failing phase as one that
+        never ran. That is exactly what made a live parse failure look like a
+        planning step that was never attempted.
+        """
+        admitted = self._admit(
+            _control_context(messages),
+            max_tokens=self.effective_max_tokens,
+            tools=[schema],
+            next_action_reserve=0,
+        )
+        self.control_attempts += 1
+        with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
+            response = self.backend.chat_stream(
+                admitted,
+                temperature=self.temperature,
+                max_tokens=self.effective_max_tokens,
+                tools=[schema],
+                # A control exchange produces no analyst-visible prose, so
+                # nothing here renders the deltas -- but `on_delta` is required
+                # by the backend, not optional, and every other call site
+                # passes one. Omitting it raised TypeError against the real
+                # backend while scripted test doubles accepted it.
+                on_delta=lambda _text: None,
+                on_progress=on_progress,
+            )
+        self.model_calls += 1
+        return response
 
     def plan_analysis(
         self,
@@ -2818,10 +2961,21 @@ class AnalysisRuntime:
         #
         # These calls count against `max_model_calls` like every other call, so
         # a covered run is bounded exactly as an uncovered one is.
+        # The control counters live on the runtime, which a REPL session
+        # reuses across analyses, so what a run reports has to be its own
+        # delta. Every sibling on the result is per-run; two lifetime totals
+        # among them would over-report the second `/analysis` in a session.
+        control_attempts_at_start = self.control_attempts
+        control_repairs_at_start = self.control_repairs
         covered_calls = 0
         plan_calls = 0
         controller: "AnalysisController | None" = None
+        covered = False
         if cover and not self.source_covered:
+            # COVER owns this block alone. It is an optimisation, and a
+            # backend that refuses it must leave the run exactly as it was --
+            # including PLAN, which is not an optimisation and runs below on
+            # its own terms.
             try:
                 coverage = self.plan_source_coverage()
                 # A call must remain for investigating. Spending the whole
@@ -2836,16 +2990,6 @@ class AnalysisRuntime:
                     # must not now tell the model to go and read it. The
                     # analyst's own line still governs what the run is for.
                     message = analyst_message
-                    # One tools-free call to declare what still needs a tool.
-                    # A ledger of None means it could not be read even after a
-                    # repair, and the run continues exactly as it did before
-                    # this existed -- an unreadable plan is not a bound.
-                    if plan and model_calls < max_model_calls:
-                        controller = AnalysisController()
-                        plan_calls = self.plan_analysis(
-                            controller, analyst_message, on_progress=on_progress
-                        )
-                        model_calls += plan_calls
             except KeyboardInterrupt:
                 cancelled = True
                 stop_reason = STOP_CANCELLED
@@ -2855,6 +2999,49 @@ class AnalysisRuntime:
                 # that refuses it leaves the run as it was and the ordinary
                 # loop below runs unchanged.
                 self._close_incomplete_turn()
+        # Whether the source was covered is read from the history, never from
+        # a local flag: the live failure raised *after* the source was
+        # appended, so an assignment below the call is skipped while the
+        # coverage it describes is real. `source_covered` is derived from the
+        # messages and survives the exception that skipped the flag.
+        covered = self.source_covered
+        # PLAN is attempted whenever coverage succeeded, in its own failure
+        # domain. A backend error here is a planning failure to be reported
+        # honestly -- never a silent slide into an unplanned run.
+        if plan and covered and not cancelled and model_calls < max_model_calls:
+            controller = AnalysisController()
+            try:
+                plan_calls = self.plan_analysis(
+                    controller, analyst_message, on_progress=on_progress
+                )
+                model_calls += plan_calls
+                # `plan_calls` alone does not make a plan valid: a planning
+                # step that returned without adopting one leaves a controller
+                # with no questions and no failure recorded, which reads as an
+                # empty plan the model never actually gave. Validity is
+                # claimed only when the protocol really ran.
+                if controller.unsupported or plan_calls == 0:
+                    # Either the protocol was refused, or planning returned
+                    # without adopting anything. Both leave a controller that
+                    # nobody planned into, and running against it would be the
+                    # unbounded loop wearing a controller's name.
+                    #
+                    # This is what keeps "PLAN never produced a plan" distinct
+                    # from "the plan was empty": an unplanned run is marked
+                    # unsupported and reports as such, while a model that was
+                    # asked and answered "nothing to investigate" leaves the
+                    # controller usable and reaches the ordinary report.
+                    controller.unsupported = True
+            except KeyboardInterrupt:
+                cancelled = True
+                stop_reason = STOP_CANCELLED
+                self._close_incomplete_turn()
+            except (ContextAdmissionError, TimeoutError, RecoverableBackendError):
+                # The protocol could not be driven. Fail closed: mark it, and
+                # let the loop report it as unsupported rather than continue
+                # with a controller nobody planned into.
+                self._close_incomplete_turn()
+                controller.unsupported = True
         shadow = ShadowLedger() if shadow_enabled() else None
         shadow_due = scheduled_actions()
         # Created only when the shadow runs: with the flag off this does no
@@ -3233,6 +3420,8 @@ class AnalysisRuntime:
             completion_shadow=shadow,
             cover_calls=covered_calls,
             plan_calls=plan_calls,
+            control_attempts=self.control_attempts - control_attempts_at_start,
+            control_repairs=self.control_repairs - control_repairs_at_start,
             initial_questions=(
                 sum(1 for q in controller.questions.values() if q.depth == 0)
                 if controller is not None else 0

--- a/tests/test_analysis_controller_runtime.py
+++ b/tests/test_analysis_controller_runtime.py
@@ -8,6 +8,7 @@ active when the call arrived.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import pathlib
 import sys
@@ -29,12 +30,18 @@ from orbit.runtime.analysis_runtime import (  # noqa: E402
     FINISH_TOOL_NAME,
     PLAN_TOOL_NAME,
     STOP_CONTROL_UNSUPPORTED,
+    MAX_CONTROL_ERROR_CHARS,
     STOP_LEDGER_EXHAUSTED,
     AnalysisRuntime,
     AnalysisSource,
     AnalysisWorkspace,
 )
 from orbit.runtime.analysis_sandbox import AnalysisResult  # noqa: E402
+from orbit.backend.llama_server import (  # noqa: E402
+    LlamaServerToolCallParseError,
+    LlamaServerBackend,
+    LlamaServerError,
+)
 from orbit.runtime.evidence import EvidenceStore  # noqa: E402
 
 CTX = 8192
@@ -117,7 +124,9 @@ class _Backend:
 
     def chat_stream(self, messages, **kwargs):
         tools = kwargs.get("tools")
-        self.chat_calls.append({"tools": tools, "messages": list(messages)})
+        self.chat_calls.append(
+            {"tools": tools, "messages": list(messages), "kwargs": dict(kwargs)}
+        )
         last = str(messages[-1].get("content", ""))
         calls = self.model.reply(tools, last) or []
         self.model.calls.extend(calls)
@@ -527,3 +536,640 @@ class PreservedBehaviourTests(_Case):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BackendSignatureTests(_Case):
+    """S. Control calls satisfy the real backend signature, not just the double.
+
+    `_Backend.chat_stream` takes `**kwargs`, so a control call that omitted a
+    required keyword-only argument still passed every scripted test here and
+    then raised TypeError against the live backend -- which is exactly how the
+    missing `on_delta` in `_control_call` reached a live run. These tests bind
+    the arguments actually passed against `LlamaServerBackend.chat_stream`.
+    """
+
+    def test_every_call_binds_against_the_real_backend_signature(self) -> None:
+        signature = inspect.signature(LlamaServerBackend.chat_stream)
+        model = _Model(plan=[_question("a"), _question("b")])
+        runtime = self._runtime(model)
+        self._run(runtime)
+
+        self.assertTrue(self.backend.chat_calls)
+        for call in self.backend.chat_calls:
+            # Raises TypeError if a required keyword-only argument is missing.
+            signature.bind(runtime.backend, call["messages"], **call["kwargs"])
+
+    def test_control_calls_pass_on_delta(self) -> None:
+        model = _Model(plan=[_question("a")])
+        runtime = self._runtime(model)
+        self._run(runtime)
+        control = [c for c in self.backend.chat_calls if c["tools"]]
+        self.assertTrue(control)
+        for call in control:
+            self.assertIn("on_delta", call["kwargs"])
+
+    def test_the_binding_check_would_catch_a_missing_on_delta(self) -> None:
+        # The guard itself must fail when the keyword is absent, or it proves
+        # nothing about the calls above.
+        signature = inspect.signature(LlamaServerBackend.chat_stream)
+        with self.assertRaises(TypeError):
+            signature.bind(
+                object(), [], temperature=0.0, max_tokens=16, tools=[],
+                on_progress=None,
+            )
+
+
+class PlanStateTests(_Case):
+    """T. PLAN_NOT_STARTED and a valid empty plan are different states.
+
+    Proven necessary by a live Ornith run: the COVER reply carried malformed
+    tool-call syntax, the backend raised `LlamaServerError`, and PLAN -- which
+    shared COVER's `try` block -- was skipped with it. The run reached the
+    loop with no controller, which looked exactly like a plan that had asked
+    nothing, and reported as though the analysis were complete. Observed:
+    `cover_calls=1`, `plan_calls=0`, `_control_call` never invoked,
+    `stop_reason="no open question requires an action"`.
+    """
+
+    def _cover_then_raise(self, runtime):
+        """COVER succeeds, then its model call raises -- the live shape.
+
+        The source is appended and coverage is real; the failure lands after
+        it. Nesting PLAN inside COVER's `try` loses planning to this.
+        """
+        real = type(runtime).cover_source
+
+        def wrapper(self_, coverage, **kwargs):
+            # The live shape: coverage completed -- the source was appended
+            # and the call counted -- and the failure landed after it.
+            calls = real(self_, coverage, **kwargs)
+            self_.model_calls += 0
+            wrapper.calls = calls
+            raise LlamaServerError("Failed to parse input at pos 118")
+
+        return mock.patch.object(type(runtime), "cover_source", wrapper)
+
+    def test_a_failure_after_cover_still_lets_planning_run(self) -> None:
+        model = _Model(plan=[_question("a")])
+        runtime = self._runtime(model)
+        with self._cover_then_raise(runtime):
+            run = self._run(runtime)
+        # The regression: PLAN must not be collateral damage of COVER's
+        # failure domain. Either it planned, or it failed closed -- never a
+        # silent unplanned run reported as a finished one.
+        self.assertNotEqual(
+            (run.plan_calls, run.stop_reason), (0, STOP_LEDGER_EXHAUSTED)
+        )
+
+    def test_a_valid_empty_plan_reports(self) -> None:
+        runtime = self._runtime(_Model(plan=[]))
+        run = self._run(runtime)
+        # The model was asked and answered "nothing to investigate". That is
+        # a real answer, and reporting is the correct transition.
+        self.assertGreater(run.plan_calls, 0)
+        self.assertEqual(run.initial_questions, 0)
+        self.assertEqual(run.stop_reason, STOP_LEDGER_EXHAUSTED)
+
+    def test_a_valid_plan_with_questions_activates_the_first(self) -> None:
+        runtime = self._runtime(_Model(plan=[_question("a"), _question("b")]))
+        run = self._run(runtime)
+        self.assertGreater(run.plan_calls, 0)
+        self.assertEqual(run.initial_questions, 2)
+        self.assertEqual(list(run.resolved_questions), ["Q1", "Q2"])
+
+    def test_zero_questions_is_only_ever_a_planned_answer(self) -> None:
+        # `initial_questions == 0` may only be reached by asking. A run that
+        # ends with no questions because PLAN never happened is the state this
+        # whole distinction exists to prevent, so the assertion is on
+        # `plan_calls`, not on the question count.
+        asked = self._runtime(_Model(plan=[]))
+        asked_run = self._run(asked)
+        self.assertEqual(asked_run.initial_questions, 0)
+        self.assertGreater(asked_run.plan_calls, 0)
+
+        # Even with COVER failing, the run that had a question to ask asks it
+        # -- planning is no longer collateral damage.
+        after_failure = self._runtime(_Model(plan=[_question("a")]))
+        with self._cover_then_raise(after_failure):
+            failed_run = self._run(after_failure)
+        self.assertGreater(failed_run.plan_calls, 0)
+        self.assertEqual(failed_run.initial_questions, 1)
+
+    def test_an_unplanned_covered_run_never_enters_the_free_form_loop(self) -> None:
+        # No controller after a covered run means nothing bounds the loop.
+        # That is the unbounded autonomy the controller replaced, so it must
+        # fail closed rather than execute actions. `plan_analysis` is replaced
+        # by one that returns without building a controller -- the exact
+        # residue a skipped or half-run planning step leaves behind.
+        runtime = self._runtime(_Model(plan=[_question("a")]))
+
+        # A controller that never adopted a plan and never reported failure:
+        # no questions, not unsupported. The loop must still refuse to run
+        # free-form actions against it.
+        def no_controller(self_, controller, message, **kwargs):
+            return 0
+
+        with mock.patch.object(type(runtime), "plan_analysis", no_controller):
+            run = self._run(runtime)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.stop_reason, STOP_CONTROL_UNSUPPORTED)
+
+    def test_a_backend_failure_during_planning_fails_closed(self) -> None:
+        # PLAN raising is not a reason to run unplanned: the controller is
+        # marked unsupported and the run reports, with no action executed.
+        runtime = self._runtime(_Model(plan=[_question("a")]))
+
+        def raising(self_, controller, message, **kwargs):
+            raise LlamaServerError("planning call failed")
+
+        with mock.patch.object(type(runtime), "plan_analysis", raising):
+            run = self._run(runtime)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.stop_reason, STOP_CONTROL_UNSUPPORTED)
+
+
+class PlanBackendErrorTests(_Case):
+    """U. A backend error during PLAN is a planning failure, not a skipped plan.
+
+    The live Ornith cause, reproduced without inference. The server raised
+
+        LlamaServerError: Failed to parse input at pos 118: <tool_call>
+        <function=execute_analysis> ...
+
+    from `chat.cpp`'s tool-call grammar parser: PLAN offers only
+    `submit_analysis_plan`, the model answered with an `execute_analysis` call
+    in a format the grammar could not accept, and the native server reported a
+    parse error rather than a message. The exception surfaced inside
+    `_control_call`, on the first and only control call PLAN makes.
+
+    What is pinned here is the runtime's response to it, not the model's
+    output: `_control_call` is reached, the failure is attributed to planning,
+    and the run fails closed instead of proceeding unplanned.
+    """
+
+    def _raising_backend(self, runtime, exc):
+        real = type(runtime.backend).chat_stream
+
+        def wrapper(self_, messages, **kwargs):
+            names = [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+            if PLAN_TOOL_NAME in names:
+                raise exc
+            return real(self_, messages, **kwargs)
+
+        return mock.patch.object(type(runtime.backend), "chat_stream", wrapper)
+
+    def test_the_plan_call_is_reached_before_the_failure(self) -> None:
+        runtime = self._runtime(_Model(plan=[_question("a")]))
+        seen: list[str] = []
+        real_control = type(runtime)._control_call
+
+        def counting(self_, messages, schema, **kwargs):
+            seen.append(schema["function"]["name"])
+            return real_control(self_, messages, schema, **kwargs)
+
+        with mock.patch.object(type(runtime), "_control_call", counting):
+            with self._raising_backend(
+                runtime, LlamaServerError("Failed to parse input at pos 118")
+            ):
+                self._run(runtime)
+        # PLAN is not skipped: it is attempted, once, and fails there.
+        self.assertEqual(seen, [PLAN_TOOL_NAME])
+
+    def test_a_parse_error_during_planning_fails_closed(self) -> None:
+        runtime = self._runtime(_Model(plan=[_question("a")]))
+        with self._raising_backend(
+            runtime, LlamaServerError("Failed to parse input at pos 118")
+        ):
+            run = self._run(runtime)
+        self.assertEqual(run.stop_reason, STOP_CONTROL_UNSUPPORTED)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.initial_questions, 0)
+
+    def test_a_healthy_plan_call_is_made_exactly_once(self) -> None:
+        # The invariant the failing runs are measured against:
+        # PLAN_NOT_STARTED -> plan_analysis -> one control call -> plan_calls 1.
+        runtime = self._runtime(_Model(plan=[_question("a")]))
+        seen: list[str] = []
+        real_control = type(runtime)._control_call
+
+        def counting(self_, messages, schema, **kwargs):
+            seen.append(schema["function"]["name"])
+            return real_control(self_, messages, schema, **kwargs)
+
+        with mock.patch.object(type(runtime), "_control_call", counting):
+            run = self._run(runtime)
+        self.assertEqual(seen.count(PLAN_TOOL_NAME), 1)
+        self.assertEqual(run.plan_calls, 1)
+        self.assertEqual(run.initial_questions, 1)
+
+
+class _StrictBackend(_Backend):
+    """A double that refuses what the real backend would refuse.
+
+    `_Backend` takes `**kwargs`, so a call missing a required keyword-only
+    argument passes here and fails only against a live server -- which is how
+    a missing `on_delta` reached production. This one binds every call against
+    `LlamaServerBackend.chat_stream` before answering it, and can be told to
+    raise a chosen exception on the phase under test.
+    """
+
+    def __init__(self, model, failures=None) -> None:
+        super().__init__(model)
+        # One entry per *control* call, popped in order: an exception to
+        # raise, or None to answer normally. Tools-free calls -- COVER and the
+        # report -- are never affected, so a test can fail exactly the phase
+        # it is about.
+        self.failures = list(failures or [])
+        self.attempts: list[str] = []
+
+    def chat_stream(self, messages, **kwargs):
+        inspect.signature(LlamaServerBackend.chat_stream).bind(
+            self, messages, **kwargs
+        )
+        names = [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+        control = [n for n in names if n in (PLAN_TOOL_NAME, FINISH_TOOL_NAME)]
+        if control:
+            self.attempts.append(control[0])
+            if self.failures:
+                failure = self.failures.pop(0)
+                if failure is not None:
+                    raise failure
+        return super().chat_stream(messages, **kwargs)
+
+
+class ControlRepairTests(_Case):
+    """V. One bounded repair when the model's output could not be parsed.
+
+    The live cause: PLAN offered only `submit_analysis_plan` while the system
+    prompt still told the model to run `execute_analysis`. The model followed
+    the prose, and the server's tool-call grammar refused to parse the reply
+    into a message at all -- so there was no assistant message to reject
+    structurally, only a `ToolCallParseError`.
+    """
+
+    def _strict(self, model, failures=None, data: bytes = None):
+        data = SOURCE.encode() if data is None else data
+        self.backend = _StrictBackend(model, failures)
+        workspace = AnalysisWorkspace.create()
+        path = workspace.source_root / "artifact.py"
+        path.write_bytes(data)
+        runtime = AnalysisRuntime(
+            backend=self.backend,
+            source=AnalysisSource(
+                snapshot_path=path, sha256=hashlib.sha256(data).hexdigest(),
+                size_bytes=len(data), original_path=str(path),
+            ),
+            evidence_store=EvidenceStore(root=workspace.root / "evidence"),
+            workspace=workspace,
+        )
+        self.addCleanup(runtime.close)
+        return runtime
+
+    # A. healthy PLAN: one attempt, one adopted plan, no repair.
+    def test_a_healthy_plan_needs_no_repair(self) -> None:
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        run = self._run(runtime)
+        self.assertEqual(run.plan_calls, 1)
+        self.assertEqual(run.control_repairs, 0)
+        self.assertEqual(run.initial_questions, 1)
+        self.assertGreater(run.control_attempts, 0)
+
+    # B. first call parse-fails, the repair succeeds, the plan is adopted.
+    def test_a_parse_failure_is_repaired_once(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[LlamaServerToolCallParseError("Failed to parse input at pos 118")],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.control_repairs, 1)
+        self.assertEqual(run.initial_questions, 1)
+        self.assertEqual(list(run.resolved_questions), ["Q1"])
+
+    # C. both the call and its repair parse-fail: unsupported, no fallback.
+    def test_a_second_parse_failure_is_unsupported(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[
+                LlamaServerToolCallParseError("Failed to parse input at pos 118"),
+                LlamaServerToolCallParseError("Failed to parse input at pos 118"),
+            ],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.stop_reason, STOP_CONTROL_UNSUPPORTED)
+        self.assertEqual(run.actions_executed, 0)
+        self.assertEqual(run.control_repairs, 1)
+
+    # D. a generic backend error is not a format repair.
+    def test_a_generic_backend_error_is_not_repaired(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[LlamaServerError("llama_decode failed")],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.control_repairs, 0)
+        self.assertEqual(run.stop_reason, STOP_CONTROL_UNSUPPORTED)
+        self.assertEqual(run.actions_executed, 0)
+
+    # E. the PLAN request carries no instruction to run an analysis action.
+    def test_the_plan_request_offers_no_analysis_instruction(self) -> None:
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        seen: list[list[dict]] = []
+        real = type(runtime.backend).chat_stream
+
+        def spy(self_, messages, **kwargs):
+            names = [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+            if PLAN_TOOL_NAME in names:
+                seen.append([dict(m) for m in messages])
+            return real(self_, messages, **kwargs)
+
+        with mock.patch.object(type(runtime.backend), "chat_stream", spy):
+            self._run(runtime)
+        self.assertTrue(seen)
+        for context in seen:
+            body = "\n".join(str(m.get("content") or "") for m in context)
+            self.assertNotIn(ANALYSIS_TOOL_NAME, body)
+
+    # F. a valid control call with empty prose is still accepted.
+    def test_empty_prose_with_a_valid_call_is_accepted(self) -> None:
+        model = _Model(plan=[_question("a")])
+        model.prose = ""
+        runtime = self._strict(model)
+        run = self._run(runtime)
+        self.assertEqual(run.initial_questions, 1)
+        self.assertEqual(list(run.resolved_questions), ["Q1"])
+
+    # G. the same repair covers a question completion, not only PLAN.
+    def test_a_completion_parse_failure_is_repaired_once(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            # PLAN answers normally; the failure lands on the finish call,
+            # which is the other structured control phase.
+            failures=[None, LlamaServerToolCallParseError("Failed to parse input at pos 4")],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.control_repairs, 1)
+        self.assertEqual(run.initial_questions, 1)
+
+    # H. every dispatched call satisfies the real backend signature.
+    def test_every_control_call_binds_against_the_real_signature(self) -> None:
+        # `_StrictBackend` binds on every call, so reaching the end is the
+        # assertion; this pins that control calls were actually made.
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        run = self._run(runtime)
+        self.assertIn(PLAN_TOOL_NAME, self.backend.attempts)
+        self.assertGreater(run.control_attempts, 0)
+
+    # I. a failed PLAN does not erase the coverage that already happened.
+    def test_cover_is_still_recorded_when_planning_fails(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[
+                LlamaServerToolCallParseError("Failed to parse input at pos 1"),
+                LlamaServerToolCallParseError("Failed to parse input at pos 1"),
+            ],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.cover_calls, 1)
+        self.assertTrue(runtime.source_covered)
+
+    # J. an attempt that raises is still an attempt.
+    def test_attempts_count_calls_that_raise(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[
+                LlamaServerToolCallParseError("Failed to parse input at pos 1"),
+                LlamaServerToolCallParseError("Failed to parse input at pos 1"),
+            ],
+        )
+        run = self._run(runtime)
+        # Both the first call and its repair raised before returning; both
+        # reached the model and both must be visible.
+        self.assertEqual(run.control_attempts, 2)
+        self.assertEqual(run.plan_calls, 0)
+
+
+class ControlRepairPromptTests(ControlRepairTests):
+    """W. What the repair turn actually says, and what survives a failure."""
+
+    def _repair_prompt(self, runtime) -> str:
+        seen: list[str] = []
+        real = type(runtime.backend).chat_stream
+
+        def spy(self_, messages, **kwargs):
+            names = [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+            if any(n in (PLAN_TOOL_NAME, FINISH_TOOL_NAME) for n in names):
+                seen.append(str(messages[-1].get("content") or ""))
+            return real(self_, messages, **kwargs)
+
+        with mock.patch.object(type(runtime.backend), "chat_stream", spy):
+            self._run(runtime)
+        return "\n".join(seen)
+
+    def test_the_repair_names_the_allowed_tool(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[LlamaServerToolCallParseError("Failed to parse input at pos 118")],
+        )
+        prompt = self._repair_prompt(runtime)
+        # The model has to be told which call is accepted, by name: the whole
+        # failure was it reaching for a tool this phase does not offer.
+        #
+        # Asserted on the repair sentence itself, not the whole prompt: the
+        # original planning instruction already names the tool, so a prompt
+        # -wide check passes even when the repair says nothing useful.
+        repair = [
+            line for line in prompt.splitlines()
+            if "This phase accepts only" in line
+        ]
+        self.assertTrue(repair, "the repair turn was not issued")
+        self.assertIn(PLAN_TOOL_NAME, repair[0])
+
+    def test_the_repair_never_offers_the_analysis_tool(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[LlamaServerToolCallParseError("Failed to parse input at pos 118")],
+        )
+        seen: list[list[str]] = []
+        real = type(runtime.backend).chat_stream
+
+        def spy(self_, messages, **kwargs):
+            names = [t["function"]["name"] for t in (kwargs.get("tools") or [])]
+            # Control phases only: a RESOLVE step legitimately offers the
+            # analysis tool, and that is not what this is about.
+            if any(n in (PLAN_TOOL_NAME, FINISH_TOOL_NAME) for n in names):
+                seen.append(names)
+            return real(self_, messages, **kwargs)
+
+        with mock.patch.object(type(runtime.backend), "chat_stream", spy):
+            self._run(runtime)
+        self.assertTrue(seen)
+        for offered in seen:
+            self.assertNotIn(ANALYSIS_TOOL_NAME, offered)
+            self.assertEqual(len(offered), 1)
+
+    def test_the_quoted_failure_is_bounded_and_single_line(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[
+                LlamaServerToolCallParseError(
+                    "Failed to parse input at pos 118: " + "<tool_call>\n" * 400
+                )
+            ],
+        )
+        prompt = self._repair_prompt(runtime)
+        marker = "could not be parsed: "
+        self.assertIn(marker, prompt)
+        # Take everything after the marker up to the instruction that
+        # follows, NOT up to the first newline -- splitting on the newline
+        # would hide exactly the failure this is meant to catch.
+        rest = prompt.split(marker, 1)[1]
+        quoted = rest.split("This phase accepts only", 1)[0].rstrip("\n")
+        # Untrusted model output, quoted back: bounded, and on one line so it
+        # cannot forge the instruction that follows it.
+        self.assertLessEqual(len(quoted), MAX_CONTROL_ERROR_CHARS + 3)
+        self.assertNotIn("\n", quoted)
+
+    def test_coverage_survives_a_cancelled_run(self) -> None:
+        # `covered` is read from the history, so it reports what the model
+        # actually holds -- not whether this run happened to finish.
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        self._run(runtime)
+        self.assertTrue(runtime.source_covered)
+        # Still true on a second look: it is derived, not a one-shot flag.
+        self.assertTrue(runtime.source_covered)
+
+
+class ControlContextTests(unittest.TestCase):
+    """X. The transient control context states one contract, whatever it wraps."""
+
+    def _roles(self, messages):
+        return [m["role"] for m in module._control_context(list(messages))]
+
+    def test_the_system_turn_is_replaced(self) -> None:
+        out = module._control_context(
+            [{"role": "system", "content": "run execute_analysis"},
+             {"role": "user", "content": "u"}]
+        )
+        self.assertIn("control turn", str(out[0]["content"]))
+        self.assertNotIn("execute_analysis", str(out[0]["content"]))
+
+    def test_a_context_without_a_system_turn_gains_one(self) -> None:
+        out = module._control_context([{"role": "user", "content": "u"}])
+        self.assertEqual(out[0]["role"], "system")
+        self.assertIn("control turn", str(out[0]["content"]))
+
+    def test_every_system_turn_is_replaced_not_only_the_first(self) -> None:
+        # Production appends exactly one, but a second would be another place
+        # the analysis instruction could reappear.
+        out = module._control_context(
+            [{"role": "system", "content": "first"},
+             {"role": "user", "content": "u"},
+             {"role": "system", "content": "run execute_analysis"}]
+        )
+        systems = [m for m in out if m["role"] == "system"]
+        self.assertEqual(len(systems), 1)
+        self.assertNotIn("execute_analysis", str(systems[0]["content"]))
+
+    def test_the_caller_list_is_not_mutated(self) -> None:
+        original = [{"role": "system", "content": "S"},
+                    {"role": "user", "content": "u"}]
+        module._control_context(original)
+        self.assertEqual(original[0]["content"], "S")
+
+
+class ControlIsolationTests(ControlRepairTests):
+    """Y. What a repair costs, and where it is not allowed to appear."""
+
+    def test_the_repair_never_reaches_the_permanent_history(self) -> None:
+        runtime = self._strict(
+            _Model(plan=[_question("a")]),
+            failures=[LlamaServerToolCallParseError("Failed to parse input at pos 118")],
+        )
+        run = self._run(runtime)
+        self.assertEqual(run.control_repairs, 1)
+        history = "\n".join(
+            str(m.get("content") or "") for m in runtime.messages
+        )
+        # The repair is transient. Control bookkeeping in the append-only
+        # record would make the permanent history grow with every prompt the
+        # protocol needed.
+        for marker in (
+            "could not be parsed",
+            "This phase accepts only",
+            "This is a control turn",
+            PLAN_TOOL_NAME,
+            FINISH_TOOL_NAME,
+        ):
+            self.assertNotIn(marker, history)
+
+    def test_a_repair_is_charged_against_the_model_call_ceiling(self) -> None:
+        # The repair is a real model call, counted inside `_control_dispatch`.
+        # If it were not, a phase that repairs could spend more of the budget
+        # than the ceiling allows -- so the property to pin is the ceiling
+        # itself, under repeated repairs, not a fixed call count.
+        for cap in (2, 3, 5, 8):
+            with self.subTest(cap=cap):
+                runtime = self._strict(
+                    _Model(plan=[_question("a"), _question("b")]),
+                    failures=[
+                        LlamaServerToolCallParseError("Failed to parse at pos 1"),
+                        None,
+                        None,
+                        LlamaServerToolCallParseError("Failed to parse at pos 2"),
+                        None,
+                        None,
+                    ],
+                )
+                counter = {"n": 0}
+
+                def distinct(**_kwargs):
+                    counter["n"] += 1
+                    return AnalysisResult(
+                        status="ok", code_sha256=f"{counter['n']:064d}",
+                        input_sha256="i" * 64, stdout="x", stderr="",
+                        exit_status=0, duration_seconds=0.1,
+                    )
+
+                with mock.patch.object(module, "execute_analysis", distinct):
+                    run = runtime.run_autonomous(
+                        "Analyse it.", finalize=False, max_model_calls=cap
+                    )
+                # The documented allowance is the ceiling plus one closing
+                # report call. A repair must not buy a call beyond it.
+                self.assertLessEqual(run.model_calls, cap + 1)
+                # And every control call is charged: `model_calls` must
+                # account for at least the control attempts this run made.
+                # Without that, an uncounted control call is free budget --
+                # the ceiling stops bounding the phase that repairs.
+                self.assertGreaterEqual(run.model_calls, run.control_attempts)
+
+    def test_the_counters_report_one_run_not_a_session(self) -> None:
+        # The counters live on the runtime, which a REPL session reuses. Every
+        # other field on the result is per-run; these must be too.
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        first = self._run(runtime)
+        second = self._run(runtime)
+        self.assertEqual(second.control_attempts, first.control_attempts)
+        self.assertEqual(second.control_repairs, first.control_repairs)
+
+    def test_one_control_dispatch_charges_exactly_one_model_call(self) -> None:
+        # Measured at the dispatch itself, not through a whole run: other
+        # phases also charge `model_calls`, so a run-level inequality stays
+        # true even when control calls stop being counted. An uncounted
+        # control call is free budget, and the ceiling stops bounding the
+        # phase that repairs.
+        runtime = self._strict(_Model(plan=[_question("a")]))
+        before_calls = runtime.model_calls
+        before_attempts = runtime.control_attempts
+        runtime._control_call(
+            [{"role": "user", "content": "x"}], module.PLAN_TOOL_SCHEMA
+        )
+        self.assertEqual(runtime.model_calls - before_calls, 1)
+        self.assertEqual(runtime.control_attempts - before_attempts, 1)
+
+    def test_the_sanitiser_collapses_whitespace(self) -> None:
+        text = module._sanitise_control_error(
+            RuntimeError("line one\nline two\r\n\tline three")
+        )
+        self.assertNotIn("\n", text)
+        self.assertEqual(text, "line one line two line three")

--- a/tests/test_llama_server_backend.py
+++ b/tests/test_llama_server_backend.py
@@ -16,6 +16,7 @@ if str(SRC) not in sys.path:
 from orbit.backend.llama_server import (
     LlamaServerBackend,
     LlamaServerError,
+    LlamaServerToolCallParseError,
     _enrich_model_info_with_props,
     _parse_chat_result,
     _parse_chat_stream,
@@ -25,7 +26,7 @@ from orbit.backend.llama_server import (
     _qwen_route_prefix_anchor_requested,
     _qwen36_shell_tool_prefix_anchor_requested,
 )
-from orbit.backend.base import ChatResult
+from orbit.backend.base import ChatResult, ToolCallParseError
 from orbit.backend.payloads import (
     ARTIFACT_CONTENT_PROTOCOL_ID,
     ARTIFACT_CONTENT_PROTOCOL_VERSION,
@@ -1564,3 +1565,71 @@ class LlamaServerBackendTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ToolCallParseErrorClassificationTests(unittest.TestCase):
+    """The narrow output-parse failure is typed once, at the boundary.
+
+    The server's tool-call grammar can refuse to parse a model's output into a
+    message at all. That is a failure the model itself could correct if asked
+    again, unlike a decode failure or a dead transport, so it gets its own
+    type here -- where output parsing is owned -- rather than being
+    string-matched by every runtime that wants to react to it.
+    """
+
+    def _stream(self, message: str):
+        return FakeStream(
+            [
+                "event: error\n",
+                "data: " + json.dumps({"message": message}) + "\n",
+                "\n",
+            ]
+        )
+
+    def test_a_grammar_parse_failure_is_typed_narrowly(self) -> None:
+        raw = (
+            "Failed to parse input at pos 118: <tool_call>\n"
+            "<function=execute_analysis>"
+        )
+        with self.assertRaises(ToolCallParseError) as caught:
+            _parse_native_stream(
+                self._stream(raw), on_delta=lambda _t: None, on_progress=None
+            )
+        # Still a LlamaServerError, so existing handlers are unaffected.
+        self.assertIsInstance(caught.exception, LlamaServerError)
+        self.assertIn("pos 118", str(caught.exception))
+
+    def test_the_match_is_case_insensitive(self) -> None:
+        with self.assertRaises(ToolCallParseError):
+            _parse_native_stream(
+                self._stream("FAILED TO PARSE INPUT AT POS 4: junk"),
+                on_delta=lambda _t: None,
+                on_progress=None,
+            )
+
+    def test_other_server_errors_are_not_output_parse_failures(self) -> None:
+        # Each of these means the model was never given a fair chance to
+        # answer, so re-prompting would spend a call to fail the same way.
+        for message in (
+            "llama_decode failed",
+            "failed to load model",
+            "context window exceeded",
+            "request cancelled",
+            "native stream error",
+        ):
+            with self.subTest(message=message):
+                with self.assertRaises(LlamaServerError) as caught:
+                    _parse_native_stream(
+                        self._stream(message),
+                        on_delta=lambda _t: None,
+                        on_progress=None,
+                    )
+                self.assertNotIsInstance(caught.exception, ToolCallParseError)
+
+    def test_an_error_event_without_a_message_is_generic(self) -> None:
+        stream = FakeStream(["event: error\n", "data: {}\n", "\n"])
+        with self.assertRaises(LlamaServerError) as caught:
+            _parse_native_stream(
+                stream, on_delta=lambda _t: None, on_progress=None
+            )
+        self.assertNotIsInstance(caught.exception, ToolCallParseError)


### PR DESCRIPTION
A live run against a local 35B model could not plan at all. The cause was an
instruction Orbit itself supplied: the PLAN turn offers exactly one tool,
`submit_analysis_plan`, but it carried the ordinary ANALYSIS system prompt,
which says "Inspect and transform it by writing Python and running it with
execute_analysis" and "Perform at most one execute_analysis action per turn".
The model followed the prose, emitted an `execute_analysis` call, and the
server's tool-call grammar refused to parse the reply into a message at all --
so there was no assistant message to reject structurally, only a
`LlamaServerError: Failed to parse input at pos 118`.

A control phase now states its own contract. `_control_context` substitutes a
control-phase system prompt for the system turn, in the transient control
context only: the permanent history keeps the ordinary prompt, because that is
what the RESOLVE steps run under. The PLAN request no longer mentions a tool it
does not offer.

The parse failure is typed once, where output parsing is owned. `_stream_error`
classifies the server's message at the backend boundary and raises
`ToolCallParseError` -- narrower than its parent on purpose. The model answered,
and the answer was in a shape the grammar refuses, which is something the model
itself could correct if asked again. A decode failure, a dead transport, a
cancelled request, a model that would not load and a context refusal all stay
generic: re-prompting those spends a call to fail the same way.
`LlamaServerToolCallParseError` inherits both types, so every existing
`except LlamaServerError` handler is unaffected.

`_control_call` catches only that type and issues exactly one repair turn,
offering the same single tool and naming it, quoting a bounded single-line
description of what went wrong. The repair calls `_control_dispatch` rather than
itself, so a second failure cannot recurse -- it propagates, the controller is
marked unsupported, and the run reports honestly. This covers question
completion too, not only PLAN.

Two correctness defects the same run exposed:

COVER and PLAN shared one `try`. A COVER failure skipped planning as collateral,
and the run reached the loop with no controller -- indistinguishable from a plan
that legitimately asked nothing. They are separate failure domains now.

`covered` was a local flag assigned after the COVER call, so an exception raised
after the source was appended unwound past it. A genuinely covered run then read
as uncovered and fell into the free-form loop this controller exists to replace
-- twelve actions, unbounded. It is derived from `source_covered`, which is read
from the history and survives the exception.

`plan_calls == 0` had meant both "planning never ran" and "planning raised on
its first call". `control_attempts` is incremented at dispatch, before the
backend can raise, and `control_repairs` counts repairs; both report the run,
not the session, since a REPL reuses the runtime. `plan_calls` keeps its
meaning.

Qualified: 16 mutants of the new surface, all caught. Full suite 4663 OK
(skipped=8). Independent review: BLOCKER 0, MAJOR 0; its five MINORs are
closed here.
