### PR TITLE
fix(analysis): let a cancellation through the completion shadow

### DIFF
--- a/src/orbit/runtime/analysis_runtime.py
+++ b/src/orbit/runtime/analysis_runtime.py
@@ -3348,7 +3348,35 @@ class AnalysisRuntime:
             # exactly the state a real gate would have seen -- while every
             # `break` below remains reachable regardless of what it says.
             if shadow is not None and shadow_due(actions):
-                observation = self._observe_completion_shadow(actions, analyst_message)
+                try:
+                    observation = self._observe_completion_shadow(
+                        actions, analyst_message
+                    )
+                except KeyboardInterrupt:
+                    # The analyst stopped the run during a checkpoint. The
+                    # observation is abandoned rather than invented: writing
+                    # a `shadow_error` for it would record their decision as
+                    # a diagnostic failure the verifier never made. Contained
+                    # here, as at every other model call, because propagating
+                    # unwinds to a caller holding only a pre-run checkpoint.
+                    #
+                    # The active question is blocked, as at the sibling
+                    # handlers. It is usually already closed by the
+                    # completion above and `exhaust_active` then no-ops --
+                    # but not always: when the model-call budget runs out,
+                    # `if model_calls < max_model_calls` skips the completion
+                    # entirely and the question reaches this checkpoint still
+                    # OPEN. Measured across a sweep of that budget, not of
+                    # plan sizes alone, which is what an earlier reading of
+                    # this path missed. Without this the analyst is told "no
+                    # answer was established" when the truth is that they
+                    # stopped the run.
+                    if controller is not None:
+                        controller.exhaust_active(CANCELLED_QUESTION_REASON)
+                    cancelled = True
+                    stop_reason = STOP_CANCELLED
+                    self._close_incomplete_turn()
+                    break
                 shadow.observations.append(observation)
                 if shadow_ledger is not None:
                     # The writer swallows its own I/O failures; this guards the
@@ -3713,7 +3741,19 @@ class AnalysisRuntime:
                 fits_budget=fits,
                 snapshot_tokens=total,
             )
