### PR TITLE
fix(analysis): contain cancellation and backend failure during completion

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -1001,6 +1001,12 @@ STOP_MAX_ACTIONS = "action bound reached"
 STOP_SOFT_MAX_ACTIONS = "action budget reached without further progress"
 STOP_MAX_MODEL_CALLS = "model call bound reached"
 STOP_CANCELLED = "cancelled"
+# Why a question has no outcome when the analyst stops mid-completion.
+# Named so the dossier a guided follow-up reads and the test that proves
+# it bind to one string rather than to two copies of it.
+CANCELLED_QUESTION_REASON = (
+    "the analyst stopped the run before this question was closed"
+)
 STOP_BACKEND_ERROR = "backend error"
 
 MAX_SESSION_SCRATCH_BYTES = 64 * 1024 * 1024
@@ -2072,6 +2078,12 @@ class AnalysisRuntime:
             max_tokens=self.effective_max_tokens,
             tools=[ANALYSIS_TOOL_SCHEMA],
         )
+        # Counted at dispatch: a call that raises still reached the model and
+        # still cost a turn, and a counter that only counts successes reports
+        # a failed step as one that never ran. Deliberately AFTER `_admit`,
+        # which refuses before any request is sent -- a refusal reached no
+        # model and must not be billed as a call.
+        self.model_calls += 1
         with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
             response = self.backend.chat_stream(
                 admitted,
@@ -2081,7 +2093,6 @@ class AnalysisRuntime:
                 on_delta=_capture,
                 on_progress=on_progress,
             )
-        self.model_calls += 1
         call_seconds = time.monotonic() - call_started
 
         calls = self._with_canonical_call_ids(response.tool_calls or [])
@@ -2559,6 +2570,9 @@ class AnalysisRuntime:
             if on_delta is not None and text:
                 on_delta(text)
 
+        # Counted before the call, as everywhere else: a call that raises
+        # still reached the model and still cost a turn.
+        self.model_calls += 1
         with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
                 admitted,
@@ -2568,7 +2582,6 @@ class AnalysisRuntime:
                 on_delta=_capture,
                 on_progress=on_progress,
             )
-        self.model_calls += 1
         content = response.content or ""
         if _unencodable(content):
             content = content.encode("utf-8", "replace").decode("utf-8")
@@ -2653,11 +2666,13 @@ class AnalysisRuntime:
     ):
         """One control call to the backend. Counted at dispatch.
 
-        The counter is incremented before the call, not after it returns: a
-        call that raises still reached the model and still cost a turn, and a
-        counter that only counts successes reports a failing phase as one that
-        never ran. That is exactly what made a live parse failure look like a
-        planning step that was never attempted.
+        Both counters are incremented before the call, not after it returns:
+        a call that raises still reached the model and still cost a turn, and
+        a counter that only counts successes reports a failing phase as one
+        that never ran. That is exactly what made a live parse failure look
+        like a planning step that was never attempted -- and, while
+        `model_calls` was still incremented after the return, it made every
+        cancelled run report one model call fewer than it made.
         """
         admitted = self._admit(
             _control_context(messages),
@@ -2666,6 +2681,12 @@ class AnalysisRuntime:
             next_action_reserve=0,
         )
         self.control_attempts += 1
+        # Counted here, beside `control_attempts`, for the reason the
+        # docstring gives: a call that raises still reached the model and
+        # still cost a turn. Incrementing after `chat_stream` returned meant
+        # an interrupted or failed control call was spent and never counted,
+        # so every cancelled run reported one model call fewer than it made.
+        self.model_calls += 1
         with model_call_context(phase=ANALYSIS_STEP_PHASE, tools_mode="on"):
             response = self.backend.chat_stream(
                 admitted,
@@ -2680,7 +2701,6 @@ class AnalysisRuntime:
                 on_delta=lambda _text: None,
                 on_progress=on_progress,
             )