-        except BaseException as exc:  # noqa: BLE001 - diagnostics must not end a run
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not end a run
+            # `Exception`, not `BaseException`. A diagnostic that fails is a
+            # diagnostic that failed, and recording it as one is right. A
+            # `KeyboardInterrupt` is not a failure of the shadow: it is the
+            # analyst stopping the run, and catching it here turned their
+            # decision into a line of shadow evidence while the analysis
+            # carried on -- resolving questions they had asked it to abandon.
+            # `SystemExit` and the rest are equally not shadow errors.
+            #
+            # They propagate to the call site, which contains them the way
+            # every other model call in the loop is contained. Propagating is
+            # only half of it: left to leave `run_autonomous` entirely they
+            # would unwind to a caller holding a pre-run checkpoint.
             return ShadowObservation(
                 action=actions,
                 snapshot_digest="",

--- a/tests/test_analysis_controller_runtime.py
+++ b/tests/test_analysis_controller_runtime.py
@@ -23,6 +23,7 @@ from orbit.backend.base import ChatResult, TokenCount  # noqa: E402
 from orbit.runtime import analysis_runtime as module  # noqa: E402
 from orbit.runtime.analysis_controller import (  # noqa: E402
     BLOCKED,
+    OPEN,
     MAX_ACTIONS_PER_QUESTION,
     RESOLVED,
 )
@@ -121,6 +122,16 @@ class _Backend:
     def count_chat_tokens(self, messages, *, tools=None, thinking=False):
         chars = sum(len(str(m.get("content") or "")) for m in messages)
         return TokenCount(tokens=int(40 + chars * 0.25), context_tokens=CTX,
+                          rendered_hash="a" * 64, token_hash="b" * 64)
+
+    def count_text_tokens(self, text: str):
+        """Whole-word counting, so a completion-shadow checkpoint can run.
+
+        Without this the shadow fails on an AttributeError before it reaches
+        anything worth observing, and every checkpoint reads `shadow_error`
+        regardless of what the run did.
+        """
+        return TokenCount(tokens=len(text.split()), context_tokens=CTX,
                           rendered_hash="a" * 64, token_hash="b" * 64)
 
     def chat_stream(self, messages, **kwargs):
@@ -1743,6 +1754,131 @@ class CancellationDuringCompletionTests(_Case):
         self.assertIsNone(run.final_report)
         # ...and still says what it cost.
         self.assertEqual(run.model_calls, reached["n"])
+
+    def test_cancelling_in_a_shadow_checkpoint_blocks_the_question(self) -> None:
+        """A Ctrl-C during a checkpoint must not leave a question resolved.
+
+        The shadow observer used to catch `BaseException`, so the analyst's
+        stop became a line of `shadow_error` evidence while the run carried
+        on -- resolving questions they had asked it to abandon. Contained
+        now, and the active question is blocked rather than answered:
+        nothing recorded an outcome, so nothing may claim one.
+        """
+        with mock.patch.dict(
+            os.environ, {"ORBIT_ANALYSIS_COMPLETION_SHADOW": "1"}, clear=False
+        ):
+            model = _Model(plan=[_question(str(i)) for i in range(6)])
+            runtime = self._runtime(model)
+            built: list = []
+            real = module.AnalysisController
+
+            def capture(*args, **kwargs):
+                controller = real(*args, **kwargs)
+                built.append(controller)
+                return controller
+
+            counter = {"n": 0}
+
+            def distinct(**_kwargs):
+                counter["n"] += 1
+                return AnalysisResult(
+                    status="ok", code_sha256=f"{counter['n']:064d}",
+                    input_sha256="i" * 64, stdout=f"F{counter['n']}",
+                    stderr="", exit_status=0, duration_seconds=0.1,
+                )
+
+            with mock.patch.object(module, "AnalysisController", capture), \
+                 mock.patch.object(module, "execute_analysis", distinct), \
+                 mock.patch.object(
+                     module, "evaluate_completion_shadow",
+                     side_effect=KeyboardInterrupt(),
+                 ):
+                run = runtime.run_autonomous("Analyse it.", finalize=False)
+
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, module.STOP_CANCELLED)
+        # No fake evidence was written for the analyst's decision.
+        self.assertEqual(run.completion_shadow.observations, [])
+        # The checkpoint fires between questions, so the one that was active
+        # had already closed honestly -- `exhaust_active` blocks only an OPEN
+        # question, and must not rewrite a settled one. What matters is that
+        # the questions the analyst abandoned stay abandoned.
+        self.assertEqual(len(built), 1)
+        controller = built[0]
+        still_open = [qid for qid in controller.order
+                      if controller.states[qid].status == OPEN]
+        self.assertTrue(still_open, "the run did not stop early")
+        for qid in still_open:
+            self.assertNotIn(qid, run.resolved_questions)
+        # And the run stopped rather than working through them.
+        self.assertLess(len(run.resolved_questions), len(controller.order))
+
+    def test_cancelling_blocks_a_question_the_budget_left_open(self) -> None:
+        """The case a sweep of plan sizes alone does not reach.
+
+        A checkpoint usually fires after the completion has closed the active
+        question, so blocking it is a no-op. But when the model-call budget
+        runs out, `if model_calls < max_model_calls` skips the completion and
+        the question arrives at the checkpoint still OPEN. Cancelling there
+        must say WHY it is unresolved: the dossier the closing report reads
+        otherwise tells the analyst "no answer was established" when the
+        truth is that they stopped the run.
+        """
+        with mock.patch.dict(
+            os.environ, {"ORBIT_ANALYSIS_COMPLETION_SHADOW": "1"}, clear=False
+        ):
+            model = _Model(plan=[_question(str(i)) for i in range(6)])
+            runtime = self._runtime(model)
+            built: list = []
+            real = module.AnalysisController
+
+            def capture(*args, **kwargs):
+                controller = real(*args, **kwargs)
+                built.append(controller)
+                return controller
+
+            counter = {"n": 0}
+
+            def distinct(**_kwargs):
+                counter["n"] += 1
+                return AnalysisResult(
+                    status="ok", code_sha256=f"{counter['n']:064d}",
+                    input_sha256="i" * 64, stdout=f"F{counter['n']}",
+                    stderr="", exit_status=0, duration_seconds=0.1,
+                )
+
+            with mock.patch.object(module, "AnalysisController", capture), \
+                 mock.patch.object(module, "execute_analysis", distinct), \
+                 mock.patch.object(
+                     module, "evaluate_completion_shadow",
+                     side_effect=KeyboardInterrupt(),
+                 ):
+                # 9 is the budget at which the completion is skipped and Q4
+                # reaches the checkpoint open.
+                run = runtime.run_autonomous(
+                    "Analyse it.", finalize=False, max_model_calls=9
+                )
+
+        self.assertTrue(run.cancelled)
+        controller = built[0]
+        blocked = [qid for qid in controller.order
+                   if controller.states[qid].status == BLOCKED]
+        self.assertTrue(
+            blocked,
+            "the question left open by the budget was not blocked",
+        )
+        for qid in blocked:
+            self.assertEqual(controller.states[qid].reason,
+                             module.CANCELLED_QUESTION_REASON)
+        # And the analyst reads that reason for the question that was in
+        # flight. Questions never started keep the generic wording, which is
+        # correct for them -- nothing stopped them, they simply never ran.
+        dossier = controller.dossier()
+        self.assertIn(module.CANCELLED_QUESTION_REASON, dossier)
+        for qid in blocked:
+            row = [ln for ln in dossier.splitlines() if ln.startswith(f"{qid} ")]
+            self.assertTrue(row, f"{qid} missing from the dossier")
+            self.assertIn("BLOCKED", row[0])
 
     def test_the_action_and_its_evidence_survive(self) -> None:
         """What ran, ran. The interrupt withholds an outcome, not a result."""