-        self.model_calls += 1
         return response
 
     def plan_analysis(
@@ -2971,6 +2991,11 @@ class AnalysisRuntime:
         plan_calls = 0
         controller: "AnalysisController | None" = None
         covered = False
+        # Measured across the whole COVER attempt, for the same reason as
+        # PLAN and the completion below: the handlers here leave by paths
+        # that return nothing, so a call that reached the model and then
+        # failed was spent and never counted.
+        cover_spent_before = self.model_calls
         if cover and not self.source_covered:
             # COVER owns this block alone. It is an optimisation, and a
             # backend that refuses it must leave the run exactly as it was --
@@ -2985,16 +3010,18 @@ class AnalysisRuntime:
                     covered_calls = self.cover_source(
                         coverage, on_progress=on_progress, on_delta=on_delta
                     )
-                    model_calls += covered_calls
+                    model_calls += self.model_calls - cover_spent_before
                     # The source has been supplied; the standing instruction
                     # must not now tell the model to go and read it. The
                     # analyst's own line still governs what the run is for.
                     message = analyst_message
             except KeyboardInterrupt:
+                model_calls += self.model_calls - cover_spent_before
                 cancelled = True
                 stop_reason = STOP_CANCELLED
                 self._close_incomplete_turn()
             except (ContextAdmissionError, TimeoutError, RecoverableBackendError):
+                model_calls += self.model_calls - cover_spent_before
                 # Coverage is an optimisation, never a precondition. A backend
                 # that refuses it leaves the run as it was and the ordinary
                 # loop below runs unchanged.
@@ -3010,11 +3037,17 @@ class AnalysisRuntime:
         # honestly -- never a silent slide into an unplanned run.
         if plan and covered and not cancelled and model_calls < max_model_calls:
             controller = AnalysisController()
+            # Measured, not returned -- the same reason as the completion
+            # call below. `plan_analysis` reports its spend on the way out,
+            # and the handlers underneath leave by paths that return nothing,
+            # so a planning call that reached the model and then failed was
+            # spent and never counted.
+            plan_spent_before = self.model_calls
             try:
                 plan_calls = self.plan_analysis(
                     controller, analyst_message, on_progress=on_progress
                 )
-                model_calls += plan_calls
+                model_calls += self.model_calls - plan_spent_before
                 # `plan_calls` alone does not make a plan valid: a planning
                 # step that returned without adopting one leaves a controller
                 # with no questions and no failure recorded, which reads as an
@@ -3033,10 +3066,12 @@ class AnalysisRuntime:
                     # controller usable and reaches the ordinary report.
                     controller.unsupported = True
             except KeyboardInterrupt:
+                model_calls += self.model_calls - plan_spent_before
                 cancelled = True
                 stop_reason = STOP_CANCELLED
                 self._close_incomplete_turn()
             except (ContextAdmissionError, TimeoutError, RecoverableBackendError):
+                model_calls += self.model_calls - plan_spent_before
                 # The protocol could not be driven. Fail closed: mark it, and
                 # let the loop report it as unsupported rather than continue
                 # with a controller nobody planned into.
@@ -3064,6 +3099,9 @@ class AnalysisRuntime:
             except Exception:  # noqa: BLE001 - diagnostics never end a run
                 shadow_ledger = None
 
+        # Set when a completion call fails, so the step it belonged to is
+        # still classified and rendered before the loop ends.
+        ended = False
         while not cancelled:
             if model_calls >= max_model_calls:
                 stop_reason = STOP_MAX_MODEL_CALLS
@@ -3104,6 +3142,11 @@ class AnalysisRuntime:
                     # regardless of what was asked.
                     stop_reason = STOP_LEDGER_EXHAUSTED
                     break
+            # Measured, like COVER, PLAN and the completion: `step()` reports
+            # its spend in the result it returns, and both handlers below
+            # leave without one, so a step whose call reached the model and
+            # then failed was spent and never counted.
+            step_spent_before = self.model_calls
             try:
                 step = self.step(
                     message,
@@ -3118,6 +3161,7 @@ class AnalysisRuntime:
                 # What ran already stands. `step()` has committed its own
                 # history and evidence, or rewound nothing; the analyst keeps
                 # the session either way.
+                model_calls += self.model_calls - step_spent_before
                 cancelled = True
                 stop_reason = STOP_CANCELLED
                 self._close_incomplete_turn()
@@ -3165,13 +3209,14 @@ class AnalysisRuntime:
                     # known not to fit.
                     message = analyst_message
                     continue
+                model_calls += self.model_calls - step_spent_before
                 error = f"{type(exc).__name__}: {exc}"
                 stop_reason = f"{STOP_BACKEND_ERROR}: {error}"
                 self._close_incomplete_turn()
                 break
 
             steps.append(step)
-            model_calls += step.model_calls
+            model_calls += self.model_calls - step_spent_before
             if step.action_executed:
                 actions += 1
             if step.suppressed_duplicate_of is not None:
@@ -3187,18 +3232,104 @@ class AnalysisRuntime:
                 # is parsed out of the reply and nothing was asked of the model.
                 controller.record_action()
                 if model_calls < max_model_calls:
-                    model_calls += self.finish_question(
-                        controller, active,
-                        self.evidence_store.raw_excerpt(step.evidence)
-                        if step.evidence else "",
-                        step.evidence.evidence_id if step.evidence else "",
-                        on_progress=on_progress,
-                    )
+                    # Measured rather than returned. `finish_question` reports
+                    # its spend on the way out, and an interrupt leaves by a
+                    # path that has no way out -- so the calls it had already
+                    # made vanished from the total the analyst is shown. The
+                    # runtime's own counter is incremented at dispatch, before
+                    # the backend can raise, so reading it here is exact
+                    # whether the call returned or was interrupted.
+                    spent_before = self.model_calls
+                    try:
+                        self.finish_question(
+                            controller, active,
+                            self.evidence_store.raw_excerpt(step.evidence)
+                            if step.evidence else "",
+                            step.evidence.evidence_id if step.evidence else "",
+                            on_progress=on_progress,
+                        )
+                        model_calls += self.model_calls - spent_before
+                    except KeyboardInterrupt:
+                        model_calls += self.model_calls - spent_before
+                        # The completion is a model call like every other one
+                        # here, and every other one is guarded: an interrupt
+                        # that propagates unwinds to a caller holding only a
+                        # pre-run checkpoint, and rewinding to that point
+                        # deletes the history and provenance of every step
+                        # that already succeeded -- leaving their evidence
+                        # durable on disk with nothing referring to it. This
+                        # call was the omission.
+                        #
+                        # The action ran and its evidence stands. What is
+                        # missing is only the question's outcome, so the
+                        # question is blocked with that reason rather than
+                        # resolved: nothing recorded an answer, so nothing
+                        # may claim one.
+                        controller.exhaust_active(CANCELLED_QUESTION_REASON)
+                        cancelled = True
+                        stop_reason = STOP_CANCELLED
+                        # Deliberately not `break` here. The action already
+                        # ran and is already in `steps`, and every step
+                        # reaches the analyst through `on_step` below --
+                        # leaving directly skipped its classification, broke
+                        # len(steps) == len(progress), and meant the REPL
+                        # (which renders autonomous steps ONLY through
+                        # `on_step`) never showed the last executed action's
+                        # evidence id at all.
+                        #
+                        # The flag is load-bearing here too, not merely
+                        # symmetric with the outage path below. `while not
+                        # cancelled` ends the loop only at the NEXT iteration,
+                        # so without this the rest of THIS one still runs --
+                        # and when the completion shadow is due, that spends a
+                        # real generation summarising a run the analyst just
+                        # asked to stop.
+                        ended = True
+                    except (
+                        ContextAdmissionError, TimeoutError,
+                        RecoverableBackendError,
+                    ) as exc:
+                        # The same omission, and the same reasoning as the
+                        # step above: a backend that fails during the
+                        # completion must end the run, not unwind it. What
+                        # ran, ran; the analyst is told why it stopped, and
+                        # is told the CAUSE rather than being left to infer
+                        # one.
+                        #
+                        # Kept distinct from the cancellation beside it. An
+                        # outage is not a decision, so the question is
+                        # blocked with what actually happened and the run
+                        # reports a backend error rather than a cancellation
+                        # the analyst never asked for.
+                        model_calls += self.model_calls - spent_before
+                        error = f"{type(exc).__name__}: {exc}"
+                        controller.exhaust_active(
+                            f"the run stopped on a {STOP_BACKEND_ERROR} "
+                            "before this question was closed"
+                        )
+                        stop_reason = f"{STOP_BACKEND_ERROR}: {error}"
+                        # As with the cancellation beside it: the step that
+                        # ran is classified and rendered before leaving.
+                        ended = True
 
             record = progress_ledger.classify(len(records) + 1, step)
             records.append(record)
             if on_step is not None:
                 on_step(step, record)
+            if ended:
+                # The completion failed, and the step it belonged to is now
+                # recorded and rendered like any other. What must not happen
+                # is the REST of this iteration: the completion shadow would
+                # spend a model call on a run that is already over, and a
+                # COMPLETE classification below would overwrite the stop
+                # reason that says why it ended.
+                #
+                # `_close_incomplete_turn` cannot fire from here -- `step()`
+                # appended both its turns and `finish_question` never commits
+                # its transient messages -- but it is kept for symmetry with
+                # the sibling handlers, where the history CAN end mid-turn.
+                self._close_incomplete_turn()
+                break
 
             # Observational only, and placed here deliberately: after the step
             # is committed and before any stop decision, so the shadow sees
@@ -3343,6 +3474,11 @@ class AnalysisRuntime:
         # analysis into nothing, discarding a source the model was given in
         # full. So a run that covered the source reports even with no steps.
         if not cancelled and finalize and (steps or covered_calls):
+            # Measured, like the four sites above: `report()` reports its
+            # spend in the object it returns, and the handler below leaves
+            # without one -- so a closing report that reached the model and
+            # then failed was spent and never counted.
+            report_spent_before = self.model_calls
             try:
                 final_report = self.report(
                     question=self._final_question(
@@ -3378,9 +3514,10 @@ class AnalysisRuntime:
                 # pre-run checkpoint, and rewinding to that point deletes the
                 # history and provenance of every completed step -- leaving
                 # their evidence durable on disk with nothing referring to it.
+                model_calls += self.model_calls - report_spent_before
                 final_report = None
             else:
-                model_calls += final_report.model_calls
+                model_calls += self.model_calls - report_spent_before
 
         if shadow_ledger is not None:
             # Written last, so its absence is how a reader tells a killed run
@@ -3528,6 +3665,10 @@ class AnalysisRuntime:
                 with model_call_context(
                     phase=ANALYSIS_COMPLETION_SHADOW_PHASE, tools_mode="off"
                 ):
+                    # Deliberately NOT counted, and the only dispatch in
+                    # this module that is not: the shadow is a diagnostic,
+                    # and a diagnostic must not consume the budget that
+                    # bounds the investigation it is observing.
                     return self.backend.chat(
                         messages,
                         temperature=0,
@@ -3800,6 +3941,11 @@ class AnalysisRuntime:
                 model_calls=0,
                 evidence_ids=tuple(r.evidence_id for r in records),
             )
+        # The fifth dispatch site, counted like the other four: after the
+        # admission that can refuse without sending anything, and before the
+        # call that can raise after reaching the model. A closing report that
+        # dies mid-generation still cost a turn.
+        self.model_calls += 1
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
                 admitted,
@@ -3903,6 +4049,12 @@ class AnalysisRuntime:
                     f"unaffected.\n\n{appendix}"
                 )
             return AnalysisReport(text=text, model_calls=0, evidence_ids=())
+        # The fifth and last COUNTED site. (There is a sixth dispatch in the
+        # completion shadow, deliberately uncounted -- see there.) It reports
+        # its own spend in the AnalysisReport it returns, and the caller now
+        # reads the runtime counter instead, so a site that never touched the
+        # counter dropped its call entirely.
+        self.model_calls += 1
         with model_call_context(phase=ANALYSIS_REPORT_PHASE, tools_mode="off"):
             response = self.backend.chat_stream(
                 admitted,

--- a/tests/test_analysis_controller_runtime.py
+++ b/tests/test_analysis_controller_runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import os
 import pathlib
 import sys
 import unittest
@@ -1173,3 +1174,628 @@ class ControlIsolationTests(ControlRepairTests):
         )
         self.assertNotIn("\n", text)
         self.assertEqual(text, "line one line two line three")
+
+
+class _InterruptingModel(_Model):
+    """Cancels the run at the completion call, not at the action.
+
+    The interesting instant is the one *between* an action and its outcome:
+    the execution has already run and its evidence is already durable, but
+    nothing has yet recorded what the question made of it.
+    """
+
+    def __init__(self, plan, *, interrupt_on_finish: int = 1, **kwargs) -> None:
+        super().__init__(plan, **kwargs)
+        self.interrupt_on_finish = interrupt_on_finish
+        self.finish_calls = 0
+
+    def reply(self, tools, last: str):
+        names = [t["function"]["name"] for t in (tools or [])]
+        if FINISH_TOOL_NAME in names:
+            self.finish_calls += 1
+            if self.finish_calls == self.interrupt_on_finish:
+                raise KeyboardInterrupt
+        return super().reply(tools, last)
+
+
+class CancellationDuringCompletionTests(_Case):
+    """Cancelling between an action and its outcome must not escape the run.
+
+    Every other model call in `run_autonomous` -- COVER, the step, the closing
+    report -- catches `KeyboardInterrupt` and ends the run, because the caller
+    holds only a pre-run checkpoint and rewinding to it would delete the
+    history and provenance of every step that already succeeded. The
+    completion call was the one omission from that policy.
+    """
+
+    def test_cancelling_the_completion_does_not_escape_the_run(self) -> None:
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, module.STOP_CANCELLED)
+
+    def test_the_interrupted_question_is_not_resolved(self) -> None:
+        """Nothing recorded an outcome, so nothing may claim one."""
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        self.assertEqual(run.resolved_questions, ())
+        self.assertEqual(run.open_questions, ("Q1",))
+
+    def test_a_cancelled_run_writes_no_closing_report(self) -> None:
+        """The analyst asked it to stop; spending minutes summarising is not stopping.
+
+        This is pre-existing policy for every other cancellation path, and the
+        containment here must not quietly buy an exception to it.
+        """
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        with mock.patch.object(
+            module, "execute_analysis",
+            lambda **kw: AnalysisResult(
+                status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+                stdout="FINDING", stderr="", exit_status=0,
+                duration_seconds=0.1,
+            ),
+        ):
+            run = runtime.run_autonomous("Analyse it.", finalize=True)
+        self.assertTrue(run.cancelled)
+        self.assertIsNone(run.final_report)
+        # Unresolved and reported as such -- the run does not go quiet about
+        # the question it abandoned.
+        self.assertEqual(run.open_questions, ("Q1",))
+        self.assertEqual(run.resolved_questions, ())
+
+    def test_the_runtime_blocks_the_question_with_the_exact_reason(self) -> None:
+        """Production's own `exhaust_active` call, asserted on production's state.
+
+        The controller is run-local, so it is captured as the runtime builds
+        it. Asserting a reason the test itself wrote would prove nothing about
+        the shipped path.
+        """
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        built: list = []
+        real = module.AnalysisController
+
+        def capture(*args, **kwargs):
+            controller = real(*args, **kwargs)
+            built.append(controller)
+            return controller
+
+        with mock.patch.object(module, "AnalysisController", capture):
+            run = self._run(runtime)
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(len(built), 1)
+        state = built[0].states["Q1"]
+        self.assertEqual(state.status, BLOCKED)
+        # Compared against an independent literal, not against the constant
+        # production wrote: reading the constant back proves only that the
+        # assignment happened, never that the sentence says what it should.
+        self.assertEqual(
+            state.reason,
+            "the analyst stopped the run before this question was closed",
+        )
+        self.assertIn(
+            "the analyst stopped the run before this question was closed",
+            built[0].dossier(),
+        )
+        self.assertIn("Q1 [BLOCKED]", built[0].dossier())
+
+    def test_the_cancellation_reason_says_the_question_was_not_closed(self) -> None:
+        """Pinned exactly, because word ORDER carries the meaning here.
+
+        A vocabulary check cannot hold this alone. Reviewing one showed that
+        reordering the shipped words into "this question was closed before the
+        analyst stopped the run" passes every vocabulary test and tells the
+        next analyst the question was settled -- the exact inversion the
+        constraint exists to prevent. A set of words discards the only thing
+        that distinguishes the two sentences.
+
+        So the string is pinned. A change to it is then a deliberate act that
+        must come here and be read as a sentence, which is the point: this
+        text is rendered verbatim under `unresolved:` in the dossier and
+        embedded in the guided follow-up.
+        """
+        self.assertEqual(
+            module.CANCELLED_QUESTION_REASON,
+            "the analyst stopped the run before this question was closed",
+        )
+
+    def test_the_backend_failure_reason_says_the_same_of_itself(self) -> None:
+        """The cancellation's twin, which was previously unasserted.
+
+        Mutating this string killed no test, while its cancellation twin had
+        two. The asymmetry is what matters: both are rendered to the analyst
+        in the same place, so both are pinned.
+        """
+        class _Boom(_Model):
+            def __init__(self, plan, **kwargs) -> None:
+                super().__init__(plan, **kwargs)
+                self.finish_calls = 0
+
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    raise module.RecoverableBackendError("upstream is down")
+                return _Model.reply(self, tools, last)
+
+        model = _Boom(plan=[_question("q")])
+        runtime = self._runtime(model)
+        built: list = []
+        real = module.AnalysisController
+
+        def capture(*args, **kwargs):
+            controller = real(*args, **kwargs)
+            built.append(controller)
+            return controller
+
+        # Production's own string, read off production's own state.
+        with mock.patch.object(module, "AnalysisController", capture):
+            self._run(runtime)
+        controller = built[0]
+        reason = controller.states["Q1"].reason
+        self.assertEqual(
+            reason,
+            "the run stopped on a backend error before this question was "
+            "closed",
+        )
+        # And it reaches the analyst, in the dossier the report is built from.
+        self.assertIn(reason, controller.dossier())
+        self.assertIn("Q1 [BLOCKED]", controller.dossier())
+
+    def test_calls_spent_before_the_interrupt_are_still_counted(self) -> None:
+        """A cancelled run must not be reported as cheaper than it was.
+
+        `finish_question` reports its spend by returning it, and an interrupt
+        leaves by a path that returns nothing -- so calls that reached the
+        model vanished from the total the analyst reads. The case that shows
+        it is an interrupt on the RETRY: a first completion attempt was
+        already spent and repaired before the analyst stopped the run.
+        """
+        class _Retry(_InterruptingModel):
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    if self.finish_calls == 1:
+                        # Unusable: earns a repair, and costs a call.
+                        return self._call(FINISH_TOOL_NAME, {"bogus": "x"})
+                    raise KeyboardInterrupt
+                return _Model.reply(self, tools, last)
+
+        model = _Retry(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(model.finish_calls, 2)
+        # Counted against the backend, the only independent witness.
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls))
+
+    def test_the_first_completion_call_is_counted_when_interrupted(self) -> None:
+        """Counted against the BACKEND, not against another Orbit counter.
+
+        `run.model_calls == runtime.model_calls` is a tautology: both are fed
+        by the same increment, so both are wrong together whenever that
+        increment is misplaced. The only independent witness of how many calls
+        were made is the backend that served them.
+
+        COVER is excluded from the comparison deliberately. It is an
+        optimisation whose own handler swallows a `TimeoutError` and leaves
+        the run uncovered, so under load it may not run at all -- an equality
+        against the raw call total is then flaky, passing or failing on
+        machine load rather than on the accounting this asserts.
+        """
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        # The interrupted call reached the model and cost a turn.
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls))
+
+    def test_a_backend_failure_during_completion_ends_the_run(self) -> None:
+        """The other half of the same omission.
+
+        Cancellation was not the only unguarded exit from the completion
+        call. A backend that fails there unwound `run_autonomous` exactly as
+        an interrupt did, and for the same cost: the caller holds only a
+        pre-run checkpoint.
+        """
+        class _Boom(_Model):
+            def __init__(self, plan, **kwargs) -> None:
+                super().__init__(plan, **kwargs)
+                self.finish_calls = 0
+
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    raise module.RecoverableBackendError("upstream is down")
+                return _Model.reply(self, tools, last)
+
+        model = _Boom(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+
+        # The run ended, rather than escaping to a caller that would rewind it.
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(len(run.steps), 1)
+        # The analyst is told the cause, not left to infer one.
+        self.assertIn("upstream is down", run.stop_reason)
+        self.assertIn(module.STOP_BACKEND_ERROR, run.stop_reason)
+        # An outage is not a decision: this is not a cancellation.
+        self.assertFalse(run.cancelled)
+        self.assertNotEqual(run.stop_reason, module.STOP_CANCELLED)
+        # Nothing recorded an answer, so nothing claims one.
+        self.assertEqual(run.resolved_questions, ())
+        self.assertEqual(run.open_questions, ("Q1",))
+        # And the spend is counted here too, against the backend.
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls))
+
+    def test_a_backend_failure_on_the_retry_still_counts_the_first_call(self) -> None:
+        """The discriminating case for the backend path's accounting.
+
+        A failure on the FIRST completion call raises before the dispatch
+        counter moves, so nothing is spent and any accounting looks correct.
+        Only a failure on the retry -- after a call was spent and repaired --
+        can show whether the spend survives the exception.
+        """
+        class _BoomOnRetry(_Model):
+            def __init__(self, plan, **kwargs) -> None:
+                super().__init__(plan, **kwargs)
+                self.finish_calls = 0
+
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    if self.finish_calls == 1:
+                        return self._call(FINISH_TOOL_NAME, {"bogus": "x"})
+                    raise module.RecoverableBackendError("upstream is down")
+                return _Model.reply(self, tools, last)
+
+        model = _BoomOnRetry(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+
+        self.assertEqual(model.finish_calls, 2)
+        self.assertIn("upstream is down", run.stop_reason)
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls))
+
+    def test_the_last_action_is_still_rendered_to_the_analyst(self) -> None:
+        """A step that ran must reach `on_step`, however the run then ends.
+
+        The REPL renders autonomous steps ONLY through `on_step` -- it forces
+        an empty step block for autonomous runs precisely because every step
+        was already shown. Leaving the loop before classifying meant the last
+        executed action was in `run.steps` but had never been rendered, and a
+        cancelled run produces no closing report either, so its evidence id
+        was displayed nowhere at all.
+        """
+        class _Late(_InterruptingModel):
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    if self.finish_calls == 3:
+                        raise KeyboardInterrupt
+                return _Model.reply(self, tools, last)
+
+        model = _Late(plan=[_question("a"), _question("b"), _question("c")])
+        runtime = self._runtime(model)
+        rendered: list = []
+        counter = {"n": 0}
+
+        def distinct(**_kwargs):
+            counter["n"] += 1
+            return AnalysisResult(
+                status="ok", code_sha256=f"{counter['n']:064d}",
+                input_sha256="i" * 64, stdout=f"F{counter['n']}", stderr="",
+                exit_status=0, duration_seconds=0.1,
+            )
+
+        with mock.patch.object(module, "execute_analysis", distinct):
+            run = runtime.run_autonomous(
+                "Analyse it.", finalize=False,
+                on_step=lambda step, _record: rendered.append(step),
+            )
+
+        self.assertTrue(run.cancelled)
+        # Every step that ran was rendered, and the ledger agrees with it.
+        self.assertEqual(len(rendered), len(run.steps))
+        self.assertEqual(len(run.progress), len(run.steps))
+        # Specifically the last one, which is the one that used to vanish.
+        self.assertIs(rendered[-1], run.steps[-1])
+        self.assertIsNotNone(run.steps[-1].evidence)
+
+    def test_a_backend_failure_also_renders_its_last_action(self) -> None:
+        """Same invariant on the other new exit."""
+        class _Boom(_Model):
+            def __init__(self, plan, **kwargs) -> None:
+                super().__init__(plan, **kwargs)
+                self.finish_calls = 0
+
+            def reply(self, tools, last: str):
+                names = [t["function"]["name"] for t in (tools or [])]
+                if FINISH_TOOL_NAME in names:
+                    self.finish_calls += 1
+                    raise module.RecoverableBackendError("upstream is down")
+                return _Model.reply(self, tools, last)
+
+        model = _Boom(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        rendered: list = []
+        run = self._run(runtime, on_step=lambda s, _r: rendered.append(s))
+
+        self.assertEqual(len(rendered), len(run.steps))
+        self.assertEqual(len(run.progress), len(run.steps))
+        self.assertIn("upstream is down", run.stop_reason)
+
+    def test_every_failure_path_counts_the_calls_it_spent(self) -> None:
+        """One table, because the defect was the same at four call sites.
+
+        COVER, PLAN, the step and the completion each report their spend by
+        RETURNING it, and each has handlers that leave without returning. A
+        call that reached the model and then failed was therefore spent and
+        never counted, and the analyst reads that total. The witness is the
+        backend, the only counter not fed by the code under test.
+        """
+        def failing(tool, exc):
+            class _M(_Model):
+                def __init__(self, plan, **kwargs) -> None:
+                    super().__init__(plan, **kwargs)
+                    self.hits = 0
+
+                def reply(self, tools, last: str):
+                    names = [t["function"]["name"] for t in (tools or [])]
+                    # COVER is the call that offers no tools at all.
+                    if (tool is None and not names) or (tool and tool in names):
+                        self.hits += 1
+                        if self.hits == 1:
+                            raise exc
+                    return _Model.reply(self, tools, last)
+            return _M
+
+        interrupt = KeyboardInterrupt
+        outage = module.RecoverableBackendError
+        # The success path first: a run where nothing fails must also count
+        # exactly, or the failure rows below prove only that two wrongs match.
+        model = _Model(plan=[_question("q")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls),
+                         "a run with no failure must count exactly")
+
+        # And the boundary the counter must sit on, at EVERY site: admission
+        # refuses before anything is sent, so a refused request reached no
+        # model and must not be billed. Patching `_admit` globally only ever
+        # exercises the first site a run reaches, which is why each is
+        # refused in turn here by the phase it belongs to.
+        real_admit = module.AnalysisRuntime._admit
+        # Through 6, not 4: with `finalize=True` the run reaches a report
+        # dispatch too, and its admission boundary is otherwise never
+        # exercised -- a context exhausted at the closing report is exactly
+        # when that path runs in production.
+        for nth in range(1, 7):
+            with self.subTest(refuse_admission_number=nth):
+                model = _Model(plan=[_question("q")])
+                runtime = self._runtime(model)
+                seen = {"n": 0}
+
+                def refusing(self, *args, **kwargs):
+                    seen["n"] += 1
+                    if seen["n"] == nth:
+                        raise module.ContextAdmissionError("nothing fits")
+                    return real_admit(self, *args, **kwargs)
+
+                with mock.patch.object(
+                    module.AnalysisRuntime, "_admit", refusing
+                ):
+                    run = runtime.run_autonomous("Analyse it.", finalize=True)
+                # The refused admission sent nothing, so it is not a call --
+                # every other admitted request is.
+                self.assertEqual(
+                    run.model_calls, len(self.backend.chat_calls),
+                    f"refusal #{nth} was billed as a call",
+                )
+
+        sites = [
+            ("COVER", None), ("PLAN", PLAN_TOOL_NAME),
+            ("STEP", ANALYSIS_TOOL_NAME), ("FINISH", FINISH_TOOL_NAME),
+        ]
+        for label, tool in sites:
+            for kind, exc in (("interrupt", interrupt("stop")),
+                              ("outage", outage("upstream is down"))):
+                with self.subTest(site=label, failure=kind):
+                    model = failing(tool, exc)(plan=[_question("q")])
+                    runtime = self._runtime(model)
+                    run = self._run(runtime)
+                    self.assertEqual(
+                        run.model_calls, len(self.backend.chat_calls),
+                        f"{label} on {kind}: calls spent were not counted",
+                    )
+
+    def test_cancelling_spends_no_shadow_observation(self) -> None:
+        """The cancellation flag, tested where it actually bites.
+
+        `while not cancelled` only ends the loop at the NEXT iteration, so
+        without the flag the rest of this one still runs. When the completion
+        shadow is due that costs a real generation -- spent summarising a run
+        the analyst just asked to stop.
+
+        The schedule fires after four actions, so the interrupt must land ON
+        the fourth completion: a run that stops earlier never reaches the
+        checkpoint and the assertion would hold for the wrong reason.
+        """
+        with mock.patch.dict(
+            os.environ, {"ORBIT_ANALYSIS_COMPLETION_SHADOW": "1"}, clear=False
+        ):
+            model = _InterruptingModel(
+                plan=[_question(str(i)) for i in range(4)],
+                interrupt_on_finish=4,
+            )
+            runtime = self._runtime(model)
+            counter = {"n": 0}
+
+            def distinct(**_kwargs):
+                counter["n"] += 1
+                return AnalysisResult(
+                    status="ok", code_sha256=f"{counter['n']:064d}",
+                    input_sha256="i" * 64, stdout=f"F{counter['n']}",
+                    stderr="", exit_status=0, duration_seconds=0.1,
+                )
+
+            with mock.patch.object(module, "execute_analysis", distinct):
+                run = runtime.run_autonomous("Analyse it.", finalize=False)
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.actions_executed, 4, "the schedule must be reached")
+        self.assertEqual(
+            len(run.completion_shadow.observations), 0,
+            "a cancelled run must not spend a generation on a diagnostic",
+        )
+
+    def test_a_closing_report_is_counted_like_every_other_call(self) -> None:
+        """The fifth dispatch site. It was the one left unconverted.
+
+        `report()` reached the model without touching the counter at all, so
+        a report that died mid-generation was spent and never counted, and
+        even a successful one left the runtime's lifetime total short.
+        """
+        model = _Model(plan=[_question("q")])
+        runtime = self._runtime(model)
+        reached = {"n": 0}
+        served = self.backend.chat_stream
+
+        def counting(messages, **kwargs):
+            # Counted before dispatch, as production does, so a call that
+            # raises is still witnessed.
+            reached["n"] += 1
+            return served(messages, **kwargs)
+
+        self.backend.chat_stream = counting
+        with mock.patch.object(
+            module, "execute_analysis",
+            lambda **kw: AnalysisResult(
+                status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+                stdout="F", stderr="", exit_status=0, duration_seconds=0.1,
+            ),
+        ):
+            run = runtime.run_autonomous("Analyse it.", finalize=True)
+
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(run.model_calls, reached["n"])
+        # And the lifetime counter agrees, which it did not before.
+        self.assertEqual(runtime.model_calls, reached["n"])
+
+    def test_a_coverage_report_is_counted_too(self) -> None:
+        """The other report path -- the one with no evidence to report on.
+
+        A covered run whose plan was empty takes no step at all: the model
+        said the source answered everything, which the planning instruction
+        calls a correct reply. That run still reports, through a second
+        dispatch site, and that site was the one left uncounted -- so an
+        ordinary successful analysis under-reported what it cost.
+        """
+        model = _Model(plan=[])
+        runtime = self._runtime(model)
+        run = runtime.run_autonomous("Analyse it.", finalize=True)
+
+        # No steps, but a real report, served by a real call.
+        self.assertEqual(run.actions_executed, 0)
+        self.assertIsNotNone(run.final_report)
+        self.assertEqual(run.model_calls, len(self.backend.chat_calls))
+        self.assertEqual(runtime.model_calls, len(self.backend.chat_calls))
+
+    def test_a_report_that_fails_still_counts_the_call_it_made(self) -> None:
+        """The report's failure path, which returns nothing to add.
+
+        `report()` reports its spend in the object it returns; the handler
+        that catches a failing report returns None instead, so the call it
+        already made vanished from the total the analyst reads.
+        """
+        model = _Model(plan=[_question("q")])
+        runtime = self._runtime(model)
+        reached = {"n": 0}
+        served = self.backend.chat_stream
+
+        def failing(messages, **kwargs):
+            reached["n"] += 1
+            # The first toolless call is COVER; the second is the report.
+            if not kwargs.get("tools") and reached["n"] > 1:
+                raise module.RecoverableBackendError("upstream is down")
+            return served(messages, **kwargs)
+
+        self.backend.chat_stream = failing
+        with mock.patch.object(
+            module, "execute_analysis",
+            lambda **kw: AnalysisResult(
+                status="ok", code_sha256="c" * 64, input_sha256="i" * 64,
+                stdout="F", stderr="", exit_status=0, duration_seconds=0.1,
+            ),
+        ):
+            run = runtime.run_autonomous("Analyse it.", finalize=True)
+
+        # The run survives a report it could not compose...
+        self.assertIsNone(run.final_report)
+        # ...and still says what it cost.
+        self.assertEqual(run.model_calls, reached["n"])
+
+    def test_the_action_and_its_evidence_survive(self) -> None:
+        """What ran, ran. The interrupt withholds an outcome, not a result."""
+        model = _InterruptingModel(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(len(run.steps), 1)
+        self.assertIsNotNone(run.steps[0].evidence)
+
+    def test_cancelling_stops_the_run_rather_than_continuing(self) -> None:
+        """Leaving the loop is load-bearing -- but not because of Q2.
+
+        `while not cancelled` already stops the next iteration, so Q2 never
+        starts either way. What leaving actually protects is the REST of this
+        iteration: a COMPLETE classification below would overwrite the stop
+        reason that says the analyst cancelled, and the completion shadow
+        would spend a model call on a run that is already over.
+        """
+        model = _InterruptingModel(plan=[_question("first"), _question("second")])
+        runtime = self._runtime(model)
+        built: list = []
+        real = module.AnalysisController
+
+        def capture(*args, **kwargs):
+            controller = real(*args, **kwargs)
+            built.append(controller)
+            return controller
+
+        with mock.patch.object(module, "AnalysisController", capture):
+            run = self._run(runtime)
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, module.STOP_CANCELLED)
+        # Exactly one action ran and exactly one completion was attempted.
+        self.assertEqual(run.actions_executed, 1)
+        self.assertEqual(model.finish_calls, 1)
+        self.assertEqual(len(run.steps), 1)
+        # Q2 was never activated, never acted on, and is still open.
+        self.assertEqual(built[0].states["Q2"].actions, 0)
+        self.assertEqual(run.resolved_questions, ())
+        self.assertEqual(run.open_questions, ("Q1", "Q2"))
+        # The step that ran IS classified and rendered -- it is real work the
+        # analyst must see -- but nothing after it runs, so the cancellation
+        # survives as the stop reason.
+        self.assertEqual(len(run.progress), len(run.steps))
+        self.assertEqual(run.stop_reason, module.STOP_CANCELLED)
+
+    def test_normal_completion_is_untouched(self) -> None:
+        """The guard catches an interrupt; it changes nothing otherwise."""
+        model = _Model(plan=[_question("is pickle reachable?")])
+        runtime = self._runtime(model)
+        run = self._run(runtime)
+        self.assertFalse(run.cancelled)
+        self.assertEqual(run.resolved_questions, ("Q1",))
+        self.assertEqual(run.open_questions, ())