--- a/tests/test_completion_shadow_integration.py
+++ b/tests/test_completion_shadow_integration.py
@@ -418,3 +418,129 @@ class SnapshotUsesActiveEvidenceOnlyTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ShadowCancellationTests(AutonomousTestBase):
+    """A checkpoint must not be able to swallow the analyst's cancellation.
+
+    The shadow is a diagnostic and its failures are contained -- that is the
+    whole point of the handler. But it caught `BaseException`, so a Ctrl-C
+    arriving during a checkpoint was recorded as `shadow_error:
+    KeyboardInterrupt` and the analysis carried on, resolving questions the
+    analyst had asked it to abandon. The three cases are different events and
+    must stay distinguishable.
+    """
+
+    def _run_with_shadow_raising(self, exc):
+        """Drive a run whose shadow observation raises `exc`.
+
+        The failure is injected at `evaluate_completion_shadow`, inside the
+        observer's own `try`, which is where a real verifier failure or a
+        real interrupt would arrive.
+        """
+        import os
+
+        backend = _CountingBackend(
+            _script(), verifier_answers=["CONTINUE missing: the payload"] * 12
+        )
+        runtime = self.runtime(backend)
+
+        def raising(**_kwargs):
+            raise exc
+
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False), \
+             mock.patch(
+                 "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                 side_effect=raising,
+             ):
+            return runtime.run_autonomous("go", finalize=False)
+
+    def test_an_ordinary_failure_is_still_contained_as_evidence(self) -> None:
+        """The behaviour the handler exists for, unchanged."""
+        run = self._run_with_shadow_raising(RuntimeError("verifier exploded"))
+        self.assertIsNotNone(run.completion_shadow)
+        self.assertEqual(
+            [o.blocked_by for o in run.completion_shadow.observations],
+            ["shadow_error: RuntimeError"],
+        )
+        # The run was not stopped by a diagnostic failing.
+        self.assertFalse(run.cancelled)
+        self.assertNotEqual(run.stop_reason, "cancelled")
+
+    def test_a_cancellation_stops_the_run(self) -> None:
+        run = self._run_with_shadow_raising(KeyboardInterrupt())
+        self.assertTrue(run.cancelled)
+        self.assertEqual(run.stop_reason, "cancelled")
+
+    def test_a_cancellation_writes_no_shadow_evidence(self) -> None:
+        """The analyst's decision is not a diagnostic failure.
+
+        Recording `shadow_error: KeyboardInterrupt` would put their stop into
+        the ledger as an observation the verifier made, which it did not.
+        """
+        run = self._run_with_shadow_raising(KeyboardInterrupt())
+        blocked = [o.blocked_by for o in run.completion_shadow.observations]
+        self.assertEqual(blocked, [])
+        self.assertNotIn("shadow_error: KeyboardInterrupt", blocked)
+
+    def test_a_cancellation_stops_the_analysis_short(self) -> None:
+        """The run must END, not carry on past the analyst's stop.
+
+        Asserting `resolved_questions == ()` would be vacuous here -- this
+        backend resolves nothing either way -- so the witness is the work
+        actually done: a cancelled run stops at the checkpoint, while the
+        same run with an ordinary shadow failure continues to completion.
+        """
+        cancelled = self._run_with_shadow_raising(KeyboardInterrupt())
+        ordinary = self._run_with_shadow_raising(RuntimeError("verifier died"))
+        self.assertLess(
+            cancelled.actions_executed, ordinary.actions_executed,
+            "the run continued past the cancellation",
+        )
+        self.assertEqual(cancelled.resolved_questions, ())
+
+    def test_a_cancellation_leaves_no_report(self) -> None:
+        """Consistent with every other cancellation path in the runtime."""
+        import os
+
+        backend = _CountingBackend(
+            _script(), verifier_answers=["CONTINUE missing: the payload"] * 12
+        )
+        runtime = self.runtime(backend)
+        with mock.patch.dict("os.environ", {SHADOW_ENV: "1"}, clear=False), \
+             mock.patch(
+                 "orbit.runtime.analysis_runtime.evaluate_completion_shadow",
+                 side_effect=KeyboardInterrupt(),
+             ):
+            run = runtime.run_autonomous("go", finalize=True)
+        self.assertTrue(run.cancelled)
+        self.assertIsNone(run.final_report)
+
+    def test_system_exit_is_not_turned_into_shadow_evidence(self) -> None:
+        """A `BaseException` that is neither ordinary nor a cancellation.
+
+        It must not be normalised into a diagnostic observation. Propagating
+        is the honest outcome: the runtime has no meaning to assign it.
+        """
+        with self.assertRaises(SystemExit):
+            self._run_with_shadow_raising(SystemExit(3))
+
+    def test_generator_exit_is_not_turned_into_shadow_evidence(self) -> None:
+        with self.assertRaises(GeneratorExit):
+            self._run_with_shadow_raising(GeneratorExit())
+
+    def test_the_three_outcomes_stay_distinct(self) -> None:
+        """One table, because conflating any two of them is the defect."""
+        ordinary = self._run_with_shadow_raising(ValueError("bad snapshot"))
+        self.assertFalse(ordinary.cancelled)
+        self.assertEqual(
+            [o.blocked_by for o in ordinary.completion_shadow.observations],
+            ["shadow_error: ValueError"],
+        )
+
+        cancelled = self._run_with_shadow_raising(KeyboardInterrupt())
+        self.assertTrue(cancelled.cancelled)
+        self.assertEqual(cancelled.completion_shadow.observations, [])
+
+        with self.assertRaises(SystemExit):
+            self._run_with_shadow_raising(SystemExit(1))