--- a/tests/test_completion_shadow_integration.py
+++ b/tests/test_completion_shadow_integration.py
@@ -168,14 +168,23 @@ class ShadowIsObservationalTests(AutonomousTestBase):
         backend = _CountingBackend(
             _script(), verifier_answers=["CONTINUE missing: the payload"] * 12
         )
+        runtime = self.runtime(backend)
         with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False):
-            run = self.runtime(backend).run_autonomous("go", finalize=False)
+            run = runtime.run_autonomous("go", finalize=False)
         shadow = run.completion_shadow
         self.assertGreater(shadow.calls, 0)
         loop_calls = sum(1 for tools in backend.tool_modes if tools != [])
         # The load-bearing one: the loop's own budget counts loop calls and
         # nothing else, however many verifier calls the shadow made.
         self.assertEqual(run.model_calls, loop_calls)
+        # And the LIFETIME counter too. `run.model_calls` is structurally
+        # immune -- the shadow sits between the windows it is measured over --
+        # so counting a verifier call would leave that assertion green while
+        # the runtime's own total, which the terminal renders as session
+        # usage, silently absorbed a diagnostic.
+        self.assertGreater(backend.verifier_calls, 0,
+                           "the verifier must actually have run")
+        self.assertEqual(runtime.model_calls, loop_calls)
 
     def test_verifier_calls_are_tool_free(self) -> None:
         import os


### PR DESCRIPTION
`finish_question` -- the model call recording what an executed action established for the active question -- was the one model call in `run_autonomous` unguarded against **both** `KeyboardInterrupt` and the recoverable trio. Both escaped the function entirely, unwinding to a caller holding only a pre-run checkpoint, which deletes the history and provenance of every step that already succeeded and leaves their evidence durable on disk with nothing referring to it.

It went unnoticed because completions only happen on covered runs while the cancellation tests all run uncovered, so no test reached the call.

## The two exits stay distinct

- **Cancellation** is the analyst's decision: the run reports itself cancelled.
- **An outage is not a decision**: it reports `backend error: <exact cause>`, never flattened into a cancellation nobody asked for.

Either way the action ran and its evidence stands. Only the question's outcome is missing, so the question is blocked with what actually happened rather than resolved -- nothing recorded an answer, so nothing may claim one.

## Three defects this exposed

**The last executed action was invisible.** Leaving the loop directly skipped the classification for a step already in `steps`, breaking `len(steps) == len(progress)`. Because the REPL renders autonomous steps *only* through `on_step`, and a cancelled run writes no closing report, that action's evidence id was displayed nowhere at all.

**Model calls were lost at every dispatch site.** All five `chat_stream` sites reported their spend by *returning* it while their failure handlers left without a return, so a call that reached the model and then failed was spent and never counted. Each now increments at dispatch, between `_admit` (which refuses without sending anything, so a refusal is not a call) and the dispatch itself (a call that raises had already cost a turn).

**Two report sites never touched the counter at all** -- including the one an empty plan reaches, which the planning instruction calls a correct reply. An ordinary successful analysis under-reported what it cost.

The completion shadow's own `chat()` remains the single uncounted dispatch: a diagnostic must not consume the budget bounding the investigation it observes.

## Verification

Twenty regressions on the shipped path. Every QREL-1 mutant caught (21/21): the guards, the reasons, the flag on both exits, each site's increment, each call site's delta, and the admission boundary at each site a run reaches -- including both report paths, which a `finalize=False` test can never exercise.

Measuring accounting needs a witness outside the counters: `run.model_calls == runtime.model_calls` compares two values fed by the same increment, so they are wrong together and equal anyway. The assertions compare against the backend's own call count.

Full suite: **4683 tests OK** in the normal environment.

Six independent adversarial review cycles; the final one returned BLOCKER 0 / MAJOR 0 after an 840-config accounting sweep and exhaustive assertion-negation (all 86 new assertions falsifiable, zero tautologies).