### PR DESCRIPTION
The completion shadow is a diagnostic, and its failures are contained so a broken verifier cannot end a real analysis. It caught `BaseException` to do that, which swept up the one exception that is not a diagnostic failure at all: a `KeyboardInterrupt` arriving during a checkpoint was written into the ledger as `shadow_error: KeyboardInterrupt`, the run continued, and questions the analyst had asked it to abandon came back resolved. `SystemExit` and the rest were normalised into evidence the same way.

## Narrowing the handler is necessary and not sufficient

The checkpoint's call site has no `try` of its own, so a propagating interrupt left `run_autonomous` entirely — measured, not assumed. Traced end to end, `repl.py` then catches it and calls `_restore_analysis_checkpoint`, which does `del self.analysis.messages[message_count:]`: **17 history messages deleted, 10 evidence records orphaned on disk with nothing referring to them.** That is the same destructive unwind the sibling handlers exist to prevent, so the fix is both halves — the observer contains ordinary failures, and the call site contains the cancellation the way every other model call in the loop does.

## Three outcomes, kept distinct

| raised in the shadow | outcome |
|---|---|
| ordinary `Exception` | contained as `shadow_error`, run continues |
| `KeyboardInterrupt` | `cancelled`, stop reason `cancelled`, **no shadow observation written** |
| `SystemExit`, `GeneratorExit` | propagate |

Inventing an observation for a cancellation would file the analyst's decision as something the verifier had seen. The runtime has no honest meaning to assign the third case, so it does not invent one.

## The active question is blocked, and why that matters

The checkpoint usually runs after the completion has closed the active question, so `exhaust_active` no-ops. Not always: when the model-call budget runs out, `if model_calls < max_model_calls` skips the completion entirely and the question reaches the checkpoint still OPEN. An earlier revision of this change called that branch unreachable on the strength of a sweep over plan sizes — which never varies the budget, and so never reaches the case. Sweeping `max_model_calls` finds it at exactly one value. Without the call the analyst is told "no answer was established" when the truth is that they stopped the run, which is the distinction `CANCELLED_QUESTION_REASON` exists to keep.

`exhaust_active` is inert where it should be: verified not to touch a RESOLVED question, and never to overwrite an existing BLOCKED reason.

## Test coverage that was fictitious

The controller test backend gained `count_text_tokens`. Without it every checkpoint in that suite failed on an `AttributeError` before reaching anything worth observing — `evaluate_completion_shadow` was reached **zero** times. The shadow path that suite appeared to cover was never exercised.

## Verification

Ten regressions, nine of which fail on the parent. Six known defects injected one at a time and all detected: the original `BaseException` handler restored, a cancellation converted back into `shadow_error`, the run not reported cancelled, fake shadow evidence emitted alongside it, `SystemExit` swallowed, and the run allowed to continue afterwards. QREL-1 RC=0.

Full suite: **4757 tests OK** in the normal environment, on a tree whose bytes were hash-verified against the reviewed candidate.

Independent adversarial review returned BLOCKER 0 / MAJOR 0 / MINOR 0, having independently reproduced the OPEN-at-checkpoint case, confirmed the regression test is causally discriminating, and challenged every claimed-equivalent mutant with measured behaviour.

Two pre-existing escapes were found and deliberately left alone: `_write_shadow_final` and `shadow_ledger.write_checkpoint` both let a `KeyboardInterrupt` escape `run_autonomous`, byte-identically on the parent. They are structural unguarded seams rather than this commit's semantic fault, and folding them in would ship changes with no test coverage.
